### PR TITLE
Remove unnecessary use of minValue and maxValue in the ProgressBar

### DIFF
--- a/packages/clay-progress-bar/demos/a11y.html
+++ b/packages/clay-progress-bar/demos/a11y.html
@@ -51,8 +51,6 @@
 
 		new metal.ClayProgressBar(
 			{
-				minValue: 0,
-				maxValue: 100,
 				spritemap: spritemap,
 				value: 40
 			},
@@ -61,8 +59,6 @@
 
 		new metal.ClayProgressBar(
 			{
-				minValue: 0,
-				maxValue: 100,
 				spritemap: spritemap,
 				status: 'warning',
 				value: 200
@@ -72,8 +68,6 @@
 
 		new metal.ClayProgressBar(
 			{
-				minValue: 0,
-				maxValue: 100,
 				spritemap: spritemap,
 				value: 100
 			},

--- a/packages/clay-progress-bar/demos/index.html
+++ b/packages/clay-progress-bar/demos/index.html
@@ -51,8 +51,6 @@
 
 		new metal.ClayProgressBar(
 			{
-				minValue: 0,
-				maxValue: 100,
 				spritemap: spritemap,
 				value: 40
 			},
@@ -61,8 +59,6 @@
 
 		new metal.ClayProgressBar(
 			{
-				minValue: 0,
-				maxValue: 100,
 				spritemap: spritemap,
 				status: 'warning',
 				value: 200
@@ -72,8 +68,6 @@
 
 		new metal.ClayProgressBar(
 			{
-				minValue: 0,
-				maxValue: 100,
 				spritemap: spritemap,
 				value: 100
 			},

--- a/packages/clay-progress-bar/src/__tests__/ClayProgressBar.js
+++ b/packages/clay-progress-bar/src/__tests__/ClayProgressBar.js
@@ -29,8 +29,6 @@ describe('ClayProgressBar', function() {
 
 	it('should render an in progress bar', function() {
 		progressBar = new ClayProgressBar({
-			minValue: 0,
-			maxValue: 100,
 			spritemap: spritemap,
 			value: 40,
 		});
@@ -40,8 +38,6 @@ describe('ClayProgressBar', function() {
 
 	it('should render a progress bar at 0% of progress', function() {
 		progressBar = new ClayProgressBar({
-			minValue: 0,
-			maxValue: 100,
 			spritemap: spritemap,
 			value: 0,
 		});
@@ -57,8 +53,6 @@ describe('ClayProgressBar', function() {
 
 	it('should render a progress bar with warning', function() {
 		progressBar = new ClayProgressBar({
-			minValue: 0,
-			maxValue: 100,
 			spritemap: spritemap,
 			status: 'warning',
 			value: 40,
@@ -69,8 +63,6 @@ describe('ClayProgressBar', function() {
 
 	it('should render a completed progress bar', function() {
 		progressBar = new ClayProgressBar({
-			minValue: 0,
-			maxValue: 100,
 			spritemap: spritemap,
 			value: 100,
 		});


### PR DESCRIPTION
In the API, it no longer uses `minValue` and `maxValue`.