### PR TITLE
ClayCSS use sassdoc syntax to document deprecated variables

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_alerts.scss
@@ -1,10 +1,15 @@
+////
+/// @group alerts
+////
+
 $alert-padding-x: 1rem !default; // 16px
 $alert-padding-y: 1.09375rem !default; // 17.5px
 
 // For top only border use: 2px 0 0 0
 $alert-border-width: 0.0625rem !default;
 
-// `$alert-close-opacity` is deprecated use `$alert-close` instead
+// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-opacity: 1 !default;
 
 $alert-font-size: 0.875rem !default; // 14px

--- a/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
@@ -1,3 +1,7 @@
+////
+/// @group customForms
+////
+
 $custom-control-indicator-size: 1.0625rem !default; // 17px
 $custom-control-indicator-bg: $white !default;
 $custom-control-indicator-border-color: $gray-400 !default;
@@ -17,21 +21,25 @@ $custom-control-indicator-disabled-border-color: $input-disabled-border-color !d
 
 // Custom Control Indicator Checked
 
-// $custom-control-indicator-active-checked-bg is deprecated as of v2.2.1
+// @deprecated as of v2.2.1 use `$custom-control-indicator-checked-active-bg` instead
+
 $custom-control-indicator-active-checked-bg: $component-active-bg !default;
 $custom-control-indicator-checked-active-bg: $custom-control-indicator-active-checked-bg !default;
 
-// $custom-control-indicator-active-checked-border-color is deprecated as of v2.2.1
+// @deprecated as of v2.2.1 use `$custom-control-indicator-checked-active-border-color` instead
+
 $custom-control-indicator-active-checked-border-color: $custom-control-indicator-checked-active-bg !default;
 $custom-control-indicator-checked-active-border-color: $custom-control-indicator-active-checked-border-color !default;
 
 $custom-control-indicator-checked-border-color: $custom-control-indicator-checked-active-bg !default;
 
-// $custom-control-indicator-disabled-checked-bg is deprecated as of v2.2.1
+// @deprecated as of v2.2.1 use `$custom-control-indicator-checked-disabled-bg` instead
+
 $custom-control-indicator-disabled-checked-bg: lighten($component-active-bg, 32.94) !default;
 $custom-control-indicator-checked-disabled-bg: $custom-control-indicator-disabled-checked-bg !default;
 
-// $custom-control-indicator-disabled-checked-border-color is deprecated as of v2.2.1
+// @deprecated as of v2.2.1 use `$custom-control-indicator-checked-disabled-border-color` instead
+
 $custom-control-indicator-disabled-checked-border-color: $custom-control-indicator-disabled-checked-bg !default;
 $custom-control-indicator-checked-disabled-border-color: $custom-control-indicator-disabled-checked-border-color !default;
 
@@ -65,6 +73,7 @@ $custom-radio-indicator-icon-checked-bg-size: 65% !default;
 
 $custom-radio-indicator-disabled-border-color: $custom-control-indicator-disabled-bg !default;
 
-// $custom-radio-indicator-disabled-checked-border-color is deprecated as of v2.2.1
+// @deprecated as of v2.2.1 use `$custom-radio-indicator-checked-disabled-border-color` instead
+
 $custom-radio-indicator-disabled-checked-border-color: $custom-control-indicator-disabled-checked-border-color !default;
 $custom-radio-indicator-checked-disabled-border-color: $custom-radio-indicator-disabled-checked-border-color !default;

--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -1,7 +1,9 @@
-// $clay-unset is deprecated as of v2.4.1 we will not support unsetting
-// variables in version 2 because it violates the Sass spec. If you
-// are using libsass you can still unset variables with the syntax
-// `$my-var: !default;`.
+////
+/// @group globals
+////
+
+// @deprecated as of v2.4.1 we will not support unsetting variables in version 2 because it violates the Sass spec. If you are using libsass you can still unset Clay CSS / Bootstrap variables with the syntax `$my-var: !default;`.
+
 $clay-unset: clay-unset !default;
 $clay-unset-placeholder: clay-unset-placeholder !default;
 

--- a/packages/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_labels.scss
@@ -1,3 +1,7 @@
+////
+/// @group labels
+////
+
 $label-border-radius: 0.125rem !default; // 2px
 $label-font-size: 0.625rem !default; // 10px
 $label-font-weight: $font-weight-semi-bold !default;
@@ -46,13 +50,21 @@ $label-base: map-merge((
 	disabled-box-shadow: none,
 ), $label-base);
 
-// $label-primary-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-primary` instead
+
 $label-primary-color: $primary !default;
-// $label-primary-hover-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-primary` instead
+
 $label-primary-hover-color: $primary-d2 !default;
-// $label-primary-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-primary` instead
+
 $label-primary-border-color: $primary-l1 !default;
-// $label-primary-hover-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-primary` instead
+
 $label-primary-hover-border-color: $label-primary-border-color !default;
 
 $label-primary: () !default;
@@ -63,13 +75,20 @@ $label-primary: map-merge((
 	hover-color: $label-primary-hover-color,
 ), $label-primary);
 
-// $label-secondary-color is deprecated as of v2.4.1
+// @deprecated as of v2.4.1 use the Sass map `$label-secondary` instead
+
 $label-secondary-color: $secondary !default;
-// $label-secondary-hover-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-secondary` instead
+
 $label-secondary-hover-color: $gray-900 !default;
-// $label-secondary-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-secondary` instead
+
 $label-secondary-border-color: $secondary-l2 !default;
-// $label-secondary-hover-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-secondary` instead
+
 $label-secondary-hover-border-color: $label-secondary-border-color !default;
 
 $label-secondary: () !default;
@@ -80,13 +99,20 @@ $label-secondary: map-merge((
 	hover-color: $label-secondary-hover-color,
 ), $label-secondary);
 
-// $label-success-color is deprecated as of v2.4.1
+// @deprecated as of v2.4.1 use the Sass map `$label-success` instead
+
 $label-success-color: $success !default;
-// $label-success-hover-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-success` instead
+
 $label-success-hover-color: $success-d2 !default;
-// $label-success-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-success` instead
+
 $label-success-border-color: $success-l1 !default;
-// $label-success-hover-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-success` instead
+
 $label-success-hover-border-color: $label-success-border-color !default;
 
 $label-success: () !default;
@@ -97,13 +123,20 @@ $label-success: map-merge((
 	hover-color: $label-success-hover-color,
 ), $label-success);
 
-// $label-info-color is deprecated as of v2.4.1
+// @deprecated as of v2.4.1 use the Sass map `$label-info` instead
+
 $label-info-color: $info !default;
-// $label-info-hover-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-info` instead
+
 $label-info-hover-color: $info-d2 !default;
-// $label-info-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-info` instead
+
 $label-info-border-color: $info-l1 !default;
-// $label-info-hover-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-info` instead
+
 $label-info-hover-border-color: $label-info-border-color !default;
 
 $label-info: () !default;
@@ -114,13 +147,20 @@ $label-info: map-merge((
 	hover-color: $label-info-hover-color,
 ), $label-info);
 
-// $label-warning-color is deprecated as of v2.4.1
+// @deprecated as of v2.4.1 use the Sass map `$label-warning` instead
+
 $label-warning-color: $warning !default;
-// $label-warning-hover-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-warning` instead
+
 $label-warning-hover-color: $warning-d2 !default;
-// $label-warning-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-warning` instead
+
 $label-warning-border-color: $warning-l1 !default;
-// $label-warning-hover-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-warning` instead
+
 $label-warning-hover-border-color: $label-warning-border-color !default;
 
 $label-warning: () !default;
@@ -131,13 +171,20 @@ $label-warning: map-merge((
 	hover-color: $label-warning-hover-color,
 ), $label-warning);
 
-// $label-danger-color is deprecated as of v2.4.1
+// @deprecated as of v2.4.1 use the Sass map `$label-danger` instead
+
 $label-danger-color: $danger !default;
-// $label-danger-hover-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-danger` instead
+
 $label-danger-hover-color: $danger-d2 !default;
-// $label-danger-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-danger` instead
+
 $label-danger-border-color: $danger-l1 !default;
-// $label-danger-hover-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-danger` instead
+
 $label-danger-hover-border-color: $label-danger-border-color !default;
 
 $label-danger: () !default;
@@ -148,15 +195,24 @@ $label-danger: map-merge((
 	hover-color: $label-danger-hover-color,
 ), $label-danger);
 
-// $label-light-color is deprecated as of v2.4.1
+// @deprecated as of v2.4.1 use the Sass map `$label-light` instead
+
 $label-light-color: $light !default;
-// $label-light-hover-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-light` instead
+
 $label-light-hover-color: $light-d2 !default;
-// $label-light-bg is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-light` instead
+
 $label-light-bg: $dark !default;
-// $label-light-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-light` instead
+
 $label-light-border-color: $light !default;
-// $label-light-hover-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-light` instead
+
 $label-light-hover-border-color: $label-light-border-color !default;
 
 $label-light: () !default;
@@ -168,13 +224,20 @@ $label-light: map-merge((
 	hover-color: $label-light-hover-color,
 ), $label-light);
 
-// $label-dark-color is deprecated as of v2.4.1
+// @deprecated as of v2.4.1 use the Sass map `$label-dark` instead
+
 $label-dark-color: $dark !default;
-// $label-dark-hover-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-dark` instead
+
 $label-dark-hover-color: $dark-l2 !default;
-// $label-dark-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-dark` instead
+
 $label-dark-border-color: $dark !default;
-// $label-dark-hover-border-color is deprecated as of v2.4.1
+
+// @deprecated as of v2.4.1 use the Sass map `$label-dark` instead
+
 $label-dark-hover-border-color: $label-dark-border-color !default;
 
 $label-dark: () !default;

--- a/packages/clay-css/src/scss/atlas/variables/_pagination.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_pagination.scss
@@ -1,17 +1,26 @@
+////
+/// @group pagination
+////
+
 $pagination-font-size: 0.875rem !default; // 14px
 $pagination-line-height: 1 !default;
 
 // Pagination Item
 
 $pagination-item-height: 2rem !default; // 32px
-// `$pagination-item-margin-x` is deprecated use `$pagination-item` instead
+
+// @deprecated as of v2 use the Sass map `$pagination-item` instead
+
 $pagination-item-margin-x: 0.25rem !default; // 4px
 
 // Pagination Link
 
-// `$pagination-link-border-radius` is deprecated use `$pagination-link` instead
+// @deprecated as of v2 use the Sass map `$pagination-link` instead
+
 $pagination-link-border-radius: 4px !default;
-// `$pagination-link-transition` is deprecated use `$pagination-link` instead
+
+// @deprecated as of v2 use the Sass map `$pagination-link` instead
+
 $pagination-link-transition: box-shadow 0.15s ease-in-out !default;
 
 $pagination-link-first-border-radius: $pagination-link-border-radius !default;
@@ -35,7 +44,9 @@ $pagination-active-color: $pagination-hover-color !default;
 $pagination-disabled-bg: transparent !default;
 $pagination-disabled-border-color: $pagination-disabled-bg !default;
 $pagination-disabled-color: $gray-600 !default;
-// `$pagination-disabled-opacity` is deprecated use `$pagination-link-disabled` instead
+
+// @deprecated as of v2 use the Sass map `$pagination-link-disabled` instead
+
 $pagination-disabled-opacity: 0.5 !default;
 
 $pagination-link-focus: () !default;

--- a/packages/clay-css/src/scss/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/variables/_alerts.scss
@@ -1,28 +1,55 @@
+////
+/// @group alerts
+////
+
 $alert-border-style: solid !default;
 
-// `$alert-close-font-size` is deprecated use `$alert-close` instead
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-font-size: 0.875rem !default; // 14px
-// `$alert-close-height` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-height: 2rem !default; // 32px
-// `$alert-close-line-height` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-line-height: null !default;
-// `$alert-close-opacity` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-opacity: null !default;
-// `$alert-close-margin-left` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-margin-left: null !default;
-// `$alert-close-padding-bottom` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-padding-bottom: 0 !default;
-// `$alert-close-padding-left` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-padding-left: 0 !default;
-// `$alert-close-padding-right` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-padding-right: 0 !default;
-// `$alert-close-padding-top` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-padding-top: 0 !default;
-// `$alert-close-position-right` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-position-right: 0.5rem !default; // 8px
-// `$alert-close-position-top` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-position-top: 0.75rem !default; // 12px
-// `$alert-close-width` is deprecated use `$alert-close` instead
+
+/// @deprecated as of v2.12.0 use the Sass map `$alert-close` instead
+
 $alert-close-width: $alert-close-height !default;
 
 $alert-close: () !default;

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -3,6 +3,7 @@
 ////
 
 /// @deprecated as of v2.4.1 we will not support unsetting variables in version 2 because it violates the Sass spec. If you are using libsass you can still unset Clay CSS / Bootstrap variables with the syntax `$my-var: !default;`.
+
 $clay-unset: clay-unset !default;
 $clay-unset-placeholder: clay-unset-placeholder !default;
 

--- a/packages/clay-css/src/scss/variables/_pagination.scss
+++ b/packages/clay-css/src/scss/variables/_pagination.scss
@@ -1,11 +1,19 @@
+////
+/// @group pagination
+////
+
 $pagination-font-size: null !default;
 
 // Pagination Item
 
 $pagination-item-height: 2.375rem !default; // 38px
-// `$pagination-item-margin-x` is deprecated use `$pagination-item` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-item` instead
+
 $pagination-item-margin-x: -0.5px !default;
-// `$pagination-item-margin-y` is deprecated use `$pagination-item` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-item` instead
+
 $pagination-item-margin-y: null !default;
 
 $pagination-item: () !default;
@@ -18,11 +26,16 @@ $pagination-item: map-merge((
 
 // Pagination Link
 
-// `$pagination-link-border-radius` is deprecated use `$pagination-link` instead
+/// @deprecated as of v2 use the Sass map `$pagination-link` instead
+
 $pagination-link-border-radius: 0 !default;
-// `$pagination-link-cursor` is deprecated use `$pagination-link` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-link` instead
+
 $pagination-link-cursor: null !default;
-// `$pagination-link-transition` is deprecated use `$pagination-link` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-link` instead
+
 $pagination-link-transition: null !default;
 
 $pagination-link-first-border-radius: $border-radius 0 0 $border-radius !default;
@@ -32,11 +45,16 @@ $pagination-margin-bottom: 0.5rem !default;
 
 $pagination-margin-top-mobile: 0.5rem !default;
 
-// `$pagination-disabled-cursor` is deprecated use `$pagination-link-disabled` instead
+/// @deprecated as of v2 use the Sass map `$pagination-link-disabled` instead
+
 $pagination-disabled-cursor: $disabled-cursor !default;
-// `$pagination-disabled-opacity` is deprecated use `$pagination-link-disabled` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-link-disabled` instead
+
 $pagination-disabled-opacity: 1 !default;
-// `$pagination-disabled-pointer-events` is deprecated use `$pagination-link-disabled` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-link-disabled` instead
+
 $pagination-disabled-pointer-events: auto !default;
 
 // Pagination Link
@@ -101,33 +119,53 @@ $pagination-dropdown-menu-spacer-y: null !default;
 
 // Pagination Items Per Page
 
-// `$pagination-items-per-page-bg` is deprecated use `$pagination-items-per-page-link` instead
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link` instead
+
 $pagination-items-per-page-bg: null !default;
-// `$pagination-items-per-page-border-color` is deprecated use `$pagination-items-per-page-link` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link` instead
+
 $pagination-items-per-page-border-color: $pagination-border-color !default;
-// `$pagination-items-per-page-border-radius` is deprecated use `$pagination-items-per-page-link` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link` instead
+
 $pagination-items-per-page-border-radius: $border-radius !default;
-// `$pagination-items-per-page-color` is deprecated use `$pagination-items-per-page-link` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link` instead
+
 $pagination-items-per-page-color: $pagination-color !default;
 $pagination-items-per-page-font-size: $pagination-font-size !default;
-// `$pagination-items-per-page-transition` is deprecated use `$pagination-items-per-page-link` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link` instead
+
 $pagination-items-per-page-transition: $pagination-link-transition !default;
 
-// `$pagination-items-per-page-hover-bg` is deprecated use `$pagination-items-per-page-link-hover` instead
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link-hover` instead
+
 $pagination-items-per-page-hover-bg: $pagination-hover-bg !default;
-// `$pagination-items-per-page-hover-border-color` is deprecated use `$pagination-items-per-page-link-hover` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link-hover` instead
+
 $pagination-items-per-page-hover-border-color: $pagination-hover-border-color !default;
-// `$pagination-items-per-page-hover-color` is deprecated use `$pagination-items-per-page-link-hover` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link-hover` instead
+
 $pagination-items-per-page-hover-color: $pagination-hover-color !default;
 
-// `$pagination-items-per-page-focus-box-shadow` is deprecated use `$pagination-items-per-page-link-focus` instead
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link-focus` instead
+
 $pagination-items-per-page-focus-box-shadow: $pagination-focus-box-shadow !default;
-// `$pagination-items-per-page-focus-outline` is deprecated use `$pagination-items-per-page-link-focus` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link-focus` instead
+
 $pagination-items-per-page-focus-outline: 0 !default;
 
-// `$pagination-items-per-page-lexicon-icon-margin-left` is deprecated use `$pagination-items-per-page-link` instead
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link` instead
+
 $pagination-items-per-page-lexicon-icon-margin-left: 0.125rem !default; // 2px
-// `$pagination-items-per-page-lexicon-icon-margin-top` is deprecated use `$pagination-items-per-page-link` instead
+
+/// @deprecated as of v2 use the Sass map `$pagination-items-per-page-link` instead
+
 $pagination-items-per-page-lexicon-icon-margin-top: 0.125rem !default; // 2px
 
 // Pagination Items Per Page Link


### PR DESCRIPTION
ClayCSS Globals use sassdoc syntax to document deprecated variables

ClayCSS Pagination use sassdoc syntax to document deprecated variables

ClayCSS Atlas Custom Forms use sassdoc syntax to document deprecated variables

ClayCSS Atlas Labels use sassdoc syntax to document deprecated variables