### PR TITLE
Update: (Fixes #719) Card added Sass map `$user-card` and set `.user-…

### DIFF
--- a/packages/clay-css/src/scss/components/_cards.scss
+++ b/packages/clay-css/src/scss/components/_cards.scss
@@ -448,6 +448,10 @@
 	@include clay-card-type-asset-variant($file-card);
 }
 
+.user-card {
+	@include clay-card-type-asset-variant($user-card);
+}
+
 // Card Type Directory
 
 .card-type-directory {

--- a/packages/clay-css/src/scss/mixins/_cards.scss
+++ b/packages/clay-css/src/scss/mixins/_cards.scss
@@ -95,6 +95,8 @@
 	$aspect-ratio-checkered-bg: map-get($map, aspect-ratio-checkered-bg);
 
 	$asset-icon-color: map-get($map, asset-icon-color);
+	$asset-icon-min-width: map-get($map, asset-icon-min-width);
+	$asset-icon-width: map-get($map, asset-icon-width);
 
 	@if ($enabled) {
 		.aspect-ratio {
@@ -107,6 +109,8 @@
 
 		.card-type-asset-icon {
 			color: $asset-icon-color;
+			min-width: $asset-icon-min-width;
+			width: $asset-icon-width;
 		}
 	}
 }

--- a/packages/clay-css/src/scss/variables/_cards.scss
+++ b/packages/clay-css/src/scss/variables/_cards.scss
@@ -84,6 +84,12 @@ $file-card: map-merge((
 	asset-icon-color: $gray-600
 ), $file-card);
 
+$user-card: () !default;
+$user-card: map-merge((
+	asset-icon-min-width: 2.5rem,
+	asset-icon-width: 26%
+), $user-card);
+
 $card-page-item-asset: () !default;
 $card-page-item-asset: map-merge((
 	base: (


### PR DESCRIPTION
…card .card-type-asset-icon` min-width to 40px and width 26%

New: (#719) Mixin `clay-card-type-asset-variant` add options to configure `asset-icon-min-width` and `asset-icon-width`