### PR TITLE
feat(navigation): add Navigation.Vertical component

### DIFF
--- a/packages/clay-navigation/package.json
+++ b/packages/clay-navigation/package.json
@@ -26,6 +26,8 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/icon": "^3.0.0-milestone.2",
+		"@clayui/link": "^3.0.0-milestone.2",
 		"@clayui/shared": "^3.0.0-milestone.2",
 		"classnames": "^2.2.6"
 	},

--- a/packages/clay-navigation/src/Breadcrumb.tsx
+++ b/packages/clay-navigation/src/Breadcrumb.tsx
@@ -40,7 +40,7 @@ const findActiveItems = (items: Array<IBreadcrumbItem>) => {
 	});
 };
 
-export const Breadcrumb: React.FunctionComponent<IProps> = ({
+export const ClayBreadcrumbNav: React.FunctionComponent<IProps> = ({
 	className,
 	ellipsisBuffer = 1,
 	ellipsisProps = {},
@@ -50,7 +50,7 @@ export const Breadcrumb: React.FunctionComponent<IProps> = ({
 }: IProps) => {
 	warning(
 		findActiveItems(items).length === 1,
-		'ClayNavigation.Breadcrumb expects at least one `active` item on `items`.'
+		'ClayBreadcrumbNav expects at least one `active` item on `items`.'
 	);
 
 	const activeItems = findActiveItems(items);

--- a/packages/clay-navigation/src/Nav.tsx
+++ b/packages/clay-navigation/src/Nav.tsx
@@ -1,0 +1,49 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import classNames from 'classnames';
+import React from 'react';
+import {NavItem} from './NavItem';
+import {NavLink} from './NavLink';
+
+interface IProps extends React.HTMLAttributes<HTMLUListElement> {
+	/**
+	 * Flag to indicate if `nav-nested` class should be applied.
+	 */
+	nested?: boolean;
+
+	/**
+	 * Flag to indicate if `nav-nested-margins` class should be applied.
+	 */
+	nestMargins?: boolean;
+
+	/**
+	 * Flag to indicate if `nav-stacked` class should be applied.
+	 */
+	stacked?: boolean;
+}
+
+const Nav: React.FunctionComponent<IProps> & {
+	Item: typeof NavItem;
+	Link: typeof NavLink;
+} = ({children, className, nestMargins, nested, stacked, ...otherProps}) => {
+	return (
+		<ul
+			{...otherProps}
+			className={classNames('nav', className, {
+				['nav-nested']: nested,
+				['nav-nested-margins']: nestMargins,
+				['nav-stacked']: stacked,
+			})}
+		>
+			{children}
+		</ul>
+	);
+};
+
+Nav.Item = NavItem;
+Nav.Link = NavLink;
+
+export default Nav;

--- a/packages/clay-navigation/src/NavItem.tsx
+++ b/packages/clay-navigation/src/NavItem.tsx
@@ -1,0 +1,17 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import classNames from 'classnames';
+import React from 'react';
+
+export const NavItem: React.FunctionComponent<
+	React.HTMLAttributes<HTMLLIElement>
+> = ({children, className, ...otherProps}) => {
+	return (
+		<li {...otherProps} className={classNames('nav-item', className)}>
+			{children}
+		</li>
+	);
+};

--- a/packages/clay-navigation/src/NavLink.tsx
+++ b/packages/clay-navigation/src/NavLink.tsx
@@ -1,0 +1,76 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import classNames from 'classnames';
+import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
+import React from 'react';
+
+interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+	/**
+	 * Flag to indicate if `active` class should be applied.
+	 */
+	active?: boolean;
+
+	/**
+	 * Flag to indicate if `collapsed` class should be applied.
+	 */
+	collapsed?: boolean;
+
+	/**
+	 * Flag to indicate if icon should be shown.
+	 */
+	showIcon?: boolean;
+
+	/**
+	 * Path to the spritemap that Icon should use when referencing symbols.
+	 */
+	spritemap?: string;
+}
+
+export const NavLink: React.FunctionComponent<IProps> = ({
+	active,
+	children,
+	className,
+	collapsed,
+	showIcon,
+	spritemap,
+	...otherProps
+}) => {
+	return (
+		<ClayLink
+			{...otherProps}
+			className={classNames('nav-link', className, {
+				active,
+				['collapse-icon']: showIcon,
+				collapsed,
+			})}
+		>
+			{children}
+
+			{showIcon && (
+				<>
+					<span className="collapse-icon-closed">
+						<ClayIcon
+							focusable="false"
+							role="presentation"
+							spritemap={spritemap}
+							symbol="caret-right"
+						/>
+					</span>
+
+					<span className="collapse-icon-open">
+						<ClayIcon
+							focusable="false"
+							role="presentation"
+							spritemap={spritemap}
+							symbol="caret-bottom"
+						/>
+					</span>
+				</>
+			)}
+		</ClayLink>
+	);
+};

--- a/packages/clay-navigation/src/Vertical.tsx
+++ b/packages/clay-navigation/src/Vertical.tsx
@@ -1,0 +1,185 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import ClayIcon from '@clayui/icon';
+import Nav from './Nav';
+import React from 'react';
+import {useTransitionHeight} from '@clayui/shared';
+
+interface IItem {
+	/**
+	 * Flag to indicate if item is active.
+	 */
+	active?: boolean;
+
+	/**
+	 * Callback for when item is clicked.
+	 */
+	onClick?: () => void;
+
+	/**
+	 * Link href for item.
+	 */
+	href?: string;
+
+	/**
+	 * Value of item.
+	 */
+	label?: string;
+}
+
+interface IItemWithItems extends IItem {
+	/**
+	 * Flag to indicate if nested items are expanded and shown.
+	 */
+	initialExpanded?: boolean;
+
+	/**
+	 * List of nested items under current item.
+	 */
+	items?: Array<IItem>;
+}
+
+interface IProps {
+	/**
+	 * Label of item that is currently active.
+	 */
+	activeLabel: string;
+
+	/**
+	 * List of items.
+	 */
+	items: Array<IItemWithItems>;
+
+	/**
+	 * Flag to indicate if `menubar-vertical-expand-lg` class is applied.
+	 */
+	large?: IItemWithItems;
+
+	/**
+	 * Path to the spritemap that Icon should use when referencing symbols.
+	 */
+	spritemap?: string;
+}
+
+interface INavItemProps extends IItemWithItems {
+	/**
+	 * Integer to keep track of what nested level the item is.
+	 */
+	level: number;
+
+	/**
+	 * Path to the spritemap that Icon should use when referencing symbols.
+	 */
+	spritemap?: string;
+}
+
+function Item({
+	active,
+	href,
+	initialExpanded = false,
+	items: subItems,
+	label,
+	level,
+	spritemap,
+}: INavItemProps) {
+	const menuRef = React.useRef(null);
+	const [expanded, setExpaned] = React.useState(!initialExpanded);
+
+	const [
+		transitioning,
+		handleTransitionEnd,
+		handleClickToggler,
+	] = useTransitionHeight(expanded, setExpaned, menuRef);
+
+	const showIconCollapsed = !(
+		(!expanded && transitioning) ||
+		(expanded && !transitioning)
+	);
+
+	return (
+		<Nav.Item>
+			<Nav.Link
+				active={active}
+				collapsed={showIconCollapsed}
+				href={href}
+				onClick={e => {
+					handleClickToggler(e);
+				}}
+				role="button"
+				showIcon={!!subItems}
+				spritemap={spritemap}
+			>
+				{label}
+			</Nav.Link>
+
+			{subItems && (
+				<div
+					className={classNames({
+						collapse: !transitioning,
+						collapsing: transitioning,
+						show: expanded,
+					})}
+					onTransitionEnd={handleTransitionEnd}
+					ref={menuRef}
+				>
+					<Nav stacked>
+						{renderItems(subItems, spritemap, level++)}
+					</Nav>
+				</div>
+			)}
+		</Nav.Item>
+	);
+}
+
+function renderItems(items: Array<IItem>, spritemap?: string, level = 0) {
+	return items.map((item, i) => {
+		const key = `${level}-${i}`;
+
+		return <Item {...item} key={key} level={level} spritemap={spritemap} />;
+	});
+}
+
+export const ClayVerticalNav: React.FunctionComponent<IProps> = ({
+	activeLabel,
+	items,
+	large,
+	spritemap,
+}) => {
+	const [active, setActive] = React.useState(false);
+
+	return (
+		<nav
+			className={classNames('menubar menubar-transparent', {
+				['menubar-vertical-expand-lg']: large,
+				['menubar-vertical-expand-md']: !large,
+			})}
+		>
+			<button
+				className="menubar-toggler"
+				onClick={() => setActive(!active)}
+			>
+				{activeLabel}
+
+				<ClayIcon
+					focusable="false"
+					role="presentation"
+					spritemap={spritemap}
+					symbol="caret-bottom"
+				/>
+			</button>
+
+			<div
+				className={classNames('collapse menubar-collapse', {
+					show: active,
+				})}
+			>
+				<Nav nested>{renderItems(items, spritemap)}</Nav>
+			</div>
+		</nav>
+	);
+};

--- a/packages/clay-navigation/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,12 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClayNavigation renders 1`] = `
+exports[`ClayBreadcrumbNav calls callback when an item is clicked 1`] = `
 <div>
-  <div />
+  <ol
+    class="breadcrumb"
+  >
+    <li
+      class="breadcrumb-item active"
+    >
+      <span
+        class="breadcrumb-text-truncate"
+        data-testid="testId1"
+        title="1"
+      >
+        1
+      </span>
+    </li>
+    <li
+      class="breadcrumb-item"
+    >
+      <button
+        class="breadcrumb-link btn btn-unstyled"
+        data-testid="testId2"
+        title="2"
+        type="button"
+      >
+        <span
+          class="breadcrumb-text-truncate"
+        >
+          2
+        </span>
+      </button>
+    </li>
+    <li
+      class="dropdown breadcrumb-item"
+    >
+      <button
+        class="dropdown-toggle breadcrumb-link btn btn-unstyled"
+        data-testid="breadcrumbDropdownTrigger"
+        type="button"
+      >
+        <svg
+          class="lexicon-icon lexicon-icon-ellipsis-h"
+          role="presentation"
+        >
+          <use
+            xlink:href="path/to/spritemap#ellipsis-h"
+          />
+        </svg>
+        <svg
+          class="lexicon-icon lexicon-icon-caret-bottom"
+          role="presentation"
+        >
+          <use
+            xlink:href="path/to/spritemap#caret-bottom"
+          />
+        </svg>
+      </button>
+    </li>
+    <li
+      class="breadcrumb-item"
+    >
+      <button
+        class="breadcrumb-link btn btn-unstyled"
+        data-testid="testId5"
+        title="5"
+        type="button"
+      >
+        <span
+          class="breadcrumb-text-truncate"
+        >
+          5
+        </span>
+      </button>
+    </li>
+  </ol>
 </div>
 `;
 
-exports[`ClayNavigation renders a Breadcrumb 1`] = `
+exports[`ClayBreadcrumbNav renders 1`] = `
 <div>
   <ol
     class="breadcrumb"
@@ -84,7 +156,7 @@ exports[`ClayNavigation renders a Breadcrumb 1`] = `
 </div>
 `;
 
-exports[`ClayNavigation renders a Breadcrumb with properties passed by \`ellipsisProps\` 1`] = `
+exports[`ClayBreadcrumbNav renders with properties passed by \`ellipsisProps\` 1`] = `
 <div>
   <ol
     class="breadcrumb"
@@ -163,85 +235,7 @@ exports[`ClayNavigation renders a Breadcrumb with properties passed by \`ellipsi
 </div>
 `;
 
-exports[`ClayNavigation should emit an event when an item is clicked 1`] = `
-<div>
-  <ol
-    class="breadcrumb"
-  >
-    <li
-      class="breadcrumb-item active"
-    >
-      <span
-        class="breadcrumb-text-truncate"
-        data-testid="testId1"
-        title="1"
-      >
-        1
-      </span>
-    </li>
-    <li
-      class="breadcrumb-item"
-    >
-      <button
-        class="breadcrumb-link btn btn-unstyled"
-        data-testid="testId2"
-        title="2"
-        type="button"
-      >
-        <span
-          class="breadcrumb-text-truncate"
-        >
-          2
-        </span>
-      </button>
-    </li>
-    <li
-      class="dropdown breadcrumb-item"
-    >
-      <button
-        class="dropdown-toggle breadcrumb-link btn btn-unstyled"
-        data-testid="breadcrumbDropdownTrigger"
-        type="button"
-      >
-        <svg
-          class="lexicon-icon lexicon-icon-ellipsis-h"
-          role="presentation"
-        >
-          <use
-            xlink:href="path/to/spritemap#ellipsis-h"
-          />
-        </svg>
-        <svg
-          class="lexicon-icon lexicon-icon-caret-bottom"
-          role="presentation"
-        >
-          <use
-            xlink:href="path/to/spritemap#caret-bottom"
-          />
-        </svg>
-      </button>
-    </li>
-    <li
-      class="breadcrumb-item"
-    >
-      <button
-        class="breadcrumb-link btn btn-unstyled"
-        data-testid="testId5"
-        title="5"
-        type="button"
-      >
-        <span
-          class="breadcrumb-text-truncate"
-        >
-          5
-        </span>
-      </button>
-    </li>
-  </ol>
-</div>
-`;
-
-exports[`ClayNavigation should throw a warning when not passing \`active\` to any \`items\` on Breadcrumb 1`] = `
+exports[`ClayBreadcrumbNav throws a warning when not passing \`active\` to any \`items\` 1`] = `
 <div>
   <ol
     class="breadcrumb"
@@ -279,5 +273,101 @@ exports[`ClayNavigation should throw a warning when not passing \`active\` to an
       </a>
     </li>
   </ol>
+</div>
+`;
+
+exports[`ClayNavigation renders 1`] = `
+<div>
+  <ul
+    class="nav"
+  >
+    <div />
+  </ul>
+</div>
+`;
+
+exports[`ClayVerticalNav renders 1`] = `
+<div>
+  <nav
+    class="menubar menubar-transparent menubar-vertical-expand-md"
+  >
+    <button
+      class="menubar-toggler"
+    >
+      Home
+      <svg
+        class="lexicon-icon lexicon-icon-caret-bottom"
+        focusable="false"
+        role="presentation"
+      >
+        <use
+          xlink:href="/path/to#caret-bottom"
+        />
+      </svg>
+    </button>
+    <div
+      class="collapse menubar-collapse"
+    >
+      <ul
+        class="nav nav-nested"
+      >
+        <li
+          class="nav-item"
+        >
+          <a
+            class="nav-link collapse-icon"
+            role="button"
+          >
+            Home
+            <span
+              class="collapse-icon-closed"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-caret-right"
+                focusable="false"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/path/to#caret-right"
+                />
+              </svg>
+            </span>
+            <span
+              class="collapse-icon-open"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-caret-bottom"
+                focusable="false"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/path/to#caret-bottom"
+                />
+              </svg>
+            </span>
+          </a>
+          <div
+            class="collapse show"
+          >
+            <ul
+              class="nav nav-stacked"
+            >
+              <li
+                class="nav-item"
+              >
+                <a
+                  class="nav-link"
+                  href="#nested1"
+                  role="button"
+                >
+                  Nested1
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </nav>
 </div>
 `;

--- a/packages/clay-navigation/src/__tests__/index.tsx
+++ b/packages/clay-navigation/src/__tests__/index.tsx
@@ -4,11 +4,25 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayNavigation from '..';
+import ClayNavigation, {ClayBreadcrumbNav, ClayVerticalNav} from '..';
 import React from 'react';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 
 describe('ClayNavigation', () => {
+	afterEach(() => cleanup());
+
+	it('renders', () => {
+		const {container} = render(
+			<ClayNavigation>
+				<div />
+			</ClayNavigation>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+});
+
+describe('ClayBreadcrumbNav', () => {
 	afterEach(() => cleanup());
 
 	const items = [
@@ -37,26 +51,13 @@ describe('ClayNavigation', () => {
 
 	it('renders', () => {
 		const {container} = render(
-			<ClayNavigation>
-				<div />
-			</ClayNavigation>
+			<ClayBreadcrumbNav items={items} spritemap="path/to/spritemap" />
 		);
 
 		expect(container).toMatchSnapshot();
 	});
 
-	it('renders a Breadcrumb', () => {
-		const {container} = render(
-			<ClayNavigation.Breadcrumb
-				items={items}
-				spritemap="path/to/spritemap"
-			/>
-		);
-
-		expect(container).toMatchSnapshot();
-	});
-
-	it('should throw a warning when not passing `active` to any `items` on Breadcrumb', () => {
+	it('throws a warning when not passing `active` to any `items`', () => {
 		const mockWarnings = jest
 			.spyOn(global.console, 'error')
 			.mockImplementation(() => null);
@@ -73,7 +74,7 @@ describe('ClayNavigation', () => {
 		];
 
 		const {container} = render(
-			<ClayNavigation.Breadcrumb
+			<ClayBreadcrumbNav
 				ellipsisBuffer={3}
 				items={items}
 				spritemap="path/to/spritemap"
@@ -82,16 +83,16 @@ describe('ClayNavigation', () => {
 
 		expect(mockWarnings).toBeCalled();
 		expect(mockWarnings.mock.calls[0][0]).toBe(
-			'Warning: ClayNavigation.Breadcrumb expects at least one `active` item on `items`.'
+			'Warning: ClayBreadcrumbNav expects at least one `active` item on `items`.'
 		);
 
 		expect(container).toMatchSnapshot();
 		jest.resetAllMocks();
 	});
 
-	it('renders a Breadcrumb with properties passed by `ellipsisProps`', () => {
+	it('renders with properties passed by `ellipsisProps`', () => {
 		const {container} = render(
-			<ClayNavigation.Breadcrumb
+			<ClayBreadcrumbNav
 				ellipsisBuffer={1}
 				ellipsisProps={{style: {fontSize: '15px'}}}
 				items={items}
@@ -102,7 +103,7 @@ describe('ClayNavigation', () => {
 		expect(container).toMatchSnapshot();
 	});
 
-	it('should emit an event when an item is clicked', () => {
+	it('calls callback when an item is clicked', () => {
 		const itemClickMock = jest.fn(event => {
 			event.persist();
 		});
@@ -132,7 +133,7 @@ describe('ClayNavigation', () => {
 		];
 
 		const {container, getByTestId} = render(
-			<ClayNavigation.Breadcrumb
+			<ClayBreadcrumbNav
 				ellipsisBuffer={1}
 				items={itemsWithoutHref}
 				spritemap="path/to/spritemap"
@@ -146,5 +147,54 @@ describe('ClayNavigation', () => {
 		expect(itemClickMock.mock.calls[0][0].type).toBe('click');
 
 		expect(container).toMatchSnapshot();
+	});
+});
+
+describe('ClayVerticalNav', () => {
+	afterEach(() => cleanup());
+
+	const items = [
+		{
+			initialExpanded: false,
+			items: [
+				{
+					href: '#nested1',
+					label: 'Nested1',
+				},
+			],
+			label: 'Home',
+		},
+	];
+
+	it('renders', () => {
+		const {container} = render(
+			<ClayVerticalNav
+				activeLabel="Home"
+				items={items}
+				spritemap="/path/to"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('expands items when clicked', () => {
+		const {container, getByText} = render(
+			<ClayVerticalNav
+				activeLabel="foo"
+				items={items}
+				spritemap="/path/to"
+			/>
+		);
+
+		expect(
+			container.querySelector('.collapsing.show .nav-item')
+		).toBeFalsy();
+
+		fireEvent.click(getByText('Home'));
+
+		expect(
+			container.querySelector('.collapsing.show .nav-item')
+		).toBeTruthy();
 	});
 });

--- a/packages/clay-navigation/src/index.tsx
+++ b/packages/clay-navigation/src/index.tsx
@@ -4,15 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React from 'react';
-import {Breadcrumb} from './Breadcrumb';
+import Nav from './Nav';
+import {ClayBreadcrumbNav} from './Breadcrumb';
+import {ClayVerticalNav} from './Vertical';
 
-const ClayNavigation: React.FunctionComponent<any> & {
-	Breadcrumb: typeof Breadcrumb;
-} = ({children}) => {
-	return children;
-};
+export {ClayBreadcrumbNav, ClayVerticalNav};
 
-ClayNavigation.Breadcrumb = Breadcrumb;
-
-export default ClayNavigation;
+export default Nav;

--- a/packages/clay-navigation/stories/index.tsx
+++ b/packages/clay-navigation/stories/index.tsx
@@ -5,8 +5,8 @@
  */
 
 import '@clayui/css/lib/css/atlas.css';
-import ClayNavigation from '../src';
 import React from 'react';
+import {ClayBreadcrumbNav, ClayVerticalNav} from '../src';
 import {number} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 
@@ -44,7 +44,7 @@ const BreadcrumbWithState = () => {
 	];
 
 	return (
-		<ClayNavigation.Breadcrumb
+		<ClayBreadcrumbNav
 			ellipsisBuffer={1}
 			items={items}
 			spritemap={spritemap}
@@ -54,7 +54,7 @@ const BreadcrumbWithState = () => {
 
 storiesOf('ClayNavigation', module)
 	.add('w/ breadcrumb', () => (
-		<ClayNavigation.Breadcrumb
+		<ClayBreadcrumbNav
 			ellipsisBuffer={number('Ellipsis Buffer', 3)}
 			items={[
 				{
@@ -111,7 +111,7 @@ storiesOf('ClayNavigation', module)
 			alert(event.target.parentElement.title);
 
 		return (
-			<ClayNavigation.Breadcrumb
+			<ClayBreadcrumbNav
 				ellipsisBuffer={number('Ellipsis Buffer', 3)}
 				items={[
 					{
@@ -164,4 +164,50 @@ storiesOf('ClayNavigation', module)
 			/>
 		);
 	})
-	.add('w/ breadcrumb using state', () => <BreadcrumbWithState />);
+	.add('w/ breadcrumb using state', () => <BreadcrumbWithState />)
+	.add('w/ vertical', () => {
+		return (
+			<ClayVerticalNav
+				activeLabel="Five"
+				items={[
+					{
+						initialExpanded: true,
+						items: [
+							{
+								href: '#nested1',
+								label: 'Nested1',
+							},
+						],
+						label: 'Home',
+					},
+					{
+						href: '#2',
+						label: 'About',
+					},
+					{
+						href: '#3',
+						label: 'Contact',
+					},
+					{
+						items: [
+							{
+								active: true,
+								href: '#5',
+								label: 'Five',
+							},
+							{
+								href: '#6',
+								label: 'Six',
+							},
+						],
+						label: 'Projects',
+					},
+					{
+						href: '#7',
+						label: 'Seven',
+					},
+				]}
+				spritemap={spritemap}
+			/>
+		);
+	});


### PR DESCRIPTION
Wanted to send this to get external opinions. As of now, I sort of see `Vertical` as a high-level component. I also created low-level nav components but I wasn't totally sure how we want to expose those within the navigation package.

Let me know your thoughts.

TODO:
- [x] exporting nav components
- [x] tests
- [x] docs