### PR TITLE
Fixes #1363 - ClayCSS Collapse Icon use em values instead of rem on t…

### DIFF
--- a/packages/clay-css/src/scss/components/_icons.scss
+++ b/packages/clay-css/src/scss/components/_icons.scss
@@ -80,7 +80,7 @@ a.collapse-icon {
 	}
 }
 
-.collapse-icon-middle {
+.collapse-icon.collapse-icon-middle {
 	.collapse-icon-closed,
 	.collapse-icon-open {
 		margin-top: 0;

--- a/packages/clay-css/src/scss/variables/_icons.scss
+++ b/packages/clay-css/src/scss/variables/_icons.scss
@@ -4,7 +4,7 @@ $collapse-icon-padding-right: 2.28125rem !default; // 45px
 $collapse-icon-position-bottom: null !default;
 $collapse-icon-position-left: null !default;
 $collapse-icon-position-right: 0.9375rem !default; // 15px
-$collapse-icon-position-top: clay-collapse-icon-align($nav-link-padding-y, 0.0625rem, $font-size-base) !default;
+$collapse-icon-position-top: clay-collapse-icon-align($nav-link-padding-y, 0.0625rem, 0.9375em) !default;
 
 $lexicon-icon-size: 1em !default; // 16px
 

--- a/packages/clay-css/src/scss/variables/_panels.scss
+++ b/packages/clay-css/src/scss/variables/_panels.scss
@@ -25,7 +25,7 @@ $panel-header-collapse-icon-font-size: 0.875rem !default; // 14px
 $panel-header-collapse-icon-bottom: null !default;
 $panel-header-collapse-icon-left: null !default;
 $panel-header-collapse-icon-right: null !default;
-$panel-header-collapse-icon-top: clay-collapse-icon-align($panel-header-padding-y, 0, $panel-header-font-size, $panel-header-line-height) !default;
+$panel-header-collapse-icon-top: clay-collapse-icon-align($panel-header-padding-y, 0, 1em, $panel-header-line-height) !default;
 
 $panel-header-collapse-icon-padding-left: null !default;
 $panel-header-collapse-icon-padding-right: null !default;

--- a/packages/clay-css/src/scss/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/variables/_sheets.scss
@@ -91,7 +91,7 @@ $sheet-subtitle-link-hover-text-decoration: none !default;
 $sheet-subtitle-collapse-icon-bottom: null !default;
 $sheet-subtitle-collapse-icon-left: null !default;
 $sheet-subtitle-collapse-icon-right: null !default;
-$sheet-subtitle-collapse-icon-top: clay-collapse-icon-align($sheet-subtitle-padding-y, 0, $sheet-subtitle-font-size, $sheet-subtitle-line-height) !default;
+$sheet-subtitle-collapse-icon-top: clay-collapse-icon-align($sheet-subtitle-padding-y, 0, 1em, $sheet-subtitle-line-height) !default;
 
 $sheet-subtitle-collapse-icon-padding-left: null !default;
 $sheet-subtitle-collapse-icon-padding-right: null !default;


### PR DESCRIPTION
…op property so it scales with font size changes

Fixes #1363 - ClayCSS Collapse Icon make `.collapse-icon-middle` more specific so it applies when nested inside components like Panel and Sheet