### PR TITLE
feat(@clayui/shared): add experimental useFocusManagement hook

### DIFF
--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -9,9 +9,9 @@ import fuzzy from 'fuzzy';
 import React from 'react';
 
 interface IProps extends React.ComponentProps<typeof ClayDropDown.Item> {
-	anchorRef?: React.Ref<HTMLAnchorElement>;
-
 	forwardRef?: React.Ref<HTMLLIElement>;
+
+	innerRef?: React.Ref<HTMLAnchorElement>;
 
 	/**
 	 * Match is the string that will be compared with value.
@@ -28,8 +28,8 @@ interface IProps extends React.ComponentProps<typeof ClayDropDown.Item> {
 const optionsFuzzy = {post: '</strong>', pre: '<strong>'};
 
 const ClayAutocompleteItem: React.FunctionComponent<IProps> = ({
-	anchorRef,
 	forwardRef,
+	innerRef,
 	match = '',
 	value,
 	...otherProps
@@ -39,7 +39,7 @@ const ClayAutocompleteItem: React.FunctionComponent<IProps> = ({
 	return (
 		<ClayDropDown.Item
 			{...otherProps}
-			anchorRef={anchorRef}
+			innerRef={innerRef}
 			ref={forwardRef}
 			tabIndex={-1}
 		>

--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -9,6 +9,8 @@ import fuzzy from 'fuzzy';
 import React from 'react';
 
 interface IProps extends React.ComponentProps<typeof ClayDropDown.Item> {
+	anchorRef?: React.Ref<HTMLAnchorElement>;
+
 	forwardRef?: React.Ref<HTMLLIElement>;
 
 	/**
@@ -26,6 +28,7 @@ interface IProps extends React.ComponentProps<typeof ClayDropDown.Item> {
 const optionsFuzzy = {post: '</strong>', pre: '<strong>'};
 
 const ClayAutocompleteItem: React.FunctionComponent<IProps> = ({
+	anchorRef,
 	forwardRef,
 	match = '',
 	value,
@@ -34,7 +37,12 @@ const ClayAutocompleteItem: React.FunctionComponent<IProps> = ({
 	const fuzzyMatch = fuzzy.match(match, value, optionsFuzzy);
 
 	return (
-		<ClayDropDown.Item {...otherProps} ref={forwardRef}>
+		<ClayDropDown.Item
+			{...otherProps}
+			anchorRef={anchorRef}
+			ref={forwardRef}
+			tabIndex={-1}
+		>
 			{match && fuzzyMatch ? (
 				<div
 					dangerouslySetInnerHTML={{

--- a/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
@@ -51,6 +51,7 @@ exports[`ClayAutocomplete renders Item with matches values 1`] = `
   >
     <span
       class="dropdown-item"
+      tabindex="-1"
     >
       Bar
     </span>

--- a/packages/clay-autocomplete/stories/index.tsx
+++ b/packages/clay-autocomplete/stories/index.tsx
@@ -115,7 +115,7 @@ const AutocompleteWithKeyboardFunctionality = () => {
 				<ClayDropDown.ItemList>
 					{filteredItems.map((item, i) => (
 						<ClayAutocomplete.Item
-							anchorRef={ref =>
+							innerRef={ref =>
 								focusManager.createScope(ref, `item${i}`, true)
 							}
 							key={item}

--- a/packages/clay-button/src/Button.tsx
+++ b/packages/clay-button/src/Button.tsx
@@ -42,38 +42,44 @@ interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 	small?: boolean;
 }
 
-interface IClayButton extends React.FunctionComponent<IProps> {
-	Group: typeof ButtonGroup;
-}
+type Button = React.ForwardRefExoticComponent<
+	IProps & React.RefAttributes<HTMLButtonElement>
+> & {Group: typeof ButtonGroup};
 
-const ClayButton: IClayButton = ({
-	block,
-	borderless,
-	children,
-	className,
-	displayType = 'primary',
-	monospaced,
-	outline,
-	small,
-	type = 'button',
-	...otherProps
-}: IProps) => (
-	<button
-		className={classNames(className, 'btn', {
-			'btn-block': block,
-			'btn-monospaced': monospaced,
-			'btn-outline-borderless': borderless,
-			'btn-sm': small,
-			[`btn-${displayType}`]: displayType && !outline && !borderless,
-			[`btn-outline-${displayType}`]:
-				displayType && (outline || borderless),
-		})}
-		type={type}
-		{...otherProps}
-	>
-		{children}
-	</button>
-);
+const ClayButton = React.forwardRef(
+	(
+		{
+			block,
+			borderless,
+			children,
+			className,
+			displayType = 'primary',
+			monospaced,
+			outline,
+			small,
+			type = 'button',
+			...otherProps
+		}: IProps,
+		ref
+	) => (
+		<button
+			className={classNames(className, 'btn', {
+				'btn-block': block,
+				'btn-monospaced': monospaced,
+				'btn-outline-borderless': borderless,
+				'btn-sm': small,
+				[`btn-${displayType}`]: displayType && !outline && !borderless,
+				[`btn-outline-${displayType}`]:
+					displayType && (outline || borderless),
+			})}
+			ref={ref}
+			type={type}
+			{...otherProps}
+		>
+			{children}
+		</button>
+	)
+) as Button;
 
 ClayButton.Group = ButtonGroup;
 

--- a/packages/clay-drop-down/src/DropDownWithBasicItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithBasicItems.tsx
@@ -84,7 +84,7 @@ export const ClayDropDownWithBasicItems: React.FunctionComponent<IProps> = ({
 
 					return (
 						<ClayDropDown.Item
-							anchorRef={(ref: HTMLLinkElement) =>
+							innerRef={(ref: HTMLLinkElement) =>
 								focusManager.createScope(ref, `item${i}`, true)
 							}
 							key={i}

--- a/packages/clay-drop-down/src/DropDownWithBasicItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithBasicItems.tsx
@@ -6,6 +6,7 @@
 
 import ClayDropDown from './DropDown';
 import React, {useState} from 'react';
+import {useFocusManagement} from '@clayui/shared';
 
 interface IItem {
 	active?: boolean;
@@ -31,15 +32,38 @@ interface IProps {
 	spritemap?: string;
 }
 
+const TAB_KEY_CODE = 9;
+const ARROW_UP_KEY_CODE = 38;
+const ARROW_DOWN_KEY_CODE = 40;
+
 export const ClayDropDownWithBasicItems: React.FunctionComponent<IProps> = ({
 	items,
 	spritemap,
 	trigger,
 }: IProps) => {
 	const [active, setActive] = useState(false);
+	const focusManager = useFocusManagement();
 
 	const hasRightSymbols = !!items.find(item => item.symbolRight);
 	const hasLeftSymbols = !!items.find(item => item.symbolLeft);
+
+	const onKeyDown = (event: React.KeyboardEvent<any>) => {
+		const {keyCode, shiftKey} = event;
+
+		if (
+			keyCode === ARROW_DOWN_KEY_CODE ||
+			(keyCode === TAB_KEY_CODE && !shiftKey)
+		) {
+			event.preventDefault();
+			focusManager.focusNext();
+		} else if (
+			keyCode === ARROW_UP_KEY_CODE ||
+			(keyCode === TAB_KEY_CODE && shiftKey)
+		) {
+			event.preventDefault();
+			focusManager.focusPrevious();
+		}
+	};
 
 	return (
 		<ClayDropDown
@@ -47,7 +71,10 @@ export const ClayDropDownWithBasicItems: React.FunctionComponent<IProps> = ({
 			hasLeftSymbols={hasLeftSymbols}
 			hasRightSymbols={hasRightSymbols}
 			onActiveChange={(newVal: boolean) => setActive(newVal)}
-			trigger={trigger}
+			onKeyDown={onKeyDown}
+			trigger={React.cloneElement(trigger, {
+				ref: (ref: any) => focusManager.createScope(ref, 'trigger'),
+			})}
 		>
 			<ClayDropDown.ItemList>
 				{items.map((item: IItem, i: number) => {
@@ -57,6 +84,9 @@ export const ClayDropDownWithBasicItems: React.FunctionComponent<IProps> = ({
 
 					return (
 						<ClayDropDown.Item
+							anchorRef={(ref: HTMLLinkElement) =>
+								focusManager.createScope(ref, `item${i}`, true)
+							}
 							key={i}
 							spritemap={spritemap}
 							{...item}

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -20,6 +20,8 @@ interface IProps
 	 */
 	disabled?: boolean;
 
+	anchorRef?: React.Ref<any>;
+
 	forwardRef?: React.Ref<HTMLLIElement>;
 
 	/**
@@ -45,6 +47,7 @@ interface IProps
 
 const ClayDropDownItem: React.FunctionComponent<IProps> = ({
 	active,
+	anchorRef,
 	children,
 	className,
 	disabled,
@@ -69,6 +72,7 @@ const ClayDropDownItem: React.FunctionComponent<IProps> = ({
 				})}
 				href={href}
 				onClick={onClick}
+				ref={anchorRef}
 			>
 				{symbolLeft && (
 					<span className="dropdown-item-indicator-start">

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -20,14 +20,14 @@ interface IProps
 	 */
 	disabled?: boolean;
 
-	anchorRef?: React.Ref<any>;
-
 	forwardRef?: React.Ref<HTMLLIElement>;
 
 	/**
 	 * Path for item to link to.
 	 */
 	href?: string;
+
+	innerRef?: React.Ref<any>;
 
 	/**
 	 * Path to icon spritemap from clay-css.
@@ -47,12 +47,12 @@ interface IProps
 
 const ClayDropDownItem: React.FunctionComponent<IProps> = ({
 	active,
-	anchorRef,
 	children,
 	className,
 	disabled,
 	forwardRef,
 	href,
+	innerRef,
 	onClick,
 	spritemap,
 	symbolLeft,
@@ -72,7 +72,7 @@ const ClayDropDownItem: React.FunctionComponent<IProps> = ({
 				})}
 				href={href}
 				onClick={onClick}
-				ref={anchorRef}
+				ref={innerRef}
 			>
 				{symbolLeft && (
 					<span className="dropdown-item-indicator-start">

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -8,3 +8,4 @@ export {ClayPortal} from './Portal';
 export {useKeyHandlerForList} from './useKeyHandlerForList';
 export {useDebounce} from './useDebounce';
 export {useTransitionHeight} from './useTransitionHeight';
+export {useFocusManagement} from './useFocusManagement';

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -1,0 +1,247 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useEffect, useRef} from 'react';
+
+type FocusManager = {
+	identifier: string;
+	portal?: boolean;
+	value: HTMLElement;
+};
+
+const TAB_KEY_CODE = 9;
+const FOCUSABLE_ELEMENTS = [
+	'a[href]',
+	'[contenteditable]',
+	'[tabindex]:not([tabindex^="-"])',
+	'area[href]',
+	'button:not([disabled]):not([aria-hidden])',
+	'embed',
+	'iframe',
+	'input:not([disabled]):not([type="hidden"]):not([aria-hidden])',
+	'object',
+	'select:not([disabled]):not([aria-hidden])',
+	'textarea:not([disabled]):not([aria-hidden])',
+];
+
+export function useFocusManagement(loop: boolean = false) {
+	const focusManagerRef = useRef<Array<FocusManager>>([]);
+	const lastPositionRef = useRef<number | null>(null);
+	const nextElementOutsideScopeRef = useRef<HTMLElement | null>(null);
+
+	const createScope = (
+		ref: any,
+		identifier: string,
+		portal: boolean = false
+	) => {
+		const elementIndex = focusManagerRef.current.findIndex(
+			el => (el && el.identifier) === identifier
+		);
+		const schema = {
+			identifier,
+			portal,
+			value: ref,
+		};
+
+		if (ref) {
+			if (elementIndex === -1) {
+				focusManagerRef.current.push(schema);
+			} else {
+				focusManagerRef.current[elementIndex] = schema;
+			}
+		} else {
+			if (lastPositionRef.current !== null) {
+				lastPositionRef.current = 0;
+			}
+			focusManagerRef.current.splice(elementIndex, 1);
+		}
+	};
+
+	const getFocusableElementOutsideScope = (
+		element: HTMLElement,
+		backwards: boolean
+	) => {
+		const firstElement = element;
+
+		element = element.parentNode as HTMLElement;
+
+		const match = () => {
+			if (!element || element.nodeType !== 1) {
+				return false;
+			}
+
+			const focusableElements = Array.prototype.slice.call(
+				element.querySelectorAll(FOCUSABLE_ELEMENTS as any)
+			);
+			const activeElementFocus = focusableElements.findIndex(
+				el => el === firstElement
+			);
+			const item = backwards
+				? activeElementFocus - 1
+				: activeElementFocus + 1;
+
+			if (focusableElements[item]) {
+				element = focusableElements[item];
+
+				return true;
+			}
+
+			return false;
+		};
+
+		while (element && !match()) {
+			element = element.parentNode as HTMLElement;
+		}
+
+		return element;
+	};
+
+	const getElementOutsidePortal = (element: FocusManager) => {
+		while (element && !element.portal === false) {
+			const index = focusManagerRef.current.findIndex(
+				el => el.identifier === element.identifier
+			);
+			element = focusManagerRef.current[index - 1];
+		}
+
+		return element;
+	};
+
+	const handleNextElementOutsideScope = (event: KeyboardEvent) => {
+		if (event.keyCode === TAB_KEY_CODE && event.shiftKey) {
+			event.preventDefault();
+			lastPositionRef.current = focusManagerRef.current.length;
+			moveFocusInScope(true);
+		}
+	};
+
+	const moveFocusInScope = (
+		backwards: boolean = false,
+		sequence: number = 0
+	) => {
+		const size = focusManagerRef.current.length - 1;
+		const activeNode = document.activeElement;
+		const firstPosition = lastPositionRef.current === 0;
+		const endPosition =
+			lastPositionRef.current !== null &&
+			size === lastPositionRef.current;
+		const firstPositionOrNullWithMoveBackwards =
+			(lastPositionRef.current === null || firstPosition) && backwards;
+		const endPositionWithMoveForward = endPosition && !backwards;
+
+		// Get the parent elements or focusable children of the
+		// non-portal element to move focus.
+		if (
+			!loop &&
+			(firstPositionOrNullWithMoveBackwards || endPositionWithMoveForward)
+		) {
+			const elementOutsidePortal = getElementOutsidePortal(
+				focusManagerRef.current[
+					firstPosition || lastPositionRef.current === null ? 0 : size
+				]
+			);
+			const elementOutsideScope = getFocusableElementOutsideScope(
+				elementOutsidePortal.value,
+				backwards
+			);
+
+			// If can not find some element that is focusable in the DOM,
+			// continue with the focus loop.
+			if (
+				elementOutsideScope &&
+				(elementOutsideScope as any) !== document &&
+				focusManagerRef.current.findIndex(
+					el => el.value === elementOutsideScope
+				) === -1
+			) {
+				elementOutsideScope.focus();
+				lastPositionRef.current = null;
+
+				// Control the tab + shift keydown of the element next to the scopo to
+				// return the focus to the last scopo element, this is necessary for
+				// when have React Portal.
+				if (!backwards) {
+					if (
+						nextElementOutsideScopeRef.current !== null &&
+						nextElementOutsideScopeRef.current !==
+							elementOutsideScope
+					) {
+						nextElementOutsideScopeRef.current.removeEventListener(
+							'keydown',
+							handleNextElementOutsideScope
+						);
+					}
+
+					elementOutsideScope.addEventListener(
+						'keydown',
+						handleNextElementOutsideScope
+					);
+					nextElementOutsideScopeRef.current = elementOutsideScope;
+				}
+
+				return null;
+			}
+		}
+
+		if (
+			lastPositionRef.current === null ||
+			(firstPosition && backwards) ||
+			endPositionWithMoveForward
+		) {
+			if (backwards) {
+				lastPositionRef.current = size;
+			} else {
+				lastPositionRef.current =
+					activeNode === focusManagerRef.current[0].value ? 1 : 0;
+			}
+		} else {
+			lastPositionRef.current = backwards
+				? lastPositionRef.current - 1
+				: lastPositionRef.current + 1;
+		}
+
+		const {value} = focusManagerRef.current[lastPositionRef.current];
+
+		// Hack to check if element is visible
+		if (!value.offsetParent) {
+			// Prevent falling into an infinite loop. It's rare but it could happen.
+			if (sequence !== size) {
+				moveFocusInScope(backwards, sequence + 1);
+			}
+		} else {
+			value.focus();
+		}
+	};
+
+	// Should reset the last positon when any click on the screen occurs.
+	const handleDocumentClick = () => {
+		if (lastPositionRef.current !== null) {
+			lastPositionRef.current = null;
+		}
+	};
+
+	useEffect(() => {
+		document.addEventListener('click', handleDocumentClick);
+
+		return () => {
+			document.removeEventListener('click', handleDocumentClick);
+			focusManagerRef.current = [];
+			if (nextElementOutsideScopeRef.current) {
+				nextElementOutsideScopeRef.current.removeEventListener(
+					'keydown',
+					handleNextElementOutsideScope
+				);
+				nextElementOutsideScopeRef.current = null;
+			}
+		};
+	}, []);
+
+	return {
+		createScope,
+		focusNext: () => moveFocusInScope(),
+		focusPrevious: () => moveFocusInScope(true),
+	};
+}


### PR DESCRIPTION
Fixes #1987

This is a draft from a focus manager, possibly a substitute for `useKeyHandlerForList`, which may cover more cases in Modal, DropDown and perhaps DatePicker. I have taken as a basis the initial and experimental implementation of the FocusManager API (https://github.com/facebook/react/pull/15849) that may be acceptable.

In terms of design the use of `createScope` becomes more feasible to dribble element problems in React Portal, I tried to do the same as FocusManager API in having a `FocusScope` but here I only have access to DOM elements and not the fibers that would become easier but I want to hear other ideas.