### PR TITLE
 Fix icon markup on ClayHorizontalCard

### DIFF
--- a/packages/clay-card-grid/src/__tests__/__snapshots__/ClayCardGrid.js.snap
+++ b/packages/clay-card-grid/src/__tests__/__snapshots__/ClayCardGrid.js.snap
@@ -12,14 +12,16 @@ exports[`ClayCardGrid should render the default markup 1`] = `
       <div class="card-type-directory card card-horizontal">
         <div class="card-body">
           <div class="card-row">
-            <span class="sticker sticker-unstyled">
-              <span class="sticker-overlay">
-                <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-                  <title>folder</title>
-                  <use xlink:href="../node_modules/lexicon-ux/build/images/icons/icons.svg#folder"></use>
-                </svg>
+            <div class="autofit-col">
+              <span class="sticker sticker-unstyled">
+                <span class="sticker-overlay">
+                  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+                    <title>folder</title>
+                    <use xlink:href="../node_modules/lexicon-ux/build/images/icons/icons.svg#folder"></use>
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <div class="autofit-col autofit-col-expand autofit-col-gutters">
               <div class="card-title text-truncate">Photos</div>
             </div>
@@ -31,14 +33,16 @@ exports[`ClayCardGrid should render the default markup 1`] = `
       <div class="card-type-directory card card-horizontal">
         <div class="card-body">
           <div class="card-row">
-            <span class="sticker sticker-unstyled">
-              <span class="sticker-overlay">
-                <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-                  <title>folder</title>
-                  <use xlink:href="../node_modules/lexicon-ux/build/images/icons/icons.svg#folder"></use>
-                </svg>
+            <div class="autofit-col">
+              <span class="sticker sticker-unstyled">
+                <span class="sticker-overlay">
+                  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+                    <title>folder</title>
+                    <use xlink:href="../node_modules/lexicon-ux/build/images/icons/icons.svg#folder"></use>
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <div class="autofit-col autofit-col-expand autofit-col-gutters">
               <div class="card-title text-truncate">Videos</div>
             </div>

--- a/packages/clay-card/src/ClayHorizontalCard.soy
+++ b/packages/clay-card/src/ClayHorizontalCard.soy
@@ -93,11 +93,13 @@
 				autofit-col autofit-col-expand autofit-col-gutters
 			{/let}
 
-      {call ClaySticker.render}
-        {param icon: $icon ?: 'folder' /}
-        {param spritemap: $spritemap /}
-        {param style: 'unstyled' /}
-      {/call}
+			<div class="autofit-col">
+				{call ClaySticker.render}
+					{param icon: $icon ?: 'folder' /}
+					{param spritemap: $spritemap /}
+					{param style: 'unstyled' /}
+				{/call}
+			</div>
 
 			<div class="{$classesDescription}">
 				{if $href}

--- a/packages/clay-card/src/__tests__/__snapshots__/ClayHorizontalCard.js.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/ClayHorizontalCard.js.snap
@@ -4,14 +4,16 @@ exports[`ClayHorizontalCard should render a ClayHorizontalCard with a different 
 <div class="card-type-directory card card-horizontal">
   <div class="card-body">
     <div class="card-row">
-      <span class="sticker sticker-unstyled">
-        <span class="sticker-overlay">
-          <svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
-            <title>list</title>
-            <use xlink:href="icons.svg#list"></use>
-          </svg>
+      <div class="autofit-col">
+        <span class="sticker sticker-unstyled">
+          <span class="sticker-overlay">
+            <svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
+              <title>list</title>
+              <use xlink:href="icons.svg#list"></use>
+            </svg>
+          </span>
         </span>
-      </span>
+      </div>
       <div class="autofit-col autofit-col-expand autofit-col-gutters">
         <div class="card-title text-truncate">My Title</div>
       </div>
@@ -24,14 +26,16 @@ exports[`ClayHorizontalCard should render a ClayHorizontalCard with actionItems 
 <div class="card-type-directory card card-horizontal">
   <div class="card-body">
     <div class="card-row">
-      <span class="sticker sticker-unstyled">
-        <span class="sticker-overlay">
-          <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-            <title>folder</title>
-            <use xlink:href="icons.svg#folder"></use>
-          </svg>
+      <div class="autofit-col">
+        <span class="sticker sticker-unstyled">
+          <span class="sticker-overlay">
+            <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+              <title>folder</title>
+              <use xlink:href="icons.svg#folder"></use>
+            </svg>
+          </span>
         </span>
-      </span>
+      </div>
       <div class="autofit-col autofit-col-expand autofit-col-gutters">
         <div class="card-title text-truncate">My Title</div>
       </div>
@@ -64,14 +68,16 @@ exports[`ClayHorizontalCard should render a ClayHorizontalCard with classes 1`] 
 <div class="card-type-directory card card-horizontal my-custom-class">
   <div class="card-body">
     <div class="card-row">
-      <span class="sticker sticker-unstyled">
-        <span class="sticker-overlay">
-          <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-            <title>folder</title>
-            <use xlink:href="icons.svg#folder"></use>
-          </svg>
+      <div class="autofit-col">
+        <span class="sticker sticker-unstyled">
+          <span class="sticker-overlay">
+            <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+              <title>folder</title>
+              <use xlink:href="icons.svg#folder"></use>
+            </svg>
+          </span>
         </span>
-      </span>
+      </div>
       <div class="autofit-col autofit-col-expand autofit-col-gutters">
         <div class="card-title text-truncate">My Title</div>
       </div>
@@ -84,14 +90,16 @@ exports[`ClayHorizontalCard should render a ClayHorizontalCard with href 1`] = `
 <div class="card-type-directory card card-horizontal">
   <div class="card-body">
     <div class="card-row">
-      <span class="sticker sticker-unstyled">
-        <span class="sticker-overlay">
-          <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-            <title>folder</title>
-            <use xlink:href="icons.svg#folder"></use>
-          </svg>
+      <div class="autofit-col">
+        <span class="sticker sticker-unstyled">
+          <span class="sticker-overlay">
+            <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+              <title>folder</title>
+              <use xlink:href="icons.svg#folder"></use>
+            </svg>
+          </span>
         </span>
-      </span>
+      </div>
       <div class="autofit-col autofit-col-expand autofit-col-gutters">
         <a class=" card-title text-truncate" href="#1">My Title</a>
       </div>
@@ -104,14 +112,16 @@ exports[`ClayHorizontalCard should render a ClayHorizontalCard with id 1`] = `
 <div class="card-type-directory card card-horizontal" id="myId">
   <div class="card-body">
     <div class="card-row">
-      <span class="sticker sticker-unstyled">
-        <span class="sticker-overlay">
-          <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-            <title>folder</title>
-            <use xlink:href="icons.svg#folder"></use>
-          </svg>
+      <div class="autofit-col">
+        <span class="sticker sticker-unstyled">
+          <span class="sticker-overlay">
+            <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+              <title>folder</title>
+              <use xlink:href="icons.svg#folder"></use>
+            </svg>
+          </span>
         </span>
-      </span>
+      </div>
       <div class="autofit-col autofit-col-expand autofit-col-gutters">
         <div class="card-title text-truncate">My Title</div>
       </div>
@@ -131,14 +141,16 @@ exports[`ClayHorizontalCard should render a disabled ClayHorizontalCard 1`] = `
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">
-            <span class="sticker sticker-unstyled">
-              <span class="sticker-overlay">
-                <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-                  <title>folder</title>
-                  <use xlink:href="icons.svg#folder"></use>
-                </svg>
+            <div class="autofit-col">
+              <span class="sticker sticker-unstyled">
+                <span class="sticker-overlay">
+                  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+                    <title>folder</title>
+                    <use xlink:href="icons.svg#folder"></use>
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <div class="autofit-col autofit-col-expand autofit-col-gutters">
               <div class="card-title text-truncate">My Title</div>
             </div>
@@ -161,14 +173,16 @@ exports[`ClayHorizontalCard should render a selectable ClayHorizontalCard 1`] = 
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">
-            <span class="sticker sticker-unstyled">
-              <span class="sticker-overlay">
-                <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-                  <title>folder</title>
-                  <use xlink:href="icons.svg#folder"></use>
-                </svg>
+            <div class="autofit-col">
+              <span class="sticker sticker-unstyled">
+                <span class="sticker-overlay">
+                  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+                    <title>folder</title>
+                    <use xlink:href="icons.svg#folder"></use>
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <div class="autofit-col autofit-col-expand autofit-col-gutters">
               <div class="card-title text-truncate">My Title</div>
             </div>
@@ -191,14 +205,16 @@ exports[`ClayHorizontalCard should render a selectable ClayHorizontalCard with i
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">
-            <span class="sticker sticker-unstyled">
-              <span class="sticker-overlay">
-                <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-                  <title>folder</title>
-                  <use xlink:href="icons.svg#folder"></use>
-                </svg>
+            <div class="autofit-col">
+              <span class="sticker sticker-unstyled">
+                <span class="sticker-overlay">
+                  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+                    <title>folder</title>
+                    <use xlink:href="icons.svg#folder"></use>
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <div class="autofit-col autofit-col-expand autofit-col-gutters">
               <div class="card-title text-truncate">My Title</div>
             </div>
@@ -221,14 +237,16 @@ exports[`ClayHorizontalCard should render a selectable ClayHorizontalCard with i
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">
-            <span class="sticker sticker-unstyled">
-              <span class="sticker-overlay">
-                <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-                  <title>folder</title>
-                  <use xlink:href="icons.svg#folder"></use>
-                </svg>
+            <div class="autofit-col">
+              <span class="sticker sticker-unstyled">
+                <span class="sticker-overlay">
+                  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+                    <title>folder</title>
+                    <use xlink:href="icons.svg#folder"></use>
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <div class="autofit-col autofit-col-expand autofit-col-gutters">
               <div class="card-title text-truncate">My Title</div>
             </div>
@@ -251,14 +269,16 @@ exports[`ClayHorizontalCard should render a selected ClayHorizontalCard 1`] = `
       <div class="card card-horizontal">
         <div class="card-body">
           <div class="card-row">
-            <span class="sticker sticker-unstyled">
-              <span class="sticker-overlay">
-                <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-                  <title>folder</title>
-                  <use xlink:href="icons.svg#folder"></use>
-                </svg>
+            <div class="autofit-col">
+              <span class="sticker sticker-unstyled">
+                <span class="sticker-overlay">
+                  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+                    <title>folder</title>
+                    <use xlink:href="icons.svg#folder"></use>
+                  </svg>
+                </span>
               </span>
-            </span>
+            </div>
             <div class="autofit-col autofit-col-expand autofit-col-gutters">
               <div class="card-title text-truncate">My Title</div>
             </div>
@@ -274,14 +294,16 @@ exports[`ClayHorizontalCard should render the default markup 1`] = `
 <div class="card-type-directory card card-horizontal">
   <div class="card-body">
     <div class="card-row">
-      <span class="sticker sticker-unstyled">
-        <span class="sticker-overlay">
-          <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-            <title>folder</title>
-            <use xlink:href="icons.svg#folder"></use>
-          </svg>
+      <div class="autofit-col">
+        <span class="sticker sticker-unstyled">
+          <span class="sticker-overlay">
+            <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+              <title>folder</title>
+              <use xlink:href="icons.svg#folder"></use>
+            </svg>
+          </span>
         </span>
-      </span>
+      </div>
       <div class="autofit-col autofit-col-expand autofit-col-gutters">
         <div class="card-title text-truncate">My Title</div>
       </div>

--- a/packages/clay-dataset-display/src/__tests__/__snapshots__/ClayDatasetDisplay.js.snap
+++ b/packages/clay-dataset-display/src/__tests__/__snapshots__/ClayDatasetDisplay.js.snap
@@ -2815,14 +2815,16 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="card card-horizontal">
                     <div class="card-body">
                       <div class="card-row">
-                        <span class="sticker sticker-unstyled">
-                          <span class="sticker-overlay">
-                            <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-                              <title>folder</title>
-                              <use xlink:href="../../../node_modules/clay/build/images/icons/icons.svg#folder"></use>
-                            </svg>
+                        <div class="autofit-col">
+                          <span class="sticker sticker-unstyled">
+                            <span class="sticker-overlay">
+                              <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+                                <title>folder</title>
+                                <use xlink:href="../../../node_modules/clay/build/images/icons/icons.svg#folder"></use>
+                              </svg>
+                            </span>
                           </span>
-                        </span>
+                        </div>
                         <div class="autofit-col autofit-col-expand autofit-col-gutters">
                           <div class="card-title text-truncate">Photos</div>
                         </div>
@@ -2854,14 +2856,16 @@ exports[`ClayDatasetDisplay should render a ClayDatasetDisplay with items and li
                   <div class="card card-horizontal">
                     <div class="card-body">
                       <div class="card-row">
-                        <span class="sticker sticker-unstyled">
-                          <span class="sticker-overlay">
-                            <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-                              <title>folder</title>
-                              <use xlink:href="../../../node_modules/clay/build/images/icons/icons.svg#folder"></use>
-                            </svg>
+                        <div class="autofit-col">
+                          <span class="sticker sticker-unstyled">
+                            <span class="sticker-overlay">
+                              <svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+                                <title>folder</title>
+                                <use xlink:href="../../../node_modules/clay/build/images/icons/icons.svg#folder"></use>
+                              </svg>
+                            </span>
                           </span>
-                        </span>
+                        </div>
                         <div class="autofit-col autofit-col-expand autofit-col-gutters">
                           <div class="card-title text-truncate">Videos</div>
                         </div>


### PR DESCRIPTION
Only correcting the markup to achieve expected behavior.

### Expected behavior

<img width="424" alt="screen shot 2018-01-24 at 19 10 10" src="https://user-images.githubusercontent.com/13750819/35359783-3bd00696-013a-11e8-922c-d24f3cd4ed7b.png">

### Current behavior

<img width="418" alt="screen shot 2018-01-24 at 19 06 36" src="https://user-images.githubusercontent.com/13750819/35359682-cc62fb74-0139-11e8-81a8-83d1c8fc6ca7.png">

