### PR TITLE
fix(generator-clay-components): add check for skipInstall

### DIFF
--- a/packages/clay-date-picker/src/InputDate.tsx
+++ b/packages/clay-date-picker/src/InputDate.tsx
@@ -31,7 +31,7 @@ const InputDate: FunctionComponent<IProps> = ({
 	time = false,
 	timeFormat,
 	useNative = false,
-	value,
+	value = '',
 }) => {
 	const isValidValue = (value: string | Date): string => {
 		const format = time ? `${dateFormat} ${timeFormat}` : dateFormat;

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -44,7 +44,11 @@ const ModalWithState: React.FunctionComponent<IProps> = ({
 };
 
 describe('Modal -> IncrementalInteractions', () => {
-	afterEach(cleanup);
+	afterEach(() => {
+		jest.clearAllTimers();
+
+		cleanup();
+	});
 
 	// this is just a little hack to silence a warning that we'll get until react
 	// fixes this: https://github.com/facebook/react/pull/14853

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -9,13 +9,7 @@ import Button from '@clayui/button';
 import ClayModal from '..';
 import React, {useState} from 'react';
 import ReactDOM from 'react-dom';
-import {
-	cleanup,
-	fireEvent,
-	render,
-	wait,
-	waitForElement,
-} from 'react-testing-library';
+import {cleanup, fireEvent, render} from 'react-testing-library';
 
 const spritemap = 'icons.svg';
 
@@ -57,6 +51,8 @@ describe('Modal -> IncrementalInteractions', () => {
 	// https://github.com/testing-library/react-testing-library/issues/281
 	const originalError = console.error;
 	beforeAll(() => {
+		jest.useFakeTimers();
+
 		// @ts-ignore
 		ReactDOM.createPortal = jest.fn(element => {
 			return element;
@@ -70,102 +66,97 @@ describe('Modal -> IncrementalInteractions', () => {
 	});
 
 	afterAll(() => {
+		jest.useRealTimers();
+
 		console.error = originalError;
 	});
 
-	it('open the modal', async () => {
+	it('open the modal', () => {
 		const {container, getByLabelText} = render(<ModalWithState />);
 
 		expect(document.body.classList).not.toContain('modal-open');
 
 		fireEvent.click(getByLabelText('button'), {});
 
-		const backdropEl = await waitForElement(() =>
-			container.querySelector('.modal-backdrop.fade.show')
-		);
-
 		expect(document.body.classList).toContain('modal-open');
+		expect(
+			container.querySelector('.modal-backdrop.fade.show')
+		).toBeDefined();
+		expect(
+			container.querySelector('.fade.modal.d-block.show')
+		).toBeDefined();
+	});
+
+	it('close the modal by clicking on the overlay', () => {
+		render(<ModalWithState initialVisible />);
+
+		jest.runAllTimers();
+
+		const backdropElSelector = '.modal-backdrop.fade.show';
+		const modalElSelector = '.fade.modal.d-block.show';
+
+		const backdropEl = document.querySelector(backdropElSelector);
+		const modalEl = document.querySelector(modalElSelector);
+
 		expect(backdropEl).toBeDefined();
+		expect(modalEl).toBeDefined();
+
+		fireEvent.click(backdropEl!, {});
+
+		expect(document.body.classList).not.toContain('modal-open');
+		expect(document.querySelector(backdropElSelector)).toBeNull();
+		expect(document.querySelector(modalElSelector)).toBeNull();
 	});
 
-	it('close the modal by clicking on the overlay', async done => {
+	it('close the modal when pressing ESC', () => {
 		const {container} = render(<ModalWithState initialVisible />);
 
-		const backdropEl: any = await waitForElement(() =>
-			container.querySelector('.modal-backdrop.fade.show')
-		);
-		const modalEl: any = await waitForElement(() =>
-			container.querySelector('.fade.modal.d-block.show')
-		);
+		jest.runAllTimers();
 
-		expect(backdropEl.classList).toContain('show');
-		expect(modalEl.classList).toContain('show');
+		const backdropElSelector = '.modal-backdrop.fade.show';
+		const modalElSelector = '.fade.modal.d-block.show';
 
-		fireEvent.click(document.body, {});
+		const backdropEl = document.querySelector(backdropElSelector);
+		const modalEl = document.querySelector(modalElSelector);
 
-		await wait(() => {
-			expect(document.body.classList).not.toContain('modal-open');
-			expect(backdropEl.classList).not.toContain('show');
-			expect(modalEl.classList).not.toContain('show');
-			done();
-		});
-	});
-
-	it('close the modal when pressing ESC', async done => {
-		const {container} = render(<ModalWithState initialVisible />);
-
-		const backdropEl: any = await waitForElement(() =>
-			container.querySelector('.modal-backdrop.fade.show')
-		);
-		const modalEl: any = await waitForElement(() =>
-			container.querySelector('.fade.modal.d-block.show')
-		);
-
-		expect(backdropEl.classList).toContain('show');
-		expect(modalEl.classList).toContain('show');
+		expect(backdropEl).toBeDefined();
+		expect(modalEl).toBeDefined();
 
 		fireEvent.keyUp(container, {keyCode: 27});
 
-		await wait(() => {
-			expect(document.body.classList).not.toContain('modal-open');
-			expect(backdropEl.classList).not.toContain('show');
-			expect(modalEl.classList).not.toContain('show');
-			done();
-		});
+		expect(document.body.classList).not.toContain('modal-open');
+		expect(document.querySelector(backdropElSelector)).toBeNull();
+		expect(document.querySelector(modalElSelector)).toBeNull();
 	});
 
-	it('close the modal when clicking on the close button of the Header component', async done => {
-		const {container, getByLabelText} = render(
+	it('close the modal when clicking on the close button of the Header component', () => {
+		const {getByLabelText} = render(
 			<ModalWithState initialVisible>
 				<ClayModal.Header>{'Title'}</ClayModal.Header>
 			</ModalWithState>
 		);
 
-		const backdropEl: any = await waitForElement(() =>
-			container.querySelector('.modal-backdrop.fade.show')
-		);
-		const modalEl: any = await waitForElement(() =>
-			container.querySelector('.fade.modal.d-block.show')
-		);
-		const buttonHeaderCloseEl: any = await waitForElement(() =>
-			getByLabelText('close')
-		);
+		jest.runAllTimers();
 
-		expect(backdropEl.classList).toContain('show');
-		expect(modalEl.classList).toContain('show');
+		const backdropElSelector = '.modal-backdrop.fade.show';
+		const modalElSelector = '.fade.modal.d-block.show';
+
+		const backdropEl = document.querySelector(backdropElSelector);
+		const modalEl = document.querySelector(modalElSelector);
+		const buttonHeaderCloseEl = getByLabelText('close');
+
+		expect(backdropEl).toBeDefined();
+		expect(modalEl).toBeDefined();
 
 		fireEvent.click(buttonHeaderCloseEl);
 
-		await wait(() => {
-			expect(document.body.classList).not.toContain('modal-open');
-			expect(backdropEl.classList).not.toContain('show');
-			expect(modalEl.classList).not.toContain('show');
-			done();
-		});
+		expect(document.body.classList).not.toContain('modal-open');
+		expect(document.querySelector(backdropElSelector)).toBeNull();
+		expect(document.querySelector(modalElSelector)).toBeNull();
 	});
 
-	it('close the modal when click on the button of Footer component', async done => {
-		const {container, getByLabelText} = render(
+	it('close the modal when click on the button of Footer component', () => {
+		const {getByLabelText} = render(
 			<ModalWithState initialVisible>
 				{(onClose: any) => (
 					<ClayModal.Footer
@@ -179,26 +170,22 @@ describe('Modal -> IncrementalInteractions', () => {
 			</ModalWithState>
 		);
 
-		const backdropEl: any = await waitForElement(() =>
-			container.querySelector('.modal-backdrop.fade.show')
-		);
-		const modalEl: any = await waitForElement(() =>
-			container.querySelector('.fade.modal.d-block.show')
-		);
-		const buttonFooterCloseEl: any = await waitForElement(() =>
-			getByLabelText('buttonFooter')
-		);
+		jest.runAllTimers();
 
-		expect(backdropEl.classList).toContain('show');
-		expect(modalEl.classList).toContain('show');
+		const backdropElSelector = '.modal-backdrop.fade.show';
+		const modalElSelector = '.fade.modal.d-block.show';
+
+		const backdropEl = document.querySelector(backdropElSelector);
+		const modalEl = document.querySelector(modalElSelector);
+		const buttonFooterCloseEl = getByLabelText('buttonFooter');
+
+		expect(backdropEl).toBeDefined();
+		expect(modalEl).toBeDefined();
 
 		fireEvent.click(buttonFooterCloseEl);
 
-		await wait(() => {
-			expect(document.body.classList).not.toContain('modal-open');
-			expect(backdropEl.classList).not.toContain('show');
-			expect(modalEl.classList).not.toContain('show');
-			done();
-		});
+		expect(document.body.classList).not.toContain('modal-open');
+		expect(document.querySelector(backdropElSelector)).toBeNull();
+		expect(document.querySelector(modalElSelector)).toBeNull();
 	});
 });

--- a/packages/clay-modal/src/index.tsx
+++ b/packages/clay-modal/src/index.tsx
@@ -24,7 +24,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement>, IContext {
 }
 
 const delay = (fn: Function) => {
-	setTimeout(() => {
+	return setTimeout(() => {
 		fn();
 	}, 100);
 };
@@ -55,9 +55,8 @@ const ClayModal: FunctionComponent<IProps> & {
 	const handleCloseModal = () => {
 		document.body.classList.remove(modalOpenClassName);
 		setVisibleClassShow(false);
-		delay(() => {
-			onClose();
-		});
+
+		delay(onClose);
 	};
 
 	const context = {
@@ -70,7 +69,13 @@ const ClayModal: FunctionComponent<IProps> & {
 
 	useEffect(() => {
 		document.body.classList.add(modalOpenClassName);
-		delay(() => setVisibleClassShow(true));
+		const timer = delay(() => {
+			setVisibleClassShow(true);
+		});
+
+		return () => {
+			clearTimeout(timer);
+		};
 	}, []);
 
 	return (

--- a/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -209,7 +209,7 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
             className="nav-item"
           >
             <a
-              className="nav-link active link-secondary"
+              className="nav-link link-secondary"
               href="#1"
             >
               <span

--- a/packages/clay-navigation-bar/src/__tests__/index.tsx
+++ b/packages/clay-navigation-bar/src/__tests__/index.tsx
@@ -189,7 +189,7 @@ describe('ClayNavigationBar', () => {
 				spritemap={spritemap}
 				triggerLabel={label}
 			>
-				<ClayNavigationBar.Item active>
+				<ClayNavigationBar.Item>
 					<ClayLink
 						className="nav-link"
 						displayType="secondary"

--- a/packages/generator-clay-component/app/index.js
+++ b/packages/generator-clay-component/app/index.js
@@ -19,11 +19,16 @@ module.exports = yeoman.generators.Base.extend({
 	},
 
 	install() {
-		this.log(`${chalk.green('Installing dependencies...')}`);
+		if (!this.options.skipInstall) {
+			this.log(`${chalk.green('Installing dependencies...')}`);
 
-		const ps = this.spawnCommand('yarn');
+			const ps = this.spawnCommand('yarn');
 
-		ps.on('close', code => console.log(`yarn install exited with ${code}`)); // eslint-disable-line no-console
+			ps.on(
+				'close',
+				code => console.log(`yarn install exited with ${code}`) // eslint-disable-line no-console
+			);
+		}
 	},
 
 	prompting() {


### PR DESCRIPTION
Got annoyed with the red errors in our tests so I went through and tried to fix some. I also cleaned up the clay-modal tests to avoid async stuff with react-testing-library. anytime we use setTimeout, I think we should try to use jest's built in fakeTimer API. makes it a bit cleaner IMO.