### PR TITLE
fix(@clayui/modal): stop closing the modal when the element is removed from the modal content

### DIFF
--- a/packages/clay-modal/src/Hook.ts
+++ b/packages/clay-modal/src/Hook.ts
@@ -82,7 +82,8 @@ const useUserInteractions = (
 		if (
 			elementRef.current &&
 			event.target !== null &&
-			!elementRef.current.contains(event.target as HTMLDivElement)
+			!elementRef.current.contains(event.target as HTMLDivElement) &&
+			document.contains(event.target as HTMLElement)
 		) {
 			onClick();
 		}


### PR DESCRIPTION
Fixes #2165

~~This was a solution that I found most appropriate at the moment, since the "document" becomes the `modal-backdrop` for the case of the modal I think it is safe to check if the click was in it so we could close the modal. But leave your thoughts.~~