### PR TITLE
Fixes #1365 - Forms `.form-group-item` use `$form-group-margin-bottom…

### DIFF
--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -430,7 +430,11 @@ fieldset[disabled] label {
 		width: 100%;
 
 		&:not(:last-child) {
-			margin-bottom: 1rem;
+			margin-bottom: $form-group-margin-bottom;
+
+			@include media-breakpoint-down(xs) {
+				margin-bottom: $form-group-margin-bottom-mobile;
+			}
 		}
 	}
 


### PR DESCRIPTION
…` and `$form-group-margin-bottom-mobile` to set bottom spacing