### PR TITLE
Fixes #1459 - Use SPDX license identifier in package.json files

### DIFF
--- a/packages/browserslist-config-clay/package.json
+++ b/packages/browserslist-config-clay/package.json
@@ -4,7 +4,7 @@
   "description": "Clay components Browserslist Shared Config",
   "main": "index.js",
   "repository": "https://github.com/liferay/clay/tree/master/packages/browserslist-config-clay",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "keywords": [
     "clay",
     "browserslist",

--- a/packages/clay-alert/package.json
+++ b/packages/clay-alert/package.json
@@ -2,7 +2,7 @@
   "name": "clay-alert",
   "version": "2.6.0",
   "description": "Metal Clay Alert component.",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-alert",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -2,7 +2,7 @@
   "name": "clay-autocomplete",
   "version": "2.6.0",
   "description": "Metal ClayAutocomplete component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-autocomplete",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-badge/package.json
+++ b/packages/clay-badge/package.json
@@ -2,7 +2,7 @@
   "name": "clay-badge",
   "version": "2.6.0",
   "description": "Metal Clay Badge component.",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-badge",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-button/package.json
+++ b/packages/clay-button/package.json
@@ -2,7 +2,7 @@
   "name": "clay-button",
   "version": "2.6.0",
   "description": "Metal Clay Button component.",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-button",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-card-grid/package.json
+++ b/packages/clay-card-grid/package.json
@@ -2,7 +2,7 @@
   "name": "clay-card-grid",
   "version": "2.6.0",
   "description": "Metal ClayCardGrid component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-card-grid",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -2,7 +2,7 @@
   "name": "clay-card",
   "version": "2.6.0",
   "description": "Metal ClayCard component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-card",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-charts-react/package.json
+++ b/packages/clay-charts-react/package.json
@@ -13,7 +13,7 @@
 		"test": "jest"
 	},
 	"author": "Bryce Osterhaus",
-	"license": "BSD",
+	"license": "BSD-2-Clause",
 	"dependencies": {
 		"clay-charts-shared": "^2.6.0",
 		"react-billboardjs": "^1.4.3"

--- a/packages/clay-charts-shared/package.json
+++ b/packages/clay-charts-shared/package.json
@@ -12,7 +12,7 @@
 		"copyAssets": "ncp src/svg lib/svg"
 	},
 	"author": "Bryce Osterhaus",
-	"license": "BSD",
+	"license": "BSD-2-Clause",
 	"dependencies": {
 		"d3": "^5.7.0",
 		"metal": "^2.16.6"

--- a/packages/clay-charts/package.json
+++ b/packages/clay-charts/package.json
@@ -2,7 +2,7 @@
 	"name": "clay-charts",
 	"version": "2.6.0",
 	"description": "Metal.js wrapper for D3 and billboard.js",
-	"license": "BSD",
+	"license": "BSD-2-Clause",
 	"repository": "https://github.com/liferay/clay/tree/master/packages/clay-charts",
 	"engines": {
 		"node": ">=0.12.0",

--- a/packages/clay-checkbox/package.json
+++ b/packages/clay-checkbox/package.json
@@ -2,7 +2,7 @@
   "name": "clay-checkbox",
   "version": "2.6.0",
   "description": "Clay Checkbox Component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-checkbox",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-collapse/package.json
+++ b/packages/clay-collapse/package.json
@@ -2,7 +2,7 @@
   "name": "clay-collapse",
   "version": "2.6.0",
   "description": "Collapse Metal Clay component.",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-collapse",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-component/package.json
+++ b/packages/clay-component/package.json
@@ -2,7 +2,7 @@
   "name": "clay-component",
   "version": "2.6.0",
   "description": "Clay Link Component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-component",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-data-provider/package.json
+++ b/packages/clay-data-provider/package.json
@@ -2,7 +2,7 @@
   "name": "clay-data-provider",
   "version": "2.6.0",
   "description": "Metal ClayDataProvider component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-data-provider",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-dataset-display/package.json
+++ b/packages/clay-dataset-display/package.json
@@ -2,7 +2,7 @@
   "name": "clay-dataset-display",
   "version": "2.6.0",
   "description": "Metal ClayDatasetDisplay component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-dataset-display",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-dropdown/package.json
+++ b/packages/clay-dropdown/package.json
@@ -2,7 +2,7 @@
   "name": "clay-dropdown",
   "version": "2.6.0",
   "description": "Clay Dropdown Component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-dropdown",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-icon/package.json
+++ b/packages/clay-icon/package.json
@@ -2,7 +2,7 @@
   "name": "clay-icon",
   "version": "2.6.0",
   "description": "Clay Icon Component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-icon",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-label/package.json
+++ b/packages/clay-label/package.json
@@ -2,7 +2,7 @@
   "name": "clay-label",
   "version": "2.6.0",
   "description": "Metal Clay Label component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-label",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-link/package.json
+++ b/packages/clay-link/package.json
@@ -2,7 +2,7 @@
   "name": "clay-link",
   "version": "2.6.0",
   "description": "Clay Link Component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-link",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-list/package.json
+++ b/packages/clay-list/package.json
@@ -2,7 +2,7 @@
   "name": "clay-list",
   "version": "2.6.0",
   "description": "Metal ClayList component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-list-group",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-loading-indicator/package.json
+++ b/packages/clay-loading-indicator/package.json
@@ -2,7 +2,7 @@
   "name": "clay-loading-indicator",
   "version": "2.6.0",
   "description": "Clay Loading Indicator Component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-loading-indicator",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-management-toolbar/package.json
+++ b/packages/clay-management-toolbar/package.json
@@ -2,7 +2,7 @@
   "name": "clay-management-toolbar",
   "version": "2.6.0",
   "description": "Metal Clay Management Toolbar component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-management-toolbar",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-modal/package.json
+++ b/packages/clay-modal/package.json
@@ -2,7 +2,7 @@
   "name": "clay-modal",
   "version": "2.6.0",
   "description": "Metal ClayModal component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-modal",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-multi-select/package.json
+++ b/packages/clay-multi-select/package.json
@@ -2,7 +2,7 @@
   "name": "clay-multi-select",
   "version": "2.6.0",
   "description": "Metal ClayMultiSelect component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-multi-select",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-navigation-bar/package.json
+++ b/packages/clay-navigation-bar/package.json
@@ -2,7 +2,7 @@
   "name": "clay-navigation-bar",
   "version": "2.6.0",
   "description": "Metal Clay Navigation Bar component.",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-navigation-bar",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-pagination-bar/package.json
+++ b/packages/clay-pagination-bar/package.json
@@ -2,7 +2,7 @@
   "name": "clay-pagination-bar",
   "version": "2.6.0",
   "description": "Metal ClayPaginationBar component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-pagination-bar",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-pagination/package.json
+++ b/packages/clay-pagination/package.json
@@ -2,7 +2,7 @@
   "name": "clay-pagination",
   "version": "2.6.0",
   "description": "Metal ClayPagination component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-pagination",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-portal/package.json
+++ b/packages/clay-portal/package.json
@@ -2,7 +2,7 @@
   "name": "clay-portal",
   "version": "2.6.0",
   "description": "Metal ClayPortal component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-portal",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-progress-bar/package.json
+++ b/packages/clay-progress-bar/package.json
@@ -2,7 +2,7 @@
   "name": "clay-progress-bar",
   "version": "2.6.0",
   "description": "Metal Clay Progress Bar component.",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-progress-bar",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-radio/package.json
+++ b/packages/clay-radio/package.json
@@ -2,7 +2,7 @@
   "name": "clay-radio",
   "version": "2.6.0",
   "description": "Clay Radio Component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-radio",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-select/package.json
+++ b/packages/clay-select/package.json
@@ -2,7 +2,7 @@
   "name": "clay-select",
   "version": "2.6.0",
   "description": "Metal Clay Select component.",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-select",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-sticker/package.json
+++ b/packages/clay-sticker/package.json
@@ -2,7 +2,7 @@
   "name": "clay-sticker",
   "version": "2.6.0",
   "description": "Clay Sticker Component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-sticker",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-table/package.json
+++ b/packages/clay-table/package.json
@@ -2,7 +2,7 @@
   "name": "clay-table",
   "version": "2.6.0",
   "description": "Metal ClayTable component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-table",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay-tooltip/package.json
+++ b/packages/clay-tooltip/package.json
@@ -2,7 +2,7 @@
   "name": "clay-tooltip",
   "version": "2.6.0",
   "description": "Clay Tooltip Component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/clay-tooltip",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/clay/package.json
+++ b/packages/clay/package.json
@@ -2,7 +2,7 @@
     "name": "clay",
     "version": "2.6.0",
     "description": "Clay",
-    "license": "BSD",
+    "license": "BSD-2-Clause",
     "repository": "https://github.com/liferay/clay/tree/master/packages/clay",
     "engines": {
         "node": ">=0.12.0",

--- a/packages/generator-metal-clay/app/templates/_package.json
+++ b/packages/generator-metal-clay/app/templates/_package.json
@@ -2,7 +2,7 @@
   "name": "<%= repoName %>",
   "version": "2.1.12",
   "description": "Metal <%= componentName %> component",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "repository": "https://github.com/liferay/clay/tree/master/packages/<%= repoName %>",
   "engines": {
     "node": ">=0.12.0",

--- a/packages/generator-metal-clay/package.json
+++ b/packages/generator-metal-clay/package.json
@@ -2,7 +2,7 @@
   "name": "generator-metal-clay",
   "version": "2.6.0",
   "description": "Yeoman generator for Clay components",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "main": "app/index.js",
   "repository": "https://github.com/liferay/clay/tree/master/packages/generator-clay",
   "scripts": {

--- a/packages/webpack-config-clay/package.json
+++ b/packages/webpack-config-clay/package.json
@@ -2,7 +2,7 @@
   "name": "webpack-config-clay",
   "version": "2.6.0",
   "description": "Webpack configuration files for Clay components",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "main": "src/webpack.config.js",
   "repository": "https://github.com/liferay/clay/tree/master/packages/webpack-config-clay",
   "dependencies": {


### PR DESCRIPTION
We are using "BSD" as the license name in our Clay package.json files, which causes Yarn to emit warnings like this:

    warning package.json: License should be a valid SPDX license expression

We should switch it to "BSD-2-Clause", as listed [here on the SPDX website](https://spdx.org/licenses/BSD-2-Clause.html) which corresponds (somewhat loosely) to our LICENSE.md.

Note that because this commit updates "packages/generator-metal-clay/app/templates/_LICENSE.md", future generated packages will automatically benefit from this change.

Related: https://issues.liferay.com/browse/IFI-412