### PR TITLE
Adds disabled="true" to force your render separate from other attributes | Fixes #522

### DIFF
--- a/packages/clay-button/src/ClayButton.soy
+++ b/packages/clay-button/src/ClayButton.soy
@@ -164,7 +164,7 @@
 	{/if}
 
 	{if $disabled}
-		disabled
+		disabled="true"
 	{/if}
 
 	{if $id}

--- a/packages/clay-button/src/ClayButton.soy
+++ b/packages/clay-button/src/ClayButton.soy
@@ -164,7 +164,7 @@
 	{/if}
 
 	{if $disabled}
-		disabled="true"
+		disabled="disabled"
 	{/if}
 
 	{if $id}

--- a/packages/clay-button/src/__tests__/__snapshots__/ClayButton.js.snap
+++ b/packages/clay-button/src/__tests__/__snapshots__/ClayButton.js.snap
@@ -61,7 +61,7 @@ exports[`ClayButton should render a button with label and icon on right side 1`]
 
 exports[`ClayButton should render a button with name 1`] = `<button class="btn btn-primary" name="myButton" type="button"></button>`;
 
-exports[`ClayButton should render a disabled button 1`] = `<button class="btn btn-primary" disabled="true" type="button"></button>`;
+exports[`ClayButton should render a disabled button 1`] = `<button class="btn btn-primary" disabled="disabled" type="button"></button>`;
 
 exports[`ClayButton should render a reset button 1`] = `<button class="btn btn-primary" type="reset"></button>`;
 

--- a/packages/clay-button/src/__tests__/__snapshots__/ClayButton.js.snap
+++ b/packages/clay-button/src/__tests__/__snapshots__/ClayButton.js.snap
@@ -61,7 +61,7 @@ exports[`ClayButton should render a button with label and icon on right side 1`]
 
 exports[`ClayButton should render a button with name 1`] = `<button class="btn btn-primary" name="myButton" type="button"></button>`;
 
-exports[`ClayButton should render a disabled button 1`] = `<button class="btn btn-primary" disabled="" type="button"></button>`;
+exports[`ClayButton should render a disabled button 1`] = `<button class="btn btn-primary" disabled="true" type="button"></button>`;
 
 exports[`ClayButton should render a reset button 1`] = `<button class="btn btn-primary" type="reset"></button>`;
 

--- a/packages/clay-management-toolbar/src/__tests__/__snapshots__/ClayManagementToolbar.js.snap
+++ b/packages/clay-management-toolbar/src/__tests__/__snapshots__/ClayManagementToolbar.js.snap
@@ -25,7 +25,7 @@ exports[`ClayManagementToolbar should render a disabled management toolbar 1`] =
         </div>
       </li>
       <li class="nav-item">
-        <button class="btn nav-link nav-link-monospaced order-arrow-up-active btn-unstyled" aria-label="order-arrow" disabled="" type="button">
+        <button class="btn nav-link nav-link-monospaced order-arrow-up-active btn-unstyled" aria-label="order-arrow" disabled="true" type="button">
           <svg aria-hidden="true" class="lexicon-icon lexicon-icon-order-arrow">
             <title>order-arrow</title>
             <use xlink:href="../node_modules/clay/lib/images/icons/icons.svg#order-arrow"></use>
@@ -46,7 +46,7 @@ exports[`ClayManagementToolbar should render a disabled management toolbar 1`] =
                     <use xlink:href="../node_modules/clay/lib/images/icons/icons.svg#times"></use>
                   </svg>
                 </button>
-                <button class="btn navbar-breakpoint-d-block btn-unstyled" aria-label="search" disabled="" type="submit">
+                <button class="btn navbar-breakpoint-d-block btn-unstyled" aria-label="search" disabled="true" type="submit">
                   <svg aria-hidden="true" class="lexicon-icon lexicon-icon-search">
                     <title>search</title>
                     <use xlink:href="../node_modules/clay/lib/images/icons/icons.svg#search"></use>
@@ -60,7 +60,7 @@ exports[`ClayManagementToolbar should render a disabled management toolbar 1`] =
     </div>
     <ul class="navbar-nav">
       <li class="nav-item navbar-breakpoint-d-none">
-        <button class="btn nav-link nav-link-monospaced btn-unstyled" aria-label="search" disabled="" type="button">
+        <button class="btn nav-link nav-link-monospaced btn-unstyled" aria-label="search" disabled="true" type="button">
           <svg aria-hidden="true" class="lexicon-icon lexicon-icon-search">
             <title>search</title>
             <use xlink:href="../node_modules/clay/lib/images/icons/icons.svg#search"></use>

--- a/packages/clay-management-toolbar/src/__tests__/__snapshots__/ClayManagementToolbar.js.snap
+++ b/packages/clay-management-toolbar/src/__tests__/__snapshots__/ClayManagementToolbar.js.snap
@@ -25,7 +25,7 @@ exports[`ClayManagementToolbar should render a disabled management toolbar 1`] =
         </div>
       </li>
       <li class="nav-item">
-        <button class="btn nav-link nav-link-monospaced order-arrow-up-active btn-unstyled" aria-label="order-arrow" disabled="true" type="button">
+        <button class="btn nav-link nav-link-monospaced order-arrow-up-active btn-unstyled" aria-label="order-arrow" disabled="disabled" type="button">
           <svg aria-hidden="true" class="lexicon-icon lexicon-icon-order-arrow">
             <title>order-arrow</title>
             <use xlink:href="../node_modules/clay/lib/images/icons/icons.svg#order-arrow"></use>
@@ -46,7 +46,7 @@ exports[`ClayManagementToolbar should render a disabled management toolbar 1`] =
                     <use xlink:href="../node_modules/clay/lib/images/icons/icons.svg#times"></use>
                   </svg>
                 </button>
-                <button class="btn navbar-breakpoint-d-block btn-unstyled" aria-label="search" disabled="true" type="submit">
+                <button class="btn navbar-breakpoint-d-block btn-unstyled" aria-label="search" disabled="disabled" type="submit">
                   <svg aria-hidden="true" class="lexicon-icon lexicon-icon-search">
                     <title>search</title>
                     <use xlink:href="../node_modules/clay/lib/images/icons/icons.svg#search"></use>
@@ -60,7 +60,7 @@ exports[`ClayManagementToolbar should render a disabled management toolbar 1`] =
     </div>
     <ul class="navbar-nav">
       <li class="nav-item navbar-breakpoint-d-none">
-        <button class="btn nav-link nav-link-monospaced btn-unstyled" aria-label="search" disabled="true" type="button">
+        <button class="btn nav-link nav-link-monospaced btn-unstyled" aria-label="search" disabled="disabled" type="button">
           <svg aria-hidden="true" class="lexicon-icon lexicon-icon-search">
             <title>search</title>
             <use xlink:href="../node_modules/clay/lib/images/icons/icons.svg#search"></use>


### PR DESCRIPTION
This can fix issue #522, forcing the attribute to be rendered separate from others. We still have to investigate why this happens only in TagLibs.