### PR TITLE
Fixes #1689 ClayCSS Toggle Switch add option to use label for="id" markup

### DIFF
--- a/packages/clay-css/src/content/test_toggle_switch_old.html
+++ b/packages/clay-css/src/content/test_toggle_switch_old.html
@@ -1,0 +1,462 @@
+---
+title: Toggle Switch (Old)
+section: Visual Tests
+---
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<div class="alert alert-warning">For customizing toggles, see <a href="../extending-toggles/">extending-toggles</a>.</div>
+
+		<h3>Toggle Switch with Checkbox</h3>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label class="toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle"></span>
+					</span>
+				</label>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Toggle Switch with Radio</h3>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label class="toggle-switch">
+					<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option1">
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle"></span>
+					</span>
+				</label>
+				<label class="toggle-switch">
+					<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option2">
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle"></span>
+					</span>
+				</label>
+				<label class="toggle-switch">
+					<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option3">
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle"></span>
+					</span>
+				</label>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Simple Toggle Switch</h3>
+
+		<div class="alert alert-warning">
+			Simple Toggle Switch is not compatible with <code>toggle-switch-text</code> or Toggle Switch with Data Attributes.
+		</div>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label class="simple-toggle-switch toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle"></span>
+					</span>
+					<span class="toggle-switch-label">Simple Toggle Switch</span>
+				</label>
+			</div>
+
+			<div class="form-group">
+				<label class="simple-toggle-switch toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle">
+							<span class="button-icon button-icon-on toggle-switch-icon">
+								<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+								</svg>
+							</span>
+							<span class="button-icon button-icon-off toggle-switch-icon">
+								<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+								</svg>
+							</span>
+						</span>
+					</span>
+					<span class="toggle-switch-label">
+						ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+						<span class="reference-mark">
+							<svg class="lexicon-icon lexicon-icon-asterisk" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+							</svg>
+						</span>
+					</span>
+				</label>
+			</div>
+
+			<div class="form-group">
+				<label class="simple-toggle-switch toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span class="toggle-switch-label">Simple Toggle Switch</span>
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle"></span>
+					</span>
+				</label>
+			</div>
+
+			<div class="form-group">
+				<label class="simple-toggle-switch toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span class="toggle-switch-label">
+						ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+						<span class="reference-mark">
+							<svg class="lexicon-icon lexicon-icon-asterisk" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+							</svg>
+						</span>
+					</span>
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle">
+							<span class="button-icon button-icon-on toggle-switch-icon">
+								<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+								</svg>
+							</span>
+							<span class="button-icon button-icon-off toggle-switch-icon">
+								<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+								</svg>
+							</span>
+						</span>
+					</span>
+				</label>
+			</div>
+
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Simple Toggle Switch Reverse</h3>
+
+		<blockquote class="blockquote">
+			Add <code>simple-toggle-switch-reverse</code> to <code>simple-toggle-switch</code> to align the label text on the left. This utility should be used when you only have limited access to the toggle switch markup. 
+		</blockquote>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label class="simple-toggle-switch simple-toggle-switch-reverse toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle"></span>
+					</span>
+					<span class="toggle-switch-label">Simple Toggle Switch</span>
+				</label>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Toggle Switch with Data Attributes</h3>
+
+		<blockquote class="blockquote">
+			<p>Use data attributes <code>data-label-on=""</code> and <code>data-label-off=""</code> on <code>```<span class="toggle-switch-handle"></span>```</code> to display specific text when the switch is on and off.</p>
+		</blockquote>
+
+<div class="sheet">
+	<div class="form-group">
+		<label class="toggle-switch">
+			<input class="toggle-switch-check" type="checkbox">
+			<span class="toggle-switch-label">Toggle Switch with data-label-on</span>
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+				</span>
+			</span>
+		</label>
+	</div>
+	<div class="form-group">
+		<label class="toggle-switch">
+			<input class="toggle-switch-check" type="checkbox">
+			<span class="toggle-switch-label">Toggle Switch with data-label on and data-label-off</span>
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle" data-label-off="Switch is off." data-label-on="Switch is on.">
+				</span>
+			</span>
+		</label>
+	</div>
+</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Toggle Switch Text</h3>
+
+		<blockquote class="blockquote">
+			<p>Add additional text with class <code>toggle-switch-text</code>.</p>
+		</blockquote>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label class="toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span class="toggle-switch-label">Adding Required Text</span>
+					<span class="toggle-switch-text">Required *</span>
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+						</span>
+					</span>
+				</label>
+			</div>
+			<div class="form-group">
+				<label class="toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span class="toggle-switch-label">Adding Required Text</span>
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+						</span>
+					</span>
+					<span class="toggle-switch-text">Required *</span>
+				</label>
+			</div>
+
+<div class="form-group">
+	<label class="toggle-switch">
+		<input class="toggle-switch-check" type="checkbox">
+		<span class="toggle-switch-label">Required Text on Right</span>
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+			</span>
+		</span>
+		<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
+	</label>
+</div>
+<div class="form-group">
+	<label class="toggle-switch">
+		<input class="toggle-switch-check" type="checkbox">
+		<span class="toggle-switch-label">Required Text on Left</span>
+		<span class="toggle-switch-text toggle-switch-text-left">Required *</span>
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+			</span>
+		</span>
+	</label>
+</div>
+
+			<div class="form-group">
+				<label class="toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span class="toggle-switch-label">The Kitchen Sink</span>
+					<span class="toggle-switch-text">Top Text</span>
+					<span class="toggle-switch-text toggle-switch-text-left">Error</span>
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle" data-label-off="OFF" data-label-on="ON">
+						</span>
+					</span>
+					<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
+					<span class="toggle-switch-text">Bottom Text</span>
+				</label>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Toggle Switches with Icons</h3>
+
+		<blockquote class="blockquote">
+			<p>Add an icon to the switch for the on position with <code>```<span class="button-icon button-icon-on icon-volume-up toggle-switch-icon"></span>```</code>.</p>
+
+			<p>Add an icon to the switch for the off position with <code>```<span class="button-icon button-icon-off icon-volume-off toggle-switch-icon"></span>```</code>.</p>
+		</blockquote>
+
+<div class="sheet">
+	<div class="form-group">
+		<label class="toggle-switch">
+			<input class="toggle-switch-check" type="checkbox">
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle">
+					<span class="button-icon button-icon-on toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+						</svg>
+					</span>
+					<span class="button-icon button-icon-off toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+						</svg>
+					</span>
+				</span>
+			</span>
+		</label>
+	</div>
+	<div class="form-group">
+		<label class="toggle-switch">
+			<input class="toggle-switch-check" type="checkbox">
+			<span class="toggle-switch-label">Toggle Switch with data-label-on</span>
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
+					<span class="button-icon button-icon-on toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#live" />
+						</svg>
+					</span>
+					<span class="button-icon button-icon-off toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
+						</svg>
+					</span>
+				</span>
+			</span>
+		</label>
+	</div>
+	<div class="form-group">
+		<label class="toggle-switch">
+			<input class="toggle-switch-check" type="checkbox">
+			<span class="toggle-switch-label">Toggle Switch with data-label on and data-label-off</span>
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle" data-label-off="Product Menu Closed" data-label-on="Product Menu Open">
+					<span class="button-icon button-icon-on toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-product-menu-open" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-open" />
+						</svg>
+					</span>
+					<span class="button-icon button-icon-off toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-closed" />
+						</svg>
+					</span>
+				</span>
+			</span>
+		</label>
+	</div>
+</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Toggle Switches with Icons (Alternate)</h3>
+
+		<blockquote class="blockquote">
+			<p>Add an icon to the switch for the on position with <code>```<span class="icon-ok toggle-switch-icon toggle-switch-icon-on"></span>```</code>.</p>
+
+			<p>Add an icon to the switch for the off position with <code>```<span class="icon-remove toggle-switch-icon toggle-switch-icon-off"></span>```</code>.</p>
+		</blockquote>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label class="toggle-switch">
+					<input class="toggle-switch-check" type="checkbox">
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle">
+							<span class="toggle-switch-icon toggle-switch-icon-on">
+								<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+								</svg>
+							</span>
+							<span class="toggle-switch-icon toggle-switch-icon-off">
+								<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+								</svg>
+							</span>
+						</span>
+					</span>
+				</label>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Disabled Toggle Switches</h3>
+
+		<blockquote class="blockquote">
+			<p>Disable a toggle-switch by adding the attribute <code>disabled</code> to <code>```<input type="checkbox">```</code>.</p>
+		</blockquote>
+
+<div class="sheet">
+	<div class="form-group">
+		<label class="toggle-switch">
+			<input class="toggle-switch-check" disabled type="checkbox">
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle">
+					<span class="button-icon button-icon-on toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+						</svg>
+					</span>
+					<span class="button-icon button-icon-off toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+						</svg>
+					</span>
+				</span>
+			</span>
+		</label>
+	</div>
+
+	<div class="form-group">
+		<label class="disabled simple-toggle-switch toggle-switch">
+			<input class="toggle-switch-check" disabled type="checkbox">
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle"></span>
+			</span>
+			<span class="toggle-switch-label">Simple Toggle Switch</span>
+		</label>
+	</div>
+
+	<div class="form-group">
+		<label class="disabled toggle-switch">
+			<input class="toggle-switch-check" disabled type="checkbox">
+			<span class="toggle-switch-label">Toggle Switch with data-label-on</span>
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
+					<span class="button-icon button-icon-on toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#live" />
+						</svg>
+					</span>
+					<span class="button-icon button-icon-off toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
+						</svg>
+					</span>
+				</span>
+			</span>
+		</label>
+	</div>
+	<div class="form-group">
+		<label class="disabled toggle-switch">
+			<input checked class="toggle-switch-check" disabled type="checkbox">
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle" data-label-off="Product Menu Closed" data-label-on="Product Menu Open">
+					<span class="button-icon button-icon-on toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-product-menu-open" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-open" />
+						</svg>
+					</span>
+					<span class="button-icon button-icon-off toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-closed" />
+						</svg>
+					</span>
+				</span>
+			</span>
+		</label>
+	</div>
+</div>
+
+	</div>
+</div>

--- a/packages/clay-css/src/content/toggle_switch.html
+++ b/packages/clay-css/src/content/toggle_switch.html
@@ -12,9 +12,11 @@ section: Components
 		<div class="sheet">
 			<div class="form-group">
 				<label class="toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle"></span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
 					</span>
 				</label>
 			</div>
@@ -29,21 +31,27 @@ section: Components
 		<div class="sheet">
 			<div class="form-group">
 				<label class="toggle-switch">
-					<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option1">
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle"></span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option1">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
 					</span>
 				</label>
 				<label class="toggle-switch">
-					<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option2">
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle"></span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option2">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
 					</span>
 				</label>
 				<label class="toggle-switch">
-					<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option3">
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle"></span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option3">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
 					</span>
 				</label>
 			</div>
@@ -62,9 +70,11 @@ section: Components
 		<div class="sheet">
 			<div class="form-group">
 				<label class="simple-toggle-switch toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle"></span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
 					</span>
 					<span class="toggle-switch-label">Simple Toggle Switch</span>
 				</label>
@@ -72,18 +82,20 @@ section: Components
 
 			<div class="form-group">
 				<label class="simple-toggle-switch toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle" data-label-off="" data-label-on="">
-							<span class="button-icon button-icon-on toggle-switch-icon">
-								<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
-								</svg>
-							</span>
-							<span class="button-icon button-icon-off toggle-switch-icon">
-								<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
-								</svg>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle">
+								<span class="button-icon button-icon-on toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+									</svg>
+								</span>
+								<span class="button-icon button-icon-off toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+									</svg>
+								</span>
 							</span>
 						</span>
 					</span>
@@ -100,17 +112,18 @@ section: Components
 
 			<div class="form-group">
 				<label class="simple-toggle-switch toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
 					<span class="toggle-switch-label">Simple Toggle Switch</span>
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle"></span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
 					</span>
 				</label>
 			</div>
 
 			<div class="form-group">
 				<label class="simple-toggle-switch toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
 					<span class="toggle-switch-label">
 						ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
 						<span class="reference-mark">
@@ -119,22 +132,26 @@ section: Components
 							</svg>
 						</span>
 					</span>
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle" data-label-off="" data-label-on="">
-							<span class="button-icon button-icon-on toggle-switch-icon">
-								<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
-								</svg>
-							</span>
-							<span class="button-icon button-icon-off toggle-switch-icon">
-								<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
-								</svg>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle">
+								<span class="button-icon button-icon-on toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+									</svg>
+								</span>
+								<span class="button-icon button-icon-off toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+									</svg>
+								</span>
 							</span>
 						</span>
 					</span>
 				</label>
 			</div>
+
 		</div>
 	</div>
 </div>
@@ -150,9 +167,11 @@ section: Components
 		<div class="sheet">
 			<div class="form-group">
 				<label class="simple-toggle-switch simple-toggle-switch-reverse toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle"></span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
 					</span>
 					<span class="toggle-switch-label">Simple Toggle Switch</span>
 				</label>
@@ -172,20 +191,24 @@ section: Components
 <div class="sheet">
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox">
 			<span class="toggle-switch-label">Toggle Switch with data-label-on</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox">
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+					</span>
 				</span>
 			</span>
 		</label>
 	</div>
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox">
 			<span class="toggle-switch-label">Toggle Switch with data-label on and data-label-off</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="Switch is off." data-label-on="Switch is on.">
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox">
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="Switch is off." data-label-on="Switch is on.">
+					</span>
 				</span>
 			</span>
 		</label>
@@ -206,21 +229,25 @@ section: Components
 		<div class="sheet">
 			<div class="form-group">
 				<label class="toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
 					<span class="toggle-switch-label">Adding Required Text</span>
 					<span class="toggle-switch-text">Required *</span>
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+							</span>
 						</span>
 					</span>
 				</label>
 			</div>
 			<div class="form-group">
 				<label class="toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
 					<span class="toggle-switch-label">Adding Required Text</span>
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+							</span>
 						</span>
 					</span>
 					<span class="toggle-switch-text">Required *</span>
@@ -229,10 +256,12 @@ section: Components
 
 <div class="form-group">
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" type="checkbox">
 		<span class="toggle-switch-label">Required Text on Right</span>
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" type="checkbox">
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+				</span>
 			</span>
 		</span>
 		<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
@@ -240,11 +269,13 @@ section: Components
 </div>
 <div class="form-group">
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" type="checkbox">
 		<span class="toggle-switch-label">Required Text on Left</span>
 		<span class="toggle-switch-text toggle-switch-text-left">Required *</span>
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" type="checkbox">
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+				</span>
 			</span>
 		</span>
 	</label>
@@ -252,12 +283,14 @@ section: Components
 
 			<div class="form-group">
 				<label class="toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
 					<span class="toggle-switch-label">The Kitchen Sink</span>
 					<span class="toggle-switch-text">Top Text</span>
 					<span class="toggle-switch-text toggle-switch-text-left">Error</span>
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle" data-label-off="OFF" data-label-on="ON">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="OFF" data-label-on="ON">
+							</span>
 						</span>
 					</span>
 					<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
@@ -281,18 +314,20 @@ section: Components
 <div class="sheet">
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox">
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="">
-					<span class="button-icon button-icon-on toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
-						</svg>
-					</span>
-					<span class="button-icon button-icon-off toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
-						</svg>
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox">
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle">
+						<span class="button-icon button-icon-on toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+							</svg>
+						</span>
+						<span class="button-icon button-icon-off toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+							</svg>
+						</span>
 					</span>
 				</span>
 			</span>
@@ -300,19 +335,21 @@ section: Components
 	</div>
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox">
 			<span class="toggle-switch-label">Toggle Switch with data-label-on</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
-					<span class="button-icon button-icon-on toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#live" />
-						</svg>
-					</span>
-					<span class="button-icon button-icon-off toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
-						</svg>
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox">
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
+						<span class="button-icon button-icon-on toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#live" />
+							</svg>
+						</span>
+						<span class="button-icon button-icon-off toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
+							</svg>
+						</span>
 					</span>
 				</span>
 			</span>
@@ -320,19 +357,21 @@ section: Components
 	</div>
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox">
 			<span class="toggle-switch-label">Toggle Switch with data-label on and data-label-off</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="Product Menu Closed" data-label-on="Product Menu Open">
-					<span class="button-icon button-icon-on toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-product-menu-open" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-open" />
-						</svg>
-					</span>
-					<span class="button-icon button-icon-off toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-closed" />
-						</svg>
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox">
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="Product Menu Closed" data-label-on="Product Menu Open">
+						<span class="button-icon button-icon-on toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-product-menu-open" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-open" />
+							</svg>
+						</span>
+						<span class="button-icon button-icon-off toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-closed" />
+							</svg>
+						</span>
 					</span>
 				</span>
 			</span>
@@ -356,18 +395,20 @@ section: Components
 		<div class="sheet">
 			<div class="form-group">
 				<label class="toggle-switch">
-					<input class="toggle-switch-check" type="checkbox">
-					<span aria-hidden="true" class="toggle-switch-bar">
-						<span class="toggle-switch-handle">
-							<span class="toggle-switch-icon toggle-switch-icon-on">
-								<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
-								</svg>
-							</span>
-							<span class="toggle-switch-icon toggle-switch-icon-off">
-								<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
-								</svg>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle">
+								<span class="toggle-switch-icon toggle-switch-icon-on">
+									<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+									</svg>
+								</span>
+								<span class="toggle-switch-icon toggle-switch-icon-off">
+									<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+									</svg>
+								</span>
 							</span>
 						</span>
 					</span>
@@ -388,18 +429,20 @@ section: Components
 <div class="sheet">
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" disabled type="checkbox">
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="">
-					<span class="button-icon button-icon-on toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
-						</svg>
-					</span>
-					<span class="button-icon button-icon-off toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
-						</svg>
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" disabled type="checkbox">
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle">
+						<span class="button-icon button-icon-on toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+							</svg>
+						</span>
+						<span class="button-icon button-icon-off toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+							</svg>
+						</span>
 					</span>
 				</span>
 			</span>
@@ -408,9 +451,11 @@ section: Components
 
 	<div class="form-group">
 		<label class="disabled simple-toggle-switch toggle-switch">
-			<input class="toggle-switch-check" disabled type="checkbox">
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle"></span>
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" disabled type="checkbox">
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle"></span>
+				</span>
 			</span>
 			<span class="toggle-switch-label">Simple Toggle Switch</span>
 		</label>
@@ -418,44 +463,374 @@ section: Components
 
 	<div class="form-group">
 		<label class="disabled toggle-switch">
-			<input class="toggle-switch-check" disabled type="checkbox">
 			<span class="toggle-switch-label">Toggle Switch with data-label-on</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
-					<span class="button-icon button-icon-on toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#live" />
-						</svg>
-					</span>
-					<span class="button-icon button-icon-off toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
-						</svg>
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" disabled type="checkbox">
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
+						<span class="button-icon button-icon-on toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#live" />
+							</svg>
+						</span>
+						<span class="button-icon button-icon-off toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
+							</svg>
+						</span>
 					</span>
 				</span>
 			</span>
 		</label>
 	</div>
 	<div class="form-group">
-		<label class="toggle-switch">
-			<input checked class="toggle-switch-check" disabled type="checkbox">
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="Product Menu Closed" data-label-on="Product Menu Open">
-					<span class="button-icon button-icon-on toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-product-menu-open" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-open" />
-						</svg>
-					</span>
-					<span class="button-icon button-icon-off toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-closed" />
-						</svg>
+		<label class="disabled toggle-switch">
+			<span class="toggle-switch-check-bar">
+				<input checked class="toggle-switch-check" disabled type="checkbox">
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="Product Menu Closed" data-label-on="Product Menu Open">
+						<span class="button-icon button-icon-on toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-product-menu-open" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-open" />
+							</svg>
+						</span>
+						<span class="button-icon button-icon-off toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-closed" />
+							</svg>
+						</span>
 					</span>
 				</span>
 			</span>
 		</label>
 	</div>
 </div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Toggle Switches with Label For Attribute</h3>
+
+		<blockquote class="blockquote">
+			<p>These are examples of <code>toggle-switch</code> using the <code>```<label for=""></label>```</code> pattern.</p>
+		</blockquote>
+
+		<div class="sheet">
+			<div class="form-group">
+				<span class="toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="toggleSwitchNoLabelCheckbox1" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" name="toggleSwitchNoLabelRadio1" type="radio" value="option1">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
+					</span>
+				</span>
+				<span class="toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" name="toggleSwitchNoLabelRadio1" type="radio" value="option2">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
+					</span>
+				</span>
+				<span class="toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" name="toggleSwitchNoLabelRadio1" type="radio" value="option3">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="simple-toggle-switch toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="simpleToggleSwitch1" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
+					</span>
+					<label class="toggle-switch-label" for="simpleToggleSwitch1">Simple Toggle Switch</label>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="simple-toggle-switch toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="simpleToggleSwitch2" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle">
+								<span class="button-icon button-icon-on toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+									</svg>
+								</span>
+								<span class="button-icon button-icon-off toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+									</svg>
+								</span>
+							</span>
+						</span>
+					</span>
+					<label class="toggle-switch-label" for="simpleToggleSwitch2">
+						ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+						<span class="reference-mark">
+							<svg class="lexicon-icon lexicon-icon-asterisk" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+							</svg>
+						</span>
+					</label>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="simple-toggle-switch toggle-switch">
+					<label class="toggle-switch-label" for="simpleToggleSwitch3">Simple Toggle Switch</label>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="simpleToggleSwitch3" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="simple-toggle-switch toggle-switch">
+					<label class="toggle-switch-label" for="simpleToggleSwitch4">
+						ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+						<span class="reference-mark">
+							<svg class="lexicon-icon lexicon-icon-asterisk" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+							</svg>
+						</span>
+					</label>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="simpleToggleSwitch4" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle">
+								<span class="button-icon button-icon-on toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+									</svg>
+								</span>
+								<span class="button-icon button-icon-off toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+									</svg>
+								</span>
+							</span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="simple-toggle-switch simple-toggle-switch-reverse toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="simpleToggleSwitchReverse1" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
+					</span>
+					<label class="toggle-switch-label" for="simpleToggleSwitchReverse1">Simple Toggle Switch Reverse</label>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="toggle-switch">
+					<label class="toggle-switch-label" for="toggleSwitchDataLabel1">Toggle Switch with data-label-on</label>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="toggleSwitchDataLabel1" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+							</span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="toggle-switch">
+					<label class="toggle-switch-label" for="toggleSwitchDataLabel2">Toggle Switch with data-label on and data-label-off</label>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="toggleSwitchDataLabel2" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="Switch is off." data-label-on="Switch is on.">
+							</span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="toggle-switch">
+					<label class="toggle-switch-label" for="toggleSwitchWithText1">Adding Required Text</label>
+					<span class="toggle-switch-text">Required *</span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="toggleSwitchWithText1" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+							</span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="toggle-switch">
+					<label class="toggle-switch-label" for="toggleSwitchWithText2">Adding Required Text</label>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="toggleSwitchWithText2" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+							</span>
+						</span>
+					</span>
+					<span class="toggle-switch-text">Required *</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="toggle-switch">
+					<label class="toggle-switch-label" for="toggleSwitchWithText3">Required Text on Right</label>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="toggleSwitchWithText3" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+							</span>
+						</span>
+					</span>
+					<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="toggle-switch">
+					<label class="toggle-switch-label" for="toggleSwitchWithText4">Required Text on Left</label>
+					<span class="toggle-switch-text toggle-switch-text-left">Required *</span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="toggleSwitchWithText4" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+							</span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="toggle-switch">
+					<label class="toggle-switch-label" for="toggleSwitchWithText5">The Kitchen Sink</label>
+					<span class="toggle-switch-text">Top Text</span>
+					<span class="toggle-switch-text toggle-switch-text-left">Error</span>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" id="toggleSwitchWithText5" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="OFF" data-label-on="ON">
+							</span>
+						</span>
+					</span>
+					<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
+					<span class="toggle-switch-text">Bottom Text</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="disabled toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" disabled type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle">
+								<span class="button-icon button-icon-on toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#unlock" />
+									</svg>
+								</span>
+								<span class="button-icon button-icon-off toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#lock" />
+									</svg>
+								</span>
+							</span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="disabled simple-toggle-switch toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" disabled id="disabledToggleSwitch1" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle"></span>
+						</span>
+					</span>
+					<label class="toggle-switch-label" for="disabledToggleSwitch1">Simple Toggle Switch</label>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="disabled toggle-switch">
+					<label class="toggle-switch-label" for="disabledToggleSwitch2">Toggle Switch with data-label-on</label>
+					<span class="toggle-switch-check-bar">
+						<input class="toggle-switch-check" disabled id="disabledToggleSwitch2" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
+								<span class="button-icon button-icon-on toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#live" />
+									</svg>
+								</span>
+								<span class="button-icon button-icon-off toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
+									</svg>
+								</span>
+							</span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+			<div class="form-group">
+				<span class="disabled toggle-switch">
+					<span class="toggle-switch-check-bar">
+						<input checked class="toggle-switch-check" disabled id="disabledToggleSwitch3" type="checkbox">
+						<span aria-hidden="true" class="toggle-switch-bar">
+							<span class="toggle-switch-handle" data-label-off="Product Menu Closed" data-label-on="Product Menu Open">
+								<span class="button-icon button-icon-on toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-product-menu-open" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-open" />
+									</svg>
+								</span>
+								<span class="button-icon button-icon-off toggle-switch-icon">
+									<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-closed" />
+									</svg>
+								</span>
+							</span>
+						</span>
+					</span>
+				</span>
+			</div>
+
+		</div>
 
 	</div>
 </div>

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -2,12 +2,20 @@
 	cursor: $form-check-input-cursor;
 	height: 14px;
 	width: 14px;
+
+	&:disabled {
+		cursor: $form-check-input-disabled-cursor;
+	}
 }
 
 [type="radio"] {
 	cursor: $form-check-input-cursor;
 	height: 15px;
 	width: 14px;
+
+	&:disabled {
+		cursor: $form-check-input-disabled-cursor;
+	}
 }
 
 fieldset {

--- a/packages/clay-css/src/scss/components/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/components/_toggle-switch.scss
@@ -58,6 +58,17 @@ label.toggle-switch {
 	font-weight: $toggle-switch-font-weight;
 	max-width: 100%;
 	position: relative;
+
+	&.disabled {
+		.toggle-switch-label {
+			color: $toggle-switch-label-disabled-color;
+			cursor: $toggle-switch-disabled-cursor;
+		}
+
+		.toggle-switch-text {
+			color: $toggle-switch-text-disabled-color;
+		}
+	}
 }
 
 .toggle-switch-check-bar {
@@ -246,7 +257,7 @@ label.toggle-switch {
 	}
 
 	&:focus ~ .toggle-switch-bar:before {
-		@include box-shadow($toggle-switch-bar-focus-box-shadow);
+		box-shadow: $toggle-switch-bar-focus-box-shadow;
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/components/_toggle-switch.scss
@@ -1,11 +1,17 @@
 // Simple Toggle Switch
 
 .simple-toggle-switch {
-	align-items: center;
-	display: inline-flex;
+	&.toggle-switch {
+		align-items: center;
+		display: inline-flex;
+	}
 
 	.toggle-switch-check + .toggle-switch-label {
 		margin-right: $simple-toggle-switch-label-spacer-x;
+	}
+
+	.toggle-switch-label + .toggle-switch-check-bar {
+		margin-left: $simple-toggle-switch-label-spacer-x;
 	}
 
 	.toggle-switch-label {
@@ -24,6 +30,14 @@
 		margin-right: $simple-toggle-switch-label-spacer-x;
 	}
 
+	.toggle-switch-check-bar {
+		order: 5;
+
+		.toggle-switch-bar {
+			order: 0;
+		}
+	}
+
 	.toggle-switch-bar {
 		order: 5;
 	}
@@ -31,14 +45,29 @@
 
 // Toggle Switch
 
+label.toggle-switch {
+	cursor: $toggle-switch-cursor;
+
+	&.disabled {
+		cursor: $toggle-switch-disabled-cursor;
+	}
+}
+
 .toggle-switch {
-	cursor: pointer;
+	display: inline-block;
+	font-weight: $toggle-switch-font-weight;
+	max-width: 100%;
+	position: relative;
+}
+
+.toggle-switch-check-bar {
+	display: inline-flex;
+	position: relative;
 }
 
 .toggle-switch-bar {
 	.toggle-switch-handle {
 		display: block;
-		float: left;
 		min-width: $toggle-switch-bar-width;
 		text-transform: uppercase;
 	}
@@ -57,14 +86,21 @@
 }
 
 .toggle-switch-check {
+	bottom: 0;
 	font-size: 62.5%;
+	height: $toggle-switch-bar-height;
 	opacity: 0;
 	position: absolute;
+	width: $toggle-switch-bar-width;
+	z-index: 2;
+
+	@include clay-scale-component {
+		height: $toggle-switch-bar-height-mobile;
+		width: $toggle-switch-bar-width-mobile;
+	}
 
 	&:empty ~ .toggle-switch-bar {
-		cursor: pointer;
-		display: block;
-		float: left;
+		display: inline-flex;
 		font-size: $toggle-switch-bar-font-size;
 		height: $toggle-switch-bar-height;
 		line-height: $toggle-switch-bar-height;
@@ -220,20 +256,18 @@
 }
 
 .toggle-switch-text {
-	clear: both;
 	display: block;
 	font-size: $toggle-switch-text-font-size;
 }
 
 .toggle-switch-text-left {
-	float: left;
+	display: inline-flex;
 	line-height: $toggle-switch-bar-height;
 	margin-right: 8px;
 }
 
 .toggle-switch-text-right {
-	clear: none;
-	float: left;
+	display: inline-flex;
 	line-height: $toggle-switch-bar-height;
 	margin-left: 8px;
 }

--- a/packages/clay-css/src/scss/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/variables/_toggle-switch.scss
@@ -46,9 +46,15 @@ $toggle-switch-button-on-icon-color: $toggle-switch-bar-on-bg !default;
 $toggle-switch-disabled-cursor: $disabled-cursor !default;
 $toggle-switch-disabled-opacity: 0.4 !default;
 
+// Toggle Switch Label
+
+$toggle-switch-label-disabled-color: $input-label-disabled-color !default;
+
 // Toggle Switch Text
 
 $toggle-switch-text-font-size: 0.75rem !default;
+
+$toggle-switch-text-disabled-color: $input-label-disabled-color !default;
 
 // Simple Toggle Switch
 

--- a/packages/clay-css/src/scss/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/variables/_toggle-switch.scss
@@ -1,3 +1,5 @@
+$toggle-switch-cursor: $link-cursor !default;
+$toggle-switch-font-weight: $input-label-font-weight !default;
 $toggle-switch-transition: background-color 100ms ease-in, border-color 100ms ease-in, color 100ms ease-in, left 100ms ease-in, right 100ms ease-in !default;
 
 // must all be same units--start


### PR DESCRIPTION
This adds support for using `<label for=""></label>` markup pattern in `toggle-switch`. I had to wrap `<input class="toggle-switch-check" id="" type="checkbox">` and `<span aria-hidden="true" class="toggle-switch-bar"></span>` in `<span class="toggle-switch-check-bar"></span>` and change the placement of the checkbox.

This is **potentially a breaking change** if you want #1618 to apply to all the Toggle Switches shown on the test site. #1618 will still apply to all the designs defined by Lexicon using the old markup pattern.

New markup:
```
<span class="simple-toggle-switch toggle-switch">
  <span class="toggle-switch-check-bar">
    <input class="toggle-switch-check" id="theToggleSwitchCheckId" type="checkbox">
    <span aria-hidden="true" class="toggle-switch-bar">
      <span class="toggle-switch-handle"></span>
    </span>
  </span>
  <label class="toggle-switch-label" for="theToggleSwitchCheckId">
    The Label Text
  </label>
</span>
```