### PR TITLE
[IFI-419] Remove redundant export from generator-metal-clay template

### DIFF
--- a/packages/generator-metal-clay/app/templates/src/_Boilerplate.js
+++ b/packages/generator-metal-clay/app/templates/src/_Boilerplate.js
@@ -60,5 +60,4 @@ defineWebComponent('<%= repoName %>', <%= componentName %>);
 
 Soy.register(<%= componentName %>, templates);
 
-export {<%= componentName %>};
 export default <%= componentName %>;


### PR DESCRIPTION
I asked about the convention of doing a double export:

```javascript
export Thing;
export default Thing;
```

here:

https://github.com/liferay/clay/pull/1440#discussion_r248758900

I just wanted to throw up this PR to have something concrete to use as a basis for discussion about potentially moving away from this pattern. I think it would be desirable in the interests of being "conventional" (down with innovation! viva la convention!).

We'd need to do 2 or potential 3 steps to make this happen:

1. (This PR) Make the generator produce only the default export.
2. In the existing packages, consider emitting a deprecation warning if people use the non-default export.
3. In a future major semver release, remove the non-default exports.

Step 2 there is optional, but would consist of some (potentially tricky) wrapping/subclassing of the exported class that would produce a once-only `console.warn` in the constructor.

Related: https://issues.liferay.com/browse/IFI-419