### PR TITLE
refactor: add useFocusManagement to components and create FocusScope

### DIFF
--- a/packages/clay-form/src/__tests__/InputWithAutocomplete.tsx
+++ b/packages/clay-form/src/__tests__/InputWithAutocomplete.tsx
@@ -9,13 +9,9 @@ import {ClayInputWithAutocomplete} from '../InputWithAutocomplete';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 
 describe('InputWithAutocomplete', () => {
-	beforeAll(() => {
-		Element.prototype.scrollIntoView = jest.fn();
-	});
-
 	afterEach(cleanup);
 
-	it('hitting down arrow and then hitting enter calls onItemSelect', () => {
+	it('hitting enter calls onItemSelect', () => {
 		const itemSelectFn = jest.fn();
 		const valueChangeFn = jest.fn();
 
@@ -37,7 +33,7 @@ describe('InputWithAutocomplete', () => {
 		);
 
 		fireEvent.keyDown(
-			container.querySelector('input') as HTMLInputElement,
+			document.querySelector('.dropdown-item') as HTMLButtonElement,
 			{
 				keyCode: 13,
 			}

--- a/packages/clay-form/src/__tests__/__snapshots__/MultiSelect.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/MultiSelect.tsx.snap
@@ -12,6 +12,7 @@ exports[`ClayMultiSelect renders 1`] = `
     >
       <div
         className="form-control form-control-tag-group"
+        onKeyDown={[Function]}
       >
         <input
           className="form-control-inset"
@@ -41,6 +42,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
     >
       <div
         className="form-control form-control-tag-group"
+        onKeyDown={[Function]}
       >
         <span
           className="label label-dismissible label-secondary"
@@ -178,6 +180,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
     >
       <div
         className="form-control form-control-tag-group"
+        onKeyDown={[Function]}
       >
         <span
           className="label label-dismissible label-secondary"

--- a/packages/clay-multi-step-nav/src/Indicator.tsx
+++ b/packages/clay-multi-step-nav/src/Indicator.tsx
@@ -13,6 +13,8 @@ interface IProps {
 	 */
 	complete?: boolean;
 
+	innerRef?: React.Ref<HTMLButtonElement>;
+
 	/**
 	 * Value to display above step icon
 	 */
@@ -35,17 +37,21 @@ interface IProps {
 }
 
 const ClayMultiStepNavIndicator = React.forwardRef<HTMLDivElement, IProps>(
-	({complete, label, onClick, spritemap, subTitle}, ref) => (
+	({complete, innerRef, label, onClick, spritemap, subTitle}, ref) => (
 		<div className="multi-step-indicator" ref={ref}>
 			{subTitle && (
 				<div className="multi-step-indicator-label">{subTitle}</div>
 			)}
 
-			<span className="multi-step-icon" onClick={onClick}>
+			<button
+				className="multi-step-icon"
+				onClick={onClick}
+				ref={innerRef}
+			>
 				{complete && <ClayIcon spritemap={spritemap} symbol="check" />}
 
 				{!complete && label}
-			</span>
+			</button>
 		</div>
 	)
 );

--- a/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
+++ b/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
@@ -50,17 +50,16 @@ interface IProps extends React.ComponentProps<typeof ClayMultiStepNav> {
 
 const MAX_STEPS_SHOWN = 7;
 
-const IndicatorWithInnerRef = React.forwardRef<
-	HTMLButtonElement,
-	any
->(({spritemap, ...otherProps}, ref) => (
-	<ClayMultiStepNav.Indicator
-		{...otherProps}
-		innerRef={ref}
-		label="..."
-		spritemap={spritemap}
-	/>
-));
+const IndicatorWithInnerRef = React.forwardRef<HTMLButtonElement, any>(
+	({spritemap, ...otherProps}, ref) => (
+		<ClayMultiStepNav.Indicator
+			{...otherProps}
+			innerRef={ref}
+			label="..."
+			spritemap={spritemap}
+		/>
+	)
+);
 
 export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<
 	IProps

--- a/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
+++ b/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
@@ -50,6 +50,18 @@ interface IProps extends React.ComponentProps<typeof ClayMultiStepNav> {
 
 const MAX_STEPS_SHOWN = 7;
 
+const IndicatorWithInnerRef = React.forwardRef<
+	HTMLButtonElement,
+	any
+>(({spritemap, ...otherProps}, ref) => (
+	<ClayMultiStepNav.Indicator
+		{...otherProps}
+		innerRef={ref}
+		label="..."
+		spritemap={spritemap}
+	/>
+));
+
 export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<
 	IProps
 > = ({
@@ -130,12 +142,7 @@ export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<
 						<ClayDropDownWithBasicItems
 							items={dropdownItems}
 							spritemap={spritemap}
-							trigger={
-								<ClayMultiStepNav.Indicator
-									label="..."
-									spritemap={spritemap}
-								/>
-							}
+							trigger={<IndicatorWithInnerRef />}
 						/>
 					</ClayMultiStepNav.Item>
 

--- a/packages/clay-multi-step-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-step-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -24,7 +24,7 @@ exports[`ClayMultiStepNav activates step on click 1`] = `
         >
           SubOne
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           <svg
@@ -35,7 +35,7 @@ exports[`ClayMultiStepNav activates step on click 1`] = `
               xlink:href="/foo/bar#check"
             />
           </svg>
-        </span>
+        </button>
       </div>
     </li>
     <li
@@ -57,7 +57,7 @@ exports[`ClayMultiStepNav activates step on click 1`] = `
         >
           SubTwo
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           <svg
@@ -68,7 +68,7 @@ exports[`ClayMultiStepNav activates step on click 1`] = `
               xlink:href="/foo/bar#check"
             />
           </svg>
-        </span>
+        </button>
       </div>
     </li>
     <li
@@ -90,11 +90,11 @@ exports[`ClayMultiStepNav activates step on click 1`] = `
         >
           SubThree
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           3
-        </span>
+        </button>
       </div>
     </li>
     <li
@@ -116,11 +116,11 @@ exports[`ClayMultiStepNav activates step on click 1`] = `
         >
           SubFour
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           4
-        </span>
+        </button>
       </div>
     </li>
   </ol>
@@ -151,7 +151,7 @@ exports[`ClayMultiStepNav renders 1`] = `
         >
           SubOne
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           <svg
@@ -162,7 +162,7 @@ exports[`ClayMultiStepNav renders 1`] = `
               xlink:href="/foo/bar#check"
             />
           </svg>
-        </span>
+        </button>
       </div>
     </li>
     <li
@@ -184,11 +184,11 @@ exports[`ClayMultiStepNav renders 1`] = `
         >
           SubTwo
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           2
-        </span>
+        </button>
       </div>
     </li>
     <li
@@ -210,11 +210,11 @@ exports[`ClayMultiStepNav renders 1`] = `
         >
           SubThree
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           3
-        </span>
+        </button>
       </div>
     </li>
     <li
@@ -236,11 +236,11 @@ exports[`ClayMultiStepNav renders 1`] = `
         >
           SubFour
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           4
-        </span>
+        </button>
       </div>
     </li>
   </ol>
@@ -271,11 +271,11 @@ exports[`ClayMultiStepNavWithBasicItems renders 1`] = `
         >
           SubOne
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           1
-        </span>
+        </button>
       </div>
     </li>
     <li
@@ -297,11 +297,11 @@ exports[`ClayMultiStepNavWithBasicItems renders 1`] = `
         >
           SubTwo
         </div>
-        <span
+        <button
           class="multi-step-icon"
         >
           2
-        </span>
+        </button>
       </div>
     </li>
   </ol>

--- a/packages/clay-navigation/src/BreadcrumbEllipsis.tsx
+++ b/packages/clay-navigation/src/BreadcrumbEllipsis.tsx
@@ -7,6 +7,7 @@ import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import React, {useState} from 'react';
+import {FocusScope, useFocusManagement} from '@clayui/shared';
 import {IBreadcrumbItem} from './BreadcrumbItem';
 
 export interface IBreadcrumbEllipsisProps {
@@ -25,37 +26,44 @@ export const BreadcrumbEllipsis: React.FunctionComponent<
 	IBreadcrumbEllipsisProps
 > = ({items, spritemap, ...otherProps}) => {
 	const [active, setActive] = useState(false);
+	const focusManager = useFocusManagement();
 
 	return (
-		<ClayDropDown
-			active={active}
-			className="breadcrumb-item"
-			containerElement="li"
-			onActiveChange={newVal => setActive(newVal)}
-			trigger={
-				<ClayButton
-					className="breadcrumb-link"
-					data-testid="breadcrumbDropdownTrigger"
-					displayType="unstyled"
-				>
-					<ClayIcon spritemap={spritemap} symbol="ellipsis-h" />
-					<ClayIcon spritemap={spritemap} symbol="caret-bottom" />
-				</ClayButton>
-			}
-			{...otherProps}
-		>
-			<ClayDropDown.ItemList>
-				{items.map(({href, label, onClick}, i) => (
-					<ClayDropDown.Item
-						href={href}
-						key={`breadcrumbEllipsisItem${i}`}
-						onClick={onClick}
-						title={label}
+		<FocusScope focusManager={focusManager}>
+			<ClayDropDown
+				active={active}
+				className="breadcrumb-item"
+				containerElement="li"
+				onActiveChange={newVal => setActive(newVal)}
+				trigger={
+					<ClayButton
+						className="breadcrumb-link"
+						data-testid="breadcrumbDropdownTrigger"
+						displayType="unstyled"
+						ref={ref => focusManager.createScope(ref, 'input')}
 					>
-						{label}
-					</ClayDropDown.Item>
-				))}
-			</ClayDropDown.ItemList>
-		</ClayDropDown>
+						<ClayIcon spritemap={spritemap} symbol="ellipsis-h" />
+						<ClayIcon spritemap={spritemap} symbol="caret-bottom" />
+					</ClayButton>
+				}
+				{...otherProps}
+			>
+				<ClayDropDown.ItemList>
+					{items.map(({href, label, onClick}, i) => (
+						<ClayDropDown.Item
+							href={href}
+							innerRef={ref =>
+								focusManager.createScope(ref, `item${i}`, true)
+							}
+							key={`breadcrumbEllipsisItem${i}`}
+							onClick={onClick}
+							title={label}
+						>
+							{label}
+						</ClayDropDown.Item>
+					))}
+				</ClayDropDown.ItemList>
+			</ClayDropDown>
+		</FocusScope>
 	);
 };

--- a/packages/clay-pagination/src/PaginationEllipsis.tsx
+++ b/packages/clay-pagination/src/PaginationEllipsis.tsx
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import ClayButton from '@clayui/button';
-import ClayDropDown from '@clayui/drop-down';
-import React, {useState} from 'react';
+import React from 'react';
+import {ClayDropDownWithBasicItems} from '@clayui/drop-down';
 
 export interface IPaginationEllipsisProps {
 	items?: Array<number>;
@@ -16,40 +16,25 @@ export interface IPaginationEllipsisProps {
 
 const ClayPaginationEllipsis: React.FunctionComponent<
 	IPaginationEllipsisProps
-> = ({disabledPages = [], hrefConstructor, items, onPageChange}) => {
-	const [active, setActive] = useState(false);
+> = ({disabledPages = [], hrefConstructor, items = [], onPageChange}) => {
+	const pages = items.map(page => ({
+		disabled: disabledPages.includes(page),
+		href: hrefConstructor ? hrefConstructor(page) : 'javascript:;',
+		label: String(page),
+		onClick: () => onPageChange && onPageChange(page),
+	}));
 
 	return (
-		<ClayDropDown
-			active={active}
+		<ClayDropDownWithBasicItems
 			className="page-item"
 			containerElement="li"
-			onActiveChange={newVal => setActive(newVal)}
+			items={pages}
 			trigger={
 				<ClayButton className="page-link" displayType="unstyled">
 					{'...'}
 				</ClayButton>
 			}
-		>
-			<ClayDropDown.ItemList>
-				{items &&
-					items.map(page => (
-						<ClayDropDown.Item
-							data-testid={`testId${page}`}
-							disabled={disabledPages.includes(page)}
-							href={
-								hrefConstructor
-									? hrefConstructor(page)
-									: 'javascript:;'
-							}
-							key={page}
-							onClick={() => onPageChange && onPageChange(page)}
-						>
-							{page}
-						</ClayDropDown.Item>
-					))}
-			</ClayDropDown.ItemList>
-		</ClayDropDown>
+		/>
 	);
 };
 

--- a/packages/clay-pagination/src/__tests__/index.tsx
+++ b/packages/clay-pagination/src/__tests__/index.tsx
@@ -96,7 +96,7 @@ describe('ClayPagination', () => {
 	it('calls onPageChange when an item is clicked in dropdown-menu', () => {
 		const changeMock = jest.fn();
 
-		const {getAllByText, getByTestId} = render(
+		const {getAllByText} = render(
 			<ClayPagination
 				activePage={12}
 				onPageChange={changeMock}
@@ -107,7 +107,7 @@ describe('ClayPagination', () => {
 
 		fireEvent.click(getAllByText('...')[0] as HTMLElement, {});
 
-		fireEvent.click(getByTestId('testId4'), {});
+		fireEvent.click(getByText(document.body, '4') as HTMLAnchorElement, {});
 
 		expect(changeMock).toHaveBeenLastCalledWith(4);
 	});

--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -1,0 +1,53 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+import {useFocusManagement} from './useFocusManagement';
+
+interface IProps {
+	arrowKeys?: boolean;
+	focusManager: ReturnType<typeof useFocusManagement>;
+}
+
+const ARROW_DOWN_KEY_CODE = 40;
+const ARROW_UP_KEY_CODE = 38;
+const TAB_KEY_CODE = 9;
+
+export const FocusScope: React.FunctionComponent<IProps> = ({
+	arrowKeys = true,
+	children,
+	focusManager,
+}) => {
+	const onKeyDown = (event: React.KeyboardEvent<any>) => {
+		const {keyCode, shiftKey} = event;
+
+		if (
+			(arrowKeys && keyCode === ARROW_DOWN_KEY_CODE) ||
+			(keyCode === TAB_KEY_CODE && !shiftKey)
+		) {
+			event.preventDefault();
+			focusManager.focusNext();
+		} else if (
+			(arrowKeys && keyCode === ARROW_UP_KEY_CODE) ||
+			(keyCode === TAB_KEY_CODE && shiftKey)
+		) {
+			event.preventDefault();
+			focusManager.focusPrevious();
+		}
+	};
+
+	return React.cloneElement(children as React.FunctionComponentElement<any>, {
+		onKeyDown: (event: React.KeyboardEvent) => {
+			onKeyDown(event);
+
+			// If the element already exists a `onKeyDown` event should invoke it as well.
+			// Any here is because React interfaces do not expose what lies under the hood.
+			if ((children as any).props.onKeyDown) {
+				(children as any).props.onKeyDown(event);
+			}
+		},
+	});
+};

--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -8,7 +8,18 @@ import React from 'react';
 import {useFocusManagement} from './useFocusManagement';
 
 interface IProps {
+	/**
+	 * Flag that indicates if the focus will be controlled by the arrow keys.
+	 * Disabling means that it will still be controlled by tab and shift + tab.
+	 */
 	arrowKeys?: boolean;
+
+	children: React.ReactElement;
+
+	/**
+	 * Instance of `useFocusManagement` hook so FocusScope can control focus
+	 * via tab or arrow keys.
+	 */
 	focusManager: ReturnType<typeof useFocusManagement>;
 }
 
@@ -16,6 +27,13 @@ const ARROW_DOWN_KEY_CODE = 40;
 const ARROW_UP_KEY_CODE = 38;
 const TAB_KEY_CODE = 9;
 
+/**
+ * FocusScope is a component only for controlling focus and listening
+ * for children's key down events, since the component handles the `onKeyDown`
+ * event, the component has assumed that you have scoped all focusable items
+ * and should be controlled if only a part of your scope being added on
+ * `createScope` there may be problems of focus experience.
+ */
 export const FocusScope: React.FunctionComponent<IProps> = ({
 	arrowKeys = true,
 	children,
@@ -39,14 +57,14 @@ export const FocusScope: React.FunctionComponent<IProps> = ({
 		}
 	};
 
-	return React.cloneElement(children as React.FunctionComponentElement<any>, {
+	return React.cloneElement(children, {
 		onKeyDown: (event: React.KeyboardEvent) => {
 			onKeyDown(event);
 
-			// If the element already exists a `onKeyDown` event should invoke it as well.
-			// Any here is because React interfaces do not expose what lies under the hood.
-			if ((children as any).props.onKeyDown) {
-				(children as any).props.onKeyDown(event);
+			// If the element already exists a `onKeyDown` event should
+			// invoke it as well.
+			if (children.props.onKeyDown) {
+				children.props.onKeyDown(event);
 			}
 		},
 	});

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -12,3 +12,4 @@ export {useKeyHandlerForList} from './useKeyHandlerForList';
 export {useTransitionHeight} from './useTransitionHeight';
 export {useFocusManagement} from './useFocusManagement';
 export {sub} from './sub';
+export {FocusScope} from './FocusScope';

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -191,8 +191,10 @@ export function useFocusManagement(loop: boolean = false) {
 			if (backwards) {
 				lastPositionRef.current = size;
 			} else {
-				lastPositionRef.current =
-					activeNode === focusManagerRef.current[0].value ? 1 : 0;
+				// Causes interaction not to start from the first item in the queue
+				// and continues to focus regardless of where it is.
+				const activeElementIndex = focusManagerRef.current.findIndex(el => el.value === activeNode);
+				lastPositionRef.current = activeElementIndex !== -1 ? activeElementIndex + 1 : 0;
 			}
 		} else {
 			lastPositionRef.current = backwards

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -108,7 +108,11 @@ export function useFocusManagement(loop: boolean = false) {
 	};
 
 	const handleNextElementOutsideScope = (event: KeyboardEvent) => {
-		if (event.keyCode === TAB_KEY_CODE && event.shiftKey) {
+		if (
+			event.keyCode === TAB_KEY_CODE &&
+			event.shiftKey &&
+			focusManagerRef.current.length > 0
+		) {
 			event.preventDefault();
 			lastPositionRef.current = focusManagerRef.current.length;
 			moveFocusInScope(true);

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -53,9 +53,6 @@ export function useFocusManagement(loop: boolean = false) {
 				focusManagerRef.current[elementIndex] = schema;
 			}
 		} else {
-			if (lastPositionRef.current !== null) {
-				lastPositionRef.current = 0;
-			}
 			focusManagerRef.current.splice(elementIndex, 1);
 		}
 	};

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -193,12 +193,14 @@ export function useFocusManagement(loop: boolean = false) {
 			} else {
 				// Causes interaction not to start from the first item in the queue
 				// and continues to focus regardless of where it is.
-				const activeElementIndex = focusManagerRef.current.findIndex(el => el.value === activeNode);
+				const activeElementIndex = focusManagerRef.current.findIndex(
+					el => el.value === activeNode
+				);
 
 				// Fixes the last position, this can happen in cases where list
 				// elements have been deleted but the lastPosition has not been reset or when
 				// the active element is the last in the queue.
-				if ((activeElementIndex + 1) > size) {
+				if (activeElementIndex + 1 > size) {
 					// If there is no element outside the scope focusable,
 					// then go back to the beginning.
 					if (sequence === 1) {
@@ -212,7 +214,8 @@ export function useFocusManagement(loop: boolean = false) {
 						return;
 					}
 				} else {
-					lastPositionRef.current = activeElementIndex !== -1 ? activeElementIndex + 1 : 0;
+					lastPositionRef.current =
+						activeElementIndex !== -1 ? activeElementIndex + 1 : 0;
 				}
 			}
 		} else {


### PR DESCRIPTION
Fixes #2227

I ended up creating the `FocusScope` component that deals only with the logic of controlling focus with tab and arrow keys to minimize the logic we may have repeated between some components.

I also made some important improvements to `useFocusManagement` to cover cases that I just caught with our components (I added some comments to the code.).

I tried to force the use of the `ClayDropDownWithBasicItems` component in some cases which I found that it was not necessary to add a low-level component. Maybe we can force more elsewhere.

These changes are also in conjunction with #2224.