### PR TITLE
Fixes #1522 - ClayCSS Label Dismissible Lg `.close` should be smaller

### DIFF
--- a/packages/clay-css/src/scss/_mixins.scss
+++ b/packages/clay-css/src/scss/_mixins.scss
@@ -4,6 +4,7 @@
 @import "mixins/_box-shadow";
 @import "mixins/_buttons";
 @import "mixins/_cards";
+@import "mixins/_close";
 @import "mixins/_forms";
 @import "mixins/_grid";
 @import "mixins/_input-groups";

--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -124,6 +124,7 @@ $form-control-label-size: map-merge((
 	lexicon-icon-height: map-get($label-lg, lexicon-icon-height), // 16px
 	lexicon-icon-width: map-get($label-lg, lexicon-icon-width), // 16px
 	sticker-size: map-get($label-lg, sticker-size), // 16px
+	close: map-get($label-lg, close)
 ), $form-control-label-size);
 
 // Form Group

--- a/packages/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_labels.scss
@@ -31,6 +31,9 @@ $label-lg: map-merge((
 	lexicon-icon-height: 1em, // 12px
 	lexicon-icon-width: 1em, // 12px
 	sticker-size: 0.875rem, // 14px
+	close: (
+		font-size: 0.625rem, // 10px
+	),
 ), $label-lg);
 
 // Label Variants

--- a/packages/clay-css/src/scss/components/_labels.scss
+++ b/packages/clay-css/src/scss/components/_labels.scss
@@ -125,7 +125,7 @@ button.label {
 	}
 
 	.close {
-		@include clay-link($label-close);
+		@include clay-close($label-close);
 	}
 
 	.lexicon-icon {

--- a/packages/clay-css/src/scss/mixins/_close.scss
+++ b/packages/clay-css/src/scss/mixins/_close.scss
@@ -1,0 +1,155 @@
+// A mixin for styling `.close` overwrites Bootstrap 4.1.2's 
+// `&:not(:disabled):not(.disabled)` selector
+
+@mixin clay-close($map) {
+	$align-items: map-get($map, align-items);
+	$bg: map-get($map, bg);
+	$border-color: map-get($map, border-color);
+	$border-radius: map-get($map, border-radius);
+	$color: map-get($map, color);
+	$display: map-get($map, display);
+	$font-family: map-get($map, font-family);
+	$font-size: map-get($map, font-size);
+	$font-weight: map-get($map, font-weight);
+	$height: map-get($map, height);
+	$justify-content: map-get($map, justify-content);
+	$line-height: map-get($map, line-height);
+	$margin-bottom: map-get($map, margin-bottom);
+	$margin-left: map-get($map, margin-left);
+	$margin-right: map-get($map, margin-right);
+	$margin-top: map-get($map, margin-top);
+	$opacity: map-get($map, opacity);
+	$padding-bottom: map-get($map, padding-bottom);
+	$padding-left: map-get($map, padding-left);
+	$padding-right: map-get($map, padding-right);
+	$padding-top: map-get($map, padding-top);
+	$text-align: map-get($map, text-align);
+	$text-decoration: map-get($map, text-decoration);
+	$text-transform: map-get($map, text-transform);
+	$transition: map-get($map, transition);
+	$vertical-align: map-get($map, vertical-align);
+	$width: map-get($map, width);
+
+	$hover-bg: map-get($map, hover-bg);
+	$hover-color: map-get($map, hover-color);
+	$hover-opacity: map-get($map, hover-opacity);
+	$hover-text-decoration: map-get($map, hover-text-decoration);
+
+	$focus-bg: map-get($map, focus-bg);
+	$focus-box-shadow: map-get($map, focus-box-shadow);
+	$focus-color: map-get($map, focus-color);
+	$focus-opacity: map-get($map, focus-opacity);
+	$focus-outline: map-get($map, focus-outline);
+	$focus-text-decoration: map-get($map, focus-text-decoration);
+
+	$active-bg: map-get($map, active-bg);
+	$active-border-color: map-get($map, active-border-color);
+	$active-color: map-get($map, active-color);
+
+	$disabled-bg: map-get($map, disabled-bg);
+	$disabled-border-color: map-get($map, disabled-border-color);
+	$disabled-color: map-get($map, disabled-color);
+	$disabled-cursor: map-get($map, disabled-cursor);
+	$disabled-opacity: map-get($map, disabled-opacity);
+	$disabled-pointer-events: map-get($map, disabled-pointer-events);
+	$disabled-text-decoration: map-get($map, disabled-text-decoration);
+
+	$btn-focus-box-shadow: map-get($map, btn-focus-box-shadow);
+	$btn-focus-outline: map-get($map, btn-focus-outline);
+
+	$lexicon-icon-margin-bottom: map-get($map, lexicon-icon-margin-bottom);
+	$lexicon-icon-margin-left: map-get($map, lexicon-icon-margin-left);
+	$lexicon-icon-margin-right: map-get($map, lexicon-icon-margin-right);
+	$lexicon-icon-margin-top: map-get($map, lexicon-icon-margin-top);
+
+	align-items: $align-items;
+	background-color: $bg;
+	border-color: $border-color;
+
+	@include border-radius($border-radius);
+
+	color: $color;
+	display: $display;
+	font-family: $font-family;
+	font-size: $font-size;
+	font-weight: $font-weight;
+	height: $height;
+	justify-content: $justify-content;
+	line-height: $line-height;
+	margin-bottom: $margin-bottom;
+	margin-left: $margin-left;
+	margin-right: $margin-right;
+	margin-top: $margin-top;
+	opacity: $opacity;
+	padding-bottom: $padding-bottom;
+	padding-left: $padding-left;
+	padding-right: $padding-right;
+	padding-top: $padding-top;
+	text-align: $text-align;
+	text-decoration: $text-decoration;
+	text-transform: $text-transform;
+	transition: $transition;
+	vertical-align: $vertical-align;
+	width: $width;
+
+	&:hover {
+		background-color: $hover-bg;
+		color: $hover-color;
+		text-decoration: $hover-text-decoration;
+	}
+
+	@at-root {
+		button#{&} {
+			&:focus {
+				box-shadow: $btn-focus-box-shadow;
+				outline: $btn-focus-outline;
+			}
+		}
+	}
+
+	&:focus {
+		background-color: $focus-bg;
+		box-shadow: $focus-box-shadow;
+		color: $focus-color;
+		outline: $focus-outline;
+		text-decoration: $focus-text-decoration;
+	}
+
+	// Bootstrap 4.1.2 Selector overwrite
+
+	&:not(:disabled):not(.disabled) {
+		&:hover {
+			opacity: $hover-opacity;
+		}
+
+		&:focus {
+			opacity: $focus-opacity;
+		}
+	}
+
+	.show > &,
+	&:active,
+	&.active {
+		background-color: $active-bg;
+		border-color: $active-border-color;
+		color: $active-color;
+	}
+
+	&:disabled,
+	&.disabled {
+		background-color: $disabled-bg;
+		border-color: $disabled-border-color;
+		color: $disabled-color;
+		cursor: $disabled-cursor;
+		opacity: $disabled-opacity;
+		pointer-events: $disabled-pointer-events;
+		text-decoration: $disabled-text-decoration;
+	}
+
+	.lexicon-icon {
+		margin-bottom: $lexicon-icon-margin-bottom;
+		margin-right: $lexicon-icon-margin-right;
+		margin-left: $lexicon-icon-margin-left;
+		margin-top: $lexicon-icon-margin-top;
+	}
+}

--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -74,7 +74,7 @@
 	}
 
 	.close {
-		@include clay-link($close);
+		@include clay-close($close);
 	}
 
 	.sticker {
@@ -177,6 +177,6 @@
 	}
 
 	.close {
-		@include clay-link($close);
+		@include clay-close($close);
 	}
 }


### PR DESCRIPTION
Also prepped the `.close` component so we can upgrade to Bootstrap 4.1.2+ in the near future.