### PR TITLE
feat(clay-button): create ClayButtonWithIcon component

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"prettier": "prettier-eslint '**/*.{js,ts,tsx}'",
 		"test": "jest",
 		"site": "cd clayui.com && npm run build && npm run serve",
-		"storybook": "start-storybook",
+		"storybook": "start-storybook -p 8888",
 		"storybook:build": "build-storybook -c .storybook -o .storybook-static"
 	},
 	"devDependencies": {

--- a/packages/clay-button/package.json
+++ b/packages/clay-button/package.json
@@ -26,6 +26,7 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/icon": "^3.0.0-milestone.1",
 		"classnames": "^2.2.6"
 	},
 	"devDependencies": {

--- a/packages/clay-button/src/Button.tsx
+++ b/packages/clay-button/src/Button.tsx
@@ -1,0 +1,80 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ButtonGroup from './Group';
+import classNames from 'classnames';
+import React from 'react';
+
+export type DisplayType = 'primary' | 'secondary' | 'link' | 'unstyled';
+
+interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+	/**
+	 * Flag to indicate if link should be borderless.
+	 */
+	borderless?: boolean;
+
+	/**
+	 * Renders the button as a block element.
+	 */
+	block?: boolean;
+
+	/**
+	 * Determines how to button is displayed.
+	 */
+	displayType?: DisplayType;
+
+	/**
+	 * Flag to indicate if button should be monospaced.
+	 */
+	monospaced?: boolean;
+
+	/**
+	 * Flag to indicate if link need have an outline.
+	 */
+	outline?: boolean;
+
+	/**
+	 * Indicates button should be a small variant.
+	 */
+	small?: boolean;
+}
+
+interface IClayButton extends React.FunctionComponent<IProps> {
+	Group: typeof ButtonGroup;
+}
+
+const ClayButton: IClayButton = ({
+	block,
+	borderless,
+	children,
+	className,
+	displayType = 'primary',
+	monospaced,
+	outline,
+	small,
+	type = 'button',
+	...otherProps
+}: IProps) => (
+	<button
+		className={classNames(className, 'btn', {
+			'btn-block': block,
+			'btn-monospaced': monospaced,
+			'btn-outline-borderless': borderless,
+			'btn-sm': small,
+			[`btn-${displayType}`]: displayType && !outline && !borderless,
+			[`btn-outline-${displayType}`]:
+				displayType && (outline || borderless),
+		})}
+		type={type}
+		{...otherProps}
+	>
+		{children}
+	</button>
+);
+
+ClayButton.Group = ButtonGroup;
+
+export default ClayButton;

--- a/packages/clay-button/src/ButtonWithIcon.tsx
+++ b/packages/clay-button/src/ButtonWithIcon.tsx
@@ -1,0 +1,26 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayButton from './Button';
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+
+interface IProps extends React.ComponentProps<typeof ClayButton> {
+	spritemap?: string;
+	symbol: string;
+}
+
+const ClayButtonWithIcon: React.FunctionComponent<IProps> = ({
+	spritemap,
+	symbol,
+	...otherProps
+}) => (
+	<ClayButton {...otherProps} monospaced>
+		<ClayIcon spritemap={spritemap} symbol={symbol} />
+	</ClayButton>
+);
+
+export default ClayButtonWithIcon;

--- a/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
@@ -7,6 +7,22 @@ exports[`ClayButton renders 1`] = `
 />
 `;
 
+exports[`ClayButton renders ButtonWithIcon 1`] = `
+<button
+  className="btn btn-monospaced btn-primary"
+  type="button"
+>
+  <svg
+    className="lexicon-icon lexicon-icon-trash"
+    role="presentation"
+  >
+    <use
+      xlinkHref="/some/path#trash"
+    />
+  </svg>
+</button>
+`;
+
 exports[`ClayButton renders a ButtonGroup with spaced 1`] = `
 <div
   className="btn-group"

--- a/packages/clay-button/src/__tests__/index.tsx
+++ b/packages/clay-button/src/__tests__/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as TestRenderer from 'react-test-renderer';
-import ClayButton from '..';
+import ClayButton, {ClayButtonWithIcon} from '..';
 import React from 'react';
 
 describe('ClayButton', () => {
@@ -87,6 +87,14 @@ describe('ClayButton', () => {
 				<ClayButton />
 				<ClayButton />
 			</ClayButton.Group>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
+	it('renders ButtonWithIcon', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayButtonWithIcon spritemap="/some/path" symbol="trash" />
 		);
 
 		expect(testRenderer.toJSON()).toMatchSnapshot();

--- a/packages/clay-button/src/index.tsx
+++ b/packages/clay-button/src/index.tsx
@@ -4,77 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ButtonGroup from './Group';
-import classNames from 'classnames';
-import React from 'react';
+import Button from './Button';
+import ClayButtonWithIcon from './ButtonWithIcon';
 
-export type DisplayType = 'primary' | 'secondary' | 'link' | 'unstyled';
-
-interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-	/**
-	 * Flag to indicate if link should be borderless.
-	 */
-	borderless?: boolean;
-
-	/**
-	 * Renders the button as a block element.
-	 */
-	block?: boolean;
-
-	/**
-	 * Determines how to button is displayed.
-	 */
-	displayType?: DisplayType;
-
-	/**
-	 * Flag to indicate if button should be monospaced.
-	 */
-	monospaced?: boolean;
-
-	/**
-	 * Flag to indicate if link need have an outline.
-	 */
-	outline?: boolean;
-
-	/**
-	 * Indicates button should be a small variant.
-	 */
-	small?: boolean;
-}
-
-interface IClayButton extends React.FunctionComponent<IProps> {
-	Group: typeof ButtonGroup;
-}
-
-const ClayButton: IClayButton = ({
-	block,
-	borderless,
-	children,
-	className,
-	displayType = 'primary',
-	monospaced,
-	outline,
-	small,
-	type = 'button',
-	...otherProps
-}: IProps) => (
-	<button
-		className={classNames(className, 'btn', {
-			'btn-block': block,
-			'btn-monospaced': monospaced,
-			'btn-outline-borderless': borderless,
-			'btn-sm': small,
-			[`btn-${displayType}`]: displayType && !outline && !borderless,
-			[`btn-outline-${displayType}`]:
-				displayType && (outline || borderless),
-		})}
-		type={type}
-		{...otherProps}
-	>
-		{children}
-	</button>
-);
-
-ClayButton.Group = ButtonGroup;
-
-export default ClayButton;
+export {ClayButtonWithIcon};
+export default Button;

--- a/packages/clay-button/stories/index.tsx
+++ b/packages/clay-button/stories/index.tsx
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import '@clayui/css/lib/css/atlas.css';
-import ClayButton from '../src';
+import ClayButton, {ClayButtonWithIcon} from '../src';
 import React from 'react';
 import {boolean, select, text} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
+
+const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
 
 storiesOf('ClayButton', module)
 	.add('default', () => (
@@ -42,4 +44,24 @@ storiesOf('ClayButton', module)
 			<ClayButton displayType="secondary">{'button'}</ClayButton>
 			<ClayButton>{'group.'}</ClayButton>
 		</ClayButton.Group>
+	))
+	.add('ButtonWithIcon', () => (
+		<>
+			<ClayButtonWithIcon spritemap={spritemap} symbol="trash" />
+			<ClayButtonWithIcon
+				displayType="secondary"
+				spritemap={spritemap}
+				symbol="cog"
+			/>
+			<ClayButtonWithIcon
+				displayType="link"
+				spritemap={spritemap}
+				symbol="cut"
+			/>
+			<ClayButtonWithIcon
+				displayType="unstyled"
+				spritemap={spritemap}
+				symbol="desktop"
+			/>
+		</>
 	));


### PR DESCRIPTION
note: I also added a static port for storybook. I got tired of builds failing and not know what url to hit after it was successful.