### PR TITLE
WIP: Create ClayAutocomplete and add experimental <ClayForm.Input />

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@storybook/react": "^5.0.6",
 		"@types/classnames": "^2.2.7",
 		"@types/jest": "^23.3.5",
+		"@types/lru-cache": "^5.1.0",
 		"@types/react": "^16.8.0",
 		"@types/react-dom": "^16.8.0",
 		"@types/react-test-renderer": "^16.8.0",

--- a/packages/clay-autocomplete/README.md
+++ b/packages/clay-autocomplete/README.md
@@ -1,0 +1,17 @@
+# clay-autocomplete
+
+ClayAutocomplete component
+
+## Setup
+
+1. Install `yarn`
+
+2. Install local dependencies:
+
+```
+yarn
+```
+
+## Contribute
+
+We'd love to get contributions from you! Please, check our [Contributing Guidelines](https://github.com/liferay/clay/blob/master/CONTRIBUTING.md) to see how you can help us improve.

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@clayui/autocomplete",
+	"version": "3.0.0",
+	"description": "ClayAutocomplete component",
+	"license": "BSD-3-Clause",
+	"repository": "https://github.com/liferay/clay/tree/master/packages/clay-autocomplete",
+	"engines": {
+		"node": ">=0.12.0",
+		"npm": ">=3.0.0"
+	},
+	"main": "lib/index.js",
+	"module": "src/index.tsx",
+	"jsnext:main": "src/index.tsx",
+	"files": ["lib", "src"],
+	"scripts": {
+		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
+		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
+		"prepublishOnly": "npm run build && npm run build:types",
+		"test": "jest --config ../../jest.config.js"
+	},
+	"keywords": ["clay", "react"],
+	"dependencies": {
+		"classnames": "^2.2.6"
+	},
+	"peerDependencies": {
+		"react": "^16.8.1",
+		"react-dom": "^16.8.1"
+	},
+	"browserslist": ["extends browserslist-config-clay"]
+}

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -20,6 +20,9 @@
 	},
 	"keywords": ["clay", "react"],
 	"dependencies": {
+		"@clayui/drop-down": "^3.0.0",
+		"@clayui/form": "^3.0.0",
+		"@clayui/loading-indicator": "^3.0.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-autocomplete/src/Context.ts
+++ b/packages/clay-autocomplete/src/Context.ts
@@ -1,0 +1,27 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+interface IContext {
+	/**
+	 * Status of a data fetch is happening, this will help
+	 * <ClayAutocomplete.Input /> add necessary markups.
+	 */
+	loading: boolean;
+
+	/**
+	 * Changes the loading status and causes a new rendering.
+	 */
+	onLoadingChange: (loading: boolean) => void;
+
+	/**
+	 * Ref of the container to align the dropdown.
+	 */
+	containerElementRef: React.RefObject<HTMLElement>;
+}
+
+export default React.createContext({} as IContext);

--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -1,0 +1,55 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import Context from './Context';
+import React, {useContext} from 'react';
+
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * HTML element that the menu should be aligned to
+	 */
+	alignElementRef?: React.RefObject<HTMLElement>;
+
+	/**
+	 * Flag to indicate if menu is showing or not.
+	 */
+	active?: boolean;
+}
+
+const DropDown: React.FunctionComponent<Props> = ({
+	active = false,
+	alignElementRef,
+	children,
+}) => {
+	const {containerElementRef} = useContext(Context);
+
+	if (!alignElementRef) {
+		alignElementRef = containerElementRef;
+	}
+
+	const menuElementRef = React.useRef<HTMLDivElement>(null);
+	const alignElementWidth =
+		alignElementRef.current && alignElementRef.current.clientWidth;
+
+	return (
+		<ClayDropDown.Menu
+			active={active}
+			alignElementRef={alignElementRef}
+			className="autocomplete-dropdown-menu"
+			onSetActive={() => {}}
+			ref={menuElementRef}
+			style={{
+				maxWidth: 'none',
+				width: `${alignElementWidth}px`,
+			}}
+		>
+			{children}
+		</ClayDropDown.Menu>
+	);
+};
+
+export default DropDown;

--- a/packages/clay-autocomplete/src/Input.tsx
+++ b/packages/clay-autocomplete/src/Input.tsx
@@ -1,0 +1,32 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import ClayForm, {InputProps} from '@clayui/form';
+import Context from './Context';
+import React, {useContext} from 'react';
+
+export interface Props
+	extends React.InputHTMLAttributes<HTMLInputElement>,
+		InputProps {}
+
+const Input = React.forwardRef<HTMLInputElement, Props>(
+	({className, ...othersProps}, ref) => {
+		const {loading} = useContext(Context);
+
+		return (
+			<ClayForm.Input
+				{...othersProps}
+				className={classNames(className, {
+					'input-group-inset input-group-inset-after': loading,
+				})}
+				ref={ref}
+			/>
+		);
+	}
+);
+
+export default Input;

--- a/packages/clay-autocomplete/src/LoadingIndicator.tsx
+++ b/packages/clay-autocomplete/src/LoadingIndicator.tsx
@@ -1,0 +1,61 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import Context from './Context';
+import React, {useContext, useEffect} from 'react';
+
+interface LoadingIndicatorMarkupProps
+	extends React.HTMLAttributes<HTMLDivElement> {}
+
+const LoadingIndicatorMarkup: React.FunctionComponent<
+	LoadingIndicatorMarkupProps
+> = ({children, className, ...otherProps}) => (
+	<div
+		{...otherProps}
+		className={classNames(
+			'input-group-inset-item input-group-inset-item-after',
+			className
+		)}
+	>
+		<span className="inline-item inline-item-middle">{children}</span>
+	</div>
+);
+
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Div component to render. It can be a one component that will replace the markup.
+	 */
+	component?:
+		| typeof LoadingIndicatorMarkup
+		| React.ComponentType<any>
+		| React.ComponentType<React.HTMLAttributes<HTMLDivElement>>;
+}
+
+const LoadingIndicator: React.FunctionComponent<Props> = ({
+	className,
+	component: Component = LoadingIndicatorMarkup,
+	...otherProps
+}) => {
+	const {onLoadingChange} = useContext(Context);
+
+	useEffect(() => {
+		onLoadingChange(true);
+
+		return () => {
+			onLoadingChange(false);
+		};
+	}, []);
+
+	return (
+		<Component {...otherProps} className={className}>
+			<ClayLoadingIndicator small />
+		</Component>
+	);
+};
+
+export default LoadingIndicator;

--- a/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,1 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP

--- a/packages/clay-autocomplete/src/__tests__/index.tsx
+++ b/packages/clay-autocomplete/src/__tests__/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as React from 'react';
+import * as TestRenderer from 'react-test-renderer';
+import ClayAutocomplete from '..';
+
+describe('ClayAutocomplete', () => {
+	it('renders', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayAutocomplete />
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+});

--- a/packages/clay-autocomplete/src/__tests__/index.tsx
+++ b/packages/clay-autocomplete/src/__tests__/index.tsx
@@ -10,9 +10,7 @@ import ClayAutocomplete from '..';
 
 describe('ClayAutocomplete', () => {
 	it('renders', () => {
-		const testRenderer = TestRenderer.create(
-			<ClayAutocomplete />
-		);
+		const testRenderer = TestRenderer.create(<ClayAutocomplete />);
 
 		expect(testRenderer.toJSON()).toMatchSnapshot();
 	});

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as React from 'react';
+import classNames from 'classnames';
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {}
+
+const ClayAutocomplete: React.FunctionComponent<Props> = ({
+	className,
+	...otherProps
+}) => {
+	return (
+		<div {...otherProps} className={classNames(className)}>{'ClayAutocomplete'}</div>
+	);
+};
+
+export default ClayAutocomplete;

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -4,18 +4,73 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import * as React from 'react';
 import classNames from 'classnames';
+import Context from './Context';
+import React, {useRef, useState} from 'react';
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {}
+import DropDown, {Props as DropDownProps} from './DropDown';
+import Input from './Input';
+import LoadingIndicator, {
+	Props as LoadingIndicatorProps,
+} from './LoadingIndicator';
 
-const ClayAutocomplete: React.FunctionComponent<Props> = ({
+interface AutocompleteMarkupProps
+	extends React.HTMLAttributes<HTMLDivElement> {}
+
+const AutocompleteMarkup = React.forwardRef<
+	HTMLDivElement,
+	AutocompleteMarkupProps
+>(({children, className, ...otherProps}, ref) => (
+	<div
+		{...otherProps}
+		className={classNames('input-group', className)}
+		ref={ref}
+	>
+		<div className="input-group-item">{children}</div>
+	</div>
+));
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Div component to render. It can be a one component that will replace the markup.
+	 */
+	component?: typeof AutocompleteMarkup | React.ComponentType<any>;
+}
+
+const ClayAutocomplete: React.FunctionComponent<Props> & {
+	DropDown: React.FunctionComponent<DropDownProps>;
+	Input: typeof Input;
+	LoadingIndicator: React.FunctionComponent<LoadingIndicatorProps>;
+} = ({
+	children,
 	className,
+	component: Component = AutocompleteMarkup,
 	...otherProps
 }) => {
+	const containerElementRef = useRef<HTMLDivElement>(null);
+	const [loading, setLoading] = useState(false);
+
 	return (
-		<div {...otherProps} className={classNames(className)}>{'ClayAutocomplete'}</div>
+		<Component
+			{...otherProps}
+			className={className}
+			ref={containerElementRef}
+		>
+			<Context.Provider
+				value={{
+					containerElementRef,
+					loading,
+					onLoadingChange: (loading: boolean) => setLoading(loading),
+				}}
+			>
+				{children}
+			</Context.Provider>
+		</Component>
 	);
 };
+
+ClayAutocomplete.DropDown = DropDown;
+ClayAutocomplete.Input = Input;
+ClayAutocomplete.LoadingIndicator = LoadingIndicator;
 
 export default ClayAutocomplete;

--- a/packages/clay-autocomplete/stories/index.tsx
+++ b/packages/clay-autocomplete/stories/index.tsx
@@ -1,0 +1,16 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import React from 'react';
+import {boolean, select, text} from '@storybook/addon-knobs';
+import {storiesOf} from '@storybook/react';
+import ClayAutocomplete from '../src';
+
+import 'clay-css/lib/css/atlas.css';
+
+storiesOf('ClayAutocomplete', module)
+	.add('default', () => (
+		<ClayAutocomplete />
+	));

--- a/packages/clay-autocomplete/stories/index.tsx
+++ b/packages/clay-autocomplete/stories/index.tsx
@@ -3,14 +3,113 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import React from 'react';
-import {boolean, select, text} from '@storybook/addon-knobs';
-import {storiesOf} from '@storybook/react';
+
 import ClayAutocomplete from '../src';
+import ClayDataProvider from '@clayui/data-provider';
+import ClayDropDown from '@clayui/drop-down';
+import React, {useState} from 'react';
+import {FetchPolicy, NetworkStatus} from '@clayui/data-provider/src/types';
+import {storiesOf} from '@storybook/react';
+import {useDebounce} from '@clayui/data-provider/src/useDebounce';
 
 import 'clay-css/lib/css/atlas.css';
 
-storiesOf('ClayAutocomplete', module)
-	.add('default', () => (
-		<ClayAutocomplete />
-	));
+const LoadingWithDebounce = ({
+	loading,
+	networkStatus,
+	render,
+}: {
+	networkStatus?: NetworkStatus;
+	loading: boolean;
+	render: any;
+}) => {
+	const debouncedLoadingChange = useDebounce(loading, 500);
+
+	if (networkStatus === 1 || debouncedLoadingChange) {
+		return (
+			<ClayDropDown.Item className="disabled">
+				{'Loading...'}
+			</ClayDropDown.Item>
+		);
+	}
+
+	return render;
+};
+
+const ClayAutocompleteWithState = () => {
+	const [value, setValue] = useState('');
+
+	return (
+		<ClayAutocomplete>
+			<ClayAutocomplete.Input
+				onChange={event => setValue(event.target.value)}
+				value={value}
+			/>
+			<ClayDataProvider
+				fetchPolicy={FetchPolicy.CacheFirst}
+				link="https://rickandmortyapi.com/api/character"
+				notifyOnNetworkStatusChange
+				variables={{name: value}}
+			>
+				{({data, error, loading, networkStatus}) => (
+					<>
+						<ClayAutocomplete.DropDown
+							active={(!!data && !!value) || networkStatus === 1}
+						>
+							<ClayDropDown.ItemList>
+								<LoadingWithDebounce
+									loading={loading}
+									networkStatus={networkStatus}
+									render={
+										<>
+											{(error ||
+												(data && data.error)) && (
+												<ClayDropDown.Item className="disabled">
+													{'No Results Found'}
+												</ClayDropDown.Item>
+											)}
+											{!error &&
+												data &&
+												data.results &&
+												data.results.map(
+													(item: any) => (
+														<ClayDropDown.Item
+															key={item.id}
+															onClick={() =>
+																setValue(
+																	item.name
+																)
+															}
+														>
+															{item.name}
+														</ClayDropDown.Item>
+													)
+												)}
+										</>
+									}
+								/>
+							</ClayDropDown.ItemList>
+						</ClayAutocomplete.DropDown>
+						{loading && <ClayAutocomplete.LoadingIndicator />}
+					</>
+				)}
+			</ClayDataProvider>
+		</ClayAutocomplete>
+	);
+};
+
+storiesOf('ClayAutocomplete', module).add(
+	'with low-level APIs (composition)',
+	() => (
+		<div className="row">
+			<div className="col-md-4">
+				<div className="sheet">
+					<div className="form-group">
+						<label>{'Name'}</label>
+						<ClayAutocompleteWithState />
+					</div>
+				</div>
+			</div>
+		</div>
+	)
+);

--- a/packages/clay-autocomplete/tsconfig.declarations.json
+++ b/packages/clay-autocomplete/tsconfig.declarations.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"declarationDir": "./lib"
+	},
+	"extends": "../../tsconfig.declarations.json",
+	"include": ["src"]
+}

--- a/packages/clay-autocomplete/tsconfig.json
+++ b/packages/clay-autocomplete/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}

--- a/packages/clay-data-provider/README.md
+++ b/packages/clay-data-provider/README.md
@@ -1,0 +1,17 @@
+# clay-data-provider
+
+ClayDataProvider Component
+
+## Setup
+
+1. Install `yarn`
+
+2. Install local dependencies:
+
+```
+yarn
+```
+
+## Contribute
+
+We'd love to get contributions from you! Please, check our [Contributing Guidelines](https://github.com/liferay/clay/blob/master/CONTRIBUTING.md) to see how you can help us improve.

--- a/packages/clay-data-provider/package.json
+++ b/packages/clay-data-provider/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@clayui/data-provider",
+	"version": "3.0.0",
+	"description": "ClayDataProvider component",
+	"license": "BSD-3-Clause",
+	"repository": "https://github.com/liferay/clay/tree/master/packages/clay-data-provider",
+	"engines": {
+		"node": ">=0.12.0",
+		"npm": ">=3.0.0"
+	},
+	"main": "lib/index.js",
+	"module": "src/index.tsx",
+	"jsnext:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
+	"scripts": {
+		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
+		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
+		"prepublishOnly": "npm run build && npm run build:types",
+		"test": "jest --config ../../jest.config.js"
+	},
+	"keywords": [
+		"clay",
+		"react"
+	],
+	"dependencies": {
+		"classnames": "^2.2.6",
+		"lru-cache": "^5.1.1"
+	},
+	"peerDependencies": {
+		"react": "^16.8.1",
+		"react-dom": "^16.8.1"
+	},
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
+}

--- a/packages/clay-data-provider/src/__tests__/index.tsx
+++ b/packages/clay-data-provider/src/__tests__/index.tsx
@@ -1,0 +1,9 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+describe('ClayDataProvider', () => {
+	it('default', () => {});
+});

--- a/packages/clay-data-provider/src/index.tsx
+++ b/packages/clay-data-provider/src/index.tsx
@@ -1,0 +1,79 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React, {useState} from 'react';
+import {IDataProvider, NetworkStatus} from './types';
+import {useResource} from './useResource';
+
+interface IChildrenProps {
+	data: any;
+	error: string | boolean;
+	loading: boolean;
+	networkStatus?: NetworkStatus;
+	refetch: Function;
+}
+
+interface Props extends IDataProvider {
+	children?: (data: IChildrenProps) => React.ReactNode;
+
+	/**
+	 * Set to true means that network status information will be passed
+	 * via `renders props` and will also cause new renderings as
+	 * networkStatus changes, when false rendering does not
+	 * happen again.
+	 */
+	notifyOnNetworkStatusChange?: boolean;
+}
+
+interface State {
+	error: boolean;
+	loading: boolean;
+	networkStatus?: NetworkStatus;
+}
+
+const ClayDataProvider: React.FunctionComponent<Props> = ({
+	children,
+	notifyOnNetworkStatusChange = false,
+	...otherProps
+}) => {
+	/**
+	 * networkStatus is only updated when notifyOnNetworkStatusChange
+	 * is enabled, this will inform of the fetch status and cause
+	 * a new rendering.
+	 */
+	const [state, setState] = useState<State>(() => ({
+		loading: false,
+		error: false,
+	}));
+
+	const handleNetworkStatus = (status: NetworkStatus) => {
+		const payload: State = {
+			loading: status < 4,
+			error: status === 5,
+		};
+
+		if (notifyOnNetworkStatusChange) {
+			payload.networkStatus = status;
+		}
+
+		setState(payload);
+	};
+
+	const {resource, refetch} = useResource({
+		...otherProps,
+		onNetworkStatusChange: handleNetworkStatus,
+	});
+
+	const payload: IChildrenProps = {
+		...state,
+		data: resource,
+		refetch,
+	};
+
+	return <>{children && children(payload)}</>;
+};
+
+export default ClayDataProvider;

--- a/packages/clay-data-provider/src/types.ts
+++ b/packages/clay-data-provider/src/types.ts
@@ -1,0 +1,174 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import LRU from 'lru-cache';
+
+export const SYMBOL_DATA_PROVIDER = Symbol('clay.data.provider');
+
+export const SYMBOL_ORIGIN = Symbol('clay.internal');
+
+/**
+ * - Loading (1) The status is set to `loading` only when the first
+ *   requisition occurs.
+ * - Refetch (2) The status is set to `refetch` when a change in the variables API
+ *   or refetch method is called.
+ * - Polling (3) The status is set to `polling` when pollInterval is set above 0.
+ * - Unused (4) When no request is happening the status will be `unused`.
+ * - Error (5) When any timeout or request `error` occurs, the status will be set
+ *   to error.
+ */
+export enum NetworkStatus {
+	Error = 5,
+	Loading = 1,
+	Polling = 3,
+	Refetch = 2,
+	Unused = 4,
+}
+
+export enum FetchPolicy {
+	CacheFirst = 'cache-first',
+	NoCache = 'no-cache',
+	CacheAndNetwork = 'cache-and-network',
+}
+
+export type TSymbolData = LRU<{}, {}>;
+
+export interface IStorage {
+	[SYMBOL_DATA_PROVIDER]?: TSymbolData;
+	[SYMBOL_ORIGIN]?: boolean;
+	[propName: string]: any;
+}
+
+export interface IFetchRetryDelay {
+	/**
+	 * The number of milliseconds to wait before attempting the first retry.
+	 *
+	 * Delays will increase exponentially for each attempt.  E.g. if this is
+	 * set to 100, subsequent retries will be delayed by 200, 400, 800, etc...
+	 *
+	 * Note that if jittering is enabled, this is the average delay.
+	 */
+	initial: number;
+
+	/**
+	 * Whether delays between attempts should be randomized.
+	 *
+	 * This helps avoid thundering herd type situations by better
+	 * distributing load during major outages.
+	 */
+	jitter: boolean;
+}
+
+export interface IFetchRetry {
+	/**
+	 * The maximum number of times to try a single request before giving up.
+	 */
+	attempts: number;
+
+	/**
+	 * Configuration for the delay strategy to use.
+	 */
+	delay: IFetchRetryDelay;
+}
+
+export interface IDataProvider {
+	/**
+	 * This API is used in conjunction with variables API, if it is always
+	 * changing its value set a debounce time to make a new request.
+	 *
+	 * Set a value in ms.
+	 */
+	fetchDelay?: number;
+
+	/**
+	 * Set ups the request options.
+	 */
+	fetchOptions?: RequestInit;
+
+	/**
+	 * Fetch policy is an option that allows you to specify how you
+	 * want your component to interact with the cache.
+	 *
+	 * (cache-first) Whenever a new request occurs, the data provider
+	 * will first look at the cache and return it if it satisfies the
+	 * data, otherwise it will perform the request.
+	 * (no-cache) It will always make a new request and return the result
+	 * and the cache is deactivated.
+	 * (cache-and-network) This case is specific to when you want your
+	 * users to have a quick response, when a new request happens, it
+	 * will first go to the cache and if it exists it will return and
+	 * regardless if it is in the cache it will make a new request on
+	 * the network.
+	 *
+	 * The data provider takes only the cached data when they meet the
+	 * requirements, the variables and URL are what they define when
+	 * the cache satisfies their request. Be careful if your request
+	 * is needed to cache to avoid problems.
+	 */
+	fetchPolicy?: FetchPolicy;
+
+	/**
+	 * Define the strategies for attempting new requests when it
+	 * fails.
+	 */
+	fetchRetry?: IFetchRetry;
+
+	/**
+	 * Set a request timeout in ms, if it reaches this limit it will
+	 * go through the retry rules and if it still persists, it will
+	 * set the networkStatus to 4 (Error).
+	 */
+	fetchTimeout?: number;
+
+	/**
+	 * Set the URL to where the data provider will have to make a
+	 * request, by default the request is solved with json, if it does
+	 * not cover your use case you can also pass a function by returning
+	 * a Promise. We do not recommend that you use a function to do so,
+	 * you will lose some benefits of the data provider,
+	 * always try to avoid.
+	 */
+	link: Function | string;
+
+	/**
+	 * The interval is set in milliseconds, setting the value to zero
+	 * will disable polling.
+	 */
+	pollInterval?: number;
+
+	/**
+	 * Reference your storage provider, like Context, Store Object...
+	 * Whenever a new request happens the data provider will look at
+	 * storage, respecting the fetch policy.
+	 *
+	 * If you have a context serving as your store in your application
+	 * independent of where the user is interacting the data provider
+	 * can retrieve the data from the cache again if it is satisfied.
+	 * The data is removed in LRU (least recently used) order.
+	 */
+	storage?: IStorage;
+
+	/**
+	 * Set the amount of items that can be cached, set to zero will be
+	 * treated as infinite, be aware to set an ideal size to offer a
+	 * positive experience for your user but not use a large amount of memory.
+	 */
+	storageMaxSize?: number;
+
+	/**
+	 * Variables are analyzed and converted to be passed as parameters
+	 * to the query of a GET request, for example.
+	 *
+	 * @example
+	 * {
+	 *   name: 'Matu',
+	 * }
+	 *
+	 * output for the link:
+	 * '/?name=Matu'
+	 */
+	variables?: Object | null;
+}

--- a/packages/clay-data-provider/src/useDebounce.ts
+++ b/packages/clay-data-provider/src/useDebounce.ts
@@ -1,0 +1,27 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useEffect, useState} from 'react';
+
+// Credits to Gabe Ragland
+// (https://dev.to/gabe_ragland/debouncing-with-react-hooks-jci)
+const useDebounce = (value: any, delay: number) => {
+	const [debouncedValue, setDebouncedValue] = useState(value);
+
+	useEffect(() => {
+		const handler = setTimeout(() => {
+			setDebouncedValue(value);
+		}, delay);
+
+		return () => {
+			clearTimeout(handler);
+		};
+	}, [value]);
+
+	return debouncedValue;
+};
+
+export {useDebounce};

--- a/packages/clay-data-provider/src/useResource.ts
+++ b/packages/clay-data-provider/src/useResource.ts
@@ -1,0 +1,286 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import LRU from 'lru-cache';
+import {
+	FetchPolicy,
+	IDataProvider,
+	NetworkStatus,
+	SYMBOL_DATA_PROVIDER,
+	SYMBOL_ORIGIN,
+	TSymbolData,
+} from './types';
+import {timeout} from './util';
+import {useDebounce} from './useDebounce';
+import {useEffect, useRef, useState} from 'react';
+
+interface IResource extends IDataProvider {
+	onNetworkStatusChange?: (status: NetworkStatus) => void;
+}
+
+const evaluteVariables = (variables: any): string | null => {
+	if (!variables) {
+		return null;
+	}
+
+	const keys = Object.keys(variables);
+
+	return keys
+		.map((key, index) => {
+			const param = `${key}=${variables[key]}`;
+			return index === keys.length - 1 ? `?${param}` : param;
+		})
+		.join('&');
+};
+
+const useResource = ({
+	fetchDelay = 300,
+	fetchOptions,
+	fetchPolicy = FetchPolicy.NoCache,
+	fetchTimeout = 6000,
+	link,
+	onNetworkStatusChange = () => {},
+	pollInterval = 0,
+	storage = {
+		/**
+		 * This will ensure that we know that the storage
+		 * reference is not external, otherwise the cache
+		 * will persist by the application.
+		 */
+		[SYMBOL_ORIGIN]: true,
+	},
+	fetchRetry = {
+		delay: {
+			initial: 300,
+			jitter: true,
+		},
+		attempts: 5,
+	},
+	storageMaxSize = 20,
+	variables = null,
+}: IResource) => {
+	const [resource, setResource] = useState<any>(null);
+
+	const getStorageCache = () => {
+		if (storage[SYMBOL_DATA_PROVIDER]) {
+			return storage[SYMBOL_DATA_PROVIDER] as TSymbolData;
+		}
+
+		return (storage[SYMBOL_DATA_PROVIDER] = new LRU(storageMaxSize));
+	};
+
+	let networkStatus = useRef<NetworkStatus>(NetworkStatus.Unused).current;
+
+	let pollingIntervalIdRef = useRef<null | NodeJS.Timeout>(null).current;
+
+	let retryDelayIntervalIdRef = useRef<null | NodeJS.Timeout>(null).current;
+
+	const cache = useRef<TSymbolData>(getStorageCache()).current;
+
+	const debouncedVariablesChange = useDebounce(variables, fetchDelay);
+
+	const setNetworkStatus = (status: NetworkStatus) => {
+		networkStatus = status;
+		onNetworkStatusChange(status);
+	};
+
+	const handleRefetch = () => {
+		handleFetch();
+		setNetworkStatus(NetworkStatus.Refetch);
+	};
+
+	const cleanRetry = () => {
+		if (retryDelayIntervalIdRef) {
+			clearInterval(retryDelayIntervalIdRef);
+		}
+	};
+
+	const getRetryDelay = (retryAttempts: number) => {
+		const {
+			delay: {jitter, initial},
+		} = fetchRetry;
+		const baseDelay = jitter ? initial : initial / 2;
+
+		let delay = Math.min(baseDelay * 2 ** retryAttempts);
+
+		if (jitter) {
+			delay = Math.random() * delay;
+		}
+
+		return delay;
+	};
+
+	const handleFetchRetry = (err: any, retryAttempts: number) => {
+		const {attempts} = fetchRetry;
+
+		cleanRetry();
+
+		if (attempts > 0 && retryAttempts < attempts) {
+			const delay = getRetryDelay(retryAttempts);
+			console.warn(
+				`DataProvider: Trying ${retryAttempts +
+					1} of ${attempts} will happen in ${delay}ms`
+			);
+			retryDelayIntervalIdRef = setInterval(() => {
+				handleFetch(retryAttempts + 1);
+			}, delay);
+		} else {
+			setNetworkStatus(NetworkStatus.Error);
+			console.error('DataProvider: Error making the requisition', err);
+		}
+	};
+
+	const cleanPoll = () => {
+		if (pollingIntervalIdRef) {
+			clearInterval(pollingIntervalIdRef);
+		}
+	};
+
+	const cacheSatisfies = () => {
+		if (typeof link === 'string') {
+			return `${link}:${JSON.stringify(variables)}`;
+		}
+
+		return null;
+	};
+
+	const evaluteCachePolicy = () => {
+		switch (fetchPolicy) {
+			case FetchPolicy.CacheFirst:
+			case FetchPolicy.CacheAndNetwork:
+				return true;
+			case FetchPolicy.NoCache:
+			default:
+				return false;
+		}
+	};
+
+	const getCache = () => {
+		const key = cacheSatisfies();
+
+		if (key && cache.has(key)) {
+			return cache.get(key);
+		}
+
+		return null;
+	};
+
+	const evaluteSetCache = (value: any) => {
+		const key = cacheSatisfies();
+
+		if (key) {
+			return cache.set(key, value);
+		}
+
+		return null;
+	};
+
+	const setupPoll = () => {
+		cleanPoll();
+
+		pollingIntervalIdRef = setInterval(() => {
+			performFetch(NetworkStatus.Polling);
+		}, pollInterval);
+	};
+
+	const fetchOnComplete = (result: any) => {
+		console.log('terminou a request')
+
+		// Should clear retry interval if any of the
+		// attempts are successful.
+		cleanRetry();
+
+		setResource(result);
+		setNetworkStatus(NetworkStatus.Unused);
+
+		if (evaluteCachePolicy()) {
+			evaluteSetCache(result);
+		}
+
+		if (pollInterval > 0) {
+			setupPoll();
+		}
+	};
+
+	const performCache = () => {
+		if (evaluteCachePolicy()) {
+			const cacheData = getCache();
+
+			if (cacheData) {
+				fetchOnComplete(cacheData);
+
+				// When fetch policy is only cache-first and gets the data from
+				// the cache, it should not perform a request, only when it is
+				// cache-and-network.
+				if (fetchPolicy === FetchPolicy.CacheFirst) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	};
+
+	const evaluateUrl = (): string => {
+		if (fetchOptions && fetchOptions.method !== 'GET') {
+			return link as string;
+		}
+
+		const query = evaluteVariables(variables);
+
+		return query ? `${link}/${query}` : (link as string);
+	};
+
+	const handleFetch = (retryAttempts = 0) => {
+		let promise: Promise<any>;
+
+		switch (typeof link) {
+			case 'function':
+				promise = link();
+				break;
+			case 'string':
+				promise = fetch(evaluateUrl(), fetchOptions).then(res =>
+					res.json()
+				);
+				break;
+			default:
+				return null;
+		}
+
+		timeout(fetchTimeout, promise)
+			.then(fetchOnComplete)
+			.catch(err => handleFetchRetry(err, retryAttempts));
+	};
+
+	const performFetch = (status: NetworkStatus) => {
+		if (performCache()) {
+			setNetworkStatus(status);
+			handleFetch();
+		}
+	};
+
+	useEffect(() => {
+		performFetch(NetworkStatus.Refetch);
+	}, [debouncedVariablesChange]);
+
+	useEffect(() => {
+		performFetch(NetworkStatus.Loading);
+
+		return () => {
+			// Reset the cache only if the storage reference is
+			// local from useResource.
+			if (storage[SYMBOL_ORIGIN]) {
+				cache.reset();
+			}
+			cleanPoll();
+			cleanRetry();
+		};
+	}, []);
+
+	return {resource, refetch: handleRefetch};
+};
+
+export {useResource};

--- a/packages/clay-data-provider/src/util.ts
+++ b/packages/clay-data-provider/src/util.ts
@@ -1,0 +1,27 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Implementation of the timeout.
+ * Based on: https://github.com/github/fetch/issues/175#issuecomment-125779262
+ */
+export const timeout = (ms: number, promise: Promise<any>) => {
+	return new Promise((resolve, reject) => {
+		const timeoutId = setTimeout(() => {
+			reject(new Error('timeout'));
+		}, ms);
+
+		promise
+			.then(res => {
+				clearTimeout(timeoutId);
+				resolve(res);
+			})
+			.catch(err => {
+				clearTimeout(timeoutId);
+				reject(err);
+			});
+	});
+};

--- a/packages/clay-data-provider/stories/index.tsx
+++ b/packages/clay-data-provider/stories/index.tsx
@@ -1,0 +1,208 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import ClayDataProvider from '../src';
+import React, {useContext, useState} from 'react';
+import {FetchPolicy} from '../src/types';
+import {number} from '@storybook/addon-knobs';
+import {storiesOf} from '@storybook/react';
+
+import 'clay-css/lib/css/atlas.css';
+
+const Store = React.createContext({});
+
+const ClayDataProviderWithVariablesAndStorage = () => {
+	const [value, setValue] = useState<undefined | string>('');
+	const store = useContext(Store);
+
+	return (
+		<div className="col-md-4">
+			<ClayDataProvider
+				fetchPolicy={FetchPolicy.CacheFirst}
+				link="https://rickandmortyapi.com/api/character"
+				notifyOnNetworkStatusChange
+				storage={store}
+				variables={{name: value}}
+			>
+				{({networkStatus, refetch, data, error}) => {
+					return (
+						<>
+							<div className="autofit-row autofit-padded-no-gutters-x">
+								<div className="autofit-col">
+									<h3>
+										{'The Rick and Morty '}
+										<small>
+											{networkStatus === 1 && 'Loading'}
+											{networkStatus === 2 && 'Refetch'}
+											{networkStatus === 3 && 'Polling'}
+											{networkStatus === 4 && 'Ready'}
+											{networkStatus === 5 && 'Error'}
+										</small>
+									</h3>
+								</div>
+								<div className="autofit-col">
+									<button
+										className="btn"
+										onClick={() => refetch()}
+										type="button"
+									>
+										Refetch
+									</button>
+								</div>
+							</div>
+							<div className="sheet">
+								<div className="form-group">
+									<input
+										className="form-control"
+										onChange={(event: any) =>
+											setValue(event.target.value)
+										}
+										placeholder="Search character"
+										type="text"
+										value={value}
+									/>
+								</div>
+								<ul className="list-group">
+									{networkStatus === 1 && (
+										<li className="list-group-item list-group-item-flex disabled">
+											Loading...
+										</li>
+									)}
+									{error && (
+										<li className="list-group-item list-group-item-flex disabled">
+											Result is not found
+										</li>
+									)}
+									{!error &&
+										data &&
+										data.results &&
+										data.results.map((item: any) => (
+											<li
+												className="list-group-item list-group-item-flex"
+												key={item.id}
+											>
+												<div className="autofit-col autofit-col-expand">
+													<p className="list-group-title text-truncate">
+														Name
+													</p>
+													<p className="list-group-subtitle text-truncate">
+														{item.name}
+													</p>
+												</div>
+											</li>
+										))}
+								</ul>
+							</div>
+						</>
+					);
+				}}
+			</ClayDataProvider>
+		</div>
+	);
+};
+
+storiesOf('ClayDataProvider', module)
+	.add('with polling', () => (
+		<ClayDataProvider
+			link="https://api-public.sandbox.pro.coinbase.com/products/BTC-USD/trades"
+			notifyOnNetworkStatusChange
+			pollInterval={number('Polling Interval', 5000)}
+			variables={{limit: 10}}
+		>
+			{props => (
+				<div className="container">
+					<div className="autofit-row autofit-padded-no-gutters-x">
+						<div className="autofit-col">
+							<h3>
+								{'Coinbase Trades '}
+								<small>
+									{props.networkStatus === 1 && 'Loading'}
+									{props.networkStatus === 2 && 'Refetch'}
+									{props.networkStatus === 3 && 'Polling'}
+									{props.networkStatus === 4 && 'Ready'}
+									{props.networkStatus === 5 && 'Error'}
+								</small>
+							</h3>
+						</div>
+						<div className="autofit-col">
+							<button
+								className="btn"
+								onClick={() => props.refetch()}
+								type="button"
+							>
+								Refetch
+							</button>
+						</div>
+					</div>
+					<div className="row">
+						<div className="col-md-5">
+							<p className="text-truncate-inline">
+								<small>
+									The polling is enabled with an interval of
+									5s, modify the values through the Storybook
+									knobs. This markup is for testing purposes
+									only with the ClayDataProvider component.
+								</small>
+							</p>
+						</div>
+					</div>
+					<ul className="list-group">
+						<li className="list-group-item list-group-item-flex">
+							<div className="autofit-col" />
+							<div className="autofit-col">
+								<p className="list-group-title">
+									{'Trade Size'}
+								</p>
+							</div>
+							<div className="autofit-col">
+								<p className="list-group-title">
+									{'Price (USD)'}
+								</p>
+							</div>
+							<div className="autofit-col">
+								<p className="list-group-title">
+									{'Time (ISO)'}
+								</p>
+							</div>
+						</li>
+						{props.networkStatus === 1 && (
+							<li className="list-group-item list-group-item-flex disabled">
+								Loading...
+							</li>
+						)}
+						{props.error && (
+							<li className="list-group-item list-group-item-flex disabled">
+								Error
+							</li>
+						)}
+						{props.data &&
+							!props.error &&
+							props.data.map((item: any) => (
+								<li
+									className="list-group-item list-group-item-flex"
+									key={item.trade_id}
+								>
+									<div className="autofit-col">
+										{item.side}
+									</div>
+									<div className="autofit-col">
+										{item.size}
+									</div>
+									<div className="autofit-col">
+										{item.price}
+									</div>
+									<div className="autofit-col">
+										{item.time}
+									</div>
+								</li>
+							))}
+					</ul>
+				</div>
+			)}
+		</ClayDataProvider>
+	))
+	.add('with variables change and storage', () => (
+		<ClayDataProviderWithVariablesAndStorage />
+	));

--- a/packages/clay-data-provider/tsconfig.declarations.json
+++ b/packages/clay-data-provider/tsconfig.declarations.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"declarationDir": "./lib"
+	},
+	"extends": "../../tsconfig.declarations.json",
+	"include": ["src"]
+}

--- a/packages/clay-data-provider/tsconfig.json
+++ b/packages/clay-data-provider/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}

--- a/packages/clay-form/README.md
+++ b/packages/clay-form/README.md
@@ -1,0 +1,17 @@
+# clay-form
+
+ClayForm component
+
+## Setup
+
+1. Install `yarn`
+
+2. Install local dependencies:
+
+```
+yarn
+```
+
+## Contribute
+
+We'd love to get contributions from you! Please, check our [Contributing Guidelines](https://github.com/liferay/clay/blob/master/CONTRIBUTING.md) to see how you can help us improve.

--- a/packages/clay-form/package.json
+++ b/packages/clay-form/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@clayui/form",
+	"version": "3.0.0",
+	"description": "ClayForm component",
+	"license": "BSD-3-Clause",
+	"repository": "https://github.com/liferay/clay/tree/master/packages/clay-form",
+	"engines": {
+		"node": ">=0.12.0",
+		"npm": ">=3.0.0"
+	},
+	"main": "lib/index.js",
+	"module": "src/index.tsx",
+	"jsnext:main": "src/index.tsx",
+	"files": ["lib", "src"],
+	"scripts": {
+		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
+		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
+		"prepublishOnly": "npm run build && npm run build:types",
+		"test": "jest --config ../../jest.config.js"
+	},
+	"keywords": ["clay", "react"],
+	"dependencies": {
+		"classnames": "^2.2.6"
+	},
+	"peerDependencies": {
+		"react": "^16.8.1",
+		"react-dom": "^16.8.1"
+	},
+	"browserslist": ["extends browserslist-config-clay"]
+}

--- a/packages/clay-form/src/Input.tsx
+++ b/packages/clay-form/src/Input.tsx
@@ -1,0 +1,59 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React, {useMemo} from 'react';
+
+export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
+	/**
+	 * Gets the accepted characters of the input
+	 * element values
+	 */
+	allowedCharacters?: RegExp;
+
+	/**
+	 * Input component to render. Can either be a string like 'input' or a component.
+	 */
+	component?:
+		| 'input'
+		| React.ComponentType<any>
+		| React.ComponentType<React.InputHTMLAttributes<HTMLInputElement>>;
+}
+
+const Input = React.forwardRef<HTMLInputElement, Props>(
+	(
+		{
+			allowedCharacters,
+			className,
+			component: Component = 'input',
+			value,
+			...otherProps
+		},
+		ref
+	) => {
+		const getCharactersAllowed = (value: string) => {
+			const regexp = new RegExp(allowedCharacters as RegExp);
+			const match = value.match(regexp);
+
+			return Array.isArray(match) ? match.join('') : '';
+		};
+
+		const memoValue = useMemo(() => {
+			return allowedCharacters ? getCharactersAllowed(value as string) : value;
+		}, [allowedCharacters, value]);
+
+		return (
+			<Component
+				{...otherProps}
+				className={classNames('form-control', className)}
+				ref={ref}
+				value={memoValue}
+			/>
+		);
+	}
+);
+
+export default Input;

--- a/packages/clay-form/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,1 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP

--- a/packages/clay-form/src/__tests__/index.tsx
+++ b/packages/clay-form/src/__tests__/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as React from 'react';
+import * as TestRenderer from 'react-test-renderer';
+import ClayForm from '..';
+
+describe('ClayForm', () => {
+	it('renders', () => {
+		const testRenderer = TestRenderer.create(<ClayForm />);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+});

--- a/packages/clay-form/src/index.tsx
+++ b/packages/clay-form/src/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as React from 'react';
+import Input, {Props as InputProps} from './Input';
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {}
+
+const ClayForm: React.FunctionComponent<Props> & {
+	Input: typeof Input;
+} = ({children}) => {
+	return <>{children}</>;
+};
+
+ClayForm.Input = Input;
+
+export {InputProps};
+export default ClayForm;

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -1,0 +1,13 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import ClayForm from '../src';
+import React from 'react';
+import {boolean, select, text} from '@storybook/addon-knobs';
+import {storiesOf} from '@storybook/react';
+
+import 'clay-css/lib/css/atlas.css';
+
+storiesOf('ClayForm', module).add('default', () => <ClayForm />);

--- a/packages/clay-form/tsconfig.declarations.json
+++ b/packages/clay-form/tsconfig.declarations.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"declarationDir": "./lib"
+	},
+	"extends": "../../tsconfig.declarations.json",
+	"include": ["src"]
+}

--- a/packages/clay-form/tsconfig.json
+++ b/packages/clay-form/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,6 +2786,10 @@
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
   integrity sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=
+"@types/lru-cache@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
+  integrity sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==
 
 "@types/node@*":
   version "11.13.7"


### PR DESCRIPTION
hey @bryceosterhaus this is an draft of how I'm creating Autocomplete, it still depends on ClayDataProvider (#1977) to enter the branch develop.

What I'm thinking more or less for ClayMultiSelect:

> I left some comments in the example.
```jsx
<ClayMultiSelect
	onValueChange={setValue}
	value={value}
>
	{({selectedItems, onLabelClick, onItemClick, onValue, value}) => (
		{/* The prop component is to replace the markup of autocomplete by the MultiSelect, */}
		{/* they are different the same happens to the LoadingIndicator, you may have */}
		{/* to do something with the Input as well. */}
		<ClayAutocomplete component={ClayMultiSelect.AutocompleteMarkup}>
			{/* This component is just an abstraction of using the selectedItems.map, */}
			{/* I think it's more beautiful like that, but it's just for examples. */}
			<Map
				data={selectedItems}
				keyExtractor={item => item.label}
				render={item => (
					<ClayLabel  closeButtonProps={{ onClick: () => onLabelClick(item) }}>{item.label}</ClayLabel>
				)}
			/>
			<ClayForm.Input
				onChange={event => onValue(event.target.value)}
				value={value}
				ref={alignElementRef}
			/>
			<ClayDataProvider
				fetchPolicy={FetchPolicy.CacheFirst}
				link="https://rickandmortyapi.com/api/character"
				notifyOnNetworkStatusChange
				variables={{name: value}}
			>
				{({data, error, loading, networkStatus}) => (
					<>
						<ClayAutocomplete.DropDown
							active={(!!data && !!value) || networkStatus === 1}
							alignElementRef={alignElementRef}
						>
							<ClayDropDown.ItemList>
								{/* This is an implementation to make the loading appear only the */}
								{/* first time and only when the request takes 500ms. */}
								<LoadingWithDebounce
									loading={loading}
									networkStatus={networkStatus}
									render={
										<If
											conditional={!error}
											then={
												<Map
													data={data.results || []}
													keyExtractor={item => item.id}
													emptyComponent={
														<ClayDropDown.Item className="disabled">
															{'No Results Found'}
														</ClayDropDown.Item>
													}
													render={item => (
														<ClayDropDown.Item
															onClick={() => onItemClick(item)}
														>
															{item.name}
														</ClayDropDown.Item>
													)}
												/>
											}
											else={
												<ClayDropDown.Item className="disabled">
													{'No Results Found'}
												</ClayDropDown.Item>
											}
										/>
									}
								/>
							</ClayDropDown.ItemList>
						</ClayAutocomplete.DropDown>
						{loading && <ClayAutocomplete.LoadingIndicator component={ClayMultiSelect.LoadingIndicatorMarkup} />}
					</>
				)}
			</ClayDataProvider>
		</ClayAutocomplete>
	)}
</ClayMultiSelect>
```

This is just a thought, the use of `component` props are useful to replace the markup of the component. For example:

```jsx
1.
<ClayAutocomplete />

2.
<ClayAutocomplete component={ClayMultiSelect.Autocomplete} />
```

output:
```jsx
1.
<div
	class="input-group"
>
	<div class="input-group-item">...</div>
</div>

2.
<div class="form-control form-control-tag-group">
</div>
```

We may not need `ClayAutocomplete` being declared and we can add within ClayMultiSelect implicitly.

The components in the example of `If` and `Map` are just abstractions, I see that it is more beautiful to look at them and it seems less messy for me... but just examples to demonstrate. Leave your thoughts.