### PR TITLE
Check if the dispose has already been done and does nothing | Fixes #582

### DIFF
--- a/packages/clay-alert/src/ClayAlertBase.js
+++ b/packages/clay-alert/src/ClayAlertBase.js
@@ -52,15 +52,17 @@ class ClayAlertBase extends Component {
 	 * @private
 	 */
 	_defaultHideAlert() {
-		this._delayTime = 0;
-		this._visible = false;
+		if (!this.isDisposed()) {
+			this._delayTime = 0;
+			this._visible = false;
 
-		if (this._timer) {
-			clearTimeout(this._timer);
-		}
+			if (this._timer) {
+				clearTimeout(this._timer);
+			}
 
-		if (this.destroyOnHide) {
-			this.dispose();
+			if (this.destroyOnHide) {
+				this.dispose();
+			}
 		}
 	}
 


### PR DESCRIPTION
hey @carloslancha, the messages from **warn** happened when the dispose was made on the components that used `ClayAlertBase`, the dispose happened from top to bottom and when it arrived in `ClayAlertBase` in some cases it had no more reference of `_visible`... The way to omit this is to check when it has already been disposed.

