### PR TITLE
fix(clay-css): Atlas Form Validation `.form-feedback-item` and `.form…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -114,7 +114,11 @@ $input-select-icon-disabled: clay-icon(caret-double-l, $input-select-icon-disabl
 
 // Form Feedback
 
+$form-feedback-font-weight: $font-weight-semi-bold !default;
+
 $form-feedback-indicator-margin-x: 0 !default;
+
+$form-text-font-weight: $font-weight-semi-bold !default;
 
 // Textarea
 


### PR DESCRIPTION
…-text` should be semi-bold

fixes #2328