### PR TITLE
Fixes #1743 ClayCSS undo Bootstrap's `text-align: left` on the `body`…

### DIFF
--- a/packages/clay-css/src/scss/components/_type.scss
+++ b/packages/clay-css/src/scss/components/_type.scss
@@ -2,6 +2,7 @@ body {
 	-moz-osx-font-smoothing: $body-moz-osx-font-smoothing;
 	-ms-overflow-style: scrollbar;
 	-webkit-font-smoothing: $body-webkit-font-smoothing;
+	text-align: $body-text-align;
 
 	@include clay-scale-component {
 		font-size: $font-size-base-mobile;

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -100,6 +100,7 @@ $h6-font-size-mobile: null !default;
 
 $body-moz-osx-font-smoothing: $moz-osx-font-smoothing !default;
 $body-webkit-font-smoothing: $webkit-font-smoothing !default;
+$body-text-align: inherit !default;
 
 // Z-Index Variables
 


### PR DESCRIPTION
… element so content with mixed languages will be properly aligned

Fixes #1743 ClayCSS Globals added option to configure `$body-text-align` and reset Bootstrap's `text-align: left` on the `body` element