### PR TITLE
feat(Autocomplete): Create ClayAutocomplete component

### DIFF
--- a/next.clayui.com/content/docs/migration/migrate-the-clay-components-from-v2-to-v3.md
+++ b/next.clayui.com/content/docs/migration/migrate-the-clay-components-from-v2-to-v3.md
@@ -2,7 +2,35 @@
 title: "Migrate the Clay components from v2 to v3"
 ---
 
-This is a reference for upgrading your components from Clay v2 to Clay v3, this symbolizes that you are migrating your application from [Metal.js](https://metaljs.com) to [React.js](https://reactjs.org). Although there is a lot of coverage here, you probably do not have to do everything. We will do our best to keep things easy to follow, and as sequential as possible, so you can quickly get rocking in v3!
+<div class="nav-toc">
+
+- [Why you should migrate](#why-you-should-migrate)
+- [General changes](#general-changes)
+
+</div>
+
+<div class="nav-toc">
+
+- [ClayAlert](#clayalert)
+- [ClayButton](#claybutton)
+- [ClayLink](#claylink)
+- [ClayNavigationBar](#claynavigationbar)
+- [ClaySticker](#claysticker)
+- [ClayIcon](#clayicon)
+- [ClayModal](#claymodal)
+- [ClayRadioGroup, ClayRadio](#clayradiogroup,-clayradio)
+- [ClayLabel](#claylabel)
+- [ClayProgressBar](#clayprogressbar)
+- [ClayList](#claylist)
+- [ClayCollapse -> ClayPanel](#claycollapse-->-claypanel)
+- [ClayDropDown](#claydropdown)
+- [ClayPagination](#claypagination)
+- [ClayDataProvider](#claydataprovider)
+- [ClayAutocomplete](#clayautocomplete)
+
+</div>
+
+ference for upgrading your components from Clay v2 to Clay v3, this symbolizes that you are migrating your application from [Metal.js](https://metaljs.com) to [React.js](https://reactjs.org). Although there is a lot of coverage here, you probably do not have to do everything. We will do our best to keep things easy to follow, and as sequential as possible, so you can quickly get rocking in v3!
 
 ## Why you should migrate
 
@@ -556,3 +584,40 @@ See the documentation to get the most out of the component.
 -   `requestOptions` renamed to `fetchOptions`
 -   `requestRetries` renamed to `fetchRetry`
 -   `requestTimeout` renamed to `fetchTimeout`
+
+## ClayAutocomplete
+
+Autocomplete has received many changes due to the change of approach we had in v2 to be delivered with composition. We recommend that you read the component documentation for a better understanding.
+
+For example purposes you can get to the same result you had in v2 using composition, autocomplete alone does not do what it really promises, you need to compose with other components, ClayDropDown, ClayDataProvider and LoadingIndicator is where all the beauty of it is, it decreases the coupling and gigantic lists of API descriptions and offers flexibility for customizing and implementing new rules.
+
+```diff
+<ClayAutocomplete
+-	dataSource={dataSource}
+-	placeholder="Placeholder"
+-	extractData={(elem) => elem.name}
+-	requestRetries={0}
+-	...
+-/>
++>
++	<ClayAutocomplete.Input
++		onChange={event => setValue(event.target.value)}
++		value={value}
++	/>
++	<ClayAutocomplete.DropDown
++		active={(!!resource && !!value) || initialLoading}
++	>
++		<ClayDropDown.ItemList>
++			{resource.map(item => (
++				<ClayAutocomplete.Item
++					key={item.id}
++					match={value}
++					onClick={() => setValue(item.name)}
++					value={item.name}
++				/>
++			))}
++		</ClayDropDown.ItemList>
++	</ClayAutocomplete.DropDown>
++	{loading && <ClayAutocomplete.LoadingIndicator />}
++</ClayAutocomplete>
+```

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"eslint-plugin-react-hooks": "^1.6.0",
 		"eslint-plugin-sort-destructure-keys": "^1.3.0",
 		"eslint-plugin-sort-imports-es6-autofix": "^0.4.0",
+		"fuzzy": "^0.1.3",
 		"jest": "^24.1.0",
 		"jest-fetch-mock": "^2.0.1",
 		"lerna": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
 		"eslint-plugin-react-hooks": "^1.6.0",
 		"eslint-plugin-sort-destructure-keys": "^1.3.0",
 		"eslint-plugin-sort-imports-es6-autofix": "^0.4.0",
-		"fuzzy": "^0.1.3",
 		"jest": "^24.1.0",
 		"jest-fetch-mock": "^2.0.1",
 		"lerna": "^3.4.0",

--- a/packages/clay-autocomplete/README.md
+++ b/packages/clay-autocomplete/README.md
@@ -1,0 +1,17 @@
+# clay-autocomplete
+
+ClayAutocomplete component
+
+## Setup
+
+1. Install `yarn`
+
+2. Install local dependencies:
+
+```
+yarn
+```
+
+## Contribute
+
+We'd love to get contributions from you! Please, check our [Contributing Guidelines](https://github.com/liferay/clay/blob/master/CONTRIBUTING.md) to see how you can help us improve.

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -20,7 +20,14 @@
 	},
 	"keywords": ["clay", "react"],
 	"dependencies": {
+		"@clayui/drop-down": "^3.0.0",
+		"@clayui/form": "^3.0.0",
+		"@clayui/loading-indicator": "^3.0.0",
 		"classnames": "^2.2.6"
+	},
+	"devDependencies": {
+		"@clayui/shared": "^3.0.0",
+		"@clayui/data-provider": "^3.0.0"
 	},
 	"peerDependencies": {
 		"react": "^16.8.1",

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@clayui/autocomplete",
+	"version": "3.0.0",
+	"description": "ClayAutocomplete component",
+	"license": "BSD-3-Clause",
+	"repository": "https://github.com/liferay/clay/tree/master/packages/clay-autocomplete",
+	"engines": {
+		"node": ">=0.12.0",
+		"npm": ">=3.0.0"
+	},
+	"main": "lib/index.js",
+	"module": "src/index.tsx",
+	"jsnext:main": "src/index.tsx",
+	"files": ["lib", "src"],
+	"scripts": {
+		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
+		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
+		"prepublishOnly": "npm run build && npm run build:types",
+		"test": "jest --config ../../jest.config.js"
+	},
+	"keywords": ["clay", "react"],
+	"dependencies": {
+		"classnames": "^2.2.6"
+	},
+	"peerDependencies": {
+		"react": "^16.8.1",
+		"react-dom": "^16.8.1"
+	},
+	"browserslist": ["extends browserslist-config-clay"]
+}

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -11,27 +11,36 @@
 	"main": "lib/index.js",
 	"module": "src/index.tsx",
 	"jsnext:main": "src/index.tsx",
-	"files": ["lib", "src"],
+	"files": [
+		"lib",
+		"src"
+	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
 		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
 		"prepublishOnly": "npm run build && npm run build:types",
 		"test": "jest --config ../../jest.config.js"
 	},
-	"keywords": ["clay", "react"],
+	"keywords": [
+		"clay",
+		"react"
+	],
 	"dependencies": {
 		"@clayui/drop-down": "^3.0.0",
 		"@clayui/form": "^3.0.0",
 		"@clayui/loading-indicator": "^3.0.0",
-		"classnames": "^2.2.6"
+		"classnames": "^2.2.6",
+		"fuzzy": "^0.1.3"
 	},
 	"devDependencies": {
-		"@clayui/shared": "^3.0.0",
-		"@clayui/data-provider": "^3.0.0"
+		"@clayui/data-provider": "^3.0.0",
+		"@clayui/shared": "^3.0.0"
 	},
 	"peerDependencies": {
 		"react": "^16.8.1",
 		"react-dom": "^16.8.1"
 	},
-	"browserslist": ["extends browserslist-config-clay"]
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
 }

--- a/packages/clay-autocomplete/src/Context.ts
+++ b/packages/clay-autocomplete/src/Context.ts
@@ -1,0 +1,27 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+interface IContext {
+	/**
+	 * Status of a data fetch is happening, this will help
+	 * <ClayAutocomplete.Input /> add necessary markups.
+	 */
+	loading: boolean;
+
+	/**
+	 * Changes the loading status and causes a new rendering.
+	 */
+	onLoadingChange: (loading: boolean) => void;
+
+	/**
+	 * Ref of the container to align the dropdown.
+	 */
+	containerElementRef: React.RefObject<HTMLElement>;
+}
+
+export default React.createContext({} as IContext);

--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -32,12 +32,12 @@ const DropDown: React.FunctionComponent<IProps> = ({
 	onSetActive = () => {},
 }) => {
 	const {containerElementRef} = useContext(Context);
+	const menuElementRef = React.useRef<HTMLDivElement>(null);
 
 	if (!alignElementRef) {
 		alignElementRef = containerElementRef;
 	}
 
-	const menuElementRef = React.useRef<HTMLDivElement>(null);
 	const alignElementWidth =
 		alignElementRef.current && alignElementRef.current.clientWidth;
 

--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -1,0 +1,62 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import Context from './Context';
+import React, {useContext} from 'react';
+
+export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * HTML element that the menu should be aligned to
+	 */
+	alignElementRef?: React.RefObject<HTMLElement>;
+
+	/**
+	 * Flag to indicate if menu is showing or not.
+	 */
+	active?: boolean;
+
+	/**
+	 * Callback function for when active state changes.
+	 */
+	onSetActive?: (val: boolean) => void;
+}
+
+const DropDown: React.FunctionComponent<IProps> = ({
+	active = false,
+	alignElementRef,
+	children,
+	onSetActive = () => {},
+}) => {
+	const {containerElementRef} = useContext(Context);
+
+	if (!alignElementRef) {
+		alignElementRef = containerElementRef;
+	}
+
+	const menuElementRef = React.useRef<HTMLDivElement>(null);
+	const alignElementWidth =
+		alignElementRef.current && alignElementRef.current.clientWidth;
+
+	return (
+		<ClayDropDown.Menu
+			active={active}
+			alignElementRef={alignElementRef}
+			autoBestAlign={false}
+			className="autocomplete-dropdown-menu"
+			onSetActive={onSetActive}
+			ref={menuElementRef}
+			style={{
+				maxWidth: 'none',
+				width: `${alignElementWidth}px`,
+			}}
+		>
+			{children}
+		</ClayDropDown.Menu>
+	);
+};
+
+export default DropDown;

--- a/packages/clay-autocomplete/src/Input.tsx
+++ b/packages/clay-autocomplete/src/Input.tsx
@@ -5,13 +5,13 @@
  */
 
 import classNames from 'classnames';
-import ClayForm, {IInputProps} from '@clayui/form';
+import ClayForm from '@clayui/form';
 import Context from './Context';
 import React, {useContext} from 'react';
 
 export interface IProps
 	extends React.InputHTMLAttributes<HTMLInputElement>,
-		IInputProps {}
+		React.ComponentProps<typeof ClayForm.Input> {}
 
 const Input = React.forwardRef<HTMLInputElement, IProps>(
 	({className, ...othersProps}, ref) => {

--- a/packages/clay-autocomplete/src/Input.tsx
+++ b/packages/clay-autocomplete/src/Input.tsx
@@ -1,0 +1,32 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import ClayForm, {IInputProps} from '@clayui/form';
+import Context from './Context';
+import React, {useContext} from 'react';
+
+export interface IProps
+	extends React.InputHTMLAttributes<HTMLInputElement>,
+		IInputProps {}
+
+const Input = React.forwardRef<HTMLInputElement, IProps>(
+	({className, ...othersProps}, ref) => {
+		const {loading} = useContext(Context);
+
+		return (
+			<ClayForm.Input
+				{...othersProps}
+				className={classNames(className, {
+					'input-group-inset input-group-inset-after': loading,
+				})}
+				ref={ref}
+			/>
+		);
+	}
+);
+
+export default Input;

--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -1,0 +1,48 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import fuzzy from 'fuzzy';
+import React from 'react';
+
+interface IProps extends React.ComponentProps<typeof ClayDropDown.Item> {
+	/**
+	 * Match is the string that will be compared with value.
+	 */
+	match: string;
+
+	/**
+	 * Value is the string that will be compared to the characters of
+	 * the match property.
+	 */
+	value: string;
+}
+
+const optionsFuzzy = {post: '</strong>', pre: '<strong>'};
+
+const Item: React.FunctionComponent<IProps> = ({
+	match,
+	value,
+	...otherProps
+}) => {
+	const fuzzyMatchResult = fuzzy.match(match, value, optionsFuzzy);
+
+	return (
+		<ClayDropDown.Item {...otherProps}>
+			{fuzzyMatchResult ? (
+				<div
+					dangerouslySetInnerHTML={{
+						__html: fuzzyMatchResult.rendered,
+					}}
+				/>
+			) : (
+				value
+			)}
+		</ClayDropDown.Item>
+	);
+};
+
+export default Item;

--- a/packages/clay-autocomplete/src/LoadingIndicator.tsx
+++ b/packages/clay-autocomplete/src/LoadingIndicator.tsx
@@ -1,0 +1,58 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import Context from './Context';
+import React, {useContext, useEffect} from 'react';
+
+const LoadingIndicatorMarkup: React.FunctionComponent<
+	React.HTMLAttributes<HTMLDivElement>
+> = ({children, className, ...otherProps}) => (
+	<div
+		{...otherProps}
+		className={classNames(
+			'input-group-inset-item input-group-inset-item-after',
+			className
+		)}
+	>
+		<span className="inline-item inline-item-middle">{children}</span>
+	</div>
+);
+
+export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Div component to render. It can be a one component that will replace the markup.
+	 */
+	component?:
+		| typeof LoadingIndicatorMarkup
+		| React.ComponentType<any>
+		| React.ComponentType<React.HTMLAttributes<HTMLDivElement>>;
+}
+
+const LoadingIndicator: React.FunctionComponent<IProps> = ({
+	className,
+	component: Component = LoadingIndicatorMarkup,
+	...otherProps
+}) => {
+	const {onLoadingChange} = useContext(Context);
+
+	useEffect(() => {
+		onLoadingChange(true);
+
+		return () => {
+			onLoadingChange(false);
+		};
+	}, []);
+
+	return (
+		<Component {...otherProps} className={className}>
+			<ClayLoadingIndicator small />
+		</Component>
+	);
+};
+
+export default LoadingIndicator;

--- a/packages/clay-autocomplete/src/LoadingIndicator.tsx
+++ b/packages/clay-autocomplete/src/LoadingIndicator.tsx
@@ -27,10 +27,7 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Div component to render. It can be a one component that will replace the markup.
 	 */
-	component?:
-		| typeof LoadingIndicatorMarkup
-		| React.ComponentType<any>
-		| React.ComponentType<React.HTMLAttributes<HTMLDivElement>>;
+	component?: React.ComponentType<any>;
 }
 
 const LoadingIndicator: React.FunctionComponent<IProps> = ({

--- a/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,1 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP

--- a/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,1 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClayAutocomplete renders 1`] = `
+<body>
+  <div>
+    <div
+      class="input-group"
+    >
+      <div
+        class="input-group-item"
+      />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ClayAutocomplete renders Autocomplete with other markup component 1`] = `
+<body>
+  <div>
+    <div
+      class="form-control form-control-tag-group"
+    />
+  </div>
+</body>
+`;

--- a/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,25 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ClayAutocomplete renders 1`] = `
+<div>
+  <div
+    class="input-group"
+  >
+    <div
+      class="input-group-item"
+    />
+  </div>
+</div>
+`;
+
+exports[`ClayAutocomplete renders Autocomplete with other markup component 1`] = `
+<div>
+  <div
+    class="form-control form-control-tag-group"
+  />
+</div>
+`;
+
+exports[`ClayAutocomplete renders DropDown with alignment with container 1`] = `
 <body>
   <div>
+    <input
+      class="form-control"
+    />
+  </div>
+  <div>
     <div
-      class="input-group"
-    >
-      <div
-        class="input-group-item"
-      />
-    </div>
+      class="dropdown-menu autocomplete-dropdown-menu show"
+      style="max-width: none;"
+    />
   </div>
 </body>
 `;
 
-exports[`ClayAutocomplete renders Autocomplete with other markup component 1`] = `
-<body>
-  <div>
-    <div
-      class="form-control form-control-tag-group"
-    />
+exports[`ClayAutocomplete renders Input with classNames when loading for true 1`] = `
+<div>
+  <input
+    class="form-control input-group-inset input-group-inset-after"
+  />
+</div>
+`;
+
+exports[`ClayAutocomplete renders Item with matches values 1`] = `
+<div>
+  <li>
+    <span
+      class="dropdown-item"
+    >
+      Bar
+    </span>
+  </li>
+</div>
+`;
+
+exports[`ClayAutocomplete renders LoadingIndicator 1`] = `
+<div>
+  <div
+    class="input-group-inset-item input-group-inset-item-after"
+  >
+    <span
+      class="inline-item inline-item-middle"
+    >
+      <span
+        aria-hidden="true"
+        class="loading-animation loading-animation-sm"
+      />
+    </span>
   </div>
-</body>
+</div>
+`;
+
+exports[`ClayAutocomplete renders LoadingIndicator with other markup component 1`] = `
+<div>
+  <span
+    class="autofit-col"
+  >
+    <span
+      class="inline-item"
+    >
+      <span
+        aria-hidden="true"
+        class="loading-animation loading-animation-sm"
+      />
+    </span>
+  </span>
+</div>
 `;

--- a/packages/clay-autocomplete/src/__tests__/index.tsx
+++ b/packages/clay-autocomplete/src/__tests__/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as React from 'react';
+import * as TestRenderer from 'react-test-renderer';
+import ClayAutocomplete from '..';
+
+describe('ClayAutocomplete', () => {
+	it('renders', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayAutocomplete />
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+});

--- a/packages/clay-autocomplete/src/__tests__/index.tsx
+++ b/packages/clay-autocomplete/src/__tests__/index.tsx
@@ -4,16 +4,35 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import * as React from 'react';
-import * as TestRenderer from 'react-test-renderer';
 import ClayAutocomplete from '..';
+import React from 'react';
+import {cleanup, render} from 'react-testing-library';
 
 describe('ClayAutocomplete', () => {
-	it('renders', () => {
-		const testRenderer = TestRenderer.create(
-			<ClayAutocomplete />
-		);
+	afterEach(cleanup);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+	it('renders', () => {
+		render(<ClayAutocomplete />);
+
+		expect(document.body).toMatchSnapshot();
+	});
+
+	it('renders Autocomplete with other markup component', () => {
+		const MyMarkup = React.forwardRef<
+			HTMLDivElement,
+			React.HTMLAttributes<HTMLDivElement>
+		>(({children, ...otherProps}, ref) => (
+			<div
+				{...otherProps}
+				className="form-control form-control-tag-group"
+				ref={ref}
+			>
+				{children}
+			</div>
+		));
+
+		render(<ClayAutocomplete component={MyMarkup} />);
+
+		expect(document.body).toMatchSnapshot();
 	});
 });

--- a/packages/clay-autocomplete/src/__tests__/index.tsx
+++ b/packages/clay-autocomplete/src/__tests__/index.tsx
@@ -5,16 +5,17 @@
  */
 
 import ClayAutocomplete from '..';
-import React from 'react';
+import Context from '../Context';
+import React, {useRef} from 'react';
 import {cleanup, render} from 'react-testing-library';
 
 describe('ClayAutocomplete', () => {
 	afterEach(cleanup);
 
 	it('renders', () => {
-		render(<ClayAutocomplete />);
+		const {container} = render(<ClayAutocomplete />);
 
-		expect(document.body).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders Autocomplete with other markup component', () => {
@@ -31,7 +32,118 @@ describe('ClayAutocomplete', () => {
 			</div>
 		));
 
-		render(<ClayAutocomplete component={MyMarkup} />);
+		const {container} = render(<ClayAutocomplete component={MyMarkup} />);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders Item with matches values', () => {
+		const {container} = render(
+			<ClayAutocomplete.Item match="Baz" value="Bar" />
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders LoadingIndicator', () => {
+		const LoadingIndicatorWithContext = () => (
+			<Context.Provider
+				value={{
+					containerElementRef: {current: null},
+					loading: false,
+					onLoadingChange: jest.fn(),
+				}}
+			>
+				<ClayAutocomplete.LoadingIndicator />
+			</Context.Provider>
+		);
+		const {container} = render(<LoadingIndicatorWithContext />);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders LoadingIndicator with other markup component', () => {
+		const MyMarkup: React.FunctionComponent<
+			React.HTMLAttributes<HTMLSpanElement>
+		> = ({children}) => (
+			<span className="autofit-col">
+				<span className="inline-item">{children}</span>
+			</span>
+		);
+		const LoadingIndicatorWithContext = () => (
+			<Context.Provider
+				value={{
+					containerElementRef: {current: null},
+					loading: false,
+					onLoadingChange: jest.fn(),
+				}}
+			>
+				<ClayAutocomplete.LoadingIndicator component={MyMarkup} />
+			</Context.Provider>
+		);
+
+		const {container} = render(<LoadingIndicatorWithContext />);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders LoadingIndicator and calls the onLoadingChange', () => {
+		const spyFn = jest.fn();
+		const LoadingIndicatorWithContext = () => (
+			<Context.Provider
+				value={{
+					containerElementRef: {current: null},
+					loading: false,
+					onLoadingChange: spyFn,
+				}}
+			>
+				<ClayAutocomplete.LoadingIndicator />
+			</Context.Provider>
+		);
+
+		render(<LoadingIndicatorWithContext />);
+
+		expect(spyFn).toBeCalled();
+		expect(spyFn).toBeCalledWith(true);
+	});
+
+	it('renders Input with classNames when loading for true', () => {
+		const InputWithContext = () => (
+			<Context.Provider
+				value={{
+					containerElementRef: {current: null},
+					loading: true,
+					onLoadingChange: jest.fn(),
+				}}
+			>
+				<ClayAutocomplete.Input />
+			</Context.Provider>
+		);
+
+		const {container} = render(<InputWithContext />);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders DropDown with alignment with container', () => {
+		const DropDownAndInputWithContext = () => {
+			const containerElementRef = useRef<HTMLDivElement>(null);
+
+			return (
+				<Context.Provider
+					value={{
+						containerElementRef,
+						loading: false,
+						onLoadingChange: jest.fn(),
+					}}
+				>
+					<ClayAutocomplete.Input />
+					<ClayAutocomplete.DropDown active />
+				</Context.Provider>
+			);
+		};
+
+		render(<DropDownAndInputWithContext />);
 
 		expect(document.body).toMatchSnapshot();
 	});

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -28,7 +28,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Div component to render. It can be a one component that will replace the markup.
 	 */
-	component?: typeof AutocompleteMarkup | React.ComponentType<any>;
+	component?: React.ForwardRefExoticComponent<any>;
 }
 
 const ClayAutocomplete: React.FunctionComponent<IProps> & {

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -4,18 +4,67 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import * as React from 'react';
 import classNames from 'classnames';
+import Context from './Context';
+import DropDown from './DropDown';
+import Input from './Input';
+import LoadingIndicator from './LoadingIndicator';
+import React, {useRef, useState} from 'react';
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {}
+const AutocompleteMarkup = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
+>(({children, className, ...otherProps}, ref) => (
+	<div
+		{...otherProps}
+		className={classNames('input-group', className)}
+		ref={ref}
+	>
+		<div className="input-group-item">{children}</div>
+	</div>
+));
 
-const ClayAutocomplete: React.FunctionComponent<Props> = ({
+interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Div component to render. It can be a one component that will replace the markup.
+	 */
+	component?: typeof AutocompleteMarkup | React.ComponentType<any>;
+}
+
+const ClayAutocomplete: React.FunctionComponent<IProps> & {
+	DropDown: typeof DropDown;
+	Input: typeof Input;
+	LoadingIndicator: typeof LoadingIndicator;
+} = ({
+	children,
 	className,
+	component: Component = AutocompleteMarkup,
 	...otherProps
 }) => {
+	const containerElementRef = useRef<HTMLDivElement>(null);
+	const [loading, setLoading] = useState(false);
+
 	return (
-		<div {...otherProps} className={classNames(className)}>{'ClayAutocomplete'}</div>
+		<Component
+			{...otherProps}
+			className={className}
+			ref={containerElementRef}
+		>
+			<Context.Provider
+				value={{
+					containerElementRef,
+					loading,
+					onLoadingChange: (loading: boolean) => setLoading(loading),
+				}}
+			>
+				{children}
+			</Context.Provider>
+		</Component>
 	);
 };
+
+ClayAutocomplete.DropDown = DropDown;
+ClayAutocomplete.Input = Input;
+ClayAutocomplete.LoadingIndicator = LoadingIndicator;
 
 export default ClayAutocomplete;

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import Context from './Context';
 import DropDown from './DropDown';
 import Input from './Input';
+import Item from './Item';
 import LoadingIndicator from './LoadingIndicator';
 import React, {useRef, useState} from 'react';
 
@@ -34,6 +35,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 const ClayAutocomplete: React.FunctionComponent<IProps> & {
 	DropDown: typeof DropDown;
 	Input: typeof Input;
+	Item: typeof Item;
 	LoadingIndicator: typeof LoadingIndicator;
 } = ({
 	children,
@@ -65,6 +67,7 @@ const ClayAutocomplete: React.FunctionComponent<IProps> & {
 
 ClayAutocomplete.DropDown = DropDown;
 ClayAutocomplete.Input = Input;
+ClayAutocomplete.Item = Item;
 ClayAutocomplete.LoadingIndicator = LoadingIndicator;
 
 export default ClayAutocomplete;

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as React from 'react';
+import classNames from 'classnames';
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {}
+
+const ClayAutocomplete: React.FunctionComponent<Props> = ({
+	className,
+	...otherProps
+}) => {
+	return (
+		<div {...otherProps} className={classNames(className)}>{'ClayAutocomplete'}</div>
+	);
+};
+
+export default ClayAutocomplete;

--- a/packages/clay-autocomplete/stories/index.tsx
+++ b/packages/clay-autocomplete/stories/index.tsx
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {FetchPolicy, NetworkStatus} from '@clayui/data-provider/src/types';
-import {storiesOf} from '@storybook/react';
-import {useDebounce} from '@clayui/shared';
-import {useResource} from '@clayui/data-provider';
 import ClayAutocomplete from '../src';
 import ClayDropDown from '@clayui/drop-down';
 import fuzzy from 'fuzzy';
 import React, {useState} from 'react';
+import {FetchPolicy, NetworkStatus} from '@clayui/data-provider/src/types';
+import {storiesOf} from '@storybook/react';
+import {useDebounce} from '@clayui/shared';
+import {useResource} from '@clayui/data-provider';
 
 import 'clay-css/lib/css/atlas.css';
 
@@ -37,7 +37,7 @@ const LoadingWithDebounce = ({
 	return render;
 };
 
-const optionsFuzzy = { pre: '<strong>', post: '</strong>' };
+const optionsFuzzy = {post: '</strong>', pre: '<strong>'};
 
 interface IProps {
 	name: string;
@@ -85,13 +85,12 @@ const ClayAutocompleteWithState = () => {
 						networkStatus={networkStatus}
 						render={
 							<>
-								{(error ||
-									(resource && resource.error)) && (
+								{(error || (resource && resource.error)) && (
 									<ClayDropDown.Item className="disabled">
 										{'No Results Found'}
 									</ClayDropDown.Item>
 								)}
-								{!(error) &&
+								{!error &&
 									resource &&
 									resource.results &&
 									resource.results.map((item: any) => (
@@ -99,7 +98,10 @@ const ClayAutocompleteWithState = () => {
 											key={item.id}
 											onClick={() => setValue(item.name)}
 										>
-											<Item name={item.name} value={value} />
+											<Item
+												name={item.name}
+												value={value}
+											/>
 										</ClayDropDown.Item>
 									))}
 							</>

--- a/packages/clay-autocomplete/stories/index.tsx
+++ b/packages/clay-autocomplete/stories/index.tsx
@@ -6,7 +6,6 @@
 
 import ClayAutocomplete from '../src';
 import ClayDropDown from '@clayui/drop-down';
-import fuzzy from 'fuzzy';
 import React, {useState} from 'react';
 import {FetchPolicy, NetworkStatus} from '@clayui/data-provider/src/types';
 import {storiesOf} from '@storybook/react';
@@ -35,23 +34,6 @@ const LoadingWithDebounce = ({
 	}
 
 	return render;
-};
-
-const optionsFuzzy = {post: '</strong>', pre: '<strong>'};
-
-interface IProps {
-	name: string;
-	value: string;
-}
-
-const Item: React.FunctionComponent<IProps> = ({name, value}) => {
-	const match = fuzzy.match(value, name, optionsFuzzy);
-
-	if (match) {
-		return <div dangerouslySetInnerHTML={{__html: match.rendered}} />;
-	}
-
-	return <>{name}</>;
 };
 
 const ClayAutocompleteWithState = () => {
@@ -94,15 +76,12 @@ const ClayAutocompleteWithState = () => {
 									resource &&
 									resource.results &&
 									resource.results.map((item: any) => (
-										<ClayDropDown.Item
+										<ClayAutocomplete.Item
 											key={item.id}
+											match={value}
 											onClick={() => setValue(item.name)}
-										>
-											<Item
-												name={item.name}
-												value={value}
-											/>
-										</ClayDropDown.Item>
+											value={item.name}
+										/>
 									))}
 							</>
 						}

--- a/packages/clay-autocomplete/stories/index.tsx
+++ b/packages/clay-autocomplete/stories/index.tsx
@@ -1,0 +1,16 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import React from 'react';
+import {boolean, select, text} from '@storybook/addon-knobs';
+import {storiesOf} from '@storybook/react';
+import ClayAutocomplete from '../src';
+
+import 'clay-css/lib/css/atlas.css';
+
+storiesOf('ClayAutocomplete', module)
+	.add('default', () => (
+		<ClayAutocomplete />
+	));

--- a/packages/clay-autocomplete/stories/index.tsx
+++ b/packages/clay-autocomplete/stories/index.tsx
@@ -3,14 +3,105 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import React from 'react';
-import {boolean, select, text} from '@storybook/addon-knobs';
-import {storiesOf} from '@storybook/react';
+
 import ClayAutocomplete from '../src';
+import ClayDropDown from '@clayui/drop-down';
+import React, {useState} from 'react';
+import {FetchPolicy, NetworkStatus} from '@clayui/data-provider/src/types';
+import {storiesOf} from '@storybook/react';
+import {useDebounce} from '@clayui/shared';
+import {useResource} from '@clayui/data-provider';
 
 import 'clay-css/lib/css/atlas.css';
 
-storiesOf('ClayAutocomplete', module)
-	.add('default', () => (
-		<ClayAutocomplete />
-	));
+const LoadingWithDebounce = ({
+	loading,
+	networkStatus,
+	render,
+}: {
+	networkStatus?: NetworkStatus;
+	loading: boolean;
+	render: any;
+}) => {
+	const debouncedLoadingChange = useDebounce(loading, 500);
+
+	if (networkStatus === 1 || debouncedLoadingChange) {
+		return (
+			<ClayDropDown.Item className="disabled">
+				{'Loading...'}
+			</ClayDropDown.Item>
+		);
+	}
+
+	return render;
+};
+
+const ClayAutocompleteWithState = () => {
+	const [value, setValue] = useState('');
+	const [networkStatus, setNetworkStatus] = useState<NetworkStatus>(
+		NetworkStatus.Unused
+	);
+	const {resource} = useResource({
+		fetchPolicy: FetchPolicy.CacheFirst,
+		link: 'https://rickandmortyapi.com/api/character/',
+		onNetworkStatusChange: setNetworkStatus,
+		variables: {name: value},
+	});
+
+	return (
+		<ClayAutocomplete>
+			<ClayAutocomplete.Input
+				onChange={event => setValue(event.target.value)}
+				value={value}
+			/>
+			<ClayAutocomplete.DropDown
+				active={(!!resource && !!value) || networkStatus === 1}
+			>
+				<ClayDropDown.ItemList>
+					<LoadingWithDebounce
+						loading={networkStatus < 4}
+						networkStatus={networkStatus}
+						render={
+							<>
+								{(networkStatus === 5 ||
+									(resource && resource.error)) && (
+									<ClayDropDown.Item className="disabled">
+										{'No Results Found'}
+									</ClayDropDown.Item>
+								)}
+								{!(networkStatus === 5) &&
+									resource &&
+									resource.results &&
+									resource.results.map((item: any) => (
+										<ClayDropDown.Item
+											key={item.id}
+											onClick={() => setValue(item.name)}
+										>
+											{item.name}
+										</ClayDropDown.Item>
+									))}
+							</>
+						}
+					/>
+				</ClayDropDown.ItemList>
+			</ClayAutocomplete.DropDown>
+			{networkStatus < 4 && <ClayAutocomplete.LoadingIndicator />}
+		</ClayAutocomplete>
+	);
+};
+
+storiesOf('ClayAutocomplete', module).add(
+	'with low-level APIs (composition)',
+	() => (
+		<div className="row">
+			<div className="col-md-5">
+				<div className="sheet">
+					<div className="form-group">
+						<label>{'Name'}</label>
+						<ClayAutocompleteWithState />
+					</div>
+				</div>
+			</div>
+		</div>
+	)
+);

--- a/packages/clay-autocomplete/tsconfig.declarations.json
+++ b/packages/clay-autocomplete/tsconfig.declarations.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"declarationDir": "./lib"
+	},
+	"extends": "../../tsconfig.declarations.json",
+	"include": ["src"]
+}

--- a/packages/clay-autocomplete/tsconfig.json
+++ b/packages/clay-autocomplete/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}

--- a/packages/clay-data-provider/src/index.tsx
+++ b/packages/clay-data-provider/src/index.tsx
@@ -83,4 +83,5 @@ const ClayDataProvider: React.FunctionComponent<IProps> = ({
 	});
 };
 
+export {useResource};
 export default ClayDataProvider;

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -22,6 +22,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	alignElementRef: React.RefObject<HTMLElement>;
 
 	/**
+	 * Flag to suggest or not the best region to align menu element.
+	 */
+	autoBestAlign?: boolean;
+
+	/**
 	 * Default position of menu element. Values come from `metal-position`.
 	 *
 	 * Align.TopCenter = 0;
@@ -58,6 +63,7 @@ const DropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 		active,
 		alignElementRef,
 		alignmentPosition = Align.BottomLeft,
+		autoBestAlign = true,
 		children,
 		className,
 		hasLeftSymbols,
@@ -83,7 +89,8 @@ const DropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 			Align.align(
 				(ref as React.RefObject<HTMLElement>).current!,
 				alignElementRef.current,
-				alignmentPosition
+				alignmentPosition,
+				autoBestAlign
 			);
 		}
 	});

--- a/packages/clay-form/README.md
+++ b/packages/clay-form/README.md
@@ -1,0 +1,17 @@
+# clay-form
+
+ClayForm component
+
+## Setup
+
+1. Install `yarn`
+
+2. Install local dependencies:
+
+```
+yarn
+```
+
+## Contribute
+
+We'd love to get contributions from you! Please, check our [Contributing Guidelines](https://github.com/liferay/clay/blob/master/CONTRIBUTING.md) to see how you can help us improve.

--- a/packages/clay-form/package.json
+++ b/packages/clay-form/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@clayui/form",
+	"version": "3.0.0",
+	"description": "ClayForm component",
+	"license": "BSD-3-Clause",
+	"repository": "https://github.com/liferay/clay/tree/master/packages/clay-form",
+	"engines": {
+		"node": ">=0.12.0",
+		"npm": ">=3.0.0"
+	},
+	"main": "lib/index.js",
+	"module": "src/index.tsx",
+	"jsnext:main": "src/index.tsx",
+	"files": ["lib", "src"],
+	"scripts": {
+		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
+		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
+		"prepublishOnly": "npm run build && npm run build:types",
+		"test": "jest --config ../../jest.config.js"
+	},
+	"keywords": ["clay", "react"],
+	"dependencies": {
+		"classnames": "^2.2.6"
+	},
+	"peerDependencies": {
+		"react": "^16.8.1",
+		"react-dom": "^16.8.1"
+	},
+	"browserslist": ["extends browserslist-config-clay"]
+}

--- a/packages/clay-form/src/Input.tsx
+++ b/packages/clay-form/src/Input.tsx
@@ -1,0 +1,63 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React, {useMemo} from 'react';
+
+export interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
+	/**
+	 * Gets the accepted characters of the input
+	 * element values
+	 */
+	allowedCharacters?: RegExp;
+
+	/**
+	 * Input component to render. Can either be a string like 'input' or a component.
+	 */
+	component?:
+		| 'input'
+		| React.ComponentType<any>
+		| React.ComponentType<React.InputHTMLAttributes<HTMLInputElement>>;
+}
+
+const Input = React.forwardRef<HTMLInputElement, IProps>(
+	(
+		{
+			allowedCharacters,
+			className,
+			component: Component = 'input',
+			value,
+			...otherProps
+		},
+		ref
+	) => {
+		const getCharactersAllowed = (value: string) => {
+			const regexp = new RegExp(allowedCharacters as RegExp);
+			const match = value.match(regexp);
+
+			return Array.isArray(match) ? match.join('') : '';
+		};
+
+		const memoValue = useMemo(
+			() =>
+				allowedCharacters
+					? getCharactersAllowed(value as string)
+					: value,
+			[allowedCharacters, value]
+		);
+
+		return (
+			<Component
+				{...otherProps}
+				className={classNames('form-control', className)}
+				ref={ref}
+				value={memoValue}
+			/>
+		);
+	}
+);
+
+export default Input;

--- a/packages/clay-form/src/Input.tsx
+++ b/packages/clay-form/src/Input.tsx
@@ -7,7 +7,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-export interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
+interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	/**
 	 * Input component to render. Can either be a string like 'input' or a component.
 	 */

--- a/packages/clay-form/src/Input.tsx
+++ b/packages/clay-form/src/Input.tsx
@@ -15,14 +15,7 @@ export interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 const Input = React.forwardRef<HTMLInputElement, IProps>(
-	(
-		{
-			className,
-			component: Component = 'input',
-			...otherProps
-		},
-		ref
-	) => (
+	({className, component: Component = 'input', ...otherProps}, ref) => (
 		<Component
 			{...otherProps}
 			className={classNames('form-control', className)}

--- a/packages/clay-form/src/Input.tsx
+++ b/packages/clay-form/src/Input.tsx
@@ -17,10 +17,7 @@ export interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	/**
 	 * Input component to render. Can either be a string like 'input' or a component.
 	 */
-	component?:
-		| 'input'
-		| React.ComponentType<any>
-		| React.ComponentType<React.InputHTMLAttributes<HTMLInputElement>>;
+	component?: 'input' | React.ForwardRefExoticComponent<any>;
 }
 
 const Input = React.forwardRef<HTMLInputElement, IProps>(

--- a/packages/clay-form/src/Input.tsx
+++ b/packages/clay-form/src/Input.tsx
@@ -5,15 +5,9 @@
  */
 
 import classNames from 'classnames';
-import React, {useMemo} from 'react';
+import React from 'react';
 
 export interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
-	/**
-	 * Gets the accepted characters of the input
-	 * element values
-	 */
-	allowedCharacters?: RegExp;
-
 	/**
 	 * Input component to render. Can either be a string like 'input' or a component.
 	 */
@@ -23,38 +17,18 @@ export interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 const Input = React.forwardRef<HTMLInputElement, IProps>(
 	(
 		{
-			allowedCharacters,
 			className,
 			component: Component = 'input',
-			value,
 			...otherProps
 		},
 		ref
-	) => {
-		const getCharactersAllowed = (value: string) => {
-			const regexp = new RegExp(allowedCharacters as RegExp);
-			const match = value.match(regexp);
-
-			return Array.isArray(match) ? match.join('') : '';
-		};
-
-		const memoValue = useMemo(
-			() =>
-				allowedCharacters
-					? getCharactersAllowed(value as string)
-					: value,
-			[allowedCharacters, value]
-		);
-
-		return (
-			<Component
-				{...otherProps}
-				className={classNames('form-control', className)}
-				ref={ref}
-				value={memoValue}
-			/>
-		);
-	}
+	) => (
+		<Component
+			{...otherProps}
+			className={classNames('form-control', className)}
+			ref={ref}
+		/>
+	)
 );
 
 export default Input;

--- a/packages/clay-form/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,1 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP

--- a/packages/clay-form/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,1 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClayForm renders 1`] = `null`;

--- a/packages/clay-form/src/__tests__/index.tsx
+++ b/packages/clay-form/src/__tests__/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as React from 'react';
+import * as TestRenderer from 'react-test-renderer';
+import ClayForm from '..';
+
+describe('ClayForm', () => {
+	it('renders', () => {
+		const testRenderer = TestRenderer.create(<ClayForm />);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+});

--- a/packages/clay-form/src/index.tsx
+++ b/packages/clay-form/src/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as React from 'react';
+import Input, {IProps as IInputProps} from './Input';
+
+const ClayForm: React.FunctionComponent<
+	React.HTMLAttributes<HTMLDivElement>
+> & {
+	Input: typeof Input;
+} = ({children}) => {
+	return <>{children}</>;
+};
+
+ClayForm.Input = Input;
+
+export {IInputProps};
+export default ClayForm;

--- a/packages/clay-form/src/index.tsx
+++ b/packages/clay-form/src/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react';
-import Input, {IProps as IInputProps} from './Input';
+import Input from './Input';
 
 const ClayForm: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement>
@@ -17,5 +17,4 @@ const ClayForm: React.FunctionComponent<
 
 ClayForm.Input = Input;
 
-export {IInputProps};
 export default ClayForm;

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import ClayForm from '../src';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+
+import 'clay-css/lib/css/atlas.css';
+
+storiesOf('ClayForm', module).add('default', () => <ClayForm />);

--- a/packages/clay-form/tsconfig.declarations.json
+++ b/packages/clay-form/tsconfig.declarations.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"declarationDir": "./lib"
+	},
+	"extends": "../../tsconfig.declarations.json",
+	"include": ["src"]
+}

--- a/packages/clay-form/tsconfig.json
+++ b/packages/clay-form/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}

--- a/packages/clay-shared/src/useDebounce.ts
+++ b/packages/clay-shared/src/useDebounce.ts
@@ -23,9 +23,9 @@ const useDebounce = (value: any, delay: number) => {
 		},
 		// This is required when the `object` has lost the
 		// reference plus the values are the same, `useEffect`
-		// uses `Object.is` or equivalent underneath the cloths.
+		// uses `Object.is` or equivalent under the covers.
 		// For some reason the reference is being lost.
-		typeof value === 'object'
+		typeof value === 'object' && value !== null
 			? [...Object.keys(value), ...Object.values(value)]
 			: [value]
 	);

--- a/packages/clay-shared/src/useDebounce.ts
+++ b/packages/clay-shared/src/useDebounce.ts
@@ -11,15 +11,24 @@ import {useEffect, useState} from 'react';
 const useDebounce = (value: any, delay: number) => {
 	const [debouncedValue, setDebouncedValue] = useState(value);
 
-	useEffect(() => {
-		const handler = setTimeout(() => {
-			setDebouncedValue(value);
-		}, delay);
+	useEffect(
+		() => {
+			const handler = setTimeout(() => {
+				setDebouncedValue(value);
+			}, delay);
 
-		return () => {
-			clearTimeout(handler);
-		};
-	}, [value]);
+			return () => {
+				clearTimeout(handler);
+			};
+		},
+		// This is required when the `object` has lost the
+		// reference plus the values are the same, `useEffect`
+		// uses `Object.is` or equivalent underneath the cloths.
+		// For some reason the reference is being lost.
+		typeof value === 'object'
+			? [...Object.keys(value), ...Object.values(value)]
+			: [value]
+	);
 
 	return debouncedValue;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6847,7 +6847,7 @@ command-exists@^1.2.2:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
-commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.2.0, commander@^2.5.0, commander@^2.6.0, commander@^2.8.1, commander@^2.9.0, commander@~2.20.0:
+commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.2.0, commander@^2.5.0, commander@^2.6.0, commander@^2.8.1, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -7003,7 +7003,7 @@ concat-with-sourcemaps@*:
   dependencies:
     source-map "^0.6.1"
 
-config-chain@^1.1.11, config-chain@~1.1.5:
+config-chain@^1.1.11, config-chain@^1.1.12:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
   integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
@@ -8943,15 +8943,14 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-editorconfig@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
-  integrity sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==
+editorconfig@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
+  integrity sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==
   dependencies:
-    bluebird "^3.0.5"
-    commander "^2.9.0"
-    lru-cache "^3.2.0"
-    semver "^5.1.0"
+    commander "^2.19.0"
+    lru-cache "^4.1.5"
+    semver "^5.6.0"
     sigmund "^1.0.1"
 
 ee-first@1.1.1:
@@ -9667,7 +9666,7 @@ event-source-polyfill@^1.0.5:
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz#b34be2740a685a8dc65ae750065fc983538ffcfe"
   integrity sha512-PdStgZ3+G2o2gjqsBYbV4931ByVmwLwSrX7mFgawCL+9I1npo9dwAQTnWtNWXe5IY2P8+AbbPteeOueiEtRCUA==
 
-event-stream@3.3.4, event-stream@^3.1.0:
+event-stream@^3.1.0:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
@@ -14163,15 +14162,16 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
   integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
-js-beautify@1.7.5, js-beautify@^1.8.9:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.7.5.tgz#69d9651ef60dbb649f65527b53674950138a7919"
-  integrity sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==
+js-beautify@^1.8.9:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.10.0.tgz#9753a13c858d96828658cd18ae3ca0e5783ea672"
+  integrity sha512-OMwf/tPDpE/BLlYKqZOhqWsd3/z2N3KOlyn1wsCRGFwViE8LOQTcDtathQvHvZc+q+zWmcNAbwKSC+iJoMaH2Q==
   dependencies:
-    config-chain "~1.1.5"
-    editorconfig "^0.13.2"
-    mkdirp "~0.5.0"
-    nopt "~3.0.1"
+    config-chain "^1.1.12"
+    editorconfig "^0.15.3"
+    glob "^7.1.3"
+    mkdirp "~0.5.1"
+    nopt "~4.0.1"
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -15554,14 +15554,7 @@ lru-cache@4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-cache@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
-  integrity sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=
-  dependencies:
-    pseudomap "^1.0.1"
-
-lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
+lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3, lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -16899,14 +16892,14 @@ noms@0.0.0:
     inherits "^2.0.1"
     readable-stream "~1.0.31"
 
-"nopt@2 || 3", nopt@^3.0.0, nopt@~3.0.1, nopt@~3.0.6:
+"nopt@2 || 3", nopt@^3.0.0, nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
 
-nopt@^4.0.1:
+nopt@^4.0.1, nopt@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
   integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=

--- a/yarn.lock
+++ b/yarn.lock
@@ -10679,6 +10679,11 @@ fuzzy-search@^3.0.1:
   resolved "https://registry.yarnpkg.com/fuzzy-search/-/fuzzy-search-3.0.1.tgz#14a4964508a9607d6e9a88818e7ff634108260b6"
   integrity sha512-rjUvzdsMlOyarm0oD5k6zVQwgvt4Tb5Xe3YdIGU+Vogw54+ueAGPUTMU2B9jfPQEie5cD11i/S9J9d+MNBSQ3Q==
 
+fuzzy@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
+  integrity sha1-THbsL/CsGjap3M+aAN+GIweNTtg=
+
 gatsby-cli@^2.5.12:
   version "2.5.12"
   resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-2.5.12.tgz#c1c92af0dd12ffbad76da05c136d926d3c66854d"


### PR DESCRIPTION
I ended up creating the `ClayForm` component to handle `Input`, but I'm still not sure if it would be necessary, what do you think?

I also did some fixes on `useResource` hook that I ended up having to deal with. I still have to add tests, as soon as we're okay with it, I'll work on it.