### PR TITLE
Update: (Fixes #516) Forms `.form-control` in Firefox should shrink t…

### DIFF
--- a/packages/clay/src/scss/components/_forms.scss
+++ b/packages/clay/src/scss/components/_forms.scss
@@ -71,6 +71,7 @@ label {
 	}
 
 	height: $input-height;
+	min-width: 0;
 
 	@if not ($input-padding-y == $btn-padding-y) {
 		padding-bottom: $input-padding-y;


### PR DESCRIPTION
…o fit its container