### PR TITLE
#546 Button added `backface-visibility: hidden` to `.…

### DIFF
--- a/packages/clay/src/scss/components/_buttons.scss
+++ b/packages/clay/src/scss/components/_buttons.scss
@@ -1,4 +1,5 @@
 .btn {
+	backface-visibility: hidden; // https://github.com/liferay/clay/issues/546
 	font-size: $btn-font-size;
 
 	@include clay-scale-component {


### PR DESCRIPTION
…btn` as a work around for left over box-shadow artifacts when tabbing through document (Blink browsers)