### PR TITLE
Fixes #1285 - API proposal to ClayLabelsInputField component

### DIFF
--- a/packages/clay-label/package.json
+++ b/packages/clay-label/package.json
@@ -28,10 +28,10 @@
     "metal"
   ],
   "dependencies": {
+    "clay-component": "^2.4.0",
     "clay-button": "^2.4.0",
     "clay-link": "^2.4.0",
     "metal": "^2.16.0",
-    "metal-component": "^2.16.0",
     "metal-soy": "^2.16.0",
     "metal-state": "^2.16.0",
     "metal-web-component": "^2.16.0"

--- a/packages/clay-label/src/ClayLabel.js
+++ b/packages/clay-label/src/ClayLabel.js
@@ -1,23 +1,31 @@
 import 'clay-button';
 import 'clay-link';
-import Component from 'metal-component';
+import {Config} from 'metal-state';
+import ClayComponent from 'clay-component';
 import defineWebComponent from 'metal-web-component';
 import Soy from 'metal-soy';
-import {Config} from 'metal-state';
 
 import templates from './ClayLabel.soy.js';
 
 /**
  * Metal Clay Label component.
- * @extends Component
+ * @extends ClayComponent
  */
-class ClayLabel extends Component {
+class ClayLabel extends ClayComponent {
 	/**
 	 * Handle `click` button and emit event `close`.
+	 * @param {!Event} event
 	 * @protected
+	 * @return {Boolean} If the event has been prevented or not.
 	 */
-	_handleCloseButtonClick() {
-		this.emit('close');
+	_handleCloseButtonClick(event) {
+		return !this.emit({
+			data: {
+				label: this.label,
+			},
+			name: 'close',
+			originalEvent: event,
+		});
 	}
 }
 

--- a/packages/clay-label/src/__tests__/ClayLabel.js
+++ b/packages/clay-label/src/__tests__/ClayLabel.js
@@ -128,6 +128,14 @@ describe('ClayLabel', function() {
 		label.refs.closeButton.element.click();
 
 		expect(spy).toHaveBeenCalled();
-		expect(spy).toHaveBeenCalledWith('close');
+		expect(spy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: {
+					label: expect.any(String),
+				},
+				name: 'close',
+				originalEvent: expect.any(Object),
+			})
+		);
 	});
 });

--- a/packages/clay-labels-input-field/LICENSE.md
+++ b/packages/clay-labels-input-field/LICENSE.md
@@ -1,0 +1,29 @@
+# Software License Agreement (BSD License)
+
+Copyright (c) 2014, Liferay Inc.
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+* The name of Liferay Inc. may not be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of Liferay Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/clay-labels-input-field/README.md
+++ b/packages/clay-labels-input-field/README.md
@@ -1,0 +1,25 @@
+# clay-labels-input-field
+
+
+## Setup
+
+1. Install NodeJS >= v0.12.0 and NPM >= v3.0.0, if you don't have it yet. You
+can find it [here](https://nodejs.org).
+
+2. Install local dependencies:
+
+  ```
+  npm install
+  ```
+
+3. Build the code:
+
+  ```
+  npm run build
+  ```
+
+4. Open the demo at demos/index.html on your browser.
+
+## Contribute
+
+We'd love to get contributions from you! Please, check our [Contributing Guidelines](CONTRIBUTING.md) to see how you can help us improve.

--- a/packages/clay-labels-input-field/demos/a11y.html
+++ b/packages/clay-labels-input-field/demos/a11y.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Demo: ClayLabelsInputField</title>
+
+	<link rel="stylesheet" href="../../../node_modules/clay-css/lib/css/atlas.css">
+
+	<style>
+		body {
+			background-color: #FFF;
+		}
+
+		.row {
+			margin-bottom: 20px;
+		}
+	</style>
+
+	<script src="../build/globals/clay-labels-input-field.js"></script>
+</head>
+<body class="container" role="main">
+	<h1 class="page-title" id="pageTitle">
+		ClayLabelsInputField
+	</h1>
+
+	<div class="row row-spacing">
+		<div class="col">
+			<h2>Default State</h2>
+			<div id="default-block"></div>
+		</div>
+	</div>
+
+	<div class="row row-spacing">
+		<div class="col">
+			<h2>With autocomplete</h2>
+			<div id="autocomplete-block"></div>
+		</div>
+	</div>
+
+	<div class="row row-spacing">
+		<div class="col">
+			<h2>With autocomplete and interaction</h2>
+			<div id="interaction-block"></div>
+		</div>
+	</div>
+
+	<script type="text/javascript">
+
+		const spritemap = '../../../node_modules/clay-css/lib/images/icons/icons.svg';
+		const selectedLabels = [
+			{
+				label: 'bread'
+			},
+			{
+				label: 'ammonia cookie'
+			}
+		];
+		const dataProvider = [
+			'Bread',
+			'Ammonia cookie',
+			'Cuisine of Antebellum America',
+			'Apple butter',
+			'Apple sauce',
+			'Baked potato',
+			'Barbecue',
+			'Bear claw',
+			'Beef Manhattan',
+			'Blue cheese dressing',
+			'Blue-plate special',
+			'Bookbinder soup',
+			'Breakfast burrito',
+			'Brunswick stew',
+			'Buffalo burger',
+			'Buffalo wing',
+			'Bull roast',
+			'Burnt ends',
+			'Butter cookie',
+		];
+
+		// Default State
+		new metal.ClayLabelsInputField({
+			helpText: 'You can use a comma to enter tags',
+			label: 'Tags',
+			selectedLabels,
+			spritemap,
+		}, '#default-block');
+
+		// With autocomplete
+		new metal.ClayLabelsInputField({
+			events: {
+				queryChange: (event) => {
+					const query = event.data.value;
+
+					if (query) {
+						const filterAutocomplete = event.target.filterAutocomplete;
+						event.target.filteredItems = filterAutocomplete(dataProvider, query);
+					} else {
+						event.target.filteredItems = [];
+					}
+				}
+			},
+			helpText: 'You can use a comma to enter tags',
+			label: 'Tags',
+			selectedLabels,
+			spritemap,
+		}, '#autocomplete-block');
+
+		// With autocomplete and interaction
+		new metal.ClayLabelsInputField({
+			label: 'Tags',
+			selectedLabels,
+			spritemap,
+			events: {
+				labelAdded: (event) => {
+					selectedLabels.push({label: event.data.value});
+					event.target.selectedLabels = selectedLabels;
+					event.target.clearInput();
+					event.target.filteredItems = [];
+				},
+				labelRemoved: (event) => {
+					selectedLabels.splice(Number(event.data.index), 1);
+					event.target.selectedLabels = selectedLabels;
+				},
+				queryChange: (event) => {
+					const query = event.data.value;
+
+					if (query) {
+						const filterAutocomplete = event.target.filterAutocomplete;
+						event.target.filteredItems = filterAutocomplete(dataProvider, query);
+					} else {
+						event.target.filteredItems = [];
+					}
+				}
+			},
+			helpText: 'You can use a comma to enter tags',
+		}, '#interaction-block');
+
+	</script>
+</body>
+</html>

--- a/packages/clay-labels-input-field/demos/index.html
+++ b/packages/clay-labels-input-field/demos/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Demo: ClayLabelsInputField</title>
+
+	<link rel="stylesheet" href="../../../node_modules/clay-css/lib/css/atlas.css">
+
+	<style>
+		body {
+			background-color: #FFF;
+		}
+
+		.row {
+			margin-bottom: 20px;
+		}
+
+		.label-focus {
+			background-color: #0B5FFF;
+			border-color: #0B5FFF;
+			color: #FFF;
+		}
+
+		.dropdown-full {
+			position: relative;
+		}
+	</style>
+
+	<script src="../build/globals/clay-labels-input-field.js"></script>
+</head>
+<body class="container" role="main">
+	<h1 class="page-title" id="pageTitle">
+		ClayLabelsInputField
+	</h1>
+
+	<div class="row row-spacing">
+		<div class="col">
+			<h2>Default State</h2>
+			<div id="default-block"></div>
+		</div>
+	</div>
+
+	<div class="row row-spacing">
+		<div class="col">
+			<h2>With autocomplete</h2>
+			<div id="autocomplete-block"></div>
+		</div>
+	</div>
+
+	<div class="row row-spacing">
+		<div class="col">
+			<h2>With autocomplete and interaction</h2>
+			<div id="interaction-block"></div>
+		</div>
+	</div>
+
+	<script type="text/javascript">
+
+		const spritemap = '../../../node_modules/clay-css/lib/images/icons/icons.svg';
+		const selectedLabels = [
+			{
+				label: 'bread'
+			},
+			{
+				label: 'ammonia cookie'
+			}
+		];
+		const dataProvider = [
+			'Bread',
+			'Ammonia cookie',
+			'Cuisine of Antebellum America',
+			'Apple butter',
+			'Apple sauce',
+			'Baked potato',
+			'Barbecue',
+			'Bear claw',
+			'Beef Manhattan',
+			'Blue cheese dressing',
+			'Blue-plate special',
+			'Bookbinder soup',
+			'Breakfast burrito',
+			'Brunswick stew',
+			'Buffalo burger',
+			'Buffalo wing',
+			'Bull roast',
+			'Burnt ends',
+			'Butter cookie',
+		];
+
+		// Default State
+		new metal.ClayLabelsInputField({
+			helpText: 'You can use a comma to enter tags',
+			label: 'Tags',
+			selectedLabels,
+			spritemap,
+		}, '#default-block');
+
+		// With autocomplete
+		new metal.ClayLabelsInputField({
+			events: {
+				queryChange: (event) => {
+					const query = event.data.value;
+
+					if (query) {
+						const filterAutocomplete = event.target.filterAutocomplete;
+						event.target.filteredItems = filterAutocomplete(dataProvider, query);
+					} else {
+						event.target.filteredItems = [];
+					}
+				}
+			},
+			helpText: 'You can use a comma to enter tags',
+			label: 'Tags',
+			selectedLabels,
+			spritemap,
+		}, '#autocomplete-block');
+
+		// With autocomplete and interaction
+		new metal.ClayLabelsInputField({
+			label: 'Tags',
+			selectedLabels,
+			spritemap,
+			events: {
+				labelAdded: (event) => {
+					selectedLabels.push({label: event.data.value});
+					event.target.selectedLabels = selectedLabels;
+					event.target.clearInput();
+					event.target.filteredItems = [];
+				},
+				labelRemoved: (event) => {
+					selectedLabels.splice(Number(event.data.index), 1);
+					event.target.selectedLabels = selectedLabels;
+				},
+				queryChange: (event) => {
+					const query = event.data.value;
+
+					if (query) {
+						const filterAutocomplete = event.target.filterAutocomplete;
+						event.target.filteredItems = filterAutocomplete(dataProvider, query);
+					} else {
+						event.target.filteredItems = [];
+					}
+				}
+			},
+			helpText: 'You can use a comma to enter tags',
+		}, '#interaction-block');
+
+	</script>
+</body>
+</html>

--- a/packages/clay-labels-input-field/package.json
+++ b/packages/clay-labels-input-field/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "clay-labels-input-field",
+  "version": "2.3.4",
+  "description": "Metal ClayLabelsInputField component",
+  "license": "BSD",
+  "repository": "https://github.com/liferay/clay/tree/master/packages/clay-labels-input-field",
+  "engines": {
+    "node": ">=0.12.0",
+    "npm": ">=3.0.0"
+  },
+  "main": "lib/ClayLabelsInputField.js",
+  "esnext:main": "src/ClayLabelsInputField.js",
+  "jsnext:main": "src/ClayLabelsInputField.js",
+  "files": [
+    "lib",
+    "src",
+    "test"
+  ],
+  "scripts": {
+    "build": "npm run soy && webpack",
+    "compile": "babel -d lib/ src/ -s --ignore src/__tests__",
+    "prepublish": "npm run soy && npm run compile",
+    "soy": "metalsoy --soyDeps '../../node_modules/clay-+(label|button|link|icon)/src/**/*.soy'"
+  },
+  "keywords": [
+    "clay",
+    "metal"
+  ],
+  "dependencies": {
+    "clay-button": "^2.3.4",
+    "clay-component": "^2.3.4",
+    "clay-label": "^2.3.4",
+    "metal": "^2.16.0",
+    "metal-component": "^2.16.0",
+    "metal-soy": "^2.16.0",
+    "metal-state": "^2.16.0",
+    "metal-web-component": "^2.16.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.0.0",
+    "babel-plugin-transform-node-env-inline": "^0.1.1",
+    "babel-preset-env": "^1.6.0",
+    "browserslist-config-clay": "^2.1.12",
+    "clay-css": "^2.1.12",
+    "metal-tools-soy": "^6.0.0",
+    "webpack": "^3.0.0",
+    "webpack-config-clay": "^2.1.12"
+  },
+  "browserslist": [
+    "extends browserslist-config-clay"
+  ]
+}

--- a/packages/clay-labels-input-field/src/ClayLabelsInputField.js
+++ b/packages/clay-labels-input-field/src/ClayLabelsInputField.js
@@ -1,0 +1,422 @@
+import 'clay-button';
+import 'clay-label';
+import {Config} from 'metal-state';
+import {EventHandler} from 'metal-events';
+import {match} from './utils';
+import ClayComponent from 'clay-component';
+import defineWebComponent from 'metal-web-component';
+import Soy from 'metal-soy';
+
+import templates from './ClayLabelsInputField.soy.js';
+
+/**
+ * Metal ClayLabelsInputField component.
+ * @extends ClayComponent
+ */
+class ClayLabelsInputField extends ClayComponent {
+	/**
+	 * Get the value typed in the input or through the filtered items.
+	 * @param {!Event} event
+	 * @protected
+	 * @return {string}
+	 */
+	_getLabelFromEvent(event) {
+		const {tagName} = event.target;
+
+		if (tagName === 'INPUT') {
+			return event.target.value.toLowerCase().replace(',', '');
+		} else if (tagName === 'A') {
+			const index = event.target.getAttribute('data-dropdown-item-index');
+			const element = this.filteredItems[Number(index)];
+
+			return element.originalString.toLowerCase();
+		}
+	}
+
+	/**
+	 * Continues the propagation of the Button clicked event.
+	 * @param {!Event} event
+	 * @protected
+	 * @return {Boolean} If the event has been prevented or not.
+	 */
+	_handleButtonClicked(event) {
+		return !this.emit({
+			name: 'buttonClicked',
+			originalEvent: event,
+		});
+	}
+
+	/**
+	 * Handle the click on the close label button.
+	 * @param {!Object} data
+	 * @protected
+	 * @return {Boolean} If the event has been prevented or not.
+	 */
+	_handleCloseButtonClick(data) {
+		return this._handleLabelRemoved(data.target.element);
+	}
+
+	/**
+	 * Handle the click on the dropdown item and the propagation of the labelAdded event.
+	 * @param {!Event} event
+	 * @protected
+	 * @return {Boolean} If the event has been prevented or not.
+	 */
+	_handleDropdownItemClick(event) {
+		return this._handleLabelAdded(event);
+	}
+
+	/**
+	 * Continues the propagation of the labelAdded event.
+	 * @param {!Event} event
+	 * @protected
+	 * @return {Boolean} If the event has been prevented or not.
+	 */
+	_handleLabelAdded(event) {
+		const label = this._getLabelFromEvent(event);
+
+		if (
+			label.trim() &&
+			!this.selectedLabels
+				.find((labelSelected) => labelSelected.label === label)
+		) {
+			return !this.emit({
+				data: {
+					value: label,
+				},
+				name: 'labelAdded',
+				originalEvent: event,
+			});
+		} else {
+			this.refs.input.value = label;
+		}
+	}
+
+	/**
+	 * Handle the focus on the selected labels and triggers the focused label event.
+	 * @param {!Event} event
+	 * @param {?Boolean} direction
+	 * @protected
+	 * @return {Boolean} If the event has been prevented or not.
+	 */
+	_handleLabelFocus(event, direction) {
+		if (this.selectedLabels.length) {
+			const {formGroupInput} = this.refs;
+			const items = formGroupInput.querySelectorAll('span[id="item-tag"]');
+
+			if (this._labelFocused) {
+				const index = this._labelFocused.getAttribute('data-tag');
+				const condition = direction
+					? Number(index) - 1
+					: Number(index) + 1;
+
+				if (condition > (items.length - 1)) {
+					this.refs.input.focus();
+					this._removeFocusedLabel();
+					return false;
+				} else if (condition >= 0) {
+					this._labelFocused.classList.remove('label-focus');
+					this._labelFocused = items[condition];
+					this._labelFocused.classList.add('label-focus');
+				} else {
+					return false;
+				}
+			} else {
+				this._labelFocused = items[items.length - 1];
+				this._labelFocused.classList.toggle('label-focus');
+			}
+
+			return !this.emit({
+				data: {
+					item: this._labelFocused,
+				},
+				name: 'labelFocused',
+				originalEvent: event,
+			});
+		}
+	}
+
+	/**
+	 * Handle the focused label removal and propagating the labelRemoved event.
+	 * @param {!Event} event
+	 * @protected
+	 * @return {Boolean} If the event has been prevented or not.
+	 */
+	_handleLabelRemoved(event) {
+		const index = event.getAttribute('data-tag');
+
+		this._removeFocusedLabel();
+
+		return !this.emit({
+			data: {
+				index,
+			},
+			name: 'labelRemoved',
+			originalEvent: event,
+		});
+	}
+
+	/**
+	 * Handles input changes and propagates the queryChange event.
+	 * @param {!Event} event
+	 * @protected
+	 * @return {Boolean} If the event has been prevented or not.
+	 */
+	_handleOnInput(event) {
+		const value = event.target.value.toLowerCase();
+
+		this._removeFocusedLabel();
+
+		switch (event.data) {
+		case ',':
+			return this._handleLabelAdded(event);
+		default:
+			return !this.emit({
+				data: {
+					value,
+				},
+				name: 'queryChange',
+				originalEvent: event,
+			});
+		}
+	}
+
+	/**
+	 * Handles form interactions and propagates corresponding events.
+	 * @param {!Event} event
+	 * @protected
+	 * @return {Boolean} If the event has been prevented or not.
+	 */
+	_handleOnKeydown(event) {
+		switch (event.key) {
+		case 'Enter':
+			event.preventDefault();
+			if (this._labelFocused) {
+				return this._handleLabelRemoved(this._labelFocused);
+			} else {
+				return this._handleLabelAdded(event);
+			}
+		case 'Backspace':
+			if (!this.refs.input.value) {
+				if (!this._labelFocused) {
+					return this._handleLabelFocus(event);
+				} else {
+					return this._handleLabelRemoved(this._labelFocused);
+				}
+			}
+			break;
+		case 'ArrowLeft':
+			if (!this.refs.input.value && this._labelFocused) {
+				return this._handleLabelFocus(event, true);
+			}
+			break;
+		case 'ArrowRight':
+			if (!this.refs.input.value && this._labelFocused) {
+				return this._handleLabelFocus(event, false);
+			}
+			break;
+		case 'ArrowUp':
+			this._setFocusItemDropdown(true);
+			break;
+		case 'ArrowDown':
+			this._setFocusItemDropdown(false);
+			break;
+		}
+	}
+
+	/**
+	 * Removes the focus from the focused element.
+	 * @protected
+	 */
+	_removeFocusedLabel() {
+		if (this._labelFocused) {
+			this._labelFocused.classList.remove('label-focus');
+			this._labelFocused = null;
+		}
+	}
+
+	/**
+	 * Handle the interactions in the dropdown and add focus on the items.
+	 * @protected
+	 * @param {!Boolean} direction
+	 */
+	_setFocusItemDropdown(direction) {
+		if (this.filteredItems.length) {
+			const elements = this.refs.dropdown.querySelectorAll('a[id="item"]');
+
+			if (direction && this._dropdownItemFocused === 0) {
+				this.refs.input.focus();
+				this._dropdownItemFocused = null;
+			} else {
+				this._dropdownItemFocused =
+					this._dropdownItemFocused === null
+					|| (elements.length - 1) === this._dropdownItemFocused
+						? 0
+						: direction
+							? this._dropdownItemFocused - 1
+							: this._dropdownItemFocused + 1;
+
+				elements[this._dropdownItemFocused].focus();
+			}
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	attached() {
+		this._labelFocused = null;
+		this._dropdownItemFocused = null;
+	}
+
+	/**
+	 * Clears the input value.
+	 * @public
+	 */
+	clearInput() {
+		this.refs.input.value = '';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	created() {
+		this._eventHandler = new EventHandler();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	disposed() {
+		this._eventHandler.removeAllListeners();
+	}
+
+	/**
+	 * Helper method to filter a list based on a string.
+	 * @param {!Array<string>} data
+	 * @param {!string} query
+	 * @public
+	 * @return {Array} A list of items containing the corresponding characters
+	 */
+	filterAutocomplete(data, query) {
+		return data
+			.reduce((prev, element, index) => {
+				let result = match(query, element);
+
+				if (result != null) {
+					prev[prev.length] = {
+						index,
+						matches: result.values,
+						originalString: element,
+						score: result.score,
+					};
+				}
+
+				return prev;
+			}, [])
+			.sort((a, b) => {
+				if (a > b) return 1;
+				if (a < b) return -1;
+			});
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	syncFilteredItems() {
+		this._dropdownItemFocused = null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	syncSelectedLabels() {
+		this.refs.input.focus();
+	}
+}
+
+/**
+ * State definition.
+ * @static
+ * @type {!Object}
+ */
+ClayLabelsInputField.STATE = {
+	/**
+	 * Variation name to render different deltemplates.
+	 * @default undefined
+	 * @instance
+	 * @memberof ClayLabelsInputField
+	 * @type {?(string|undefined)}
+	 */
+	contentRenderer: Config.string(),
+
+	/**
+	 * CSS classes to be applied to the element.
+	 * @default undefined
+	 * @instance
+	 * @memberof ClayLabelsInputField
+	 * @type {?(string|undefined)}
+	 */
+	elementClasses: Config.string(),
+
+	/**
+	 * List of filtered items for suggestion or autocomplete.
+	 * @default []
+	 * @instance
+	 * @memberof ClayLabelsInputField
+	 * @type {?Array}
+	 */
+	filteredItems: Config.array(Config.object()).value([]),
+
+	/**
+	 * Help text to guide the user in the interaction.
+	 * @default undefined
+	 * @instance
+	 * @memberof ClayLabelsInputField
+	 * @type {!string}
+	 */
+	helpText: Config.string().required(),
+
+	/**
+     * Id to be applied to the element.
+     * @default undefined
+     * @instance
+     * @memberof ClayLabelsInputField
+     * @type {?(string|undefined)}
+     */
+	id: Config.string(),
+
+	/**
+	 * Label of the input element.
+	 * @default undefined
+	 * @instance
+	 * @memberof ClayLabelsInputField
+	 * @type {?(string|undefined)}
+	 */
+	label: Config.string(),
+
+	/**
+	 * List of the selected Labels.
+	 * @default []
+	 * @instance
+	 * @memberof ClayLabelsInputField
+	 * @type {?Array<Object>}
+	 */
+	selectedLabels: Config.array(Config.object()).value([]),
+
+	/**
+	 * The path to the SVG spritemap file containing the icons.
+	 * @default undefined
+	 * @instance
+	 * @memberof ClayLabelsInputField
+	 * @type {!string}
+	 */
+	spritemap: Config.string().required(),
+};
+
+defineWebComponent('clay-labels-input-field', ClayLabelsInputField);
+
+Soy.register(ClayLabelsInputField, templates);
+
+export {ClayLabelsInputField};
+export default ClayLabelsInputField;

--- a/packages/clay-labels-input-field/src/ClayLabelsInputField.js
+++ b/packages/clay-labels-input-field/src/ClayLabelsInputField.js
@@ -77,8 +77,9 @@ class ClayLabelsInputField extends ClayComponent {
 
 		if (
 			label.trim() &&
-			!this.selectedLabels
-				.find((labelSelected) => labelSelected.label === label)
+			!this.selectedLabels.find(
+				labelSelected => labelSelected.label === label
+			)
 		) {
 			return !this.emit({
 				data: {
@@ -102,7 +103,9 @@ class ClayLabelsInputField extends ClayComponent {
 	_handleLabelFocus(event, direction) {
 		if (this.selectedLabels.length) {
 			const {formGroupInput} = this.refs;
-			const items = formGroupInput.querySelectorAll('span[id="item-tag"]');
+			const items = formGroupInput.querySelectorAll(
+				'span[id="item-tag"]'
+			);
 
 			if (this._labelFocused) {
 				const index = this._labelFocused.getAttribute('data-tag');
@@ -110,7 +113,7 @@ class ClayLabelsInputField extends ClayComponent {
 					? Number(index) - 1
 					: Number(index) + 1;
 
-				if (condition > (items.length - 1)) {
+				if (condition > items.length - 1) {
 					this.refs.input.focus();
 					this._removeFocusedLabel();
 					return false;
@@ -242,15 +245,17 @@ class ClayLabelsInputField extends ClayComponent {
 	 */
 	_setFocusItemDropdown(direction) {
 		if (this.filteredItems.length) {
-			const elements = this.refs.dropdown.querySelectorAll('a[id="item"]');
+			const elements = this.refs.dropdown.querySelectorAll(
+				'a[id="item"]'
+			);
 
 			if (direction && this._dropdownItemFocused === 0) {
 				this.refs.input.focus();
 				this._dropdownItemFocused = null;
 			} else {
 				this._dropdownItemFocused =
-					this._dropdownItemFocused === null
-					|| (elements.length - 1) === this._dropdownItemFocused
+					this._dropdownItemFocused === null ||
+					elements.length - 1 === this._dropdownItemFocused
 						? 0
 						: direction
 							? this._dropdownItemFocused - 1
@@ -378,12 +383,12 @@ ClayLabelsInputField.STATE = {
 	helpText: Config.string().required(),
 
 	/**
-     * Id to be applied to the element.
-     * @default undefined
-     * @instance
-     * @memberof ClayLabelsInputField
-     * @type {?(string|undefined)}
-     */
+	 * Id to be applied to the element.
+	 * @default undefined
+	 * @instance
+	 * @memberof ClayLabelsInputField
+	 * @type {?(string|undefined)}
+	 */
 	id: Config.string(),
 
 	/**

--- a/packages/clay-labels-input-field/src/ClayLabelsInputField.soy
+++ b/packages/clay-labels-input-field/src/ClayLabelsInputField.soy
@@ -4,6 +4,7 @@
  * This renders the component's whole content.
  */
 {template .render}
+	{@param helpText: string}
 	{@param spritemap: string}
 	{@param? _handleButtonClicked: any}
 	{@param? _handleCloseButtonClick: any}
@@ -14,7 +15,6 @@
 	{@param? contentRenderer: string}
 	{@param? elementClasses: string}
 	{@param? filteredItems: list<?>}
-	{@param? helpText: string}
 	{@param? id: string}
 	{@param? label: string}
 	{@param? selectedLabels: list<?>}
@@ -53,6 +53,7 @@
 {/template}
 
 {template .content}
+	{@param helpText: string}
 	{@param spritemap: string}
 	{@param? _handleButtonClicked: any}
 	{@param? _handleCloseButtonClick: any}
@@ -62,7 +63,6 @@
 	{@param? _removeFocusedLabel: any}
 	{@param? contentRenderer: string}
 	{@param? filteredItems: list<?>}
-	{@param? helpText: string}
 	{@param? selectedLabels: list<?>}
 
 	<div class="input-group input-group-stacked-sm-down">
@@ -111,7 +111,7 @@
 				</ul>
 			</div>
 
-			{if $helpText and not $isVisible}
+			{if not $isVisible}
 				<div class="form-feedback-group">
 					<div class="form-text">
 						{$helpText}

--- a/packages/clay-labels-input-field/src/ClayLabelsInputField.soy
+++ b/packages/clay-labels-input-field/src/ClayLabelsInputField.soy
@@ -1,0 +1,171 @@
+{namespace ClayLabelsInputField}
+
+/**
+ * This renders the component's whole content.
+ */
+{template .render}
+	{@param spritemap: string}
+	{@param? _handleButtonClicked: any}
+	{@param? _handleCloseButtonClick: any}
+	{@param? _handleDropdownItemClick: any}
+	{@param? _handleOnInput: any}
+	{@param? _handleOnKeydown: any}
+	{@param? _removeFocusedLabel: any}
+	{@param? contentRenderer: string}
+	{@param? elementClasses: string}
+	{@param? filteredItems: list<?>}
+	{@param? helpText: string}
+	{@param? id: string}
+	{@param? label: string}
+	{@param? selectedLabels: list<?>}
+
+	{let $attributes kind="attributes"}
+		class="from-group
+			{if $elementClasses}
+				{sp}{$elementClasses}
+			{/if}
+		"
+
+		{if $id}
+			id="{$id}"
+		{/if}
+	{/let}
+
+	<div {$attributes}>
+		{if $label}
+			<label>{$label}</label>
+		{/if}
+
+		{call .content}
+			{param _handleButtonClicked: $_handleButtonClicked /}
+			{param _handleCloseButtonClick: $_handleCloseButtonClick /}
+			{param _handleDropdownItemClick: $_handleDropdownItemClick /}
+			{param _handleOnInput: $_handleOnInput /}
+			{param _handleOnKeydown: $_handleOnKeydown /}
+			{param _removeFocusedLabel: $_removeFocusedLabel /}
+			{param contentRenderer: $contentRenderer /}
+			{param filteredItems: $filteredItems /}
+			{param helpText: $helpText /}
+			{param selectedLabels: $selectedLabels /}
+			{param spritemap: $spritemap /}
+		{/call}
+	</div>
+{/template}
+
+{template .content}
+	{@param spritemap: string}
+	{@param? _handleButtonClicked: any}
+	{@param? _handleCloseButtonClick: any}
+	{@param? _handleDropdownItemClick: any}
+	{@param? _handleOnInput: any}
+	{@param? _handleOnKeydown: any}
+	{@param? _removeFocusedLabel: any}
+	{@param? contentRenderer: string}
+	{@param? filteredItems: list<?>}
+	{@param? helpText: string}
+	{@param? selectedLabels: list<?>}
+
+	<div class="input-group input-group-stacked-sm-down">
+		<div class="input-group-item">
+			<div data-keydown="{$_handleOnKeydown}" ref="formGroupInput" class="form-control dropdown-full form-control-tag-group">
+				{if $selectedLabels}
+					{foreach $item in $selectedLabels}
+						{delcall ClayInputField.Label variant="$contentRenderer" allowemptydefault="true"}
+							{param _handleCloseButtonClick: $_handleCloseButtonClick /}
+							{param data: $item /}
+							{param index: index($item) /}
+							{param spritemap: $spritemap /}
+						{/delcall}
+					{/foreach}
+				{/if}
+
+				<input
+					class="form-control-inset"
+					onBlur="{$_removeFocusedLabel}"
+					onFocus="{$_removeFocusedLabel}"
+					onInput="{$_handleOnInput}"
+					onKeydown="{$_handleOnKeydown}"
+					ref="input"
+					type="text"
+				/>
+
+				{let $isVisible: $filteredItems and length($filteredItems) > 0 ? true : false /}
+
+				{let $classes kind="text"}
+					dropdown-menu
+					{if $isVisible}
+						{sp}show
+					{/if}
+				{/let}
+
+				<ul onkeydown="{$_handleOnKeydown}" class="{$classes}" ref="dropdown">
+					{if $filteredItems}
+						{foreach $item in $filteredItems}
+							{delcall ClayInputField.ItemDropdown variant="$contentRenderer" allowemptydefault="true"}
+								{param _handleDropdownItemClick: $_handleDropdownItemClick /}
+								{param data: $item /}
+								{param index: index($item) /}
+							{/delcall}
+						{/foreach}
+					{/if}
+				</ul>
+			</div>
+
+			{if $helpText and not $isVisible}
+				<div class="form-feedback-group">
+					<div class="form-text">
+						{$helpText}
+					</div>
+				</div>
+			{/if}
+		</div>
+		<div class="input-group-item input-group-item-shrink">
+			{call ClayButton.render}
+				{param events: ['click': $_handleButtonClicked] /}
+				{param label kind="text"}
+					{msg desc="Select items"}
+						select
+					{/msg}
+				{/param}
+
+				{param style: 'secondary' /}
+			{/call}
+		</div>
+	</div>
+{/template}
+
+{deltemplate ClayInputField.Label}
+	{@param data: ?}
+	{@param index: int}
+	{@param spritemap: string}
+	{@param? _handleCloseButtonClick: any}
+
+	{call ClayLabel.render}
+		{param closeable: true /}
+		{param data: ['tag': $index] /}
+		{param events: ['close': $_handleCloseButtonClick] /}
+		{param id: 'item-tag' /}
+		{param label: $data.label /}
+		{param spritemap: $spritemap /}
+	{/call}
+{/deltemplate}
+
+{deltemplate ClayInputField.ItemDropdown}
+	{@param data: ?}
+	{@param index: number}
+	{@param? _handleDropdownItemClick: any}
+
+	<li>
+		<a data-onclick="{$_handleDropdownItemClick}" data-dropdown-item-index="{$index}" id="item" class="dropdown-item" href="javascript:;">
+			{if $data.matches and length($data.matches) > 0}
+				{foreach $char in $data.matches}
+					{if $char.match}
+						<strong>{$char.value}</strong>
+					{else}
+						{$char.value}
+					{/if}
+				{/foreach}
+			{/if}
+		</a>
+	</li>
+{/deltemplate}

--- a/packages/clay-labels-input-field/src/__tests__/ClayLabelsInputField.js
+++ b/packages/clay-labels-input-field/src/__tests__/ClayLabelsInputField.js
@@ -1,0 +1,42 @@
+import ClayLabelsInputField from '../ClayLabelsInputField';
+
+let component;
+let spritemap = 'icons.svg';
+let helpText = 'You can use a comma to enter tags';
+
+describe('ClayLabelsInputField', function() {
+	afterEach(() => {
+		if (component) {
+			component.dispose();
+		}
+	});
+
+	it('should render the default markup', () => {
+		component = new ClayLabelsInputField({
+			helpText,
+			spritemap,
+		});
+
+		expect(component).toMatchSnapshot();
+	});
+
+	it('should render a ClayLabelsInputField with classes', () => {
+		component = new ClayLabelsInputField({
+			elementClasses: 'my-custom-class',
+			helpText,
+			spritemap,
+		});
+
+		expect(component).toMatchSnapshot();
+	});
+
+	it('should render a ClayLabelsInputField with id', () => {
+		component = new ClayLabelsInputField({
+			helpText,
+			id: 'myId',
+			spritemap,
+		});
+
+		expect(component).toMatchSnapshot();
+	});
+});

--- a/packages/clay-labels-input-field/src/__tests__/__snapshots__/ClayLabelsInputField.js.snap
+++ b/packages/clay-labels-input-field/src/__tests__/__snapshots__/ClayLabelsInputField.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClayLabelsInputField should render a ClayLabelsInputField with classes 1`] = `
+<div class="from-group my-custom-class">
+  <div class="input-group input-group-stacked-sm-down">
+    <div class="input-group-item">
+      <div ref="formGroupInput" class="form-control dropdown-full form-control-tag-group">
+        <input class="form-control-inset" ref="input" type="text">
+        <ul class="dropdown-menu" ref="dropdown"></ul>
+      </div>
+      <div class="form-feedback-group">
+        <div class="form-text">You can use a comma to enter tags</div>
+      </div>
+    </div>
+    <div class="input-group-item input-group-item-shrink">
+      <button class="btn btn-secondary" type="button">select</button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayLabelsInputField should render a ClayLabelsInputField with id 1`] = `
+<div class="from-group" id="myId">
+  <div class="input-group input-group-stacked-sm-down">
+    <div class="input-group-item">
+      <div ref="formGroupInput" class="form-control dropdown-full form-control-tag-group">
+        <input class="form-control-inset" ref="input" type="text">
+        <ul class="dropdown-menu" ref="dropdown"></ul>
+      </div>
+      <div class="form-feedback-group">
+        <div class="form-text">You can use a comma to enter tags</div>
+      </div>
+    </div>
+    <div class="input-group-item input-group-item-shrink">
+      <button class="btn btn-secondary" type="button">select</button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayLabelsInputField should render the default markup 1`] = `
+<div class="from-group">
+  <div class="input-group input-group-stacked-sm-down">
+    <div class="input-group-item">
+      <div ref="formGroupInput" class="form-control dropdown-full form-control-tag-group">
+        <input class="form-control-inset" ref="input" type="text">
+        <ul class="dropdown-menu" ref="dropdown"></ul>
+      </div>
+      <div class="form-feedback-group">
+        <div class="form-text">You can use a comma to enter tags</div>
+      </div>
+    </div>
+    <div class="input-group-item input-group-item-shrink">
+      <button class="btn btn-secondary" type="button">select</button>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/clay-labels-input-field/src/utils.js
+++ b/packages/clay-labels-input-field/src/utils.js
@@ -32,7 +32,7 @@ export const match = (query, string) => {
 	}
 
 	if (queryIndex === query.length) {
-		totalScore = (string === query) ? Infinity : totalScore;
+		totalScore = string === query ? Infinity : totalScore;
 		return {values: result, score: totalScore};
 	}
 

--- a/packages/clay-labels-input-field/src/utils.js
+++ b/packages/clay-labels-input-field/src/utils.js
@@ -1,0 +1,40 @@
+/**
+ * If `query` matches to `string`, returns an object with the
+ * corresponding characters. If there is no match, return null.
+ * @param {!String} query
+ * @param {!String} string
+ * @return {null|Object}
+ */
+export const match = (query, string) => {
+	let currentScore = 0;
+	let totalScore = 0;
+	let queryIndex = 0;
+	let result = [];
+
+	let queryToLowerCase = query.toLowerCase();
+	let stringToLowerCase = string.toLowerCase();
+
+	for (let index = 0; index < string.length; index++) {
+		let element = string[index];
+
+		if (stringToLowerCase[index] === queryToLowerCase[queryIndex]) {
+			element = {value: element, match: true};
+
+			queryIndex += 1;
+			currentScore += 1 + currentScore;
+		} else {
+			element = {value: element};
+			currentScore = 0;
+		}
+
+		totalScore += currentScore;
+		result[result.length] = element;
+	}
+
+	if (queryIndex === query.length) {
+		totalScore = (string === query) ? Infinity : totalScore;
+		return {values: result, score: totalScore};
+	}
+
+	return null;
+};

--- a/packages/clay-labels-input-field/webpack.config.js
+++ b/packages/clay-labels-input-field/webpack.config.js
@@ -1,0 +1,8 @@
+const webpackCommonConfig = require('webpack-config-clay');
+
+module.exports = Object.assign(webpackCommonConfig, {
+	entry: './src/ClayLabelsInputField.js',
+	output: Object.assign(webpackCommonConfig.output, {
+		filename: './build/globals/clay-labels-input-field.js',
+	}),
+});


### PR DESCRIPTION
> 🚨 This PR is not to be merged. Do not stick to the code now, but the idea behind. I will still send another PR to evaluate the implementation and our good practices, once this idea is valid.

## Disclaimer

I'm sending the API proposal to the new ClayLabelsInputField component. View the documents and Invision to analyze the use cases.

- [Invision](https://liferay.invisionapp.com/share/UKE9RIJDY#/screens/261808490_Label-Input-Field)
- [Doc](https://docs.google.com/document/d/1cIx6RkWNbnho_fOSR__3Fp5alIBE_ObhO-jecfXlA9I/edit?usp=sharing)

## Proposal

The component does not manipulate the data or changes internal states, it only triggers events of what is happening and letting the developer decide what to do with the information or validate the information for example. but always respecting the principles that the Lexicon is predicting.

### Events

The developer has the freedom to make decisions using the "life cycles" of the component, some of them are:

- **labelAdded** - The event is triggered when the user interacts with the input or dropdown by pressing comma or enter to create a new label or by clicking a dropdown item.
  - It's a good time for the developer to create their validation rules to add the label.
- **labelRemoved** - The event is triggered when the user interacts with the labels, removing them through the backspace or clicking the label's close button.
- **labelFocused** - The event is triggered when any label is focused.
- **queryChange** - The event is triggered when the user is typing in the input.
  - This is a good time to evaluate autocomplete or provide suggestions based on your criteria.

> I'm still not sure about the names of the events, if you think of something please comment.

### Helper methods

The component provides some auxiliary methods so that it can be used with events.

- **filterAutocomplete** - Filters an `Array<string>` that corresponds to `query`.
- **clearInput**- It just clears the input.

### Extension points

Lexicon predicts that developers can customize dropdown items with a list of contacts, phones ... or customize the labels for example. You can start by creating a variation using soy exclusivity `deltemplate` to achieve the expected results.

- **ClayInputField.Label**
- **ClayInputField.ItemDropdown**

> Both `deltemplates` are given the corresponding `data` parameter. causing the developer to decide the data API.

As the markup is still not 100% ready I added some css on the demo page to get closer to the Lexicon just for testing purposes, this will change when the markup is ready.