### PR TITLE
ClayCSS: (Fixes #1125) Atlas Forms changing individual border-widths …

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -10,6 +10,9 @@ $input-border-bottom-width: 0.0625rem !default; // 1px
 $input-border-left-width: 0.0625rem !default; // 1px
 $input-border-right-width: 0.0625rem !default; // 1px
 $input-border-top-width: 0.0625rem !default; // 1px
+$input-border-width: $input-border-top-width $input-border-right-width $input-border-bottom-width $input-border-left-width !default;
+
+$input-border-style: solid !default;
 
 $input-padding-x: 1rem !default; // 16px
 $input-padding-y: 0.5rem !default; // 8px

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -64,6 +64,8 @@ label {
 
 .form-control {
 	background-clip: border-box;
+	border-color: $input-border-color;
+	border-style: $input-border-style;
 	border-width: $input-border-width;
 
 	@if not ($input-font-size == $font-size-base) {

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -4,6 +4,8 @@ $input-border-bottom-width: 0.0625rem !default;
 $input-border-left-width: 0.0625rem !default;
 $input-border-width: $input-border-top-width $input-border-right-width $input-border-bottom-width $input-border-left-width !default;
 
+$input-border-style: null !default;
+
 $input-font-size: $font-size-base !default;
 $input-font-size-mobile: null !default;
 $input-height-mobile: null !default;


### PR DESCRIPTION
…for an input doesn't apply

ClayCSS: (#1125) Forms added option to configure `$input-border-style` and declare `border-style`, `border-color` separately so we can size borders individually