### PR TITLE
Fixes #1592 - Adds collapse height when closing to ensure animation happens

### DIFF
--- a/packages/clay-navigation-bar/src/ClayNavigationBar.js
+++ b/packages/clay-navigation-bar/src/ClayNavigationBar.js
@@ -23,11 +23,11 @@ class ClayNavigationBar extends ClayComponent {
 	 */
 	// eslint-disable-next-line
 	sync_isTransitioning() {
-		if (this._isTransitioning && !this._visible) {
+		if (this._isTransitioning) {
 			this._setCollapseHeight();
-		} else if (this._isTransitioning && this._visible) {
-			this._setCollapseHeight();
-			this._removeCollapseHeight();
+			if (this._visible) {
+				this._removeCollapseHeight();
+			}
 		}
 	}
 

--- a/packages/clay-navigation-bar/src/ClayNavigationBar.js
+++ b/packages/clay-navigation-bar/src/ClayNavigationBar.js
@@ -26,6 +26,7 @@ class ClayNavigationBar extends ClayComponent {
 		if (this._isTransitioning && !this._visible) {
 			this._setCollapseHeight();
 		} else if (this._isTransitioning && this._visible) {
+			this._setCollapseHeight();
 			this._removeCollapseHeight();
 		}
 	}


### PR DESCRIPTION
This is an assumption I can not debug to see if this happens, when you add `_setCollapseHeight` in the click and then remove it in `sync_isTransitioning` if they happen in a short period so that it does not cause an animation and breaks the menu.