### PR TITLE
Revert "Add fix from https://github.com/liferay/clay/commit/0bec13276…

### DIFF
--- a/src/scss/lexicon-base/_icons.scss
+++ b/src/scss/lexicon-base/_icons.scss
@@ -2,7 +2,6 @@
 	display: inline-block;
 	fill: currentColor;
 	height: $lexicon-icon-size;
-	pointer-events: none;
 	transform: translateZ(0);
 	vertical-align: middle;
 	width: $lexicon-icon-size;


### PR DESCRIPTION
https://github.com/liferay/clay/issues/1439

This reverts commit e8825c2f81edb38a941159443fa07057a545dae9 to fix https://github.com/liferay/clay/issues/1439.  This commit is originally added from https://github.com/liferay/clay/issues/926 for https://issues.liferay.com/browse/LPS-81456 which I can no longer reproduce even without this commit (which is why this is a simple revert and there are no additional changes to address #926).

