### PR TITLE
Fixes #1164 - Type added options to configure `$moz-osx-font-smoothin…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -23,6 +23,9 @@ $container-max-widths: (
 
 $grid-gutter-width: 24px !default;
 
+$moz-osx-font-smoothing: grayscale !default;
+$webkit-font-smoothing: antialiased !default;
+
 $font-size-base: 1rem !default; // 16px
 $font-size-lg: 1.125rem !default; // 18px
 $font-size-sm: 0.875rem !default; // 14px

--- a/packages/clay-css/src/scss/components/_type.scss
+++ b/packages/clay-css/src/scss/components/_type.scss
@@ -1,7 +1,7 @@
 body {
-	-moz-osx-font-smoothing: grayscale;
+	-moz-osx-font-smoothing: $body-moz-osx-font-smoothing;
 	-ms-overflow-style: scrollbar;
-	-webkit-font-smoothing: antialiased;
+	-webkit-font-smoothing: $body-webkit-font-smoothing;
 
 	@include clay-scale-component {
 		font-size: $font-size-base-mobile;

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -32,6 +32,9 @@ $container-view: map-merge((
 
 // Fonts
 
+$moz-osx-font-smoothing: null !default;
+$webkit-font-smoothing: null !default;
+
 $font-import-url: null !default;
 
 $font-family-serif: Georgia, "Times New Roman", Times, serif !default;
@@ -48,6 +51,9 @@ $h3-font-size-mobile: null !default;
 $h4-font-size-mobile: null !default;
 $h5-font-size-mobile: null !default;
 $h6-font-size-mobile: null !default;
+
+$body-moz-osx-font-smoothing: $moz-osx-font-smoothing !default;
+$body-webkit-font-smoothing: $webkit-font-smoothing !default;
 
 // Z-Index Variables
 


### PR DESCRIPTION
…g`, `$webkit-font-smoothing`, `$body-moz-osx-font-smoothing`, `$body-webkit-font-smoothing` and use browser default font smoothing in Base theme