### PR TITLE
Fixes #1266 Reflow sidenav to prevent issue in IE11

### DIFF
--- a/packages/clay-css/src/js/side-navigation.js
+++ b/packages/clay-css/src/js/side-navigation.js
@@ -934,6 +934,8 @@
 
 				instance._renderNav();
 			}
+
+			container.css({display: ''});
 		},
 
 		_setScreenSize: function() {


### PR DESCRIPTION
Fixes https://github.com/liferay/clay/issues/1266
https://issues.liferay.com/browse/LPS-86163

Being able to reflow the content will fix the issue in IE11. I was able to find examples of reflowing content which can be found [here](https://github.com/liferay/clay/blob/1.x/src/js/bootstrap/tab.js#L87). I was unable to get the reflow to work using offsetWidth and found using .css() worked. Adding the reflow to _renderUI will make sure this issue will not be reproducible for any sidenav created.
Let me know if there is a better way to cause the reflow and if there are any questions or comments.

Thank you.