### PR TITLE
Update: (Fixes #746) Atlas List Group change `$list-group-header-padd…

### DIFF
--- a/packages/clay/src/scss/atlas/variables/_list-group.scss
+++ b/packages/clay/src/scss/atlas/variables/_list-group.scss
@@ -11,7 +11,7 @@ $list-group-item-padding-y: 1rem !default; // 16px
 // List Group Header
 
 $list-group-header-bg: lighten(saturate(adjust-hue($secondary, -27), 6.13), 51.57) !default;
-$list-group-header-padding-y: 0.78125rem !default; // 12.5px
+$list-group-header-padding-y: 0.53125rem !default; // 8.5px
 
 $list-group-header-title: () !default;
 $list-group-header-title: map-merge((


### PR DESCRIPTION
…ing-y` so `.list-group-header` is 32px tall