### PR TITLE
ClayCSS Management Bar navbar-text should break to new line

### DIFF
--- a/packages/clay-css/src/content/management-bar.html
+++ b/packages/clay-css/src/content/management-bar.html
@@ -288,7 +288,7 @@ section: Components
 					</label>
 				</div>
 			</li>
-			<li class="nav-item">
+			<li class="nav-item nav-item-shrink">
 				<span class="navbar-text">
 					3 of 7
 					<span class="navbar-breakpoint-down-d-none">items selected</span>
@@ -378,9 +378,9 @@ section: Components
 					</label>
 				</div>
 			</li>
-			<li class="nav-item">
+			<li class="nav-item nav-item-shrink">
 				<span class="navbar-text">
-					20 of 200
+					20,000,000 of 200,000,000
 					<span class="navbar-breakpoint-down-d-none">items selected</span>
 				</span>
 			</li>
@@ -585,7 +585,7 @@ section: Components
 									</label>
 								</div>
 							</li>
-							<li class="dropdown nav-item">
+							<li class="dropdown nav-item nav-item-shrink">
 								<span class="navbar-text">3 of 25</span>
 							</li>
 							<li class="nav-item">

--- a/packages/clay-css/src/scss/components/_management-bar.scss
+++ b/packages/clay-css/src/scss/components/_management-bar.scss
@@ -1,6 +1,13 @@
 .management-bar {
 	@include clay-navbar-size($management-bar-size);
 	@include clay-navbar-variant($management-bar-base);
+
+	&.navbar-nowrap {
+		.navbar-text {
+			white-space: normal;
+			word-wrap: break-word;
+		}
+	}
 }
 
 .management-bar-light {


### PR DESCRIPTION
https://issues.liferay.com/browse/LEXI-477

![management-bar](https://user-images.githubusercontent.com/788266/59870827-1bd0a680-934b-11e9-8ef6-3e4cdd835ac3.png)

We need to add the class `nav-item-shrink` to the `navbar-text` container to make long text with no white space break to new line.