### PR TITLE
refactor: remove another cast

### DIFF
--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -50,7 +50,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement | HTMLLIElement> {
 	/**
 	 * Element that is used as the trigger which will activate the dropdown on click.
 	 */
-	trigger: React.ReactElement;
+	trigger: React.ReactElement & {ref?: (node: HTMLButtonElement | null) => void};
 }
 
 const ClayDropDown: React.FunctionComponent<IProps> & {
@@ -92,11 +92,7 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 				ref: (node: HTMLButtonElement) => {
 					triggerElementRef.current = node;
 					// Call the original ref, if any.
-					// Type is any because the React.ReactElement
-					// interface does not necessarily state that trigger
-					// will always be a fiber under the hood, so we have
-					// to declare any to get away from it.
-					const {ref} = trigger as any;
+					const {ref} = trigger;
 					if (typeof ref === 'function') {
 						ref(node);
 					}

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -50,7 +50,9 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement | HTMLLIElement> {
 	/**
 	 * Element that is used as the trigger which will activate the dropdown on click.
 	 */
-	trigger: React.ReactElement & {ref?: (node: HTMLButtonElement | null) => void};
+	trigger: React.ReactElement & {
+		ref?: (node: HTMLButtonElement | null) => void;
+	};
 }
 
 const ClayDropDown: React.FunctionComponent<IProps> & {


### PR DESCRIPTION
Noticed this while looking at: https://github.com/liferay/clay/pull/2223

This is perhaps a better fix than casting to `any`, which can hide legitimate errors.