### PR TITLE
Fixes #1919 ClayCSS 2.x Panels move `.panel-header-link` and `a.sheet-sub…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_panels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_panels.scss
@@ -6,6 +6,13 @@ $panel-header-link-hover-text-decoration: none !default;
 
 $panel-header-collapse-icon-font-size: 0.75rem !default; // 12px
 
+$panel-header-link: () !default;
+$panel-header-link: map-merge((
+	transition: box-shadow 0.15s ease-in-out,
+	focus-box-shadow: $component-focus-box-shadow,
+	focus-outline: 0,
+), $panel-header-link);
+
 // Panel Footer
 
 $panel-footer-border-top-width: 0 !default;
@@ -47,5 +54,6 @@ $panel-secondary: map-merge((
 
 $panel-unstyled-header-link: () !default;
 $panel-unstyled-header-link: map-merge((
+	border-radius: 1px,
 	focus-box-shadow: 0 0 0 0.25rem $white#{','} 0 0 0 0.375rem $primary-l1,
 ), $panel-unstyled-header-link);

--- a/packages/clay-css/src/scss/atlas/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sheets.scss
@@ -33,7 +33,10 @@ $sheet-subtitle-margin-bottom-mobile: 1rem !default; // 16px
 
 $sheet-subtitle-link: () !default;
 $sheet-subtitle-link: map-merge((
+	border-radius: 1px,
+	transition: box-shadow 0.15s ease-in-out,
 	focus-box-shadow: 0 0 0 0.25rem $white#{','} 0 0 0 0.375rem $primary-l1,
+	focus-outline: 0,
 ), $sheet-subtitle-link);
 
 $sheet-subtitle-collapse-icon-font-size: 0.75rem !default;

--- a/packages/clay-css/src/scss/variables/_panels.scss
+++ b/packages/clay-css/src/scss/variables/_panels.scss
@@ -38,11 +38,8 @@ $panel-header-link: map-merge((
 	color: inherit,
 	display: block,
 	text-decoration: $panel-header-link-text-decoration,
-	transition: box-shadow 0.15s ease-in-out,
 	hover-color: inherit,
 	hover-text-decoration: $panel-header-link-hover-text-decoration,
-	focus-box-shadow: $btn-focus-box-shadow,
-	focus-outline: 0,
 	focus-z-index: 1,
 ), $panel-header-link);
 
@@ -111,10 +108,6 @@ $panel-secondary: map-merge((
 // Panel Unstyled
 
 $panel-unstyled-header-link: () !default;
-$panel-unstyled-header-link: map-merge((
-	border-radius: 1px,
-	focus-box-shadow: 0 0 0 $input-btn-focus-width $white#{','} 0 0 0 ($input-btn-focus-width * 2) $input-btn-focus-color,
-), $panel-unstyled-header-link);
 
 $panel-unstyled: () !default;
 $panel-unstyled: map-merge((

--- a/packages/clay-css/src/scss/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/variables/_sheets.scss
@@ -90,14 +90,10 @@ $sheet-subtitle-link-hover-text-decoration: none !default;
 
 $sheet-subtitle-link: () !default;
 $sheet-subtitle-link: map-merge((
-	border-radius: 1px,
 	color: $sheet-subtitle-link-color,
 	text-decoration: $sheet-subtitle-link-text-decoration,
-	transition: box-shadow 0.15s ease-in-out,
 	hover-color: $sheet-subtitle-link-hover-color,
 	hover-text-decoration: $sheet-subtitle-link-hover-text-decoration,
-	focus-box-shadow: 0 0 0 $input-btn-focus-width $white#{','} 0 0 0 ($input-btn-focus-width * 2) $input-btn-focus-color,
-	focus-outline: 0,
 ), $sheet-subtitle-link);
 
 $sheet-subtitle-collapse-icon-font-size: null !default;


### PR DESCRIPTION
…title` focus styles from Base to Atlas