### PR TITLE
fix: stop closing DropDown or Modal when clicking inside element on a nested sub portal

### DIFF
--- a/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
@@ -28,10 +28,12 @@ exports[`ClayAutocomplete renders DropDown with alignment with container 1`] = `
     />
   </div>
   <div>
-    <div
-      class="dropdown-menu autocomplete-dropdown-menu show"
-      style="max-width: none;"
-    />
+    <div>
+      <div
+        class="dropdown-menu autocomplete-dropdown-menu show"
+        style="max-width: none;"
+      />
+    </div>
   </div>
 </body>
 `;

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -104,291 +104,293 @@ exports[`Rendering default 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu clay-color-dropdown-menu"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="clay-color-header"
-      >
-        <span
-          class="component-title"
-        >
-          Default Colors
-        </span>
-      </div>
-      <div
-        class="clay-color-swatch"
+        class="dropdown-menu clay-color-dropdown-menu"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="clay-color-swatch-item"
+          class="clay-color-header"
         >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(0, 0, 0); height: 24px; width: 24px;"
-            title="000000"
-          />
+          <span
+            class="component-title"
+          >
+            Default Colors
+          </span>
         </div>
         <div
-          class="clay-color-swatch-item"
+          class="clay-color-swatch"
         >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(95, 95, 95); height: 24px; width: 24px;"
-            title="5F5F5F"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(154, 154, 154); height: 24px; width: 24px;"
-            title="9A9A9A"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(203, 203, 203); height: 24px; width: 24px;"
-            title="CBCBCB"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(225, 225, 225); height: 24px; width: 24px;"
-            title="E1E1E1"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border: 1px solid #e7e7ed; background: rgb(255, 255, 255); height: 24px; width: 24px;"
-            title="FFFFFF"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 13, 13); height: 24px; width: 24px;"
-            title="FF0D0D"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 138, 28); height: 24px; width: 24px;"
-            title="FF8A1C"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(43, 166, 118); height: 24px; width: 24px;"
-            title="2BA676"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(0, 110, 248); height: 24px; width: 24px;"
-            title="006EF8"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(127, 38, 255); height: 24px; width: 24px;"
-            title="7F26FF"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 33, 160); height: 24px; width: 24px;"
-            title="FF21A0"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 95, 95); height: 24px; width: 24px;"
-            title="FF5F5F"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 180, 110); height: 24px; width: 24px;"
-            title="FFB46E"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(80, 210, 160); height: 24px; width: 24px;"
-            title="50D2A0"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(75, 155, 255); height: 24px; width: 24px;"
-            title="4B9BFF"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(175, 120, 255); height: 24px; width: 24px;"
-            title="AF78FF"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 115, 195); height: 24px; width: 24px;"
-            title="FF73C3"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 177, 177); height: 24px; width: 24px;"
-            title="FFB1B1"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 222, 192); height: 24px; width: 24px;"
-            title="FFDEC0"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(145, 227, 195); height: 24px; width: 24px;"
-            title="91E3C3"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(157, 200, 255); height: 24px; width: 24px;"
-            title="9DC8FF"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(223, 202, 255); height: 24px; width: 24px;"
-            title="DFCAFF"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 197, 230); height: 24px; width: 24px;"
-            title="FFC5E6"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 217, 217); height: 24px; width: 24px;"
-            title="FFD9D9"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border: 1px solid #e7e7ed; background: rgb(255, 243, 232); height: 24px; width: 24px;"
-            title="FFF3E8"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(177, 235, 213); height: 24px; width: 24px;"
-            title="B1EBD5"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(197, 223, 255); height: 24px; width: 24px;"
-            title="C5DFFF"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border: 1px solid #e7e7ed; background: rgb(248, 242, 255); height: 24px; width: 24px;"
-            title="F8F2FF"
-          />
-        </div>
-        <div
-          class="clay-color-swatch-item"
-        >
-          <button
-            class="btn clay-color-btn "
-            style="border-width: 0px; background: rgb(255, 237, 247); height: 24px; width: 24px;"
-            title="FFEDF7"
-          />
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(0, 0, 0); height: 24px; width: 24px;"
+              title="000000"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(95, 95, 95); height: 24px; width: 24px;"
+              title="5F5F5F"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(154, 154, 154); height: 24px; width: 24px;"
+              title="9A9A9A"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(203, 203, 203); height: 24px; width: 24px;"
+              title="CBCBCB"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(225, 225, 225); height: 24px; width: 24px;"
+              title="E1E1E1"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border: 1px solid #e7e7ed; background: rgb(255, 255, 255); height: 24px; width: 24px;"
+              title="FFFFFF"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 13, 13); height: 24px; width: 24px;"
+              title="FF0D0D"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 138, 28); height: 24px; width: 24px;"
+              title="FF8A1C"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(43, 166, 118); height: 24px; width: 24px;"
+              title="2BA676"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(0, 110, 248); height: 24px; width: 24px;"
+              title="006EF8"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(127, 38, 255); height: 24px; width: 24px;"
+              title="7F26FF"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 33, 160); height: 24px; width: 24px;"
+              title="FF21A0"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 95, 95); height: 24px; width: 24px;"
+              title="FF5F5F"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 180, 110); height: 24px; width: 24px;"
+              title="FFB46E"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(80, 210, 160); height: 24px; width: 24px;"
+              title="50D2A0"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(75, 155, 255); height: 24px; width: 24px;"
+              title="4B9BFF"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(175, 120, 255); height: 24px; width: 24px;"
+              title="AF78FF"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 115, 195); height: 24px; width: 24px;"
+              title="FF73C3"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 177, 177); height: 24px; width: 24px;"
+              title="FFB1B1"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 222, 192); height: 24px; width: 24px;"
+              title="FFDEC0"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(145, 227, 195); height: 24px; width: 24px;"
+              title="91E3C3"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(157, 200, 255); height: 24px; width: 24px;"
+              title="9DC8FF"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(223, 202, 255); height: 24px; width: 24px;"
+              title="DFCAFF"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 197, 230); height: 24px; width: 24px;"
+              title="FFC5E6"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 217, 217); height: 24px; width: 24px;"
+              title="FFD9D9"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border: 1px solid #e7e7ed; background: rgb(255, 243, 232); height: 24px; width: 24px;"
+              title="FFF3E8"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(177, 235, 213); height: 24px; width: 24px;"
+              title="B1EBD5"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(197, 223, 255); height: 24px; width: 24px;"
+              title="C5DFFF"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border: 1px solid #e7e7ed; background: rgb(248, 242, 255); height: 24px; width: 24px;"
+              title="F8F2FF"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn "
+              style="border-width: 0px; background: rgb(255, 237, 247); height: 24px; width: 24px;"
+              title="FFEDF7"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -46,478 +46,480 @@ exports[`BasicRendering renders by default 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>
@@ -572,478 +574,480 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>
@@ -1128,611 +1132,613 @@ exports[`BasicRendering renders date picker with time 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
-              >
-                <option
-                  value="0"
-                >
-                  January
-                </option>
-                <option
-                  value="1"
-                >
-                  February
-                </option>
-                <option
-                  value="2"
-                >
-                  March
-                </option>
-                <option
-                  value="3"
-                >
-                  April
-                </option>
-                <option
-                  value="4"
-                >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
-            >
-              <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
-              </button>
-              <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
-              </button>
-              <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
-              </button>
-            </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                M
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                W
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-footer"
-        >
-          <div
-            class="time-picker"
-          >
-            <div
-              class="clay-time"
+              class="date-picker-nav"
             >
               <div
-                class="input-group"
+                class="date-picker-nav-item input-date-picker-month"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
+                >
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
+                >
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                31
+              </button>
+              <button
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
+              </button>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-footer"
+          >
+            <div
+              class="time-picker"
+            >
+              <div
+                class="clay-time"
               >
                 <div
-                  class="input-group-item input-group-item-shrink"
+                  class="input-group"
                 >
                   <div
-                    class="input-group-text"
-                  >
-                    <svg
-                      class="lexicon-icon lexicon-icon-time"
-                      role="presentation"
-                    >
-                      <use
-                        xlink:href="icons.svg#time"
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="input-group-item input-group-item-shrink"
-                >
-                  <div
-                    class="form-control"
-                    data-testid="formControl"
+                    class="input-group-item input-group-item-shrink"
                   >
                     <div
-                      class="clay-time-edit"
+                      class="input-group-text"
                     >
-                      <input
-                        class="clay-time-hours form-control-inset"
-                        data-testid="hours"
-                        maxlength="2"
-                        readonly=""
-                        type="text"
-                        value="0"
-                      />
-                      <span
-                        class="clay-time-divider"
+                      <svg
+                        class="lexicon-icon lexicon-icon-time"
+                        role="presentation"
                       >
-                        :
-                      </span>
-                      <input
-                        class="clay-time-minutes form-control-inset"
-                        data-testid="minutes"
-                        maxlength="2"
-                        readonly=""
-                        type="text"
-                        value="0"
-                      />
+                        <use
+                          xlink:href="icons.svg#time"
+                        />
+                      </svg>
                     </div>
+                  </div>
+                  <div
+                    class="input-group-item input-group-item-shrink"
+                  >
                     <div
-                      class="clay-time-action-group"
+                      class="form-control"
+                      data-testid="formControl"
                     >
                       <div
-                        class="clay-time-action-group-item"
-                        data-testid="containerReset"
-                        style="opacity: 0; pointer-events: none;"
+                        class="clay-time-edit"
                       >
-                        <button
-                          class="clay-time-clear-btn btn btn-unstyled"
-                          type="button"
+                        <input
+                          class="clay-time-hours form-control-inset"
+                          data-testid="hours"
+                          maxlength="2"
+                          readonly=""
+                          type="text"
+                          value="0"
+                        />
+                        <span
+                          class="clay-time-divider"
                         >
-                          <svg
-                            class="lexicon-icon lexicon-icon-times-circle"
-                            role="presentation"
-                          >
-                            <use
-                              xlink:href="icons.svg#times-circle"
-                            />
-                          </svg>
-                        </button>
+                          :
+                        </span>
+                        <input
+                          class="clay-time-minutes form-control-inset"
+                          data-testid="minutes"
+                          maxlength="2"
+                          readonly=""
+                          type="text"
+                          value="0"
+                        />
                       </div>
                       <div
-                        class="clay-time-action-group-item"
-                        data-testid="containerSpin"
-                        style="opacity: 0;"
+                        class="clay-time-action-group"
                       >
                         <div
-                          class="btn-group-vertical clay-time-inner-spin"
-                          role="group"
+                          class="clay-time-action-group-item"
+                          data-testid="containerReset"
+                          style="opacity: 0; pointer-events: none;"
                         >
                           <button
-                            class="clay-time-inner-spin-btn clay-time-inner-spin-btn-inc btn btn-secondary"
-                            data-testid="spinInc"
+                            class="clay-time-clear-btn btn btn-unstyled"
                             type="button"
                           >
                             <svg
-                              class="lexicon-icon lexicon-icon-angle-up"
+                              class="lexicon-icon lexicon-icon-times-circle"
                               role="presentation"
                             >
                               <use
-                                xlink:href="icons.svg#angle-up"
-                              />
-                            </svg>
-                          </button>
-                          <button
-                            class="clay-time-inner-spin-btn clay-time-inner-spin-btn-dec btn btn-secondary"
-                            data-testid="spinDec"
-                            type="button"
-                          >
-                            <svg
-                              class="lexicon-icon lexicon-icon-angle-down"
-                              role="presentation"
-                            >
-                              <use
-                                xlink:href="icons.svg#angle-down"
+                                xlink:href="icons.svg#times-circle"
                               />
                             </svg>
                           </button>
                         </div>
+                        <div
+                          class="clay-time-action-group-item"
+                          data-testid="containerSpin"
+                          style="opacity: 0;"
+                        >
+                          <div
+                            class="btn-group-vertical clay-time-inner-spin"
+                            role="group"
+                          >
+                            <button
+                              class="clay-time-inner-spin-btn clay-time-inner-spin-btn-inc btn btn-secondary"
+                              data-testid="spinInc"
+                              type="button"
+                            >
+                              <svg
+                                class="lexicon-icon lexicon-icon-angle-up"
+                                role="presentation"
+                              >
+                                <use
+                                  xlink:href="icons.svg#angle-up"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              class="clay-time-inner-spin-btn clay-time-inner-spin-btn-dec btn btn-secondary"
+                              data-testid="spinDec"
+                              type="button"
+                            >
+                              <svg
+                                class="lexicon-icon lexicon-icon-angle-down"
+                                role="presentation"
+                              >
+                                <use
+                                  xlink:href="icons.svg#angle-down"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  class="input-group-item input-group-item-shrink"
-                >
                   <div
-                    class="input-group-text"
+                    class="input-group-item input-group-item-shrink"
                   >
-                    (GMT+01:00)
+                    <div
+                      class="input-group-text"
+                    >
+                      (GMT+01:00)
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1791,613 +1797,615 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="1997"
+                  >
+                    1997
+                  </option>
+                  <option
+                    value="1998"
+                  >
+                    1998
+                  </option>
+                  <option
+                    value="1999"
+                  >
+                    1999
+                  </option>
+                  <option
+                    value="2000"
+                  >
+                    2000
+                  </option>
+                  <option
+                    value="2001"
+                  >
+                    2001
+                  </option>
+                  <option
+                    value="2002"
+                  >
+                    2002
+                  </option>
+                  <option
+                    value="2003"
+                  >
+                    2003
+                  </option>
+                  <option
+                    value="2004"
+                  >
+                    2004
+                  </option>
+                  <option
+                    value="2005"
+                  >
+                    2005
+                  </option>
+                  <option
+                    value="2006"
+                  >
+                    2006
+                  </option>
+                  <option
+                    value="2007"
+                  >
+                    2007
+                  </option>
+                  <option
+                    value="2008"
+                  >
+                    2008
+                  </option>
+                  <option
+                    value="2009"
+                  >
+                    2009
+                  </option>
+                  <option
+                    value="2010"
+                  >
+                    2010
+                  </option>
+                  <option
+                    value="2011"
+                  >
+                    2011
+                  </option>
+                  <option
+                    value="2012"
+                  >
+                    2012
+                  </option>
+                  <option
+                    value="2013"
+                  >
+                    2013
+                  </option>
+                  <option
+                    value="2014"
+                  >
+                    2014
+                  </option>
+                  <option
+                    value="2015"
+                  >
+                    2015
+                  </option>
+                  <option
+                    value="2016"
+                  >
+                    2016
+                  </option>
+                  <option
+                    value="2017"
+                  >
+                    2017
+                  </option>
+                  <option
+                    value="2018"
+                  >
+                    2018
+                  </option>
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                  <option
+                    value="2020"
+                  >
+                    2020
+                  </option>
+                  <option
+                    value="2021"
+                  >
+                    2021
+                  </option>
+                  <option
+                    value="2022"
+                  >
+                    2022
+                  </option>
+                  <option
+                    value="2023"
+                  >
+                    2023
+                  </option>
+                  <option
+                    value="2024"
+                  >
+                    2024
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="1997"
-                >
-                  1997
-                </option>
-                <option
-                  value="1998"
-                >
-                  1998
-                </option>
-                <option
-                  value="1999"
-                >
-                  1999
-                </option>
-                <option
-                  value="2000"
-                >
-                  2000
-                </option>
-                <option
-                  value="2001"
-                >
-                  2001
-                </option>
-                <option
-                  value="2002"
-                >
-                  2002
-                </option>
-                <option
-                  value="2003"
-                >
-                  2003
-                </option>
-                <option
-                  value="2004"
-                >
-                  2004
-                </option>
-                <option
-                  value="2005"
-                >
-                  2005
-                </option>
-                <option
-                  value="2006"
-                >
-                  2006
-                </option>
-                <option
-                  value="2007"
-                >
-                  2007
-                </option>
-                <option
-                  value="2008"
-                >
-                  2008
-                </option>
-                <option
-                  value="2009"
-                >
-                  2009
-                </option>
-                <option
-                  value="2010"
-                >
-                  2010
-                </option>
-                <option
-                  value="2011"
-                >
-                  2011
-                </option>
-                <option
-                  value="2012"
-                >
-                  2012
-                </option>
-                <option
-                  value="2013"
-                >
-                  2013
-                </option>
-                <option
-                  value="2014"
-                >
-                  2014
-                </option>
-                <option
-                  value="2015"
-                >
-                  2015
-                </option>
-                <option
-                  value="2016"
-                >
-                  2016
-                </option>
-                <option
-                  value="2017"
-                >
-                  2017
-                </option>
-                <option
-                  value="2018"
-                >
-                  2018
-                </option>
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-                <option
-                  value="2020"
-                >
-                  2020
-                </option>
-                <option
-                  value="2021"
-                >
-                  2021
-                </option>
-                <option
-                  value="2022"
-                >
-                  2022
-                </option>
-                <option
-                  value="2023"
-                >
-                  2023
-                </option>
-                <option
-                  value="2024"
-                >
-                  2024
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -47,477 +47,479 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 06 30"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                30
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 07 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 07 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 07 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 07 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 07 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 07 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 07 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 07 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 07 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 07 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 07 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 07 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 07 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 07 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 07 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 07 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 07 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 07 18"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 07 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 07 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 07 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 07 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 07 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 07 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 07 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 07 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 07 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 07 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 07 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 07 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 07 31"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                31
+              </button>
+              <button
+                aria-label="2019 08 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 08 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 08 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 06 30"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 07 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 07 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 07 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 07 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 07 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 07 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 07 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 07 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 07 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 07 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 07 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 07 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 07 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 07 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 07 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 07 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 07 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 07 18"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 07 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 07 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 07 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 07 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 07 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 07 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 07 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 07 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 07 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 07 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 07 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 07 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 07 31"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 08 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 08 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 08 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
           </div>
         </div>
       </div>
@@ -573,478 +575,480 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>
@@ -1100,478 +1104,480 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>
@@ -1627,478 +1633,480 @@ exports[`IncrementalInteractions clicking on the dot button should select curren
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>
@@ -2154,493 +2162,495 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2017"
+                  >
+                    2017
+                  </option>
+                  <option
+                    value="2018"
+                  >
+                    2018
+                  </option>
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                  <option
+                    value="2020"
+                  >
+                    2020
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2017"
-                >
-                  2017
-                </option>
-                <option
-                  value="2018"
-                >
-                  2018
-                </option>
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-                <option
-                  value="2020"
-                >
-                  2020
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2018 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2018 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                2
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2018 04 03"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                3
+              </button>
+              <button
+                aria-label="2018 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2018 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2018 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
+              </button>
+              <button
+                aria-label="2018 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2018 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2018 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2018 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2018 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2018 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2018 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
+              <button
+                aria-label="2018 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2018 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2018 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2018 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2018 04 18"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2018 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2018 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
+              <button
+                aria-label="2018 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2018 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2018 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2018 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2018 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2018 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2018 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
+              <button
+                aria-label="2018 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2018 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2018 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2018 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2018 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2018 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2018 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2018 05 05"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                5
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2018 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2018 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2018 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2018 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2018 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2018 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-            <button
-              aria-label="2018 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2018 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2018 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2018 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2018 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2018 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2018 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-            <button
-              aria-label="2018 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2018 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2018 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2018 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2018 04 18"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2018 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2018 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-            <button
-              aria-label="2018 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2018 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2018 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2018 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2018 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2018 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2018 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-            <button
-              aria-label="2018 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2018 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2018 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2018 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2018 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2018 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2018 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2018 05 05"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              5
-            </button>
           </div>
         </div>
       </div>
@@ -2701,478 +2711,480 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>
@@ -3228,478 +3240,480 @@ exports[`IncrementalInteractions date entered in the input element should reflec
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -47,478 +47,480 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 29"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                29
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 30"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                30
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                31
+              </button>
+              <button
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                F
-              </abbr>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
+              </button>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                W
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 29"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 03 30"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
           </div>
         </div>
       </div>
@@ -574,478 +576,480 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>
@@ -1101,478 +1105,480 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 30"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                30
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                1
+              </button>
+              <button
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
+              </button>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                W
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 30"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
           </div>
         </div>
       </div>
@@ -1628,478 +1634,480 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                31
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                1
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                M
-              </abbr>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                F
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
           </div>
         </div>
       </div>
@@ -2155,478 +2163,480 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 28"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                28
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 29"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                29
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 30"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                30
+              </button>
+              <button
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                31
+              </button>
+              <button
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
+              </button>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                F
-              </abbr>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                M
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                W
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 28"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 03 29"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 03 30"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
           </div>
         </div>
       </div>
@@ -2682,538 +2692,540 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 26"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                26
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 27"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                27
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 28"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                28
+              </button>
+              <button
+                aria-label="2019 03 29"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 03 30"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                31
+              </button>
+              <button
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                1
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
+              </button>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                F
-              </abbr>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 05 05"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 05 06"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                6
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                M
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 26"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 03 27"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              27
-            </button>
-            <button
-              aria-label="2019 03 28"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 03 29"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 03 30"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 05 05"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 05 06"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              6
-            </button>
           </div>
         </div>
       </div>
@@ -3269,478 +3281,480 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
+              class="date-picker-nav"
             >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
+              <div
+                class="date-picker-nav-item input-date-picker-month"
               >
-                <option
-                  value="0"
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
                 >
-                  January
-                </option>
-                <option
-                  value="1"
+                  <option
+                    value="0"
+                  >
+                    January
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    February
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    March
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    April
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    May
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    June
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    July
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    August
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    September
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    October
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    November
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    December
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
                 >
-                  February
-                </option>
-                <option
-                  value="2"
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  March
-                </option>
-                <option
-                  value="3"
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  April
-                </option>
-                <option
-                  value="4"
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
                 >
-                  May
-                </option>
-                <option
-                  value="5"
-                >
-                  June
-                </option>
-                <option
-                  value="6"
-                >
-                  July
-                </option>
-                <option
-                  value="7"
-                >
-                  August
-                </option>
-                <option
-                  value="8"
-                >
-                  September
-                </option>
-                <option
-                  value="9"
-                >
-                  October
-                </option>
-                <option
-                  value="10"
-                >
-                  November
-                </option>
-                <option
-                  value="11"
-                >
-                  December
-                </option>
-              </select>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  W
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  F
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  S
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  M
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  T
+                </abbr>
+              </div>
             </div>
             <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              class="date-picker-date-row date-picker-row"
             >
               <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 27"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
+                27
               </button>
               <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 28"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
+                28
               </button>
               <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
+                aria-label="2019 03 29"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
+                29
+              </button>
+              <button
+                aria-label="2019 03 30"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 03 31"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                31
+              </button>
+              <button
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                2
               </button>
             </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                W
-              </abbr>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
+              </button>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                T
-              </abbr>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                F
-              </abbr>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
             </div>
             <div
-              class="date-picker-day date-picker-calendar-item"
+              class="date-picker-date-row date-picker-row"
             >
-              <abbr>
-                S
-              </abbr>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
             </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                S
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                M
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                T
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 03 27"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              27
-            </button>
-            <button
-              aria-label="2019 03 28"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 03 29"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 03 30"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 03 31"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              31
-            </button>
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
           </div>
         </div>
       </div>
@@ -3796,734 +3810,736 @@ exports[`Internationalization should render the date picker in russian 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu date-picker-dropdown-menu show"
-      data-testid="dropdown"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="date-picker-calendar"
+        class="dropdown-menu date-picker-dropdown-menu show"
+        data-testid="dropdown"
+        style="top: 0px; left: 0px;"
       >
         <div
-          class="date-picker-calendar-header"
+          class="date-picker-calendar"
         >
           <div
-            class="date-picker-nav"
+            class="date-picker-calendar-header"
           >
             <div
-              class="date-picker-nav-item input-date-picker-month"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="month-select"
-                name="month"
-              >
-                <option
-                  value="0"
-                >
-                  Январь
-                </option>
-                <option
-                  value="1"
-                >
-                  Февраль
-                </option>
-                <option
-                  value="2"
-                >
-                  Март
-                </option>
-                <option
-                  value="3"
-                >
-                  Апрель
-                </option>
-                <option
-                  value="4"
-                >
-                  Май
-                </option>
-                <option
-                  value="5"
-                >
-                  Июнь
-                </option>
-                <option
-                  value="6"
-                >
-                  Июль
-                </option>
-                <option
-                  value="7"
-                >
-                  Август
-                </option>
-                <option
-                  value="8"
-                >
-                  Сентябрь
-                </option>
-                <option
-                  value="9"
-                >
-                  Октябрь
-                </option>
-                <option
-                  value="10"
-                >
-                  Ноябрь
-                </option>
-                <option
-                  value="11"
-                >
-                  Декабрь
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item input-date-picker-year"
-            >
-              <select
-                class="form-control form-control-sm"
-                data-testid="year-select"
-                name="year"
-              >
-                <option
-                  value="1997"
-                >
-                  1997
-                </option>
-                <option
-                  value="1998"
-                >
-                  1998
-                </option>
-                <option
-                  value="1999"
-                >
-                  1999
-                </option>
-                <option
-                  value="2000"
-                >
-                  2000
-                </option>
-                <option
-                  value="2001"
-                >
-                  2001
-                </option>
-                <option
-                  value="2002"
-                >
-                  2002
-                </option>
-                <option
-                  value="2003"
-                >
-                  2003
-                </option>
-                <option
-                  value="2004"
-                >
-                  2004
-                </option>
-                <option
-                  value="2005"
-                >
-                  2005
-                </option>
-                <option
-                  value="2006"
-                >
-                  2006
-                </option>
-                <option
-                  value="2007"
-                >
-                  2007
-                </option>
-                <option
-                  value="2008"
-                >
-                  2008
-                </option>
-                <option
-                  value="2009"
-                >
-                  2009
-                </option>
-                <option
-                  value="2010"
-                >
-                  2010
-                </option>
-                <option
-                  value="2011"
-                >
-                  2011
-                </option>
-                <option
-                  value="2012"
-                >
-                  2012
-                </option>
-                <option
-                  value="2013"
-                >
-                  2013
-                </option>
-                <option
-                  value="2014"
-                >
-                  2014
-                </option>
-                <option
-                  value="2015"
-                >
-                  2015
-                </option>
-                <option
-                  value="2016"
-                >
-                  2016
-                </option>
-                <option
-                  value="2017"
-                >
-                  2017
-                </option>
-                <option
-                  value="2018"
-                >
-                  2018
-                </option>
-                <option
-                  value="2019"
-                >
-                  2019
-                </option>
-                <option
-                  value="2020"
-                >
-                  2020
-                </option>
-                <option
-                  value="2021"
-                >
-                  2021
-                </option>
-                <option
-                  value="2022"
-                >
-                  2022
-                </option>
-                <option
-                  value="2023"
-                >
-                  2023
-                </option>
-                <option
-                  value="2024"
-                >
-                  2024
-                </option>
-              </select>
-            </div>
-            <div
-              class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
-            >
-              <button
-                aria-label="Select the previous month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-left"
-                  />
-                </svg>
-              </button>
-              <button
-                aria-label="Select current date"
-                class="btn btn-monospaced btn-sm btn-unstyled"
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-simple-circle"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#simple-circle"
-                  />
-                </svg>
-              </button>
-              <button
-                aria-label="Select the next month"
-                class="btn btn-monospaced btn-sm btn-unstyled"
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#angle-right"
-                  />
-                </svg>
-              </button>
-            </div>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-body"
-        >
-          <div
-            class="date-picker-days-row date-picker-row"
-          >
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                Пн
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                Вт
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                Ср
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                Чт
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                Пт
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                Сб
-              </abbr>
-            </div>
-            <div
-              class="date-picker-day date-picker-calendar-item"
-            >
-              <abbr>
-                Вс
-              </abbr>
-            </div>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 01"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 04 02"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 04 03"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 04 04"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 04 05"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              5
-            </button>
-            <button
-              aria-label="2019 04 06"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              6
-            </button>
-            <button
-              aria-label="2019 04 07"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              7
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 08"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              8
-            </button>
-            <button
-              aria-label="2019 04 09"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              9
-            </button>
-            <button
-              aria-label="2019 04 10"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              10
-            </button>
-            <button
-              aria-label="2019 04 11"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              11
-            </button>
-            <button
-              aria-label="2019 04 12"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              12
-            </button>
-            <button
-              aria-label="2019 04 13"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              13
-            </button>
-            <button
-              aria-label="2019 04 14"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              14
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 15"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              15
-            </button>
-            <button
-              aria-label="2019 04 16"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              16
-            </button>
-            <button
-              aria-label="2019 04 17"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              17
-            </button>
-            <button
-              aria-label="2019 04 18"
-              class="date-picker-date date-picker-calendar-item active"
-              type="button"
-            >
-              18
-            </button>
-            <button
-              aria-label="2019 04 19"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              19
-            </button>
-            <button
-              aria-label="2019 04 20"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              20
-            </button>
-            <button
-              aria-label="2019 04 21"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              21
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 22"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              22
-            </button>
-            <button
-              aria-label="2019 04 23"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              23
-            </button>
-            <button
-              aria-label="2019 04 24"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              24
-            </button>
-            <button
-              aria-label="2019 04 25"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              25
-            </button>
-            <button
-              aria-label="2019 04 26"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              26
-            </button>
-            <button
-              aria-label="2019 04 27"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              27
-            </button>
-            <button
-              aria-label="2019 04 28"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              28
-            </button>
-          </div>
-          <div
-            class="date-picker-date-row date-picker-row"
-          >
-            <button
-              aria-label="2019 04 29"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              29
-            </button>
-            <button
-              aria-label="2019 04 30"
-              class="date-picker-date date-picker-calendar-item"
-              type="button"
-            >
-              30
-            </button>
-            <button
-              aria-label="2019 05 01"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              1
-            </button>
-            <button
-              aria-label="2019 05 02"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              2
-            </button>
-            <button
-              aria-label="2019 05 03"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              3
-            </button>
-            <button
-              aria-label="2019 05 04"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              4
-            </button>
-            <button
-              aria-label="2019 05 05"
-              class="date-picker-date date-picker-calendar-item disabled"
-              disabled=""
-              type="button"
-            >
-              5
-            </button>
-          </div>
-        </div>
-        <div
-          class="date-picker-calendar-footer"
-        >
-          <div
-            class="time-picker"
-          >
-            <div
-              class="clay-time"
+              class="date-picker-nav"
             >
               <div
-                class="input-group"
+                class="date-picker-nav-item input-date-picker-month"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="month-select"
+                  name="month"
+                >
+                  <option
+                    value="0"
+                  >
+                    Январь
+                  </option>
+                  <option
+                    value="1"
+                  >
+                    Февраль
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    Март
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    Апрель
+                  </option>
+                  <option
+                    value="4"
+                  >
+                    Май
+                  </option>
+                  <option
+                    value="5"
+                  >
+                    Июнь
+                  </option>
+                  <option
+                    value="6"
+                  >
+                    Июль
+                  </option>
+                  <option
+                    value="7"
+                  >
+                    Август
+                  </option>
+                  <option
+                    value="8"
+                  >
+                    Сентябрь
+                  </option>
+                  <option
+                    value="9"
+                  >
+                    Октябрь
+                  </option>
+                  <option
+                    value="10"
+                  >
+                    Ноябрь
+                  </option>
+                  <option
+                    value="11"
+                  >
+                    Декабрь
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item input-date-picker-year"
+              >
+                <select
+                  class="form-control form-control-sm"
+                  data-testid="year-select"
+                  name="year"
+                >
+                  <option
+                    value="1997"
+                  >
+                    1997
+                  </option>
+                  <option
+                    value="1998"
+                  >
+                    1998
+                  </option>
+                  <option
+                    value="1999"
+                  >
+                    1999
+                  </option>
+                  <option
+                    value="2000"
+                  >
+                    2000
+                  </option>
+                  <option
+                    value="2001"
+                  >
+                    2001
+                  </option>
+                  <option
+                    value="2002"
+                  >
+                    2002
+                  </option>
+                  <option
+                    value="2003"
+                  >
+                    2003
+                  </option>
+                  <option
+                    value="2004"
+                  >
+                    2004
+                  </option>
+                  <option
+                    value="2005"
+                  >
+                    2005
+                  </option>
+                  <option
+                    value="2006"
+                  >
+                    2006
+                  </option>
+                  <option
+                    value="2007"
+                  >
+                    2007
+                  </option>
+                  <option
+                    value="2008"
+                  >
+                    2008
+                  </option>
+                  <option
+                    value="2009"
+                  >
+                    2009
+                  </option>
+                  <option
+                    value="2010"
+                  >
+                    2010
+                  </option>
+                  <option
+                    value="2011"
+                  >
+                    2011
+                  </option>
+                  <option
+                    value="2012"
+                  >
+                    2012
+                  </option>
+                  <option
+                    value="2013"
+                  >
+                    2013
+                  </option>
+                  <option
+                    value="2014"
+                  >
+                    2014
+                  </option>
+                  <option
+                    value="2015"
+                  >
+                    2015
+                  </option>
+                  <option
+                    value="2016"
+                  >
+                    2016
+                  </option>
+                  <option
+                    value="2017"
+                  >
+                    2017
+                  </option>
+                  <option
+                    value="2018"
+                  >
+                    2018
+                  </option>
+                  <option
+                    value="2019"
+                  >
+                    2019
+                  </option>
+                  <option
+                    value="2020"
+                  >
+                    2020
+                  </option>
+                  <option
+                    value="2021"
+                  >
+                    2021
+                  </option>
+                  <option
+                    value="2022"
+                  >
+                    2022
+                  </option>
+                  <option
+                    value="2023"
+                  >
+                    2023
+                  </option>
+                  <option
+                    value="2024"
+                  >
+                    2024
+                  </option>
+                </select>
+              </div>
+              <div
+                class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+              >
+                <button
+                  aria-label="Select the previous month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-left"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select current date"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-simple-circle"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#simple-circle"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Select the next month"
+                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-body"
+          >
+            <div
+              class="date-picker-days-row date-picker-row"
+            >
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  Пн
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  Вт
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  Ср
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  Чт
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  Пт
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  Сб
+                </abbr>
+              </div>
+              <div
+                class="date-picker-day date-picker-calendar-item"
+              >
+                <abbr>
+                  Вс
+                </abbr>
+              </div>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 04 01"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 04 02"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 04 03"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 04 04"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 04 05"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                5
+              </button>
+              <button
+                aria-label="2019 04 06"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                6
+              </button>
+              <button
+                aria-label="2019 04 07"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                7
+              </button>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 04 08"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                8
+              </button>
+              <button
+                aria-label="2019 04 09"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                9
+              </button>
+              <button
+                aria-label="2019 04 10"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                10
+              </button>
+              <button
+                aria-label="2019 04 11"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                11
+              </button>
+              <button
+                aria-label="2019 04 12"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                12
+              </button>
+              <button
+                aria-label="2019 04 13"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                13
+              </button>
+              <button
+                aria-label="2019 04 14"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                14
+              </button>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 04 15"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                15
+              </button>
+              <button
+                aria-label="2019 04 16"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                16
+              </button>
+              <button
+                aria-label="2019 04 17"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                17
+              </button>
+              <button
+                aria-label="2019 04 18"
+                class="date-picker-date date-picker-calendar-item active"
+                type="button"
+              >
+                18
+              </button>
+              <button
+                aria-label="2019 04 19"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                19
+              </button>
+              <button
+                aria-label="2019 04 20"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                20
+              </button>
+              <button
+                aria-label="2019 04 21"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                21
+              </button>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 04 22"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                22
+              </button>
+              <button
+                aria-label="2019 04 23"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                23
+              </button>
+              <button
+                aria-label="2019 04 24"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                24
+              </button>
+              <button
+                aria-label="2019 04 25"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                25
+              </button>
+              <button
+                aria-label="2019 04 26"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                26
+              </button>
+              <button
+                aria-label="2019 04 27"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                27
+              </button>
+              <button
+                aria-label="2019 04 28"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                28
+              </button>
+            </div>
+            <div
+              class="date-picker-date-row date-picker-row"
+            >
+              <button
+                aria-label="2019 04 29"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                29
+              </button>
+              <button
+                aria-label="2019 04 30"
+                class="date-picker-date date-picker-calendar-item"
+                type="button"
+              >
+                30
+              </button>
+              <button
+                aria-label="2019 05 01"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                1
+              </button>
+              <button
+                aria-label="2019 05 02"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                2
+              </button>
+              <button
+                aria-label="2019 05 03"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                3
+              </button>
+              <button
+                aria-label="2019 05 04"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                4
+              </button>
+              <button
+                aria-label="2019 05 05"
+                class="date-picker-date date-picker-calendar-item disabled"
+                disabled=""
+                type="button"
+              >
+                5
+              </button>
+            </div>
+          </div>
+          <div
+            class="date-picker-calendar-footer"
+          >
+            <div
+              class="time-picker"
+            >
+              <div
+                class="clay-time"
               >
                 <div
-                  class="input-group-item input-group-item-shrink"
+                  class="input-group"
                 >
                   <div
-                    class="input-group-text"
-                  >
-                    <svg
-                      class="lexicon-icon lexicon-icon-time"
-                      role="presentation"
-                    >
-                      <use
-                        xlink:href="icons.svg#time"
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <div
-                  class="input-group-item input-group-item-shrink"
-                >
-                  <div
-                    class="form-control"
-                    data-testid="formControl"
+                    class="input-group-item input-group-item-shrink"
                   >
                     <div
-                      class="clay-time-edit"
+                      class="input-group-text"
                     >
-                      <input
-                        class="clay-time-hours form-control-inset"
-                        data-testid="hours"
-                        maxlength="2"
-                        readonly=""
-                        type="text"
-                        value="0"
-                      />
-                      <span
-                        class="clay-time-divider"
+                      <svg
+                        class="lexicon-icon lexicon-icon-time"
+                        role="presentation"
                       >
-                        :
-                      </span>
-                      <input
-                        class="clay-time-minutes form-control-inset"
-                        data-testid="minutes"
-                        maxlength="2"
-                        readonly=""
-                        type="text"
-                        value="0"
-                      />
+                        <use
+                          xlink:href="icons.svg#time"
+                        />
+                      </svg>
                     </div>
+                  </div>
+                  <div
+                    class="input-group-item input-group-item-shrink"
+                  >
                     <div
-                      class="clay-time-action-group"
+                      class="form-control"
+                      data-testid="formControl"
                     >
                       <div
-                        class="clay-time-action-group-item"
-                        data-testid="containerReset"
-                        style="opacity: 0; pointer-events: none;"
+                        class="clay-time-edit"
                       >
-                        <button
-                          class="clay-time-clear-btn btn btn-unstyled"
-                          type="button"
+                        <input
+                          class="clay-time-hours form-control-inset"
+                          data-testid="hours"
+                          maxlength="2"
+                          readonly=""
+                          type="text"
+                          value="0"
+                        />
+                        <span
+                          class="clay-time-divider"
                         >
-                          <svg
-                            class="lexicon-icon lexicon-icon-times-circle"
-                            role="presentation"
-                          >
-                            <use
-                              xlink:href="icons.svg#times-circle"
-                            />
-                          </svg>
-                        </button>
+                          :
+                        </span>
+                        <input
+                          class="clay-time-minutes form-control-inset"
+                          data-testid="minutes"
+                          maxlength="2"
+                          readonly=""
+                          type="text"
+                          value="0"
+                        />
                       </div>
                       <div
-                        class="clay-time-action-group-item"
-                        data-testid="containerSpin"
-                        style="opacity: 0;"
+                        class="clay-time-action-group"
                       >
                         <div
-                          class="btn-group-vertical clay-time-inner-spin"
-                          role="group"
+                          class="clay-time-action-group-item"
+                          data-testid="containerReset"
+                          style="opacity: 0; pointer-events: none;"
                         >
                           <button
-                            class="clay-time-inner-spin-btn clay-time-inner-spin-btn-inc btn btn-secondary"
-                            data-testid="spinInc"
+                            class="clay-time-clear-btn btn btn-unstyled"
                             type="button"
                           >
                             <svg
-                              class="lexicon-icon lexicon-icon-angle-up"
+                              class="lexicon-icon lexicon-icon-times-circle"
                               role="presentation"
                             >
                               <use
-                                xlink:href="icons.svg#angle-up"
+                                xlink:href="icons.svg#times-circle"
                               />
                             </svg>
                           </button>
-                          <button
-                            class="clay-time-inner-spin-btn clay-time-inner-spin-btn-dec btn btn-secondary"
-                            data-testid="spinDec"
-                            type="button"
+                        </div>
+                        <div
+                          class="clay-time-action-group-item"
+                          data-testid="containerSpin"
+                          style="opacity: 0;"
+                        >
+                          <div
+                            class="btn-group-vertical clay-time-inner-spin"
+                            role="group"
                           >
-                            <svg
-                              class="lexicon-icon lexicon-icon-angle-down"
-                              role="presentation"
+                            <button
+                              class="clay-time-inner-spin-btn clay-time-inner-spin-btn-inc btn btn-secondary"
+                              data-testid="spinInc"
+                              type="button"
                             >
-                              <use
-                                xlink:href="icons.svg#angle-down"
-                              />
-                            </svg>
-                          </button>
+                              <svg
+                                class="lexicon-icon lexicon-icon-angle-up"
+                                role="presentation"
+                              >
+                                <use
+                                  xlink:href="icons.svg#angle-up"
+                                />
+                              </svg>
+                            </button>
+                            <button
+                              class="clay-time-inner-spin-btn clay-time-inner-spin-btn-dec btn btn-secondary"
+                              data-testid="spinDec"
+                              type="button"
+                            >
+                              <svg
+                                class="lexicon-icon lexicon-icon-angle-down"
+                                role="presentation"
+                              >
+                                <use
+                                  xlink:href="icons.svg#angle-down"
+                                />
+                              </svg>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -5,7 +5,7 @@
  */
 
 import classNames from 'classnames';
-import React, {useLayoutEffect} from 'react';
+import React, {useLayoutEffect, useRef} from 'react';
 import {Align} from 'metal-position';
 import {ClayPortal} from '@clayui/shared';
 import {useDropdownCloseInteractions} from './hooks';
@@ -76,10 +76,9 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 	// See https://github.com/microsoft/TypeScript/issues/30748#issuecomment-480197036
 	ref
 ) => {
-	useDropdownCloseInteractions(
-		[alignElementRef, ref as React.RefObject<HTMLDivElement>],
-		onSetActive
-	);
+	const subPortalRef = useRef<HTMLDivElement | null>(null);
+
+	useDropdownCloseInteractions([alignElementRef, subPortalRef], onSetActive);
 
 	useLayoutEffect(() => {
 		if (
@@ -96,17 +95,19 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 	});
 
 	return (
-		<ClayPortal>
-			<div
-				{...otherProps}
-				className={classNames('dropdown-menu', className, {
-					'dropdown-menu-indicator-end': hasRightSymbols,
-					'dropdown-menu-indicator-start': hasLeftSymbols,
-					show: active,
-				})}
-				ref={ref}
-			>
-				{children}
+		<ClayPortal subPortalRef={subPortalRef}>
+			<div ref={subPortalRef}>
+				<div
+					{...otherProps}
+					className={classNames('dropdown-menu', className, {
+						'dropdown-menu-indicator-end': hasRightSymbols,
+						'dropdown-menu-indicator-start': hasLeftSymbols,
+						show: active,
+					})}
+					ref={ref}
+				>
+					{children}
+				</div>
 			</div>
 		</ClayPortal>
 	);

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
@@ -15,40 +15,42 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu"
-      style="top: 0px; left: 0px;"
-    >
-      <ul
-        class="list-unstyled"
+    <div>
+      <div
+        class="dropdown-menu"
+        style="top: 0px; left: 0px;"
       >
-        <li
-          tabindex="-1"
+        <ul
+          class="list-unstyled"
         >
-          <button
-            class="dropdown-item"
-            label="clickable"
+          <li
+            tabindex="-1"
           >
-            clickable
-          </button>
-        </li>
-        <li
-          aria-hidden="true"
-          class="dropdown-divider"
-          role="presentation"
-        />
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#"
-            label="linkable"
+            <button
+              class="dropdown-item"
+              label="clickable"
+            >
+              clickable
+            </button>
+          </li>
+          <li
+            aria-hidden="true"
+            class="dropdown-divider"
+            role="presentation"
+          />
+          <li
+            tabindex="-1"
           >
-            linkable
-          </a>
-        </li>
-      </ul>
+            <a
+              class="dropdown-item"
+              href="#"
+              label="linkable"
+            >
+              linkable
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </body>
@@ -69,29 +71,31 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with caption 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu"
-      style="top: 0px; left: 0px;"
-    >
-      <ul
-        class="list-unstyled"
-      >
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#"
-            label="linkable"
-          >
-            linkable
-          </a>
-        </li>
-      </ul>
+    <div>
       <div
-        class="dropdown-caption"
+        class="dropdown-menu"
+        style="top: 0px; left: 0px;"
       >
-        Showing 7 of 203 Structures
+        <ul
+          class="list-unstyled"
+        >
+          <li
+            tabindex="-1"
+          >
+            <a
+              class="dropdown-item"
+              href="#"
+              label="linkable"
+            >
+              linkable
+            </a>
+          </li>
+        </ul>
+        <div
+          class="dropdown-caption"
+        >
+          Showing 7 of 203 Structures
+        </div>
       </div>
     </div>
   </div>
@@ -113,83 +117,85 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with checkbox 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu"
-      style="top: 0px; left: 0px;"
-    >
-      <ul
-        class="list-unstyled"
+    <div>
+      <div
+        class="dropdown-menu"
+        style="top: 0px; left: 0px;"
       >
-        <li
-          class="dropdown-subheader"
-          role="presentation"
-        >
-          checkbox
-        </li>
         <ul
           class="list-unstyled"
         >
           <li
-            tabindex="-1"
+            class="dropdown-subheader"
+            role="presentation"
           >
-            <span
-              class="dropdown-item"
-            >
-              <div
-                class="custom-control custom-checkbox"
-              >
-                <label>
-                  <input
-                    checked=""
-                    class="custom-control-input"
-                    spritemap="icons.svg"
-                    type="checkbox"
-                    value="true"
-                  />
-                  <span
-                    class="custom-control-label"
-                  >
-                    <span
-                      class="custom-control-label-text"
-                    >
-                      checkbox
-                    </span>
-                  </span>
-                </label>
-              </div>
-            </span>
+            checkbox
           </li>
-          <li
-            tabindex="-1"
+          <ul
+            class="list-unstyled"
           >
-            <span
-              class="dropdown-item"
+            <li
+              tabindex="-1"
             >
-              <div
-                class="custom-control custom-checkbox"
+              <span
+                class="dropdown-item"
               >
-                <label>
-                  <input
-                    class="custom-control-input"
-                    spritemap="icons.svg"
-                    type="checkbox"
-                    value="false"
-                  />
-                  <span
-                    class="custom-control-label"
-                  >
+                <div
+                  class="custom-control custom-checkbox"
+                >
+                  <label>
+                    <input
+                      checked=""
+                      class="custom-control-input"
+                      spritemap="icons.svg"
+                      type="checkbox"
+                      value="true"
+                    />
                     <span
-                      class="custom-control-label-text"
+                      class="custom-control-label"
                     >
-                      checkbox 1
+                      <span
+                        class="custom-control-label-text"
+                      >
+                        checkbox
+                      </span>
                     </span>
-                  </span>
-                </label>
-              </div>
-            </span>
-          </li>
+                  </label>
+                </div>
+              </span>
+            </li>
+            <li
+              tabindex="-1"
+            >
+              <span
+                class="dropdown-item"
+              >
+                <div
+                  class="custom-control custom-checkbox"
+                >
+                  <label>
+                    <input
+                      class="custom-control-input"
+                      spritemap="icons.svg"
+                      type="checkbox"
+                      value="false"
+                    />
+                    <span
+                      class="custom-control-label"
+                    >
+                      <span
+                        class="custom-control-label-text"
+                      >
+                        checkbox 1
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              </span>
+            </li>
+          </ul>
         </ul>
-      </ul>
+      </div>
     </div>
   </div>
 </body>
@@ -210,41 +216,43 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with footer content 1
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu"
-      style="top: 0px; left: 0px;"
-    >
-      <form>
-        <div
-          class="inline-scroller"
-        >
-          <ul
-            class="list-unstyled"
+    <div>
+      <div
+        class="dropdown-menu"
+        style="top: 0px; left: 0px;"
+      >
+        <form>
+          <div
+            class="inline-scroller"
           >
-            <li
-              tabindex="-1"
+            <ul
+              class="list-unstyled"
             >
-              <a
-                class="dropdown-item"
-                href="#"
-                label="linkable"
+              <li
+                tabindex="-1"
               >
-                linkable
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div
-          class="dropdown-section"
-        >
-          <button
-            class="btn btn-primary"
-            type="button"
+                <a
+                  class="dropdown-item"
+                  href="#"
+                  label="linkable"
+                >
+                  linkable
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="dropdown-section"
           >
-            Done
-          </button>
-        </div>
-      </form>
+            <button
+              class="btn btn-primary"
+              type="button"
+            >
+              Done
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </body>
@@ -265,31 +273,33 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with help text 1`] = 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu"
-      style="top: 0px; left: 0px;"
-    >
+    <div>
       <div
-        class="alert alert-fluid alert-info"
-        role="alert"
+        class="dropdown-menu"
+        style="top: 0px; left: 0px;"
       >
-        Help Text
-      </div>
-      <ul
-        class="list-unstyled"
-      >
-        <li
-          tabindex="-1"
+        <div
+          class="alert alert-fluid alert-info"
+          role="alert"
         >
-          <a
-            class="dropdown-item"
-            href="#"
-            label="linkable"
+          Help Text
+        </div>
+        <ul
+          class="list-unstyled"
+        >
+          <li
+            tabindex="-1"
           >
-            linkable
-          </a>
-        </li>
-      </ul>
+            <a
+              class="dropdown-item"
+              href="#"
+              label="linkable"
+            >
+              linkable
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </body>
@@ -310,91 +320,93 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with radio group 1`] 
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu"
-      style="top: 0px; left: 0px;"
-    >
-      <ul
-        class="list-unstyled"
+    <div>
+      <div
+        class="dropdown-menu"
+        style="top: 0px; left: 0px;"
       >
-        <li
-          class="dropdown-subheader"
-          role="presentation"
+        <ul
+          class="list-unstyled"
         >
-          radio
-        </li>
-        <li
-          aria-label="radio"
-          role="radiogroup"
-        >
-          <ul
-            class="list-unstyled"
+          <li
+            class="dropdown-subheader"
+            role="presentation"
           >
-            <li
-              tabindex="-1"
+            radio
+          </li>
+          <li
+            aria-label="radio"
+            role="radiogroup"
+          >
+            <ul
+              class="list-unstyled"
             >
-              <span
-                class="dropdown-item"
+              <li
+                tabindex="-1"
               >
-                <div
-                  class="custom-control custom-radio custom-control-inline"
+                <span
+                  class="dropdown-item"
                 >
-                  <label>
-                    <input
-                      class="custom-control-input"
-                      name="radio"
-                      role="radio"
-                      spritemap="icons.svg"
-                      type="radio"
-                      value="one"
-                    />
-                    <span
-                      class="custom-control-label"
-                    >
+                  <div
+                    class="custom-control custom-radio custom-control-inline"
+                  >
+                    <label>
+                      <input
+                        class="custom-control-input"
+                        name="radio"
+                        role="radio"
+                        spritemap="icons.svg"
+                        type="radio"
+                        value="one"
+                      />
                       <span
-                        class="custom-control-label-text"
+                        class="custom-control-label"
                       >
-                        one
+                        <span
+                          class="custom-control-label-text"
+                        >
+                          one
+                        </span>
                       </span>
-                    </span>
-                  </label>
-                </div>
-              </span>
-            </li>
-            <li
-              tabindex="-1"
-            >
-              <span
-                class="dropdown-item"
+                    </label>
+                  </div>
+                </span>
+              </li>
+              <li
+                tabindex="-1"
               >
-                <div
-                  class="custom-control custom-radio custom-control-inline"
+                <span
+                  class="dropdown-item"
                 >
-                  <label>
-                    <input
-                      class="custom-control-input"
-                      name="radio"
-                      role="radio"
-                      spritemap="icons.svg"
-                      type="radio"
-                      value="two"
-                    />
-                    <span
-                      class="custom-control-label"
-                    >
+                  <div
+                    class="custom-control custom-radio custom-control-inline"
+                  >
+                    <label>
+                      <input
+                        class="custom-control-input"
+                        name="radio"
+                        role="radio"
+                        spritemap="icons.svg"
+                        type="radio"
+                        value="two"
+                      />
                       <span
-                        class="custom-control-label-text"
+                        class="custom-control-label"
                       >
-                        two
+                        <span
+                          class="custom-control-label-text"
+                        >
+                          two
+                        </span>
                       </span>
-                    </span>
-                  </label>
-                </div>
-              </span>
-            </li>
-          </ul>
-        </li>
-      </ul>
+                    </label>
+                  </div>
+                </span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </body>
@@ -415,61 +427,63 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with search 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu"
-      style="top: 0px; left: 0px;"
-    >
-      <form>
-        <div
-          class="dropdown-section"
-        >
+    <div>
+      <div
+        class="dropdown-menu"
+        style="top: 0px; left: 0px;"
+      >
+        <form>
           <div
-            class="input-group input-group-sm"
+            class="dropdown-section"
           >
             <div
-              class="input-group-item"
+              class="input-group input-group-sm"
             >
-              <input
-                class="form-control input-group-inset input-group-inset-after"
-                type="text"
-                value="Search"
-              />
-              <span
-                class="input-group-inset-item input-group-inset-item-after"
+              <div
+                class="input-group-item"
               >
-                <button
-                  class="btn btn-unstyled"
-                  type="button"
+                <input
+                  class="form-control input-group-inset input-group-inset-after"
+                  type="text"
+                  value="Search"
+                />
+                <span
+                  class="input-group-inset-item input-group-inset-item-after"
                 >
-                  <svg
-                    class="lexicon-icon lexicon-icon-search"
-                    role="presentation"
+                  <button
+                    class="btn btn-unstyled"
+                    type="button"
                   >
-                    <use
-                      xlink:href="icons.svg#search"
-                    />
-                  </svg>
-                </button>
-              </span>
+                    <svg
+                      class="lexicon-icon lexicon-icon-search"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="icons.svg#search"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-      </form>
-      <ul
-        class="list-unstyled"
-      >
-        <li
-          tabindex="-1"
+        </form>
+        <ul
+          class="list-unstyled"
         >
-          <a
-            class="dropdown-item"
-            href="#"
-            label="linkable"
+          <li
+            tabindex="-1"
           >
-            linkable
-          </a>
-        </li>
-      </ul>
+            <a
+              class="dropdown-item"
+              href="#"
+              label="linkable"
+            >
+              linkable
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </body>

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -14,44 +14,46 @@ exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu show"
-      style="top: 0px; left: 0px;"
-    >
-      <ul
-        class="list-unstyled"
+    <div>
+      <div
+        class="dropdown-menu show"
+        style="top: 0px; left: 0px;"
       >
-        <li
-          tabindex="-1"
+        <ul
+          class="list-unstyled"
         >
-          <a
-            class="dropdown-item"
-            href="#one"
+          <li
+            tabindex="-1"
           >
-            one
-          </a>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#two"
+            <a
+              class="dropdown-item"
+              href="#one"
+            >
+              one
+            </a>
+          </li>
+          <li
+            tabindex="-1"
           >
-            two
-          </a>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#three"
+            <a
+              class="dropdown-item"
+              href="#two"
+            >
+              two
+            </a>
+          </li>
+          <li
+            tabindex="-1"
           >
-            three
-          </a>
-        </li>
-      </ul>
+            <a
+              class="dropdown-item"
+              href="#three"
+            >
+              three
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </body>
@@ -71,86 +73,88 @@ exports[`ClayDropDown renders with groups 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu show"
-      style="top: 0px; left: 0px;"
-    >
-      <ul
-        class="list-unstyled"
+    <div>
+      <div
+        class="dropdown-menu show"
+        style="top: 0px; left: 0px;"
       >
-        <li
-          class="dropdown-subheader"
-          role="presentation"
+        <ul
+          class="list-unstyled"
         >
-          Group #1
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#one"
+          <li
+            class="dropdown-subheader"
+            role="presentation"
           >
-            one
-          </a>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#two"
+            Group #1
+          </li>
+          <li
+            tabindex="-1"
           >
-            two
-          </a>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#three"
+            <a
+              class="dropdown-item"
+              href="#one"
+            >
+              one
+            </a>
+          </li>
+          <li
+            tabindex="-1"
           >
-            three
-          </a>
-        </li>
-        <li
-          class="dropdown-subheader"
-          role="presentation"
-        >
-          Group #2
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#one"
+            <a
+              class="dropdown-item"
+              href="#two"
+            >
+              two
+            </a>
+          </li>
+          <li
+            tabindex="-1"
           >
-            one
-          </a>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#two"
+            <a
+              class="dropdown-item"
+              href="#three"
+            >
+              three
+            </a>
+          </li>
+          <li
+            class="dropdown-subheader"
+            role="presentation"
           >
-            two
-          </a>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#three"
+            Group #2
+          </li>
+          <li
+            tabindex="-1"
           >
-            three
-          </a>
-        </li>
-      </ul>
+            <a
+              class="dropdown-item"
+              href="#one"
+            >
+              one
+            </a>
+          </li>
+          <li
+            tabindex="-1"
+          >
+            <a
+              class="dropdown-item"
+              href="#two"
+            >
+              two
+            </a>
+          </li>
+          <li
+            tabindex="-1"
+          >
+            <a
+              class="dropdown-item"
+              href="#three"
+            >
+              three
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </body>
@@ -170,89 +174,91 @@ exports[`ClayDropDown renders with icons 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu dropdown-menu-indicator-end dropdown-menu-indicator-start show"
-      style="top: 0px; left: 0px;"
-    >
-      <ul
-        class="list-unstyled"
+    <div>
+      <div
+        class="dropdown-menu dropdown-menu-indicator-end dropdown-menu-indicator-start show"
+        style="top: 0px; left: 0px;"
       >
-        <li
-          tabindex="-1"
+        <ul
+          class="list-unstyled"
         >
-          <span
-            class="dropdown-item"
+          <li
+            tabindex="-1"
           >
             <span
-              class="dropdown-item-indicator-start"
+              class="dropdown-item"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-trash"
-                role="presentation"
+              <span
+                class="dropdown-item-indicator-start"
               >
-                <use
-                  xlink:href="/foo/bar#trash"
-                />
-              </svg>
+                <svg
+                  class="lexicon-icon lexicon-icon-trash"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/foo/bar#trash"
+                  />
+                </svg>
+              </span>
+              Left
             </span>
-            Left
-          </span>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <span
-            class="dropdown-item"
-          >
-            Right
-            <span
-              class="dropdown-item-indicator-end"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-check"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#check"
-                />
-              </svg>
-            </span>
-          </span>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <span
-            class="dropdown-item"
+          </li>
+          <li
+            tabindex="-1"
           >
             <span
-              class="dropdown-item-indicator-start"
+              class="dropdown-item"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-trash"
-                role="presentation"
+              Right
+              <span
+                class="dropdown-item-indicator-end"
               >
-                <use
-                  xlink:href="/foo/bar#trash"
-                />
-              </svg>
+                <svg
+                  class="lexicon-icon lexicon-icon-check"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/foo/bar#check"
+                  />
+                </svg>
+              </span>
             </span>
-            Both
+          </li>
+          <li
+            tabindex="-1"
+          >
             <span
-              class="dropdown-item-indicator-end"
+              class="dropdown-item"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-check"
-                role="presentation"
+              <span
+                class="dropdown-item-indicator-start"
               >
-                <use
-                  xlink:href="/foo/bar#check"
-                />
-              </svg>
+                <svg
+                  class="lexicon-icon lexicon-icon-trash"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/foo/bar#trash"
+                  />
+                </svg>
+              </span>
+              Both
+              <span
+                class="dropdown-item-indicator-end"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-check"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/foo/bar#check"
+                  />
+                </svg>
+              </span>
             </span>
-          </span>
-        </li>
-      </ul>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </body>
@@ -272,80 +278,82 @@ exports[`ClayDropDown renders with search input 1`] = `
     </div>
   </div>
   <div>
-    <div
-      class="dropdown-menu show"
-      style="top: 0px; left: 0px;"
-    >
-      <form>
-        <div
-          class="dropdown-section"
-        >
+    <div>
+      <div
+        class="dropdown-menu show"
+        style="top: 0px; left: 0px;"
+      >
+        <form>
           <div
-            class="input-group input-group-sm"
+            class="dropdown-section"
           >
             <div
-              class="input-group-item"
+              class="input-group input-group-sm"
             >
-              <input
-                class="form-control input-group-inset input-group-inset-after"
-                type="text"
-                value="test"
-              />
-              <span
-                class="input-group-inset-item input-group-inset-item-after"
+              <div
+                class="input-group-item"
               >
-                <button
-                  class="btn btn-unstyled"
-                  type="button"
+                <input
+                  class="form-control input-group-inset input-group-inset-after"
+                  type="text"
+                  value="test"
+                />
+                <span
+                  class="input-group-inset-item input-group-inset-item-after"
                 >
-                  <svg
-                    class="lexicon-icon lexicon-icon-search"
-                    role="presentation"
+                  <button
+                    class="btn btn-unstyled"
+                    type="button"
                   >
-                    <use
-                      xlink:href="/foo/bar#search"
-                    />
-                  </svg>
-                </button>
-              </span>
+                    <svg
+                      class="lexicon-icon lexicon-icon-search"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#search"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-      </form>
-      <ul
-        class="list-unstyled"
-      >
-        <li
-          tabindex="-1"
+        </form>
+        <ul
+          class="list-unstyled"
         >
-          <a
-            class="dropdown-item"
-            href="#one"
+          <li
+            tabindex="-1"
           >
-            one
-          </a>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#two"
+            <a
+              class="dropdown-item"
+              href="#one"
+            >
+              one
+            </a>
+          </li>
+          <li
+            tabindex="-1"
           >
-            two
-          </a>
-        </li>
-        <li
-          tabindex="-1"
-        >
-          <a
-            class="dropdown-item"
-            href="#three"
+            <a
+              class="dropdown-item"
+              href="#two"
+            >
+              two
+            </a>
+          </li>
+          <li
+            tabindex="-1"
           >
-            three
-          </a>
-        </li>
-      </ul>
+            <a
+              class="dropdown-item"
+              href="#three"
+            >
+              three
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </body>

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -43,9 +43,8 @@ const ClayModal: FunctionComponent<IProps> & {
 	...otherProps
 }: IProps) => {
 	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
-	const modalDialogElementRef = useRef<HTMLDivElement | null>(null);
 
-	useUserInteractions(modalDialogElementRef, () =>
+	useUserInteractions(modalBodyElementRef, () =>
 		observer.dispatch(ObserverType.Close)
 	);
 
@@ -63,27 +62,31 @@ const ClayModal: FunctionComponent<IProps> & {
 				className={classNames('fade modal d-block', className, {
 					show: observer.mutation,
 				})}
-				ref={modalBodyElementRef}
 			>
 				<div
-					className={classNames('modal-dialog', {
-						[`modal-${size}`]: size,
-						[`modal-${status}`]: status,
-					})}
-					ref={modalDialogElementRef}
-					tabIndex={-1}
+					className={`modal-${size}`}
+					ref={modalBodyElementRef}
+					style={{margin: 'auto'}}
 				>
-					<div className="modal-content">
-						<Context.Provider
-							value={{
-								onClose: () =>
-									observer.dispatch(ObserverType.Close),
-								spritemap,
-								status,
-							}}
-						>
-							{children}
-						</Context.Provider>
+					<div
+						className={classNames('modal-dialog', {
+							[`modal-${size}`]: size,
+							[`modal-${status}`]: status,
+						})}
+						tabIndex={-1}
+					>
+						<div className="modal-content">
+							<Context.Provider
+								value={{
+									onClose: () =>
+										observer.dispatch(ObserverType.Close),
+									spritemap,
+									status,
+								}}
+							>
+								{children}
+							</Context.Provider>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -28,60 +28,65 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
       class="fade modal d-block"
     >
       <div
-        class="modal-dialog modal-lg"
-        tabindex="-1"
+        class="modal-lg"
+        style="margin: auto;"
       >
         <div
-          class="modal-content"
+          class="modal-dialog modal-lg"
+          tabindex="-1"
         >
           <div
-            class="modal-header"
+            class="modal-content"
           >
             <div
-              class="modal-title"
+              class="modal-header"
             >
-              Title
-            </div>
-            <button
-              aria-label="close"
-              class="close btn btn-unstyled"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times"
-                role="presentation"
+              <div
+                class="modal-title"
               >
-                <use
-                  xlink:href="icons.svg#times"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="modal-body"
-          >
-            <h1>
-              Hello world!
-            </h1>
-          </div>
-          <div
-            class="modal-footer"
-          >
-            <div
-              class="modal-item-first"
-            />
-            <div
-              class="modal-item"
-            />
-            <div
-              class="modal-item-last"
-            >
+                Title
+              </div>
               <button
-                class="btn btn-primary"
+                aria-label="close"
+                class="close btn btn-unstyled"
                 type="button"
               >
-                Primary
+                <svg
+                  class="lexicon-icon lexicon-icon-times"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="icons.svg#times"
+                  />
+                </svg>
               </button>
+            </div>
+            <div
+              class="modal-body"
+            >
+              <h1>
+                Hello world!
+              </h1>
+            </div>
+            <div
+              class="modal-footer"
+            >
+              <div
+                class="modal-item-first"
+              />
+              <div
+                class="modal-item"
+              />
+              <div
+                class="modal-item-last"
+              >
+                <button
+                  class="btn btn-primary"
+                  type="button"
+                >
+                  Primary
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -12,60 +12,65 @@ exports[`ClayModal renders 1`] = `
       class="fade modal d-block"
     >
       <div
-        class="modal-dialog"
-        tabindex="-1"
+        class="modal-undefined"
+        style="margin: auto;"
       >
         <div
-          class="modal-content"
+          class="modal-dialog"
+          tabindex="-1"
         >
           <div
-            class="modal-header"
+            class="modal-content"
           >
             <div
-              class="modal-title"
+              class="modal-header"
             >
-              Foo
-            </div>
-            <button
-              aria-label="close"
-              class="close btn btn-unstyled"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times"
-                role="presentation"
+              <div
+                class="modal-title"
               >
-                <use
-                  xlink:href="icons.svg#times"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="modal-body"
-          >
-            <h1>
-              Hello world!
-            </h1>
-          </div>
-          <div
-            class="modal-footer"
-          >
-            <div
-              class="modal-item-first"
-            />
-            <div
-              class="modal-item"
-            />
-            <div
-              class="modal-item-last"
-            >
+                Foo
+              </div>
               <button
-                class="btn btn-primary"
+                aria-label="close"
+                class="close btn btn-unstyled"
                 type="button"
               >
-                Primary
+                <svg
+                  class="lexicon-icon lexicon-icon-times"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="icons.svg#times"
+                  />
+                </svg>
               </button>
+            </div>
+            <div
+              class="modal-body"
+            >
+              <h1>
+                Hello world!
+              </h1>
+            </div>
+            <div
+              class="modal-footer"
+            >
+              <div
+                class="modal-item-first"
+              />
+              <div
+                class="modal-item"
+              />
+              <div
+                class="modal-item-last"
+              >
+                <button
+                  class="btn btn-primary"
+                  type="button"
+                >
+                  Primary
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -88,19 +93,24 @@ exports[`ClayModal renders a body component with url 1`] = `
       class="fade modal d-block"
     >
       <div
-        class="modal-dialog"
-        tabindex="-1"
+        class="modal-undefined"
+        style="margin: auto;"
       >
         <div
-          class="modal-content"
+          class="modal-dialog"
+          tabindex="-1"
         >
           <div
-            class="modal-body modal-body-iframe"
+            class="modal-content"
           >
-            <iframe
-              src="http://localhost"
-              title="http://localhost"
-            />
+            <div
+              class="modal-body modal-body-iframe"
+            >
+              <iframe
+                src="http://localhost"
+                title="http://localhost"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -122,44 +132,49 @@ exports[`ClayModal renders a footer component with buttons 1`] = `
       class="fade modal d-block"
     >
       <div
-        class="modal-dialog"
-        tabindex="-1"
+        class="modal-undefined"
+        style="margin: auto;"
       >
         <div
-          class="modal-content"
+          class="modal-dialog"
+          tabindex="-1"
         >
           <div
-            class="modal-footer"
+            class="modal-content"
           >
             <div
-              class="modal-item-first"
+              class="modal-footer"
             >
-              <button
-                class="btn btn-primary"
-                type="button"
+              <div
+                class="modal-item-first"
               >
-                Bar
-              </button>
-            </div>
-            <div
-              class="modal-item"
-            >
-              <button
-                class="btn btn-primary"
-                type="button"
+                <button
+                  class="btn btn-primary"
+                  type="button"
+                >
+                  Bar
+                </button>
+              </div>
+              <div
+                class="modal-item"
               >
-                Baz
-              </button>
-            </div>
-            <div
-              class="modal-item-last"
-            >
-              <button
-                class="btn btn-primary"
-                type="button"
+                <button
+                  class="btn btn-primary"
+                  type="button"
+                >
+                  Baz
+                </button>
+              </div>
+              <div
+                class="modal-item-last"
               >
-                Foo
-              </button>
+                <button
+                  class="btn btn-primary"
+                  type="button"
+                >
+                  Foo
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -182,34 +197,39 @@ exports[`ClayModal renders with Header 1`] = `
       class="fade modal d-block"
     >
       <div
-        class="modal-dialog"
-        tabindex="-1"
+        class="modal-undefined"
+        style="margin: auto;"
       >
         <div
-          class="modal-content"
+          class="modal-dialog"
+          tabindex="-1"
         >
           <div
-            class="modal-header"
+            class="modal-content"
           >
             <div
-              class="modal-title"
+              class="modal-header"
             >
-              Foo
-            </div>
-            <button
-              aria-label="close"
-              class="close btn btn-unstyled"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times"
-                role="presentation"
+              <div
+                class="modal-title"
               >
-                <use
-                  xlink:href="icons.svg#times"
-                />
-              </svg>
-            </button>
+                Foo
+              </div>
+              <button
+                aria-label="close"
+                class="close btn btn-unstyled"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-times"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="icons.svg#times"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -231,12 +251,17 @@ exports[`ClayModal renders with size 1`] = `
       class="fade modal d-block"
     >
       <div
-        class="modal-dialog modal-lg"
-        tabindex="-1"
+        class="modal-lg"
+        style="margin: auto;"
       >
         <div
-          class="modal-content"
-        />
+          class="modal-dialog modal-lg"
+          tabindex="-1"
+        >
+          <div
+            class="modal-content"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -256,12 +281,17 @@ exports[`ClayModal renders with status 1`] = `
       class="fade modal d-block"
     >
       <div
-        class="modal-dialog modal-success"
-        tabindex="-1"
+        class="modal-undefined"
+        style="margin: auto;"
       >
         <div
-          class="modal-content"
-        />
+          class="modal-dialog modal-success"
+          tabindex="-1"
+        >
+          <div
+            class="modal-content"
+          />
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fix #2288

- This prevents DropDown from closing when it has a portal nested to it, for example DatePicker.
- The same is done for Modal, it was closing when it has some action on these portals nested to it, the strategy was to wrap them all in a `fade modal` child element and simulate the element as if it were `modal-dialog` without an overflow for example to keep the modal closed when clicking outside the modal.
- There have been many updated snapshot tests due to the wraps on top of these components that affect many others.

Let me know if you think this is weird or have another strategy.