### PR TITLE
Remove redundant aria-label in clayButton

### DIFF
--- a/packages/clay-button/src/ClayButton.soy
+++ b/packages/clay-button/src/ClayButton.soy
@@ -48,9 +48,7 @@
 
 		{if $ariaLabel}
 			aria-label="{$ariaLabel}"
-		{elseif $label}
-			aria-label="{$label}"
-		{elseif $icon}
+		{elseif $icon and not $label}
 			aria-label="{$icon}"
 		{/if}
 


### PR DESCRIPTION
If a `button` contains a label, `aria-label` should not be set.
If there is no `label` or `ariaLabel` present, use the `icon` as aria-label.

Closes #1174