### PR TITLE
Update: (Fixes #827) Stickers should use `display: inline-flex` to ma…

### DIFF
--- a/packages/clay/src/scss/components/_stickers.scss
+++ b/packages/clay/src/scss/components/_stickers.scss
@@ -1,15 +1,18 @@
 .sticker {
+	align-items: center;
+
 	@include border-radius($sticker-border-radius);
 
 	border-style: $sticker-border-style;
 	border-width: $sticker-border-width;
 	color: $sticker-color;
-	display: inline-block;
-	font-size: $sticker-font-size;
-	font-weight: $sticker-font-weight;
 
 	@include clay-monospace($sticker-size);
 
+	display: inline-flex;
+	font-size: $sticker-font-size;
+	font-weight: $sticker-font-weight;
+	justify-content: center;
 	position: relative;
 	text-align: center;
 	vertical-align: middle;


### PR DESCRIPTION
…ke it consistent with badges and labels