### PR TITLE
docs(clay-badge/README/package.json): changed displyType error to dan…

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To contribute to the documentation and the site in general, you can try to run l
 1. Move to the site folder
 
 ```
-cd clayui.com
+cd next.clayui.com
 ```
 
 2. Install dependencies:

--- a/next.clayui.com/src/components/clay/Badge.js
+++ b/next.clayui.com/src/components/clay/Badge.js
@@ -18,7 +18,7 @@ const BadgeCode = `const Component = () => {
             <ClayBadge displayType="secondary" label="100" />
             <ClayBadge displayType="info" label="100" />
             <ClayBadge displayType="warning" label="100" />
-            <ClayBadge displayType="error" label="100" />
+            <ClayBadge displayType="danger" label="100" />
         </>
 	);
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"lint": "eslint '**/*.{js,ts,tsx}'",
 		"prettier": "prettier-eslint '**/*.{js,ts,tsx}'",
 		"test": "jest",
-		"site": "cd clayui.com && npm run build && npm run serve",
+		"site": "cd next.clayui.com && npm run build && npm run serve",
 		"storybook": "start-storybook -p 8888",
 		"storybook:build": "build-storybook -c .storybook -o .storybook-static"
 	},

--- a/packages/clay-badge/src/index.tsx
+++ b/packages/clay-badge/src/index.tsx
@@ -10,7 +10,7 @@ type DisplayType =
 	| 'primary'
 	| 'secondary'
 	| 'info'
-	| 'error'
+	| 'danger'
 	| 'success'
 	| 'warning';
 

--- a/packages/clay-badge/stories/index.tsx
+++ b/packages/clay-badge/stories/index.tsx
@@ -15,7 +15,7 @@ storiesOf('ClayBadge', module).add('default', () => (
 			select(
 				'Display Type',
 				{
-					error: 'error',
+					danger: 'danger',
 					info: 'info',
 					primary: 'primary',
 					secondary: 'secondary',


### PR DESCRIPTION
…ger in the clay-badge component and update its related documentation. Updated package.json `site` script in the root folder from **cd clayui.com..**. to **cd next.clayui.com...** . Updated README file.

To fix : [#2202](https://github.com/liferay/clay/issues/2202#issue-469338113)

There is a test failing in the base master branch, see screenshot below:

![image](https://user-images.githubusercontent.com/11823457/61424328-7973f680-a8e9-11e9-84f1-be1d64fe483d.png)
