### PR TITLE
Fixes #1564 - ClayCSS 2.x Aspect Ratio added utilities `.aspect-ratio-item-flush` and `.aspect-ratio-item-vertical-flush` to force images to fill remaining space

### DIFF
--- a/packages/clay-css/src/content/images_aspect_ratio.html
+++ b/packages/clay-css/src/content/images_aspect_ratio.html
@@ -12,10 +12,47 @@ section: Components
 		<h3>Image Aspect Ratios</h3>
 
 		<blockquote class="blockquote">
-			<p>Sometimes you can't control the size of an image, constrain your images with aspect-ratios. The base class <code>aspect-ratio</code> maintains a 1 to 1 ratio relative to its container's width.</p>
+			<p>Sometimes you can't control the size of an image, you can constrain your images with aspect-ratios. The base class <code>aspect-ratio</code> maintains a 1 to 1 ratio relative to its container's width.</p>
 
 			<p>Use <code>aspect-ratio-3-to-2</code>, <code>aspect-ratio-4-to-3</code>, <code>aspect-ratio-8-to-5</code>, or <code>aspect-ratio-16-to-9</code> to maintain the specific ratio relative to its container or create your own by setting <code>padding-bottom</code> to the ratio you want e.g. 2 to 1 <code>.aspect-ratio-2-to-1 { padding-bottom: 50% }</code>.</p>
 		</blockquote>
+	</div>
+
+	<div class="col-3">
+		<h6>1:1</h6>
+		<div class="aspect-ratio"></div>
+	</div>
+	<div class="col-3">
+		<h6>3:2</h6>
+		<div class="aspect-ratio aspect-ratio-3-to-2"></div>
+	</div>
+	<div class="col-3">
+		<h6>4:3</h6>
+		<div class="aspect-ratio aspect-ratio-4-to-3"></div>
+	</div>
+	<div class="col-3">
+		<h6>8:5</h6>
+		<div class="aspect-ratio aspect-ratio-8-to-5"></div>
+	</div>
+	<div class="col-3">
+		<h6>16:9</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9"></div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Aspect Ratio Item</h3>
+
+		<blockquote class="blockquote">
+			<p>Use <code>aspect-ratio-item</code> if you want to keep the content's original size and crop the visible area.</p>
+		</blockquote>
+	</div>
+
+	<div class="col-3">
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class=" aspect-ratio-item" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
+		</div>
 	</div>
 </div>
 
@@ -23,40 +60,50 @@ section: Components
 	<div class="col-md-12">
 		<h3>Aspect Ratio Item Fluid</h3>
 
+		<blockquote class="blockquote">
+			<p><code>aspect-ratio-item-fluid</code> sets the max-width to be 100%, similar to <code>img-fluid</code>. If the image is narrower than its container, it won't expand to fill the remaining space. This generally should be used to keep wide images viewable inside the <code>aspect-ratio</code> container.</p>
+		</blockquote>
+	</div>
+
+	<div class="col-md-6">
 		<h6>Original Image</h6>
 		<img alt="thumbnail" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg" style="max-width:300px;width:100%;">
+	</div>
+	<div class="col-md-6">
+		<h6>16:9</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
+		</div>
+	</div>
 
-		<div class="row">
-			<div class="col-3">
-				<h6>1:1</h6>
-				<div class="aspect-ratio">
-					<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>3:2</h6>
-				<div class="aspect-ratio aspect-ratio-3-to-2">
-					<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>4:3</h6>
-				<div class="aspect-ratio aspect-ratio-4-to-3">
-					<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>8:5</h6>
-				<div class="aspect-ratio aspect-ratio-8-to-5">
-					<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>16:9</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
+	<div class="col-3">
+		<h6>1:1</h6>
+		<div class="aspect-ratio">
+			<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>3:2</h6>
+		<div class="aspect-ratio aspect-ratio-3-to-2">
+			<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>4:3</h6>
+		<div class="aspect-ratio aspect-ratio-4-to-3">
+			<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>8:5</h6>
+		<div class="aspect-ratio aspect-ratio-8-to-5">
+			<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>16:9</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
 		</div>
 	</div>
 </div>
@@ -65,53 +112,88 @@ section: Components
 	<div class="col-md-12">
 		<h3>Aspect Ratio Item Vertical Fluid</h3>
 
-		<div class="row">
-			<div class="col-3">
-				<h6>1:1</h6>
-				<div class="aspect-ratio">
-					<img alt="thumbnail" class="aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>3:2</h6>
-				<div class="aspect-ratio aspect-ratio-3-to-2">
-					<img alt="thumbnail" class="aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>4:3</h6>
-				<div class="aspect-ratio aspect-ratio-4-to-3">
-					<img alt="thumbnail" class="aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>8:5</h6>
-				<div class="aspect-ratio aspect-ratio-8-to-5">
-					<img alt="thumbnail" class=" aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>16:9</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class=" aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
-				</div>
-			</div>
+		<blockquote class="blockquote">
+			<p><code>aspect-ratio-item-vertical-fluid</code> sets the max-height to be 100%. If the image is shorter than its container, it won't expand to fill the remaining space. This generally should be used to keep tall images viewable inside the <code>aspect-ratio</code> container.</p>
+		</blockquote>
+	</div>
+	<div class="col-3">
+		<h6>1:1</h6>
+		<div class="aspect-ratio">
+			<img alt="thumbnail" class="aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/long_user_image.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>3:2</h6>
+		<div class="aspect-ratio aspect-ratio-3-to-2">
+			<img alt="thumbnail" class="aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/long_user_image.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>4:3</h6>
+		<div class="aspect-ratio aspect-ratio-4-to-3">
+			<img alt="thumbnail" class="aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/long_user_image.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>8:5</h6>
+		<div class="aspect-ratio aspect-ratio-8-to-5">
+			<img alt="thumbnail" class="aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/long_user_image.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>16:9</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-vertical-fluid" src="{{rootPath}}/images/long_user_image.png">
 		</div>
 	</div>
 </div>
 
 <div class="clay-site-row-spacer row">
 	<div class="col-md-12">
-		<h3>Aspect Ratio Item</h3>
+		<h3>Aspect Ratio Item Flush</h3>
 
-		<blockquote>
-			<p>Use <code>aspect-ratio-item</code> if you want to keep the content's original size and crop the visible area.</p>
+		<blockquote class="blockquote">
+			<p><code>aspect-ratio-item-flush</code> forces the width to be 100.6%. This utility should generally be used for images that are too narrow when using <code>aspect-ratio-item-fluid</code> and you still want to fill the remaining space.</p>
+		</blockquote>
+
+		<div class="alert alert-info">
+			The 100.6% width is to account for browser subpixel rendering issues.
+		</div>
+	</div>
+
+	<div class="col-6">
+		<h6>16:9</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-flush" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
+		</div>
+	</div>
+	<div class="col-6">
+		<h6>16:9</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-flush" src="{{rootPath}}/images/liferay_logo_tagline.png">
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Aspect Ratio Item Vertical Flush</h3>
+
+		<blockquote class="blockquote">
+			<p><code>aspect-ratio-item-vertical-flush</code> forces the height to be 100.6%. This utility should generally be used for images that are too short when using <code>aspect-ratio-item-flush</code> and you still want to fill the remaining space.</p>
 		</blockquote>
 	</div>
 
-	<div class="col-3">
+	<div class="col-6">
+		<h6>16:9</h6>
 		<div class="aspect-ratio aspect-ratio-16-to-9">
-			<img alt="thumbnail" class=" aspect-ratio-item aspect-ratio-item-center aspect-ratio-item-middle" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
+			<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-vertical-flush" src="{{rootPath}}/images/thumbnail_graph2.png">
+		</div>
+	</div>
+	<div class="col-6">
+		<h6>16:9</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-vertical-flush" src="{{rootPath}}/images/liferay_logo_tagline.png">
 		</div>
 	</div>
 </div>
@@ -119,62 +201,60 @@ section: Components
 <div class="clay-site-row-spacer row">
 	<div class="col-md-12">
 		<h3>Aspect Ratio Item Helper Classes</h3>
+	</div>
 
-		<div class="row">
-			<div class="col-3">
-				<h6>aspect-ratio-item-center-middle</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>aspect-ratio-item-fluid</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>aspect-ratio-item-top-center</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-top-center aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>aspect-ratio-item-top-right</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-fluid aspect-ratio-item-top-right" src="{{rootPath}}/images/liferay_logo_tagline.png">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>aspect-ratio-item-right-middle</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-fluid aspect-ratio-item-right-middle" src="{{rootPath}}/images/liferay_logo_tagline.png">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>aspect-ratio-item-bottom-right</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-bottom-right aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>aspect-ratio-item-bottom-center</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-bottom-center aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>aspect-ratio-item-bottom-left</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-bottom-left aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
-				</div>
-			</div>
-			<div class="col-3">
-				<h6>aspect-ratio-item-left-middle</h6>
-				<div class="aspect-ratio aspect-ratio-16-to-9">
-					<img alt="thumbnail" class="aspect-ratio-item-left-middle aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
-				</div>
-			</div>
+	<div class="col-3">
+		<h6>aspect-ratio-item-center-middle</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-center-middle aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>aspect-ratio-item-fluid</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>aspect-ratio-item-top-center</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-top-center aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>aspect-ratio-item-top-right</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-fluid aspect-ratio-item-top-right" src="{{rootPath}}/images/liferay_logo_tagline.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>aspect-ratio-item-right-middle</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-fluid aspect-ratio-item-right-middle" src="{{rootPath}}/images/liferay_logo_tagline.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>aspect-ratio-item-bottom-right</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-bottom-right aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>aspect-ratio-item-bottom-center</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-bottom-center aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>aspect-ratio-item-bottom-left</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-bottom-left aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
+		</div>
+	</div>
+	<div class="col-3">
+		<h6>aspect-ratio-item-left-middle</h6>
+		<div class="aspect-ratio aspect-ratio-16-to-9">
+			<img alt="thumbnail" class="aspect-ratio-item-left-middle aspect-ratio-item-fluid" src="{{rootPath}}/images/liferay_logo_tagline.png">
 		</div>
 	</div>
 </div>

--- a/packages/clay-css/src/scss/components/_aspect-ratio.scss
+++ b/packages/clay-css/src/scss/components/_aspect-ratio.scss
@@ -45,6 +45,28 @@
 	@extend %aspect-ratio-item-vertical-fluid;
 }
 
+// Flush
+
+%aspect-ratio-item-flush {
+	max-width: none;
+	position: absolute;
+	width: 100.6%; // Fixes subpixel rendering issues
+}
+
+.aspect-ratio-item-flush {
+	@extend %aspect-ratio-item-flush;
+}
+
+%aspect-ratio-item-vertical-flush {
+	height: 100.6%; // Fixes subpixel rendering issues
+	max-height: none;
+	position: absolute;
+}
+
+.aspect-ratio-item-vertical-flush {
+	@extend %aspect-ratio-item-vertical-flush;
+}
+
 // Top Center
 
 %aspect-ratio-item-top-center {


### PR DESCRIPTION
@carloslancha @matuzalemsteles we will need to update Clay Card to accept different aspect ratio classes.