### PR TITLE
Update: (Fixes #882) Application Bar, Navigation Bar, Management Bar …

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_application-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_application-bar.scss
@@ -8,6 +8,8 @@ $application-bar-dark: map-merge((
 	bg: lighten(desaturate(adjust-hue($dark, 1), 0.77), 3.92),
 	link-border-radius: $border-radius,
 	link-font-weight: $font-weight-semi-bold,
-	link-hover-bg: rgba(255, 255, 255, 0.04),
-	link-active-bg: rgba(255, 255, 255, 0.08)
+	link-hover-bg: rgba(255, 255, 255, 0.03),
+	link-active-bg: rgba(255, 255, 255, 0.06),
+	link-disabled-bg: transparent,
+	link-disabled-opacity: 0.5
 ), $application-bar-dark);

--- a/packages/clay-css/src/scss/atlas/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_management-bar.scss
@@ -4,8 +4,9 @@ $management-bar-light: map-merge((
 	link-border-radius: $border-radius,
 	link-font-weight: $font-weight-semi-bold,
 	link-hover-color: $body-color,
-	link-hover-bg: rgba(0, 0, 0, 0.02),
-	link-active-bg: rgba(0, 0, 0, 0.04)
+	link-hover-bg: rgba(#272833, 0.03),
+	link-active-bg: rgba(#272833, 0.06),
+	link-disabled-bg: transparent
 ), $management-bar-light);
 
 $management-bar-primary: () !default;
@@ -13,6 +14,7 @@ $management-bar-primary: map-merge((
 	link-border-radius: $border-radius,
 	link-font-weight: $font-weight-semi-bold,
 	link-hover-color: $body-color,
-	link-hover-bg: rgba(0, 0, 0, 0.02),
-	link-active-bg: rgba(0, 0, 0, 0.04)
+	link-hover-bg: rgba(#272833, 0.03),
+	link-active-bg: rgba(#272833, 0.06),
+	link-disabled-bg: transparent
 ), $management-bar-primary);

--- a/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
@@ -18,5 +18,6 @@ $navigation-bar-secondary: map-merge((
 	link-font-weight: $font-weight-semi-bold,
 	link-hover-color: #FFF,
 	link-active-color: #FFF,
-	link-disabled-color: $nav-link-disabled-color
+	link-disabled-color: $nav-link-disabled-color,
+	link-disabled-opacity: 0.5
 ), $navigation-bar-secondary);

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -83,6 +83,15 @@
 		text-decoration: $link-decoration;
 	}
 
+	&.disabled,
+	&:disabled {
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
 	@include hover {
 		text-decoration: $link-hover-decoration;
 	}

--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -409,15 +409,16 @@
 	$border-style: setter(map-get($map, border-style), solid);
 	$color: map-get($map, color);
 	$link-border-radius: map-get($map, link-border-radius);
+	$link-bg: map-get($map, link-bg);
 	$link-color: map-get($map, link-color);
 	$link-font-weight: map-get($map, link-font-weight);
-	$link-hover-color: map-get($map, link-hover-color);
-	$link-active-color: map-get($map, link-active-color);
-	$link-disabled-color: map-get($map, link-disabled-color);
-	$link-bg: map-get($map, link-bg);
 	$link-hover-bg: map-get($map, link-hover-bg);
+	$link-hover-color: map-get($map, link-hover-color);
 	$link-active-bg: map-get($map, link-active-bg);
+	$link-active-color: map-get($map, link-active-color);
 	$link-disabled-bg: map-get($map, link-disabled-bg);
+	$link-disabled-color: map-get($map, link-disabled-color);
+	$link-disabled-opacity: map-get($map, link-disabled-opacity);
 	$btn-font-weight: setter(map-get($map, btn-font-weight), $link-font-weight);
 	$brand-color: map-get($map, brand-color);
 	$brand-hover-color: map-get($map, brand-hover-color);
@@ -453,9 +454,11 @@
 				color: $link-active-color;
 			}
 
-			&.disabled {
+			&.disabled,
+			&:disabled {
 				background-color: $link-disabled-bg;
 				color: $link-disabled-color;
+				opacity: $link-disabled-opacity;
 			}
 		}
 

--- a/packages/clay-css/src/scss/variables/_application-bar.scss
+++ b/packages/clay-css/src/scss/variables/_application-bar.scss
@@ -20,5 +20,6 @@ $application-bar-dark: map-merge((
 	link-color: $navbar-dark-color,
 	link-hover-color: $navbar-dark-hover-color,
 	link-active-color: $navbar-dark-active-color,
-	link-disabled-color: $navbar-dark-disabled-color
+	link-disabled-color: $navbar-dark-disabled-color,
+	link-disabled-opacity: 1
 ), $application-bar-dark);

--- a/packages/clay-css/src/scss/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/variables/_management-bar.scss
@@ -25,7 +25,8 @@ $management-bar-light: map-merge((
 	link-color: $navbar-light-color,
 	link-hover-color: $navbar-light-hover-color,
 	link-active-color: $navbar-light-active-color,
-	link-disabled-color: $navbar-light-disabled-color
+	link-disabled-color: $navbar-light-disabled-color,
+	link-disabled-opacity: 1
 ), $management-bar-light);
 
 $management-bar-primary: () !default;
@@ -36,5 +37,6 @@ $management-bar-primary: map-merge((
 	link-color: $navbar-light-color,
 	link-hover-color: $navbar-light-hover-color,
 	link-active-color: $navbar-light-active-color,
-	link-disabled-color: $navbar-light-disabled-color
+	link-disabled-color: $navbar-light-disabled-color,
+	link-disabled-opacity: 1
 ), $management-bar-primary);

--- a/packages/clay-css/src/scss/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/variables/_navigation-bar.scss
@@ -19,7 +19,8 @@ $navigation-bar-light: map-merge((
 	link-color: $navbar-light-color,
 	link-hover-color: $navbar-light-hover-color,
 	link-active-color: $navbar-light-active-color,
-	link-disabled-color: $navbar-light-disabled-color
+	link-disabled-color: $navbar-light-disabled-color,
+	link-disabled-opacity: 1
 ), $navigation-bar-light);
 
 $navigation-bar-secondary: () !default;
@@ -30,6 +31,7 @@ $navigation-bar-secondary: map-merge((
 	link-hover-color: rgba(255, 255, 255, 0.9),
 	link-active-color: rgba(255, 255, 255, 0.9),
 	link-disabled-color: rgba(255, 255, 255, 0.25),
+	link-disabled-opacity: 1,
 	brand-color: rgba(255, 255, 255, 0.9),
 	brand-hover-color: rgba(255, 255, 255, 0.9)
 ), $navigation-bar-secondary);


### PR DESCRIPTION
…disabled links and buttons should have no color changes on hover

New: Mixin `clay-navbar-variant` added option to configure `link-disabled-opacity`