### PR TITLE
Fixes #1240 - Dropdown Menu added `.dropdown-item-indicator-start` and `.dropdown-item-indicator-end` for placing icons on either side of a dropdown-item and deprecated `.dropdown-item-indicator`

### DIFF
--- a/clayui.com/content/docs/components/dropdowns.md
+++ b/clayui.com/content/docs/components/dropdowns.md
@@ -549,6 +549,112 @@ A dropdown is a list of options related to the element that triggers it.
 </div>
 ```
 
+#### Dropdown with Left and Right Icons
+
+<div class="clay-site-dropdown-menu-container">
+	<div aria-labelledby="theDropdownToggleId" class="dropdown-menu dropdown-menu-indicator-end dropdown-menu-indicator-start">
+		<ul class="list-unstyled">
+			<li>
+				<a class="dropdown-item" href="#1">
+					<span class="dropdown-item-indicator-start">
+						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-pencil">
+							<use xlink:href="/images/icons/icons.svg#pencil" />
+						</svg>
+					</span>
+					Normal Option
+					<span class="dropdown-item-indicator-end">
+						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-angle-right">
+							<use xlink:href="/images/icons/icons.svg#angle-right" />
+						</svg>
+					</span>
+				</a>
+			</li>
+			<li>
+				<a class="dropdown-item" href="#1">
+					<span class="dropdown-item-indicator-start">
+						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-view">
+							<use xlink:href="/images/icons/icons.svg#view" />
+						</svg>
+					</span>
+					Second Option
+					<span class="dropdown-item-indicator-end">
+						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-angle-right">
+							<use xlink:href="/images/icons/icons.svg#angle-right" />
+						</svg>
+					</span>
+				</a>
+			</li>
+			<li>
+				<a class="dropdown-item" href="#1">
+					<span class="dropdown-item-indicator-start">
+						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
+							<use xlink:href="/images/icons/icons.svg#check" />
+						</svg>
+					</span>
+					Third Option
+					<span class="dropdown-item-indicator-end">
+						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-angle-right">
+							<use xlink:href="/images/icons/icons.svg#angle-right" />
+						</svg>
+					</span>
+				</a>
+			</li>
+		</ul>
+	</div>
+</div>
+
+```html
+<div aria-labelledby="theDropdownToggleId" class="dropdown-menu dropdown-menu-indicator-end dropdown-menu-indicator-start">
+	<ul class="list-unstyled">
+		<li>
+			<a class="dropdown-item" href="#1">
+				<span class="dropdown-item-indicator-start">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-pencil">
+						<use xlink:href="/images/icons/icons.svg#pencil" />
+					</svg>
+				</span>
+				Normal Option
+				<span class="dropdown-item-indicator-end">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-angle-right">
+						<use xlink:href="/images/icons/icons.svg#angle-right" />
+					</svg>
+				</span>
+			</a>
+		</li>
+		<li>
+			<a class="dropdown-item" href="#1">
+				<span class="dropdown-item-indicator-start">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-view">
+						<use xlink:href="/images/icons/icons.svg#view" />
+					</svg>
+				</span>
+				Second Option
+				<span class="dropdown-item-indicator-end">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-angle-right">
+						<use xlink:href="/images/icons/icons.svg#angle-right" />
+					</svg>
+				</span>
+			</a>
+		</li>
+		<li>
+			<a class="dropdown-item" href="#1">
+				<span class="dropdown-item-indicator-start">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
+						<use xlink:href="/images/icons/icons.svg#check" />
+					</svg>
+				</span>
+				Third Option
+				<span class="dropdown-item-indicator-end">
+					<svg aria-hidden="true" class="lexicon-icon lexicon-icon-angle-right">
+						<use xlink:href="/images/icons/icons.svg#angle-right" />
+					</svg>
+				</span>
+			</a>
+		</li>
+	</ul>
+</div>
+```
+
 #### Dropdown with groups
 
 > This dropdown menu variation is for use with the management bar Filter and Order dropdown button. This configuration is used to refine the management bar UI options, providing the user with more specific mechanisms to find data.

--- a/packages/clay-css/src/content/dropdowns.html
+++ b/packages/clay-css/src/content/dropdowns.html
@@ -541,31 +541,31 @@ section: Components
 	<li class="dropdown-subheader">Dropdown Sub Header</li>
 	<li>
 		<a class="dropdown-item" href="#1">
-			<div class="dropdown-item-indicator">
+			<span class="dropdown-item-indicator-start">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 					<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 				</svg>
-			</div>
+			</span>
 			Ticket Buyer Information
 		</a>
 	</li>
 	<li>
 		<a class="dropdown-item" href="#1">
-			<div class="dropdown-item-indicator">
+			<span class="dropdown-item-indicator-start">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 					<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 				</svg>
-			</div>
+			</span>
 			Attendee Information
 		</a>
 	</li>
 	<li>
 		<a class="dropdown-item" href="#1">
-			<div class="dropdown-item-indicator">
+			<span class="dropdown-item-indicator-start">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 					<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 				</svg>
-			</div>
+			</span>
 			Seat Assignment
 		</a>
 	</li>
@@ -586,36 +586,86 @@ section: Components
 	<li>
 		<a class="active dropdown-item" href="#1">
 			Step 01
-			<div class="dropdown-item-indicator">
+			<span class="dropdown-item-indicator-end">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 					<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 				</svg>
-			</div>
+			</span>
 		</a>
 	</li>
 	<li>
 		<a class="disabled dropdown-item" href="#1" tabindex="-1">
 			Step 02
-			<div class="dropdown-item-indicator">
+			<span class="dropdown-item-indicator-end">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 					<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 				</svg>
-			</div>
+			</span>
 		</a>
 	</li>
 	<li>
 		<a class="dropdown-item" href="#1">
 			Step 03
-			<div class="dropdown-item-indicator">
+			<span class="dropdown-item-indicator-end">
 				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
 					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 				</svg>
-			</div>
+			</span>
 		</a>
 	</li>
 	<li><a class="dropdown-item" href="#1">Step 04</a></li>
 	<li><a class="dropdown-item" href="#1">Step 05</a></li>
 	<li class="dropdown-caption">Showing 190,722 of 192,842 Things</li>
+</ul>
+
+	</div>
+
+	<div class="col-md-6">
+		<h6>dropdown-menu-indicator-start</h6>
+		<h6>dropdown-menu-indicator-end</h6>
+
+<ul aria-labelledby="theDropdownToggleId" class="dropdown-menu dropdown-menu-indicator-end dropdown-menu-indicator-start">
+	<li class="dropdown-header">Dropdown Header</li>
+	<li class="dropdown-divider"></li>
+	<li class="dropdown-subheader">Dropdown Sub Header</li>
+	<li>
+		<a class="dropdown-item" href="#1">
+			<span class="dropdown-item-indicator-start">
+				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-pencil">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#pencil" />
+				</svg>
+			</span>
+			ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+			<span class="dropdown-item-indicator-end">
+				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-angle-right">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+				</svg>
+			</span>
+		</a>
+	</li>
+	<li>
+		<a class="dropdown-item" href="#1">
+			<span class="dropdown-item-indicator-start">
+				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-view">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#view" />
+				</svg>
+			</span>
+			Attendee Information
+		</a>
+	</li>
+	<li>
+		<a class="dropdown-item" href="#1">
+			<span class="dropdown-item-indicator">
+				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+				</svg>
+			</span>
+			Seat Assignment
+		</a>
+	</li>
+	<li><a class="active dropdown-item" href="#1">Dinner Preference</a></li>
+	<li><a class="dropdown-item" href="#1">Submit Payment</a></li>
+	<li class="dropdown-caption">Dropdown Caption</li>
 </ul>
 
 	</div>

--- a/packages/clay-css/src/content/management-bar.html
+++ b/packages/clay-css/src/content/management-bar.html
@@ -99,7 +99,7 @@ section: Components
 						<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
 							<li>
 								<a class="active dropdown-item" href="#1">
-									<span class="dropdown-item-indicator">
+									<span class="dropdown-item-indicator-start">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
 										</svg>
@@ -109,7 +109,7 @@ section: Components
 							</li>
 							<li>
 								<a class="dropdown-item" href="#1">
-									<span class="dropdown-item-indicator">
+									<span class="dropdown-item-indicator-start">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-table">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
 										</svg>
@@ -119,7 +119,7 @@ section: Components
 							</li>
 							<li>
 								<a class="dropdown-item" href="#1">
-									<span class="dropdown-item-indicator">
+									<span class="dropdown-item-indicator-start">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-cards2">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
 										</svg>
@@ -224,7 +224,7 @@ section: Components
 				<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
 					<li>
 						<a class="active dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
 								</svg>
@@ -234,7 +234,7 @@ section: Components
 					</li>
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-table">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
 								</svg>
@@ -244,7 +244,7 @@ section: Components
 					</li>
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-cards2">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
 								</svg>
@@ -333,7 +333,7 @@ section: Components
 				<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
 					<li>
 						<a class="active dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
 								</svg>
@@ -343,7 +343,7 @@ section: Components
 					</li>
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-table">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
 								</svg>
@@ -353,7 +353,7 @@ section: Components
 					</li>
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-cards2">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
 								</svg>
@@ -679,7 +679,7 @@ section: Components
 						<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
 							<li>
 								<a class="active dropdown-item" href="#1">
-									<span class="dropdown-item-indicator">
+									<span class="dropdown-item-indicator-start">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
 										</svg>
@@ -689,7 +689,7 @@ section: Components
 							</li>
 							<li>
 								<a class="dropdown-item" href="#1">
-									<span class="dropdown-item-indicator">
+									<span class="dropdown-item-indicator-start">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-table">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
 										</svg>
@@ -699,7 +699,7 @@ section: Components
 							</li>
 							<li>
 								<a class="dropdown-item" href="#1">
-									<span class="dropdown-item-indicator">
+									<span class="dropdown-item-indicator-start">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-cards2">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
 										</svg>
@@ -804,7 +804,7 @@ section: Components
 						<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
 							<li>
 								<a class="active dropdown-item" href="#1">
-									<span class="dropdown-item-indicator">
+									<span class="dropdown-item-indicator-start">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
 										</svg>
@@ -814,7 +814,7 @@ section: Components
 							</li>
 							<li>
 								<a class="dropdown-item" href="#1">
-									<span class="dropdown-item-indicator">
+									<span class="dropdown-item-indicator-start">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-table">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
 										</svg>
@@ -824,7 +824,7 @@ section: Components
 							</li>
 							<li>
 								<a class="dropdown-item" href="#1">
-									<span class="dropdown-item-indicator">
+									<span class="dropdown-item-indicator-start">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-cards2">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
 										</svg>

--- a/packages/clay-css/src/content/multi_step_nav.html
+++ b/packages/clay-css/src/content/multi_step_nav.html
@@ -35,7 +35,7 @@ section: Components
 							<li>
 								<a class="complete dropdown-item" href="#1">
 									1. Step One
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -45,7 +45,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									2. Step Two
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -82,7 +82,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									5. Step Five
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -92,7 +92,7 @@ section: Components
 							<li>
 								<a class="complete dropdown-item" href="#1">
 									6. Step Six
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -102,7 +102,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									7. Step Seven
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -112,7 +112,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									8. Step Eight
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -134,7 +134,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									5. Step Five
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -144,7 +144,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									6. Step Six
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -154,7 +154,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									7. Step Seven
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -164,7 +164,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									8. Step Eight
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -186,7 +186,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									5. Step Five
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -196,7 +196,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									6. Step Six
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -206,7 +206,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									7. Step Seven
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -216,7 +216,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									8. Step Eight
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -238,7 +238,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									5. Step Five
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -248,7 +248,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									6. Step Six
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -258,7 +258,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									7. Step Seven
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -268,7 +268,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									8. Step Eight
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -453,7 +453,7 @@ section: Components
 					<li>
 						<a class="active complete dropdown-item" href="#1">
 							5. Step Five
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -463,7 +463,7 @@ section: Components
 					<li>
 						<a class="complete dropdown-item" href="#1">
 							6. Step Six
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -473,7 +473,7 @@ section: Components
 					<li>
 						<a class="complete dropdown-item" href="#1">
 							7. Step Seven
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -483,7 +483,7 @@ section: Components
 					<li>
 						<a class="dropdown-item" href="#1">
 							8. Step Eight
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -554,7 +554,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									5. Step Five
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -564,7 +564,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									6. Step Six
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -574,7 +574,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									7. Step Seven
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -584,7 +584,7 @@ section: Components
 							<li>
 								<a class="dropdown-item" href="#1">
 									8. Step Eight
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -671,7 +671,7 @@ section: Components
 							<li>
 								<button class="active btn btn-unstyled complete dropdown-item" type="button">
 									5. Step Five
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -681,7 +681,7 @@ section: Components
 							<li>
 								<button class="complete btn btn-unstyled dropdown-item" type="button">
 									6. Step Six
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -691,7 +691,7 @@ section: Components
 							<li>
 								<button class="complete btn btn-unstyled dropdown-item" type="button">
 									7. Step Seven
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>
@@ -701,7 +701,7 @@ section: Components
 							<li>
 								<button class="btn btn-unstyled dropdown-item" type="button">
 									8. Step Eight
-									<span aria-hidden="true" class="dropdown-item-indicator">
+									<span aria-hidden="true" class="dropdown-item-indicator-end">
 										<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 										</svg>

--- a/packages/clay-css/src/content/nav_tabs.html
+++ b/packages/clay-css/src/content/nav_tabs.html
@@ -28,7 +28,7 @@ section: Components
 			<li>
 				<a aria-controls="setup" class="dropdown-item" data-toggle="tab" href="#setup" id="setupTab" role="tab">
 					Setup
-					<span aria-hidden="true" class="dropdown-item-indicator">
+					<span aria-hidden="true" class="dropdown-item-indicator-end">
 						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 							<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 						</svg>
@@ -38,7 +38,7 @@ section: Components
 			<li>
 				<a aria-controls="supportedClients" class="dropdown-item" data-toggle="tab" href="#supportedClients" id="supportedClientsTab" role="tab">
 					Supported Clients
-					<span aria-hidden="true" class="dropdown-item-indicator">
+					<span aria-hidden="true" class="dropdown-item-indicator-end">
 						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 							<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 						</svg>
@@ -94,7 +94,7 @@ section: Components
 					<li>
 						<button aria-controls="buttonSetup" class="dropdown-item" data-target="#buttonSetup" data-toggle="tab" id="buttonSetupTab" role="tab" type="button">
 							Setup
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -104,7 +104,7 @@ section: Components
 					<li>
 						<button aria-controls="buttonSupportedClients" class="dropdown-item" data-target="#buttonSupportedClients" data-toggle="tab" id="supportedClientsTab" role="tab">
 							Supported Clients
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -159,7 +159,7 @@ section: Components
 					<li>
 						<a aria-controls="navJustifiedSetup" class="dropdown-item" data-toggle="tab" href="#navJustifiedSetup" id="navJustifiedSetupTab" role="tab">
 							Setup
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -169,7 +169,7 @@ section: Components
 					<li>
 						<a aria-controls="navJustifiedSupportedClients" class="dropdown-item" data-toggle="tab" href="#navJustifiedSupportedClients" id="navJustifiedSupportedClientsTab" role="tab">
 							Supported Clients
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -228,7 +228,7 @@ section: Components
 					<li>
 						<a aria-controls="navTabsGridSetup" class="dropdown-item" data-toggle="tab" href="#navTabsGridSetup" id="navTabsGridSetupTab" role="tab">
 							Setup
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -238,7 +238,7 @@ section: Components
 					<li>
 						<a aria-controls="navTabsGridSupportedClients" class="dropdown-item" data-toggle="tab" href="#navTabsGridSupportedClients" id="navTabsGridSupportedClientsTab" role="tab">
 							Supported Clients
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>

--- a/packages/clay-css/src/content/nav_underline.html
+++ b/packages/clay-css/src/content/nav_underline.html
@@ -43,7 +43,7 @@ section: Components
 			<li>
 				<a aria-controls="navUnderlineSetup" class="dropdown-item" data-toggle="tab" href="#navUnderlineSetup" id="navUnderlineSetupTab" role="tab">
 					Setup
-					<span aria-hidden="true" class="dropdown-item-indicator">
+					<span aria-hidden="true" class="dropdown-item-indicator-end">
 						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 							<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 						</svg>
@@ -53,7 +53,7 @@ section: Components
 			<li>
 				<a aria-controls="navUnderlineSupportedClients" class="dropdown-item" data-toggle="tab" href="#navUnderlineSupportedClients" id="navUnderlineSupportedClientsTab" role="tab">
 					Supported Clients
-					<span aria-hidden="true" class="dropdown-item-indicator">
+					<span aria-hidden="true" class="dropdown-item-indicator-end">
 						<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 							<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 						</svg>
@@ -109,7 +109,7 @@ section: Components
 					<li>
 						<button aria-controls="buttonNavUnderlineSetup" class="dropdown-item" data-target="#buttonNavUnderlineSetup" data-toggle="tab" id="buttonNavUnderlineSetupTab" role="tab" type="button">
 							Setup
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>
@@ -119,7 +119,7 @@ section: Components
 					<li>
 						<button aria-controls="buttonNavUnderlineSupportedClients" class="dropdown-item" data-target="#buttonNavUnderlineSupportedClients" data-toggle="tab" id="buttonNavUnderlineSupportedClientsTab" role="tab" type="button">
 							Supported Clients
-							<span aria-hidden="true" class="dropdown-item-indicator">
+							<span aria-hidden="true" class="dropdown-item-indicator-end">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-check">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
 								</svg>

--- a/packages/clay-css/src/content/test_card_view_template.html
+++ b/packages/clay-css/src/content/test_card_view_template.html
@@ -164,7 +164,7 @@ section: Visual Tests
 				<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start" role="menu">
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
 								</svg>
@@ -174,7 +174,7 @@ section: Visual Tests
 					</li>
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-table">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
 								</svg>
@@ -184,7 +184,7 @@ section: Visual Tests
 					</li>
 					<li>
 						<a class="active dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-cards2">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
 								</svg>

--- a/packages/clay-css/src/content/test_list_view_template.html
+++ b/packages/clay-css/src/content/test_list_view_template.html
@@ -164,7 +164,7 @@ section: Visual Tests
 				<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start" role="menu">
 					<li>
 						<a class="active dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
 								</svg>
@@ -174,7 +174,7 @@ section: Visual Tests
 					</li>
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-table">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
 								</svg>
@@ -184,7 +184,7 @@ section: Visual Tests
 					</li>
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-cards2">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
 								</svg>

--- a/packages/clay-css/src/content/test_table_view_template.html
+++ b/packages/clay-css/src/content/test_table_view_template.html
@@ -164,7 +164,7 @@ section: Visual Tests
 				<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-list">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
 								</svg>
@@ -174,7 +174,7 @@ section: Visual Tests
 					</li>
 					<li>
 						<a class="active dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-table">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
 								</svg>
@@ -184,7 +184,7 @@ section: Visual Tests
 					</li>
 					<li>
 						<a class="dropdown-item" href="#1">
-							<span class="dropdown-item-indicator">
+							<span class="dropdown-item-indicator-start">
 								<svg aria-hidden="true" class="lexicon-icon lexicon-icon-cards2">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
 								</svg>

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -237,10 +237,21 @@
 // Dropdown Menu with Indicators
 
 .dropdown-menu-indicator-start {
+	// `.dropdown-item-indicator` is deprecated in v2.3.5 use
+	// `.dropdown-item-indicator-start` instead
 	.dropdown-item-indicator {
 		height: $dropdown-item-indicator-size;
 		left: $dropdown-item-padding-x;
 		position: absolute;
+		top: $dropdown-item-padding-y;
+		width: $dropdown-item-indicator-size;
+	}
+
+	.dropdown-item-indicator-start {
+		height: $dropdown-item-indicator-size;
+		left: $dropdown-item-padding-x;
+		position: absolute;
+		right: auto;
 		top: $dropdown-item-padding-y;
 		width: $dropdown-item-indicator-size;
 	}
@@ -254,7 +265,16 @@
 }
 
 .dropdown-menu-indicator-end {
+	// `.dropdown-item-indicator` is deprecated in v2.3.5 use
+	// `.dropdown-item-indicator-end` instead
 	.dropdown-item-indicator {
+		position: absolute;
+		right: $dropdown-item-padding-x;
+		top: $dropdown-item-padding-y;
+	}
+
+	.dropdown-item-indicator-end {
+		left: auto;
 		position: absolute;
 		right: $dropdown-item-padding-x;
 		top: $dropdown-item-padding-y;

--- a/packages/clay-css/src/scss/components/_multi-step-nav.scss
+++ b/packages/clay-css/src/scss/components/_multi-step-nav.scss
@@ -171,12 +171,18 @@
 	position: relative;
 	width: $multi-step-indicator-width;
 
-	.dropdown-item-indicator {
+	.dropdown-item-indicator,
+	.dropdown-item-indicator-start,
+	.dropdown-item-indicator-end {
 		display: none;
 	}
 
-	.complete .dropdown-item-indicator {
-		display: block;
+	.complete {
+		.dropdown-item-indicator,
+		.dropdown-item-indicator-start,
+		.dropdown-item-indicator-end {
+			display: block;
+		}
 	}
 
 	.multi-step-indicator-label {

--- a/packages/clay-css/src/scss/components/_navs.scss
+++ b/packages/clay-css/src/scss/components/_navs.scss
@@ -201,12 +201,16 @@
 }
 
 .dropdown-item[data-toggle="tab"] {
-	.dropdown-item-indicator {
+	.dropdown-item-indicator,
+	.dropdown-item-indicator-start,
+	.dropdown-item-indicator-end {
 		display: none;
 	}
 
 	&.active {
-		.dropdown-item-indicator {
+		.dropdown-item-indicator,
+		.dropdown-item-indicator-start,
+		.dropdown-item-indicator-end {
 			display: block;
 		}
 	}


### PR DESCRIPTION
The pattern for icons on both sides:
```
<ul class="dropdown-menu dropdown-menu-indicator-end dropdown-menu-indicator-start">
    <li>
        <a class="dropdown-item">
            <span class="dropdown-item-indicator-start">
                <svg></svg>
            </span>
            Text
            <span class="dropdown-item-indicator-end">
                <svg></svg>
            </span>
        </a>
    </li>
</ul>
```

The pattern for icons on left:
```
<ul class="dropdown-menu dropdown-menu-indicator-start">
    <li>
        <a class="dropdown-item">
            <span class="dropdown-item-indicator-start">
                <svg></svg>
            </span>
            Text
        </a>
    </li>
</ul>
```

The pattern for icons on right:
```
<ul class="dropdown-menu dropdown-menu-indicator-end">
    <li>
        <a class="dropdown-item">
            Text
            <span class="dropdown-item-indicator-end">
                <svg></svg>
            </span>
        </a>
    </li>
</ul>
```