### PR TITLE
[TECHNICAL-SUPPORT] LPS-85974 Minimalize gap between menu and dropdown

### DIFF
--- a/packages/clay-css/src/scss/bootstrap/_dropdown.scss
+++ b/packages/clay-css/src/scss/bootstrap/_dropdown.scss
@@ -19,7 +19,7 @@
   float: left;
   min-width: $dropdown-min-width;
   padding: $dropdown-padding-y 0;
-  margin: $dropdown-spacer 0 0; // override default ul
+  margin: 0.05rem 0 0; // override default ul
   font-size: $font-size-base; // Redeclare because nesting can cause inheritance issues
   color: $body-color;
   text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)


### PR DESCRIPTION
Hey,

[LPS-85974](https://issues.liferay.com/browse/LPS-85974),
If the dropdown is triggered on hover, It can disappear when the user passes over the gap between the menu and the dropdown, when the cursor moves slowly.
I set the top margin a bit under 1px.

Thanks,

