### PR TITLE
refactor: remove an unnecessary cast

### DIFF
--- a/packages/clay-card/src/Description.tsx
+++ b/packages/clay-card/src/Description.tsx
@@ -33,7 +33,7 @@ const CARD_TYPE_ELEMENTS = {
 	subtitle: 'span',
 	text: 'div',
 	title: 'h3',
-};
+} as const;
 
 const ClayCardDescription: React.FunctionComponent<ICardDescriptionProps> = ({
 	children,
@@ -43,7 +43,7 @@ const ClayCardDescription: React.FunctionComponent<ICardDescriptionProps> = ({
 	truncate = true,
 	...otherProps
 }: ICardDescriptionProps) => {
-	const OuterTag = CARD_TYPE_ELEMENTS[displayType] as ('span' | 'div' | 'h3');
+	const OuterTag = CARD_TYPE_ELEMENTS[displayType];
 	const InnerTag = href ? 'a' : 'span';
 
 	return (


### PR DESCRIPTION
As described [here](https://github.com/liferay/clay/pull/2208#discussion_r310028803), we can use `as const` to prevent TypeScript from widening the type from the desired `'span' | 'div' | 'h3'` to `string`.