### PR TITLE
Fixes #1913 ClayCSS 2.x Atlas Breadcrumb focus styles should match Lexicon

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_breadcrumbs.scss
@@ -5,6 +5,14 @@ $breadcrumb-padding-x: 0.125rem !default; // 2px
 $breadcrumb-link-color: $gray-600 !default;
 $breadcrumb-link-hover-color: $breadcrumb-link-color !default;
 
+$breadcrumb-link: () !default;
+$breadcrumb-link: map-merge((
+	border-radius: 1px,
+	transition: box-shadow 0.15s ease-in-out,
+	focus-box-shadow: $component-focus-box-shadow,
+	focus-outline: 0,
+), $breadcrumb-link);
+
 $breadcrumb-active-color: $gray-900 !default;
 
 $breadcrumb-divider-color: $breadcrumb-link-color !default;

--- a/packages/clay-css/src/scss/components/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/components/_breadcrumbs.scss
@@ -1,21 +1,5 @@
 .breadcrumb-link {
-	display: block;
-	color: $breadcrumb-link-color;
-
-	@if not ($breadcrumb-link-text-decoration == $link-decoration) {
-		text-decoration: $breadcrumb-link-text-decoration;
-	}
-
-	text-transform: $breadcrumb-text-transform;
-
-	&:hover,
-	&:focus {
-		color: $breadcrumb-link-hover-color;
-
-		@if not ($breadcrumb-link-hover-text-decoration == $link-hover-decoration) {
-			text-decoration: $breadcrumb-link-hover-text-decoration;
-		}
-	}
+	@include clay-link($breadcrumb-link);
 
 	> .breadcrumb-text-truncate {
 		text-decoration: $breadcrumb-link-text-decoration;

--- a/packages/clay-css/src/scss/variables/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/variables/_breadcrumbs.scss
@@ -14,6 +14,18 @@ $breadcrumb-link-text-decoration: $link-decoration !default;
 $breadcrumb-link-hover-color: $link-hover-color !default;
 $breadcrumb-link-hover-text-decoration: $link-hover-decoration !default;
 
+$breadcrumb-link: () !default;
+$breadcrumb-link: map-merge((
+	color: $breadcrumb-link-color,
+	display: block,
+	text-decoration: $breadcrumb-link-text-decoration,
+	text-transform: $breadcrumb-text-transform,
+	hover-color: $breadcrumb-link-hover-color,
+	hover-text-decoration: $breadcrumb-link-hover-text-decoration,
+	focus-color: $breadcrumb-link-hover-color,
+	focus-text-decoration: $breadcrumb-link-hover-text-decoration,
+), $breadcrumb-link);
+
 $breadcrumb-divider-color: $breadcrumb-active-color !default;
 $breadcrumb-divider-font-family: null !default;
 $breadcrumb-divider-font-weight: null !default;


### PR DESCRIPTION
Fixes #1913 ClayCSS Breadcrumb use `clay-link` mixin for `.breadcrumb-link` and add Sass map `$breadcrumb-link`