### PR TITLE
fix(clay-css): Globals added `_globals-z-index.scss` to list z-index …

### DIFF
--- a/packages/clay-css/src/scss/_variables.scss
+++ b/packages/clay-css/src/scss/_variables.scss
@@ -1,4 +1,5 @@
 @import "variables/_globals";
+@import "variables/_globals-z-index";
 
 @import "variables/_alerts";
 @import "variables/_badges";

--- a/packages/clay-css/src/scss/variables/_globals-z-index.scss
+++ b/packages/clay-css/src/scss/variables/_globals-z-index.scss
@@ -1,0 +1,22 @@
+$zindex-dropdown: 1000 !default;
+$zindex-sticky: 1020 !default;
+$zindex-fixed: 1030 !default;
+$zindex-modal-backdrop: 1040 !default;
+$zindex-modal: 1050 !default;
+$zindex-popover: 1060 !default;
+$zindex-tooltip: 1070 !default;
+
+$zindex-alert-notifications: 5000 !default;
+$zindex-clay-range-input-form-control: 1 !default;
+$zindex-input-group-hover: 3 !default;
+$zindex-input-group-focus: $zindex-input-group-hover + 1 !default; // 4
+$zindex-navbar-collapse-absolute: 500 !default;
+$zindex-navbar-overlay: 450 !default;
+$zindex-navbar-toggler-focus: 525 !default;
+$zindex-menubar-vertical-expand-md-collapse-mobile: $zindex-navbar-collapse-absolute - 1 !default; // 499
+$zindex-menubar-vertical-expand-lg-collapse-mobile: $zindex-navbar-collapse-absolute - 1 !default; // 499
+$zindex-pagination-link-focus: 4 !default;
+$zindex-pagination-link-active: 3 !default;
+$zindex-pagination-link-disabled: 0 !default;
+$zindex-panel-header-link-focus: 1 !default;
+$zindex-sidenav: $zindex-fixed + 5 !default; // 1035

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -103,13 +103,3 @@ $h6-font-size-mobile: null !default;
 $body-moz-osx-font-smoothing: $moz-osx-font-smoothing !default;
 $body-webkit-font-smoothing: $webkit-font-smoothing !default;
 $body-text-align: inherit !default;
-
-// Z-Index Variables
-
-$zindex-alert-notifications: 5000 !default;
-$zindex-input-group-hover: 3 !default;
-$zindex-input-group-focus: $zindex-input-group-hover + 1 !default; // 4
-$zindex-navbar-collapse-absolute: 500 !default;
-$zindex-navbar-overlay: 450 !default;
-$zindex-navbar-toggler-focus: 525 !default;
-$zindex-sidenav: $zindex-fixed + 5 !default;

--- a/packages/clay-css/src/scss/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/variables/_menubar.scss
@@ -5,7 +5,7 @@ $menubar-vertical-expand-md: map-merge((
 	margin-bottom-mobile: 1.5rem,
 	margin-left-mobile: -($grid-gutter-width / 2),
 	margin-right-mobile: -($grid-gutter-width / 2),
-	collapse-z-index-mobile: $zindex-navbar-collapse-absolute - 1
+	collapse-z-index-mobile: $zindex-menubar-vertical-expand-md-collapse-mobile,
 ), $menubar-vertical-expand-md);
 
 $menubar-vertical-transparent-md: () !default;
@@ -24,7 +24,7 @@ $menubar-vertical-expand-lg: map-merge((
 	margin-bottom-mobile: 1.5rem,
 	margin-left-mobile: -($grid-gutter-width / 2),
 	margin-right-mobile: -($grid-gutter-width / 2),
-	collapse-z-index-mobile: $zindex-navbar-collapse-absolute - 1
+	collapse-z-index-mobile: $zindex-menubar-vertical-expand-lg-collapse-mobile,
 ), $menubar-vertical-expand-lg);
 
 $menubar-vertical-transparent-lg: () !default;

--- a/packages/clay-css/src/scss/variables/_pagination.scss
+++ b/packages/clay-css/src/scss/variables/_pagination.scss
@@ -89,7 +89,7 @@ $pagination-link-hover: map-merge((
 $pagination-link-focus: () !default;
 $pagination-link-focus: map-merge((
 	box-shadow: $pagination-focus-box-shadow,
-	z-index: 4,
+	z-index: $zindex-pagination-link-focus,
 ), $pagination-link-focus);
 
 $pagination-link-active: () !default;
@@ -98,7 +98,7 @@ $pagination-link-active: map-merge((
 	border-color: $pagination-active-border-color,
 	cursor: default,
 	color: $pagination-active-color,
-	z-index: 3,
+	z-index: $zindex-pagination-link-active,
 ), $pagination-link-active);
 
 $pagination-link-disabled: () !default;
@@ -110,7 +110,7 @@ $pagination-link-disabled: map-merge((
 	cursor: $pagination-disabled-cursor,
 	opacity: $pagination-disabled-opacity,
 	pointer-events: $pagination-disabled-pointer-events,
-	z-index: 0,
+	z-index: $zindex-pagination-link-disabled,
 ), $pagination-link-disabled);
 
 // Pagination Dropdown Menu

--- a/packages/clay-css/src/scss/variables/_panels.scss
+++ b/packages/clay-css/src/scss/variables/_panels.scss
@@ -41,7 +41,7 @@ $panel-header-link: map-merge((
 	transition: border-color 0.1s ease#{','} border-radius 0.5s ease,
 	hover-color: inherit,
 	hover-text-decoration: $panel-header-link-hover-text-decoration,
-	focus-z-index: 1,
+	focus-z-index: $zindex-panel-header-link-focus,
 ), $panel-header-link);
 
 $panel-header-collapsed-link: () !default;

--- a/packages/clay-css/src/scss/variables/_range.scss
+++ b/packages/clay-css/src/scss/variables/_range.scss
@@ -69,7 +69,7 @@ $clay-range-input: map-merge((
 	form-control-bg: transparent,
 	form-control-height: $input-height,
 	form-control-position: relative,
-	form-control-z-index: 1,
+	form-control-z-index: $zindex-clay-range-input-form-control,
 	data-label-font-size: 0.875rem,
 	data-label-font-weight: $font-weight-semi-bold,
 	data-label-line-height: 1,


### PR DESCRIPTION
…variables used in Bootstrap/ClayCSS

fix(clay-css): Globals Z Index added variables `$zindex-clay-range-input-form-control`, `$zindex-menubar-vertical-expand-md-collapse-mobile`, `$zindex-menubar-vertical-expand-lg-collapse-mobile`, `$zindex-pagination-link-focus`, `$zindex-pagination-link-active`, `$zindex-pagination-link-disabled`, `$zindex-panel-header-link-focus`

fixes #2339