### PR TITLE
Fixes #1834 - Update deployment clayui.com

### DIFF
--- a/clayui.com/README.md
+++ b/clayui.com/README.md
@@ -11,3 +11,7 @@ The main Clay site at clayui.com
 
 ## Serving production generated files:
 `yarn serve`
+
+## Deployment
+
+`yarn deploy --remote upstream`

--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "copy:icons": "cpx '../packages/clay-css/lib/images/icons/*.svg' static/images/icons",
-    "deploy": "gatsby build && gh-pages -d public -b wedeploy",
+    "deploy": "gatsby build && gh-pages -d public -b gh-pages",
     "develop": "npm run copy:icons && gatsby develop",
     "build": "npm run copy:icons && gatsby build",
     "serve": "gatsby serve"

--- a/clayui.com/static/wedeploy.json
+++ b/clayui.com/static/wedeploy.json
@@ -1,4 +1,0 @@
-{
-	"id": "hosting",
-	"image": "wedeploy/hosting:2.0.1"
-}


### PR DESCRIPTION
I'm just updating the new way of deploying clayui.com, we will keep the version of 2.x on gh-pages and the new site will go to Netlify to get into our workflow process.