### PR TITLE
chore(@clayui/modal): adds a warning when observer is not passed to ClayModal

### DIFF
--- a/packages/clay-modal/package.json
+++ b/packages/clay-modal/package.json
@@ -29,7 +29,8 @@
 		"@clayui/button": "^3.0.0-milestone.3",
 		"@clayui/icon": "^3.0.0-milestone.3",
 		"@clayui/shared": "^3.0.0-milestone.3",
-		"classnames": "^2.2.6"
+		"classnames": "^2.2.6",
+		"warning": "^4.0.3"
 	},
 	"devDependencies": {
 		"@clayui/css": "^3.0.0-milestone.3"

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -10,6 +10,7 @@ import Context, {IContext} from './Context';
 import Footer from './Footer';
 import Header from './Header';
 import React, {FunctionComponent, useEffect, useRef} from 'react';
+import warning from 'warning';
 import {ClayPortal} from '@clayui/shared';
 import {Observer, ObserverType, Size} from './types';
 import {useUserInteractions} from './Hook';
@@ -29,6 +30,17 @@ interface IProps
 	observer: Observer;
 }
 
+const warningMessage = `You need to pass the 'observer' prop to ClayModal for everything to work fine, use the 'useModal' hook that exposes the observer.
+
+> const {observer} = useModal({...});
+>
+> return (
+> 	<ClayModal observer={observer}>
+> 		...
+> 	</ClayModal>
+> ); 
+`;
+
 const ClayModal: FunctionComponent<IProps> & {
 	Body: typeof Body;
 	Footer: typeof Footer;
@@ -43,6 +55,8 @@ const ClayModal: FunctionComponent<IProps> & {
 	...otherProps
 }: IProps) => {
 	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
+
+	warning(observer !== undefined, warningMessage);
 
 	useUserInteractions(modalBodyElementRef, () =>
 		observer.dispatch(ObserverType.Close)


### PR DESCRIPTION
Just adding a warning to help developers correctly use `ClayModal`.