### PR TITLE
Breaking: (Fixes #592) Remove references to BS4's `.form-inline` comp…

### DIFF
--- a/packages/clay/src/scss/components/_navbar.scss
+++ b/packages/clay/src/scss/components/_navbar.scss
@@ -129,12 +129,6 @@
 	> form {
 		width: 100%;
 	}
-
-	.form-inline {
-		.form-control {
-			margin-bottom: 0;
-		}
-	}
 }
 
 .navbar-form-autofit {
@@ -143,19 +137,6 @@
 
 	form {
 		display: flex;
-		width: 100%;
-	}
-
-	.form-inline {
-		align-items: flex-end;
-		flex: 1;
-		flex-direction: row;
-		width: 100%;
-	}
-
-	.form-control {
-		flex: 1;
-		min-width: 50px;
 		width: 100%;
 	}
 }


### PR DESCRIPTION
…onent, use `.input-group` component for inline forms