### PR TITLE
Fixes #1510 - ClayCSS Atlas Stickers invert background-color with color (Breaking)

### DIFF
--- a/packages/clay-css/src/content/badges_and_labels.html
+++ b/packages/clay-css/src/content/badges_and_labels.html
@@ -662,17 +662,32 @@ section: Components
 			<p>Stickers are monospaced badges/labels.</p>
 		</blockquote>
 
-<span class="sticker sticker-primary">133</span>
-<span class="sticker sticker-secondary">133</span>
-<span class="sticker sticker-success">133</span>
-<span class="sticker sticker-info">133</span>
-<span class="sticker sticker-warning">133</span>
-<span class="sticker sticker-danger">133</span>
+<div>
+	<span class="sticker sticker-primary">133</span>
+	<span class="sticker sticker-secondary">133</span>
+	<span class="sticker sticker-success">133</span>
+	<span class="sticker sticker-info">133</span>
+	<span class="sticker sticker-warning">133</span>
+	<span class="sticker sticker-danger">133</span>
+	<div class="clay-site-light-container" style="vertical-align: baseline;">
+		<span class="sticker sticker-light">133</span>
+	</div>
+	<span class="sticker sticker-dark">133</span>
+</div>
 
-		<div class="clay-site-light-container" style="vertical-align: baseline;">
-			<span class="sticker sticker-light">133</span>
-		</div>
-		<span class="sticker sticker-dark">133</span>
+<div>
+	<span class="sticker sticker-circle sticker-primary">133</span>
+	<span class="sticker sticker-circle sticker-secondary">133</span>
+	<span class="sticker sticker-circle sticker-success">133</span>
+	<span class="sticker sticker-circle sticker-info">133</span>
+	<span class="sticker sticker-circle sticker-warning">133</span>
+	<span class="sticker sticker-circle sticker-danger">133</span>
+	<div class="clay-site-light-container" style="vertical-align: baseline;">
+		<span class="sticker sticker-circle sticker-light">133</span>
+	</div>
+	<span class="sticker sticker-circle sticker-dark">133</span>
+</div>
+
 	</div>
 </div>
 
@@ -772,25 +787,25 @@ section: Components
 			<p>Overlay content over stickers by nesting <code>sticker-overlay</code> inside <code>sticker</code>.</p>
 		</blockquote>
 
-		<span class="sticker sticker-primary sticker-sm">
+		<span class="sticker sticker-dark sticker-sm">
 			<span class="sticker-overlay">
 				<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_coffee.jpg">
 			</span>
 			<span class="sticker-overlay">JB</span>
 		</span>
-		<span class="sticker sticker-primary">
+		<span class="sticker sticker-dark">
 			<span class="sticker-overlay">
 				<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_hot_air_ballon.jpg">
 			</span>
 			<span class="sticker-overlay">TT</span>
 		</span>
-		<span class="sticker sticker-primary sticker-lg">
+		<span class="sticker sticker-dark sticker-lg">
 			<span class="sticker-overlay">
 				<img alt="thumbnail" class="sticker-img" src="../../images/tv-at-beach.png">
 			</span>
 			<span class="sticker-overlay">SP</span>
 		</span>
-		<span class="sticker sticker-primary sticker-xl">
+		<span class="sticker sticker-dark sticker-xl">
 			<span class="sticker-overlay">
 				<img alt="thumbnail" class="sticker-img" src="../../images/long_user_image.png">
 			</span>
@@ -907,41 +922,41 @@ section: Components
 	</div>
 	<div class="col-md-12">
 
-<span class="sticker sticker-circle sticker-primary sticker-sm">
+<span class="sticker sticker-sm sticker-user-icon">
 	<span class="sticker-overlay">
 		<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
 	</span>
 </span>
-<span class="sticker sticker-circle sticker-primary">
+<span class="sticker sticker-user-icon">
 	<span class="sticker-overlay">
 		<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_coyote.jpg">
 	</span>
 </span>
-<span class="sticker sticker-circle sticker-lg sticker-primary">
+<span class="sticker sticker-lg sticker-user-icon">
 	<span class="sticker-overlay">
 		<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_hot_air_ballon.jpg">
 	</span>
 </span>
-<span class="sticker sticker-circle sticker-primary sticker-xl">
+<span class="sticker sticker-user-icon sticker-xl">
 	<span class="sticker-overlay">
 		<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_coffee.jpg">
 	</span>
 </span>
-<span class="sticker sticker-circle sticker-primary sticker-xl">
+<span class="sticker sticker-user-icon sticker-xl">
 	<span class="sticker-overlay">
 		<img alt="thumbnail" class="sticker-img" src="../../images/long_user_image.png">
 	</span>
 </span>
-<span class="sticker sticker-circle sticker-primary sticker-xl">
+<span class="sticker sticker-primary sticker-user-icon sticker-xl">
 	<span class="sticker-overlay">
 		<img alt="thumbnail" class="sticker-img" src="../../images/tv-at-beach.png">
 	</span>
 </span>
 
-<span class="sticker sticker-circle sticker-danger sticker-xl">JB</span>
-<span class="sticker sticker-circle sticker-lg sticker-success">TT</span>
-<span class="sticker sticker-circle sticker-secondary">SP</span>
-<span class="sticker sticker-circle sticker-primary sticker-sm">BC</span>
+<span class="sticker sticker-danger sticker-user-icon sticker-xl">JB</span>
+<span class="sticker sticker-lg sticker-success sticker-user-icon">TT</span>
+<span class="sticker sticker-secondary sticker-user-icon">SP</span>
+<span class="sticker sticker-primary sticker-sm sticker-user-icon">BC</span>
 
 	</div>
 </div>

--- a/packages/clay-css/src/content/cards.html
+++ b/packages/clay-css/src/content/cards.html
@@ -372,7 +372,7 @@ section: Components
 		<div class="card card-type-asset user-card">
 			<div class="aspect-ratio card-item-first">
 				<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
-					<span class="sticker sticker-circle sticker-secondary">
+					<span class="sticker sticker-secondary sticker-user-icon">
 						<span class="sticker-overlay">
 							<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_coffee.jpg">
 						</span>
@@ -403,7 +403,7 @@ section: Components
 		<div class="card card-type-asset user-card">
 			<div class="aspect-ratio card-item-first">
 				<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
-					<span class="sticker sticker-circle sticker-secondary">
+					<span class="sticker sticker-secondary sticker-user-icon">
 						<span class="sticker-overlay">
 							<img alt="thumbnail" class="sticker-img" src="../../images/long_user_image.png">
 						</span>
@@ -434,7 +434,7 @@ section: Components
 		<div class="card card-type-asset user-card">
 			<div class="aspect-ratio card-item-first">
 				<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
-					<span class="sticker sticker-circle sticker-secondary">
+					<span class="sticker sticker-secondary sticker-user-icon">
 						<span class="sticker-overlay">
 							<img alt="thumbnail" class="sticker-img" src="../../images/tv-at-beach.png">
 						</span>
@@ -470,7 +470,7 @@ section: Components
 							<input class="custom-control-input" type="checkbox">
 							<span class="custom-control-label"></span>
 							<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
-								<span class="sticker sticker-circle sticker-danger">
+								<span class="sticker sticker-danger sticker-user-icon">
 									<span class="sticker-overlay">HS</span>
 								</span>
 							</div>

--- a/packages/clay-css/src/content/images_aspect_ratio.html
+++ b/packages/clay-css/src/content/images_aspect_ratio.html
@@ -305,7 +305,7 @@ section: Components
 	<div class="col-4">
 		<div class="aspect-ratio aspect-ratio-16-to-9">
 			<div class="aspect-ratio-item-center-middle aspect-ratio-item-fluid">
-				<span class="sticker sticker-circle sticker-danger">LR</span>
+				<span class="sticker sticker-danger sticker-user-icon">LR</span>
 			</div>
 		</div>
 	</div>

--- a/packages/clay-css/src/content/test_table_valign.html
+++ b/packages/clay-css/src/content/test_table_valign.html
@@ -790,7 +790,7 @@ section: Visual Tests
 						<td class="table-cell-expand table-cell-start">
 							<div class="autofit-row">
 								<div class="autofit-col">
-									<span class="sticker sticker-circle sticker-danger">MT</span>
+									<span class="sticker sticker-danger sticker-user-icon">MT</span>
 								</div>
 								<div class="autofit-col autofit-col-expand">
 									<div class="table-list-title">
@@ -912,7 +912,7 @@ section: Visual Tests
 						<td class="table-cell-expand table-cell-start">
 							<div class="autofit-row">
 								<div class="autofit-col">
-									<span class="sticker sticker-circle sticker-danger">MT</span>
+									<span class="sticker sticker-danger sticker-user-icon">MT</span>
 								</div>
 								<div class="autofit-col autofit-col-expand">
 									<div class="table-list-title">

--- a/packages/clay-css/src/content/test_table_view_template.html
+++ b/packages/clay-css/src/content/test_table_view_template.html
@@ -607,7 +607,7 @@ section: Visual Tests
 						<td class="table-cell-expand">
 							<div class="autofit-row">
 								<div class="autofit-col">
-									<span class="sticker sticker-circle sticker-danger">MT</span>
+									<span class="sticker sticker-danger sticker-user-icon">MT</span>
 								</div>
 								<div class="autofit-col autofit-col-expand">
 									<div class="table-list-title">

--- a/packages/clay-css/src/content/test_table_view_template_info_panel.html
+++ b/packages/clay-css/src/content/test_table_view_template_info_panel.html
@@ -531,7 +531,7 @@ section: Visual Tests
 						<td class="table-cell-expand">
 							<div class="autofit-row">
 								<div class="autofit-col">
-									<span class="sticker sticker-circle sticker-danger">MT</span>
+									<span class="sticker sticker-danger sticker-user-icon">MT</span>
 								</div>
 								<div class="autofit-col autofit-col-expand">
 									<h1 class="table-list-title">

--- a/packages/clay-css/src/content/timelines.html
+++ b/packages/clay-css/src/content/timelines.html
@@ -180,7 +180,7 @@ section: Components
 			<a aria-controls="panelCollapseTimelineCenter0" aria-expanded="false" class="collapsed panel-header panel-header-link" data-toggle="collapse" href="#panelCollapseTimelineCenter0" id="headingTimelineCenter0" role="tab">
 				<span class="panel-title">Single Collapsible Panel</span>
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -198,7 +198,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #2
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -211,7 +211,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #3
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -238,7 +238,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #1
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -251,7 +251,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #2
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -264,7 +264,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #3
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -286,7 +286,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #1
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -299,7 +299,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #2
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -312,7 +312,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #3
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -339,7 +339,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #1
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -352,7 +352,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #2
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -365,7 +365,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #3
 				<div class="timeline-increment">
-					<div class="sticker sticker-circle sticker-danger">
+					<div class="sticker sticker-danger sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -398,7 +398,7 @@ section: Components
 			<a aria-controls="panelCollapseTimelineSpacing0" aria-expanded="false" class="collapsed panel-header panel-header-link" data-toggle="collapse" href="#panelCollapseTimelineSpacing0" id="headingTimelineSpacing0" role="tab">
 				<span class="panel-title">Single Collapsible Panel</span>
 				<div class="timeline-increment">
-					<div class="sticker sticker-danger sticker-circle sticker-xl">
+					<div class="sticker sticker-danger sticker-xl sticker-user-icon">
 						<span>LR</span>
 					</div>
 				</div>
@@ -416,7 +416,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #2
 				<div class="timeline-increment">
-					<div class="sticker sticker-danger sticker-circle sticker-xl">
+					<div class="sticker sticker-danger sticker-user-icon sticker-xl">
 						<span>LR</span>
 					</div>
 				</div>
@@ -429,7 +429,7 @@ section: Components
 			<div class="panel-body">
 				Panel Text #3
 				<div class="timeline-increment">
-					<div class="sticker sticker-danger sticker-circle sticker-xl">
+					<div class="sticker sticker-danger sticker-user-icon sticker-xl">
 						<span>LR</span>
 					</div>
 				</div>

--- a/packages/clay-css/src/content/utilities.html
+++ b/packages/clay-css/src/content/utilities.html
@@ -457,7 +457,7 @@ section: Components
 				</div>
 				<div class="autofit-padded-no-gutters-x autofit-row">
 					<div class="autofit-col">
-						<span class="sticker sticker-circle sticker-lg sticker-success">LC</span>
+						<span class="sticker sticker-lg sticker-success sticker-user-icon">LC</span>
 					</div>
 					<div class="autofit-col autofit-col-expand">
 						<div class="form-group">
@@ -470,7 +470,7 @@ section: Components
 				</div>
 				<div class="autofit-padded-no-gutters-x autofit-row">
 					<div class="autofit-col">
-						<span class="sticker sticker-circle sticker-lg sticker-warning">DA</span>
+						<span class="sticker sticker-lg sticker-user-icon sticker-warning">DA</span>
 					</div>
 					<div class="autofit-col autofit-col-expand">
 						<div class="autofit-row">
@@ -528,7 +528,7 @@ section: Components
 						</div>
 						<div class="autofit-padded-no-gutters-x autofit-row">
 							<div class="autofit-col">
-								<span class="sticker sticker-circle sticker-lg sticker-success">LC</span>
+								<span class="sticker sticker-lg sticker-success sticker-user-icon">LC</span>
 							</div>
 							<div class="autofit-col autofit-col-expand">
 								<div class="autofit-row">

--- a/packages/clay-css/src/scss/atlas/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_stickers.scss
@@ -1,32 +1,56 @@
-$sticker-font-size: 0.625rem !default; // 10px
+$sticker-font-size: 1rem !default; // 16px
 $sticker-font-weight: $font-weight-bold !default;
-
-$sticker-inline-item-font-size: 1rem !default; // 16px
 
 // Sticker Sizes
 
 $sticker-sm: () !default;
 $sticker-sm: map-merge((
-	font-size: 0.5625rem, // 9px
-	inline-item-font-size: 0.75rem // 14px
+	font-size: 0.75rem, // 12px
 ), $sticker-sm);
 
 $sticker-lg: () !default;
 $sticker-lg: map-merge((
-	font-size: 0.9375rem, // 15px
-	inline-item-font-size: 1.25rem // 20px
+	font-size: 1.25rem, // 20px
 ), $sticker-lg);
 
 $sticker-xl: () !default;
 $sticker-xl: map-merge((
-	font-size: 1.0625rem, // 17px
-	inline-item-font-size: 1.5rem // 24px
+	font-size: 1.5rem, // 25px
 ), $sticker-xl);
 
 // Sticker Positions
 
 $sticker-inside-offset: 1rem !default; // 16px
 
+// Sticker User Icon
+
+$sticker-user-icon: () !default;
+$sticker-user-icon: map-merge((
+	box-shadow: 0 0 0 1px #E7E7ED,
+), $sticker-user-icon);
+
 // Sticker Variants
 
+$sticker-primary-bg: #FFF !default;
+$sticker-primary-color: $primary !default;
+
+$sticker-secondary-bg: #FFF !default;
+$sticker-secondary-color: $secondary !default;
+
+$sticker-info-bg: #FFF !default;
+$sticker-info-color: $info !default;
+
+$sticker-success-bg: #FFF !default;
+$sticker-success-color: $success !default;
+
+$sticker-warning-bg: #FFF !default;
+$sticker-warning-color: $warning !default;
+
+$sticker-danger-bg: #FFF !default;
+$sticker-danger-color: $danger !default;
+
+$sticker-light-bg: #FFF !default;
 $sticker-light-color: $dark !default;
+
+$sticker-dark-bg: $dark !default;
+$sticker-dark-color: #FFF !default;

--- a/packages/clay-css/src/scss/components/_stickers.scss
+++ b/packages/clay-css/src/scss/components/_stickers.scss
@@ -1,6 +1,5 @@
 .sticker {
 	align-items: center;
-
 	border-color: $sticker-border-color;
 
 	@include border-radius($sticker-border-radius);
@@ -117,6 +116,12 @@
 		left: auto;
 		right: $sticker-outside-offset;
 	}
+}
+
+// Sticker User Icon
+
+.sticker-user-icon {
+	@include clay-sticker-variant($sticker-user-icon);
 }
 
 // Sticker Sizes

--- a/packages/clay-css/src/scss/mixins/_stickers.scss
+++ b/packages/clay-css/src/scss/mixins/_stickers.scss
@@ -34,3 +34,48 @@
 		}
 	}
 }
+
+@mixin clay-sticker-variant($map) {
+	$align-items: map-get($map, align-items);
+	$background-color: map-get($map, background-color);
+	$bg: setter(map-get($map, bg), $background-color);
+	$border-color: map-get($map, border-color);
+	$border-radius: map-get($map, border-radius);
+	$border-style: map-get($map, border-style);
+	$border-width: map-get($map, border-width);
+	$box-shadow: map-get($map, box-shadow);
+	$color: map-get($map, color);
+	$display: map-get($map, display);
+	$font-size: map-get($map, font-size);
+	$font-weight: map-get($map, font-weight);
+	$height: map-get($map, height);
+	$justify-content: map-get($map, justify-content);
+	$line-height: map-get($map, line-height);
+	$position: map-get($map, position);
+	$text-align: map-get($map, text-align);
+	$vertical-align: map-get($map, vertical-align);
+	$width: map-get($map, width);
+
+	align-items: $align-items;
+	background-color: $bg;
+	border-color: $border-color;
+	border-radius: $border-radius;
+	border-style: $border-style;
+	border-width: $border-width;
+	box-shadow: $box-shadow;
+	color: $color;
+	display: $display;
+	height: $height;
+	line-height: $line-height;
+	font-size: $font-size;
+	font-weight: $font-weight;
+	justify-content: $justify-content;
+	position: $position;
+	text-align: $text-align;
+	vertical-align: $vertical-align;
+	width: $width;
+
+	.sticker-overlay {
+		border-radius: $border-radius;
+	}
+}

--- a/packages/clay-css/src/scss/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/variables/_stickers.scss
@@ -38,6 +38,15 @@ $sticker-outside-offset: -($sticker-size / 2) !default;
 
 $sticker-circle-border-radius: $rounded-circle-border-radius !default;
 
+// Sticker User Icon
+
+$sticker-user-icon: () !default;
+$sticker-user-icon: map-merge((
+	bg: $white,
+	border-radius: $rounded-circle-border-radius,
+	box-shadow: 0 0 0 1px rgba($black, 0.125),
+), $sticker-user-icon);
+
 // Sticker Variants
 
 $sticker-primary-bg: $primary !default;


### PR DESCRIPTION
ClayCSS Mixins added `clay-sticker-variant` for creating other sticker types

ClayCSS Stickers added new variant `.sticker-user-icon` and Sass map `$sticker-user-icon` which uses `clay-sticker-variant` mixin