### PR TITLE
Revert the use of the atlas by link

### DIFF
--- a/clayui.com/src/html.js
+++ b/clayui.com/src/html.js
@@ -15,7 +15,6 @@ class HTML extends Component {
                     {this.props.headComponents}
 
                     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-                    <link id="clayCSSTheme" rel="stylesheet" href="/css/atlas.css" />
                     <script type="text/javascript" src="/js/jquery.min.js"></script>
                     <script type="text/javascript" src="/js/popper.js"></script>
                     <script type="text/javascript" src="/js/bootstrap.js"></script>

--- a/clayui.com/src/styles/main.scss
+++ b/clayui.com/src/styles/main.scss
@@ -1,5 +1,4 @@
-@import "atlas-variables";
-
+@import "atlas";
 @import "charts";
 
 @import "site/variables";


### PR DESCRIPTION
hey @pat270 I'm reversing the use of Atlas direct from css, it was breaking the site's css in production. We can analyze this better in 3.x.