### PR TITLE
Fixes #1198 - Mixin `clay-menubar-vertical-variant` added options to …

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_menubar.scss
@@ -3,6 +3,10 @@
 $menubar-vertical-transparent-md: () !default;
 $menubar-vertical-transparent-md: map-merge((
 	bg-mobile: #FFF,
+	link-border-radius: 0.375rem,
+	link-border-radius-mobile: 0,
+	link-hover-bg: rgba(#272833, 0.03),
+	link-hover-color: #272833,
 	link-active-font-weight: $font-weight-semi-bold,
 	toggler-font-size-mobile: 0.875rem,
 	toggler-font-weight-mobile: $font-weight-semi-bold
@@ -13,6 +17,10 @@ $menubar-vertical-transparent-md: map-merge((
 $menubar-vertical-transparent-lg: () !default;
 $menubar-vertical-transparent-lg: map-merge((
 	bg-mobile: #FFF,
+	link-border-radius: 0.375rem,
+	link-border-radius-mobile: 0,
+	link-hover-bg: rgba(#272833, 0.03),
+	link-hover-color: #272833,
 	link-active-font-weight: $font-weight-semi-bold,
 	toggler-font-size-mobile: 0.875rem,
 	toggler-font-weight-mobile: $font-weight-semi-bold

--- a/packages/clay-css/src/scss/mixins/_menubar.scss
+++ b/packages/clay-css/src/scss/mixins/_menubar.scss
@@ -140,12 +140,18 @@
 
 	// .nav-link
 
+	$link-bg: map-get($map, link-bg);
+	$link-border-radius: map-get($map, link-border-radius);
 	$link-color: setter(map-get($map, link-color), $navbar-light-color);
+	$link-hover-bg: map-get($map, link-hover-bg);
 	$link-hover-color: setter(map-get($map, link-hover-color), $navbar-light-hover-color);
+	$link-active-bg: map-get($map, link-active-bg);
 	$link-active-color: setter(map-get($map, link-active-color), $navbar-light-active-color);
 	$link-active-font-weight: map-get($map, link-active-font-weight);
+	$link-disabled-bg: map-get($map, link-disabled-bg);
 	$link-disabled-color: setter(map-get($map, link-disabled-color), $navbar-light-disabled-color);
 
+	$link-border-radius-mobile: map-get($map, link-border-radius-mobile);
 	$link-color-mobile: setter(map-get($map, link-color-mobile), $dropdown-link-color);
 
 	$link-hover-bg-mobile: setter(map-get($map, link-hover-bg-mobile), $dropdown-link-hover-bg);
@@ -208,14 +214,17 @@
 	}
 
 	.nav-link {
+		background-color: $link-bg;
+		border-radius: $link-border-radius;
 		color: $link-color;
 
-		&:hover,
-		&:focus {
+		&:hover {
+			background-color: $link-hover-bg;
 			color: $link-hover-color;
 		}
 
 		@include media-breakpoint-down($breakpoint-down) {
+			border-radius: $link-border-radius-mobile;
 			color: $link-color-mobile;
 
 			&:hover {
@@ -225,6 +234,7 @@
 		}
 
 		&.active {
+			background-color: $link-active-bg;
 			color: $link-active-color;
 			font-weight: $link-active-font-weight;
 
@@ -236,6 +246,7 @@
 		}
 
 		&.disabled {
+			background-color: $link-disabled-bg;
 			color: $link-disabled-color;
 
 			@include media-breakpoint-down($breakpoint-down) {


### PR DESCRIPTION
…configure `link-bg`, `link-hover-bg`, `link-active-bg`, `link-disabled-bg`, `link-border-radius`, `link-border-radius-mobile`.