### PR TITLE
add useArrowKeysForList and useEnterKey hooks

### DIFF
--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -9,6 +9,8 @@ import fuzzy from 'fuzzy';
 import React from 'react';
 
 interface IProps extends React.ComponentProps<typeof ClayDropDown.Item> {
+	forwardRef?: React.Ref<HTMLLIElement>;
+
 	/**
 	 * Match is the string that will be compared with value.
 	 */
@@ -24,6 +26,7 @@ interface IProps extends React.ComponentProps<typeof ClayDropDown.Item> {
 const optionsFuzzy = {post: '</strong>', pre: '<strong>'};
 
 const ClayAutocompleteItem: React.FunctionComponent<IProps> = ({
+	forwardRef,
 	match,
 	value,
 	...otherProps
@@ -31,7 +34,7 @@ const ClayAutocompleteItem: React.FunctionComponent<IProps> = ({
 	const fuzzyMatchResult = fuzzy.match(match, value, optionsFuzzy);
 
 	return (
-		<ClayDropDown.Item {...otherProps}>
+		<ClayDropDown.Item {...otherProps} ref={forwardRef}>
 			{fuzzyMatchResult ? (
 				<div
 					dangerouslySetInnerHTML={{
@@ -45,4 +48,8 @@ const ClayAutocompleteItem: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default ClayAutocompleteItem;
+export default React.forwardRef(
+	(props: Omit<IProps, 'forwardRef'>, ref?: React.Ref<HTMLLIElement>) => (
+		<ClayAutocompleteItem {...props} forwardRef={ref} />
+	)
+);

--- a/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
@@ -46,7 +46,9 @@ exports[`ClayAutocomplete renders Input with classNames when loading for true 1`
 
 exports[`ClayAutocomplete renders Item with matches values 1`] = `
 <div>
-  <li>
+  <li
+    tabindex="-1"
+  >
     <span
       class="dropdown-item"
     >

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -20,6 +20,8 @@ interface IProps
 	 */
 	disabled?: boolean;
 
+	forwardRef?: React.Ref<HTMLLIElement>;
+
 	/**
 	 * Path for item to link to.
 	 */
@@ -46,6 +48,7 @@ const ClayDropDownItem: React.FunctionComponent<IProps> = ({
 	children,
 	className,
 	disabled,
+	forwardRef,
 	href,
 	spritemap,
 	symbolLeft,
@@ -55,7 +58,7 @@ const ClayDropDownItem: React.FunctionComponent<IProps> = ({
 	const ItemElement = href ? 'a' : 'span';
 
 	return (
-		<li>
+		<li aria-selected={active} ref={forwardRef} tabIndex={-1}>
 			<ItemElement
 				{...otherProps}
 				className={classNames('dropdown-item', className, {
@@ -82,4 +85,8 @@ const ClayDropDownItem: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default ClayDropDownItem;
+export default React.forwardRef(
+	(props: Omit<IProps, 'forwardRef'>, ref?: React.Ref<HTMLLIElement>) => (
+		<ClayDropDownItem {...props} forwardRef={ref} />
+	)
+);

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -7,7 +7,7 @@
 import classNames from 'classnames';
 import React, {useLayoutEffect} from 'react';
 import {Align} from 'metal-position';
-import {Portal} from '@clayui/shared';
+import {ClayPortal} from '@clayui/shared';
 import {useDropdownCloseInteractions} from './hooks';
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -96,7 +96,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 	});
 
 	return (
-		<Portal>
+		<ClayPortal>
 			<div
 				{...otherProps}
 				className={classNames('dropdown-menu', className, {
@@ -108,7 +108,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 			>
 				{children}
 			</div>
-		</Portal>
+		</ClayPortal>
 	);
 });
 

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -25,7 +25,9 @@ exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
       <ul
         class="list-unstyled"
       >
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#one"
@@ -33,7 +35,9 @@ exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
             one
           </a>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#two"
@@ -41,7 +45,9 @@ exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
             two
           </a>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#three"
@@ -86,7 +92,9 @@ exports[`ClayDropDown renders with groups 1`] = `
         >
           Group #1
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#one"
@@ -94,7 +102,9 @@ exports[`ClayDropDown renders with groups 1`] = `
             one
           </a>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#two"
@@ -102,7 +112,9 @@ exports[`ClayDropDown renders with groups 1`] = `
             two
           </a>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#three"
@@ -116,7 +128,9 @@ exports[`ClayDropDown renders with groups 1`] = `
         >
           Group #2
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#one"
@@ -124,7 +138,9 @@ exports[`ClayDropDown renders with groups 1`] = `
             one
           </a>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#two"
@@ -132,7 +148,9 @@ exports[`ClayDropDown renders with groups 1`] = `
             two
           </a>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#three"
@@ -171,7 +189,9 @@ exports[`ClayDropDown renders with icons 1`] = `
       <ul
         class="list-unstyled"
       >
-        <li>
+        <li
+          tabindex="-1"
+        >
           <span
             class="dropdown-item"
           >
@@ -190,7 +210,9 @@ exports[`ClayDropDown renders with icons 1`] = `
             Left
           </span>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <span
             class="dropdown-item"
           >
@@ -209,7 +231,9 @@ exports[`ClayDropDown renders with icons 1`] = `
             </span>
           </span>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <span
             class="dropdown-item"
           >
@@ -307,7 +331,9 @@ exports[`ClayDropDown renders with search input 1`] = `
       <ul
         class="list-unstyled"
       >
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#one"
@@ -315,7 +341,9 @@ exports[`ClayDropDown renders with search input 1`] = `
             one
           </a>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#two"
@@ -323,7 +351,9 @@ exports[`ClayDropDown renders with search input 1`] = `
             two
           </a>
         </li>
-        <li>
+        <li
+          tabindex="-1"
+        >
           <a
             class="dropdown-item"
             href="#three"

--- a/packages/clay-modal/src/index.tsx
+++ b/packages/clay-modal/src/index.tsx
@@ -10,7 +10,7 @@ import Context, {IContext} from './Context';
 import Footer from './Footer';
 import Header from './Header';
 import React, {FunctionComponent, useEffect, useRef, useState} from 'react';
-import {Portal} from '@clayui/shared';
+import {ClayPortal} from '@clayui/shared';
 import {Size} from './types';
 import {useUserInteractions} from './Hook';
 
@@ -79,7 +79,7 @@ const ClayModal: FunctionComponent<IProps> & {
 	}, []);
 
 	return (
-		<Portal>
+		<ClayPortal>
 			<div
 				className={classNames('modal-backdrop fade', {
 					show: visibleClassShow,
@@ -108,7 +108,7 @@ const ClayModal: FunctionComponent<IProps> & {
 					</div>
 				</div>
 			</div>
-		</Portal>
+		</ClayPortal>
 	);
 };
 

--- a/packages/clay-shared/src/Portal.tsx
+++ b/packages/clay-shared/src/Portal.tsx
@@ -7,7 +7,7 @@
 import React, {useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
 
-const ClayPortal: React.FunctionComponent<
+export const ClayPortal: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement>
 > = ({children}) => {
 	const portalRef = useRef(
@@ -32,5 +32,3 @@ const ClayPortal: React.FunctionComponent<
 
 	return <>{children}</>;
 };
-
-export default ClayPortal;

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import Portal from './Portal';
-import useTransitionHeight from './useTransitionHeight';
-
+export {ClayPortal} from './Portal';
+export {useKeyHandlerForList} from './useKeyHandlerForList';
 export {useDebounce} from './useDebounce';
-export {Portal, useTransitionHeight};
+export {useTransitionHeight} from './useTransitionHeight';

--- a/packages/clay-shared/src/useDebounce.ts
+++ b/packages/clay-shared/src/useDebounce.ts
@@ -8,7 +8,7 @@ import {useEffect, useState} from 'react';
 
 // Credits to Gabe Ragland
 // (https://dev.to/gabe_ragland/debouncing-with-react-hooks-jci)
-const useDebounce = (value: any, delay: number) => {
+export function useDebounce(value: any, delay: number) {
 	const [debouncedValue, setDebouncedValue] = useState(value);
 
 	useEffect(
@@ -31,6 +31,4 @@ const useDebounce = (value: any, delay: number) => {
 	);
 
 	return debouncedValue;
-};
-
-export {useDebounce};
+}

--- a/packages/clay-shared/src/useKeyHandlerForList.ts
+++ b/packages/clay-shared/src/useKeyHandlerForList.ts
@@ -1,0 +1,57 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+const ENTER_KEY_CODE = 13;
+const UP_ARROW_KEY_CODE = 38;
+const DOWN_ARROW_KEY_CODE = 40;
+
+interface IArgs {
+	activeListItemRef: React.RefObject<HTMLLIElement>;
+	index: number;
+	inputRef: React.RefObject<HTMLInputElement>;
+	onIndexChange: (newVal: number) => void;
+	onIndexSelect: (activeIndex: number) => void;
+	totalItems: number;
+}
+
+/**
+ * Hook that returns a function for handling arrow keys
+ * and enter key for a list.
+ */
+export function useKeyHandlerForList({
+	activeListItemRef,
+	index,
+	inputRef,
+	onIndexChange,
+	onIndexSelect,
+	totalItems,
+}: IArgs): React.KeyboardEventHandler {
+	React.useEffect(() => {
+		if (activeListItemRef.current && inputRef.current) {
+			activeListItemRef.current.scrollIntoView({block: 'nearest'});
+		}
+	}, [activeListItemRef.current]);
+
+	return event => {
+		const {keyCode} = event;
+
+		if (keyCode === UP_ARROW_KEY_CODE || keyCode === DOWN_ARROW_KEY_CODE) {
+			event.preventDefault();
+
+			const nextIndex = index === totalItems - 1 ? 0 : index + 1;
+			const prevIndex = index === 0 ? totalItems - 1 : index - 1;
+
+			onIndexChange(
+				keyCode === UP_ARROW_KEY_CODE ? prevIndex : nextIndex
+			);
+		} else if (keyCode === ENTER_KEY_CODE) {
+			onIndexChange(0);
+			onIndexSelect(index);
+		}
+	};
+}

--- a/packages/clay-shared/src/useTransitionHeight.ts
+++ b/packages/clay-shared/src/useTransitionHeight.ts
@@ -29,7 +29,7 @@ function setCollapseHeight(collapseElementRef: React.RefObject<any>) {
 	}
 }
 
-function useTransitionHeight(
+export function useTransitionHeight(
 	visible: boolean,
 	setVisible: any,
 	contentRef: React.RefObject<any>
@@ -73,5 +73,3 @@ function useTransitionHeight(
 		(event: React.MouseEvent | MouseEvent) => void
 	];
 }
-
-export default useTransitionHeight;


### PR DESCRIPTION
The aim of these hooks is to address https://github.com/liferay/clay/issues/2107. To see how they work, checkout the autocomplete stories. 

My initial thought is to get these reviewed and approved and if they look good, add them to the multiselect high-level component for an initial testing ground.