### PR TITLE
Update: (Fixes #931) Atlas `.btn-sm` padding left and right should be…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -21,15 +21,20 @@ $btn-padding-y-lg: 0.59375rem !default; // 9.5px
 $btn-inline-item-font-size-lg: $font-size-lg !default; // 18px
 
 $btn-font-size-sm: $font-size-sm !default; // 14px
-$btn-line-height-sm: 1 !default;
-$btn-padding-x-sm: 0.5rem !default; // 8px
-$btn-padding-y-sm: 0.5rem !default; // 8px
-$btn-inline-item-font-size-sm: $font-size-sm !default; // 14px
+$btn-line-height-sm: 1.15 !default;
+$btn-padding-x-sm: 0.75rem !default; // 12px
+$btn-padding-y-sm: 0.4375rem !default; // 7px
 
 // Button Monospaced
 
+$btn-monospaced-padding-y: 0.25rem !default; // 4px
 $btn-monospaced-size: 2.5rem !default; // 40px
+
+$btn-monospaced-padding-x-sm: null !default;
+$btn-monospaced-padding-y-sm: 0.1875rem !default; // 3px
 $btn-monospaced-size-sm: 2rem !default; // 32px
+
+$btn-monospaced-padding-y-lg: 0.375rem !default; // 6px
 
 // Button Group
 

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -136,13 +136,13 @@
 // Button Monospaced
 
 .btn-monospaced {
-	align-items: center;
-	display: inline-flex;
-	flex-direction: column;
 	height: $btn-monospaced-size;
-	justify-content: center;
+	line-height: 1;
 	overflow: hidden;
-	padding: 0;
+	padding-bottom: $btn-monospaced-padding-y;
+	padding-left: $btn-monospaced-padding-x;
+	padding-right: $btn-monospaced-padding-x;
+	padding-top: $btn-monospaced-padding-y;
 	text-align: center;
 	white-space: normal;
 	width: $btn-monospaced-size;
@@ -155,6 +155,10 @@
 
 	&.btn-lg {
 		height: $btn-monospaced-size-lg;
+		padding-bottom: $btn-monospaced-padding-y-lg;
+		padding-left: $btn-monospaced-padding-x-lg;
+		padding-right: $btn-monospaced-padding-x-lg;
+		padding-top: $btn-monospaced-padding-y-lg;
 		width: $btn-monospaced-size-lg;
 
 		@include clay-scale-component {
@@ -165,6 +169,10 @@
 
 	&.btn-sm {
 		height: $btn-monospaced-size-sm;
+		padding-bottom: $btn-monospaced-padding-y-sm;
+		padding-left: $btn-monospaced-padding-x-sm;
+		padding-right: $btn-monospaced-padding-x-sm;
+		padding-top: $btn-monospaced-padding-y-sm;
 		width: $btn-monospaced-size-sm;
 
 		@include clay-scale-component {

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -288,6 +288,11 @@
 
 		.btn-monospaced {
 			height: $btn-monospaced-size-lg;
+			line-height: 1;
+			padding-bottom: $btn-monospaced-padding-y-lg;
+			padding-left: $btn-monospaced-padding-x-lg;
+			padding-right: $btn-monospaced-padding-x-lg;
+			padding-top: $btn-monospaced-padding-y-lg;
 			width: $btn-monospaced-size-lg;
 
 			@include clay-scale-component {
@@ -296,7 +301,6 @@
 			}
 		}
 
-		> .btn,
 		.form-control,
 		.form-file .btn {
 			font-size: $input-font-size-lg;
@@ -387,6 +391,11 @@
 
 		.btn-monospaced {
 			height: $btn-monospaced-size-sm;
+			line-height: 1;
+			padding-bottom: $btn-monospaced-padding-y-sm;
+			padding-left: $btn-monospaced-padding-x-sm;
+			padding-right: $btn-monospaced-padding-x-sm;
+			padding-top: $btn-monospaced-padding-y-sm;
 			width: $btn-monospaced-size-sm;
 
 			@include clay-scale-component {
@@ -395,7 +404,6 @@
 			}
 		}
 
-		> .btn,
 		.form-control,
 		.form-file .btn {
 			font-size: $input-font-size-sm;

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -30,8 +30,16 @@ $btn-section-font-size-sm: 0.5625rem !default; // 9px
 
 // Button Monospaced
 
+$btn-monospaced-padding-x: 0 !default;
+$btn-monospaced-padding-y: 0.1875rem !default; // 3px
 $btn-monospaced-size: 2.375rem !default; // 38px
+
+$btn-monospaced-padding-x-lg: 0 !default;
+$btn-monospaced-padding-y-lg: 0.3125rem !default; // 5px
 $btn-monospaced-size-lg: 3rem !default; // 48px
+
+$btn-monospaced-padding-x-sm: 0 !default;
+$btn-monospaced-padding-y-sm: 0.125rem !default; // 2px
 $btn-monospaced-size-sm: 1.9375rem !default; // 31px
 
 $btn-monospaced-size-mobile: null !default;


### PR DESCRIPTION
… 12px and `.btn-sm .inline-item` font-size should be 16px

New: (#931) Button Monospaced added options to configure `$btn-monospaced-padding-x`, `$btn-monospaced-padding-y`, `$btn-monospaced-padding-x-lg`, `$btn-monospaced-padding-y-lg`, `$btn-monospaced-padding-x-sm`, `$btn-monospaced-padding-y-sm`

Update: (#931) Input Group with `.btn-monospaced` should also size and align properly