### PR TITLE
Update: (Fixes #787) Utilities `.inline-item-before` and `inline-item…

### DIFF
--- a/packages/clay/src/scss/atlas/variables/_utilities.scss
+++ b/packages/clay/src/scss/atlas/variables/_utilities.scss
@@ -1,5 +1,3 @@
 $bg-checkered-fg: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
 
-$inline-item-spacer-x: 0.85714em !default; // ~12px
-
 $page-header-bg: #FFF !default;

--- a/packages/clay/src/scss/variables/_utilities.scss
+++ b/packages/clay/src/scss/variables/_utilities.scss
@@ -15,6 +15,6 @@ $heading-text-margin-top: auto;
 // Inline Item
 
 $inline-item-lexicon-icon-margin-top: -0.21429em !default;
-$inline-item-spacer-x: 0.5em !default; // 8px
+$inline-item-spacer-x: 0.5rem !default; // 8px
 
 $page-header-bg: $gray-200 !default;


### PR DESCRIPTION
…-after` spacer should be 8px