### PR TITLE
refactor(@clayui/pagination): remove low-level components from DropDown and use ClayDropDownWithBasicItems

### DIFF
--- a/packages/clay-drop-down/src/DropDownWithBasicItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithBasicItems.tsx
@@ -13,12 +13,20 @@ interface IItem {
 	href?: string;
 	label?: string;
 	type?: 'divider';
-	onClick?: () => void;
+	onClick?: (
+		event: React.MouseEvent<
+			HTMLSpanElement | HTMLButtonElement | HTMLAnchorElement,
+			MouseEvent
+		>,
+		item: IItem
+	) => void;
 	symbolRight?: string;
 	symbolLeft?: string;
 }
 
 interface IProps {
+	className?: string;
+
 	/**
 	 * List of items to display in drop down menu
 	 */
@@ -37,6 +45,7 @@ const ARROW_UP_KEY_CODE = 38;
 const ARROW_DOWN_KEY_CODE = 40;
 
 export const ClayDropDownWithBasicItems: React.FunctionComponent<IProps> = ({
+	className,
 	items,
 	spritemap,
 	trigger,
@@ -68,6 +77,7 @@ export const ClayDropDownWithBasicItems: React.FunctionComponent<IProps> = ({
 	return (
 		<ClayDropDown
 			active={active}
+			className={className}
 			hasLeftSymbols={hasLeftSymbols}
 			hasRightSymbols={hasRightSymbols}
 			onActiveChange={(newVal: boolean) => setActive(newVal)}
@@ -77,7 +87,7 @@ export const ClayDropDownWithBasicItems: React.FunctionComponent<IProps> = ({
 			})}
 		>
 			<ClayDropDown.ItemList>
-				{items.map((item: IItem, i: number) => {
+				{items.map(({onClick, ...item}: IItem, i: number) => {
 					if (item.type === 'divider') {
 						return <ClayDropDown.Divider key={i} />;
 					}
@@ -88,6 +98,11 @@ export const ClayDropDownWithBasicItems: React.FunctionComponent<IProps> = ({
 								focusManager.createScope(ref, `item${i}`, true)
 							}
 							key={i}
+							onClick={
+								onClick
+									? event => onClick(event, item)
+									: undefined
+							}
 							spritemap={spritemap}
 							{...item}
 						>

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -9,7 +9,9 @@ import ClayIcon from '@clayui/icon';
 import React from 'react';
 
 interface IProps
-	extends React.HTMLAttributes<HTMLSpanElement | HTMLAnchorElement> {
+	extends React.HTMLAttributes<
+		HTMLSpanElement | HTMLButtonElement | HTMLAnchorElement
+	> {
 	/**
 	 * Flag that indicates if item is selected.
 	 */

--- a/packages/clay-pagination/src/PaginationWithBar.tsx
+++ b/packages/clay-pagination/src/PaginationWithBar.tsx
@@ -6,26 +6,28 @@
 
 import classNames from 'classnames';
 import ClayButton from '@clayui/button';
-import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayPagination from './index';
 import React, {useState} from 'react';
+import {ClayDropDownWithBasicItems} from '@clayui/drop-down';
 import {noop, sub} from '@clayui/shared';
 
 const defaultDeltas = [
 	{
-		value: 10,
+		label: 10,
 	},
 	{
-		value: 20,
+		label: 20,
 	},
 	{
-		value: 30,
+		label: 30,
 	},
 	{
-		value: 50,
+		label: 50,
 	},
 ];
+
+type Items = React.ComponentProps<typeof ClayDropDownWithBasicItems>['items'];
 
 interface IDelta {
 	/**
@@ -34,9 +36,9 @@ interface IDelta {
 	href?: string;
 
 	/**
-	 * Value of the delta
+	 * Label of the delta
 	 */
-	value: number;
+	label: number;
 }
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -132,9 +134,31 @@ export const ClayPaginationWithBar: React.FunctionComponent<IProps> = ({
 	totalItems,
 	...otherProps
 }: IProps) => {
-	const [active, setActive] = useState<boolean>(false);
 	const [activePage, setActivePage] = useState<number>(initialActivePage);
-	const [perPage, setPerPage] = useState<number>(initialSelectedDelta.value);
+	const [perPage, setPerPage] = useState<number>(
+		initialSelectedDelta.label as number
+	);
+	const items: Items = deltas.map(({href, label}) => {
+		const item: {
+			href?: string;
+			label?: string;
+			onClick?: () => void;
+		} = {
+			href,
+			label: sub(labels.selectPerPageItems, [String(label)]),
+		};
+
+		if (!href) {
+			item.onClick = () => {
+				setPerPage(label as number);
+				if (onDeltaChange) {
+					onDeltaChange(label as number);
+				}
+			};
+		}
+
+		return item;
+	});
 
 	return (
 		<div
@@ -143,10 +167,9 @@ export const ClayPaginationWithBar: React.FunctionComponent<IProps> = ({
 			})}
 			{...otherProps}
 		>
-			<ClayDropDown
-				active={active}
+			<ClayDropDownWithBasicItems
 				className="pagination-items-per-page"
-				onActiveChange={newVal => setActive(newVal)}
+				items={items}
 				trigger={
 					<ClayButton
 						data-testid="selectPaginationBar"
@@ -159,29 +182,7 @@ export const ClayPaginationWithBar: React.FunctionComponent<IProps> = ({
 						/>
 					</ClayButton>
 				}
-			>
-				<ClayDropDown.ItemList>
-					{deltas.map(({href, value}: IDelta, i: number) => (
-						<ClayDropDown.Item
-							data-testid={`dropdownItem${i}`}
-							href={href}
-							key={`dropdownItem${i}`}
-							onClick={
-								href
-									? undefined
-									: () => {
-											setPerPage(value);
-											if (onDeltaChange) {
-												onDeltaChange(value);
-											}
-									  }
-							}
-						>
-							{sub(labels.selectPerPageItems, [String(value)])}
-						</ClayDropDown.Item>
-					))}
-				</ClayDropDown.ItemList>
-			</ClayDropDown>
+			/>
 
 			<div className="pagination-results">
 				{sub(labels.paginationResults, [

--- a/packages/clay-pagination/src/__tests__/index.tsx
+++ b/packages/clay-pagination/src/__tests__/index.tsx
@@ -6,13 +6,7 @@
 
 import ClayPagination, {ClayPaginationWithBar} from '..';
 import React from 'react';
-import {
-	cleanup,
-	fireEvent,
-	getByTestId,
-	getByText,
-	render,
-} from '@testing-library/react';
+import {cleanup, fireEvent, getByText, render} from '@testing-library/react';
 
 const spritemap = 'path/to/spritemap';
 
@@ -48,7 +42,7 @@ describe('ClayPagination', () => {
 	it('calls onPageChange when arrow is clicked', () => {
 		const changeMock = jest.fn();
 
-		const {container} = render(
+		const {getByTestId} = render(
 			<ClayPagination
 				activePage={12}
 				onPageChange={changeMock}
@@ -57,17 +51,11 @@ describe('ClayPagination', () => {
 			/>
 		);
 
-		fireEvent.click(
-			getByTestId(container, 'prevArrow') as HTMLButtonElement,
-			{}
-		);
+		fireEvent.click(getByTestId('prevArrow'), {});
 
 		expect(changeMock).toHaveBeenLastCalledWith(11);
 
-		fireEvent.click(
-			getByTestId(container, 'nextArrow') as HTMLButtonElement,
-			{}
-		);
+		fireEvent.click(getByTestId('nextArrow'), {});
 
 		expect(changeMock).toHaveBeenLastCalledWith(13);
 	});
@@ -75,7 +63,7 @@ describe('ClayPagination', () => {
 	it('calls onPageChange when individual page is clicked', () => {
 		const changeMock = jest.fn();
 
-		const {container} = render(
+		const {getByText} = render(
 			<ClayPagination
 				activePage={12}
 				onPageChange={changeMock}
@@ -84,7 +72,7 @@ describe('ClayPagination', () => {
 			/>
 		);
 
-		fireEvent.click(getByText(container, '25') as HTMLElement, {});
+		fireEvent.click(getByText('25'), {});
 
 		expect(changeMock).toHaveBeenLastCalledWith(25);
 	});
@@ -108,7 +96,7 @@ describe('ClayPagination', () => {
 	it('calls onPageChange when an item is clicked in dropdown-menu', () => {
 		const changeMock = jest.fn();
 
-		const {getAllByText} = render(
+		const {getAllByText, getByTestId} = render(
 			<ClayPagination
 				activePage={12}
 				onPageChange={changeMock}
@@ -119,10 +107,7 @@ describe('ClayPagination', () => {
 
 		fireEvent.click(getAllByText('...')[0] as HTMLElement, {});
 
-		fireEvent.click(
-			getByTestId(document.body, 'testId4') as HTMLElement,
-			{}
-		);
+		fireEvent.click(getByTestId('testId4'), {});
 
 		expect(changeMock).toHaveBeenLastCalledWith(4);
 	});
@@ -142,7 +127,7 @@ describe('ClayPaginationWithBar', () => {
 	it('calls onPageChange when arrow is clicked', () => {
 		const changeMock = jest.fn();
 
-		const {container} = render(
+		const {getByTestId} = render(
 			<ClayPaginationWithBar
 				initialActivePage={12}
 				onPageChange={changeMock}
@@ -151,17 +136,11 @@ describe('ClayPaginationWithBar', () => {
 			/>
 		);
 
-		fireEvent.click(
-			getByTestId(container, 'prevArrow') as HTMLButtonElement,
-			{}
-		);
+		fireEvent.click(getByTestId('prevArrow'), {});
 
 		expect(changeMock).toHaveBeenLastCalledWith(11);
 
-		fireEvent.click(
-			getByTestId(container, 'nextArrow') as HTMLButtonElement,
-			{}
-		);
+		fireEvent.click(getByTestId('nextArrow'), {});
 
 		expect(changeMock).toHaveBeenLastCalledWith(12);
 	});
@@ -169,7 +148,7 @@ describe('ClayPaginationWithBar', () => {
 	it('calls onDeltaChange when select is expanded', () => {
 		const deltaChangeMock = jest.fn();
 
-		const {container} = render(
+		const {getByTestId} = render(
 			<ClayPaginationWithBar
 				initialActivePage={12}
 				onDeltaChange={deltaChangeMock}
@@ -178,24 +157,15 @@ describe('ClayPaginationWithBar', () => {
 			/>
 		);
 
-		fireEvent.click(
-			getByTestId(container, 'selectPaginationBar') as HTMLButtonElement,
-			{}
-		);
+		fireEvent.click(getByTestId('selectPaginationBar'), {});
 
-		fireEvent.click(
-			getByTestId(
-				window.document.documentElement,
-				'dropdownItem1'
-			) as HTMLButtonElement,
-			{}
-		);
+		fireEvent.click(getByText(document.body, '20 items'), {});
 
 		expect(deltaChangeMock).toHaveBeenLastCalledWith(20);
 	});
 
 	it('shows dropdown when pagination dropdown is clicked', () => {
-		const {container} = render(
+		const {getByTestId} = render(
 			<ClayPaginationWithBar
 				initialActivePage={12}
 				spritemap={spritemap}
@@ -203,10 +173,7 @@ describe('ClayPaginationWithBar', () => {
 			/>
 		);
 
-		fireEvent.click(
-			getByTestId(container, 'selectPaginationBar') as HTMLElement,
-			{}
-		);
+		fireEvent.click(getByTestId('selectPaginationBar'), {});
 
 		expect(
 			document.body.querySelector('.dropdown-menu')!.classList

--- a/packages/clay-pagination/stories/index.tsx
+++ b/packages/clay-pagination/stories/index.tsx
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 import '@clayui/css/lib/css/atlas.css';
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
@@ -167,17 +168,17 @@ storiesOf('ClayPagination', module)
 		const deltas = [
 			{
 				href: '#1',
-				value: 1,
+				label: 1,
 			},
 			{
-				value: 2,
+				label: 2,
 			},
 			{
 				href: '#3',
-				value: 3,
+				label: 3,
 			},
 			{
-				value: 4,
+				label: 4,
 			},
 		];
 


### PR DESCRIPTION
This will probably conflict with #2223, but do not need to enter to `milestone.2` now. We have to always try to use `ClayDropDownWithBasicItems` and when we can't have to add `useFocusManagement` hook we should do the same for the other components that are using DropDown.