### PR TITLE
Update: (Closes #405) Mixin `clay-nav-variant` add more configuration…

### DIFF
--- a/packages/clay/src/scss/mixins/_nav.scss
+++ b/packages/clay/src/scss/mixins/_nav.scss
@@ -1,7 +1,9 @@
 @mixin clay-nav-variant($map) {
+	$bg: map-get($map, bg);
 	$link-bg: map-get($map, link-bg);
 	$link-border-radius: map-get($map, link-border-radius);
 	$link-color: map-get($map, link-color);
+	$link-font-weight: map-get($map, link-font-weight);
 	$link-hover-bg: map-get($map, link-hover-bg);
 	$link-hover-color: map-get($map, link-hover-color);
 	$link-focus-bg: map-get($map, link-focus-bg);
@@ -11,6 +13,9 @@
 	$link-disabled-opacity: map-get($map, link-disabled-opacity);
 	$link-active-bg: map-get($map, link-active-bg);
 	$link-active-color: map-get($map, link-active-color);
+	$link-active-font-weight: map-get($map, link-active-font-weight);
+
+	background-color: $bg;
 
 	.nav-btn.btn-unstyled,
 	.nav-link {
@@ -19,17 +24,20 @@
 		@include border-radius($link-border-radius);
 
 		color: $link-color;
+		font-weight: $link-font-weight;
 
-		@include hover {
+		&:hover {
 			background-color: $link-hover-bg;
 			color: $link-hover-color;
 		}
 
-		&:focus {
+		&:focus,
+		&.focus {
 			background-color: $link-focus-bg;
 			color: $link-focus-color;
 		}
 
+		&:disabled,
 		&.disabled {
 			background-color: $link-disabled-bg;
 			color: $link-disabled-color;
@@ -39,6 +47,7 @@
 		&.active {
 			background-color: $link-active-bg;
 			color: $link-active-color;
+			font-weight: $link-active-font-weight;
 		}
 	}
 }


### PR DESCRIPTION
… options `bg`, `link-font-weight`, `link-active-font-weight`

This lets us create variants for base nav if we ever need a base nav styled like #405. 