### PR TITLE
fix: update components to include 'types' and 'ts:main' package keys

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -14,6 +14,9 @@ module.exports = ({config}) => {
 		test: /\.(ts|tsx)$/,
 		use: [require.resolve('awesome-typescript-loader')],
 	});
+
+	config.resolve.mainFields = ['ts:main', 'module', 'main'];
+
 	config.resolve.extensions.push('.ts', '.tsx');
 	return config;
 };

--- a/next.clayui.com/gatsby/onCreateWebpackConfig.js
+++ b/next.clayui.com/gatsby/onCreateWebpackConfig.js
@@ -26,6 +26,7 @@ module.exports = ({actions, stage}) => {
 			alias: {
 				$components: path.resolve(__dirname, '../src/components'),
 			},
+			mainFields: ['ts:main', 'module', 'main'],
 			modules: [path.resolve(__dirname, 'src'), 'node_modules'],
 		},
 	});

--- a/packages/clay-alert/package.json
+++ b/packages/clay-alert/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.js",
-	"jsnext:main": "src/index.js",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-badge/package.json
+++ b/packages/clay-badge/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-button/package.json
+++ b/packages/clay-button/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -9,16 +9,22 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
-	"files": ["lib", "src"],
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
 		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
 		"prepublishOnly": "npm run build && npm run build:types",
 		"test": "jest --config ../../jest.config.js"
 	},
-	"keywords": ["clay", "react"],
+	"keywords": [
+		"clay",
+		"react"
+	],
 	"dependencies": {
 		"classnames": "^2.2.6"
 	},
@@ -26,5 +32,7 @@
 		"react": "^16.8.1",
 		"react-dom": "^16.8.1"
 	},
-	"browserslist": ["extends browserslist-config-clay"]
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
 }

--- a/packages/clay-charts/package.json
+++ b/packages/clay-charts/package.json
@@ -4,7 +4,7 @@
 	"description": "React.js wrapper for D3 and billboard.js",
 	"private": true,
 	"main": "lib/index.js",
-	"jsnext:main": "src/index.tsx",
+	"ts:main": "src/index.tsx",
 	"scripts": {
 		"build": "npm run sass && npm run compile && npm run copySvg",
 		"compile": "./node_modules/.bin/babel -d lib/ src/ -s --ignore src/__tests__",

--- a/packages/clay-checkbox/package.json
+++ b/packages/clay-checkbox/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-color-picker/package.json
+++ b/packages/clay-color-picker/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.js",
-	"jsnext:main": "src/index.js",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-data-provider/package.json
+++ b/packages/clay-data-provider/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -5,8 +5,8 @@
 	"license": "BSD-3-Clause",
 	"repository": "https://github.com/liferay/clay/tree/master/packages/clay-date-picker",
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-drop-down/package.json
+++ b/packages/clay-drop-down/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-form/package.json
+++ b/packages/clay-form/package.json
@@ -9,16 +9,22 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
-	"files": ["lib", "src"],
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
 		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
 		"prepublishOnly": "npm run build && npm run build:types",
 		"test": "jest --config ../../jest.config.js"
 	},
-	"keywords": ["clay", "react"],
+	"keywords": [
+		"clay",
+		"react"
+	],
 	"dependencies": {
 		"classnames": "^2.2.6"
 	},
@@ -26,5 +32,7 @@
 		"react": "^16.8.1",
 		"react-dom": "^16.8.1"
 	},
-	"browserslist": ["extends browserslist-config-clay"]
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
 }

--- a/packages/clay-icon/package.json
+++ b/packages/clay-icon/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-label/package.json
+++ b/packages/clay-label/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-link/package.json
+++ b/packages/clay-link/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-list/package.json
+++ b/packages/clay-list/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-loading-indicator/package.json
+++ b/packages/clay-loading-indicator/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-modal/package.json
+++ b/packages/clay-modal/package.json
@@ -9,16 +9,22 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
-	"files": ["lib", "src"],
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
 		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
 		"prepublishOnly": "npm run build && npm run build:types",
 		"test": "jest --config ../../jest.config.js"
 	},
-	"keywords": ["clay", "react"],
+	"keywords": [
+		"clay",
+		"react"
+	],
 	"dependencies": {
 		"@clayui/button": "^3.0.0",
 		"@clayui/icon": "^3.0.0",
@@ -29,5 +35,7 @@
 		"react": "^16.8.1",
 		"react-dom": "^16.8.1"
 	},
-	"browserslist": ["extends browserslist-config-clay"]
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
 }

--- a/packages/clay-navigation-bar/package.json
+++ b/packages/clay-navigation-bar/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.js",
-	"jsnext:main": "src/index.js",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-pagination/package.json
+++ b/packages/clay-pagination/package.json
@@ -9,16 +9,22 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
-	"files": ["lib", "src"],
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
 		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
 		"prepublishOnly": "npm run build && npm run build:types",
 		"test": "jest --config ../../jest.config.js"
 	},
-	"keywords": ["clay", "react"],
+	"keywords": [
+		"clay",
+		"react"
+	],
 	"dependencies": {
 		"@clayui/button": "^3.0.0",
 		"@clayui/drop-down": "^3.0.0",
@@ -29,5 +35,7 @@
 		"react": "^16.8.1",
 		"react-dom": "^16.8.1"
 	},
-	"browserslist": ["extends browserslist-config-clay"]
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
 }

--- a/packages/clay-panel/package.json
+++ b/packages/clay-panel/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-progress-bar/package.json
+++ b/packages/clay-progress-bar/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-radio-group/package.json
+++ b/packages/clay-radio-group/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-select/package.json
+++ b/packages/clay-select/package.json
@@ -9,16 +9,22 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
-	"files": ["lib", "src"],
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
 		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
 		"prepublishOnly": "npm run build && npm run build:types",
 		"test": "jest --config ../../jest.config.js"
 	},
-	"keywords": ["clay", "react"],
+	"keywords": [
+		"clay",
+		"react"
+	],
 	"dependencies": {
 		"classnames": "^2.2.6"
 	},
@@ -26,5 +32,7 @@
 		"react": "^16.8.1",
 		"react-dom": "^16.8.1"
 	},
-	"browserslist": ["extends browserslist-config-clay"]
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
 }

--- a/packages/clay-shared/package.json
+++ b/packages/clay-shared/package.json
@@ -9,16 +9,22 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
-	"files": ["lib", "src"],
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
 		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
 		"prepublishOnly": "npm run build && npm run build:types",
 		"test": "jest --config ../../jest.config.js"
 	},
-	"keywords": ["clay", "react"],
+	"keywords": [
+		"clay",
+		"react"
+	],
 	"dependencies": {
 		"classnames": "^2.2.6"
 	},
@@ -26,5 +32,7 @@
 		"react": "^16.8.1",
 		"react-dom": "^16.8.1"
 	},
-	"browserslist": ["extends browserslist-config-clay"]
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
 }

--- a/packages/clay-sticker/package.json
+++ b/packages/clay-sticker/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-table/package.json
+++ b/packages/clay-table/package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/clay-time-picker/package.json
+++ b/packages/clay-time-picker/package.json
@@ -5,8 +5,8 @@
 	"license": "BSD-3-Clause",
 	"repository": "https://github.com/liferay/clay/tree/master/packages/clay-time-picker",
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": [
 		"lib",
 		"src"

--- a/packages/generator-clay-component/app/templates/_package.json
+++ b/packages/generator-clay-component/app/templates/_package.json
@@ -9,8 +9,8 @@
 		"npm": ">=3.0.0"
 	},
 	"main": "lib/index.js",
-	"module": "src/index.tsx",
-	"jsnext:main": "src/index.tsx",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
 	"files": ["lib", "src"],
 	"scripts": {
 		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",

--- a/scripts/jest-clay-lerna-resolver.js
+++ b/scripts/jest-clay-lerna-resolver.js
@@ -10,7 +10,7 @@ const resolve = require('resolve');
 module.exports = function(file, data) {
 	if (file.indexOf('clay-') === 0 || file.indexOf('@clayui') === 0) {
 		data.packageFilter = function(pkg) {
-			return {main: pkg['jsnext:main']};
+			return {main: pkg['ts:main']};
 		};
 	}
 


### PR DESCRIPTION
I was testing some of these components in faro and realized we had issues with our [mainFields](https://webpack.js.org/configuration/resolve/#resolvemainfields) in non typescript projects. I removed the "module" field since that was the primary field that webpack looked for, this way projects consuming our components will default to use the `lib` version. I also specified `types` to be picked up for projects that use ts.

I additionally added `ts:main` field. I am a little unsure about this and I am welcome to suggestions, but we needed a way for our storybook config to pick up the `src` files and not the built `lib` versions. By specifying `ts:main` in each package and also in our storybook webpack config, this allows us to use our source files in storybook.

Let me know what you guys think.