### PR TITLE
(Fixes #1105, Fixes #1147) Subnav Tbar Primary should support labels, break to new line, have disabled state, and `.component-link` color should have more contrast

### DIFF
--- a/packages/clay-css/src/content/tbar.html
+++ b/packages/clay-css/src/content/tbar.html
@@ -152,17 +152,142 @@ section: Components
 		<h3>Subnav Tbar Primary</h3>
 
 		<blockquote class="blockquote">
-			<p>Sub Navigation used in Management Bar</p>
+			<p>Sub-navigation used in Management Bar</p>
 		</blockquote>
 
-		<nav class="tbar subnav-tbar subnav-tbar-primary">
+		<nav class="tbar tbar-inline-md-down subnav-tbar subnav-tbar-primary">
 			<div class="container-fluid container-fluid-max-xl">
-				<ul class="tbar-nav">
+				<ul class="tbar-nav tbar-nav-wrap">
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-text">10,000 results for "<strong>ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</strong>"</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Category: <strong>Productivity</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Status: <strong>Approved</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
 					<li class="tbar-item tbar-item-expand">
 						<div class="tbar-section">
-							<span class="component-title text-truncate-inline">
-								<span class="text-truncate">Results for Master (19 Items)</span>
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Type: <strong>png</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
 							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<button class="btn btn-unstyled component-link tbar-link" type="button">Clear All</button>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<nav class="tbar tbar-inline-md-down subnav-tbar subnav-tbar-primary">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="tbar-nav tbar-nav-wrap">
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-text">7 results for "<strong>banner</strong>"</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Category: <strong>Productivity</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Status: <strong>Approved</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item tbar-item-expand">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Type: <strong>png</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<a class="component-link disabled tbar-link" href="#1" role="button" tabindex="-1">Apply to Root</a>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<button class="btn btn-unstyled component-link tbar-link" type="button">Clear All</button>
 						</div>
 					</li>
 				</ul>
@@ -184,13 +309,196 @@ section: Components
 						</div>
 					</li>
 					<li class="tbar-item">
-						<a class="component-link tbar-link" href="#1" role="button">Clear</a>
+						<div class="tbar-section">
+							<a class="component-link tbar-link" href="#1" role="button">Apply to Root</a>
+						</div>
 					</li>
 					<li class="tbar-item">
-						<button class="btn btn-unstyled component-link tbar-link" type="button">Clear</button>
+						<div class="tbar-section">
+							<button class="btn btn-unstyled component-link tbar-link" type="button">Clear</button>
+						</div>
 					</li>
 				</ul>
 			</div>
 		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Subnav Tbar Primary Subnav Tbar Disabled</h3>
+
+		<blockquote class="blockquote">
+			<p>Disabled sub-navigation used in Management Bar, just add <code>subnav-tbar-disabled</code>. The <code>disabled</code> attribute must be added to any <code>button</code> tag. The class <code>disabled</code> and attribute <code>tabindex="-1"</code> must be added to any <code>anchor</code> tag and clicks disabled via javascript.</p>
+		</blockquote>
+
+		<nav class="tbar tbar-inline-md-down subnav-tbar subnav-tbar-disabled subnav-tbar-primary">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="tbar-nav tbar-nav-wrap">
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-text">10,000 results for "<strong>ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</strong>"</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Category: <strong>Productivity</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Status: <strong>Approved</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item tbar-item-expand">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Type: <strong>png</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<button class="btn btn-unstyled component-link tbar-link" disabled type="button">Clear All</button>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<nav class="tbar tbar-inline-md-down subnav-tbar subnav-tbar-disabled subnav-tbar-primary">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="tbar-nav tbar-nav-wrap">
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-text">7 results for "<strong>banner</strong>"</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Category: <strong>Productivity</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Status: <strong>Approved</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item tbar-item-expand">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Type: <strong>png</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<a class="component-link disabled tbar-link" href="#1" role="button" tabindex="-1">Apply to Root</a>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<button class="btn btn-unstyled component-link tbar-link" disabled type="button">Clear All</button>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Tbar Inline {xs|sm|md|lg|xl} Down</h3>
+
+		<blockquote class="blockquote">
+			<p>A helper class on <code>tbar</code> that turns <code>tbar-nav</code>, <code>tbar-item</code>, <code>tbar-section</code>, and <code>component-title</code> inline at specific breakpoints.</p>
+		</blockquote>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Tbar Nav Wrap</h3>
+
+		<blockquote class="blockquote">
+			<p>A helper class on <code>tbar-nav</code> that breaks <code>tbar-nav</code> content to new line when the container becomes too small.</p>
+		</blockquote>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Tbar Nav Shrink</h3>
+
+		<blockquote class="blockquote">
+			<p>A helper class on <code>tbar-nav</code> that makes it only as wide as its content, use with other <code>tbar-nav</code>'s.</p>
+		</blockquote>
 	</div>
 </div>

--- a/packages/clay-css/src/content/test_subnav_tbar.html
+++ b/packages/clay-css/src/content/test_subnav_tbar.html
@@ -102,29 +102,23 @@ section: Visual Tests
 					</li>
 					<li class="tbar-item">
 						<a class="component-link tbar-btn-monospaced" href="#1" role="button">
-							<span class="inline-item">
-								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-add-cell">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell" />
-								</svg>
-							</span>
+							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-add-cell">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell" />
+							</svg>
 						</a>
 					</li>
 					<li class="tbar-item">
 						<a class="link-outline link-outline-primary tbar-link-monospaced" href="#1" role="button">
-							<span class="inline-item">
-								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-add-cell">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell" />
-								</svg>
-							</span>
+							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-add-cell">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell" />
+							</svg>
 						</a>
 					</li>
 					<li class="tbar-item">
 						<a class="link-outline link-outline-primary link-outline-primary-borderless tbar-link-monospaced" href="#1" role="button">
-							<span class="inline-item">
-								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-add-cell">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell" />
-								</svg>
-							</span>
+							<svg aria-hidden="true" class="lexicon-icon lexicon-icon-add-cell">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell" />
+							</svg>
 						</a>
 					</li>
 				</ul>
@@ -154,6 +148,296 @@ section: Visual Tests
 						<button class="btn btn-outline-primary tbar-btn" type="button">
 							.btn-outline-primary.tbar-btn
 						</button>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<nav class="tbar tbar-inline-xs-down subnav-tbar subnav-tbar-primary">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="tbar-nav tbar-nav-wrap">
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-text">10,000 results for "<strong>Really...</strong>"</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Category: <strong>Productivity</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Status: <strong>Approved</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Type: <strong>png</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+				<ul class="tbar-nav tbar-nav-shrink">
+					<li class="tbar-item">
+						<a class="component-link tbar-link" href="#1" role="button">Apply to Root</a>
+					</li>
+					<li class="tbar-item">
+						<button class="btn btn-unstyled component-link tbar-link" type="button">Clear All</button>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<nav class="tbar tbar-inline-md-down subnav-tbar subnav-tbar-primary">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="tbar-nav tbar-nav-wrap">
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-text">10,000 results for "<strong>Really...</strong>"</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Category: <strong>Productivity</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Status: <strong>Approved</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item tbar-item-expand">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Type: <strong>png</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<a class="component-link tbar-link" href="#1" role="button">Apply to Root</a>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<button class="btn btn-unstyled component-link tbar-link" type="button">Clear All</button>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<nav class="tbar tbar-inline-xs-down subnav-tbar subnav-tbar-primary">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="tbar-nav tbar-nav-wrap">
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-text">10,000 results for "<strong>Really...</strong>"</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Category: <strong>Productivity</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<a aria-label="Close" class="close disabled" href="#1" role="button" tabindex="-1">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</a>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Status: <strong>Approved</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Type: <strong>png</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+				<ul class="tbar-nav tbar-nav-shrink">
+					<li class="tbar-item">
+						<a class="component-link disabled tbar-link" href="#1" role="button" tabindex="-1">Apply to Root</a>
+					</li>
+					<li class="tbar-item">
+						<button class="btn btn-unstyled component-link tbar-link" disabled type="button">Clear All</button>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<nav class="tbar tbar-inline-xs-down subnav-tbar subnav-tbar-disabled subnav-tbar-primary">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="tbar-nav tbar-nav-wrap">
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-text">10,000 results for "<strong>Really...</strong>"</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Category: <strong>Productivity</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<a aria-label="Close" class="close disabled" href="#1" role="button" tabindex="-1">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</a>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Status: <strong>Approved</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Type: <strong>png</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" disabled type="button">
+										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										</svg>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+				<ul class="tbar-nav tbar-nav-shrink">
+					<li class="tbar-item">
+						<a class="component-link disabled tbar-link" href="#1" role="button" tabindex="-1">Apply to Root</a>
+					</li>
+					<li class="tbar-item">
+						<button class="btn btn-unstyled component-link tbar-link" disabled type="button">Clear All</button>
 					</li>
 				</ul>
 			</div>

--- a/packages/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_labels.scss
@@ -12,6 +12,15 @@ $label-anchor-hover-text-decoration: underline !default;
 $label-link-text-decoration: none !default;
 $label-link-hover-text-decoration: underline !default;
 
+// Label Close
+
+$label-close: () !default;
+$label-close: map-merge((
+	disabled-color: inherit
+), $label-close);
+
+// Label Sizes
+
 $label-lg: () !default;
 $label-lg: map-merge((
 	font-size: 0.75rem, // 12px

--- a/packages/clay-css/src/scss/atlas/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tbar.scss
@@ -4,13 +4,31 @@ $component-tbar: map-merge((
 	color: $secondary
 ), $component-tbar);
 
-// Subnav Tbar
+// Subnav Tbar Primary
 
-$subnav-tbar: () !default;
-$subnav-tbar: map-merge((
-	btn-height: 1.4375rem,
-	btn-monospaced-font-size: 0.8125rem
-), $subnav-tbar);
+$subnav-tbar-primary-component-link: () !default;
+$subnav-tbar-primary-component-link: map-merge((
+	disabled-opacity: 0.65
+), $subnav-tbar-primary-component-link);
+
+$subnav-tbar-primary-component-label-close: () !default;
+$subnav-tbar-primary-component-label-close: map-merge((
+	disabled-opacity: 0.65
+), $subnav-tbar-primary-component-label-close);
+
+// Subnav Tbar Primary Disabled
+
+$subnav-tbar-primary-disabled-component-label: () !default;
+$subnav-tbar-primary-disabled-component-label: map-merge((
+	border-color: #8E94AA
+), $subnav-tbar-primary-disabled-component-label);
+
+$subnav-tbar-primary-disabled: () !default;
+$subnav-tbar-primary-disabled: map-merge((
+	color: #8E94AA
+), $subnav-tbar-primary-disabled);
+
+// Subnav Tbar Light
 
 $subnav-tbar-light: () !default;
 $subnav-tbar-light: map-merge((

--- a/packages/clay-css/src/scss/components/_tbar.scss
+++ b/packages/clay-css/src/scss/components/_tbar.scss
@@ -8,18 +8,35 @@
 }
 
 .tbar-nav {
-	@extend %autofit-row;
-
+	display: flex;
+	flex-grow: 1;
+	flex-shrink: 1;
+	flex-wrap: nowrap;
+	list-style: none;
 	margin-bottom: 0;
+	min-width: 3.125rem;
+	padding-left: 0;
+	word-wrap: break-word;
 
 	> .tbar-item {
 		justify-content: center;
 	}
 }
 
+.tbar-nav-shrink {
+	flex-grow: 0;
+	flex-shrink: 0;
+	width: auto;
+}
+
+.tbar-nav-wrap {
+	flex-wrap: wrap;
+}
+
 .tbar-item {
 	@extend %autofit-col;
 
+	max-width: 100%;
 	padding-bottom: $tbar-item-padding-y;
 	padding-left: $tbar-item-padding-x;
 	padding-right: $tbar-item-padding-x;
@@ -44,6 +61,10 @@
 	@extend %autofit-section;
 }
 
+.tbar-link {
+	display: inline-block;
+}
+
 .tbar-btn-monospaced,
 .tbar-link-monospaced {
 	align-items: center;
@@ -58,6 +79,28 @@
 	.lexicon-icon {
 		margin-top: 0;
 	}
+}
+
+// Tbar Inline {xs|sm|md|lg|xl} Down
+
+.tbar-inline-xs-down {
+	@include clay-tbar-inline-down($tbar-inline-xs-down);
+}
+
+.tbar-inline-sm-down {
+	@include clay-tbar-inline-down($tbar-inline-sm-down);
+}
+
+.tbar-inline-md-down {
+	@include clay-tbar-inline-down($tbar-inline-md-down);
+}
+
+.tbar-inline-lg-down {
+	@include clay-tbar-inline-down($tbar-inline-lg-down);
+}
+
+.tbar-inline-xl-down {
+	@include clay-tbar-inline-down($tbar-inline-xl-down);
 }
 
 // Component Tbar
@@ -82,8 +125,14 @@
 	@include clay-tbar-variant($subnav-tbar);
 }
 
+// Subnav Tbar Variants
+
 .subnav-tbar-primary {
 	@include clay-tbar-variant($subnav-tbar-primary);
+
+	&.subnav-tbar-disabled {
+		@include clay-tbar-variant($subnav-tbar-primary-disabled);
+	}
 }
 
 .subnav-tbar-light {

--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -3,6 +3,10 @@
 	$font-size: map-get($map, font-size);
 	$height: map-get($map, height);
 	$line-height: map-get($map, line-height);
+	$margin-bottom: map-get($map, margin-bottom);
+	$margin-left: map-get($map, margin-left);
+	$margin-right: map-get($map, margin-right);
+	$margin-top: map-get($map, margin-top);
 	$padding-x: map-get($map, padding-x);
 	$padding-y: map-get($map, padding-y);
 	$text-transform: map-get($map, text-transform);
@@ -15,6 +19,10 @@
 	font-size: $font-size;
 	height: auto;
 	line-height: $line-height;
+	margin-bottom: $margin-bottom;
+	margin-left: $margin-left;
+	margin-right: $margin-right;
+	margin-top: $margin-top;
 	min-height: $height;
 	padding-bottom: $padding-y;
 	padding-left: $padding-x;
@@ -34,5 +42,78 @@
 			margin-top: $lexicon-icon-margin-top;
 			width: $lexicon-icon-width;
 		}
+	}
+}
+
+@mixin clay-label-variant($map) {
+	$bg: map-get($map, bg);
+	$border-color: map-get($map, border-color);
+	$color: map-get($map, color);
+	$text-decoration: map-get($map, text-decoration);
+	$hover-bg: map-get($map, hover-bg);
+	$hover-border-color: map-get($map, hover-border-color);
+	$hover-color: map-get($map, hover-color);
+	$hover-text-decoration: map-get($map, hover-text-decoration);
+	$focus-bg: map-get($map, focus-bg);
+	$focus-border-color: map-get($map, focus-border-color);
+	$focus-box-shadow: map-get($map, focus-box-shadow);
+	$focus-color: map-get($map, focus-color);
+	$focus-outline: map-get($map, focus-outline);
+	$focus-text-decoration: map-get($map, focus-text-decoration);
+	$disabled-bg: map-get($map, disabled-bg);
+	$disabled-border-color: map-get($map, disabled-border-color);
+	$disabled-color: map-get($map, disabled-color);
+	$link-color: map-get($map, link-color);
+	$link-text-decoration: map-get($map, link-text-decoration);
+	$link-hover-color: map-get($map, link-hover-color);
+	$link-hover-text-decoration: map-get($map, link-hover-text-decoration);
+	$close: setter(map-get($map, close), ());
+
+	background-color: $bg;
+	border-color: $border-color;
+	color: $color;
+	text-decoration: $text-decoration;
+
+	@at-root {
+		a#{&},
+		button#{&} {
+			&:hover {
+				background-color: $hover-bg;
+				border-color: $hover-border-color;
+				color: $hover-color;
+				text-decoration: $hover-text-decoration;
+			}
+
+			&:focus {
+				background-color: $focus-bg;
+				border-color: $focus-border-color;
+				box-shadow: $focus-box-shadow;
+				color: $focus-border-color;
+				outline: $focus-outline;
+				text-decoration: $focus-text-decoration;
+			}
+		}
+	}
+
+	&:disabled,
+	&.disabled {
+		background-color: $disabled-bg;
+		border-color: $disabled-border-color;
+		color: $disabled-color;
+	}
+
+	a {
+		color: $link-color;
+		text-decoration: $link-text-decoration;
+
+		&:hover,
+		&:focus {
+			color: $link-hover-color;
+			text-decoration: $link-hover-text-decoration;
+		}
+	}
+
+	.close {
+		@include clay-link($close);
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -51,6 +51,7 @@
 	$disabled-cursor: map-get($map, disabled-cursor);
 	$disabled-opacity: map-get($map, disabled-opacity);
 	$disabled-pointer-events: map-get($map, disabled-pointer-events);
+	$disabled-text-decoration: map-get($map, disabled-text-decoration);
 
 	$btn-focus-box-shadow: map-get($map, btn-focus-box-shadow);
 	$btn-focus-outline: map-get($map, btn-focus-outline);
@@ -131,6 +132,7 @@
 		cursor: $disabled-cursor;
 		opacity: $disabled-opacity;
 		pointer-events: $disabled-pointer-events;
+		text-decoration: $disabled-text-decoration;
 	}
 
 	.lexicon-icon {

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -145,6 +145,7 @@
 
 @mixin clay-text-typography($map) {
 	$color: map-get($map, color);
+	$display: map-get($map, display);
 	$font-family: map-get($map, font-family);
 	$font-size: map-get($map, font-size);
 	$font-weight: map-get($map, font-weight);
@@ -154,15 +155,18 @@
 	$margin-left: map-get($map, margin-left);
 	$margin-right: map-get($map, margin-right);
 	$margin-top: map-get($map, margin-top);
+	$max-width: map-get($map, max-width);
 	$padding-bottom: map-get($map, padding-bottom);
 	$padding-left: map-get($map, padding-left);
 	$padding-right: map-get($map, padding-right);
 	$padding-top: map-get($map, padding-top);
 	$text-transform: map-get($map, text-transform);
+	$word-wrap: map-get($map, word-wrap);
 
 	$clay-link: setter(map-get($map, clay-link), ());
 
 	color: $color;
+	display: $display;
 	font-family: $font-family;
 	font-size: $font-size;
 	font-weight: $font-weight;
@@ -172,11 +176,13 @@
 	margin-left: $margin-left;
 	margin-right: $margin-right;
 	margin-top: $margin-top;
+	max-width: $max-width;
 	padding-bottom: $padding-bottom;
 	padding-left: $padding-left;
 	padding-right: $padding-right;
 	padding-top: $padding-top;
 	text-transform: $text-transform;
+	word-wrap: $word-wrap;
 
 	a {
 		@include clay-link($clay-link);

--- a/packages/clay-css/src/scss/mixins/_tbar.scss
+++ b/packages/clay-css/src/scss/mixins/_tbar.scss
@@ -6,9 +6,12 @@
 	$color: map-get($map, color);
 	$font-size: map-get($map, font-size);
 	$height: map-get($map, height);
+	$padding-x: map-get($map, padding-x);
+	$padding-y: map-get($map, padding-y);
 
 	$strong-font-weight: map-get($map, strong-font-weight);
 
+	$item-justify-content: map-get($map, item-justify-content);
 	$item-padding-x: map-get($map, item-padding-x);
 	$item-padding-y: map-get($map, item-padding-y);
 
@@ -24,6 +27,8 @@
 	$btn-monospaced-border-radius: map-get($map, btn-monospaced-border-radius);
 	$btn-monospaced-border-width: map-get($map, btn-monospaced-border-width);
 	$btn-monospaced-font-size: map-get($map, btn-monospaced-font-size);
+	$btn-monospaced-margin-x: map-get($map, btn-monospaced-margin-x);
+	$btn-monospaced-margin-y: map-get($map, btn-monospaced-margin-y);
 	$btn-monospaced-padding: map-get($map, btn-monospaced-padding);
 	$btn-monospaced-size: setter(map-get($map, btn-monospaced-size), $btn-height);
 
@@ -35,6 +40,8 @@
 	$link-monospaced-border-radius: map-get($map, link-monospaced-border-radius);
 	$link-monospaced-border-width: map-get($map, link-monospaced-border-width);
 	$link-monospaced-font-size: map-get($map, link-monospaced-font-size);
+	$link-monospaced-margin-x: map-get($map, link-monospaced-margin-x);
+	$link-monospaced-margin-y: map-get($map, link-monospaced-margin-y);
 	$link-monospaced-padding: map-get($map, link-monospaced-padding);
 	$link-monospaced-size: map-get($map, link-monospaced-size);
 
@@ -48,6 +55,10 @@
 
 	$component-text: setter(map-get($map, component-text), ());
 
+	$component-label: setter(map-get($map, component-label), ());
+
+	$tbar-label-size: setter(map-get($map, tbar-label-size), ());
+
 	background-color: $bg-color;
 	border-color: $border-color;
 	border-style: $border-style;
@@ -55,6 +66,10 @@
 	color: $color;
 	font-size: $font-size;
 	height: $height;
+	padding-bottom: $padding-y;
+	padding-left: $padding-x;
+	padding-right: $padding-x;
+	padding-top: $padding-y;
 
 	strong {
 		font-weight: $strong-font-weight;
@@ -69,6 +84,7 @@
 	}
 
 	.tbar-item {
+		justify-content: $item-justify-content;
 		padding-bottom: $item-padding-y;
 		padding-left: $item-padding-x;
 		padding-right: $item-padding-x;
@@ -106,6 +122,10 @@
 		border-width: $btn-monospaced-border-width;
 		font-size: $btn-monospaced-font-size;
 		height: $btn-monospaced-size;
+		margin-bottom: $btn-monospaced-margin-y;
+		margin-left: $btn-monospaced-margin-x;
+		margin-right: $btn-monospaced-margin-x;
+		margin-top: $btn-monospaced-margin-y;
 		padding: $btn-monospaced-padding;
 		width: $btn-monospaced-size;
 
@@ -119,6 +139,10 @@
 		border-width: $link-monospaced-border-width;
 		font-size: $link-monospaced-font-size;
 		height: $link-monospaced-size;
+		margin-bottom: $link-monospaced-margin-y;
+		margin-left: $link-monospaced-margin-x;
+		margin-right: $link-monospaced-margin-x;
+		margin-top: $link-monospaced-margin-y;
 		padding: $link-monospaced-padding;
 		width: $link-monospaced-size;
 
@@ -137,5 +161,42 @@
 
 	.component-text {
 		@include clay-text-typography($component-text);
+	}
+
+	.component-label {
+		@include clay-label-variant($component-label);
+	}
+
+	.tbar-label {
+		@include clay-label-size($tbar-label-size);
+	}
+}
+
+@mixin clay-tbar-inline-down($map) {
+	$breakpoint-down: map-get($map, breakpoint-down);
+	$item-padding-left: map-get($map, item-padding-left);
+	$item-padding-right: map-get($map, item-padding-right);
+
+	@if ($breakpoint-down) {
+		@include media-breakpoint-down($breakpoint-down) {
+			display: block;
+
+			.container,
+			.container-fluid {
+				display: block;
+			}
+
+			.component-title,
+			.tbar-nav,
+			.tbar-section {
+				display: inline;
+			}
+
+			.tbar-item {
+				display: inline;
+				padding-left: $item-padding-left;
+				padding-right: $item-padding-right;
+			}
+		}
 	}
 }

--- a/packages/clay-css/src/scss/variables/_labels.scss
+++ b/packages/clay-css/src/scss/variables/_labels.scss
@@ -39,6 +39,7 @@ $label-close: map-merge((
 	hover-color: inherit,
 	hover-opacity: 1,
 	focus-opacity: 1,
+	disabled-opacity: $btn-disabled-opacity,
 	border-radius: 1px,
 	display: inline-flex,
 	font-size: inherit,

--- a/packages/clay-css/src/scss/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/variables/_tbar.scss
@@ -1,6 +1,38 @@
 $tbar-item-padding-x: 0.25rem !default;
 $tbar-item-padding-y: null !default;
 
+// Tbar Inline {xs|sm|md|lg|xl} Down
+
+$tbar-inline-xs-down: () !default;
+$tbar-inline-xs-down: map-merge((
+	breakpoint-down: nth(map-keys($grid-breakpoints), 1),
+	item-padding-left: 0
+), $tbar-inline-xs-down);
+
+$tbar-inline-sm-down: () !default;
+$tbar-inline-sm-down: map-merge((
+	breakpoint-down: nth(map-keys($grid-breakpoints), 2),
+	item-padding-left: 0
+), $tbar-inline-sm-down);
+
+$tbar-inline-md-down: () !default;
+$tbar-inline-md-down: map-merge((
+	breakpoint-down: nth(map-keys($grid-breakpoints), 3),
+	item-padding-left: 0
+), $tbar-inline-md-down);
+
+$tbar-inline-lg-down: () !default;
+$tbar-inline-lg-down: map-merge((
+	breakpoint-down: nth(map-keys($grid-breakpoints), 4),
+	item-padding-left: 0
+), $tbar-inline-lg-down);
+
+$tbar-inline-xl-down: () !default;
+$tbar-inline-xl-down: map-merge((
+	breakpoint-down: nth(map-keys($grid-breakpoints), 5),
+	item-padding-left: 0
+), $tbar-inline-xl-down);
+
 // Component Tbar
 
 $component-tbar: () !default;
@@ -15,9 +47,13 @@ $component-tbar: map-merge((
 
 $subnav-tbar-component-title: () !default;
 $subnav-tbar-component-title: map-merge((
+	display: inline-block,
 	font-size: 0.875rem,
 	font-weight: $font-weight-semi-bold,
-	line-height: normal
+	line-height:1.45,
+	margin-bottom: 0.25rem,
+	margin-top: 0.25rem,
+	max-width: 100%
 ), $subnav-tbar-component-title);
 
 $subnav-tbar-component-link: () !default;
@@ -27,31 +63,105 @@ $subnav-tbar-component-link: map-merge((
 	font-weight: $font-weight-semi-bold
 ), $subnav-tbar-component-link);
 
+$subnav-tbar-component-text: () !default;
+$subnav-tbar-component-text: map-merge((
+	display: inline-block,
+	line-height: 1.45,
+	margin-bottom: 0.25rem,
+	margin-top: 0.25rem,
+	max-width: 100%
+), $subnav-tbar-component-text);
+
 $subnav-tbar: () !default;
 $subnav-tbar: map-merge((
 	font-size: 0.875rem,
-	height: 2rem,
 	section-text-align: left,
 	strong-font-weight: $font-weight-semi-bold,
 	item-padding-x: 0.5rem,
-	btn-height: 1.625rem,
+	btn-height: 1.5rem,
 	btn-line-height: 1,
+	btn-margin-y: 0.125rem,
 	btn-padding-y: 0,
+	btn-monospaced-margin-y: 0.125rem,
+	btn-monospaced-padding: 0.25rem,
 	component-link: $subnav-tbar-component-link,
 	component-title: $subnav-tbar-component-title,
+	component-text: $subnav-tbar-component-text,
+	link-margin-y: 0.125rem,
 	link-padding-x: 0.25rem,
-	link-monospaced-border-radius: 0,
-	link-monospaced-border-width: 0,
-	link-monospaced-size: 2rem
+	link-padding-y: 0.09375rem,
+	link-monospaced-margin-y: 0.125rem,
+	link-monospaced-size: 1.5rem
 ), $subnav-tbar);
+
+// Subnav Tbar Variants
 
 $subnav-tbar-light: () !default;
 $subnav-tbar-light: map-merge((
 	bg-color: $light,
-	color: $navbar-light-color
+	color: $navbar-light-color,
+	padding-y: 0.125rem
 ), $subnav-tbar-light);
+
+// Subnav Tbar Primary
+
+$subnav-tbar-primary-component-link: () !default;
+$subnav-tbar-primary-component-link: map-merge((
+	color: $body-color,
+	hover-color: $body-color,
+	disabled-color: $secondary,
+	disabled-cursor: $disabled-cursor,
+	disabled-opacity: $btn-disabled-opacity,
+	disabled-text-decoration: none
+), $subnav-tbar-primary-component-link);
+
+$subnav-tbar-primary-component-label-close: () !default;
+$subnav-tbar-primary-component-label-close: map-merge((
+	focus-color: inherit,
+	disabled-color: $secondary,
+	disabled-opacity: $btn-disabled-opacity
+), $subnav-tbar-primary-component-label-close);
+
+$subnav-tbar-primary-component-label: () !default;
+$subnav-tbar-primary-component-label: map-merge((
+	close: $subnav-tbar-primary-component-label-close
+), $subnav-tbar-primary-component-label);
+
+$subnav-tbar-primary-tbar-label-size: () !default;
+$subnav-tbar-primary-tbar-label-size: map-merge((
+	font-size: 0.75rem,
+	margin-right: 0,
+	padding-x: 0.625rem,
+	padding-y: 0.3125rem,
+	text-transform: none
+), $subnav-tbar-primary-tbar-label-size);
 
 $subnav-tbar-primary: () !default;
 $subnav-tbar-primary: map-merge((
-	bg-color: lighten($primary, 32.94)
+	bg-color: lighten($primary, 32.94),
+	padding-x: 0.25rem,
+	padding-y: 0.625rem,
+	item-justify-content: flex-start,
+	item-padding-x: 0.25rem,
+	link-monospaced-border-radius: 0,
+	link-monospaced-border-width: 0,
+	link-monospaced-margin-y: -0.625rem,
+	link-monospaced-size: 3rem,
+	component-link: $subnav-tbar-primary-component-link,
+	component-label: $subnav-tbar-primary-component-label,
+	tbar-label-size: $subnav-tbar-primary-tbar-label-size
 ), $subnav-tbar-primary);
+
+// Subnav Tbar Primary Disabled
+
+$subnav-tbar-primary-disabled-component-label: () !default;
+$subnav-tbar-primary-disabled-component-label: map-merge((
+	border-color: #6C757D
+), $subnav-tbar-primary-disabled-component-label);
+
+$subnav-tbar-primary-disabled: () !default;
+$subnav-tbar-primary-disabled: map-merge((
+	bg-color: lighten(desaturate($primary, 27.03), 37.06),
+	color: #6C757D,
+	component-label: $subnav-tbar-primary-disabled-component-label
+), $subnav-tbar-primary-disabled);

--- a/packages/clay-css/src/scss/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/variables/_tbar.scss
@@ -50,7 +50,7 @@ $subnav-tbar-component-title: map-merge((
 	display: inline-block,
 	font-size: 0.875rem,
 	font-weight: $font-weight-semi-bold,
-	line-height:1.45,
+	line-height: 1.45,
 	margin-bottom: 0.25rem,
 	margin-top: 0.25rem,
 	max-width: 100%


### PR DESCRIPTION
@carloslancha The markup for this is contained under Components on the Tbar (Toolbar) page on my test site. For the disabled state to work you need to add `subnav-tbar-disabled` to `subnav-disabled-primary` and make sure every link/button has the `disabled` class or attribute.