### PR TITLE
New: (Fixes #1060) SVG Icons added option to customize `$scale-lexico…

### DIFF
--- a/src/scss/lexicon-base/_icons.scss
+++ b/src/scss/lexicon-base/_icons.scss
@@ -24,9 +24,9 @@
 }
 
 %scale-lexicon-icon {
-	height: 1em;
-	margin-top: -0.13em;
-	width: 1em;
+	height: $scale-lexicon-icon-size;
+	margin-top: $scale-lexicon-icon-margin-top;
+	width: $scale-lexicon-icon-size;
 }
 
 .scale-lexicon-icon.lexicon-icon,
@@ -176,7 +176,7 @@ a .icon-monospaced,
 
 .icon-monospaced {
 	&.lexicon-icon {
-		padding: lx-icon-padding($icon-monospaced-size, $lexicon-icon-size);
+		padding: $icon-monospaced-lexicon-icon-padding;
 	}
 
 	.lexicon-icon {
@@ -184,7 +184,7 @@ a .icon-monospaced,
 
 		@include monospace($icon-monospaced-size);
 
-		padding: lx-icon-padding($icon-monospaced-size, $lexicon-icon-size);
+		padding: $icon-monospaced-lexicon-icon-padding;
 	}
 }
 

--- a/src/scss/lexicon-base/variables/_icons.scss
+++ b/src/scss/lexicon-base/variables/_icons.scss
@@ -10,10 +10,14 @@ $help-icon-default-bg: $input-group-addon-bg !default;
 $help-icon-default-color: lx-color-by-lightness($text-color, $help-icon-default-bg) !default;
 $help-icon-default-hover-color: lx-color-by-lightness($text-color, $help-icon-default-bg, "secondary") !default;
 
-$icon-monospaced-size: 32px !default;
-
 $lexicon-icon-size: 16px !default;
 
 $lexicon-icon-lg-size: 128px !default;
 $lexicon-icon-md-size: 32px !default;
 $lexicon-icon-sm-size: 7px !default;
+
+$icon-monospaced-size: 32px !default;
+$icon-monospaced-lexicon-icon-padding: lx-icon-padding($icon-monospaced-size, $lexicon-icon-size) !default;
+
+$scale-lexicon-icon-margin-top: -0.13em !default;
+$scale-lexicon-icon-size: 1em !default;


### PR DESCRIPTION
…n-icon-margin-top`, `$scale-lexicon-icon-size`, and `$icon-monospaced-lexicon-icon-padding` for better sizing of svg icons