### PR TITLE
New: (Fixes #1017) Mixin `clay-menubar-vertical-variant` added option…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_menubar.scss
@@ -3,6 +3,7 @@
 $menubar-vertical-transparent-md: (
 	bg-mobile: #FFF,
 	link-active-font-weight: $font-weight-semi-bold,
+	toggler-font-size-mobile: 0.875rem,
 	toggler-font-weight-mobile: $font-weight-semi-bold
 ) !default;
 
@@ -11,5 +12,6 @@ $menubar-vertical-transparent-md: (
 $menubar-vertical-transparent-lg: (
 	bg-mobile: #FFF,
 	link-active-font-weight: $font-weight-semi-bold,
+	toggler-font-size-mobile: 0.875rem,
 	toggler-font-weight-mobile: $font-weight-semi-bold
 ) !default;

--- a/packages/clay-css/src/scss/mixins/_menubar.scss
+++ b/packages/clay-css/src/scss/mixins/_menubar.scss
@@ -32,6 +32,7 @@
 	$collapse-max-width-mobile: map-get($map, collapse-max-width-mobile);
 	$collapse-left-mobile: setter(map-get($map, collapse-left-mobile), -0.0625rem); // -1px
 	$collapse-right-mobile: setter(map-get($map, collapse-right-mobile), -0.0625rem); // -1px
+	$collapse-z-index-mobile: map-get($map, collapse-z-index-mobile);
 
 	// .menubar-toggler
 
@@ -82,7 +83,7 @@
 				position: absolute;
 				right: $collapse-right-mobile;
 				top: 100%;
-				z-index: $zindex-navbar-collapse-absolute;
+				z-index: $collapse-z-index-mobile;
 
 				> .nav {
 					margin-bottom: $collapse-inner-spacer-y-mobile;
@@ -170,6 +171,7 @@
 	$toggler-border-color-mobile: map-get($map, toggler-border-color-mobile);
 	$toggler-border-style-mobile: map-get($map, toggler-border-style-mobile);
 	$toggler-color-mobile: setter(map-get($map, toggler-color-mobile), $link-active-color);
+	$toggler-font-size-mobile: map-get($map, toggler-font-size-mobile);
 	$toggler-font-weight-mobile: map-get($map, toggler-font-weight-mobile);
 
 	background-color: $bg;
@@ -200,6 +202,7 @@
 			border-color: $toggler-border-color-mobile;
 			border-style: $toggler-border-style-mobile;
 			color: $toggler-color-mobile;
+			font-size: $toggler-font-size-mobile;
 			font-weight: $toggler-font-weight-mobile;
 		}
 	}

--- a/packages/clay-css/src/scss/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/variables/_menubar.scss
@@ -4,7 +4,8 @@ $menubar-vertical-expand-md: () !default;
 $menubar-vertical-expand-md: map-merge((
 	margin-bottom-mobile: 1.5rem,
 	margin-left-mobile: -($grid-gutter-width / 2),
-	margin-right-mobile: -($grid-gutter-width / 2)
+	margin-right-mobile: -($grid-gutter-width / 2),
+	collapse-z-index-mobile: $zindex-navbar-collapse-absolute - 1
 ), $menubar-vertical-expand-md);
 
 $menubar-vertical-transparent-md: () !default;
@@ -19,7 +20,8 @@ $menubar-vertical-expand-lg: map-merge((
 	breakpoint-up: lg,
 	margin-bottom-mobile: 1.5rem,
 	margin-left-mobile: -($grid-gutter-width / 2),
-	margin-right-mobile: -($grid-gutter-width / 2)
+	margin-right-mobile: -($grid-gutter-width / 2),
+	collapse-z-index-mobile: $zindex-navbar-collapse-absolute - 1
 ), $menubar-vertical-expand-lg);
 
 $menubar-vertical-transparent-lg: () !default;


### PR DESCRIPTION
… to configure `toggler-font-size-mobile` and set it to 14px for `.menubar-vertical-expand-md` and `.menubar-vertical-expand-lg`