### PR TITLE
Fixes #1546 ClayCSS Base Single collapsible panels shouldn't shift 1p…

### DIFF
--- a/packages/clay-css/src/scss/components/_panels.scss
+++ b/packages/clay-css/src/scss/components/_panels.scss
@@ -28,8 +28,6 @@
 		@if not ($panel-header-offset-border-radius == 0) {
 			@include border-bottom-radius($panel-header-offset-border-radius);
 		}
-
-		border-bottom-width: 0;
 	}
 
 	&.collapse-icon {
@@ -49,6 +47,10 @@
 
 .panel-header-link {
 	@include clay-link($panel-header-link);
+
+	&.panel-header.collapsed {
+		@include clay-link($panel-header-collapsed-link);
+	}
 
 	.collapse-icon {
 		padding-left: $collapse-icon-padding-left;

--- a/packages/clay-css/src/scss/variables/_panels.scss
+++ b/packages/clay-css/src/scss/variables/_panels.scss
@@ -38,10 +38,17 @@ $panel-header-link: map-merge((
 	color: inherit,
 	display: block,
 	text-decoration: $panel-header-link-text-decoration,
+	transition: border-color 0.1s ease,
 	hover-color: inherit,
 	hover-text-decoration: $panel-header-link-hover-text-decoration,
 	focus-z-index: 1,
 ), $panel-header-link);
+
+$panel-header-collapsed-link: () !default;
+$panel-header-collapsed-link: map-merge((
+	border-color: transparent,
+	transition: border-color 0.75s ease,
+), $panel-header-collapsed-link);
 
 // Panel Body
 


### PR DESCRIPTION
…x on open/close

Fixes #1546 ClayCSS Panels added Sass map `$panel-header-collapsed-link` and use `clay-link` mixin for `.panel-header-link.panel-header.collapsed`