### PR TITLE
Fixes #1574 ClayCSS Form Control Tag Group change spacing between `.l…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -117,6 +117,9 @@ $form-control-label-size: map-merge((
 	border-width: 0.0625rem, // 1px
 	font-size: map-get($label-lg, font-size),
 	height: 1.5rem, // 24px
+	margin-bottom: 0.3125rem, // 5px
+	margin-right: 0.625rem, // 10px
+	margin-top: 0.3125rem, // 5px
 	padding-x: map-get($label-lg, padding-x),
 	padding-y: map-get($label-lg, padding-y),
 	text-transform: none,

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -60,12 +60,15 @@ $input-textarea-height: 150px !default;
 $form-control-label-size: () !default;
 $form-control-label-size: map-merge((
 	border-width: 0.0625rem, // 1px
-	height: 1.25rem // 20px
+	height: 1.25rem, // 20px
+	margin-bottom: 0.25rem, // 4px
+	margin-right: 0.5rem, // 8px
+	margin-top: 0.25rem, // 4px
 ), $form-control-label-size);
 
 // Form Control Tag Group
 
-$form-control-tag-group-padding-y: ($input-height-inner - map-get($form-control-label-size, height) - ($label-spacer-y * 2)) / 2 !default;
+$form-control-tag-group-padding-y: ($input-height-inner - map-get($form-control-label-size, height) - (map-get($form-control-label-size, margin-bottom)) - (map-get($form-control-label-size, margin-top))) / 2 !default;
 
 // Form Control Inset
 


### PR DESCRIPTION
…abel`