### PR TITLE
Fixes #1959, Fixes #1951 ClayCSS Atlas Navigation Bar focus styles sh…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
@@ -11,9 +11,7 @@ $navigation-bar-size: map-merge((
 
 $navigation-bar-base: () !default;
 $navigation-bar-base: map-merge((
-	link-border-radius: $border-radius,
 	link-outline: 0,
-	link-transition: box-shadow 0.15s ease-in-out,
 	link-focus-box-shadow: $btn-focus-box-shadow,
 	link-disabled-box-shadow: none,
 ), $navigation-bar-base);


### PR DESCRIPTION
…ouldn't have rounded corners and remove focus transition so it matches `dropdown-item`