### PR TITLE
ClayCSS: (Fixes 1092) Modal Variant Variables moved header-close map …

### DIFF
--- a/packages/clay-css/src/content/modals.html
+++ b/packages/clay-css/src/content/modals.html
@@ -454,14 +454,12 @@ section: Components
 				</div>
 				<div class="modal-item">Some other content</div>
 				<div class="modal-item-last">
-					<div class="modal-item-last">
-						<div class="btn-group">
-							<div class="btn-group-item">
-								<button class="btn btn-secondary" data-dismiss="modal" type="button">Close</button>
-							</div>
-							<div class="btn-group-item">
-								<button class="btn btn-primary" type="button">Primary</button>
-							</div>
+					<div class="btn-group">
+						<div class="btn-group-item">
+							<button class="btn btn-secondary" data-dismiss="modal" type="button">Close</button>
+						</div>
+						<div class="btn-group-item">
+							<button class="btn btn-primary" type="button">Primary</button>
 						</div>
 					</div>
 				</div>

--- a/packages/clay-css/src/scss/atlas/variables/_modals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_modals.scss
@@ -14,60 +14,56 @@ $modal-title-font-weight: $font-weight-bold !default;
 
 // Modal Success
 
+$modal-success-header-close: () !default;
+$modal-success-header-close: map-merge((
+	color: $success
+), $modal-success-header-close);
+
 $modal-success: () !default;
 $modal-success: map-merge((
 	header-bg: lighten(desaturate(#287d3d, 1.52), 62.94),
 	header-border-color: lighten(desaturate(#287d3d, 0.14), 24.90),
-	header-color: $success,
-	header-close: (
-		color: $success,
-		hover-color: inherit,
-		focus-color: inherit,
-		disabled-color: inherit
-	)
+	header-color: $success
 ), $modal-success);
 
 // Modal Info
+
+$modal-info-header-close: () !default;
+$modal-info-header-close: map-merge((
+	color: $info
+), $modal-info-header-close);
 
 $modal-info: () !default;
 $modal-info: map-merge((
 	header-bg: lighten(desaturate(adjust-hue($info, 1), 3.25), 52.94),
 	header-border-color: lighten(saturate($info, 0.59), 28.04),
-	header-color: $info,
-	header-close: (
-		color: $info,
-		hover-color: inherit,
-		focus-color: inherit,
-		disabled-color: inherit
-	)
+	header-color: $info
 ), $modal-info);
 
 // Modal Warning
+
+$modal-warning-header-close: () !default;
+$modal-warning-header-close: map-merge((
+	color: $warning
+), $modal-warning-header-close);
 
 $modal-warning: () !default;
 $modal-warning: map-merge((
 	header-bg: lighten(adjust-hue($warning, -1), 60.00),
 	header-border-color: lighten($warning, 24.90),
-	header-color: $warning,
-	header-close: (
-		color: $warning,
-		hover-color: inherit,
-		focus-color: inherit,
-		disabled-color: inherit
-	)
+	header-color: $warning
 ), $modal-warning);
 
 // Modal Danger
+
+$modal-danger-header-close: () !default;
+$modal-danger-header-close: map-merge((
+	color: $danger
+), $modal-danger-header-close);
 
 $modal-danger: () !default;
 $modal-danger: map-merge((
 	header-bg: lighten(saturate($danger, 5.04), 50.00),
 	header-border-color: lighten(desaturate($danger, 0.25), 28.04),
-	header-color: $danger,
-	header-close: (
-		color: $danger,
-		hover-color: inherit,
-		focus-color: inherit,
-		disabled-color: inherit
-	)
+	header-color: $danger
 ), $modal-danger);

--- a/packages/clay-css/src/scss/variables/_modals.scss
+++ b/packages/clay-css/src/scss/variables/_modals.scss
@@ -33,62 +33,74 @@ $modal-close-spacer-x: 0.3125rem !default; // 5px
 
 // Modal Success
 
+$modal-success-header-close: () !default;
+$modal-success-header-close: map-merge((
+	color: theme-color-level(success, 6),
+	hover-color: inherit,
+	focus-color: inherit,
+	disabled-color: inherit
+), $modal-success-header-close);
+
 $modal-success: () !default;
 $modal-success: map-merge((
 	header-bg: theme-color-level(success, -10),
 	header-border-color: theme-color-level(success, -9),
 	header-color: theme-color-level(success, 6),
-	header-close: (
-		color: theme-color-level(success, 6),
-		hover-color: inherit,
-		focus-color: inherit,
-		disabled-color: inherit
-	)
+	header-close: $modal-success-header-close
 ), $modal-success);
 
 // Modal Info
+
+$modal-info-header-close: () !default;
+$modal-info-header-close: map-merge((
+	color: theme-color-level(info, 6),
+	hover-color: inherit,
+	focus-color: inherit,
+	disabled-color: inherit
+), $modal-info-header-close);
 
 $modal-info: () !default;
 $modal-info: map-merge((
 	header-bg: theme-color-level(info, -10),
 	header-border-color: theme-color-level(info, -9),
 	header-color: theme-color-level(info, 6),
-	header-close: (
-		color: theme-color-level(info, 6),
-		hover-color: inherit,
-		focus-color: inherit,
-		disabled-color: inherit
-	)
+	header-close: $modal-info-header-close
 ), $modal-info);
 
 // Modal Warning
+
+$modal-warning-header-close: () !default;
+$modal-warning-header-close: map-merge((
+	color: theme-color-level(warning, 6),
+	hover-color: inherit,
+	focus-color: inherit,
+	disabled-color: inherit
+), $modal-warning-header-close);
 
 $modal-warning: () !default;
 $modal-warning: map-merge((
 	header-bg: theme-color-level(warning, -10),
 	header-border-color: theme-color-level(warning, -9),
 	header-color: theme-color-level(warning, 6),
-	header-close: (
-		color: theme-color-level(warning, 6),
-		hover-color: inherit,
-		focus-color: inherit,
-		disabled-color: inherit
-	)
+	header-close: $modal-warning-header-close
 ), $modal-warning);
 
 // Modal Danger
+
+$modal-danger-header-close: () !default;
+$modal-danger-header-close: map-merge((
+	color: theme-color-level(danger, 6),
+	hover-color: inherit,
+	focus-color: inherit,
+	disabled-color: inherit
+), $modal-danger-header-close);
 
 $modal-danger: () !default;
 $modal-danger: map-merge((
 	header-bg: theme-color-level(danger, -10),
 	header-border-color: theme-color-level(danger, -9),
 	header-color: theme-color-level(danger, 6),
-	header-close: (
-		color: theme-color-level(danger, 6),
-		hover-color: inherit,
-		focus-color: inherit,
-		disabled-color: inherit
-	)
+	header-close: $modal-danger-header-close
 ), $modal-danger);
 
 $modal-palette: () !default;


### PR DESCRIPTION
…to separate variables `$modal-success-header-close`, `$modal-info-header-close`, `$modal-warning-header-close`, `$modal-danger-header-close`