### PR TITLE
Update: (Fixes #1053) Atlas Card box-shadow should match Lexicon card…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_cards.scss
@@ -1,6 +1,6 @@
 $card-border-radius: $border-radius !default;
 $card-border-width: 0 !default;
-$card-box-shadow: 0 1px 10px -4px rgba(0, 0, 0, 0.6) !default;
+$card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
 
 $card-body-padding-bottom: 1rem !default;
 $card-body-padding-left: 1rem !default;


### PR DESCRIPTION
… box shadow better