### PR TITLE
Add onlySearch API to render only search | Fixes #543

### DIFF
--- a/packages/clay-management-toolbar/demos/a11y.html
+++ b/packages/clay-management-toolbar/demos/a11y.html
@@ -24,12 +24,20 @@
 		ClayManagementToolbar
 	</h1>
 
+	<div id="container0"></div>
 	<div id="container1"></div>
 	<div id="container2"></div>
 	<div id="container3"></div>
 
 	<script type="text/javascript">
 		var spritemap = '../../../node_modules/clay/lib/images/icons/icons.svg';
+
+		new metal.ClayManagementToolbar({
+			onlySearch: true,
+			searchFormName: 'mySearchName',
+			searchInputName: 'mySearchInputName',
+			spritemap: spritemap
+		}, '#container0');
 
 		new metal.ClayManagementToolbar({
 			creationMenu: {

--- a/packages/clay-management-toolbar/demos/index.html
+++ b/packages/clay-management-toolbar/demos/index.html
@@ -24,12 +24,20 @@
 		ClayManagementToolbar
 	</h1>
 
+	<div id="container0"></div>
 	<div id="container1"></div>
 	<div id="container2"></div>
 	<div id="container3"></div>
 
 	<script type="text/javascript">
 		var spritemap = '../../../node_modules/clay/lib/images/icons/icons.svg';
+
+		new metal.ClayManagementToolbar({
+			onlySearch: true,
+			searchFormName: 'mySearchName',
+			searchInputName: 'mySearchInputName',
+			spritemap: spritemap
+		}, '#container0');
 
 		new metal.ClayManagementToolbar({
 			creationMenu: {

--- a/packages/clay-management-toolbar/src/ClayManagementToolbar.js
+++ b/packages/clay-management-toolbar/src/ClayManagementToolbar.js
@@ -221,6 +221,16 @@ ClayManagementToolbar.STATE = {
 	id: Config.string(),
 
 	/**
+	 * Flag to indicate if the management toolbar should the render
+	 * only search.
+	 * @instance
+	 * @memberof ClayManagementToolbar
+	 * @type {?bool}
+	 * @default false
+	 */
+	onlySearch: Config.bool().value(false),
+
+	/**
 	 * URL of the search form action
 	 * @instance
 	 * @memberof ClayManagementToolbar

--- a/packages/clay-management-toolbar/src/ClayManagementToolbar.soy
+++ b/packages/clay-management-toolbar/src/ClayManagementToolbar.soy
@@ -52,6 +52,7 @@
 	{@param? handleViewTypeClicked_: any}
 	{@param? hideFiltersDoneButton: bool}
 	{@param? id: string}
+	{@param? onlySearch: bool}
 	{@param? searchActionURL: string}
 	{@param? searchFormName: string}
 	{@param? searchInputName: string}
@@ -67,46 +68,57 @@
 		label: string
 	]>}
 
-	{let $isActive: $selectedItems and $selectedItems > 0 /}
-
-	{if $isActive}
-		{call .active}
-			{param actionItems: $actionItems /}
+	{if $onlySearch}
+		{call .onlySearch}
 			{param elementClasses: $elementClasses /}
-			{param handleActionClicked_: $handleActionClicked_ /}
-			{param handleDeselectAllClicked_: $handleDeselectAllClicked_ /}
-			{param handleSelectAllClicked_: $handleSelectAllClicked_ /}
-			{param handleSelectPageCheckboxChanged_: $handleSelectPageCheckboxChanged_ /}
-			{param selectedItems: $selectedItems /}
-			{param spritemap: $spritemap /}
-			{param totalItems: $totalItems /}
-		{/call}
-	{else}
-		{call .default}
-			{param contentRenderer: $contentRenderer ?: '' /}
-			{param creationMenu: $creationMenu /}
-			{param disabled: $totalItems == 0 /}
-			{param elementClasses: $elementClasses /}
-			{param filterItems: $filterItems /}
-			{param handleCloseMobileSearchClick_: $handleCloseMobileSearchClick_ /}
-			{param handleCreationButtonClicked_: $handleCreationButtonClicked_ /}
-			{param handleFilterDoneButtonClick_: $handleFilterDoneButtonClick_ /}
-			{param handleOpenMobileSearchClick_: $handleOpenMobileSearchClick_ /}
-			{param handleSearchSearchClick_: $handleSearchSearchClick_ /}
-			{param handleSelectPageCheckboxChanged_: $handleSelectPageCheckboxChanged_ /}
-			{param handleSortingButtonClicked_: $handleSortingButtonClicked_ /}
-			{param handleViewTypeClicked_: $handleViewTypeClicked_ /}
-			{param hideFiltersDoneButton: $hideFiltersDoneButton /}
 			{param id: $id /}
 			{param searchActionURL: $searchActionURL /}
 			{param searchFormName: $searchFormName /}
 			{param searchInputName: $searchInputName /}
-			{param selectable: $selectable /}
-			{param showSearch_: $showSearch_ /}
-			{param sortingOrder: $sortingOrder /}
 			{param spritemap: $spritemap /}
-			{param viewTypes: $viewTypes /}
 		{/call}
+	{else}
+		{let $isActive: $selectedItems and $selectedItems > 0 /}
+
+		{if $isActive}
+			{call .active}
+				{param actionItems: $actionItems /}
+				{param elementClasses: $elementClasses /}
+				{param handleActionClicked_: $handleActionClicked_ /}
+				{param handleDeselectAllClicked_: $handleDeselectAllClicked_ /}
+				{param handleSelectAllClicked_: $handleSelectAllClicked_ /}
+				{param handleSelectPageCheckboxChanged_: $handleSelectPageCheckboxChanged_ /}
+				{param selectedItems: $selectedItems /}
+				{param spritemap: $spritemap /}
+				{param totalItems: $totalItems /}
+			{/call}
+		{else}
+			{call .default}
+				{param contentRenderer: $contentRenderer ?: '' /}
+				{param creationMenu: $creationMenu /}
+				{param disabled: $totalItems == 0 /}
+				{param elementClasses: $elementClasses /}
+				{param filterItems: $filterItems /}
+				{param handleCloseMobileSearchClick_: $handleCloseMobileSearchClick_ /}
+				{param handleCreationButtonClicked_: $handleCreationButtonClicked_ /}
+				{param handleFilterDoneButtonClick_: $handleFilterDoneButtonClick_ /}
+				{param handleOpenMobileSearchClick_: $handleOpenMobileSearchClick_ /}
+				{param handleSearchSearchClick_: $handleSearchSearchClick_ /}
+				{param handleSelectPageCheckboxChanged_: $handleSelectPageCheckboxChanged_ /}
+				{param handleSortingButtonClicked_: $handleSortingButtonClicked_ /}
+				{param handleViewTypeClicked_: $handleViewTypeClicked_ /}
+				{param hideFiltersDoneButton: $hideFiltersDoneButton /}
+				{param id: $id /}
+				{param searchActionURL: $searchActionURL /}
+				{param searchFormName: $searchFormName /}
+				{param searchInputName: $searchInputName /}
+				{param selectable: $selectable /}
+				{param showSearch_: $showSearch_ /}
+				{param sortingOrder: $sortingOrder /}
+				{param spritemap: $spritemap /}
+				{param viewTypes: $viewTypes /}
+			{/call}
+		{/if}
 	{/if}
 {/template}
 
@@ -215,7 +227,7 @@
 {/template}
 
 /**
- * This renders the component's active content.
+ * This renders the component's default content.
  */
 {template .default}
 	{@param spritemap: string}
@@ -345,6 +357,7 @@
 				<div class="container">
 					{delcall ClayManagementToolbar.SearchForm variant="$contentRenderer"}
 						{param disabled: $disabled /}
+						{param elementClassesSearchButton: 'navbar-breakpoint-d-block' /}
 						{param handleCloseMobileSearchClick_: $handleCloseMobileSearchClick_ /}
 						{param handleSearchSearchClick_: $handleSearchSearchClick_ /}
 						{param searchActionURL: $searchActionURL /}
@@ -451,11 +464,50 @@
 {/template}
 
 /**
+ * This renders the component's only search content.
+ */
+{template .onlySearch}
+	{@param spritemap: string}
+	{@param? elementClasses: string}
+	{@param? id: string}
+	{@param? searchActionURL: string}
+	{@param? searchFormName: string}
+	{@param? searchInputName: string}
+
+	{let $navAttributes kind="attributes"}
+		class="management-bar management-bar-light navbar navbar-expand-md
+			{if $elementClasses}
+				{sp}{$elementClasses}
+			{/if}
+		"
+
+		{if $id}
+			id="{$id}"
+		{/if}
+	{/let}
+
+	<nav {$navAttributes}>
+		<div class="container-fluid container-fluid-max-xl">
+				<div class="navbar-form navbar-form-autofit">
+					{delcall ClayManagementToolbar.SearchForm}
+						{param disabled: false /}
+						{param searchActionURL: $searchActionURL /}
+						{param searchFormName: $searchFormName /}
+						{param searchInputName: $searchInputName /}
+						{param spritemap: $spritemap /}
+					{/delcall}
+				</div>
+		</div>
+	</nav>
+{/template}
+
+/**
  * This renders the search form.
  */
 {deltemplate ClayManagementToolbar.SearchForm}
 	{@param spritemap: string}
 	{@param? disabled: bool}
+	{@param? elementClassesSearchButton: string}
 	{@param? handleCloseMobileSearchClick_: any}
 	{@param? handleSearchSearchClick_: any}
 	{@param? searchActionURL: string}
@@ -493,17 +545,19 @@
 				<input {$inputAttributes} />
 
 				<span class="input-group-inset-item input-group-inset-item-after">
-					{call ClayButton.render}
-						{param elementClasses: 'navbar-breakpoint-d-none' /}
-						{param events: ['click': $handleCloseMobileSearchClick_] /}
-						{param icon: 'times' /}
-						{param spritemap: $spritemap /}
-						{param style: 'unstyled' /}
-					{/call}
+					{if $handleCloseMobileSearchClick_}
+						{call ClayButton.render}
+							{param elementClasses: 'navbar-breakpoint-d-none' /}
+							{param events: ['click': $handleCloseMobileSearchClick_] /}
+							{param icon: 'times' /}
+							{param spritemap: $spritemap /}
+							{param style: 'unstyled' /}
+						{/call}
+					{/if}
 
 					{call ClayButton.render}
 						{param disabled: $disabled /}
-						{param elementClasses: 'navbar-breakpoint-d-block' /}
+						{param elementClasses: $elementClassesSearchButton /}
 						{param events: ['click': $handleSearchSearchClick_] /}
 						{param icon: 'search' /}
 						{param ref: 'searchButton' /}

--- a/packages/clay-management-toolbar/src/__tests__/ClayManagementToolbar.js
+++ b/packages/clay-management-toolbar/src/__tests__/ClayManagementToolbar.js
@@ -64,6 +64,15 @@ describe('ClayManagementToolbar', function() {
 		expect(managementToolbar).toMatchSnapshot();
 	});
 
+	it('should render a management toolbar with only search', () => {
+		managementToolbar = new ClayManagementToolbar({
+			onlySearch: true,
+			spritemap: spritemap,
+		});
+
+		expect(managementToolbar).toMatchSnapshot();
+	});
+
 	it('should render a management toolbar with selection enabled', () => {
 		managementToolbar = new ClayManagementToolbar({
 			selectable: true,

--- a/packages/clay-management-toolbar/src/__tests__/__snapshots__/ClayManagementToolbar.js.snap
+++ b/packages/clay-management-toolbar/src/__tests__/__snapshots__/ClayManagementToolbar.js.snap
@@ -879,6 +879,30 @@ exports[`ClayManagementToolbar should render a management toolbar with id in act
 </nav>
 `;
 
+exports[`ClayManagementToolbar should render a management toolbar with only search 1`] = `
+<nav class="management-bar management-bar-light navbar navbar-expand-md">
+  <div class="container-fluid container-fluid-max-xl">
+    <div class="navbar-form navbar-form-autofit">
+      <form role="search">
+        <div class="input-group">
+          <div class="input-group-item">
+            <input aria-label="Search" class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." ref="search" type="text">
+            <span class="input-group-inset-item input-group-inset-item-after">
+              <button class="btn btn-unstyled" aria-label="search" type="submit">
+                <svg aria-hidden="true" class="lexicon-icon lexicon-icon-search">
+                  <title>search</title>
+                  <use xlink:href="../node_modules/clay/lib/images/icons/icons.svg#search"></use>
+                </svg>
+              </button>
+            </span>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</nav>
+`;
+
 exports[`ClayManagementToolbar should render a management toolbar with plus button with more than one option 1`] = `
 <nav class="management-bar management-bar-light navbar navbar-expand-md">
   <div class="container">


### PR DESCRIPTION
hey @carloslancha, I thought to follow the line of adding a Flag, to say when you want only the search, not to have to create many conditions in the code just to know when the user only wants the search. Maybe we could follow the line of a new component within ManagementToolbar just for this use case but I do not know if it is needed at the moment. This is a short implementation.