### PR TITLE
Fixes #1822 ClayCSS Autocomplete Dropdown Menu remove `z-index` worka…

### DIFF
--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -72,8 +72,6 @@ $autocomplete-dropdown-menu: map-merge((
 	max-height: calc(9rem + 2px),
 	max-width: none,
 	width: 100%,
-	// https://issues.liferay.com/browse/LPS-92801 causes issues when autocomplete is on main page and modal is opened, eventually needs fixing in ClayAutocomplete
-	z-index: $zindex-modal + 1,
 ), $autocomplete-dropdown-menu);
 
 // Dropdown Action


### PR DESCRIPTION
…round was fixed in ClayAutocomplete