### PR TITLE
New: (Fixes #840) Stickers added option to configure `$sticker-border…

### DIFF
--- a/packages/clay/src/scss/components/_stickers.scss
+++ b/packages/clay/src/scss/components/_stickers.scss
@@ -1,6 +1,8 @@
 .sticker {
 	align-items: center;
 
+	border-color: $sticker-border-color;
+
 	@include border-radius($sticker-border-radius);
 
 	border-style: $sticker-border-style;

--- a/packages/clay/src/scss/variables/_stickers.scss
+++ b/packages/clay/src/scss/variables/_stickers.scss
@@ -1,3 +1,4 @@
+$sticker-border-color: null !default;
 $sticker-border-radius: $border-radius !default;
 $sticker-border-style: null !default;
 $sticker-border-width: null !default;


### PR DESCRIPTION
…-color` so black border doesn't appear if you set `border-style` and `border-width`