### PR TITLE
feat(clay-css): Clay Time add focus styles for hours, minutes, seconds, etc

### DIFF
--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -118,6 +118,8 @@
 	$width: map-get($map, width);
 	$placeholder-color: map-get($map, placeholder-color);
 	$placeholder-opacity: map-get($map, placeholder-opacity);
+	$selection-bg: map-get($map, selection-bg);
+	$selection-color: map-get($map, selection-color);
 
 	$hover-bg: map-get($map, hover-bg);
 	$hover-border-color: map-get($map, hover-border-color);
@@ -190,6 +192,16 @@
 			opacity: $placeholder-opacity;
 		}
 
+		&::-moz-selection {
+			background-color: $selection-bg;
+			color: $selection-color;
+		}
+
+		&::selection {
+			background-color: $selection-bg;
+			color: $selection-color;
+		}
+
 		&:hover {
 			background-color: $hover-bg;
 			border-color: $hover-border-color;
@@ -201,7 +213,8 @@
 			}
 		}
 
-		&:focus {
+		&:focus,
+		&.focus {
 			background-color: $focus-bg;
 			background-image: $focus-bg-image;
 			border-color: $focus-border-color;

--- a/packages/clay-css/src/scss/variables/_time.scss
+++ b/packages/clay-css/src/scss/variables/_time.scss
@@ -27,6 +27,8 @@ $clay-time-form-control-inset: map-merge((
 	margin-top: 0,
 	text-align: center,
 	width: 1.25rem,
+	selection-bg: transparent,
+	focus-bg: #B3D8FD,
 ), $clay-time-form-control-inset);
 
 $clay-time-ampm: () !default;


### PR DESCRIPTION
@matuzalemsteles the class to add is `focus`