### PR TITLE
fix(tsconfig.json): consume clay packages from `node_modules` to correctly generate of the types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 		"allowJs": true,
 		"baseUrl": ".",
 		"paths": {
-			"@clayui/*": ["packages/clay-*/src"],
+			"@clayui/*": ["node_modules/@clayui/*/src"],
 			"*": ["custom-types/*", "node_modules/*", "packages/*"]
 		}
 	},


### PR DESCRIPTION
Fixes #2235

I just changed the `@clayui/*` package path so that typescript looks inside `node_modules`, so it does not consider that it should generate types at build time but will still look at them to make sure everything is fine.