### PR TITLE
Site: Don't run build:rtl task by default

### DIFF
--- a/packages/clay/gulpfile.js
+++ b/packages/clay/gulpfile.js
@@ -28,7 +28,6 @@ gulp.task('build', function(cb) {
 		'build:svg',
 		'build:svg:scss-icons',
 		'build:metalsmith',
-		'build:rtl',
 		function(err) {
 			gulp.emit('build:finished', err);
 


### PR DESCRIPTION
Test site build task fails when building rtl files.

```
[00:00:00] Starting 'build:rtl'...
events.js:161
      throw er; // Unhandled 'error' event
      ^

Error: missing '}' near line 382:11572
    at error (/clay/packages/clay/node_modules/liferay-css-parse/index.js:69:15)
    at declarations (/clay/packages/clay/node_modules/liferay-css-parse/index.js:242:26)
    at rule (/clay/packages/clay/node_modules/liferay-css-parse/index.js:533:21)
    at rules (/clay/packages/clay/node_modules/liferay-css-parse/index.js:112:70)
    at stylesheet (/clay/packages/clay/node_modules/liferay-css-parse/index.js:82:16)
    at module.exports (/clay/packages/clay/node_modules/liferay-css-parse/index.js:537:10)
    at r2 (/clay/packages/clay/node_modules/liferay-r2/r2.js:166:9)
    at Object.module.exports.swap (/clay/packages/clay/node_modules/liferay-r2/r2.js:216:10)
    at swapBuffer (/clay/packages/clay/node_modules/gulp-liferay-r2-css/index.js:39:26)
    at DestroyableTransform._transform (/clay/packages/clay/node_modules/gulp-liferay-r2-css/index.js:19:21)
```