### PR TITLE
Allow overriding of highlight color

### DIFF
--- a/packages/clay-css/src/scss/mixins/_type.scss
+++ b/packages/clay-css/src/scss/mixins/_type.scss
@@ -2,7 +2,7 @@
 // @param $bg-color - Color of the highlight
 // @param $color - Colors the text
 
-@mixin clay-highlight-text($bg-color: theme-color-level(warning, -10), $color: $body-color) {
+@mixin clay-highlight-text($bg-color: $highlight-color, $color: $body-color) {
 	background-color: $bg-color;
 	box-decoration-break: clone;
 	box-shadow: -0.25em 0 0 $bg-color;

--- a/packages/clay-css/src/scss/variables/_type.scss
+++ b/packages/clay-css/src/scss/variables/_type.scss
@@ -4,3 +4,6 @@ $strong-font-weight: null !default;
 
 $reference-mark-font-size: 0.75rem !default;
 $reference-mark-vertical-align: super !default;
+
+$highlight-bg-color: theme-color-level(warning, -10) !default;
+$highlight-text-color: $body-color !default;


### PR DESCRIPTION
Currently there is no easy way of overriding the highlight color. I extracted the default mixin parameters to sass variables.