### PR TITLE
fix: normalize names of components and context

### DIFF
--- a/packages/clay-alert/src/ToastContainer.tsx
+++ b/packages/clay-alert/src/ToastContainer.tsx
@@ -16,7 +16,7 @@ interface IToastContainerProps extends React.HTMLAttributes<HTMLDivElement> {
 		| React.ReactElement<IClayAlertProps>[];
 }
 
-export const ToastContainer = ({
+const ClayToastContainer = ({
 	children,
 	className,
 	...otherProps
@@ -32,3 +32,5 @@ export const ToastContainer = ({
 		</div>
 	);
 };
+
+export default ClayToastContainer;

--- a/packages/clay-alert/src/index.tsx
+++ b/packages/clay-alert/src/index.tsx
@@ -7,7 +7,7 @@
 import classNames from 'classnames';
 import Icon from '@clayui/icon';
 import React, {useEffect, useRef} from 'react';
-import {ToastContainer} from './ToastContainer';
+import ToastContainer from './ToastContainer';
 
 const useAutoClose = (autoClose?: boolean | number, onClose = () => {}) => {
 	const startedTime = useRef<number>(0);

--- a/packages/clay-autocomplete/src/Context.ts
+++ b/packages/clay-autocomplete/src/Context.ts
@@ -28,4 +28,4 @@ const context = React.createContext({} as IContext);
 
 context.displayName = 'ClayAutocompleteContext';
 
-export default context
+export default context;

--- a/packages/clay-autocomplete/src/Context.ts
+++ b/packages/clay-autocomplete/src/Context.ts
@@ -24,4 +24,8 @@ interface IContext {
 	containerElementRef: React.RefObject<HTMLElement>;
 }
 
-export default React.createContext({} as IContext);
+const context = React.createContext({} as IContext);
+
+context.displayName = 'ClayAutocompleteContext';
+
+export default context

--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -25,7 +25,7 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	onSetActive?: (val: boolean) => void;
 }
 
-const DropDown: React.FunctionComponent<IProps> = ({
+const ClayAutocompleteDropDown: React.FunctionComponent<IProps> = ({
 	active = false,
 	alignElementRef,
 	children,
@@ -59,4 +59,4 @@ const DropDown: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default DropDown;
+export default ClayAutocompleteDropDown;

--- a/packages/clay-autocomplete/src/Input.tsx
+++ b/packages/clay-autocomplete/src/Input.tsx
@@ -13,7 +13,7 @@ export interface IProps
 	extends React.InputHTMLAttributes<HTMLInputElement>,
 		React.ComponentProps<typeof ClayForm.Input> {}
 
-const Input = React.forwardRef<HTMLInputElement, IProps>(
+const ClayAutocompleteInput = React.forwardRef<HTMLInputElement, IProps>(
 	({className, ...othersProps}: IProps, ref) => {
 		const {loading} = useContext(Context);
 
@@ -29,4 +29,4 @@ const Input = React.forwardRef<HTMLInputElement, IProps>(
 	}
 );
 
-export default Input;
+export default ClayAutocompleteInput;

--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -23,7 +23,7 @@ interface IProps extends React.ComponentProps<typeof ClayDropDown.Item> {
 
 const optionsFuzzy = {post: '</strong>', pre: '<strong>'};
 
-const Item: React.FunctionComponent<IProps> = ({
+const ClayAutocompleteItem: React.FunctionComponent<IProps> = ({
 	match,
 	value,
 	...otherProps
@@ -45,4 +45,4 @@ const Item: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default Item;
+export default ClayAutocompleteItem;

--- a/packages/clay-autocomplete/src/LoadingIndicator.tsx
+++ b/packages/clay-autocomplete/src/LoadingIndicator.tsx
@@ -30,7 +30,7 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	component?: React.ComponentType<any>;
 }
 
-const LoadingIndicator: React.FunctionComponent<IProps> = ({
+const ClayAutocompleteLoadingIndicator: React.FunctionComponent<IProps> = ({
 	className,
 	component: Component = LoadingIndicatorMarkup,
 	...otherProps
@@ -52,4 +52,4 @@ const LoadingIndicator: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default LoadingIndicator;
+export default ClayAutocompleteLoadingIndicator;

--- a/packages/clay-button/src/Group.tsx
+++ b/packages/clay-button/src/Group.tsx
@@ -13,7 +13,7 @@ interface IButtonGroupProps extends React.HTMLAttributes<HTMLDivElement> {
 	spaced?: boolean;
 }
 
-export const ClayButtonGroup: React.FunctionComponent<IButtonGroupProps> = ({
+const ClayButtonGroup: React.FunctionComponent<IButtonGroupProps> = ({
 	children,
 	className,
 	role = 'group',
@@ -35,3 +35,5 @@ export const ClayButtonGroup: React.FunctionComponent<IButtonGroupProps> = ({
 			: children}
 	</div>
 );
+
+export default ClayButtonGroup;

--- a/packages/clay-button/src/index.tsx
+++ b/packages/clay-button/src/index.tsx
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import ButtonGroup from './Group';
 import classNames from 'classnames';
 import React from 'react';
-import {ClayButtonGroup} from './Group';
 
 export type DisplayType = 'primary' | 'secondary' | 'link' | 'unstyled';
 
@@ -43,7 +43,7 @@ interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 interface IClayButton extends React.FunctionComponent<IProps> {
-	Group: typeof ClayButtonGroup;
+	Group: typeof ButtonGroup;
 }
 
 const ClayButton: IClayButton = ({
@@ -75,6 +75,6 @@ const ClayButton: IClayButton = ({
 	</button>
 );
 
-ClayButton.Group = ClayButtonGroup;
+ClayButton.Group = ButtonGroup;
 
 export default ClayButton;

--- a/packages/clay-card/src/AspectRatio.tsx
+++ b/packages/clay-card/src/AspectRatio.tsx
@@ -25,7 +25,7 @@ interface ICardAspectRatioProps
 	containerAspectRatio?: ContainerAspectRatioType;
 }
 
-const AspectRatio: React.FunctionComponent<ICardAspectRatioProps> = ({
+const ClayCardAspectRatio: React.FunctionComponent<ICardAspectRatioProps> = ({
 	backgroundImageAspectRatio,
 	children,
 	className,
@@ -51,4 +51,4 @@ const AspectRatio: React.FunctionComponent<ICardAspectRatioProps> = ({
 	);
 };
 
-export default AspectRatio;
+export default ClayCardAspectRatio;

--- a/packages/clay-card/src/Body.tsx
+++ b/packages/clay-card/src/Body.tsx
@@ -8,11 +8,9 @@ import classNames from 'classnames';
 import Context from './Context';
 import React from 'react';
 
-const Body: React.FunctionComponent<React.HTMLAttributes<HTMLDivElement>> = ({
-	children,
-	className,
-	...otherProps
-}) => {
+const ClayCardBody: React.FunctionComponent<
+	React.HTMLAttributes<HTMLDivElement>
+> = ({children, className, ...otherProps}) => {
 	const {horizontal, interactive} = React.useContext(Context);
 
 	const TagName = interactive ? 'span' : 'div';
@@ -34,4 +32,4 @@ const Body: React.FunctionComponent<React.HTMLAttributes<HTMLDivElement>> = ({
 	return content;
 };
 
-export default Body;
+export default ClayCardBody;

--- a/packages/clay-card/src/Caption.tsx
+++ b/packages/clay-card/src/Caption.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import Context from './Context';
 import React from 'react';
 
-const Caption: React.FunctionComponent<
+const ClayCardCaption: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement | HTMLSpanElement>
 > = ({children, className, ...otherProps}) => {
 	const {interactive} = React.useContext(Context);
@@ -25,4 +25,4 @@ const Caption: React.FunctionComponent<
 	);
 };
 
-export default Caption;
+export default ClayCardCaption;

--- a/packages/clay-card/src/Context.ts
+++ b/packages/clay-card/src/Context.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {createContext} from 'react';
+import { createContext } from 'react';
 
 export interface IContext {
 	/**
@@ -22,4 +22,8 @@ export interface IContext {
 	interactive?: boolean;
 }
 
-export default createContext({} as IContext);
+const context = createContext({} as IContext);
+
+context.displayName = 'ClayCardContext';
+
+export default context

--- a/packages/clay-card/src/Context.ts
+++ b/packages/clay-card/src/Context.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { createContext } from 'react';
+import {createContext} from 'react';
 
 export interface IContext {
 	/**
@@ -26,4 +26,4 @@ const context = createContext({} as IContext);
 
 context.displayName = 'ClayCardContext';
 
-export default context
+export default context;

--- a/packages/clay-card/src/Description.tsx
+++ b/packages/clay-card/src/Description.tsx
@@ -23,7 +23,7 @@ interface ICardDescriptionProps
 	truncate?: boolean;
 }
 
-const Description: React.FunctionComponent<ICardDescriptionProps> = ({
+const ClayCardDescription: React.FunctionComponent<ICardDescriptionProps> = ({
 	children,
 	className,
 	displayType,
@@ -46,4 +46,4 @@ const Description: React.FunctionComponent<ICardDescriptionProps> = ({
 	);
 };
 
-export default Description;
+export default ClayCardDescription;

--- a/packages/clay-card/src/Group.tsx
+++ b/packages/clay-card/src/Group.tsx
@@ -14,7 +14,7 @@ interface ICardGroupProps extends React.HTMLAttributes<HTMLUListElement> {
 	label?: string;
 }
 
-const Group: React.FunctionComponent<ICardGroupProps> = ({
+const ClayCardGroup: React.FunctionComponent<ICardGroupProps> = ({
 	children,
 	className,
 	label,
@@ -40,4 +40,4 @@ const Group: React.FunctionComponent<ICardGroupProps> = ({
 	);
 };
 
-export default Group;
+export default ClayCardGroup;

--- a/packages/clay-color-picker/src/Basic.tsx
+++ b/packages/clay-color-picker/src/Basic.tsx
@@ -26,7 +26,11 @@ interface IProps {
 /**
  * Renders basic color picker
  */
-const Basic: React.FunctionComponent<IProps> = ({colors, label, onChange}) => (
+const ClayColorPickerBasic: React.FunctionComponent<IProps> = ({
+	colors,
+	label,
+	onChange,
+}) => (
 	<React.Fragment>
 		{label && (
 			<div className="clay-color-header">
@@ -44,4 +48,4 @@ const Basic: React.FunctionComponent<IProps> = ({colors, label, onChange}) => (
 	</React.Fragment>
 );
 
-export default Basic;
+export default ClayColorPickerBasic;

--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -103,7 +103,7 @@ interface IProps {
 /**
  * Renders the custom color picker
  */
-const Custom: React.FunctionComponent<IProps> = ({
+const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 	colors,
 	label,
 	onChange,
@@ -290,4 +290,4 @@ const Custom: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default Custom;
+export default ClayColorPickerCustom;

--- a/packages/clay-color-picker/src/GradientSelector.tsx
+++ b/packages/clay-color-picker/src/GradientSelector.tsx
@@ -28,7 +28,7 @@ interface IProps {
 /**
  * Renders GradientSelector component
  */
-const GradientSelector: React.FunctionComponent<IProps> = ({
+const ClayColorPickerGradientSelector: React.FunctionComponent<IProps> = ({
 	color,
 	onChange = () => {},
 	hue = 0,
@@ -89,4 +89,4 @@ const GradientSelector: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default GradientSelector;
+export default ClayColorPickerGradientSelector;

--- a/packages/clay-color-picker/src/Hue.tsx
+++ b/packages/clay-color-picker/src/Hue.tsx
@@ -22,7 +22,7 @@ interface IProps {
 /**
  * Renders Hue component
  */
-const Hue: React.FunctionComponent<IProps> = ({
+const ClayColorPickerHue: React.FunctionComponent<IProps> = ({
 	value = 0,
 	onChange = () => {},
 }) => {
@@ -76,4 +76,4 @@ const Hue: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default Hue;
+export default ClayColorPickerHue;

--- a/packages/clay-color-picker/src/Splotch.tsx
+++ b/packages/clay-color-picker/src/Splotch.tsx
@@ -26,7 +26,7 @@ interface IProps extends React.HTMLAttributes<HTMLButtonElement> {
 /**
  * Renders component that displays a color
  */
-const Splotch: React.FunctionComponent<IProps> = ({
+const ClayColorPickerSplotch: React.FunctionComponent<IProps> = ({
 	active,
 	className,
 	size = 24,
@@ -53,4 +53,4 @@ const Splotch: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default Splotch;
+export default ClayColorPickerSplotch;

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -113,7 +113,7 @@ interface IProps {
 	value?: string;
 }
 
-const ColorPicker: React.FunctionComponent<IProps> = ({
+const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	ariaLabels = DEFAULT_ARIA_LABELS,
 	colors,
 	label,
@@ -249,4 +249,4 @@ const ColorPicker: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default ColorPicker;
+export default ClayColorPicker;

--- a/packages/clay-data-provider/stories/index.tsx
+++ b/packages/clay-data-provider/stories/index.tsx
@@ -13,6 +13,8 @@ import '@clayui/css/lib/css/atlas.css';
 
 const Store = React.createContext({});
 
+Store.displayName = 'StoreContext';
+
 const ClayDataProviderWithVariablesAndStorage = () => {
 	const [value, setValue] = useState<undefined | string>('');
 	const store = useContext(Store);

--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -22,7 +22,7 @@ interface IProps extends HTMLAttributes<HTMLDivElement> {
 	years: IYears;
 }
 
-const DateNavigation: FunctionComponent<IProps> = ({
+const ClayDatePickerDateNavigation: FunctionComponent<IProps> = ({
 	ariaLabels,
 	currentMonth,
 	months,
@@ -152,4 +152,4 @@ const DateNavigation: FunctionComponent<IProps> = ({
 	);
 };
 
-export default DateNavigation;
+export default ClayDatePickerDateNavigation;

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -15,7 +15,11 @@ interface IProps {
 	onClick: (date: Date) => void;
 }
 
-const DayNumber: FunctionComponent<IProps> = ({day, daySelected, onClick}) => {
+const ClayDatePickerDayNumber: FunctionComponent<IProps> = ({
+	day,
+	daySelected,
+	onClick,
+}) => {
 	const classNames = classnames(
 		'date-picker-date date-picker-calendar-item',
 		{
@@ -47,4 +51,4 @@ const DayNumber: FunctionComponent<IProps> = ({day, daySelected, onClick}) => {
 	);
 };
 
-export default DayNumber;
+export default ClayDatePickerDayNumber;

--- a/packages/clay-date-picker/src/DaysTable.tsx
+++ b/packages/clay-date-picker/src/DaysTable.tsx
@@ -17,7 +17,10 @@ interface IProps {
 	weeks: Month;
 }
 
-const DaysTable: FunctionComponent<IProps> = ({children, weeks}) => {
+const ClayDatePickerDaysTable: FunctionComponent<IProps> = ({
+	children,
+	weeks,
+}) => {
 	return (
 		<React.Fragment>
 			{weeks.map((days, index) => (
@@ -34,4 +37,4 @@ const DaysTable: FunctionComponent<IProps> = ({children, weeks}) => {
 	);
 };
 
-export default DaysTable;
+export default ClayDatePickerDaysTable;

--- a/packages/clay-date-picker/src/InputDate.tsx
+++ b/packages/clay-date-picker/src/InputDate.tsx
@@ -21,7 +21,7 @@ interface IProps {
 	value: string;
 }
 
-const InputDate: FunctionComponent<IProps> = ({
+const ClayDatePickerInputDate: FunctionComponent<IProps> = ({
 	ariaLabel,
 	currentTime,
 	dateFormat,
@@ -71,4 +71,4 @@ const InputDate: FunctionComponent<IProps> = ({
 	);
 };
 
-export default InputDate;
+export default ClayDatePickerInputDate;

--- a/packages/clay-date-picker/src/Select.tsx
+++ b/packages/clay-date-picker/src/Select.tsx
@@ -19,7 +19,7 @@ interface IProps extends SelectHTMLAttributes<HTMLSelectElement> {
 	value: string | number;
 }
 
-const Select = forwardRef(
+const ClayDatePickerSelect = forwardRef(
 	(
 		{name, onChange, options, testId, value}: IProps,
 		ref: React.Ref<HTMLSelectElement>
@@ -45,4 +45,4 @@ const Select = forwardRef(
 	)
 );
 
-export default Select;
+export default ClayDatePickerSelect;

--- a/packages/clay-date-picker/src/TimePicker.tsx
+++ b/packages/clay-date-picker/src/TimePicker.tsx
@@ -17,7 +17,7 @@ interface IProps {
 	timezone?: string;
 }
 
-const TimePicker: FunctionComponent<IProps> = ({
+const ClayDatePickerTimePicker: FunctionComponent<IProps> = ({
 	currentTime,
 	onTimeChange,
 	spritemap,
@@ -52,4 +52,4 @@ const TimePicker: FunctionComponent<IProps> = ({
 	);
 };
 
-export default TimePicker;
+export default ClayDatePickerTimePicker;

--- a/packages/clay-date-picker/src/Weekday.tsx
+++ b/packages/clay-date-picker/src/Weekday.tsx
@@ -10,10 +10,10 @@ interface IProps {
 	weekday: string;
 }
 
-const Weekday: FunctionComponent<IProps> = ({weekday}) => (
+const ClayDatePickerWeekday: FunctionComponent<IProps> = ({weekday}) => (
 	<div className="date-picker-day date-picker-calendar-item">
 		<abbr>{weekday}</abbr>
 	</div>
 );
 
-export default Weekday;
+export default ClayDatePickerWeekday;

--- a/packages/clay-date-picker/src/WeekdayHeader.tsx
+++ b/packages/clay-date-picker/src/WeekdayHeader.tsx
@@ -18,7 +18,7 @@ interface IProps {
 	weekdaysShort: Array<string>;
 }
 
-const WeekdayHeader: FunctionComponent<IProps> = ({
+const ClayDatePickerWeekdayHeader: FunctionComponent<IProps> = ({
 	children,
 	firstDayOfWeek = 0,
 	weekdaysShort,
@@ -35,4 +35,4 @@ const WeekdayHeader: FunctionComponent<IProps> = ({
 	</div>
 );
 
-export default WeekdayHeader;
+export default ClayDatePickerWeekdayHeader;

--- a/packages/clay-drop-down/src/Action.tsx
+++ b/packages/clay-drop-down/src/Action.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import ClayButton from '@clayui/button';
 import React from 'react';
 
-const DropDownAction: React.FunctionComponent<
+const ClayDropDownAction: React.FunctionComponent<
 	React.HTMLAttributes<HTMLButtonElement>
 > = ({children, className, ...otherProps}) => {
 	return (
@@ -18,4 +18,4 @@ const DropDownAction: React.FunctionComponent<
 	);
 };
 
-export default DropDownAction;
+export default ClayDropDownAction;

--- a/packages/clay-drop-down/src/Caption.tsx
+++ b/packages/clay-drop-down/src/Caption.tsx
@@ -7,7 +7,7 @@
 import classnames from 'classnames';
 import React from 'react';
 
-const DropDownCaption: React.FunctionComponent<
+const ClayDropDownCaption: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement>
 > = ({children, className, ...otherProps}) => {
 	return (
@@ -20,4 +20,4 @@ const DropDownCaption: React.FunctionComponent<
 	);
 };
 
-export default DropDownCaption;
+export default ClayDropDownCaption;

--- a/packages/clay-drop-down/src/Divider.tsx
+++ b/packages/clay-drop-down/src/Divider.tsx
@@ -6,10 +6,10 @@
 
 import React from 'react';
 
-const Divider: React.FunctionComponent<
+const ClayDropDownDivider: React.FunctionComponent<
 	React.HTMLAttributes<HTMLLIElement>
 > = () => (
 	<li aria-hidden="true" className="dropdown-divider" role="presentation" />
 );
 
-export default Divider;
+export default ClayDropDownDivider;

--- a/packages/clay-drop-down/src/Group.tsx
+++ b/packages/clay-drop-down/src/Group.tsx
@@ -13,7 +13,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	header?: string;
 }
 
-const DropDownGroup: React.FunctionComponent<IProps> = ({
+const ClayDropDownGroup: React.FunctionComponent<IProps> = ({
 	children,
 	header,
 }: IProps) => {
@@ -30,4 +30,4 @@ const DropDownGroup: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default DropDownGroup;
+export default ClayDropDownGroup;

--- a/packages/clay-drop-down/src/Help.tsx
+++ b/packages/clay-drop-down/src/Help.tsx
@@ -7,7 +7,7 @@
 import classnames from 'classnames';
 import React from 'react';
 
-const DropDownHelp: React.FunctionComponent<
+const ClayDropDownHelp: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement>
 > = ({children, className, ...otherProps}) => {
 	return (
@@ -21,4 +21,4 @@ const DropDownHelp: React.FunctionComponent<
 	);
 };
 
-export default DropDownHelp;
+export default ClayDropDownHelp;

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -41,7 +41,7 @@ interface IProps
 	symbolRight?: string;
 }
 
-const DropDownItem: React.FunctionComponent<IProps> = ({
+const ClayDropDownItem: React.FunctionComponent<IProps> = ({
 	active,
 	children,
 	className,
@@ -82,4 +82,4 @@ const DropDownItem: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default DropDownItem;
+export default ClayDropDownItem;

--- a/packages/clay-drop-down/src/ItemList.tsx
+++ b/packages/clay-drop-down/src/ItemList.tsx
@@ -7,7 +7,7 @@
 import classnames from 'classnames';
 import React from 'react';
 
-const DropDownItemList: React.FunctionComponent<
+const ClayDropDownItemList: React.FunctionComponent<
 	React.HTMLAttributes<HTMLUListElement>
 > = ({children, className, ...otherProps}) => {
 	return (
@@ -17,4 +17,4 @@ const DropDownItemList: React.FunctionComponent<
 	);
 };
 
-export default DropDownItemList;
+export default ClayDropDownItemList;

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -58,7 +58,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	onSetActive: (val: boolean) => void;
 }
 
-const DropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
+const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 	{
 		active,
 		alignElementRef,
@@ -114,4 +114,4 @@ const DropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 
 export {Align};
 
-export default DropDownMenu;
+export default ClayDropDownMenu;

--- a/packages/clay-drop-down/src/Search.tsx
+++ b/packages/clay-drop-down/src/Search.tsx
@@ -25,7 +25,7 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	value: React.ReactText;
 }
 
-const DropDownSearch: React.FunctionComponent<IProps> = ({
+const ClayDropDownSearch: React.FunctionComponent<IProps> = ({
 	className,
 	spritemap,
 	...otherProps
@@ -56,4 +56,4 @@ const DropDownSearch: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default DropDownSearch;
+export default ClayDropDownSearch;

--- a/packages/clay-form/src/Input.tsx
+++ b/packages/clay-form/src/Input.tsx
@@ -14,7 +14,7 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	component?: 'input' | React.ForwardRefExoticComponent<any>;
 }
 
-const Input = React.forwardRef<HTMLInputElement, IProps>(
+const ClayFormInput = React.forwardRef<HTMLInputElement, IProps>(
 	({className, component: Component = 'input', ...otherProps}, ref) => (
 		<Component
 			{...otherProps}
@@ -24,4 +24,4 @@ const Input = React.forwardRef<HTMLInputElement, IProps>(
 	)
 );
 
-export default Input;
+export default ClayFormInput;

--- a/packages/clay-list/src/Header.tsx
+++ b/packages/clay-list/src/Header.tsx
@@ -7,11 +7,9 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const Header: React.FunctionComponent<React.HTMLAttributes<HTMLLIElement>> = ({
-	children,
-	className,
-	...otherProps
-}) => {
+const ClayListHeader: React.FunctionComponent<
+	React.HTMLAttributes<HTMLLIElement>
+> = ({children, className, ...otherProps}) => {
 	return (
 		<li
 			{...otherProps}
@@ -22,4 +20,4 @@ const Header: React.FunctionComponent<React.HTMLAttributes<HTMLLIElement>> = ({
 	);
 };
 
-export default Header;
+export default ClayListHeader;

--- a/packages/clay-list/src/Item.tsx
+++ b/packages/clay-list/src/Item.tsx
@@ -33,7 +33,7 @@ interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	header?: boolean;
 }
 
-const ClayItem: React.FunctionComponent<IProps> = ({
+const ClayListItem: React.FunctionComponent<IProps> = ({
 	action = false,
 	active = false,
 	children,
@@ -59,4 +59,4 @@ const ClayItem: React.FunctionComponent<IProps> = ({
 		</li>
 	);
 };
-export default ClayItem;
+export default ClayListItem;

--- a/packages/clay-list/src/ItemField.tsx
+++ b/packages/clay-list/src/ItemField.tsx
@@ -15,7 +15,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	expand?: boolean;
 }
 
-const ItemField: React.FunctionComponent<IProps> = ({
+const ClayListItemField: React.FunctionComponent<IProps> = ({
 	children,
 	className,
 	expand,
@@ -33,4 +33,4 @@ const ItemField: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default ItemField;
+export default ClayListItemField;

--- a/packages/clay-list/src/ItemText.tsx
+++ b/packages/clay-list/src/ItemText.tsx
@@ -12,7 +12,7 @@ interface IProps extends React.HTMLAttributes<HTMLParagraphElement> {
 	 */
 	subtext?: boolean;
 }
-const ItemText: React.FunctionComponent<IProps> = ({
+const ClayListItemText: React.FunctionComponent<IProps> = ({
 	children,
 	className,
 	subtext,
@@ -31,4 +31,4 @@ const ItemText: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default ItemText;
+export default ClayListItemText;

--- a/packages/clay-list/src/ItemTitle.tsx
+++ b/packages/clay-list/src/ItemTitle.tsx
@@ -7,7 +7,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const ItemTitle: React.FunctionComponent<
+const ClayListItemTitle: React.FunctionComponent<
 	React.HTMLAttributes<HTMLHeadingElement>
 > = ({children, className, ...otherProps}) => {
 	return (
@@ -20,4 +20,4 @@ const ItemTitle: React.FunctionComponent<
 	);
 };
 
-export default ItemTitle;
+export default ClayListItemTitle;

--- a/packages/clay-list/src/QuickActionMenu.tsx
+++ b/packages/clay-list/src/QuickActionMenu.tsx
@@ -5,10 +5,10 @@
  */
 
 import classNames from 'classnames';
+import QuickActionMenuItem from './QuickActionMenuItem';
 import React from 'react';
-import {QuickActionMenuItem} from './QuickActionMenuItem';
 
-const QuickActionMenu: React.FunctionComponent<
+const ClayListQuickActionMenu: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement>
 > & {
 	Item: typeof QuickActionMenuItem;
@@ -23,6 +23,6 @@ const QuickActionMenu: React.FunctionComponent<
 	);
 };
 
-QuickActionMenu.Item = QuickActionMenuItem;
+ClayListQuickActionMenu.Item = QuickActionMenuItem;
 
-export default QuickActionMenu;
+export default ClayListQuickActionMenu;

--- a/packages/clay-list/src/QuickActionMenuItem.tsx
+++ b/packages/clay-list/src/QuickActionMenuItem.tsx
@@ -26,7 +26,7 @@ interface IItemProps
 	symbol: string;
 }
 
-export const QuickActionMenuItem: React.FunctionComponent<IItemProps> = ({
+const ClayListQuickActionMenuItem: React.FunctionComponent<IItemProps> = ({
 	className,
 	href,
 	spritemap,
@@ -49,3 +49,5 @@ export const QuickActionMenuItem: React.FunctionComponent<IItemProps> = ({
 		</ElementTag>
 	);
 };
+
+export default ClayListQuickActionMenuItem;

--- a/packages/clay-modal/src/Body.tsx
+++ b/packages/clay-modal/src/Body.tsx
@@ -14,7 +14,10 @@ interface IBodyProps extends HTMLAttributes<HTMLDivElement> {
 	url?: string;
 }
 
-const Body: FunctionComponent<IBodyProps> = ({children, url}: IBodyProps) => (
+const ClayModalBody: FunctionComponent<IBodyProps> = ({
+	children,
+	url,
+}: IBodyProps) => (
 	<div
 		className={classNames('modal-body', {
 			'modal-body-iframe': url,
@@ -24,4 +27,4 @@ const Body: FunctionComponent<IBodyProps> = ({children, url}: IBodyProps) => (
 	</div>
 );
 
-export default Body;
+export default ClayModalBody;

--- a/packages/clay-modal/src/Context.ts
+++ b/packages/clay-modal/src/Context.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {createContext} from 'react';
-import {Status} from './types';
+import { createContext } from 'react';
+import { Status } from './types';
 
 export interface IContext {
 	/**
@@ -24,4 +24,8 @@ export interface IContext {
 	status?: Status;
 }
 
-export default createContext({} as IContext);
+const context = createContext({} as IContext);
+
+context.displayName = 'ClayModalContext';
+
+export default context

--- a/packages/clay-modal/src/Context.ts
+++ b/packages/clay-modal/src/Context.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { createContext } from 'react';
-import { Status } from './types';
+import {createContext} from 'react';
+import {Status} from './types';
 
 export interface IContext {
 	/**
@@ -28,4 +28,4 @@ const context = createContext({} as IContext);
 
 context.displayName = 'ClayModalContext';
 
-export default context
+export default context;

--- a/packages/clay-modal/src/Footer.tsx
+++ b/packages/clay-modal/src/Footer.tsx
@@ -26,7 +26,7 @@ interface IFooterProps {
 	middle?: React.ReactElement;
 }
 
-const Footer: FunctionComponent<IFooterProps> = ({
+const ClayModalFooter: FunctionComponent<IFooterProps> = ({
 	first,
 	last,
 	middle,
@@ -38,4 +38,4 @@ const Footer: FunctionComponent<IFooterProps> = ({
 	</div>
 );
 
-export default Footer;
+export default ClayModalFooter;

--- a/packages/clay-modal/src/Header.tsx
+++ b/packages/clay-modal/src/Header.tsx
@@ -18,7 +18,9 @@ const ICON_MAP = {
 	warning: 'question-circle-full',
 };
 
-const Header: FunctionComponent<HeaderProps> = ({children}: HeaderProps) => {
+const ClayModalHeader: FunctionComponent<HeaderProps> = ({
+	children,
+}: HeaderProps) => {
 	const {onClose, spritemap, status} = useContext(Context);
 
 	return (
@@ -41,4 +43,4 @@ const Header: FunctionComponent<HeaderProps> = ({children}: HeaderProps) => {
 	);
 };
 
-export default Header;
+export default ClayModalHeader;

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-export interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
+interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Determines the active state of an dropdown list item.
 	 */
@@ -18,7 +18,7 @@ export interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
 	children: React.ReactElement;
 }
 
-export const Item: React.FunctionComponent<IItemProps> = ({
+const ClayNavigationBarIcon: React.FunctionComponent<IItemProps> = ({
 	active = false,
 	children,
 	className,
@@ -40,3 +40,5 @@ export const Item: React.FunctionComponent<IItemProps> = ({
 		</li>
 	);
 };
+
+export default ClayNavigationBarIcon;

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -7,16 +7,16 @@
 import classNames from 'classnames';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
+import Item from './Item';
 import React, {useRef, useState} from 'react';
 import warning from 'warning';
-import {IItemProps, Item} from './Item';
 import {useTransitionHeight} from '@clayui/shared';
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Children elements received from ClayNavigationBar component.
 	 */
-	children: React.ReactElement<IItemProps>[];
+	children: React.ReactElement<React.ComponentProps<typeof Item>>[];
 
 	/**
 	 * Determines the style of the Navigation Bar

--- a/packages/clay-pagination/src/PaginationEllipsis.tsx
+++ b/packages/clay-pagination/src/PaginationEllipsis.tsx
@@ -14,12 +14,9 @@ export interface IPaginationEllipsisProps {
 	onPageChange?: (page?: number) => void;
 }
 
-const PaginationEllipsis: React.FunctionComponent<IPaginationEllipsisProps> = ({
-	disabledPages = [],
-	hrefConstructor,
-	items,
-	onPageChange,
-}) => {
+const ClayPaginationEllipsis: React.FunctionComponent<
+	IPaginationEllipsisProps
+> = ({disabledPages = [], hrefConstructor, items, onPageChange}) => {
 	const [active, setActive] = useState(false);
 
 	return (
@@ -55,4 +52,4 @@ const PaginationEllipsis: React.FunctionComponent<IPaginationEllipsisProps> = ({
 	);
 };
 
-export default PaginationEllipsis;
+export default ClayPaginationEllipsis;

--- a/packages/clay-pagination/src/PaginationItem.tsx
+++ b/packages/clay-pagination/src/PaginationItem.tsx
@@ -13,7 +13,7 @@ interface IPaginationItemProps
 	href?: string;
 }
 
-const PaginationItem: React.FunctionComponent<IPaginationItemProps> = ({
+const ClayPaginationItem: React.FunctionComponent<IPaginationItemProps> = ({
 	active = false,
 	children,
 	disabled = false,
@@ -38,4 +38,4 @@ const PaginationItem: React.FunctionComponent<IPaginationItemProps> = ({
 	);
 };
 
-export default PaginationItem;
+export default ClayPaginationItem;

--- a/packages/clay-pagination/src/index.tsx
+++ b/packages/clay-pagination/src/index.tsx
@@ -104,7 +104,7 @@ interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	spritemap: string;
 }
 
-const Pagination: React.FunctionComponent<IProps> = ({
+const ClayPagination: React.FunctionComponent<IProps> = ({
 	activePage,
 	className,
 	disabledPages = [],
@@ -174,4 +174,4 @@ const Pagination: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default Pagination;
+export default ClayPagination;

--- a/packages/clay-radio-group/src/Radio.tsx
+++ b/packages/clay-radio-group/src/Radio.tsx
@@ -30,7 +30,7 @@ export interface IRadioProps
 	value: React.ReactText;
 }
 
-const Radio: React.FunctionComponent<IRadioProps> = ({
+const ClayRadioGroupRadio: React.FunctionComponent<IRadioProps> = ({
 	checked,
 	children,
 	className,
@@ -73,4 +73,4 @@ const Radio: React.FunctionComponent<IRadioProps> = ({
 	);
 };
 
-export default Radio;
+export default ClayRadioGroupRadio;

--- a/packages/clay-select/src/Option.tsx
+++ b/packages/clay-select/src/Option.tsx
@@ -6,8 +6,8 @@
 
 import React, {OptionHTMLAttributes} from 'react';
 
-const Option: React.FunctionComponent<
+const ClaySelectOption: React.FunctionComponent<
 	OptionHTMLAttributes<HTMLOptionElement>
 > = ({label, ...otherProps}) => <option {...otherProps}>{label}</option>;
 
-export default Option;
+export default ClaySelectOption;

--- a/packages/clay-select/src/Select.tsx
+++ b/packages/clay-select/src/Select.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import Option from './Option';
 import React, {SelectHTMLAttributes} from 'react';
 
-const Select: React.FunctionComponent<
+const ClaySelectSelect: React.FunctionComponent<
 	SelectHTMLAttributes<HTMLSelectElement>
 > & {
 	Option: typeof Option;
@@ -18,6 +18,6 @@ const Select: React.FunctionComponent<
 	</select>
 );
 
-Select.Option = Option;
+ClaySelectSelect.Option = Option;
 
-export default Select;
+export default ClaySelectSelect;

--- a/packages/clay-select/src/SelectWithOption.tsx
+++ b/packages/clay-select/src/SelectWithOption.tsx
@@ -15,7 +15,7 @@ interface IProps extends React.ComponentProps<typeof Select> {
 	options: Array<React.ComponentProps<typeof Option>>;
 }
 
-const SelectWithOption: React.FunctionComponent<IProps> = ({
+const ClaySelectWithOption: React.FunctionComponent<IProps> = ({
 	options = [],
 	...otherProps
 }: IProps) => (
@@ -26,4 +26,4 @@ const SelectWithOption: React.FunctionComponent<IProps> = ({
 	</Select>
 );
 
-export default SelectWithOption;
+export default ClaySelectWithOption;

--- a/packages/clay-shared/src/Portal.tsx
+++ b/packages/clay-shared/src/Portal.tsx
@@ -7,9 +7,9 @@
 import React, {useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
 
-const Portal: React.FunctionComponent<React.HTMLAttributes<HTMLDivElement>> = ({
-	children,
-}) => {
+const ClayPortal: React.FunctionComponent<
+	React.HTMLAttributes<HTMLDivElement>
+> = ({children}) => {
 	const portalRef = useRef(
 		typeof document !== 'undefined' && document.createElement('div')
 	);
@@ -33,4 +33,4 @@ const Portal: React.FunctionComponent<React.HTMLAttributes<HTMLDivElement>> = ({
 	return <>{children}</>;
 };
 
-export default Portal;
+export default ClayPortal;

--- a/packages/clay-table/src/Body.tsx
+++ b/packages/clay-table/src/Body.tsx
@@ -6,10 +6,10 @@
 
 import React from 'react';
 
-const Body: React.FunctionComponent<
+const ClayTableBody: React.FunctionComponent<
 	React.TableHTMLAttributes<HTMLTableSectionElement>
 > = ({children, ...otherProps}) => {
 	return <tbody {...otherProps}>{children}</tbody>;
 };
 
-export default Body;
+export default ClayTableBody;

--- a/packages/clay-table/src/Cell.tsx
+++ b/packages/clay-table/src/Cell.tsx
@@ -51,7 +51,7 @@ interface ICellProps extends TableCellBaseProps {
 	headingTitle?: boolean;
 }
 
-const Cell: React.FunctionComponent<ICellProps> = ({
+const ClayTableCell: React.FunctionComponent<ICellProps> = ({
 	align,
 	cellDelimiter,
 	children,
@@ -85,4 +85,4 @@ const Cell: React.FunctionComponent<ICellProps> = ({
 	);
 };
 
-export default Cell;
+export default ClayTableCell;

--- a/packages/clay-table/src/Head.tsx
+++ b/packages/clay-table/src/Head.tsx
@@ -6,10 +6,10 @@
 
 import React from 'react';
 
-const Head: React.FunctionComponent<
+const ClayTableHead: React.FunctionComponent<
 	React.TableHTMLAttributes<HTMLTableSectionElement>
 > = ({children, ...otherProps}) => {
 	return <thead {...otherProps}>{children}</thead>;
 };
 
-export default Head;
+export default ClayTableHead;

--- a/packages/clay-table/src/Row.tsx
+++ b/packages/clay-table/src/Row.tsx
@@ -26,7 +26,7 @@ interface IRowProps extends React.HTMLAttributes<HTMLTableRowElement> {
 	rowDelimiter?: TDelimiter;
 }
 
-const Row: React.FunctionComponent<IRowProps> = ({
+const ClayTableRow: React.FunctionComponent<IRowProps> = ({
 	active = false,
 	children,
 	className,
@@ -48,4 +48,4 @@ const Row: React.FunctionComponent<IRowProps> = ({
 	);
 };
 
-export default Row;
+export default ClayTableRow;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6103,7 +6103,7 @@ command-exists@^1.2.2:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
-commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.2.0, commander@^2.5.0, commander@^2.6.0, commander@^2.8.1, commander@~2.20.0:
+commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.2.0, commander@^2.5.0, commander@^2.6.0, commander@^2.8.1, commander@^2.9.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -6245,7 +6245,7 @@ concat-with-sourcemaps@*:
   dependencies:
     source-map "^0.6.1"
 
-config-chain@^1.1.11, config-chain@^1.1.12:
+config-chain@^1.1.11, config-chain@~1.1.5:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
   integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
@@ -8090,14 +8090,15 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-editorconfig@^0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
-  integrity sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==
+editorconfig@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
+  integrity sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==
   dependencies:
-    commander "^2.19.0"
-    lru-cache "^4.1.5"
-    semver "^5.6.0"
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    semver "^5.1.0"
     sigmund "^1.0.1"
 
 ee-first@1.1.1:
@@ -8792,7 +8793,7 @@ event-source-polyfill@^1.0.5:
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz#b34be2740a685a8dc65ae750065fc983538ffcfe"
   integrity sha512-PdStgZ3+G2o2gjqsBYbV4931ByVmwLwSrX7mFgawCL+9I1npo9dwAQTnWtNWXe5IY2P8+AbbPteeOueiEtRCUA==
 
-event-stream@^3.1.0:
+event-stream@3.3.4, event-stream@^3.1.0:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
@@ -13259,16 +13260,15 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
   integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
-js-beautify@^1.8.9:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.10.0.tgz#9753a13c858d96828658cd18ae3ca0e5783ea672"
-  integrity sha512-OMwf/tPDpE/BLlYKqZOhqWsd3/z2N3KOlyn1wsCRGFwViE8LOQTcDtathQvHvZc+q+zWmcNAbwKSC+iJoMaH2Q==
+js-beautify@1.7.5, js-beautify@^1.8.9:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.7.5.tgz#69d9651ef60dbb649f65527b53674950138a7919"
+  integrity sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==
   dependencies:
-    config-chain "^1.1.12"
-    editorconfig "^0.15.3"
-    glob "^7.1.3"
-    mkdirp "~0.5.1"
-    nopt "~4.0.1"
+    config-chain "~1.1.5"
+    editorconfig "^0.13.2"
+    mkdirp "~0.5.0"
+    nopt "~3.0.1"
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -14623,7 +14623,14 @@ lru-cache@4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3, lru-cache@^4.1.5:
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  integrity sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=
+  dependencies:
+    pseudomap "^1.0.1"
+
+lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -15936,14 +15943,14 @@ noms@0.0.0:
     inherits "^2.0.1"
     readable-stream "~1.0.31"
 
-"nopt@2 || 3", nopt@^3.0.0, nopt@~3.0.6:
+"nopt@2 || 3", nopt@^3.0.0, nopt@~3.0.1, nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
 
-nopt@^4.0.1, nopt@~4.0.1:
+nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
   integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=


### PR DESCRIPTION
Fixes #2104 

Prefixed all components with "Clay..."

Added `displayName` to context to further help dev tool debugging