### PR TITLE
Fixes #1629 ClayCSS Atlas Accordion collapse icon should be 12px

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_panels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_panels.scss
@@ -1,7 +1,10 @@
 // Panel Header
 
 $panel-header-border-bottom-width: 0 !default;
+$panel-header-font-size: 0.875rem !default; // 14px
 $panel-header-link-hover-text-decoration: none !default;
+
+$panel-header-collapse-icon-font-size: 0.75rem !default; // 12px
 
 // Panel Footer
 

--- a/packages/clay-css/src/scss/atlas/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sheets.scss
@@ -28,6 +28,10 @@ $sheet-subtitle-font-size: 0.875rem !default; // 14px
 $sheet-subtitle-padding-y: 0.5rem !default; // 8px
 $sheet-subtitle-margin-bottom-mobile: 1rem !default; // 16px
 
+// Sheet Subtitle as Panel Header
+
+$sheet-subtitle-collapse-icon-font-size: 0.75rem !default;
+
 // Sheet Tertiary Title
 
 $sheet-tertiary-title-margin-bottom-mobile: 0.5rem !default; // 8px

--- a/packages/clay-css/src/scss/components/_sheets.scss
+++ b/packages/clay-css/src/scss/components/_sheets.scss
@@ -176,6 +176,7 @@ fieldset {
 	.collapse-icon-closed,
 	.collapse-icon-open {
 		bottom: $sheet-subtitle-collapse-icon-bottom;
+		font-size: $sheet-subtitle-collapse-icon-font-size;
 		left: $sheet-subtitle-collapse-icon-left;
 		right: $sheet-subtitle-collapse-icon-right;
 		top: $sheet-subtitle-collapse-icon-top;

--- a/packages/clay-css/src/scss/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/variables/_sheets.scss
@@ -88,6 +88,7 @@ $sheet-subtitle-link-text-decoration: null !default;
 $sheet-subtitle-link-hover-color: null !default;
 $sheet-subtitle-link-hover-text-decoration: none !default;
 
+$sheet-subtitle-collapse-icon-font-size: null !default;
 $sheet-subtitle-collapse-icon-bottom: null !default;
 $sheet-subtitle-collapse-icon-left: null !default;
 $sheet-subtitle-collapse-icon-right: null !default;


### PR DESCRIPTION
Fixes #1629 ClayCSS Sheet added option to configure `$sheet-subtitle-collapse-icon-font-size`

Fixes #1629 ClayCSS Atlas Sheet `$sheet-subtitle-collapse-icon-font-size` should be 12px