### PR TITLE
Fixes #1855 ClayCSS Stickers that are `display: inline-block` with ic…

### DIFF
--- a/packages/clay-css/src/scss/components/_stickers.scss
+++ b/packages/clay-css/src/scss/components/_stickers.scss
@@ -24,7 +24,8 @@
 	}
 
 	> .inline-item .lexicon-icon,
-	.lexicon-icon {
+	> .sticker-overlay .lexicon-icon,
+	> .lexicon-icon {
 		margin-top: 0;
 	}
 


### PR DESCRIPTION
…ons aren't centered

https://issues.liferay.com/browse/LPS-93914