### PR TITLE
chore(travis.yml): remove java usage in favor of nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ cache:
 install:
   - yarn
 
-jdk:
-  - oraclejdk8
+language: node_js
 
-language: java
+node_js:
+  - '10'
 
 script:
   - yarn run checkFormat


### PR DESCRIPTION
It is no longer necessary to use java since we no longer have Java dependencies as in v2.