### PR TITLE
Clayui.com `atlas.css` should be above `this.props.headComponents` Ga…

### DIFF
--- a/clayui.com/src/html.js
+++ b/clayui.com/src/html.js
@@ -12,6 +12,7 @@ class HTML extends Component {
                         content="width=device-width, initial-scale=1.0"
                     />
                     <link rel="shortcut icon" type="image/png" href="/images/favicon-32x32.png" sizes="16x16 32x32"/>
+                    <link id="clayCSSTheme" rel="stylesheet" href="/css/atlas.css" />
                     {this.props.headComponents}
 
                     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

--- a/clayui.com/src/styles/main.scss
+++ b/clayui.com/src/styles/main.scss
@@ -1,4 +1,4 @@
-@import "atlas";
+@import "atlas-variables";
 @import "charts";
 
 @import "site/variables";


### PR DESCRIPTION
…tsby switches up the load order for files in <head> in production

@matuzalemsteles I fixed the CSS issue in #1964.