### PR TITLE
Fixes #1094 ClayCSS 2.x Atlas Nav deprecate unused variables `$nav-co…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_navs.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navs.scss
@@ -5,7 +5,10 @@ $nav-link-disabled-color: $gray-500 !default;
 $nav-link-padding-x: 1rem !default; // 16px
 $nav-link-padding-y: 0.625rem !default; // 10px
 
+// $nav-collapse-icon-closed is deprecated in v2
 $nav-collapse-icon-closed: "\f0da" !default;
+
+// $nav-collapse-icon-open is deprecated in v2
 $nav-collapse-icon-open: "\f0d7" !default;
 
 // Nav Nested


### PR DESCRIPTION
…llapse-icon-closed` and `$nav-collapse-icon-open`