### PR TITLE
Fixes #1369 - ClayCSS Nav `.nav-unstyled` change spacing between link…

### DIFF
--- a/packages/clay-css/src/scss/components/_navbar.scss
+++ b/packages/clay-css/src/scss/components/_navbar.scss
@@ -85,8 +85,8 @@
 }
 
 .navbar-text {
-	padding-left: 0.5rem;
-	padding-right: 0.5rem;
+	padding-left: $navbar-nav-link-padding-x;
+	padding-right: $navbar-nav-link-padding-x;
 }
 
 .navbar-collapse {
@@ -427,7 +427,7 @@
 			bottom: -$navbar-padding-y;
 			content: '';
 			display: block;
-			height: 0.1875rem;
+			height: $nav-underline-link-active-highlight-height;
 			left: 0;
 			position: absolute;
 			right: 0;
@@ -449,7 +449,7 @@
 						bottom: -$navbar-padding-y;
 						content: '';
 						display: block;
-						height: 0.1875rem;
+						height: $nav-underline-link-active-highlight-height;
 						left: 0;
 						position: absolute;
 						right: 0;

--- a/packages/clay-css/src/scss/components/_navs.scss
+++ b/packages/clay-css/src/scss/components/_navs.scss
@@ -133,17 +133,17 @@
 	flex-wrap: nowrap;
 
 	.nav-btn {
-		margin: 0 0.25rem;
-		padding: 0 0.25rem;
+		margin: 0 4px;
+		padding: 0 4px;
 	}
 
 	.nav-link {
 		line-height: $nav-item-monospaced-size;
-		padding: 0 0.25rem;
+		padding: 0 4px;
 	}
 
 	.nav-link-monospaced {
-		margin: 0 0.25rem;
+		margin: 0 4px;
 	}
 }
 


### PR DESCRIPTION
…s and buttons from `0.25rem` to `4px`

Fixes #1369 - ClayCSS Navbar replace hardcoded rem values with `$nav-*` variable equivalent in `.navbar-text` and `.navbar-underline`