### PR TITLE
Fixes #1099 ClayCSS 2.x Atlas Panel deprecate `$panel-collapse-icon-font-…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_panels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_panels.scss
@@ -21,8 +21,8 @@ $panel-title-small-font-size: 100% !default;
 $panel-title-small-margin-left: 0.375rem !default; // 6px
 
 // Panel Collapse Icon
-
-$panel-collapse-icon-font-size: 0.75rem !default; // 12px
+// $panel-collapse-icon-font-size is deprecated in v2 use $panel-header-collapse-icon-font-size instead
+$panel-collapse-icon-font-size: 0.75rem !default;
 
 // Panel Variants
 


### PR DESCRIPTION
…size`