### PR TITLE
fix(clay-css): 2.x Table Header (th) should be aligned left by default in…

### DIFF
--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -4,6 +4,7 @@ table {
 
 th {
 	height: 20px;
+	text-align: left;
 }
 
 .table-head-title {


### PR DESCRIPTION
… Safari

Caused by #1743 and fixes #2219