### PR TITLE
Fix render unnecessary custom-control-label-text on other components in ClayCheckbox

### DIFF
--- a/packages/clay-card/src/__tests__/__snapshots__/ClayFileCard.js.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/ClayFileCard.js.snap
@@ -566,9 +566,7 @@ exports[`ClayFileCard should render a selectable ClayFileCard 1`] = `
       <div class="custom-control custom-checkbox">
         <label>
           <input class="custom-control-input" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <svg aria-hidden="true" class="lexicon-icon lexicon-icon-documents-and-media">
               <title>documents-and-media</title>
@@ -596,9 +594,7 @@ exports[`ClayFileCard should render a selectable ClayFileCard with input \`name\
       <div class="custom-control custom-checkbox">
         <label>
           <input class="custom-control-input" name="checkbox01" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <svg aria-hidden="true" class="lexicon-icon lexicon-icon-documents-and-media">
               <title>documents-and-media</title>
@@ -626,9 +622,7 @@ exports[`ClayFileCard should render a selectable ClayFileCard with input \`value
       <div class="custom-control custom-checkbox">
         <label>
           <input class="custom-control-input" value="checkbox" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <svg aria-hidden="true" class="lexicon-icon lexicon-icon-documents-and-media">
               <title>documents-and-media</title>
@@ -656,9 +650,7 @@ exports[`ClayFileCard should render a selectable disabled ClayFileCard 1`] = `
       <div class="custom-control custom-checkbox">
         <label>
           <input disabled="disabled" class="custom-control-input" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <svg aria-hidden="true" class="lexicon-icon lexicon-icon-documents-and-media">
               <title>documents-and-media</title>
@@ -686,9 +678,7 @@ exports[`ClayFileCard should render a selectable selected ClayFileCard 1`] = `
       <div class="custom-control custom-checkbox">
         <label>
           <input checked="" class="custom-control-input" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <svg aria-hidden="true" class="lexicon-icon lexicon-icon-documents-and-media">
               <title>documents-and-media</title>

--- a/packages/clay-card/src/__tests__/__snapshots__/ClayHorizontalCard.js.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/ClayHorizontalCard.js.snap
@@ -125,9 +125,7 @@ exports[`ClayHorizontalCard should render a disabled ClayHorizontalCard 1`] = `
   <div class="custom-control custom-checkbox">
     <label>
       <input disabled="disabled" class="custom-control-input" ref="input" type="checkbox">
-      <span class="custom-control-label">
-        <span class="custom-control-label-text"></span>
-      </span>
+      <span class="custom-control-label"></span>
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">
@@ -155,9 +153,7 @@ exports[`ClayHorizontalCard should render a selectable ClayHorizontalCard 1`] = 
   <div class="custom-control custom-checkbox">
     <label>
       <input class="custom-control-input" ref="input" type="checkbox">
-      <span class="custom-control-label">
-        <span class="custom-control-label-text"></span>
-      </span>
+      <span class="custom-control-label"></span>
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">
@@ -185,9 +181,7 @@ exports[`ClayHorizontalCard should render a selectable ClayHorizontalCard with i
   <div class="custom-control custom-checkbox">
     <label>
       <input class="custom-control-input" name="checkbox01" ref="input" type="checkbox">
-      <span class="custom-control-label">
-        <span class="custom-control-label-text"></span>
-      </span>
+      <span class="custom-control-label"></span>
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">
@@ -215,9 +209,7 @@ exports[`ClayHorizontalCard should render a selectable ClayHorizontalCard with i
   <div class="custom-control custom-checkbox">
     <label>
       <input class="custom-control-input" value="checkbox" ref="input" type="checkbox">
-      <span class="custom-control-label">
-        <span class="custom-control-label-text"></span>
-      </span>
+      <span class="custom-control-label"></span>
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">
@@ -245,9 +237,7 @@ exports[`ClayHorizontalCard should render a selected ClayHorizontalCard 1`] = `
   <div class="custom-control custom-checkbox">
     <label>
       <input checked="" class="custom-control-input" ref="input" type="checkbox">
-      <span class="custom-control-label">
-        <span class="custom-control-label-text"></span>
-      </span>
+      <span class="custom-control-label"></span>
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">

--- a/packages/clay-card/src/__tests__/__snapshots__/ClayImageCard.js.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/ClayImageCard.js.snap
@@ -442,9 +442,7 @@ exports[`ClayImageCard should render a disabled ClayImageCard 1`] = `
       <div class="custom-control custom-checkbox">
         <label>
           <input disabled="disabled" class="custom-control-input" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
         </label>
       </div>
     </div>
@@ -466,9 +464,7 @@ exports[`ClayImageCard should render a selectable ClayImageCard 1`] = `
       <div class="custom-control custom-checkbox">
         <label>
           <input class="custom-control-input" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
         </label>
       </div>
     </div>
@@ -490,9 +486,7 @@ exports[`ClayImageCard should render a selectable ClayImageCard with input \`nam
       <div class="custom-control custom-checkbox">
         <label>
           <input class="custom-control-input" name="checkbox01" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
         </label>
       </div>
     </div>
@@ -514,9 +508,7 @@ exports[`ClayImageCard should render a selectable ClayImageCard with input \`val
       <div class="custom-control custom-checkbox">
         <label>
           <input class="custom-control-input" name="checkbox" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
         </label>
       </div>
     </div>
@@ -538,9 +530,7 @@ exports[`ClayImageCard should render a selected ClayImageCard 1`] = `
       <div class="custom-control custom-checkbox">
         <label>
           <input checked="" class="custom-control-input" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
         </label>
       </div>
     </div>

--- a/packages/clay-card/src/__tests__/__snapshots__/ClayUserCard.js.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/ClayUserCard.js.snap
@@ -334,9 +334,7 @@ exports[`ClayUserCard should render a disabled ClayUserCard 1`] = `
       <div class="custom-control custom-checkbox">
         <label>
           <input disabled="disabled" class="custom-control-input" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <span class="sticker sticker-primary rounded-circle sticker-xl">
               <span class="sticker-overlay"></span>
@@ -363,9 +361,7 @@ exports[`ClayUserCard should render a selectable ClayUserCard 1`] = `
       <div class="custom-control custom-checkbox">
         <label>
           <input class="custom-control-input" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <span class="sticker sticker-primary rounded-circle sticker-xl">
               <span class="sticker-overlay"></span>
@@ -392,9 +388,7 @@ exports[`ClayUserCard should render a selectable ClayUserCard with input \`name\
       <div class="custom-control custom-checkbox">
         <label>
           <input class="custom-control-input" name="checkbox01" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <span class="sticker sticker-primary rounded-circle sticker-xl">
               <span class="sticker-overlay"></span>
@@ -421,9 +415,7 @@ exports[`ClayUserCard should render a selectable ClayUserCard with input \`value
       <div class="custom-control custom-checkbox">
         <label>
           <input class="custom-control-input" value="checkbox" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <span class="sticker sticker-primary rounded-circle sticker-xl">
               <span class="sticker-overlay"></span>
@@ -450,9 +442,7 @@ exports[`ClayUserCard should render a selected ClayUserCard 1`] = `
       <div class="custom-control custom-checkbox">
         <label>
           <input checked="" class="custom-control-input" ref="input" type="checkbox">
-          <span class="custom-control-label">
-            <span class="custom-control-label-text"></span>
-          </span>
+          <span class="custom-control-label"></span>
           <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
             <span class="sticker sticker-primary rounded-circle sticker-xl">
               <span class="sticker-overlay"></span>

--- a/packages/clay-checkbox/src/ClayCheckbox.soy
+++ b/packages/clay-checkbox/src/ClayCheckbox.soy
@@ -91,14 +91,16 @@
 		<input {$inputAttributes}></input>
 
 		<span class="custom-control-label">
-			{let $spanLabelClasses kind="text"}
-				custom-control-label-text
-				{if $hideLabel}
-					{sp}sr-only
-				{/if}
-			{/let}
+			{if $label}
+				{let $spanLabelClasses kind="text"}
+					custom-control-label-text
+					{if $hideLabel}
+						{sp}sr-only
+					{/if}
+				{/let}
 
-			<span class="{$spanLabelClasses}">{$label}</span>
+				<span class="{$spanLabelClasses}">{$label}</span>
+			{/if}
 		</span>
 
 		{if $labelContent}

--- a/packages/clay-checkbox/src/__tests__/__snapshots__/ClayCheckbox.js.snap
+++ b/packages/clay-checkbox/src/__tests__/__snapshots__/ClayCheckbox.js.snap
@@ -15,9 +15,7 @@ exports[`ClayCheckbox should render a checkbox with custom label content 1`] = `
 <div class="custom-control custom-checkbox">
   <label>
     <input class="custom-control-input" ref="input" type="checkbox">
-    <span class="custom-control-label">
-      <span class="custom-control-label-text"></span>
-    </span>
+    <span class="custom-control-label"></span>
     <div>
       <h4>My Checkbox</h4>
     </div>

--- a/packages/clay-dataset-display/src/__tests__/__snapshots__/ClayDatasetDisplay.js.snap
+++ b/packages/clay-dataset-display/src/__tests__/__snapshots__/ClayDatasetDisplay.js.snap
@@ -2809,9 +2809,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
               <div class="custom-control custom-checkbox">
                 <label>
                   <input aria-labelledby="group-0" class="custom-control-input" name="folder" value="1" ref="input" type="checkbox">
-                  <span class="custom-control-label">
-                    <span class="custom-control-label-text"></span>
-                  </span>
+                  <span class="custom-control-label"></span>
                   <div class="card card-horizontal">
                     <div class="card-body">
                       <div class="card-row">
@@ -2848,9 +2846,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
               <div class="custom-control custom-checkbox">
                 <label>
                   <input aria-labelledby="group-0" class="custom-control-input" name="folder" value="2" ref="input" type="checkbox">
-                  <span class="custom-control-label">
-                    <span class="custom-control-label-text"></span>
-                  </span>
+                  <span class="custom-control-label"></span>
                   <div class="card card-horizontal">
                     <div class="card-body">
                       <div class="card-row">
@@ -2892,9 +2888,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="custom-control custom-checkbox">
                     <label>
                       <input aria-labelledby="group-1" class="custom-control-input" name="recipe" value="3" ref="input" type="checkbox">
-                      <span class="custom-control-label">
-                        <span class="custom-control-label-text"></span>
-                      </span>
+                      <span class="custom-control-label"></span>
                       <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
                         <svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-circle">
                           <title>exclamation-circle</title>
@@ -2938,9 +2932,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="custom-control custom-checkbox">
                     <label>
                       <input aria-labelledby="group-1" class="custom-control-input" name="recipe" value="4" ref="input" type="checkbox">
-                      <span class="custom-control-label">
-                        <span class="custom-control-label-text"></span>
-                      </span>
+                      <span class="custom-control-label"></span>
                       <img alt="Ramen" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="./ramen.jpg">
                       <span class="sticker sticker-danger sticker-bottom-left">
                         <span class="sticker-overlay">PDF</span>
@@ -2979,9 +2971,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="custom-control custom-checkbox">
                     <label>
                       <input aria-labelledby="group-1" class="custom-control-input" name="recipe" value="5" ref="input" type="checkbox">
-                      <span class="custom-control-label">
-                        <span class="custom-control-label-text"></span>
-                      </span>
+                      <span class="custom-control-label"></span>
                       <img alt="Paella" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="./paella.jpg">
                       <span class="sticker sticker-danger sticker-bottom-left">
                         <span class="sticker-overlay">PDF</span>
@@ -3020,9 +3010,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="custom-control custom-checkbox">
                     <label>
                       <input aria-labelledby="group-1" class="custom-control-input" name="recipe" value="6" ref="input" type="checkbox">
-                      <span class="custom-control-label">
-                        <span class="custom-control-label-text"></span>
-                      </span>
+                      <span class="custom-control-label"></span>
                       <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
                         <svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-circle">
                           <title>exclamation-circle</title>
@@ -3066,9 +3054,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="custom-control custom-checkbox">
                     <label>
                       <input aria-labelledby="group-1" class="custom-control-input" name="recipe" value="7" ref="input" type="checkbox">
-                      <span class="custom-control-label">
-                        <span class="custom-control-label-text"></span>
-                      </span>
+                      <span class="custom-control-label"></span>
                       <img alt="Carcamusas" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="./carcamusas.jpg">
                       <span class="sticker sticker-danger sticker-bottom-left">
                         <span class="sticker-overlay">PDF</span>
@@ -3107,9 +3093,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="custom-control custom-checkbox">
                     <label>
                       <input aria-labelledby="group-1" class="custom-control-input" name="recipe" value="8" ref="input" type="checkbox">
-                      <span class="custom-control-label">
-                        <span class="custom-control-label-text"></span>
-                      </span>
+                      <span class="custom-control-label"></span>
                       <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
                         <svg aria-hidden="true" class="lexicon-icon lexicon-icon-exclamation-circle">
                           <title>exclamation-circle</title>
@@ -3156,9 +3140,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="custom-control custom-checkbox">
                     <label>
                       <input aria-labelledby="group-2" class="custom-control-input" name="chef" value="9" ref="input" type="checkbox">
-                      <span class="custom-control-label">
-                        <span class="custom-control-label-text"></span>
-                      </span>
+                      <span class="custom-control-label"></span>
                       <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
                         <span class="sticker sticker-danger rounded-circle sticker-xl">
                           <span class="sticker-overlay">FA</span>
@@ -3194,9 +3176,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="custom-control custom-checkbox">
                     <label>
                       <input aria-labelledby="group-2" class="custom-control-input" name="chef" value="10" ref="input" type="checkbox">
-                      <span class="custom-control-label">
-                        <span class="custom-control-label-text"></span>
-                      </span>
+                      <span class="custom-control-label"></span>
                       <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
                         <span class="sticker sticker-primary rounded-circle sticker-xl">
                           <span class="sticker-overlay">
@@ -3234,9 +3214,7 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="custom-control custom-checkbox">
                     <label>
                       <input aria-labelledby="group-2" class="custom-control-input" name="chef" value="11" ref="input" type="checkbox">
-                      <span class="custom-control-label">
-                        <span class="custom-control-label-text"></span>
-                      </span>
+                      <span class="custom-control-label"></span>
                       <div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
                         <span class="sticker sticker-primary rounded-circle sticker-xl">
                           <span class="sticker-overlay">AC</span>


### PR DESCRIPTION
In use cases like ClayCard when it is not necessary to pass `$label` it is rendered unnecessarily. Only by placing inside the `{if}` conditional so that they are not rendered in these use cases. What do you think?

```soy
{let $spanLabelClasses kind="text"}
	custom-control-label-text
	{if $hideLabel}
		{sp}sr-only
	{/if}
{/let}

<span class="{$spanLabelClasses}">{$label}</span>
```