### PR TITLE
New: (Fixes #886) Stickers added support for `.inline-item`. Icons in…

### DIFF
--- a/packages/clay-css/src/content/badges_and_labels.html
+++ b/packages/clay-css/src/content/badges_and_labels.html
@@ -502,24 +502,32 @@ section: Components
 <span class="sticker sticker-danger sticker-xl">133</span>
 
 <span class="sticker sticker-primary sticker-xl">
-	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
-		<use xlink:href="{{rootPath}}/images/icons/icons.svg#format" />
-	</svg>
+	<span class="inline-item">
+		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
+			<use xlink:href="{{rootPath}}/images/icons/icons.svg#format" />
+		</svg>
+	</span>
 </span>
 <span class="sticker sticker-lg sticker-secondary">
-	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
-		<use xlink:href="{{rootPath}}/images/icons/icons.svg#format" />
-	</svg>
+	<span class="inline-item">
+		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
+			<use xlink:href="{{rootPath}}/images/icons/icons.svg#format" />
+		</svg>
+	</span>
 </span>
 <span class="sticker sticker-success">
-	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
-		<use xlink:href="{{rootPath}}/images/icons/icons.svg#format" />
-	</svg>
+	<span class="inline-item">
+		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
+			<use xlink:href="{{rootPath}}/images/icons/icons.svg#format" />
+		</svg>
+	</span>
 </span>
 <span class="sticker sticker-danger sticker-sm">
-	<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
-		<use xlink:href="{{rootPath}}/images/icons/icons.svg#format" />
-	</svg>
+	<span class="inline-item">
+		<svg aria-hidden="true" class="lexicon-icon lexicon-icon-format">
+			<use xlink:href="{{rootPath}}/images/icons/icons.svg#format" />
+		</svg>
+	</span>
 </span>
 
 	</div>
@@ -597,49 +605,65 @@ section: Components
 <div class="clay-site-row-spacer row">
 	<div class="col-md-3 col-6">
 		<span class="sticker sticker-dark">
-			<svg aria-hidden="true" class="lexicon-icon lexicon-icon-picture">
-				<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
-			</svg>
-			<span class="sticker sticker-circle sticker-info sticker-sm sticker-outside sticker-top-left">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-sun">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#sun" />
+			<span class="inline-item">
+				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-picture">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
 				</svg>
+			</span>
+			<span class="sticker sticker-circle sticker-info sticker-sm sticker-outside sticker-top-left">
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-sun">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#sun" />
+					</svg>
+				</span>
 			</span>
 		</span>
 	</div>
 	<div class="col-md-3 col-6">
 		<span class="sticker sticker-info">
-			<svg aria-hidden="true" class="lexicon-icon lexicon-icon-picture">
-				<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
-			</svg>
-			<span class="sticker sticker-circle sticker-info sticker-sm sticker-outside sticker-bottom-left">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-magic">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#magic" />
+			<span class="inline-item">
+				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-picture">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
 				</svg>
+			</span>
+			<span class="sticker sticker-circle sticker-info sticker-sm sticker-outside sticker-bottom-left">
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-magic">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#magic" />
+					</svg>
+				</span>
 			</span>
 		</span>
 	</div>
 	<div class="col-md-3 col-6">
 		<span class="sticker sticker-danger">
-			<svg aria-hidden="true" class="lexicon-icon lexicon-icon-picture">
-				<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
-			</svg>
-			<span class="sticker sticker-circle sticker-info sticker-sm sticker-outside sticker-top-right">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-transform">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#transform" />
+			<span class="inline-item">
+				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-picture">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
 				</svg>
+			</span>
+			<span class="sticker sticker-circle sticker-info sticker-sm sticker-outside sticker-top-right">
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-transform">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#transform" />
+					</svg>
+				</span>
 			</span>
 		</span>
 	</div>
 	<div class="col-md-3 col-6">
 		<span class="sticker sticker-success">
-			<svg aria-hidden="true" class="lexicon-icon lexicon-icon-picture">
-				<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
-			</svg>
-			<span class="sticker sticker-circle sticker-info sticker-sm sticker-outside sticker-bottom-right">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-undo">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#undo" />
+			<span class="inline-item">
+				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-picture">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
 				</svg>
+			</span>
+			<span class="sticker sticker-circle sticker-info sticker-sm sticker-outside sticker-bottom-right">
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-undo">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#undo" />
+					</svg>
+				</span>
 			</span>
 		</span>
 	</div>

--- a/packages/clay-css/src/content/cards.html
+++ b/packages/clay-css/src/content/cards.html
@@ -528,9 +528,11 @@ section: Components
 				<div class="card-row">
 					<div class="autofit-col">
 						<span class="sticker">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</span>
 					</div>
 					<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -557,9 +559,11 @@ section: Components
 							<div class="card-row">
 								<div class="autofit-col">
 									<span class="sticker">
-										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-										</svg>
+										<span class="inline-item">
+											<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+											</svg>
+										</span>
 									</span>
 								</div>
 								<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -621,9 +625,11 @@ section: Components
 				<div class="card-row">
 					<div class="autofit-col" style="background-color:aliceblue;">
 						<span class="sticker">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</span>
 					</div>
 					<div class="autofit-col autofit-col-expand autofit-col-gutters" style="background-color:antiquewhite;">
@@ -657,9 +663,11 @@ section: Components
 				<div class="card-row">
 					<div class="autofit-col" style="background-color:aliceblue;">
 						<span class="sticker">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</span>
 					</div>
 					<div class="autofit-col autofit-col-gutters" style="background-color:antiquewhite;">
@@ -693,9 +701,11 @@ section: Components
 					<div class="autofit-col autofit-col-expand" style="background-color:aliceblue;">
 						<section class="autofit-section">
 							<span class="sticker">
-								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-								</svg>
+								<span class="inline-item">
+									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+									</svg>
+								</span>
 							</span>
 						</section>
 					</div>
@@ -785,9 +795,11 @@ section: Components
 						<div class="card-row">
 							<div class="autofit-col">
 								<span class="sticker">
-									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-									</svg>
+									<span class="inline-item">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
 								</span>
 							</div>
 							<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -827,9 +839,11 @@ section: Components
 						<div class="card-row">
 							<div class="autofit-col">
 								<span class="sticker">
-									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-									</svg>
+									<span class="inline-item">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
 								</span>
 							</div>
 							<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -865,9 +879,11 @@ section: Components
 						<div class="card-row">
 							<div class="autofit-col">
 								<span class="sticker">
-									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-									</svg>
+									<span class="inline-item">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
 								</span>
 							</div>
 							<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -907,9 +923,11 @@ section: Components
 						<div class="card-row">
 							<div class="autofit-col">
 								<span class="sticker">
-									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-									</svg>
+									<span class="inline-item">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
 								</span>
 							</div>
 							<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -1230,9 +1248,11 @@ section: Components
 						<div class="card-row">
 							<div class="autofit-col">
 								<span class="sticker">
-									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-									</svg>
+									<span class="inline-item">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
 								</span>
 							</div>
 							<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -1336,9 +1356,11 @@ section: Components
 							<div class="card-row">
 								<div class="autofit-col">
 									<span class="sticker">
-										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-										</svg>
+										<span class="inline-item">
+											<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+											</svg>
+										</span>
 									</span>
 								</div>
 								<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -1455,9 +1477,11 @@ section: Components
 						<div class="card-row">
 							<div class="autofit-col">
 								<span class="sticker">
-									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-									</svg>
+									<span class="inline-item">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
 								</span>
 							</div>
 							<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -1561,9 +1585,11 @@ section: Components
 							<div class="card-row">
 								<div class="autofit-col">
 									<span class="sticker">
-										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-										</svg>
+										<span class="inline-item">
+											<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+											</svg>
+										</span>
 									</span>
 								</div>
 								<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -1684,9 +1710,11 @@ section: Components
 					<div class="card-row">
 						<div class="autofit-col">
 							<span class="sticker">
-								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-								</svg>
+								<span class="inline-item">
+									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+									</svg>
+								</span>
 							</span>
 						</div>
 						<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -1732,9 +1760,11 @@ section: Components
 					<div class="card-row">
 						<div class="autofit-col">
 							<span class="sticker">
-								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-								</svg>
+								<span class="inline-item">
+									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+									</svg>
+								</span>
 							</span>
 						</div>
 						<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -1853,9 +1883,11 @@ section: Components
 					<div class="card-row">
 						<div class="autofit-col">
 							<span class="sticker">
-								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-								</svg>
+								<span class="inline-item">
+									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+									</svg>
+								</span>
 							</span>
 						</div>
 						<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -1901,9 +1933,11 @@ section: Components
 					<div class="card-row">
 						<div class="autofit-col">
 							<span class="sticker">
-								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-								</svg>
+								<span class="inline-item">
+									<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+									</svg>
+								</span>
 							</span>
 						</div>
 						<div class="autofit-col autofit-col-expand autofit-col-gutters">

--- a/packages/clay-css/src/content/list_groups.html
+++ b/packages/clay-css/src/content/list_groups.html
@@ -29,9 +29,11 @@ section: Components
 		</div>
 		<div class="autofit-col">
 			<div class="sticker sticker-secondary">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-				</svg>
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
 			</div>
 		</div>
 		<div class="autofit-col autofit-col-expand">
@@ -86,9 +88,11 @@ section: Components
 		</div>
 		<div class="autofit-col">
 			<div class="sticker sticker-secondary">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-				</svg>
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
 			</div>
 		</div>
 		<div class="autofit-col autofit-col-expand">
@@ -142,9 +146,11 @@ section: Components
 		</div>
 		<div class="autofit-col">
 			<div class="sticker sticker-secondary">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-				</svg>
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
 			</div>
 		</div>
 		<div class="autofit-col autofit-col-expand">
@@ -207,9 +213,11 @@ section: Components
 		</div>
 		<div class="autofit-col">
 			<div class="sticker sticker-secondary">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-				</svg>
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
 			</div>
 		</div>
 		<div class="autofit-col autofit-col-expand">
@@ -263,9 +271,11 @@ section: Components
 		</div>
 		<div class="autofit-col">
 			<div class="sticker sticker-secondary">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-				</svg>
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
 			</div>
 		</div>
 		<div class="autofit-col autofit-col-expand">
@@ -333,9 +343,11 @@ section: Components
 				</div>
 				<div class="autofit-col">
 					<div class="sticker sticker-secondary">
-						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-						</svg>
+						<span class="inline-item">
+							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+							</svg>
+						</span>
 					</div>
 				</div>
 				<div class="autofit-col autofit-col-expand">
@@ -415,9 +427,11 @@ section: Components
 				</div>
 				<div class="autofit-col">
 					<div class="sticker sticker-secondary">
-						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-						</svg>
+						<span class="inline-item">
+							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+							</svg>
+						</span>
 					</div>
 				</div>
 				<div class="autofit-col autofit-col-expand">
@@ -535,9 +549,11 @@ section: Components
 		</div>
 		<div class="autofit-col">
 			<div class="sticker sticker-secondary">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-				</svg>
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
 			</div>
 		</div>
 		<div class="autofit-col autofit-col-expand">
@@ -602,9 +618,11 @@ section: Components
 		</div>
 		<div class="autofit-col">
 			<div class="sticker sticker-secondary">
-				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-				</svg>
+				<span class="inline-item">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
 			</div>
 		</div>
 		<div class="autofit-col autofit-col-expand">
@@ -673,9 +691,11 @@ section: Components
 				</div>
 				<div class="autofit-col">
 					<div class="sticker sticker-secondary">
-						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-						</svg>
+						<span class="inline-item">
+							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+							</svg>
+						</span>
 					</div>
 				</div>
 				<div class="autofit-col autofit-col-expand">
@@ -735,9 +755,11 @@ section: Components
 				</div>
 				<div class="autofit-col">
 					<div class="sticker sticker-secondary">
-						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-						</svg>
+						<span class="inline-item">
+							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+							</svg>
+						</span>
 					</div>
 				</div>
 				<div class="autofit-col autofit-col-expand">

--- a/packages/clay-css/src/content/sidebar.html
+++ b/packages/clay-css/src/content/sidebar.html
@@ -188,9 +188,11 @@ section: Components
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -204,9 +206,11 @@ section: Components
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">

--- a/packages/clay-css/src/content/test_card_view_template.html
+++ b/packages/clay-css/src/content/test_card_view_template.html
@@ -371,9 +371,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -387,9 +389,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -478,9 +482,11 @@ section: Visual Tests
 										<div class="card-row">
 											<div class="autofit-col">
 												<span class="sticker">
-													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-													</svg>
+													<span class="inline-item">
+														<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+														</svg>
+													</span>
 												</span>
 											</div>
 											<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -527,9 +533,11 @@ section: Visual Tests
 										<div class="card-row">
 											<div class="autofit-col">
 												<span class="sticker">
-													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-													</svg>
+													<span class="inline-item">
+														<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+														</svg>
+													</span>
 												</span>
 											</div>
 											<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -576,9 +584,11 @@ section: Visual Tests
 										<div class="card-row">
 											<div class="autofit-col">
 												<span class="sticker">
-													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-													</svg>
+													<span class="inline-item">
+														<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+														</svg>
+													</span>
 												</span>
 											</div>
 											<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -625,9 +635,11 @@ section: Visual Tests
 										<div class="card-row">
 											<div class="autofit-col">
 												<span class="sticker">
-													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-													</svg>
+													<span class="inline-item">
+														<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+														</svg>
+													</span>
 												</span>
 											</div>
 											<div class="autofit-col autofit-col-expand autofit-col-gutters">

--- a/packages/clay-css/src/content/test_card_view_template_info_panel.html
+++ b/packages/clay-css/src/content/test_card_view_template_info_panel.html
@@ -297,9 +297,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -313,9 +315,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -401,9 +405,11 @@ section: Visual Tests
 										<div class="card-row">
 											<div class="autofit-col">
 												<span class="sticker">
-													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-													</svg>
+													<span class="inline-item">
+														<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+														</svg>
+													</span>
 												</span>
 											</div>
 											<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -450,9 +456,11 @@ section: Visual Tests
 										<div class="card-row">
 											<div class="autofit-col">
 												<span class="sticker">
-													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-													</svg>
+													<span class="inline-item">
+														<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+														</svg>
+													</span>
 												</span>
 											</div>
 											<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -499,9 +507,11 @@ section: Visual Tests
 										<div class="card-row">
 											<div class="autofit-col">
 												<span class="sticker">
-													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-													</svg>
+													<span class="inline-item">
+														<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+														</svg>
+													</span>
 												</span>
 											</div>
 											<div class="autofit-col autofit-col-expand autofit-col-gutters">
@@ -548,9 +558,11 @@ section: Visual Tests
 										<div class="card-row">
 											<div class="autofit-col">
 												<span class="sticker">
-													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-													</svg>
+													<span class="inline-item">
+														<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+														</svg>
+													</span>
 												</span>
 											</div>
 											<div class="autofit-col autofit-col-expand autofit-col-gutters">

--- a/packages/clay-css/src/content/test_list_view_template.html
+++ b/packages/clay-css/src/content/test_list_view_template.html
@@ -371,9 +371,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -387,9 +389,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -477,9 +481,11 @@ section: Visual Tests
 					</div>
 					<div class="autofit-col">
 						<div class="sticker sticker-secondary">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</div>
 					</div>
 					<div class="autofit-col autofit-col-expand">
@@ -533,9 +539,11 @@ section: Visual Tests
 					</div>
 					<div class="autofit-col">
 						<div class="sticker sticker-secondary">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</div>
 					</div>
 					<div class="autofit-col autofit-col-expand">
@@ -591,9 +599,11 @@ section: Visual Tests
 					</div>
 					<div class="autofit-col">
 						<div class="sticker sticker-secondary">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</div>
 					</div>
 					<div class="autofit-col autofit-col-expand">
@@ -652,9 +662,11 @@ section: Visual Tests
 					</div>
 					<div class="autofit-col">
 						<div class="sticker sticker-secondary">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</div>
 					</div>
 					<div class="autofit-col autofit-col-expand">

--- a/packages/clay-css/src/content/test_list_view_template_info_panel.html
+++ b/packages/clay-css/src/content/test_list_view_template_info_panel.html
@@ -295,9 +295,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -311,9 +313,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -401,9 +405,11 @@ section: Visual Tests
 					</div>
 					<div class="autofit-col">
 						<div class="sticker sticker-secondary">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</div>
 					</div>
 					<div class="autofit-col autofit-col-expand">
@@ -457,9 +463,11 @@ section: Visual Tests
 					</div>
 					<div class="autofit-col">
 						<div class="sticker sticker-secondary">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</div>
 					</div>
 					<div class="autofit-col autofit-col-expand">
@@ -515,9 +523,11 @@ section: Visual Tests
 					</div>
 					<div class="autofit-col">
 						<div class="sticker sticker-secondary">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</div>
 					</div>
 					<div class="autofit-col autofit-col-expand">
@@ -576,9 +586,11 @@ section: Visual Tests
 					</div>
 					<div class="autofit-col">
 						<div class="sticker sticker-secondary">
-							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
+							<span class="inline-item">
+								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
 						</div>
 					</div>
 					<div class="autofit-col autofit-col-expand">

--- a/packages/clay-css/src/content/test_table_view_template.html
+++ b/packages/clay-css/src/content/test_table_view_template.html
@@ -371,9 +371,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -387,9 +389,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">

--- a/packages/clay-css/src/content/test_table_view_template_info_panel.html
+++ b/packages/clay-css/src/content/test_table_view_template_info_panel.html
@@ -295,9 +295,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">
@@ -311,9 +313,11 @@ section: Visual Tests
 									<li class="list-group-item list-group-item-flex">
 										<div class="autofit-col">
 											<div class="sticker sticker-secondary">
-												<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-												</svg>
+												<span class="inline-item">
+													<svg aria-hidden="true" class="lexicon-icon lexicon-icon-folder">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
 											</div>
 										</div>
 										<div class="autofit-col autofit-col-expand">

--- a/packages/clay-css/src/scss/atlas/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_stickers.scss
@@ -1,24 +1,31 @@
 $sticker-font-size: 0.625rem !default; // 10px
 $sticker-font-weight: $font-weight-bold !default;
 
-$sticker-inside-offset: 1rem !default; // 16px
+$sticker-inline-item-font-size: 1rem !default; // 16px
 
 // Sticker Sizes
 
 $sticker-sm: () !default;
 $sticker-sm: map-merge((
-	font-size: 0.5625rem // 9px
+	font-size: 0.5625rem, // 9px
+	inline-item-font-size: 0.75rem // 14px
 ), $sticker-sm);
 
 $sticker-lg: () !default;
 $sticker-lg: map-merge((
-	font-size: 0.9375rem // 15px
+	font-size: 0.9375rem, // 15px
+	inline-item-font-size: 1.25rem // 20px
 ), $sticker-lg);
 
 $sticker-xl: () !default;
 $sticker-xl: map-merge((
-	font-size: 1.0625rem // 17px
+	font-size: 1.0625rem, // 17px
+	inline-item-font-size: 1.5rem // 24px
 ), $sticker-xl);
+
+// Sticker Positions
+
+$sticker-inside-offset: 1rem !default; // 16px
 
 // Sticker Variants
 

--- a/packages/clay-css/src/scss/components/_stickers.scss
+++ b/packages/clay-css/src/scss/components/_stickers.scss
@@ -25,6 +25,14 @@
 		margin: auto;
 	}
 
+	> .inline-item {
+		font-size: $sticker-inline-item-font-size;
+
+		.lexicon-icon {
+			margin-top: 0;
+		}
+	}
+
 	&.rounded .sticker-overlay {
 		border-radius: $rounded-border-radius;
 	}

--- a/packages/clay-css/src/scss/mixins/_stickers.scss
+++ b/packages/clay-css/src/scss/mixins/_stickers.scss
@@ -1,11 +1,16 @@
 @mixin clay-sticker-size($map) {
 	$font-size: map-get($map, font-size);
+	$inline-item-font-size: map-get($map, inline-item-font-size);
 	$outside-offset: setter(map-get($map, outside-offset), -(map-get($map, size) / 2));
 	$size: map-get($map, size);
 
 	font-size: $font-size;
 
 	@include clay-monospace($size);
+
+	> .inline-item {
+		font-size: $inline-item-font-size;
+	}
 
 	&.sticker-outside {
 		left: $outside-offset;

--- a/packages/clay-css/src/scss/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/variables/_stickers.scss
@@ -7,6 +7,8 @@ $sticker-font-size: 0.875rem !default; // 14px
 $sticker-font-weight: $font-weight-semi-bold !default;
 $sticker-size: 2rem !default; // 32px
 
+$sticker-inline-item-font-size: null !default;
+
 // Sticker Sizes
 
 $sticker-sm: () !default;


### PR DESCRIPTION
… `.sticker` should be wrapped by `.inline-item`

New: Stickers added option to configure `$sticker-inline-item-font-size` and added option to configure `inline-item-font-size` to mixin `clay-sticker-size`

Icons in sticker must be wrapped by:
```
<span class="inline-item"></span>
```
for sizes specified in #886 to apply.