### PR TITLE
Fixes #1649 ClayCSS 2.x Add Color Variables Defined in Lexicon

### DIFF
--- a/packages/clay-css/src/content/colors.html
+++ b/packages/clay-css/src/content/colors.html
@@ -1,0 +1,449 @@
+---
+title: Colors
+section: Colors
+---
+
+<div class="alert alert-warning">
+	These are the color variables available in Clay CSS. The variables are used inconsistently throughout the project (especially in the Base Theme) and will require you to verify the colors have applied to each component to your liking. 
+</div>
+
+<div class="alert alert-info">
+	Only use this color system if it fits your application otherwise, we recommend using your own color system and applying it to each component.
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Grays</h3>
+
+		<blockquote class="blockquote">
+			<p>This color palette is generally used for setting colors on base components like <code>background-color</code>, <code>border-color</code>, and <code>color</code> in Cards.</p>
+		</blockquote>
+
+		<div class="clay-site-swatch clay-site-swatch-white">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-gray-100">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-gray-200">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-gray-300">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-gray-400">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-gray-500">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-gray-600">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-gray-700">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-gray-800">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-gray-900">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-black">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Colors</h3>
+
+		<div class="clay-site-swatch clay-site-swatch-blue">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-indigo">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-purple">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-pink">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-red">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-orange">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-yellow">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-green">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-teal">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-cyan">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Theme Colors</h3>
+
+		<blockquote class="blockquote">
+			<p>These color palettes are used to globally set the colors for component variants such as, <code>buttons</code>, <code>labels</code>, and <code>stickers</code>.</p>
+		</blockquote>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Primary</h3>
+
+		<div class="clay-site-swatch clay-site-swatch-primary-l3">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-primary-l2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-primary-l1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-primary">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-primary-d1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-primary-d2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Secondary</h3>
+
+		<div class="clay-site-swatch clay-site-swatch-secondary-l3">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-secondary-l2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-secondary-l1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-secondary">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-secondary-d1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+		<div class="clay-site-swatch clay-site-swatch-secondary-d2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Info</h3>
+
+		<div class="clay-site-swatch clay-site-swatch-info-l2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-info-l1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-info">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-info-d1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-info-d2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Success</h3>
+
+		<div class="clay-site-swatch clay-site-swatch-success-l2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-success-l1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-success">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-success-d1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-success-d2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Warning</h3>
+
+		<div class="clay-site-swatch clay-site-swatch-warning-l2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-warning-l1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-warning">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-warning-d1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-warning-d2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Danger</h3>
+
+		<div class="clay-site-swatch clay-site-swatch-danger-l2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-danger-l1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-danger">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-danger-d1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-danger-d2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Light</h3>
+
+		<div class="clay-site-swatch clay-site-swatch-light-l2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-light-l1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-light">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-light-d1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-light-d2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dark</h3>
+
+		<div class="clay-site-swatch clay-site-swatch-dark-l2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-dark-l1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-dark">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-dark-d1">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+
+		<div class="clay-site-swatch clay-site-swatch-dark-d2">
+			<span class="clay-site-var clay-site-swatch-text"></span>:
+			<span class="clay-site-hex clay-site-swatch-text"></span>
+			<span class="clay-site-rgb clay-site-swatch-text"></span>
+		</div>
+	</div>
+</div>
+
+<script>
+$(document).on('claySiteToggleTheme', function(event) {
+	$('.clay-site-swatch').each(function() {
+		var hex = $(this).css('content').replace(/"/g, "");
+		var rgb = $(this).css('background-color');
+		var clayVar = $(this).find('.clay-site-var').css('content').replace(/"/g, "");
+
+		$(this).find('.clay-site-hex').text(hex);
+		$(this).find('.clay-site-rgb').text(rgb);
+		$(this).find('.clay-site-var').text(clayVar);
+	});
+});
+</script>

--- a/packages/clay-css/src/js/site/toggle_css.js
+++ b/packages/clay-css/src/js/site/toggle_css.js
@@ -13,6 +13,28 @@
 		return $('link[href$="site-main.css"]');
 	};
 
+	var checkCSSLoaded = function(cssHref) {
+		function loaded () {
+			clearInterval(checkCSS);
+
+			$(document).trigger('claySiteToggleTheme');
+
+			$('#claySiteCSS').remove();
+		};
+
+		var clayBase = cssHref.match(/site-lexicon-font-awesome.css$/);
+
+		var theme = clayBase ? '"clay-base"' : '"clay-atlas"';
+
+		var checkCSS = setInterval(function() {
+			if ($('#claySiteCSS').css('content') === theme) {
+				loaded();
+			}
+		}, 100);
+
+		$('body').append('<div id="claySiteCSS"></div>');
+	};
+
 	var toggleLexiconLink = function() {
 		var lexiconLink = getLexiconLink();
 
@@ -27,6 +49,8 @@
 			lexiconLink.prop('href', href);
 
 			localStorage.setItem('nate.lexiconHref', href);
+
+			checkCSSLoaded(href);
 		}
 	};
 
@@ -79,6 +103,8 @@
 
 			toggleSiteCss.prop('checked', !lexiconSiteLink.prop('disabled'));
 		}
+
+		checkCSSLoaded(lexiconHref);
 	});
 
 	var siteNavToggle = $('#siteNavToggle');

--- a/packages/clay-css/src/scss/atlas/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_alerts.scss
@@ -37,63 +37,64 @@ $alert-notifications-box-shadow: 0 0.5rem 2rem -0.25rem rgba(0, 0, 0, 0.3) !defa
 // Alert Variants
 
 $alert-primary-color: $primary !default;
-$alert-primary-bg: lighten($alert-primary-color, 44.90) !default;
-$alert-primary-border-color: lighten($alert-primary-color, 22.94) !default;
+$alert-primary-bg: $primary-l3 !default;
+$alert-primary-border-color: $primary-l1 !default;
 $alert-primary-close-color: $alert-primary-color !default;
 $alert-primary-close-hover-color: $alert-primary-color !default;
 $alert-primary-lead-color: $alert-primary-color !default;
 $alert-primary-link-color: $link-color !default;
 
 $alert-secondary-color: $secondary !default;
-$alert-secondary-bg: lighten(saturate(adjust-hue($alert-secondary-color, 3), 6.13), 46.08) !default;
-$alert-secondary-border-color: lighten(saturate(adjust-hue($alert-secondary-color, -3), 5.39), 23.92) !default;
+$alert-secondary-bg: $secondary-l3 !default;
+$alert-secondary-border-color: $secondary-l1 !default;
 $alert-secondary-close-color: $alert-secondary-color !default;
 $alert-secondary-close-hover-color: $alert-secondary-color !default;
 $alert-secondary-lead-color: $alert-secondary-color !default;
 $alert-secondary-link-color: $link-color !default;
 
-$alert-info-color: $info !default;
-$alert-info-bg: lighten(desaturate(adjust-hue($alert-info-color, 1), 3.25), 52.94) !default;
-$alert-info-border-color: lighten(saturate($alert-info-color, 0.59), 28.04) !default;
-$alert-info-close-color: $alert-info-color !default;
-$alert-info-close-hover-color: $alert-info-color !default;
-$alert-info-lead-color: $alert-info-color !default;
-$alert-info-link-color: $link-color !default;
-
 $alert-success-color: $success !default;
-$alert-success-bg: lighten(desaturate($alert-success-color, 1.52), 62.94) !default;
-$alert-success-border-color: lighten(desaturate($alert-success-color, 0.14), 24.90) !default;
+$alert-success-bg: $success-l2 !default;
+$alert-success-border-color: $success-l1 !default;
 $alert-success-close-color: $alert-success-color !default;
 $alert-success-close-hover-color: $alert-success-color !default;
 $alert-success-lead-color: $alert-success-color !default;
 $alert-success-link-color: $link-color !default;
 
+$alert-info-color: $info !default;
+$alert-info-bg: $info-l2 !default;
+$alert-info-border-color: $info-l1 !default;
+$alert-info-close-color: $alert-info-color !default;
+$alert-info-close-hover-color: $alert-info-color !default;
+$alert-info-lead-color: $alert-info-color !default;
+$alert-info-link-color: $link-color !default;
+
 $alert-warning-color: $warning !default;
-$alert-warning-bg: lighten(adjust-hue($alert-warning-color, -1), 60.00) !default;
-$alert-warning-border-color: lighten($alert-warning-color, 24.90) !default;
+$alert-warning-bg: $warning-l2 !default;
+$alert-warning-border-color: $warning-l1 !default;
 $alert-warning-close-color: $alert-warning-color !default;
 $alert-warning-close-hover-color: $alert-warning-color !default;
 $alert-warning-lead-color: $alert-warning-color !default;
 $alert-warning-link-color: $link-color !default;
 
 $alert-danger-color: $danger !default;
-$alert-danger-bg: lighten(saturate($alert-danger-color, 5.04), 50.00) !default;
-$alert-danger-border-color: lighten(desaturate($alert-danger-color, 0.25), 28.04) !default;
+$alert-danger-bg: $danger-l2 !default;
+$alert-danger-border-color: $danger-l1 !default;
 $alert-danger-close-color: $alert-danger-color !default;
 $alert-danger-close-hover-color: $alert-danger-color !default;
 $alert-danger-lead-color: $alert-danger-color !default;
 $alert-danger-link-color: $link-color !default;
 
 $alert-light-color: $dark !default;
-$alert-light-border-color: lighten(desaturate($alert-light-color, 0.65), 64.90) !default;
-$alert-light-close-color: $secondary !default;
-$alert-light-close-hover-color: $secondary !default;
+$alert-light-bg: $light-l2 !default;
+$alert-light-border-color: $light-l1 !default;
+$alert-light-close-color: $alert-light-color !default;
+$alert-light-close-hover-color: $alert-light-color !default;
 $alert-light-lead-color: $alert-light-color !default;
 $alert-light-link-color: $link-color !default;
 
 $alert-dark-color: $light !default;
-$alert-dark-bg: darken(desaturate(adjust-hue($alert-dark-color, 11), 3.69), 69.61) !default;
-$alert-dark-border-color: darken(desaturate(adjust-hue($alert-dark-color, 10), 2.38), 77.45) !default;
+$alert-dark-bg: $dark-l2 !default;
+$alert-dark-border-color: $dark-l1 !default;
 $alert-dark-close-color: $alert-dark-color !default;
 $alert-dark-close-hover-color: $alert-dark-color !default;
 $alert-dark-lead-color: $alert-dark-color !default;

--- a/packages/clay-css/src/scss/atlas/variables/_application-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_application-bar.scss
@@ -5,7 +5,7 @@ $application-bar-size: map-merge((
 
 $application-bar-dark: () !default;
 $application-bar-dark: map-merge((
-	bg: lighten(desaturate(adjust-hue($dark, 1), 0.77), 3.92),
+	bg: $dark-l1,
 	link-border-radius: $border-radius,
 	link-font-weight: $font-weight-semi-bold,
 	link-hover-bg: rgba(255, 255, 255, 0.03),

--- a/packages/clay-css/src/scss/atlas/variables/_badges.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_badges.scss
@@ -12,44 +12,44 @@ $badge-pill-padding-x: 0.25rem !default; // 4px
 
 // Badge Variants
 
-$badge-primary-color: #FFF !default;
+$badge-primary-color: $white !default;
 $badge-primary-bg: $primary !default;
 $badge-primary-hover-bg: $badge-primary-bg !default;
 $badge-primary-hover-color: $badge-primary-color !default;
 
-$badge-secondary-color: $dark !default;
-$badge-secondary-bg: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
+$badge-secondary-color: $gray-900 !default;
+$badge-secondary-bg: $secondary-l3 !default;
 $badge-secondary-hover-bg: $badge-secondary-bg !default;
 $badge-secondary-hover-color: $badge-secondary-color !default;
 $badge-secondary-link-color: $badge-secondary-color !default;
 
-$badge-success-color: #FFF !default;
+$badge-success-color: $white !default;
 $badge-success-bg: $success !default;
 $badge-success-hover-bg: $badge-success-bg !default;
 $badge-success-hover-color: $badge-success-color !default;
 
-$badge-info-color: #FFF !default;
+$badge-info-color: $white !default;
 $badge-info-bg: $info !default;
 $badge-info-hover-bg: $badge-info-bg !default;
 $badge-info-hover-color: $badge-info-color !default;
 
-$badge-warning-color: #FFF !default;
+$badge-warning-color: $white !default;
 $badge-warning-bg: $warning !default;
 $badge-warning-hover-bg: $badge-warning-bg !default;
 $badge-warning-hover-color: $badge-warning-color !default;
 
-$badge-danger-color: #FFF !default;
+$badge-danger-color: $white !default;
 $badge-danger-bg: $danger !default;
 $badge-danger-hover-bg: $badge-danger-bg !default;
 $badge-danger-hover-color: $badge-danger-color !default;
 
-$badge-light-color: $dark !default;
+$badge-light-color: $gray-900 !default;
 $badge-light-bg: $light !default;
 $badge-light-hover-bg: $badge-light-bg !default;
 $badge-light-hover-color: $badge-light-color !default;
 $badge-light-link-color: $badge-light-color !default;
 
-$badge-dark-color: #FFF !default;
+$badge-dark-color: $white !default;
 $badge-dark-bg: $dark !default;
 $badge-dark-hover-bg: $badge-dark-bg !default;
 $badge-dark-hover-color: $badge-dark-color !default;

--- a/packages/clay-css/src/scss/atlas/variables/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_breadcrumbs.scss
@@ -2,10 +2,10 @@ $breadcrumb-bg: transparent !default;
 $breadcrumb-font-size: 0.875rem !default; // 14px
 $breadcrumb-padding-x: 0.125rem !default; // 2px
 
-$breadcrumb-link-color: $secondary !default;
+$breadcrumb-link-color: $gray-600 !default;
 $breadcrumb-link-hover-color: $breadcrumb-link-color !default;
 
-$breadcrumb-active-color: $body-color !default;
+$breadcrumb-active-color: $gray-900 !default;
 
 $breadcrumb-divider-color: $breadcrumb-link-color !default;
 $breadcrumb-divider-svg-icon-height: 0.6em !default;

--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -44,64 +44,64 @@ $btn-group-item-margin-right: 1rem !default;
 
 $btn-primary: () !default;
 $btn-primary: map-merge((
-	hover-bg: darken($primary, 5.10),
+	hover-bg: $primary-d1,
 	hover-border-color: transparent,
-	focus-box-shadow: 0 0 0 2px rgba(darken($primary, 5.10), 0.5),
+	focus-box-shadow: 0 0 0 2px rgba($primary-d1, 0.5),
 	disabled-bg: $primary,
-	active-bg: darken($primary, 10.00),
+	active-bg: $primary-d2,
 	active-border-color: transparent,
 	active-box-shadow: none
 ), $btn-primary);
 
 $btn-secondary: () !default;
 $btn-secondary: map-merge((
-	bg: #FFF,
-	border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06),
+	bg: $white,
+	border-color: $secondary-l2,
 	color: $secondary,
-	hover-bg: lighten(saturate(adjust-hue($secondary, -27), 6.13), 51.57),
-	hover-border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06),
-	hover-color: $body-color,
-	focus-box-shadow: 0 0 0 2px rgba(lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06), 0.5),
-	focus-color: $body-color,
-	disabled-bg: #FFF,
-	disabled-border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06),
+	hover-bg: $gray-100,
+	hover-border-color: $secondary-l2,
+	hover-color: $gray-900,
+	focus-box-shadow: 0 0 0 2px rgba($secondary-l2, 0.5),
+	focus-color: $gray-900,
+	disabled-bg: $white,
+	disabled-border-color: $secondary-l2,
 	disabled-color: $secondary,
-	active-border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06),
-	active-color: $body-color,
-	active-bg: lighten(saturate(adjust-hue($secondary, -12), 8.51), 49.61),
+	active-border-color: $secondary-l2,
+	active-color: $gray-900,
+	active-bg: $gray-200,
 	active-box-shadow: none,
 	loading-animation: null
 ), $btn-secondary);
 
 $btn-success: () !default;
 $btn-success: map-merge((
-	hover-bg: darken($success, 4%),
+	hover-bg: $success-d1,
 	hover-border-color: transparent,
-	focus-box-shadow: 0 0 0 2px rgba(darken($success, 4%), 0.5),
+	focus-box-shadow: 0 0 0 2px rgba($success-d1, 0.5),
 	disabled-bg: $success,
-	active-bg: darken($success, 8%),
+	active-bg: $success-d2,
 	active-border-color: transparent,
 	active-box-shadow: none
 ), $btn-success);
 
 $btn-info: () !default;
 $btn-info: map-merge((
-	hover-bg: darken($info, 4%),
+	hover-bg: $info-d1,
 	hover-border-color: transparent,
-	focus-box-shadow: 0 0 0 2px rgba(darken($info, 4%), 0.5),
+	focus-box-shadow: 0 0 0 2px rgba($info-d1, 0.5),
 	disabled-bg: $info,
-	active-bg: darken($info, 8%),
+	active-bg: $info-d2,
 	active-border-color: transparent,
 	active-box-shadow: none
 ), $btn-info);
 
 $btn-warning: () !default;
 $btn-warning: map-merge((
-	hover-bg: darken($warning, 4%),
+	hover-bg: $warning-d1,
 	hover-border-color: transparent,
-	focus-box-shadow: 0 0 0 2px rgba(darken($warning, 4%), 0.5),
+	focus-box-shadow: 0 0 0 2px rgba($warning-d1, 0.5),
 	disabled-bg: $warning,
-	active-bg: darken($warning, 8%),
+	active-bg: $warning-d2,
 	active-border-color: transparent,
 	active-box-shadow: none,
 	loading-animation: 'loading-animation-light'
@@ -109,34 +109,34 @@ $btn-warning: map-merge((
 
 $btn-danger: () !default;
 $btn-danger: map-merge((
-	hover-bg: darken($danger, 4%),
+	hover-bg: $danger-d1,
 	hover-border-color: transparent,
-	focus-box-shadow: 0 0 0 2px rgba(darken($danger, 4%), 0.5),
+	focus-box-shadow: 0 0 0 2px rgba($danger-d1, 0.5),
 	disabled-bg: $danger,
-	active-bg: darken($danger, 8%),
+	active-bg: $danger-d2,
 	active-border-color: transparent,
 	active-box-shadow: none
 ), $btn-danger);
 
 $btn-light: () !default;
 $btn-light: map-merge((
-	color: $body-color,
-	hover-bg: darken($light, 4%),
+	color: $gray-900,
+	hover-bg: $light-d1,
 	hover-border-color: transparent,
-	focus-box-shadow: 0 0 0 2px rgba(darken($light, 4%), 0.5),
+	focus-box-shadow: 0 0 0 2px rgba($light-d1, 0.5),
 	disabled-bg: $light,
-	active-bg: darken($light, 8%),
+	active-bg: $light-d2,
 	active-border-color: transparent,
 	active-box-shadow: none
 ), $btn-light);
 
 $btn-dark: () !default;
 $btn-dark: map-merge((
-	hover-bg: darken($dark, 4%),
+	hover-bg: $dark-d1,
 	hover-border-color: transparent,
-	focus-box-shadow: 0 0 0 2px rgba(darken($dark, 4%), 0.5),
+	focus-box-shadow: 0 0 0 2px rgba($dark-d1, 0.5),
 	disabled-bg: $dark,
-	active-bg: darken($dark, 8%),
+	active-bg: $dark-d2,
 	active-border-color: transparent,
 	active-box-shadow: none
 ), $btn-dark);
@@ -145,10 +145,10 @@ $btn-dark: map-merge((
 
 $btn-outline-primary: () !default;
 $btn-outline-primary: map-merge((
-	hover-bg: lighten($primary, 44.90),
+	hover-bg: $primary-l3,
 	hover-color: $primary,
-	focus-bg: lighten($primary, 44.90),
-	focus-box-shadow: 0 0 0 2px rgba(darken($primary, 5.10), 0.25),
+	focus-bg: $primary-l3,
+	focus-box-shadow: 0 0 0 2px rgba($primary-d1, 0.25),
 	focus-color: $primary,
 	disabled-bg: transparent,
 	disabled-border-color: map-get($btn-primary, bg),
@@ -161,9 +161,9 @@ $btn-outline-primary: map-merge((
 $btn-outline-secondary: () !default;
 $btn-outline-secondary: map-merge((
 	bg: null,
-	border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06),
+	border-color: $secondary-l2,
 	color: null,
-	hover-bg: rgba($dark, 0.03),
+	hover-bg: rgba($gray-900, 0.03),
 	hover-border-color: transparent,
 	hover-color: map-get($btn-secondary, hover-color),
 	focus-bg: map-get($btn-secondary, focus-bg),
@@ -173,7 +173,7 @@ $btn-outline-secondary: map-merge((
 	disabled-bg: transparent,
 	disabled-border-color: $secondary,
 	disabled-color: $secondary,
-	active-bg: rgba($dark, 0.06),
+	active-bg: rgba($gray-900, 0.06),
 	active-border-color: transparent,
 	active-box-shadow: map-get($btn-secondary, active-box-shadow),
 	active-color: map-get($btn-secondary, active-color)
@@ -183,7 +183,7 @@ $btn-outline-info: () !default;
 $btn-outline-info: map-merge((
 	hover-bg: map-get($btn-info, hover-bg),
 	focus-box-shadow: map-get($btn-info, focus-box-shadow),
-	focus-color: #FFF,
+	focus-color: $white,
 	disabled-bg: transparent,
 	disabled-border-color: map-get($btn-info, bg),
 	disabled-color: map-get($btn-info, bg),
@@ -195,7 +195,7 @@ $btn-outline-success: () !default;
 $btn-outline-success: map-merge((
 	hover-bg: map-get($btn-success, hover-bg),
 	focus-box-shadow: map-get($btn-success, focus-box-shadow),
-	focus-color: #FFF,
+	focus-color: $white,
 	disabled-bg: transparent,
 	disabled-border-color: map-get($btn-success, bg),
 	disabled-color: map-get($btn-success, bg),
@@ -207,7 +207,7 @@ $btn-outline-warning: () !default;
 $btn-outline-warning: map-merge((
 	hover-bg: map-get($btn-warning, hover-bg),
 	focus-box-shadow: map-get($btn-warning, focus-box-shadow),
-	focus-color: #FFF,
+	focus-color: $white,
 	disabled-bg: transparent,
 	disabled-border-color: map-get($btn-warning, bg),
 	disabled-color: map-get($btn-warning, bg),
@@ -219,7 +219,7 @@ $btn-outline-danger: () !default;
 $btn-outline-danger: map-merge((
 	hover-bg: map-get($btn-danger, hover-bg),
 	focus-box-shadow: map-get($btn-danger, focus-box-shadow),
-	focus-color: #FFF,
+	focus-color: $white,
 	disabled-bg: transparent,
 	disabled-border-color: map-get($btn-danger, bg),
 	disabled-color: map-get($btn-danger, bg),
@@ -243,7 +243,7 @@ $btn-outline-dark: () !default;
 $btn-outline-dark: map-merge((
 	hover-bg: map-get($btn-dark, hover-bg),
 	focus-box-shadow: map-get($btn-dark, focus-box-shadow),
-	focus-color: #FFF,
+	focus-color: $white,
 	disabled-bg: transparent,
 	disabled-border-color: map-get($btn-dark, bg),
 	disabled-color: map-get($btn-dark, bg),

--- a/packages/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_cards.scss
@@ -13,7 +13,7 @@ $card-inner-border-radius: if($card-border-width > 0, calc(#{$card-border-radius
 
 $card-title: () !default;
 $card-title: map-merge((
-	color: $body-color,
+	color: $gray-900,
 	font-size: 0.875rem // 14px
 ), $card-title);
 
@@ -31,16 +31,16 @@ $card-subtitle: map-merge((
 
 $card-subtitle-link: () !default;
 $card-subtitle-link: map-merge((
-	hover-color: $secondary
+	hover-color: $gray-600,
 ), $card-subtitle-link);
 
 // Card Link
 
 $card-link: () !default;
 $card-link: map-merge((
-	color: $secondary,
+	color: $gray-600,
 	font-size: 0.875rem, // 14px
-	hover-color: $secondary,
+	hover-color: $gray-600,
 	hover-text-decoration: underline
 ), $card-link);
 
@@ -72,18 +72,18 @@ $card-interactive-secondary: map-merge((
 
 $card-type-asset: () !default;
 $card-type-asset: map-merge((
-	aspect-ratio-border-color: lighten(map-get($theme-colors, secondary), 46%),
+	aspect-ratio-border-color: $gray-300,
 	card-body-padding-top: 0.75rem
 ), $card-type-asset);
 
 $image-card: () !default;
 $image-card: map-merge((
-	aspect-ratio-checkered-fg: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08)
+	aspect-ratio-checkered-fg: $gray-300,
 ), $image-card);
 
 $file-card: () !default;
 $file-card: map-merge((
-	asset-icon-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06)
+	asset-icon-color: $gray-400,
 ), $file-card);
 
 // Card Type Template

--- a/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
@@ -1,13 +1,13 @@
 $custom-control-indicator-size: 1.0625rem !default; // 17px
-$custom-control-indicator-bg: #FFF !default;
-$custom-control-indicator-border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06) !default;
+$custom-control-indicator-bg: $white !default;
+$custom-control-indicator-border-color: $gray-400 !default;
 $custom-control-indicator-border-style: solid !default;
 $custom-control-indicator-border-width: 0.0625rem !default; // 1px
 $custom-control-indicator-box-shadow: none !default;
 
 $custom-control-indicator-focus-box-shadow: 0 0 0 1px $body-bg, 0 0 0 2px lighten($component-active-bg, 22.94) !default;
 
-$custom-control-indicator-active-bg: #FFF !default;
+$custom-control-indicator-active-bg: $white !default;
 $custom-control-indicator-active-border-color: $custom-control-indicator-border-color !default;
 $custom-control-indicator-active-box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1) !default;
 
@@ -51,7 +51,7 @@ $custom-control-description-small-font-size: 100% !default;
 
 // Custom Checkbox
 
-$custom-checkbox-indicator-icon-checked: clay-icon(check, #FFF) !default;
+$custom-checkbox-indicator-icon-checked: clay-icon(check, $white) !default;
 $custom-checkbox-indicator-icon-checked-bg-size: 60% !default;
 $custom-checkbox-indicator-icon-indeterminate-bg-size: 53% !default;
 

--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -1,4 +1,4 @@
-$dropdown-border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
+$dropdown-border-color: $gray-300 !default;
 $dropdown-border-width: 0 !default;
 $dropdown-box-shadow: 0 1px 5px -1px rgba(0, 0, 0, 0.3) !default;
 $dropdown-font-size: 0.875rem !default; // 14px
@@ -11,21 +11,21 @@ $dropdown-max-width: 240px !default;
 $dropdown-item-padding-x: 1.25rem !default; // 20px
 $dropdown-item-padding-y: 0.5rem !default; // 8px
 
-$dropdown-header-color: $secondary !default;
+$dropdown-header-color: $gray-600 !default;
 $dropdown-header-font-size: 0.875rem !default; // 14px
 $dropdown-header-margin-top: 0.625rem !default; // 10px
 
 $dropdown-subheader-font-size: 0.75rem !default; // 12px
 $dropdown-subheader-margin-top: 0.625rem !default; // 10px
 
-$dropdown-link-color: $secondary !default;
+$dropdown-link-color: $gray-600 !default;
 $dropdown-link-font-weight: $font-weight-normal !default;
-$dropdown-link-hover-color: $body-color !default;
+$dropdown-link-hover-color: $gray-900 !default;
 $dropdown-link-hover-bg: lighten($component-active-bg, 44.90) !default;
 $dropdown-link-active-color: $dropdown-link-hover-color !default;
 $dropdown-link-active-bg: $dropdown-link-hover-bg !default;
 $dropdown-link-active-font-weight: $font-weight-semi-bold !default;
-$dropdown-link-disabled-color: lighten(desaturate(adjust-hue($body-color, -1), 0.74), 51.76) !default;
+$dropdown-link-disabled-color: $gray-500 !default;
 
 $dropdown-divider-bg: $dropdown-border-color !default;
 

--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -34,7 +34,7 @@ $input-height-inner-sm: $input-height-sm - $input-height-border !default;
 
 $form-feedback-font-size: 0.875rem !default; // 14px
 
-$form-text-color: $secondary !default;
+$form-text-color: $gray-600 !default;
 
 $form-group-margin-bottom: 1.5rem !default; // 24px
 $form-group-margin-bottom-mobile: 1rem !default; // 16px
@@ -48,28 +48,28 @@ $form-check-label-text-margin-left: -0.1875rem !default; // 3px
 
 // Skin
 
-$input-color: $body-color !default;
-$input-bg: $light !default;
-$input-border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
+$input-color: $gray-900 !default;
+$input-bg: $gray-200 !default;
+$input-border-color: $gray-300 !default;
 $input-box-shadow: none !default;
-$input-placeholder-color: $secondary !default;
-$input-label-color: $body-color !default;
+$input-placeholder-color: $gray-600 !default;
+$input-label-color: $gray-900 !default;
 
 $input-focus-bg: lighten($component-active-bg, 44.90) !default;
 $input-focus-border-color: lighten($component-active-bg, 22.94) !default;
 $input-focus-box-shadow: none !default;
 
-$input-disabled-color: $text-muted !default;
+$input-disabled-color: $gray-500 !default;
 $input-disabled-bg: $input-bg !default;
 $input-disabled-border-color: $input-bg !default;
 $input-placeholder-disabled-color: $input-disabled-color !default;
 
-$input-label-disabled-color: $text-muted !default;
+$input-label-disabled-color: $gray-500 !default;
 
 $input-readonly-bg: $input-border-color !default;
 
-$input-danger-bg: lighten(saturate($danger, 5.04), 50.00) !default;
-$input-danger-border-color: lighten(desaturate($danger, 0.25), 28.04) !default;
+$input-danger-bg: $danger-l2 !default;
+$input-danger-border-color: $danger-l1 !default;
 $input-danger-box-shadow: none !default;
 $input-danger-focus-box-shadow: none !default;
 $input-danger-color: $input-color !default;
@@ -77,8 +77,8 @@ $input-danger-checkbox-label-color: $danger !default;
 $input-danger-select-icon-color: $input-danger-border-color !default;
 $input-danger-select-icon: clay-icon(caret-double-l, $input-danger-select-icon-color) !default;
 
-$input-success-bg: lighten(desaturate($success, 1.52), 62.94) !default;
-$input-success-border-color: lighten(desaturate($success, 0.14), 24.90) !default;
+$input-success-bg: $success-l2 !default;
+$input-success-border-color: $success-l1 !default;
 $input-success-box-shadow: none !default;
 $input-success-focus-box-shadow: none !default;
 $input-success-color: $input-color !default;
@@ -86,8 +86,8 @@ $input-success-checkbox-label-color: $success !default;
 $input-success-select-icon-color: $input-success-border-color !default;
 $input-success-select-icon: clay-icon(caret-double-l, $input-success-select-icon-color) !default;
 
-$input-warning-bg: lighten(adjust-hue($warning, -1), 60.00) !default;
-$input-warning-border-color: lighten($warning, 24.90) !default;
+$input-warning-bg: $warning-l2 !default;
+$input-warning-border-color: $warning-l1 !default;
 $input-warning-box-shadow: none !default;
 $input-warning-focus-box-shadow: none !default;
 $input-warning-color: $input-color !default;
@@ -101,13 +101,13 @@ $input-select-bg-position: right 0.5em center !default;
 $input-select-bg-size: 1.5em auto !default;
 $input-select-padding-right: 2em !default;
 
-$input-select-icon-color: $secondary !default;
+$input-select-icon-color: $gray-600 !default;
 $input-select-icon: clay-icon(caret-double-l, $input-select-icon-color) !default;
 
 $input-select-icon-focus-color: $input-select-icon-color !default;
 $input-select-icon-focus: clay-icon(caret-double-l, $input-select-icon-focus-color) !default;
 
-$input-select-icon-disabled-color: $text-muted !default;
+$input-select-icon-disabled-color: $gray-500 !default;
 $input-select-icon-disabled: clay-icon(caret-double-l, $input-select-icon-disabled-color) !default;
 
 // Textarea
@@ -140,9 +140,9 @@ $form-group-item-label-spacer: ($input-label-font-size * $line-height-base) + $i
 
 // Input Groups
 
-$input-group-addon-bg: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
+$input-group-addon-bg: $gray-300 !default;
 $input-group-addon-border-color: $input-group-addon-bg !default;
-$input-group-addon-color: $secondary !default;
+$input-group-addon-color: $gray-600 !default;
 $input-group-addon-font-weight: $font-weight-semi-bold !default;
 $input-group-addon-min-width: 2.5rem !default; // 40px
 $input-group-addon-padding-x: 0.75rem !default; // 12px
@@ -153,6 +153,6 @@ $input-group-addon-min-width-sm: 2rem !default; // 32px
 
 // Input Group Secondary
 
-$input-group-secondary-addon-bg: #FFF !default;
-$input-group-secondary-addon-border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06) !default;
+$input-group-secondary-addon-bg: $white !default;
+$input-group-secondary-addon-border-color: $secondary-l2 !default;
 $input-group-secondary-addon-color: $secondary !default;

--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -133,10 +133,10 @@ $theme-colors: map-merge((
 	dark: $dark
 ), $theme-colors);
 
-$yiq-text-dark: $dark !default;
-$yiq-text-light: #FFF !default;
+$yiq-text-dark: $gray-900 !default;
+$yiq-text-light: $white !default;
 
-$body-bg: #F1F2F5 !default;
+$body-bg: $gray-200 !default;
 $body-color: $gray-900 !default;
 $text-muted: $gray-500 !default;
 

--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -49,9 +49,9 @@ $headings-font-weight: $font-weight-bold !default;
 // Theme Base Colors
 
 $white: #FFF !default;
-$gray-100: #F8F9FA !default;
+$gray-100: #F7F8F9 !default;
 $gray-200: #F1F2F5 !default;
-$gray-300: #DEE2E6 !default;
+$gray-300: #E7E7ED !default;
 $gray-400: #CDCED9 !default;
 $gray-500: #A7A9BC !default;
 $gray-600: #6B6C7E !default;
@@ -79,35 +79,47 @@ $primary-l2: lighten($primary, 32.94) !default;
 $primary-l3: lighten($primary, 44.90) !default;
 
 $secondary: #6B6C7E !default;
-$secondary-d1: #393A4A !default;
-$secondary-d2: #30313F !default;
-$secondary-l1: #A7A9BC !default;
-$secondary-l2: #CDCED9 !default;
-$secondary-l3: #E7E7ED !default;
+$secondary-d1: darken(saturate($secondary, 4.82), 20) !default;
+$secondary-d2: darken(saturate($secondary, 5.36), 23.92) !default;
+$secondary-l1: lighten(saturate(adjust-hue($secondary, -3), 5.39), 23.92) !default;
+$secondary-l2: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06) !default;
+$secondary-l3: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
 
 $info: #2E5AAC !default;
-$info-l1: #89A7E0 !default;
-$info-l2: #EEF2FA !default;
+$info-d1: darken($info, 5.10) !default;
+$info-d2: darken($info, 10) !default;
+$info-l1: lighten(saturate($info, 0.59), 28.04) !default;
+$info-l2: lighten(desaturate($info, 3.25), 52.94) !default;
 
 $success: #287D3D !default;
-$success-l1: #5ACA75 !default;
-$success-l2: #EDF9F0 !default;
+$success-d1: darken($success, 5.10) !default;
+$success-d2: darken($success, 10) !default;
+$success-l1: lighten(desaturate($success, 0.14), 24.90) !default;
+$success-l2: lighten(desaturate($success, 1.52), 62.94) !default;
 
 $warning: #B95000 !default;
-$warning-l1: #FF8F39 !default;
-$warning-l2: #FFF4EC !default;
+$warning-d1: darken($warning, 5.10) !default;
+$warning-d2: darken($warning, 10) !default;
+$warning-l1: lighten($warning, 24.90) !default;
+$warning-l2: lighten($warning, 60) !default;
 
 $danger: #DA1414 !default;
-$danger-l1: #F48989 !default;
-$danger-l2: #FEEFEF !default;
+$danger-d1: darken($danger, 5.10) !default;
+$danger-d2: darken($danger, 10) !default;
+$danger-l1: lighten(desaturate($danger, 0.25), 28.04) !default;
+$danger-l2: lighten(saturate($danger, 5.04), 50) !default;
 
 $light: #F1F2F5 !default;
-$light-l1: #F7F8F9 !default;
-$light-l2: #FFF !default;
+$light-d1: darken($light, 5.10) !default;
+$light-d2: darken($light, 10) !default;
+$light-l1: lighten(desaturate(adjust-hue($light, -15), 2.38), 1.96) !default;
+$light-l2: lighten(desaturate(adjust-hue($light, -225), 16.67), 4.71) !default;
 
 $dark: #272833 !default;
-$dark-l1: #30313F !default;
-$dark-l2: #393A4A !default;
+$dark-d1: darken($dark, 5.10) !default;
+$dark-d2: darken($dark, 10) !default;
+$dark-l1: lighten(saturate($dark, 0.18), 4.12) !default;
+$dark-l2: lighten(desaturate($dark, 0.36), 8.04) !default;
 
 $theme-colors: () !default;
 $theme-colors: map-merge((
@@ -125,11 +137,11 @@ $yiq-text-dark: $dark !default;
 $yiq-text-light: #FFF !default;
 
 $body-bg: #F1F2F5 !default;
-$body-color: $dark !default;
-$text-muted: lighten(saturate(adjust-hue($body-color, -1), 0.22), 51.96) !default;
+$body-color: $gray-900 !default;
+$text-muted: $gray-500 !default;
 
-$link-color: #0B5FFF !default;
-$link-hover-color: darken($link-color, 8%) !default;
+$link-color: $primary !default;
+$link-hover-color: $primary-d2 !default;
 
 $component-active-bg: #0B5FFF !default;
 $component-active-color: #FFF !default;

--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -72,13 +72,42 @@ $teal: #20C997 !default;
 $cyan: #17A2B8 !default;
 
 $primary: #0B5FFF !default;
+$primary-d1: darken($primary, 5.10) !default;
+$primary-d2: darken($primary, 10) !default;
+$primary-l1: lighten($primary, 22.94) !default;
+$primary-l2: lighten($primary, 32.94) !default;
+$primary-l3: lighten($primary, 44.90) !default;
+
 $secondary: #6B6C7E !default;
-$success: #287D3D !default;
+$secondary-d1: #393A4A !default;
+$secondary-d2: #30313F !default;
+$secondary-l1: #A7A9BC !default;
+$secondary-l2: #CDCED9 !default;
+$secondary-l3: #E7E7ED !default;
+
 $info: #2E5AAC !default;
+$info-l1: #89A7E0 !default;
+$info-l2: #EEF2FA !default;
+
+$success: #287D3D !default;
+$success-l1: #5ACA75 !default;
+$success-l2: #EDF9F0 !default;
+
 $warning: #B95000 !default;
+$warning-l1: #FF8F39 !default;
+$warning-l2: #FFF4EC !default;
+
 $danger: #DA1414 !default;
+$danger-l1: #F48989 !default;
+$danger-l2: #FEEFEF !default;
+
 $light: #F1F2F5 !default;
+$light-l1: #F7F8F9 !default;
+$light-l2: #FFF !default;
+
 $dark: #272833 !default;
+$dark-l1: #30313F !default;
+$dark-l2: #393A4A !default;
 
 $theme-colors: () !default;
 $theme-colors: map-merge((

--- a/packages/clay-css/src/scss/atlas/variables/_icons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_icons.scss
@@ -1,2 +1,2 @@
-$order-arrow-down-active-color: lighten(saturate(adjust-hue($secondary, -3), 5.39), 23.92) !default;
+$order-arrow-down-active-color: $gray-500 !default;
 $order-arrow-up-active-color: $order-arrow-down-active-color !default;

--- a/packages/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_labels.scss
@@ -41,9 +41,9 @@ $label-lg: map-merge((
 // $label-primary-color is deprecated as of v2.4.1
 $label-primary-color: $primary !default;
 // $label-primary-hover-color is deprecated as of v2.4.1
-$label-primary-hover-color: #004AD7 !default;
+$label-primary-hover-color: $primary-d2 !default;
 // $label-primary-border-color is deprecated as of v2.4.1
-$label-primary-border-color: lighten($label-primary-color, 22.94) !default;
+$label-primary-border-color: $primary-l1 !default;
 // $label-primary-hover-border-color is deprecated as of v2.4.1
 $label-primary-hover-border-color: $label-primary-border-color !default;
 
@@ -59,15 +59,15 @@ $label-primary: map-merge((
 	hover-border-color: $label-primary-hover-border-color,
 	hover-color: $label-primary-hover-color,
 	focus-outline: 0,
-	focus-box-shadow: 0 0 0 1px #80ACFF,
+	focus-box-shadow: 0 0 0 1px $primary-l1,
 ), $label-primary);
 
 // $label-secondary-color is deprecated as of v2.4.1
 $label-secondary-color: $secondary !default;
 // $label-secondary-hover-color is deprecated as of v2.4.1
-$label-secondary-hover-color: $dark !default;
+$label-secondary-hover-color: $gray-900 !default;
 // $label-secondary-border-color is deprecated as of v2.4.1
-$label-secondary-border-color: lighten(saturate(adjust-hue($label-secondary-color, -2), 5.48), 37.06) !default;
+$label-secondary-border-color: $secondary-l2 !default;
 // $label-secondary-hover-border-color is deprecated as of v2.4.1
 $label-secondary-hover-border-color: $label-secondary-border-color !default;
 
@@ -82,17 +82,17 @@ $label-secondary: map-merge((
 	color: $label-secondary-color,
 	hover-border-color: $label-secondary-hover-border-color,
 	hover-color: $label-secondary-hover-color,
-	focus-border-color: #80ACFF,
+	focus-border-color: $primary-l1,
 	focus-outline: 0,
-	focus-box-shadow: 0 0 0 1px #80ACFF,
+	focus-box-shadow: 0 0 0 1px $primary-l1,
 ), $label-secondary);
 
 // $label-success-color is deprecated as of v2.4.1
 $label-success-color: $success !default;
 // $label-success-hover-color is deprecated as of v2.4.1
-$label-success-hover-color: darken($label-success-color, 8) !default;
+$label-success-hover-color: $success-d2 !default;
 // $label-success-border-color is deprecated as of v2.4.1
-$label-success-border-color: lighten(desaturate($label-success-color, 0.14), 24.90) !default;
+$label-success-border-color: $success-l1 !default;
 // $label-success-hover-border-color is deprecated as of v2.4.1
 $label-success-hover-border-color: $label-success-border-color !default;
 
@@ -107,17 +107,17 @@ $label-success: map-merge((
 	color: $label-success-color,
 	hover-border-color: $label-success-hover-border-color,
 	hover-color: $label-success-hover-color,
-	focus-border-color: #80ACFF,
+	focus-border-color: $primary-l1,
 	focus-outline: 0,
-	focus-box-shadow: 0 0 0 1px #80ACFF,
+	focus-box-shadow: 0 0 0 1px $primary-l1,
 ), $label-success);
 
 // $label-info-color is deprecated as of v2.4.1
 $label-info-color: $info !default;
 // $label-info-hover-color is deprecated as of v2.4.1
-$label-info-hover-color: darken($label-info-color, 8) !default;
+$label-info-hover-color: $info-d2 !default;
 // $label-info-border-color is deprecated as of v2.4.1
-$label-info-border-color: lighten(saturate($label-info-color, 0.59), 28.04) !default;
+$label-info-border-color: $info-l1 !default;
 // $label-info-hover-border-color is deprecated as of v2.4.1
 $label-info-hover-border-color: $label-info-border-color !default;
 
@@ -132,17 +132,17 @@ $label-info: map-merge((
 	color: $label-info-color,
 	hover-border-color: $label-info-hover-border-color,
 	hover-color: $label-info-hover-color,
-	focus-border-color: #80ACFF,
+	focus-border-color: $primary-l1,
 	focus-outline: 0,
-	focus-box-shadow: 0 0 0 1px #80ACFF,
+	focus-box-shadow: 0 0 0 1px $primary-l1,
 ), $label-info);
 
 // $label-warning-color is deprecated as of v2.4.1
 $label-warning-color: $warning !default;
 // $label-warning-hover-color is deprecated as of v2.4.1
-$label-warning-hover-color: darken($label-warning-color, 8) !default;
+$label-warning-hover-color: $warning-d2 !default;
 // $label-warning-border-color is deprecated as of v2.4.1
-$label-warning-border-color: lighten($label-warning-color, 24.90) !default;
+$label-warning-border-color: $warning-l1 !default;
 // $label-warning-hover-border-color is deprecated as of v2.4.1
 $label-warning-hover-border-color: $label-warning-border-color !default;
 
@@ -157,17 +157,17 @@ $label-warning: map-merge((
 	color: $label-warning-color,
 	hover-border-color: $label-warning-hover-border-color,
 	hover-color: $label-warning-hover-color,
-	focus-border-color: #80ACFF,
+	focus-border-color: $primary-l1,
 	focus-outline: 0,
-	focus-box-shadow: 0 0 0 1px #80ACFF,
+	focus-box-shadow: 0 0 0 1px $primary-l1,
 ), $label-warning);
 
 // $label-danger-color is deprecated as of v2.4.1
 $label-danger-color: $danger !default;
 // $label-danger-hover-color is deprecated as of v2.4.1
-$label-danger-hover-color: darken($label-danger-color, 8) !default;
+$label-danger-hover-color: $danger-d2 !default;
 // $label-danger-border-color is deprecated as of v2.4.1
-$label-danger-border-color: lighten(desaturate($label-danger-color, 0.25), 28.04) !default;
+$label-danger-border-color: $danger-l1 !default;
 // $label-danger-hover-border-color is deprecated as of v2.4.1
 $label-danger-hover-border-color: $label-danger-border-color !default;
 
@@ -182,15 +182,15 @@ $label-danger: map-merge((
 	color: $label-danger-color,
 	hover-border-color: $label-danger-hover-border-color,
 	hover-color: $label-danger-hover-color,
-	focus-border-color: #80ACFF,
+	focus-border-color: $primary-l1,
 	focus-outline: 0,
-	focus-box-shadow: 0 0 0 1px #80ACFF,
+	focus-box-shadow: 0 0 0 1px $primary-l1,
 ), $label-danger);
 
 // $label-light-color is deprecated as of v2.4.1
 $label-light-color: $light !default;
 // $label-light-hover-color is deprecated as of v2.4.1
-$label-light-hover-color: darken($label-light-color, 12) !default;
+$label-light-hover-color: $light-d2 !default;
 // $label-light-bg is deprecated as of v2.4.1
 $label-light-bg: $dark !default;
 // $label-light-border-color is deprecated as of v2.4.1
@@ -210,15 +210,15 @@ $label-light: map-merge((
 	color: $label-light-color,
 	hover-border-color: $label-light-hover-border-color,
 	hover-color: $label-light-hover-color,
-	focus-border-color: #80ACFF,
+	focus-border-color: $primary-l1,
 	focus-outline: 0,
-	focus-box-shadow: 0 0 0 1px #80ACFF,
+	focus-box-shadow: 0 0 0 1px $primary-l1,
 ), $label-light);
 
 // $label-dark-color is deprecated as of v2.4.1
 $label-dark-color: $dark !default;
 // $label-dark-hover-color is deprecated as of v2.4.1
-$label-dark-hover-color: lighten($label-dark-color, 20) !default;
+$label-dark-hover-color: $dark-l2 !default;
 // $label-dark-border-color is deprecated as of v2.4.1
 $label-dark-border-color: $dark !default;
 // $label-dark-hover-border-color is deprecated as of v2.4.1
@@ -235,7 +235,7 @@ $label-dark: map-merge((
 	color: $label-dark-color,
 	hover-border-color: $label-dark-hover-border-color,
 	hover-color: $label-dark-hover-color,
-	focus-border-color: #80ACFF,
+	focus-border-color: $primary-l1,
 	focus-outline: 0,
-	focus-box-shadow: 0 0 0 1px #80ACFF,
+	focus-box-shadow: 0 0 0 1px $primary-l1,
 ), $label-dark);

--- a/packages/clay-css/src/scss/atlas/variables/_links.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_links.scss
@@ -1,6 +1,6 @@
 $link-secondary: () !default;
 $link-secondary: map-merge((
-	hover-color: $body-color
+	hover-color: $gray-900,
 ), $link-secondary);
 
 // Component Title
@@ -23,7 +23,7 @@ $component-subtitle: map-merge((
 
 $component-subtitle-link: () !default;
 $component-subtitle-link: map-merge((
-	hover-color: $body-color
+	hover-color: $gray-900,
 ), $component-subtitle-link);
 
 // Component Action
@@ -31,10 +31,10 @@ $component-subtitle-link: map-merge((
 $component-action: () !default;
 $component-action: map-merge((
 	font-size: 1rem, // 16px
-	hover-bg: rgba($dark, 0.03),
-	hover-color: $body-color,
-	active-bg: rgba($dark, 0.06),
-	active-color: $body-color,
+	hover-bg: rgba($gray-900, 0.03),
+	hover-color: $gray-900,
+	active-bg: rgba($gray-900, 0.06),
+	active-color: $gray-900,
 	btn-focus-box-shadow: map-get($btn-secondary, focus-box-shadow),
 	disabled-bg: transparent
 ), $component-action);
@@ -43,7 +43,7 @@ $component-action: map-merge((
 
 $link-outline-primary: () !default;
 $link-outline-primary: map-merge((
-	hover-bg: lighten($primary, 44.90),
+	hover-bg: $primary-l3,
 	hover-color: $primary,
 	btn-focus-box-shadow: map-get($btn-outline-primary, focus-box-shadow),
 	btn-focus-outline: 0,
@@ -53,11 +53,11 @@ $link-outline-primary: map-merge((
 
 $link-outline-secondary: () !default;
 $link-outline-secondary: map-merge((
-	border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06),
-	hover-bg: rgba($dark, 0.03),
-	hover-color: $body-color,
+	border-color: $secondary-l2,
+	hover-bg: rgba($gray-900, 0.03),
+	hover-color: $gray-900,
 	btn-focus-box-shadow: map-get($btn-secondary, focus-box-shadow),
 	btn-focus-outline: 0,
-	active-bg: rgba($dark, 0.06),
-	active-color: $body-color
+	active-bg: rgba($gray-900, 0.06),
+	active-color: $gray-900,
 ), $link-outline-secondary);

--- a/packages/clay-css/src/scss/atlas/variables/_list-group.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_list-group.scss
@@ -1,9 +1,9 @@
-$list-group-border-color: rgba(220, 220, 220, 0.5) !default;
-$list-group-color: $secondary !default;
+$list-group-border-color: $gray-300 !default;
+$list-group-color: $gray-600 !default;
 $list-group-hover-bg: lighten($component-active-bg, 44.90) !default;
 $list-group-active-bg: $list-group-hover-bg !default;
 $list-group-active-border-color: $list-group-border-color !default;
-$list-group-active-color: $dark !default;
+$list-group-active-color: $gray-900 !default;
 
 $list-group-font-size: 0.875rem !default; // 14px
 $list-group-item-padding-x: 1rem !default; // 16px
@@ -11,12 +11,12 @@ $list-group-item-padding-y: 1rem !default; // 16px
 
 // List Group Header
 
-$list-group-header-bg: lighten(saturate(adjust-hue($secondary, -27), 6.13), 51.57) !default;
+$list-group-header-bg: $gray-100 !default;
 $list-group-header-padding-y: 0.5rem !default; // 8px
 
 $list-group-header-title: () !default;
 $list-group-header-title: map-merge((
-	color: $secondary,
+	color: $gray-600,
 	font-size: 0.75rem, // 12px
 	text-transform: uppercase
 ), $list-group-header-title);
@@ -25,12 +25,12 @@ $list-group-header-title: map-merge((
 
 $list-group-title-link: () !default;
 $list-group-title-link: map-merge((
-	hover-color: $dark
+	hover-color: $gray-900,
 ), $list-group-title-link);
 
 $list-group-title: () !default;
 $list-group-title: map-merge((
-	color: $body-color,
+	color: $gray-900,
 	font-size: 0.875rem, // 14px
 	line-height: 1.45
 ), $list-group-title);
@@ -39,14 +39,14 @@ $list-group-title: map-merge((
 
 $list-group-subtitle-link: () !default;
 $list-group-subtitle-link: map-merge((
-	hover-color: $body-color
+	hover-color: $gray-900,
 ), $list-group-subtitle-link);
 
 // List Group Text
 
 $list-group-text-link: () !default;
 $list-group-text-link: map-merge((
-	hover-color: $body-color
+	hover-color: $gray-900,
 ), $list-group-text-link);
 
 $list-group-text: () !default;
@@ -58,7 +58,7 @@ $list-group-text: map-merge((
 
 $list-group-subtext-link: () !default;
 $list-group-subtext-link: map-merge((
-	hover-color: $body-color
+	hover-color: $gray-900,
 ), $list-group-subtext-link);
 
 $list-group-subtext: () !default;
@@ -66,11 +66,11 @@ $list-group-subtext: map-merge((
 	line-height: 1.45
 ), $list-group-subtext);
 
-$list-group-subtext-active-color: $secondary !default;
+$list-group-subtext-active-color: $gray-600 !default;
 
 // List Group Link
 
-$list-group-link-color: $body-color !default;
+$list-group-link-color: $gray-900 !default;
 $list-group-link-hover-color: $list-group-link-color !default;
 $list-group-link-active-color: $list-group-link-color !default;
 

--- a/packages/clay-css/src/scss/atlas/variables/_loaders.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_loaders.scss
@@ -1,4 +1,4 @@
 $loading-animation: () !default;
 $loading-animation: map-merge((
-	color: $secondary
+	color: $gray-600
 ), $loading-animation);

--- a/packages/clay-css/src/scss/atlas/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_management-bar.scss
@@ -1,11 +1,11 @@
 $management-bar-light: () !default;
 $management-bar-light: map-merge((
-	bg: #FFF,
+	bg: $white,
 	link-border-radius: $border-radius,
 	link-font-weight: $font-weight-semi-bold,
-	link-hover-color: $body-color,
-	link-hover-bg: rgba($dark, 0.03),
-	link-active-bg: rgba($dark, 0.06),
+	link-hover-color: $gray-900,
+	link-hover-bg: rgba($gray-900, 0.03),
+	link-active-bg: rgba($gray-900, 0.06),
 	link-disabled-bg: transparent
 ), $management-bar-light);
 
@@ -13,8 +13,8 @@ $management-bar-primary: () !default;
 $management-bar-primary: map-merge((
 	link-border-radius: $border-radius,
 	link-font-weight: $font-weight-semi-bold,
-	link-hover-color: $body-color,
-	link-hover-bg: rgba($dark, 0.03),
-	link-active-bg: rgba($dark, 0.06),
+	link-hover-color: $gray-900,
+	link-hover-bg: rgba($gray-900, 0.03),
+	link-active-bg: rgba($gray-900, 0.06),
 	link-disabled-bg: transparent
 ), $management-bar-primary);

--- a/packages/clay-css/src/scss/atlas/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_menubar.scss
@@ -2,11 +2,11 @@
 
 $menubar-vertical-transparent-md: () !default;
 $menubar-vertical-transparent-md: map-merge((
-	bg-mobile: #FFF,
+	bg-mobile: $white,
 	link-border-radius: 0.375rem,
 	link-border-radius-mobile: 0,
-	link-hover-bg: rgba($dark, 0.03),
-	link-hover-color: $dark,
+	link-hover-bg: rgba($gray-900, 0.03),
+	link-hover-color: $gray-900,
 	link-active-font-weight: $font-weight-semi-bold,
 	toggler-font-size-mobile: 0.875rem,
 	toggler-font-weight-mobile: $font-weight-semi-bold
@@ -16,11 +16,11 @@ $menubar-vertical-transparent-md: map-merge((
 
 $menubar-vertical-transparent-lg: () !default;
 $menubar-vertical-transparent-lg: map-merge((
-	bg-mobile: #FFF,
+	bg-mobile: $white,
 	link-border-radius: 0.375rem,
 	link-border-radius-mobile: 0,
-	link-hover-bg: rgba($dark, 0.03),
-	link-hover-color: $dark,
+	link-hover-bg: rgba($gray-900, 0.03),
+	link-hover-color: $gray-900,
 	link-active-font-weight: $font-weight-semi-bold,
 	toggler-font-size-mobile: 0.875rem,
 	toggler-font-weight-mobile: $font-weight-semi-bold

--- a/packages/clay-css/src/scss/atlas/variables/_modals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_modals.scss
@@ -1,4 +1,4 @@
-$modal-backdrop-bg: lighten($body-color, 8%) !default;
+$modal-backdrop-bg: lighten($gray-900, 8%) !default;
 $modal-backdrop-opacity: 0.8 !default;
 
 $modal-content-box-shadow-xs: 0 0 3px 1px rgba(0, 0, 0, 0.2) !default;
@@ -6,7 +6,7 @@ $modal-content-border-color: transparent !default;
 
 $modal-inner-padding: 1.5rem !default; // 24px
 
-$modal-header-border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
+$modal-header-border-color: $gray-300 !default;
 $modal-header-padding: 1.5rem !default; // 24px
 
 $modal-title-font-size: 1.25rem !default; // 20px
@@ -16,8 +16,8 @@ $modal-title-font-weight: $font-weight-bold !default;
 
 $modal-success: () !default;
 $modal-success: map-merge((
-	header-bg: lighten(desaturate(#287d3d, 1.52), 62.94),
-	header-border-color: lighten(desaturate(#287d3d, 0.14), 24.90),
+	header-bg: $success-l2,
+	header-border-color: $success-l1,
 	header-color: $success,
 	header-close: (
 		color: $success,
@@ -31,8 +31,8 @@ $modal-success: map-merge((
 
 $modal-info: () !default;
 $modal-info: map-merge((
-	header-bg: lighten(desaturate(adjust-hue($info, 1), 3.25), 52.94),
-	header-border-color: lighten(saturate($info, 0.59), 28.04),
+	header-bg: $info-l2,
+	header-border-color: $info-l1,
 	header-color: $info,
 	header-close: (
 		color: $info,
@@ -46,8 +46,8 @@ $modal-info: map-merge((
 
 $modal-warning: () !default;
 $modal-warning: map-merge((
-	header-bg: lighten(adjust-hue($warning, -1), 60.00),
-	header-border-color: lighten($warning, 24.90),
+	header-bg: $warning-l2,
+	header-border-color: $warning-l1,
 	header-color: $warning,
 	header-close: (
 		color: $warning,
@@ -61,8 +61,8 @@ $modal-warning: map-merge((
 
 $modal-danger: () !default;
 $modal-danger: map-merge((
-	header-bg: lighten(saturate($danger, 5.04), 50.00),
-	header-border-color: lighten(desaturate($danger, 0.25), 28.04),
+	header-bg: $danger-l2,
+	header-border-color: $danger-l1,
 	header-color: $danger,
 	header-close: (
 		color: $danger,

--- a/packages/clay-css/src/scss/atlas/variables/_multi-step-nav.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_multi-step-nav.scss
@@ -1,18 +1,18 @@
-$multi-step-icon-bg: lighten(saturate(adjust-hue($secondary, -12), 8.51), 49.61) !default;
-$multi-step-icon-color: $secondary !default;
+$multi-step-icon-bg: $gray-200 !default;
+$multi-step-icon-color: $gray-600 !default;
 $multi-step-icon-border-radius: 100px !default;
 $multi-step-icon-font-size: 0.875rem !default;
 $multi-step-icon-font-weight: $font-weight-semi-bold !default;
 
 $multi-step-icon-hover-color: $multi-step-icon-color !default;
 
-$multi-step-indicator-label-color: $secondary !default;
+$multi-step-indicator-label-color: $gray-600 !default;
 $multi-step-indicator-label-font-size: 0.875rem !default;
 $multi-step-indicator-label-font-weight: $font-weight-semi-bold !default;
 
-$multi-step-title-color: $secondary !default;
+$multi-step-title-color: $gray-600 !default;
 $multi-step-title-font-size: 0.875rem !default;
 $multi-step-title-font-weight: $font-weight-semi-bold !default;
 
 $multi-step-icon-disabled-bg: $multi-step-icon-bg !default;
-$multi-step-icon-disabled-color: lighten(saturate(adjust-hue($secondary, -3), 5.39), 23.92) !default;
+$multi-step-icon-disabled-color: $gray-500 !default;

--- a/packages/clay-css/src/scss/atlas/variables/_navbar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navbar.scss
@@ -4,14 +4,14 @@ $navbar-underline-active-bg: lighten($component-active-bg, 22.94) !default;
 
 // Navbar Light
 
-$navbar-light-color: $secondary !default;
+$navbar-light-color: $gray-600 !default;
 $navbar-light-hover-color: $navbar-light-color !default;
-$navbar-light-active-color: $body-color !default;
+$navbar-light-active-color: $gray-900 !default;
 $navbar-light-disabled-color: $nav-link-disabled-color !default;
 
 // Navbar Dark
 
-$navbar-dark-color: #FFF !default;
+$navbar-dark-color: $white !default;
 $navbar-dark-hover-color: $navbar-dark-color !default;
 $navbar-dark-active-color: $navbar-dark-color !default;
 $navbar-dark-disabled-color: $nav-link-disabled-color !default;

--- a/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
@@ -7,17 +7,17 @@ $navigation-bar-light: () !default;
 $navigation-bar-light: map-merge((
 	bg: #FFF,
 	link-font-weight: $font-weight-semi-bold,
-	link-hover-color: $body-color
+	link-hover-color: $gray-900,
 ), $navigation-bar-light);
 
 
 $navigation-bar-secondary: () !default;
 $navigation-bar-secondary: map-merge((
-	bg: darken(saturate($secondary, 4.82), 20.00),
-	link-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06),
+	bg: $secondary-d1,
+	link-color: $secondary-l2,
 	link-font-weight: $font-weight-semi-bold,
-	link-hover-color: #FFF,
-	link-active-color: #FFF,
+	link-hover-color: $white,
+	link-active-color: $white,
 	link-disabled-color: $nav-link-disabled-color,
 	link-disabled-opacity: 0.5
 ), $navigation-bar-secondary);

--- a/packages/clay-css/src/scss/atlas/variables/_navs.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navs.scss
@@ -1,6 +1,6 @@
 $nav-font-size: 0.875rem !default;
 
-$nav-link-disabled-color: lighten(saturate(adjust-hue($secondary, -3), 5.39), 23.92) !default;
+$nav-link-disabled-color: $gray-500 !default;
 
 $nav-link-padding-x: 1rem !default; // 16px
 $nav-link-padding-y: 0.625rem !default; // 10px
@@ -16,12 +16,12 @@ $nav-nested-spacer-x: 1rem !default; // 16px
 
 $nav-tabs-border-color: transparent !default;
 $nav-tabs-font-size: 0.875rem !default; // 14px
-$nav-tabs-link-color: $secondary !default;
+$nav-tabs-link-color: $gray-600 !default;
 
 $nav-tabs-link-hover-border-color: transparent !default;
 
-$nav-tabs-link-active-color: $body-color !default;
-$nav-tabs-link-active-bg: #FFF !default;
+$nav-tabs-link-active-color: $gray-900 !default;
+$nav-tabs-link-active-bg: $white !default;
 
 $nav-tabs-link-active-border-color: transparent transparent $body-bg !default;
 $nav-tabs-link-show-color: $nav-tabs-link-active-color !default;
@@ -30,19 +30,19 @@ $nav-tabs-link-show-border-color: transparent transparent $nav-tabs-border-color
 
 $nav-tabs-link-padding-y: 0.28125rem !default; // 4.5px
 
-$nav-tabs-tab-pane-bg: #FFF !default;
+$nav-tabs-tab-pane-bg: $white !default;
 $nav-tabs-tab-pane-border-radius: 4px !default;
 $nav-tabs-tab-pane-padding: 2rem !default;
 
 // Nav Underline
 
-$nav-underline-link-color: $secondary !default;
+$nav-underline-link-color: $gray-600 !default;
 
 $nav-underline-link-highlight-left: 0 !default;
 $nav-underline-link-highlight-right: 0 !default;
 
 $nav-underline-link-disabled-color: $nav-link-disabled-color !default;
 
-$nav-underline-link-active-color: $body-color !default;
+$nav-underline-link-active-color: $gray-900 !default;
 $nav-underline-link-active-highlight: $component-active-bg !default;
 $nav-underline-link-active-highlight-height: 0.125rem !default; // 2px

--- a/packages/clay-css/src/scss/atlas/variables/_pagination.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_pagination.scss
@@ -12,13 +12,13 @@ $pagination-link-last-border-radius: $pagination-link-border-radius !default;
 $pagination-bg: transparent !default;
 $pagination-border-color: $pagination-bg !default;
 $pagination-border-width: 0.0625rem !default; // 1px
-$pagination-color: $secondary !default;
+$pagination-color: $gray-600 !default;
 $pagination-padding-x: 0.625rem !default; // 10px
 $pagination-padding-y: 0 !default;
 
 $pagination-hover-bg: rgba(0, 0, 0, 0.02) !default;
 $pagination-hover-border-color: transparent !default;
-$pagination-hover-color: $body-color !default;
+$pagination-hover-color: $gray-900 !default;
 
 $pagination-active-bg: rgba(0, 0, 0, 0.04) !default;
 $pagination-active-border-color: transparent !default;
@@ -26,7 +26,7 @@ $pagination-active-color: $pagination-hover-color !default;
 
 $pagination-disabled-bg: transparent !default;
 $pagination-disabled-border-color: $pagination-disabled-bg !default;
-$pagination-disabled-color: $secondary !default;
+$pagination-disabled-color: $gray-600 !default;
 $pagination-disabled-opacity: 0.5 !default;
 
 $pagination-dropdown-menu-spacer-y: 0.625rem !default; // 10px

--- a/packages/clay-css/src/scss/atlas/variables/_panels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_panels.scss
@@ -25,10 +25,10 @@ $panel-collapse-icon-font-size: 0.75rem !default; // 12px
 
 $panel-secondary: () !default;
 $panel-secondary: map-merge((
-	border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08),
-	color: $secondary,
+	border-color: $gray-300,
+	color: $gray-600,
 	header-bg: null,
-	header-border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08),
+	header-border-color: $gray-300,
 	footer-bg: null,
-	footer-border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08)
+	footer-border-color: $gray-300,
 ), $panel-secondary);

--- a/packages/clay-css/src/scss/atlas/variables/_popovers.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_popovers.scss
@@ -12,14 +12,14 @@ $popover-arrow-width: $popover-arrow-height * 2 !default;
 $popover-inner-padding: 0 !default;
 
 $popover-header-bg: #FFF !default;
-$popover-header-border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
-$popover-header-color: $body-color !default;
+$popover-header-border-color: $gray-300 !default;
+$popover-header-color: $gray-900 !default;
 $popover-header-font-size: 0.875rem !default; // 14px
 $popover-header-margin-x: 1rem !default; // 16px
 $popover-header-margin-y: 0 !default;
 $popover-header-padding-x: 0 !default;
 $popover-header-padding-y: 0.75rem !default; // 12px
 
-$popover-body-color: $secondary !default;
+$popover-body-color: $gray-600 !default;
 $popover-body-padding-x: 1rem !default; // 16px
 $popover-body-padding-y: 0.75rem !default; // 12px

--- a/packages/clay-css/src/scss/atlas/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sheets.scss
@@ -1,4 +1,4 @@
-$sheet-border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
+$sheet-border-color: $gray-300 !default;
 
 $sheet-padding-bottom-mobile: null !default;
 $sheet-padding-left-mobile: 1rem !default; // 16px
@@ -23,7 +23,7 @@ $sheet-title-margin-bottom-mobile: 1rem !default; // 16px
 // Sheet Subtitle
 
 $sheet-subtitle-color: $body-color !default;
-$sheet-subtitle-border-color: lighten(saturate(adjust-hue($secondary, -3), 5.39), 23.92) !default;
+$sheet-subtitle-border-color: $gray-500 !default;
 $sheet-subtitle-font-size: 0.875rem !default; // 14px
 $sheet-subtitle-padding-y: 0.5rem !default; // 8px
 $sheet-subtitle-margin-bottom-mobile: 1rem !default; // 16px
@@ -32,6 +32,6 @@ $sheet-subtitle-margin-bottom-mobile: 1rem !default; // 16px
 
 $sheet-tertiary-title-margin-bottom-mobile: 0.5rem !default; // 8px
 
-$sheet-text-color: $secondary !default;
+$sheet-text-color: $gray-600 !default;
 
 $sheet-text-margin-bottom-mobile: 1rem !default; // 16px

--- a/packages/clay-css/src/scss/atlas/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sheets.scss
@@ -1,3 +1,4 @@
+$sheet-bg: $white !default;
 $sheet-border-color: $gray-300 !default;
 
 $sheet-padding-bottom-mobile: null !default;

--- a/packages/clay-css/src/scss/atlas/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sidebar.scss
@@ -29,28 +29,28 @@ $sidebar-dd: map-merge((
 
 // Sidebar List Group
 
-$sidebar-list-group-border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06) !default;
+$sidebar-list-group-border-color: $secondary-l2 !default;
 
 // Sidebar Light
 
 $sidebar-light: () !default;
 $sidebar-light: map-merge((
-	bg: #FFF,
+	bg: $white,
 	border-left-width: 0,
 	box-shadow: -0.25rem 0 0.5rem -0.25rem rgba(0, 0, 0, 0.1),
-	panel-bg: $light,
+	panel-bg: $gray-200,
 	dt: (
-		color: $secondary
+		color: $gray-600
 	),
 	dd: (
 		clay-link: (
-			color: $body-color
+			color: $gray-900
 		)
 	)
 ), $sidebar-light);
 
 $sidebar-light-navigation-bar: () !default;
 $sidebar-light-navigation-bar: map-merge((
-	bg: #FFF,
-	border-color: lighten(saturate(adjust-hue($secondary, -2), 5.48), 37.06)
+	bg: $white,
+	border-color: $secondary-l2
 ), $sidebar-light-navigation-bar);

--- a/packages/clay-css/src/scss/atlas/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_stickers.scss
@@ -26,31 +26,31 @@ $sticker-inside-offset: 1rem !default; // 16px
 
 $sticker-user-icon: () !default;
 $sticker-user-icon: map-merge((
-	box-shadow: 0 0 0 1px #E7E7ED,
+	box-shadow: 0 0 0 1px $gray-300,
 ), $sticker-user-icon);
 
 // Sticker Variants
 
-$sticker-primary-bg: #FFF !default;
+$sticker-primary-bg: $white !default;
 $sticker-primary-color: $primary !default;
 
-$sticker-secondary-bg: #FFF !default;
+$sticker-secondary-bg: $white !default;
 $sticker-secondary-color: $secondary !default;
 
-$sticker-info-bg: #FFF !default;
+$sticker-info-bg: $white !default;
 $sticker-info-color: $info !default;
 
-$sticker-success-bg: #FFF !default;
+$sticker-success-bg: $white !default;
 $sticker-success-color: $success !default;
 
-$sticker-warning-bg: #FFF !default;
+$sticker-warning-bg: $white !default;
 $sticker-warning-color: $warning !default;
 
-$sticker-danger-bg: #FFF !default;
+$sticker-danger-bg: $white !default;
 $sticker-danger-color: $danger !default;
 
-$sticker-light-bg: #FFF !default;
+$sticker-light-bg: $white !default;
 $sticker-light-color: $dark !default;
 
 $sticker-dark-bg: $dark !default;
-$sticker-dark-color: #FFF !default;
+$sticker-dark-color: $white !default;

--- a/packages/clay-css/src/scss/atlas/variables/_tables.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tables.scss
@@ -1,24 +1,24 @@
-$table-bg: #FFF !default;
-$table-accent-bg: lighten(saturate(adjust-hue($secondary, -27), 6.13), 51.57) !default;
+$table-bg: $white !default;
+$table-accent-bg: $gray-100 !default;
 $table-hover-bg: lighten($component-active-bg, 44.90) !default;
-$table-border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
+$table-border-color: $gray-300 !default;
 $table-font-size: 0.875rem !default;
 
-$table-disabled-color: #D9D9DD !default;
+$table-disabled-color: $gray-500 !default;
 
-$table-head-bg: #FFF !default;
+$table-head-bg: $white !default;
 $table-head-border-bottom-width: 1px !default;
-$table-head-color: $secondary !default;
+$table-head-color: $gray-600 !default;
 $table-head-font-weight: $font-weight-semi-bold !default;
 
 $table-head-link: () !default;
 $table-head-link: map-merge((
-	color: $secondary,
-	hover-color: $body-color
+	color: $gray-600,
+	hover-color: $gray-900,
 ), $table-head-link);
 
-$table-divider-bg: lighten(saturate(adjust-hue($secondary, -27), 6.13), 51.57) !default;
-$table-divider-color: $secondary !default;
+$table-divider-bg: $gray-100 !default;
+$table-divider-color: $gray-600 !default;
 $table-divider-font-size: 0.75rem !default; // 12px
 $table-divider-font-weight: $font-weight-semi-bold !default;
 $table-divider-padding: 0.4375rem 0.75rem !default;
@@ -26,14 +26,14 @@ $table-divider-text-transform: uppercase !default;
 
 $table-quick-action-menu-accent-bg: $table-accent-bg !default;
 $table-quick-action-menu-accent-active-bg: $table-hover-bg !default;
-$table-quick-action-menu-active-bg: lighten(saturate(adjust-hue($secondary, -12), 8.51), 49.61) !default;
+$table-quick-action-menu-active-bg: $gray-200 !default;
 $table-quick-action-menu-hover-bg: $table-hover-bg !default;
 
 // Table Title
 
 $table-title: () !default;
 $table-title: map-merge((
-	color: $body-color,
+	color: $gray-900,
 	font-size: 0.875rem // 14px
 ), $table-title);
 
@@ -41,10 +41,10 @@ $table-title: map-merge((
 
 $table-action-link: () !default;
 $table-action-link: map-merge((
-	color: $secondary,
+	color: $gray-600,
 	font-size: 1rem, // 16px
 	hover-bg: rgba(0, 0, 0, 0.02),
-	hover-color: $body-color,
+	hover-color: $gray-900,
 	active-bg: rgba(0, 0, 0, 0.04)
 ), $table-action-link);
 
@@ -52,23 +52,23 @@ $table-action-link: map-merge((
 
 $table-link: () !default;
 $table-link: map-merge((
-	color: $body-color,
-	hover-color: $body-color
+	color: $gray-900,
+	hover-color: $gray-900,
 ), $table-link);
 
 // Table List
 
-$table-list-accent-bg: lighten(saturate(adjust-hue($secondary, -27), 6.13), 51.57) !default;
+$table-list-accent-bg: $gray-100 !default;
 $table-list-hover-bg: $table-hover-bg !default;
 $table-list-active-bg: $table-list-hover-bg !default;
-$table-list-border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
+$table-list-border-color: $gray-300 !default;
 $table-list-color: $body-color !default;
 
-$table-list-disabled-color: #D9D9DD !default;
+$table-list-disabled-color: $gray-500 !default;
 
-$table-list-head-bg: #FFF !default;
+$table-list-head-bg: $white !default;
 
-$table-list-link-color: $secondary !default;
+$table-list-link-color: $gray-600 !default;
 
 $table-list-divider-padding-x: 0.75rem !default; // 12px
 $table-list-divider-padding-y: 0.4375rem !default; // 7px
@@ -77,30 +77,30 @@ $table-list-divider-padding-y: 0.4375rem !default; // 7px
 
 $table-list-title: () !default;
 $table-list-title: map-merge((
-	color: $body-color,
+	color: $gray-900,
 	font-size: 0.875rem, // 14px
 	line-height: 1.45
 ), $table-list-title);
 
 $table-list-title-link: () !default;
 $table-list-title-link: map-merge((
-	color: $body-color,
-	hover-color: $body-color
+	color: $gray-900,
+	hover-color: $gray-900,
 ), $table-list-title-link);
 
 // Table List Link
 
 $table-list-link: () !default;
 $table-list-link: map-merge((
-	color: $body-color,
-	hover-color: $body-color
+	color: $gray-900,
+	hover-color: $gray-900,
 ), $table-list-link);
 
 // Table List Action Link
 
 $table-list-action-link: () !default;
 $table-list-action-link: map-merge((
-	color: $secondary,
+	color: $gray-600,
 	hover-bg: rgba(0, 0, 0, 0.02),
-	hover-color: $body-color
+	hover-color: $gray-900,
 ), $table-list-action-link);

--- a/packages/clay-css/src/scss/atlas/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tbar.scss
@@ -1,7 +1,7 @@
 $component-tbar: () !default;
 $component-tbar: map-merge((
-	border-color: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08),
-	color: $secondary
+	border-color: $gray-300,
+	color: $gray-600,
 ), $component-tbar);
 
 // Subnav Tbar Primary
@@ -32,6 +32,6 @@ $subnav-tbar-primary-disabled: map-merge((
 
 $subnav-tbar-light: () !default;
 $subnav-tbar-light: map-merge((
-	bg-color: #FFF,
-	color: $secondary
+	bg-color: $light-l2,
+	color: $gray-600,
 ), $subnav-tbar-light);

--- a/packages/clay-css/src/scss/atlas/variables/_timelines.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_timelines.scss
@@ -1,3 +1,3 @@
-$timeline-border-color: $dark !default;
-$timeline-icon-border-color: $secondary !default;
-$timeline-increment-label-color: $secondary !default;
+$timeline-border-color: $gray-900 !default;
+$timeline-icon-border-color: $gray-600 !default;
+$timeline-increment-label-color: $gray-600 !default;

--- a/packages/clay-css/src/scss/atlas/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_toggle-switch.scss
@@ -12,29 +12,29 @@ $toggle-switch-bar-width: 60px !default; // width of switch bar
 $toggle-switch-bar-width-mobile: 44px !default; // width of switch bar
 // must all be same units--end
 
-$toggle-switch-bar-bg: lighten(saturate(adjust-hue($secondary, -3), 5.39), 23.92) !default;
+$toggle-switch-bar-bg: $gray-500 !default;
 $toggle-switch-bar-border-color: $toggle-switch-bar-bg !default;
 $toggle-switch-bar-border-radius: 20px !default;
 $toggle-switch-bar-border-width: 1px !default;
 $toggle-switch-bar-font-size: 0.75rem !default; // 12px
 $toggle-switch-bar-font-size-mobile: 0.625rem !default; // 10px
-$toggle-switch-bar-icon-color: #FFF !default;
+$toggle-switch-bar-icon-color: $white !default;
 $toggle-switch-bar-focus-box-shadow: $custom-control-indicator-focus-box-shadow !default;
 
-$toggle-switch-button-bg: #FFF !default;
+$toggle-switch-button-bg: $white !default;
 $toggle-switch-button-border-color: $toggle-switch-button-bg !default;
 $toggle-switch-button-border-radius: 50% !default;
 $toggle-switch-button-border-width: 1px !default;
 $toggle-switch-button-font-size: $toggle-switch-bar-font-size !default; // 12px
 $toggle-switch-button-font-size-mobile: $toggle-switch-bar-font-size-mobile !default; // 10px
-$toggle-switch-button-icon-color: $body-color !default;
+$toggle-switch-button-icon-color: $gray-900 !default;
 
 // Toggle Switch On
 $toggle-switch-bar-on-bg: $component-active-bg !default;
 $toggle-switch-bar-on-border-color: $toggle-switch-bar-on-bg !default;
-$toggle-switch-bar-on-icon-color: #FFF !default;
+$toggle-switch-bar-on-icon-color: $white !default;
 
-$toggle-switch-button-on-bg: #FFF !default;
-$toggle-switch-button-on-border-color: #FFF !default;
+$toggle-switch-button-on-bg: $white !default;
+$toggle-switch-button-on-border-color: $white !default;
 $toggle-switch-button-on-border-radius: $toggle-switch-button-border-radius !default;
-$toggle-switch-button-on-icon-color: $body-color !default;
+$toggle-switch-button-on-icon-color: $gray-900 !default;

--- a/packages/clay-css/src/scss/atlas/variables/_tooltip.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tooltip.scss
@@ -1,4 +1,4 @@
-$tooltip-bg: $body-color !default;
+$tooltip-bg: $gray-900 !default;
 $tooltip-box-shadow: 0 1px 4px 0px rgba(0, 0, 0, 0.4) !default;
 $tooltip-font-size: 0.875rem !default; // 14px
 $tooltip-max-width: 230px !default;

--- a/packages/clay-css/src/scss/atlas/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_utilities.scss
@@ -1,16 +1,16 @@
-$bg-checkered-fg: lighten(saturate(adjust-hue($secondary, 3), 6.13), 46.08) !default;
+$bg-checkered-fg: $gray-300 !default;
 
 // Close
 
 $close: () !default;
 $close: map-merge((
-	color: $body-color,
+	color: $gray-900,
 	opacity: 1,
-	hover-color: $body-color,
+	hover-color: $gray-900,
 	hover-opacity: 1,
 	focus-opacity: 1,
-	disabled-color: $secondary,
+	disabled-color: $gray-600,
 	disabled-opacity: $btn-disabled-opacity
 ), $close);
 
-$page-header-bg: #FFF !default;
+$page-header-bg: $white !default;

--- a/packages/clay-css/src/scss/site/_site.scss
+++ b/packages/clay-css/src/scss/site/_site.scss
@@ -164,6 +164,952 @@ section.row {
 	vertical-align: baseline;
 }
 
+// Colors Page
+
+.clay-site-swatch {
+	display: block;
+	padding: 0.5rem 1rem;
+}
+
+.clay-site-hex {
+	margin-left: 6px;
+	margin-right: 12px;
+	text-transform: uppercase;
+}
+
+.clay-site-hex,
+.clay-site-rgb,
+.clay-site-var {
+	-moz-user-select: all;
+	-ms-user-select: all;
+	-webkit-user-select: all;
+	user-select: all;
+}
+
+.clay-site-swatch-text {
+	&::-moz-selection {
+		background-color: #FFF;
+	}
+
+	&::selection {
+		background-color: #FFF;
+	}
+}
+
+// Colors Page (Grays)
+
+@mixin clay-site-selection($color) {
+	&::-moz-selection {
+		background-color: color-yiq($color);
+		color: color-yiq(color-yiq($color));
+	}
+
+	&::selection {
+		background-color: color-yiq($color);
+		color: color-yiq(color-yiq($color));
+	}
+}
+
+.clay-site-swatch-white {
+	background-color: $white;
+	color: color-yiq($white);
+	content: '#{$white}';
+
+	.clay-site-var {
+		content: '$white';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($white);
+	}
+}
+
+.clay-site-swatch-gray-100 {
+	background-color: $gray-100;
+	color: color-yiq($gray-100);
+	content: '#{$gray-100}';
+
+	.clay-site-var {
+		content: '$gray-100';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($gray-100);
+	}
+}
+
+.clay-site-swatch-gray-200 {
+	background-color: $gray-200;
+	color: color-yiq($gray-200);
+	content: '#{$gray-200}';
+
+	.clay-site-var {
+		content: '$gray-200';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($gray-200);
+	}
+}
+
+.clay-site-swatch-gray-300 {
+	background-color: $gray-300;
+	color: color-yiq($gray-300);
+	content: '#{$gray-300}';
+
+	.clay-site-var {
+		content: '$gray-300';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($gray-300);
+	}
+}
+
+.clay-site-swatch-gray-400 {
+	background-color: $gray-400;
+	color: color-yiq($gray-400);
+	content: '#{$gray-400}';
+
+	.clay-site-var {
+		content: '$gray-400';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($gray-400);
+	}
+}
+
+.clay-site-swatch-gray-500 {
+	background-color: $gray-500;
+	color: color-yiq($gray-500);
+	content: '#{$gray-500}';
+
+	.clay-site-var {
+		content: '$gray-500';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($gray-500);
+	}
+}
+
+.clay-site-swatch-gray-600 {
+	background-color: $gray-600;
+	color: color-yiq($gray-600);
+	content: '#{$gray-600}';
+
+	.clay-site-var {
+		content: '$gray-600';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($gray-600);
+	}
+}
+
+.clay-site-swatch-gray-700 {
+	background-color: $gray-700;
+	color: color-yiq($gray-700);
+	content: '#{$gray-700}';
+
+	.clay-site-var {
+		content: '$gray-700';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($gray-700);
+	}
+}
+
+.clay-site-swatch-gray-800 {
+	background-color: $gray-800;
+	color: color-yiq($gray-800);
+	content: '#{$gray-800}';
+
+	.clay-site-var {
+		content: '$gray-800';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($gray-800);
+	}
+}
+
+.clay-site-swatch-gray-900 {
+	background-color: $gray-900;
+	color: color-yiq($gray-900);
+	content: '#{$gray-900}';
+
+	.clay-site-var {
+		content: '$gray-900';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($gray-900);
+	}
+}
+
+.clay-site-swatch-black {
+	background-color: $black;
+	color: color-yiq($black);
+	content: '#{$black}';
+
+	.clay-site-var {
+		content: '$black';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($black);
+	}
+}
+
+// Colors Page (Colors)
+
+.clay-site-swatch-blue {
+	background-color: $blue;
+	color: color-yiq($blue);
+	content: '#{$blue}';
+
+	.clay-site-var {
+		content: '$blue';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($blue);
+	}
+}
+
+.clay-site-swatch-indigo {
+	background-color: $indigo;
+	color: color-yiq($indigo);
+	content: '#{$indigo}';
+
+	.clay-site-var {
+		content: '$indigo';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($indigo);
+	}
+}
+
+.clay-site-swatch-purple {
+	background-color: $purple;
+	color: color-yiq($purple);
+	content: '#{$purple}';
+
+	.clay-site-var {
+		content: '$purple';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($purple);
+	}
+}
+
+.clay-site-swatch-pink {
+	background-color: $pink;
+	color: color-yiq($pink);
+	content: '#{$pink}';
+
+	.clay-site-var {
+		content: '$pink';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($pink);
+	}
+}
+
+.clay-site-swatch-red {
+	background-color: $red;
+	color: color-yiq($red);
+	content: '#{$red}';
+
+	.clay-site-var {
+		content: '$red';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($red);
+	}
+}
+
+.clay-site-swatch-orange {
+	background-color: $orange;
+	color: color-yiq($orange);
+	content: '#{$orange}';
+
+	.clay-site-var {
+		content: '$orange';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($orange);
+	}
+}
+
+.clay-site-swatch-yellow {
+	background-color: $yellow;
+	color: color-yiq($yellow);
+	content: '#{$yellow}';
+
+	.clay-site-var {
+		content: '$yellow';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($yellow);
+	}
+}
+
+.clay-site-swatch-green {
+	background-color: $green;
+	color: color-yiq($green);
+	content: '#{$green}';
+
+	.clay-site-var {
+		content: '$green';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($green);
+	}
+}
+
+.clay-site-swatch-teal {
+	background-color: $teal;
+	color: color-yiq($teal);
+	content: '#{$teal}';
+
+	.clay-site-var {
+		content: '$teal';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($teal);
+	}
+}
+
+.clay-site-swatch-cyan {
+	background-color: $cyan;
+	color: color-yiq($cyan);
+	content: '#{$cyan}';
+
+	.clay-site-var {
+		content: '$cyan';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($cyan);
+	}
+}
+
+// Colors Page (Primary)
+
+.clay-site-swatch-primary {
+	background-color: $primary;
+	color: color-yiq($primary);
+	content: '#{$primary}';
+
+	.clay-site-var {
+		content: '$primary';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($primary);
+	}
+}
+
+.clay-site-swatch-primary-d1 {
+	background-color: $primary-d1;
+	color: color-yiq($primary-d1);
+	content: '#{$primary-d1}';
+
+	.clay-site-var {
+		content: '$primary-d1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($primary-d1);
+	}
+}
+
+.clay-site-swatch-primary-d2 {
+	background-color: $primary-d2;
+	color: color-yiq($primary-d2);
+	content: '#{$primary-d2}';
+
+	.clay-site-var {
+		content: '$primary-d2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($primary-d2);
+	}
+}
+
+.clay-site-swatch-primary-l1 {
+	background-color: $primary-l1;
+	color: color-yiq($primary-l1);
+	content: '#{$primary-l1}';
+
+	.clay-site-var {
+		content: '$primary-l1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($primary-l1);
+	}
+}
+
+.clay-site-swatch-primary-l2 {
+	background-color: $primary-l2;
+	color: color-yiq($primary-l2);
+	content: '#{$primary-l2}';
+
+	.clay-site-var {
+		content: '$primary-l2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($primary-l2);
+	}
+}
+
+.clay-site-swatch-primary-l3 {
+	background-color: $primary-l3;
+	color: color-yiq($primary-l3);
+	content: '#{$primary-l3}';
+
+	.clay-site-var {
+		content: '$primary-l3';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($primary-l3);
+	}
+}
+
+// Colors Page (Secondary)
+
+.clay-site-swatch-secondary {
+	background-color: $secondary;
+	color: color-yiq($secondary);
+	content: '#{$secondary}';
+
+	.clay-site-var {
+		content: '$secondary';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($secondary);
+	}
+}
+
+.clay-site-swatch-secondary-d1 {
+	background-color: $secondary-d1;
+	color: color-yiq($secondary-d1);
+	content: '#{$secondary-d1}';
+
+	.clay-site-var {
+		content: '$secondary-d1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($secondary-d1);
+	}
+}
+
+.clay-site-swatch-secondary-d2 {
+	background-color: $secondary-d2;
+	color: color-yiq($secondary-d2);
+	content: '#{$secondary-d2}';
+
+	.clay-site-var {
+		content: '$secondary-d2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($secondary-d2);
+	}
+}
+
+.clay-site-swatch-secondary-l1 {
+	background-color: $secondary-l1;
+	color: color-yiq($secondary-l1);
+	content: '#{$secondary-l1}';
+
+	.clay-site-var {
+		content: '$secondary-l1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($secondary-l1);
+	}
+}
+
+.clay-site-swatch-secondary-l2 {
+	background-color: $secondary-l2;
+	color: color-yiq($secondary-l2);
+	content: '#{$secondary-l2}';
+
+	.clay-site-var {
+		content: '$secondary-l2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($secondary-l2);
+	}
+}
+
+.clay-site-swatch-secondary-l3 {
+	background-color: $secondary-l3;
+	color: color-yiq($secondary-l3);
+	content: '#{$secondary-l3}';
+
+	.clay-site-var {
+		content: '$secondary-l3';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($secondary-l3);
+	}
+}
+
+// Colors Page (Info)
+
+.clay-site-swatch-info {
+	background-color: $info;
+	color: color-yiq($info);
+	content: '#{$info}';
+
+	.clay-site-var {
+		content: '$info';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($info);
+	}
+}
+
+.clay-site-swatch-info-d1 {
+	background-color: $info-d1;
+	color: color-yiq($info-d1);
+	content: '#{$info-d1}';
+
+	.clay-site-var {
+		content: '$info-d1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($info-d1);
+	}
+}
+
+.clay-site-swatch-info-d2 {
+	background-color: $info-d2;
+	color: color-yiq($info-d2);
+	content: '#{$info-d2}';
+
+	.clay-site-var {
+		content: '$info-d2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($info-d2);
+	}
+}
+
+.clay-site-swatch-info-l1 {
+	background-color: $info-l1;
+	color: color-yiq($info-l1);
+	content: '#{$info-l1}';
+
+	.clay-site-var {
+		content: '$info-l1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($info-l1);
+	}
+}
+
+.clay-site-swatch-info-l2 {
+	background-color: $info-l2;
+	color: color-yiq($info-l2);
+	content: '#{$info-l2}';
+
+	.clay-site-var {
+		content: '$info-l2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($info-l2);
+	}
+}
+
+// Colors Page (Success)
+
+.clay-site-swatch-success {
+	background-color: $success;
+	color: color-yiq($success);
+	content: '#{$success}';
+
+	.clay-site-var {
+		content: '$success';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($success);
+	}
+}
+
+.clay-site-swatch-success-d1 {
+	background-color: $success-d1;
+	color: color-yiq($success-d1);
+	content: '#{$success-d1}';
+
+	.clay-site-var {
+		content: '$success-d1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($success-d1);
+	}
+}
+
+.clay-site-swatch-success-d2 {
+	background-color: $success-d2;
+	color: color-yiq($success-d2);
+	content: '#{$success-d2}';
+
+	.clay-site-var {
+		content: '$success-d2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($success-d2);
+	}
+}
+
+.clay-site-swatch-success-l1 {
+	background-color: $success-l1;
+	color: color-yiq($success-l1);
+	content: '#{$success-l1}';
+
+	.clay-site-var {
+		content: '$success-l1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($success-l1);
+	}
+}
+
+.clay-site-swatch-success-l2 {
+	background-color: $success-l2;
+	color: color-yiq($success-l2);
+	content: '#{$success-l2}';
+
+	.clay-site-var {
+		content: '$success-l2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($success-l2);
+	}
+}
+
+// Colors Page (Warning)
+
+.clay-site-swatch-warning {
+	background-color: $warning;
+	color: color-yiq($warning);
+	content: '#{$warning}';
+
+	.clay-site-var {
+		content: '$warning';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($warning);
+	}
+}
+
+.clay-site-swatch-warning-d1 {
+	background-color: $warning-d1;
+	color: color-yiq($warning-d1);
+	content: '#{$warning-d1}';
+
+	.clay-site-var {
+		content: '$warning-d1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($warning-d1);
+	}
+}
+
+.clay-site-swatch-warning-d2 {
+	background-color: $warning-d2;
+	color: color-yiq($warning-d2);
+	content: '#{$warning-d2}';
+
+	.clay-site-var {
+		content: '$warning-d2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($warning-d2);
+	}
+}
+
+.clay-site-swatch-warning-l1 {
+	background-color: $warning-l1;
+	color: color-yiq($warning-l1);
+	content: '#{$warning-l1}';
+
+	.clay-site-var {
+		content: '$warning-l1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($warning-l1);
+	}
+}
+
+.clay-site-swatch-warning-l2 {
+	background-color: $warning-l2;
+	color: color-yiq($warning-l2);
+	content: '#{$warning-l2}';
+
+	.clay-site-var {
+		content: '$warning-l2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($warning-l2);
+	}
+}
+
+// Colors Page (Danger)
+
+.clay-site-swatch-danger {
+	background-color: $danger;
+	color: color-yiq($danger);
+	content: '#{$danger}';
+
+	.clay-site-var {
+		content: '$danger';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($danger);
+	}
+}
+
+.clay-site-swatch-danger-d1 {
+	background-color: $danger-d1;
+	color: color-yiq($danger-d1);
+	content: '#{$danger-d1}';
+
+	.clay-site-var {
+		content: '$danger-d1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($danger-d1);
+	}
+}
+
+.clay-site-swatch-danger-d2 {
+	background-color: $danger-d2;
+	color: color-yiq($danger-d2);
+	content: '#{$danger-d2}';
+
+	.clay-site-var {
+		content: '$danger-d2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($danger-d2);
+	}
+}
+
+.clay-site-swatch-danger-l1 {
+	background-color: $danger-l1;
+	color: color-yiq($danger-l1);
+	content: '#{$danger-l1}';
+
+	.clay-site-var {
+		content: '$danger-l1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($danger-l1);
+	}
+}
+
+.clay-site-swatch-danger-l2 {
+	background-color: $danger-l2;
+	color: color-yiq($danger-l2);
+	content: '#{$danger-l2}';
+
+	.clay-site-var {
+		content: '$danger-l2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($danger-l2);
+	}
+}
+
+// Colors Page (Light)
+
+.clay-site-swatch-light {
+	background-color: $light;
+	color: color-yiq($light);
+	content: '#{$light}';
+
+	.clay-site-var {
+		content: '$light';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($light);
+	}
+}
+
+.clay-site-swatch-light-d1 {
+	background-color: $light-d1;
+	color: color-yiq($light-d1);
+	content: '#{$light-d1}';
+
+	.clay-site-var {
+		content: '$light-d1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($light-d1);
+	}
+}
+
+.clay-site-swatch-light-d2 {
+	background-color: $light-d2;
+	color: color-yiq($light-d2);
+	content: '#{$light-d2}';
+
+	.clay-site-var {
+		content: '$light-d2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($light-d2);
+	}
+}
+
+.clay-site-swatch-light-l1 {
+	background-color: $light-l1;
+	color: color-yiq($light-l1);
+	content: '#{$light-l1}';
+
+	.clay-site-var {
+		content: '$light-l1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($light-l1);
+	}
+}
+
+.clay-site-swatch-light-l2 {
+	background-color: $light-l2;
+	color: color-yiq($light-l2);
+	content: '#{$light-l2}';
+
+	.clay-site-var {
+		content: '$light-l2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($light-l2);
+	}
+}
+
+// Colors Page (Dark)
+
+.clay-site-swatch-dark {
+	background-color: $dark;
+	color: color-yiq($dark);
+	content: '#{$dark}';
+
+	.clay-site-var {
+		content: '$dark';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($dark);
+	}
+}
+
+.clay-site-swatch-dark-d1 {
+	background-color: $dark-d1;
+	color: color-yiq($dark-d1);
+	content: '#{$dark-d1}';
+
+	.clay-site-var {
+		content: '$dark-d1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($dark-d1);
+	}
+}
+
+.clay-site-swatch-dark-d2 {
+	background-color: $dark-d2;
+	color: color-yiq($dark-d2);
+	content: '#{$dark-d2}';
+
+	.clay-site-var {
+		content: '$dark-d2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($dark-d2);
+	}
+}
+
+.clay-site-swatch-dark-l1 {
+	background-color: $dark-l1;
+	color: color-yiq($dark-l1);
+	content: '#{$dark-l1}';
+
+	.clay-site-var {
+		content: '$dark-l1';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($dark-l1);
+	}
+}
+
+.clay-site-swatch-dark-l2 {
+	background-color: $dark-l2;
+	color: color-yiq($dark-l2);
+	content: '#{$dark-l2}';
+
+	.clay-site-var {
+		content: '$dark-l2';
+	}
+
+	.clay-site-swatch-text {
+		@include clay-site-selection($dark-l2);
+	}
+}
+
 // Alerts Page
 
 .clay-site-alerts {

--- a/packages/clay-css/src/scss/site/site-atlas-font-awesome.scss
+++ b/packages/clay-css/src/scss/site/site-atlas-font-awesome.scss
@@ -1,1 +1,8 @@
 @import "../atlas";
+
+@import "site";
+
+#claySiteCSS {
+	content: 'clay-atlas';
+	display: none;
+}

--- a/packages/clay-css/src/scss/site/site-lexicon-font-awesome.scss
+++ b/packages/clay-css/src/scss/site/site-lexicon-font-awesome.scss
@@ -1,1 +1,8 @@
 @import "../base";
+
+@import "site";
+
+#claySiteCSS {
+	content: 'clay-base';
+	display: none;
+}

--- a/packages/clay-css/src/scss/site/site-main.scss
+++ b/packages/clay-css/src/scss/site/site-main.scss
@@ -1,3 +1,3 @@
-@import "../atlas-variables";
+// @import "../atlas-variables";
 
-@import "site";
+// @import "site";

--- a/packages/clay-css/src/scss/variables/_badges.scss
+++ b/packages/clay-css/src/scss/variables/_badges.scss
@@ -13,7 +13,7 @@ $badge-lexicon-icon-width: 0.875em !default;
 $badge-item-expand-min-width: 0.375rem !default;
 $badge-item-spacer-x: 0.5em !default;
 
-$badge-link-color: #FFF !default;
+$badge-link-color: $white !default;
 $badge-link-hover-color: null !default;
 $badge-link-text-decoration: underline !default;
 $badge-link-hover-text-decoration: none !default;

--- a/packages/clay-css/src/scss/variables/_cards.scss
+++ b/packages/clay-css/src/scss/variables/_cards.scss
@@ -7,7 +7,7 @@ $card-body-padding-left: null !default;
 $card-body-padding-right: null !default;
 $card-body-padding-top: null !default;
 
-$card-section-header-color: $secondary !default;
+$card-section-header-color: $gray-600 !default;
 $card-section-header-font-size: 0.75rem !default;
 $card-section-header-font-weight: $font-weight-semi-bold !default;
 $card-section-header-line-height: 2.5 !default;
@@ -34,7 +34,7 @@ $card-title-link: map-merge((
 
 $card-subtitle: () !default;
 $card-subtitle: map-merge((
-	color: $secondary,
+	color: $gray-600,
 	font-size: 0.875rem, // 14px
 	font-weight: $font-weight-semi-bold,
 	margin-bottom: 0,
@@ -44,7 +44,7 @@ $card-subtitle: map-merge((
 $card-subtitle-link: () !default;
 $card-subtitle-link: map-merge((
 	color: map-get($card-subtitle, color),
-	hover-color: darken($secondary, 15%)
+	hover-color: darken($gray-600, 15%)
 ), $card-subtitle-link);
 
 // Card Link

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -37,7 +37,7 @@ $input-label-margin-bottom: null !default;
 
 $input-label-for-cursor: $link-cursor !default;
 
-$input-label-disabled-color: $text-muted !default;
+$input-label-disabled-color: $gray-600 !default;
 $input-label-disabled-cursor: $disabled-cursor !default;
 
 $input-label-reference-mark-color: $warning !default;
@@ -171,7 +171,7 @@ $form-feedback-margin-top: 0.25rem !default;
 
 $form-feedback-indicator-margin-x: 0.3125rem !default;
 
-$form-text-color: $text-muted !default;
+$form-text-color: $gray-600 !default;
 $form-text-font-size: 0.875rem !default; // 14px
 $form-text-font-weight: null !default;
 

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -5,6 +5,48 @@
 $clay-unset: clay-unset !default;
 $clay-unset-placeholder: clay-unset-placeholder !default;
 
+$primary-d1: darken($primary, 7.5) !default;
+$primary-d2: darken($primary, 10) !default;
+$primary-l1: lighten($primary, 22.94) !default;
+$primary-l2: lighten($primary, 32.94) !default;
+$primary-l3: lighten($primary, 44.90) !default;
+
+$secondary-d1: darken($secondary, 7.5) !default;
+$secondary-d2: darken($secondary, 10) !default;
+$secondary-l1: lighten($secondary, 22.94) !default;
+$secondary-l2: lighten($secondary, 32.94) !default;
+$secondary-l3: lighten($secondary, 44.90) !default;
+
+$info-d1: darken($info, 7.5) !default;
+$info-d2: darken($info, 10) !default;
+$info-l1: lighten($info, 22.94) !default;
+$info-l2: lighten($info, 32.94) !default;
+
+$success-d1: darken($success, 7.5) !default;
+$success-d2: darken($success, 10) !default;
+$success-l1: lighten($success, 22.94) !default;
+$success-l2: lighten($success, 32.94) !default;
+
+$warning-d1: darken($warning, 7.5) !default;
+$warning-d2: darken($warning, 10) !default;
+$warning-l1: lighten($warning, 22.94) !default;
+$warning-l2: lighten($warning, 32.94) !default;
+
+$danger-d1: darken($danger, 7.5) !default;
+$danger-d2: darken($danger, 10) !default;
+$danger-l1: lighten($danger, 22.94) !default;
+$danger-l2: lighten($danger, 32.94) !default;
+
+$light-d1: darken($light, 7.5) !default;
+$light-d2: darken($light, 10) !default;
+$light-l1: lighten($light, 22.94) !default;
+$light-l2: lighten($light, 32.94) !default;
+
+$dark-d1: darken($dark, 7.5) !default;
+$dark-d2: darken($dark, 10) !default;
+$dark-l1: lighten($dark, 22.94) !default;
+$dark-l2: lighten($dark, 32.94) !default;
+
 $enable-scaling-components: false !default;
 $scaling-breakpoint-down: sm !default;
 

--- a/packages/clay-css/src/scss/variables/_labels.scss
+++ b/packages/clay-css/src/scss/variables/_labels.scss
@@ -31,7 +31,7 @@ $label-anchor-hover-text-decoration: null !default;
 $label-link-text-decoration: underline !default;
 $label-link-hover-text-decoration: none !default;
 
-$label-border-color: $body-color !default;
+$label-border-color: $gray-900 !default;
 $label-border-radius: $border-radius !default;
 $label-border-style: solid !default;
 $label-border-width: 0.0625rem !default;
@@ -70,7 +70,7 @@ $label-primary-color: $primary !default;
 // $label-primary-hover-color is deprecated as of v2.4.1
 $label-primary-hover-color: darken($label-primary-color, 10%) !default;
 // $label-primary-bg is deprecated as of v2.4.1
-$label-primary-bg: #FFF !default;
+$label-primary-bg: $white !default;
 // $label-primary-hover-bg is deprecated as of v2.4.1
 $label-primary-hover-bg: null !default;
 // $label-primary-border-color is deprecated as of v2.4.1
@@ -107,7 +107,7 @@ $label-secondary-color: $secondary !default;
 // $label-secondary-hover-color is deprecated as of v2.4.1
 $label-secondary-hover-color: darken($label-secondary-color, 10%) !default;
 // $label-secondary-bg is deprecated as of v2.4.1
-$label-secondary-bg: #FFF !default;
+$label-secondary-bg: $white !default;
 // $label-secondary-hover-bg is deprecated as of v2.4.1
 $label-secondary-hover-bg: null !default;
 // $label-secondary-border-color is deprecated as of v2.4.1
@@ -144,7 +144,7 @@ $label-success-color: $success !default;
 // $label-success-hover-color is deprecated as of v2.4.1
 $label-success-hover-color: darken($label-success-color, 10%) !default;
 // $label-success-bg is deprecated as of v2.4.1
-$label-success-bg: #FFF !default;
+$label-success-bg: $white !default;
 // $label-success-hover-bg is deprecated as of v2.4.1
 $label-success-hover-bg: null !default;
 // $label-success-border-color is deprecated as of v2.4.1
@@ -181,7 +181,7 @@ $label-info-color: $info !default;
 // $label-info-hover-color is deprecated as of v2.4.1
 $label-info-hover-color: darken($label-info-color, 10%) !default;
 // $label-info-bg is deprecated as of v2.4.1
-$label-info-bg: #FFF !default;
+$label-info-bg: $white !default;
 // $label-info-hover-bg is deprecated as of v2.4.1
 $label-info-hover-bg: null !default;
 // $label-info-border-color is deprecated as of v2.4.1
@@ -218,7 +218,7 @@ $label-warning-color: $warning !default;
 // $label-warning-hover-color is deprecated as of v2.4.1
 $label-warning-hover-color: darken($label-warning-color, 10%) !default;
 // $label-warning-bg is deprecated as of v2.4.1
-$label-warning-bg: #FFF !default;
+$label-warning-bg: $white !default;
 // $label-warning-hover-bg is deprecated as of v2.4.1
 $label-warning-hover-bg: null !default;
 // $label-warning-border-color is deprecated as of v2.4.1
@@ -255,7 +255,7 @@ $label-danger-color: $danger !default;
 // $label-danger-hover-color is deprecated as of v2.4.1
 $label-danger-hover-color: darken($label-danger-color, 10%) !default;
 // $label-danger-bg is deprecated as of v2.4.1
-$label-danger-bg: #FFF !default;
+$label-danger-bg: $white !default;
 // $label-danger-hover-bg is deprecated as of v2.4.1
 $label-danger-hover-bg: null !default;
 // $label-danger-border-color is deprecated as of v2.4.1
@@ -292,7 +292,7 @@ $label-light-color: $light !default;
 // $label-light-hover-color is deprecated as of v2.4.1
 $label-light-hover-color: darken($label-light-color, 10%) !default;
 // $label-light-bg is deprecated as of v2.4.1
-$label-light-bg: $dark !default;
+$label-light-bg: $gray-800 !default;
 // $label-light-hover-bg is deprecated as of v2.4.1
 $label-light-hover-bg: null !default;
 // $label-light-border-color is deprecated as of v2.4.1
@@ -329,7 +329,7 @@ $label-dark-color: $dark !default;
 // $label-dark-hover-color is deprecated as of v2.4.1
 $label-dark-hover-color: darken($label-dark-color, 10%) !default;
 // $label-dark-bg is deprecated as of v2.4.1
-$label-dark-bg: #FFF !default;
+$label-dark-bg: $white !default;
 // $label-dark-hover-bg is deprecated as of v2.4.1
 $label-dark-hover-bg: null !default;
 // $label-dark-border-color is deprecated as of v2.4.1

--- a/packages/clay-css/src/scss/variables/_links.scss
+++ b/packages/clay-css/src/scss/variables/_links.scss
@@ -2,8 +2,8 @@ $single-link-font-weight: $font-weight-semi-bold !default;
 
 $component-link: () !default;
 $component-link: map-merge((
-	color: $secondary,
-	hover-color: darken($secondary, 15%)
+	color: $gray-600,
+	hover-color: darken($gray-600, 15%)
 ), $component-link);
 
 $link-primary: () !default;
@@ -22,7 +22,7 @@ $link-secondary: map-merge((
 
 $component-title: () !default;
 $component-title: map-merge((
-	color: $body-color,
+	color: $gray-900,
 	font-size: 1.125rem,
 	font-weight: $headings-font-weight,
 	line-height: $headings-line-height,
@@ -32,22 +32,22 @@ $component-title: map-merge((
 
 $component-title-link: () !default;
 $component-title-link: map-merge((
-	color: $body-color,
-	hover-color: darken($body-color, 15%)
+	color: $gray-900,
+	hover-color: darken($gray-900, 15%)
 ), $component-title-link);
 
 // Component Subtitle
 
 $component-subtitle: () !default;
 $component-subtitle: map-merge((
-	color: $secondary,
+	color: $gray-600,
 	margin-bottom: 0
 ), $component-subtitle);
 
 $component-subtitle-link: () !default;
 $component-subtitle-link: map-merge((
-	color: $secondary,
-	hover-color: darken($secondary, 15%)
+	color: $gray-600,
+	hover-color: darken($gray-600, 15%)
 ), $component-subtitle-link);
 
 // Component Action
@@ -59,11 +59,11 @@ $component-action: map-merge((
 	border-radius: $border-radius,
 	color: $secondary,
 	hover-bg: $secondary,
-	hover-color: #FFF,
+	hover-color: $white,
 	btn-focus-box-shadow: 0 0 0 $btn-focus-width rgba($secondary, 0.5),
 	btn-focus-outline: 0,
 	active-bg: $secondary,
-	active-color: #FFF,
+	active-color: $white,
 	disabled-bg: transparent,
 	disabled-color: $secondary,
 	disabled-cursor: $disabled-cursor,
@@ -87,7 +87,7 @@ $link-outline-primary: map-merge((
 	border-color: $primary,
 	color: $primary,
 	hover-bg: $primary,
-	hover-color: #FFF,
+	hover-color: $white,
 	btn-focus-box-shadow: 0 0 0 $btn-focus-width rgba($primary, 0.5),
 	btn-focus-outline: 0,
 	disabled-bg: transparent,
@@ -95,7 +95,7 @@ $link-outline-primary: map-merge((
 	disabled-cursor: $btn-disabled-cursor,
 	disabled-opacity: $btn-disabled-opacity,
 	active-bg: $primary,
-	active-color: #FFF
+	active-color: $white,
 ), $link-outline-primary);
 
 $link-outline-secondary: () !default;
@@ -103,7 +103,7 @@ $link-outline-secondary: map-merge((
 	border-color: $secondary,
 	color: $secondary,
 	hover-bg: $secondary,
-	hover-color: #FFF,
+	hover-color: $white,
 	btn-focus-box-shadow: 0 0 0 $btn-focus-width rgba($secondary, 0.5),
 	btn-focus-outline: 0,
 	disabled-bg: transparent,
@@ -111,7 +111,7 @@ $link-outline-secondary: map-merge((
 	disabled-cursor: $btn-disabled-cursor,
 	disabled-opacity: $btn-disabled-opacity,
 	active-bg: $secondary,
-	active-color: #FFF
+	active-color: $white,
 ), $link-outline-secondary);
 
 // Link Monospaced

--- a/packages/clay-css/src/scss/variables/_list-group.scss
+++ b/packages/clay-css/src/scss/variables/_list-group.scss
@@ -30,8 +30,8 @@ $list-group-header-title: map-merge((
 
 $list-group-title-link: () !default;
 $list-group-title-link: map-merge((
-	color: $body-color,
-	hover-color: darken($body-color, 15%)
+	color: $gray-900,
+	hover-color: darken($gray-900, 15%)
 ), $list-group-title-link);
 
 $list-group-title: () !default;
@@ -49,13 +49,13 @@ $list-group-title-active-color: $list-group-active-color !default;
 
 $list-group-subtitle-link: () !default;
 $list-group-subtitle-link: map-merge((
-	color: $secondary,
-	hover-color: darken($secondary, 15%)
+	color: $gray-600,
+	hover-color: darken($gray-600, 15%)
 ), $list-group-subtitle-link);
 
 $list-group-subtitle: () !default;
 $list-group-subtitle: map-merge((
-	color: $secondary,
+	color: $gray-600,
 	margin-bottom: 0,
 	clay-link: $list-group-subtitle-link
 ), $list-group-subtitle);
@@ -64,13 +64,13 @@ $list-group-subtitle: map-merge((
 
 $list-group-text-link: () !default;
 $list-group-text-link: map-merge((
-	color: $body-color,
-	hover-color: darken($body-color, 15%)
+	color: $gray-900,
+	hover-color: darken($gray-900, 15%)
 ), $list-group-text-link);
 
 $list-group-text: () !default;
 $list-group-text: map-merge((
-	color: $body-color,
+	color: $gray-900,
 	margin-bottom: 0,
 	clay-link: $list-group-text-link
 ), $list-group-text);
@@ -81,13 +81,13 @@ $list-group-text-active-color: $list-group-active-color !default;
 
 $list-group-subtext-link: () !default;
 $list-group-subtext-link: map-merge((
-	color: $secondary,
-	hover-color: darken($secondary, 15%)
+	color: $gray-600,
+	hover-color: darken($gray-600, 15%)
 ), $list-group-subtext-link);
 
 $list-group-subtext: () !default;
 $list-group-subtext: map-merge((
-	color: $secondary,
+	color: $gray-600,
 	margin-bottom: 0,
 	clay-link: $list-group-subtext-link
 ), $list-group-subtext);

--- a/packages/clay-css/src/scss/variables/_loaders.scss
+++ b/packages/clay-css/src/scss/variables/_loaders.scss
@@ -7,11 +7,11 @@ $loading-icon-font-size-sm: 1.25rem !default; // 20px
 $loading-animation: () !default;
 $loading-animation: map-merge((
 	animation-name: loading-animation,
-	color: $body-color
+	color: $gray-900,
 ), $loading-animation);
 
 $loading-animation-light: () !default;
 $loading-animation-light: map-merge((
 	animation-name: loading-animation-light,
-	color: #FFF
+	color: $white
 ), $loading-animation-light);

--- a/packages/clay-css/src/scss/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/variables/_management-bar.scss
@@ -31,7 +31,7 @@ $management-bar-light: map-merge((
 
 $management-bar-primary: () !default;
 $management-bar-primary: map-merge((
-	bg: lighten($primary, 44.90),
+	bg: $primary-l3,
 	border-color: $primary,
 	color: $navbar-light-color,
 	link-color: $navbar-light-color,

--- a/packages/clay-css/src/scss/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/variables/_menubar.scss
@@ -10,7 +10,10 @@ $menubar-vertical-expand-md: map-merge((
 
 $menubar-vertical-transparent-md: () !default;
 $menubar-vertical-transparent-md: map-merge((
-	bg-mobile: $light
+	link-color: $gray-600,
+	link-hover-color: darken($gray-600, 15),
+	link-active-color: $gray-900,
+	bg-mobile: $gray-100,
 ), $menubar-vertical-transparent-md);
 
 // Menubar Vertical LG
@@ -27,5 +30,8 @@ $menubar-vertical-expand-lg: map-merge((
 $menubar-vertical-transparent-lg: () !default;
 $menubar-vertical-transparent-lg: map-merge((
 	breakpoint-up: lg,
-	bg-mobile: $light
+	link-color: $gray-600,
+	link-hover-color: darken($gray-600, 15),
+	link-active-color: $gray-900,
+	bg-mobile: $gray-100,
 ), $menubar-vertical-transparent-lg);

--- a/packages/clay-css/src/scss/variables/_multi-step-nav.scss
+++ b/packages/clay-css/src/scss/variables/_multi-step-nav.scss
@@ -35,8 +35,8 @@ $multi-step-item-margin-bottom: 10px !default;
 $multi-step-item-width: 75px !default;
 $multi-step-item-fixed-width: 150px !default;
 
-$multi-step-icon-complete-color: #FFF !default;
-$multi-step-icon-complete-bg: $secondary !default;
+$multi-step-icon-complete-color: $white !default;
+$multi-step-icon-complete-bg: $gray-600 !default;
 $multi-step-icon-complete-bg-image: clay-icon(check, $multi-step-icon-complete-color) !default;
 $multi-step-icon-complete-bg-position: center !default;
 $multi-step-icon-complete-bg-size: $multi-step-icon-font-size !default;

--- a/packages/clay-css/src/scss/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/variables/_navigation-bar.scss
@@ -26,7 +26,7 @@ $navigation-bar-light: map-merge((
 $navigation-bar-secondary: () !default;
 $navigation-bar-secondary: map-merge((
 	bg: $secondary,
-	color: #FFF,
+	color: $white,
 	link-color: rgba(255, 255, 255, 0.65),
 	link-hover-color: rgba(255, 255, 255, 0.9),
 	link-active-color: rgba(255, 255, 255, 0.9),

--- a/packages/clay-css/src/scss/variables/_panels.scss
+++ b/packages/clay-css/src/scss/variables/_panels.scss
@@ -1,4 +1,4 @@
-$panel-bg: #FFF !default;
+$panel-bg: $white !default;
 $panel-border-color: transparent !default;
 $panel-border-style: solid !default;
 

--- a/packages/clay-css/src/scss/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/variables/_sheets.scss
@@ -1,5 +1,5 @@
-$sheet-bg: $white !default;
-$sheet-border-color: rgba($black, 0.125) !default;
+$sheet-bg: $body-bg !default;
+$sheet-border-color: $gray-300 !default;
 $sheet-border-style: solid !default;
 $sheet-border-width: 0.0625rem !default; // 1px
 

--- a/packages/clay-css/src/scss/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/variables/_sidebar.scss
@@ -10,7 +10,7 @@ $sidebar-header-component-title: map-merge((
 	font-size: 1.5rem, // 24px,
 	font-weight: $font-weight-semi-bold,
 	clay-link: (
-		color: $body-color
+		color: $gray-900
 	)
 ), $sidebar-header-component-title);
 
@@ -67,17 +67,17 @@ $sidebar-light: map-merge((
 	bg: $light,
 	border-color: $gray-300,
 	border-left-width: 1px,
-	color: $body-color,
+	color: $gray-900,
 	dd: (
 		clay-link: (
-			color: $body-color
+			color: $gray-900,
 		)
 	),
 	panel-bg: $gray-200,
 	sidebar-list-group-title: (
 		font-size: 1rem,
 		clay-link: (
-			color: $body-color
+			color: $gray-900,
 		)
 	)
 ), $sidebar-light);

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -7,7 +7,7 @@ $table-margin-bottom: 0 !default;
 
 $table-cell-gutters: $grid-gutter-width / 2 !default; // 15px
 
-$table-disabled-bg: #FFF !default;
+$table-disabled-bg: $white !default;
 $table-disabled-color: #ACACAC !default;
 $table-disabled-cursor: $disabled-cursor !default;
 $table-disabled-pointer-events: none !default;
@@ -32,7 +32,7 @@ $table-data-border-color: $table-border-color !default;
 $table-data-border-style: solid !default;
 $table-data-vertical-align: middle !default;
 
-$table-divider-bg: #FFF !default;
+$table-divider-bg: $white !default;
 $table-divider-color: null !default;
 $table-divider-font-weight: null !default;
 $table-divider-font-size: null !default;
@@ -73,8 +73,8 @@ $table-title: map-merge((
 
 $table-title-link: () !default;
 $table-title-link: map-merge((
-	color: $body-color,
-	hover-color: $body-color
+	color: $gray-900,
+	hover-color: $gray-900,
 ), $table-title-link);
 
 // Table Link
@@ -106,13 +106,13 @@ $table-img-max-height: 100px !default;
 
 // Table List
 
-$table-list-bg: #FFF !default;
+$table-list-bg: $white !default;
 $table-list-color: null !default;
 $table-list-accent-bg: #F2F2F2 !default;
 $table-list-hover-bg: #ECECEC !default;
 $table-list-active-bg: #DADADA !default;
 
-$table-list-disabled-bg: #FFF !default;
+$table-list-disabled-bg: $white !default;
 $table-list-disabled-color: #ACACAC !default;
 $table-list-disabled-cursor: $disabled-cursor !default;
 $table-list-disabled-pointer-events: none !default;
@@ -159,8 +159,8 @@ $table-list-title: map-merge((
 
 $table-list-title-link: () !default;
 $table-list-title-link: map-merge((
-	color: $body-color,
-	hover-color: $body-color
+	color: $gray-900,
+	hover-color: $gray-900,
 ), $table-list-title-link);
 
 // Table List Link

--- a/packages/clay-css/src/scss/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/variables/_tbar.scss
@@ -107,9 +107,9 @@ $subnav-tbar-light: map-merge((
 
 $subnav-tbar-primary-component-link: () !default;
 $subnav-tbar-primary-component-link: map-merge((
-	color: $body-color,
-	hover-color: $body-color,
-	disabled-color: $secondary,
+	color: $gray-900,
+	hover-color: $gray-900,
+	disabled-color: $gray-600,
 	disabled-cursor: $disabled-cursor,
 	disabled-opacity: $btn-disabled-opacity,
 	disabled-text-decoration: none
@@ -118,7 +118,7 @@ $subnav-tbar-primary-component-link: map-merge((
 $subnav-tbar-primary-component-label-close: () !default;
 $subnav-tbar-primary-component-label-close: map-merge((
 	focus-color: inherit,
-	disabled-color: $secondary,
+	disabled-color: $gray-600,
 	disabled-opacity: $btn-disabled-opacity
 ), $subnav-tbar-primary-component-label-close);
 
@@ -138,7 +138,7 @@ $subnav-tbar-primary-tbar-label-size: map-merge((
 
 $subnav-tbar-primary: () !default;
 $subnav-tbar-primary: map-merge((
-	bg-color: lighten($primary, 32.94),
+	bg-color: $primary-l2,
 	padding-x: 0.25rem,
 	padding-y: 0.625rem,
 	item-justify-content: flex-start,

--- a/packages/clay-css/src/scss/variables/_timelines.scss
+++ b/packages/clay-css/src/scss/variables/_timelines.scss
@@ -1,4 +1,4 @@
-$timeline-border-color: #DDD !default;
+$timeline-border-color: $gray-300 !default;
 $timeline-border-width: 2px !default;
 
 $timeline-border-modifier: ceil($timeline-border-width / 2) !default;

--- a/packages/clay-css/src/scss/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/variables/_toggle-switch.scss
@@ -34,7 +34,7 @@ $toggle-switch-bar-on-bg: $component-active-bg !default;
 $toggle-switch-bar-on-border-color: $toggle-switch-bar-on-bg !default;
 $toggle-switch-bar-on-icon-color: $component-active-color !default;
 
-$toggle-switch-button-on-bg: #FFF !default;
+$toggle-switch-button-on-bg: $white !default;
 $toggle-switch-button-on-border-color: $toggle-switch-bar-on-bg !default;
 $toggle-switch-button-on-border-radius: 0 3px 3px 0 !default;
 $toggle-switch-button-on-icon-color: $toggle-switch-bar-on-bg !default;


### PR DESCRIPTION
This is for 2.x. I mapped the grays color palette to color base component backgrounds, borders, and text. The theme color palette (primary, secondary, success, etc) to color variant components (e.g., btn-primary, btn-secondary). If this is too big a change, we can just add the changes in 7b2ce36 and scrap the rest.