### PR TITLE
Add babel-loader peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@types/storybook__react": "^4.0.1",
 		"@typescript-eslint/parser": "^1.4.0",
 		"awesome-typescript-loader": "^5.2.1",
+		"babel-loader": "^7.0.0",
 		"babel-plugin-dev-expression": "^0.2.1",
 		"babel-plugin-react-remove-properties": "^0.3.0",
 		"babel-plugin-transform-inline-environment-variables": "^0.4.3",
@@ -65,7 +66,9 @@
 			"packages/*",
 			"next.clayui.com"
 		],
-		"nohoist": ["gatsby"]
+		"nohoist": [
+			"gatsby"
+		]
 	},
 	"resolutions": {
 		"js-beautify": "1.7.5",


### PR DESCRIPTION
Needed as a peer dependency of `@storybook/react` otherwise we get issues running storybook. Not sure why the yarn.lock didn't update after adding this...