### PR TITLE
Fixes #1872 ClayCSS Card set `background-color` and `border-width` on…

### DIFF
--- a/packages/clay-css/src/scss/components/_cards.scss
+++ b/packages/clay-css/src/scss/components/_cards.scss
@@ -1,6 +1,8 @@
 .card,
 .card-horizontal {
+	background-color: $card-bg;
 	border-style: $card-border-style;
+	border-width: $card-border-width;
 
 	@include box-shadow($card-box-shadow);
 


### PR DESCRIPTION
… `.card` and `.card-horizontal` due to specificity issues with Liferay Portal compat layer