### PR TITLE
Fixes #1956, Fixes #1951 ClayCSS Atlas `dropdown-item` focus shouldn'…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -32,7 +32,6 @@ $dropdown-item-padding-y: 0.5rem !default; // 8px
 $dropdown-item-base: () !default;
 $dropdown-item-base: map-merge((
 	font-size: inherit,
-	focus-border-radius: 0.375rem,
 	// Weird box-shadow inset with border-radius render in IE https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12515080/
 	focus-box-shadow: inset 0 0 0 0.125rem $primary-l1#{','} inset 0 0 0 0.25rem $white,
 	focus-outline: 0,


### PR DESCRIPTION
…t have rounded corners