### PR TITLE
Fixes #1094 ClayCSS 3.x Atlas Nav remove unused variables `$nav-colla…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_navs.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navs.scss
@@ -5,9 +5,6 @@ $nav-link-disabled-color: $gray-500 !default;
 $nav-link-padding-x: 1rem !default; // 16px
 $nav-link-padding-y: 0.625rem !default; // 10px
 
-$nav-collapse-icon-closed: "\f0da" !default;
-$nav-collapse-icon-open: "\f0d7" !default;
-
 // Nav Nested
 
 $nav-nested-spacer-x: 1rem !default; // 16px


### PR DESCRIPTION
…pse-icon-closed` and `$nav-collapse-icon-open`