### PR TITLE
Add events to ClayDropdown to close on mobile and when the esq is pressed and when the iframe is clicked

### DIFF
--- a/packages/clay-dropdown/src/ClayDropdownBase.js
+++ b/packages/clay-dropdown/src/ClayDropdownBase.js
@@ -14,6 +14,8 @@ import {EventHandler} from 'metal-events';
 import itemsValidator from './items_validator';
 import templates from './ClayDropdownBase.soy.js';
 
+const KEY_CODE_ESC = 27;
+
 /**
  * Implementation of the base for Metal Clay Dropdown.
  * @extends ClayComponent
@@ -31,9 +33,10 @@ class ClayDropdownBase extends ClayComponent {
 	 */
 	created() {
 		this._eventHandler = new EventHandler();
+		this._eventHandlerKeyup = new EventHandler();
 
 		this._eventHandler.add(
-			dom.on(document, 'click', this._handleDocClick.bind(this))
+			dom.on(document, 'click', this._handleDocClick.bind(this), true)
 		);
 	}
 
@@ -57,6 +60,7 @@ class ClayDropdownBase extends ClayComponent {
 	 */
 	_close() {
 		this.expanded = false;
+		this._eventHandlerKeyup.removeAllListeners();
 	}
 
 	/**
@@ -122,6 +126,17 @@ class ClayDropdownBase extends ClayComponent {
 			name: 'itemClicked',
 			originalEvent: event,
 		});
+	}
+
+	/**
+	 * Handle click key code esc and close dropdown.
+	 * @param {!Event} event
+	 * @private
+	 */
+	_handleKeyup(event) {
+		if (event.keyCode === KEY_CODE_ESC) {
+			this._close();
+		}
 	}
 
 	/**
@@ -195,6 +210,17 @@ class ClayDropdownBase extends ClayComponent {
 			name: 'itemsFiltered',
 			originalEvent: event,
 		});
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	syncExpanded() {
+		if (this.expanded) {
+			this._eventHandlerKeyup.add(
+				dom.on(document, 'keyup', this._handleKeyup.bind(this), true)
+			);
+		}
 	}
 
 	/**

--- a/packages/clay-dropdown/src/ClayDropdownBase.js
+++ b/packages/clay-dropdown/src/ClayDropdownBase.js
@@ -208,6 +208,17 @@ class ClayDropdownBase extends ClayComponent {
 	}
 
 	/**
+	 * Handles blur window in order to hide menu.
+	 * @private
+	 */
+	_handleWinBlur() {
+		const activeElement = document.activeElement;
+		if (activeElement != null && activeElement.nodeName === 'IFRAME') {
+			this._close();
+		}
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	syncExpanded() {
@@ -225,7 +236,8 @@ class ClayDropdownBase extends ClayComponent {
 					'touchend',
 					this._handleDocClick.bind(this),
 					true
-				)
+				),
+				dom.on(window, 'blur', this._handleWinBlur.bind(this), true)
 			);
 		}
 	}

--- a/packages/clay-dropdown/src/ClayDropdownBase.js
+++ b/packages/clay-dropdown/src/ClayDropdownBase.js
@@ -36,7 +36,8 @@ class ClayDropdownBase extends ClayComponent {
 		this._eventHandlerKeyup = new EventHandler();
 
 		this._eventHandler.add(
-			dom.on(document, 'click', this._handleDocClick.bind(this), true)
+			dom.on(document, 'click', this._handleDocClick.bind(this), true),
+			dom.on(document, 'touchend', this._handleDocClick.bind(this), true),
 		);
 	}
 

--- a/packages/clay-dropdown/src/ClayDropdownBase.js
+++ b/packages/clay-dropdown/src/ClayDropdownBase.js
@@ -33,12 +33,6 @@ class ClayDropdownBase extends ClayComponent {
 	 */
 	created() {
 		this._eventHandler = new EventHandler();
-		this._eventHandlerKeyup = new EventHandler();
-
-		this._eventHandler.add(
-			dom.on(document, 'click', this._handleDocClick.bind(this), true),
-			dom.on(document, 'touchend', this._handleDocClick.bind(this), true),
-		);
 	}
 
 	/**
@@ -61,7 +55,7 @@ class ClayDropdownBase extends ClayComponent {
 	 */
 	_close() {
 		this.expanded = false;
-		this._eventHandlerKeyup.removeAllListeners();
+		this._eventHandler.removeAllListeners();
 	}
 
 	/**
@@ -218,8 +212,20 @@ class ClayDropdownBase extends ClayComponent {
 	 */
 	syncExpanded() {
 		if (this.expanded) {
-			this._eventHandlerKeyup.add(
-				dom.on(document, 'keyup', this._handleKeyup.bind(this), true)
+			this._eventHandler.add(
+				dom.on(
+					document,
+					'click',
+					this._handleDocClick.bind(this),
+					true
+				),
+				dom.on(document, 'keyup', this._handleKeyup.bind(this), true),
+				dom.on(
+					document,
+					'touchend',
+					this._handleDocClick.bind(this),
+					true
+				)
 			);
 		}
 	}


### PR DESCRIPTION
I've been working on looking at the best approach to close the dropdown when it has a click on the iframe.

#### Approach 1
We could listen to the click events of some iframe element on the screen, but we would have problems with some use cases:

* We do not know when there will be an iframe on screen (Modal case)
* The click event will only work if the iframe domain is the same as the navigation

#### Approach 2
We could go with the simpler approach of closing the dropdown when clicking on some dropdown item but we can not due to interactions in the dropdown.

#### Approach 3
We can listen to the `blur` event in `window` and check the `activeElement` if it is an iframe so we can close the dropdown.

I'm following with the 3 approach to cover use cases.

> NOTE: I ended up changing the way we are attaching the events, instead of adding them when created, is only adding when the dropdown is open, since it only becomes necessary at that moment. It helps in the case of when we have too many dropdowns on the screen not to be listening to events unnecessarily.