### PR TITLE
fix(portal): automatically nest portals if they are inside one another

### DIFF
--- a/packages/clay-modal/src/index.tsx
+++ b/packages/clay-modal/src/index.tsx
@@ -46,6 +46,7 @@ const ClayModal: FunctionComponent<IProps> & {
 }: IProps) => {
 	const [visibleClassShow, setVisibleClassShow] = useState<boolean>(false);
 
+	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
 	const modalDialogElementRef = useRef<HTMLDivElement | null>(null);
 
 	/**
@@ -79,7 +80,7 @@ const ClayModal: FunctionComponent<IProps> & {
 	}, []);
 
 	return (
-		<ClayPortal>
+		<ClayPortal subPortalRef={modalBodyElementRef}>
 			<div
 				className={classNames('modal-backdrop fade', {
 					show: visibleClassShow,
@@ -90,6 +91,7 @@ const ClayModal: FunctionComponent<IProps> & {
 				className={classNames('fade modal d-block', className, {
 					show: visibleClassShow,
 				})}
+				ref={modalBodyElementRef}
 			>
 				<div
 					className={classNames('modal-dialog', {

--- a/packages/clay-shared/src/__tests__/Portal.tsx
+++ b/packages/clay-shared/src/__tests__/Portal.tsx
@@ -1,0 +1,144 @@
+/*eslint no-console: 0 */
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+import {ClayPortal} from '..';
+import {cleanup, render} from '@testing-library/react';
+
+describe('Portal', () => {
+	afterEach(() => {
+		jest.clearAllTimers();
+
+		cleanup();
+	});
+
+	it('renders to document.body', () => {
+		render(
+			<div id="parent">
+				<ClayPortal>
+					<div id="portal" />
+				</ClayPortal>
+			</div>
+		);
+
+		expect(
+			document.body.contains(document.getElementById('portal'))
+		).toBeTruthy();
+
+		expect(
+			document
+				.getElementById('parent')!
+				.contains(document.getElementById('portal'))
+		).not.toBeTruthy();
+	});
+
+	it('renders multiple portals to document.body', () => {
+		render(
+			<div id="parent">
+				<ClayPortal>
+					<div id="portal1" />
+				</ClayPortal>
+				{'Normal Content'}
+				<ClayPortal>
+					<div id="portal2" />
+				</ClayPortal>
+			</div>
+		);
+
+		expect(
+			document.body.contains(document.getElementById('portal1'))
+		).toBeTruthy();
+
+		expect(
+			document.body.contains(document.getElementById('portal2'))
+		).toBeTruthy();
+
+		expect(
+			document
+				.getElementById('parent')!
+				.contains(document.getElementById('portal'))
+		).not.toBeTruthy();
+	});
+
+	it('renders inside existing portal', () => {
+		render(
+			<div id="parent">
+				<ClayPortal>
+					<div id="portal1">
+						<ClayPortal>
+							<div id="portal2" />
+						</ClayPortal>
+					</div>
+				</ClayPortal>
+			</div>
+		);
+
+		const portalContainer = document.getElementById('portal1')!.parentNode!;
+
+		expect(
+			document.getElementById('parent')!.contains(portalContainer)
+		).toBeFalsy();
+
+		expect(
+			portalContainer.contains(document.getElementById('portal2'))
+		).toBeTruthy();
+	});
+
+	it('renders inside defined container', () => {
+		const App = () => {
+			const contentRef = React.useRef<HTMLDivElement | null>(null);
+
+			return (
+				<div>
+					<div id="content" ref={contentRef}>
+						{'content'}
+					</div>
+
+					<ClayPortal containerRef={contentRef}>
+						<div id="portal" />
+					</ClayPortal>
+				</div>
+			);
+		};
+
+		render(<App />);
+
+		expect(
+			document
+				.getElementById('content')!
+				.contains(document.getElementById('portal'))
+		).toBeTruthy();
+	});
+
+	it('renders nested portals inside the defined container', () => {
+		const App = () => {
+			const contentRef = React.useRef<HTMLDivElement | null>(null);
+
+			return (
+				<ClayPortal subPortalRef={contentRef}>
+					<div>
+						<div id="content" ref={contentRef}>
+							{'content'}
+						</div>
+					</div>
+
+					<ClayPortal>
+						<div id="portal" />
+					</ClayPortal>
+				</ClayPortal>
+			);
+		};
+
+		render(<App />);
+
+		expect(
+			document
+				.getElementById('content')!
+				.contains(document.getElementById('portal'))
+		).toBeTruthy();
+	});
+});


### PR DESCRIPTION
Added two new APIs to our portals. One is a target for nested portals, and the other is to render the portal to a specific element. By default portals now nest in one another as well.

this fixes https://github.com/liferay/clay/issues/2246