### PR TITLE
Fixes #1618 ClayCSS Custom Checkbox/Radio up `z-index` on `.custom-co…

### DIFF
--- a/packages/clay-css/src/scss/components/_cards.scss
+++ b/packages/clay-css/src/scss/components/_cards.scss
@@ -275,7 +275,7 @@
 	}
 
 	.custom-control-input {
-		z-index: 1;
+		z-index: 2;
 	}
 
 	.custom-control-label {

--- a/packages/clay-css/src/scss/components/_custom-forms.scss
+++ b/packages/clay-css/src/scss/components/_custom-forms.scss
@@ -206,7 +206,7 @@ label.custom-control-label {
 	left: 0;
 	top: $custom-control-indicator-position-top;
 	width: $custom-control-indicator-size;
-	z-index: 0;
+	z-index: 1;
 }
 
 .custom-control-label::before {


### PR DESCRIPTION
…ntrol-input` so it doesn't lose focus when you decide not to click it