### PR TITLE
Update: (Fixes #993) Utilities `.autofit-padded-no-gutters-y` should …

### DIFF
--- a/packages/clay-css/src/scss/components/_utilities.scss
+++ b/packages/clay-css/src/scss/components/_utilities.scss
@@ -100,8 +100,6 @@
 
 .autofit-padded-no-gutters-y {
 	margin-bottom: math-sign($autofit-padded-col-padding-y);
-	margin-left: math-sign($autofit-padded-col-padding-x);
-	margin-right: math-sign($autofit-padded-col-padding-x);
 	margin-top: math-sign($autofit-padded-col-padding-y);
 	width: auto;
 


### PR DESCRIPTION
…only offset top and bottom padding