### PR TITLE
Fixes #1388 - ClayCSS Pagination unify the way we set the height of e…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_pagination.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_pagination.scss
@@ -1,4 +1,5 @@
 $pagination-font-size: 0.875rem !default; // 14px
+$pagination-line-height: 1 !default;
 
 $pagination-item-height: 2rem !default; // 32px
 $pagination-item-margin-x: 0.125rem !default;
@@ -14,7 +15,6 @@ $pagination-border-width: 0.0625rem !default; // 1px
 $pagination-color: $secondary !default;
 $pagination-padding-x: 0.625rem !default; // 10px
 $pagination-padding-y: 0 !default;
-$pagination-line-height: $pagination-item-height - ($pagination-border-width * 2) !default;
 
 $pagination-hover-bg: rgba(0, 0, 0, 0.02) !default;
 $pagination-hover-border-color: transparent !default;
@@ -38,12 +38,10 @@ $pagination-results-color: $pagination-color !default;
 $pagination-link-border-radius-sm: 0.3125rem !default;
 $pagination-font-size-sm: 0.75rem !default; // 12px
 $pagination-item-height-sm: 1.5rem !default; // 24px
-$pagination-line-height-sm: $pagination-item-height-sm - ($pagination-border-width * 2) !default;
 $pagination-padding-y-sm: 0 !default;
 
 $pagination-link-border-radius-lg: 0.3125rem !default; // 5px
 $pagination-font-size-lg: 1.125rem !default; // 18px
 $pagination-item-height-lg: 2.75rem !default; //44px
-$pagination-line-height-lg: $pagination-item-height-lg - ($pagination-border-width * 2) !default;
 $pagination-padding-x-lg: 1rem !default; // 16px
 $pagination-padding-y-lg: 0 !default;

--- a/packages/clay-css/src/scss/components/_pagination.scss
+++ b/packages/clay-css/src/scss/components/_pagination.scss
@@ -22,7 +22,14 @@
 }
 
 .page-link {
+	align-items: center;
+
 	@include border-radius($pagination-link-border-radius);
+
+	display: inline-flex;
+	height: $pagination-item-height;
+	justify-content: center;
+
 	@include transition($pagination-link-transition);
 
 	&:focus {
@@ -56,6 +63,10 @@
 			color: $pagination-disabled-color;
 			opacity: $pagination-disabled-opacity;
 		}
+	}
+
+	.lexicon-icon {
+		margin-top: 0;
 	}
 }
 
@@ -100,6 +111,7 @@
 
 	> a,
 	> .btn-unstyled {
+		align-items: center;
 		background-color: $pagination-items-per-page-bg;
 		border-color: $pagination-items-per-page-border-color;
 
@@ -108,7 +120,9 @@
 		border-style: solid;
 		border-width: $pagination-border-width;
 		color: $pagination-items-per-page-color;
-		display: block;
+		display: inline-flex;
+		height: $pagination-item-height;
+		justify-content: center;
 		line-height: $pagination-line-height;
 		padding: $pagination-padding-y $pagination-padding-x;
 		text-decoration: none;
@@ -124,6 +138,11 @@
 		&:focus {
 			box-shadow: $pagination-items-per-page-focus-box-shadow;
 			outline: $pagination-items-per-page-focus-outline;
+		}
+
+		.lexicon-icon {
+			margin-left: $pagination-items-per-page-lexicon-icon-margin-left;
+			margin-top: $pagination-items-per-page-lexicon-icon-margin-top;
 		}
 	}
 
@@ -160,7 +179,9 @@
 	line-height: $pagination-line-height;
 	margin-bottom: $pagination-margin-bottom;
 	margin-right: auto;
+	max-width: 100%;
 	padding: $pagination-padding-y $pagination-padding-x;
+	word-wrap: break-word;
 }
 
 // Pagination Sizes
@@ -168,10 +189,21 @@
 .pagination-sm {
 	.pagination-items-per-page {
 		@include border-radius($pagination-link-border-radius-sm);
+
+		.lexicon-icon {
+			margin-left: $pagination-items-per-page-lexicon-icon-margin-left-sm;
+			margin-right: $pagination-items-per-page-lexicon-icon-margin-top-sm;
+		}
 	}
 
 	.pagination-items-per-page > a,
-	.pagination-items-per-page > .btn-unstyled,
+	.pagination-items-per-page > .btn-unstyled {
+		font-size: $pagination-font-size-sm;
+		height: $pagination-item-height-sm;
+		line-height: $pagination-line-height-sm;
+		padding: $pagination-padding-y-sm $pagination-padding-x;
+	}
+
 	.pagination-results {
 		font-size: $pagination-font-size-sm;
 		line-height: $pagination-line-height-sm;
@@ -180,6 +212,7 @@
 
 	.page-link {
 		font-size: $pagination-font-size-sm;
+		height: $pagination-item-height-sm;
 		line-height: $pagination-line-height-sm;
 
 		&.btn-unstyled {
@@ -191,10 +224,21 @@
 .pagination-lg {
 	.pagination-items-per-page {
 		@include border-radius($pagination-link-border-radius-lg);
+
+		.lexicon-icon {
+			margin-left: $pagination-items-per-page-lexicon-icon-margin-left-lg;
+			margin-right: $pagination-items-per-page-lexicon-icon-margin-top-lg;
+		}
 	}
 
 	.pagination-items-per-page > a,
-	.pagination-items-per-page > .btn-unstyled,
+	.pagination-items-per-page > .btn-unstyled {
+		font-size: $pagination-font-size-lg;
+		height: $pagination-item-height-lg;
+		line-height: $pagination-line-height-lg;
+		padding: $pagination-padding-y-lg $pagination-padding-x;
+	}
+
 	.pagination-results {
 		font-size: $pagination-font-size-lg;
 		line-height: $pagination-line-height-lg;
@@ -203,6 +247,7 @@
 
 	.page-link {
 		font-size: $pagination-font-size-lg;
+		height: $pagination-item-height-lg;
 		line-height: $pagination-line-height-lg;
 
 		&.btn-unstyled {

--- a/packages/clay-css/src/scss/variables/_pagination.scss
+++ b/packages/clay-css/src/scss/variables/_pagination.scss
@@ -1,5 +1,6 @@
 $pagination-font-size: null !default;
 
+$pagination-item-height: 2.375rem !default; // 38px
 $pagination-item-margin-x: null !default;
 $pagination-item-margin-y: null !default;
 
@@ -34,14 +35,25 @@ $pagination-items-per-page-hover-color: $pagination-hover-color !default;
 $pagination-items-per-page-focus-box-shadow: $pagination-focus-box-shadow !default;
 $pagination-items-per-page-focus-outline: 0 !default;
 
+$pagination-items-per-page-lexicon-icon-margin-left: 0.125rem !default; // 2px
+$pagination-items-per-page-lexicon-icon-margin-top: 0.125rem !default; // 2px
+
 $pagination-results-color: null !default;
 
 // Sizes
 
 $pagination-font-size-sm: $font-size-sm !default;
-$pagination-line-height-sm: $line-height-sm !default;
+$pagination-item-height-sm: 1.9375rem !default; // 31px
+$pagination-line-height-sm: 1 !default;
 $pagination-link-border-radius-sm: null !default;
 
+$pagination-items-per-page-lexicon-icon-margin-left-sm: null !default;
+$pagination-items-per-page-lexicon-icon-margin-top-sm: null !default;
+
 $pagination-font-size-lg: $font-size-lg !default;
-$pagination-line-height-lg: $line-height-lg !default;
+$pagination-item-height-lg: 3.5rem !default; // 56px
+$pagination-line-height-lg: 1 !default;
 $pagination-link-border-radius-lg: null !default;
+
+$pagination-items-per-page-lexicon-icon-margin-left-lg: null !default;
+$pagination-items-per-page-lexicon-icon-margin-top-lg: null !default;


### PR DESCRIPTION
…ach page item between Atlas and Base

Fixes #1388 - ClayCSS added options to customize `$pagination-items-per-page-lexicon-icon-margin-left`, `$pagination-items-per-page-lexicon-icon-margin-top`, `$pagination-items-per-page-lexicon-icon-margin-left-sm`, `$pagination-items-per-page-lexicon-icon-margin-top-sm`, `$pagination-items-per-page-lexicon-icon-margin-left-lg`, `$pagination-items-per-page-lexicon-icon-margin-top-lg`