### PR TITLE
feat(@clayui/form): adds the Clear All specification in multi-select

### DIFF
--- a/packages/clay-css/src/content/form_elements_input_groups.html
+++ b/packages/clay-css/src/content/form_elements_input_groups.html
@@ -795,8 +795,10 @@ section: Components
 				<label for="tagsField1">Tags</label>
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
-						<div class="form-control form-control-tag-group">
-							<input class="form-control-inset" id="tagsField1" type="text" value="some value">
+						<div class="form-control form-control-tag-group input-group">
+							<div class="input-group-item">
+								<input class="form-control-inset" id="tagsField1" type="text" value="some value">
+							</div>
 						</div>
 						<div class="form-feedback-group">
 							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
@@ -812,96 +814,8 @@ section: Components
 				<label for="tagsField2">Tags</label>
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
-						<div class="form-control form-control-tag-group">
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-										</span>
-									</span>
-								</span>
-								<span class="label-item label-item-expand">wall</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-										</span>
-									</span>
-								</span>
-								<span class="label-item label-item-expand">wallpaper</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-										</span>
-									</span>
-								</span>
-								<span class="label-item label-item-expand">wonderwall</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-expand">winterfell</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<input class="form-control-inset" id="tagsField2" type="text" value="some value">
-						</div>
-						<div class="form-feedback-group">
-							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
-						</div>
-					</div>
-					<div class="input-group-item input-group-item-shrink">
-						<button class="btn btn-secondary" type="button">Select All the Things</button>
-					</div>
-				</div>
-			</div>
-
-			<div class="form-group">
-				<label for="tagsField3">Tags</label>
-				<div class="input-group input-group-stacked-sm-down">
-					<div class="input-group-item">
-						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
+						<div class="form-control form-control-tag-group input-group">
+							<div class="input-group-item">
 								<span class="label label-dismissible label-secondary" tabindex="0">
 									<span class="label-item label-item-before">
 										<span class="sticker">
@@ -973,7 +887,99 @@ section: Components
 										</button>
 									</span>
 								</span>
-								<input class="form-control-inset" id="tagsField3" type="text" value="some value">
+								<input class="form-control-inset" id="tagsField2" type="text" value="some value">
+							</div>
+						</div>
+						<div class="form-feedback-group">
+							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
+						</div>
+					</div>
+					<div class="input-group-item input-group-item-shrink">
+						<button class="btn btn-secondary" type="button">Select All the Things</button>
+					</div>
+				</div>
+			</div>
+
+			<div class="form-group">
+				<label for="tagsField3">Tags</label>
+				<div class="input-group input-group-stacked-sm-down">
+					<div class="input-group-item">
+						<div class="dropdown">
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
+											</span>
+										</span>
+										<span class="label-item label-item-expand">wall</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
+											</span>
+										</span>
+										<span class="label-item label-item-expand">wallpaper</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
+											</span>
+										</span>
+										<span class="label-item label-item-expand">wonderwall</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-expand">winterfell</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<input class="form-control-inset" id="tagsField3" type="text" value="some value">
+								</div>
 							</div>
 							<ul class="autocomplete-dropdown-menu dropdown-menu show">
 								<li><a class="dropdown-item" href="#1">Some Value</a></li>
@@ -1016,9 +1022,11 @@ section: Components
 				<label for="tagsFieldContentEditable1">Tags (Content Editable)</label>
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
-						<div class="form-control form-control-tag-group">
-							<input aria-hidden="true" class="form-control-hidden" id="tagsFieldContentEditable1" tabindex="-1" type="text">
-							<span class="form-control-inset" contenteditable="true"></span>
+						<div class="form-control form-control-tag-group input-group">
+							<div class="input-group-item">
+								<input aria-hidden="true" class="form-control-hidden" id="tagsFieldContentEditable1" tabindex="-1" type="text">
+								<span class="form-control-inset" contenteditable="true"></span>
+							</div>
 						</div>
 						<div class="form-feedback-group">
 							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
@@ -1034,80 +1042,82 @@ section: Components
 				<label for="tagsContentEditableField2">Tags (Content Editable)</label>
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
-						<div class="form-control form-control-tag-group">
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+						<div class="form-control form-control-tag-group input-group">
+							<div class="input-group-item">
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-before">
+										<span class="sticker">
+											<span class="sticker-overlay">
+												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+											</span>
 										</span>
 									</span>
-								</span>
-								<span class="label-item label-item-expand">wall</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-										</span>
+									<span class="label-item label-item-expand">wall</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
 									</span>
 								</span>
-								<span class="label-item label-item-expand">wallpaper</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-before">
+										<span class="sticker">
+											<span class="sticker-overlay">
+												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+											</span>
 										</span>
 									</span>
+									<span class="label-item label-item-expand">wallpaper</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
+									</span>
 								</span>
-								<span class="label-item label-item-expand">wonderwall</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-before">
+										<span class="sticker">
+											<span class="sticker-overlay">
+												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+											</span>
+										</span>
+									</span>
+									<span class="label-item label-item-expand">wonderwall</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
+									</span>
 								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-expand">winterfell</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-expand">winterfell</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
+									</span>
 								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-expand">kings landing</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-expand">kings landing</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
+									</span>
 								</span>
-							</span>
-							<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableField2" tabindex="-1" type="text">
-							<span class="form-control-inset" contenteditable>some value</span>
+								<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableField2" tabindex="-1" type="text">
+								<span class="form-control-inset" contenteditable>some value</span>
+							</div>
 						</div>
 						<div class="form-feedback-group">
 							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>

--- a/packages/clay-css/src/content/form_elements_multiselect.html
+++ b/packages/clay-css/src/content/form_elements_multiselect.html
@@ -16,11 +16,9 @@ section: Components
 					<div class="input-group input-group-stacked-sm-down">
 						<div class="input-group-item">
 							<div class="dropdown">
-								<div class="form-control form-control-tag-group">
-									<span class="autofit-row">
-										<span class="autofit-col autofit-col-expand">
-											<input class="form-control-inset" id="tagsField1" type="text" value="some value">
-										</span>
+								<div class="form-control form-control-tag-group input-group">
+									<span class="input-group-item">
+										<input class="form-control-inset" id="tagsField1" type="text" value="some value">
 									</span>
 								</div>
 								<ul class="autocomplete-dropdown-menu dropdown-menu">
@@ -54,83 +52,81 @@ section: Components
 					<div class="input-group input-group-stacked-sm-down">
 						<div class="input-group-item">
 							<div class="dropdown">
-								<div class="form-control form-control-tag-group">
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+								<div class="form-control form-control-tag-group input-group">
+									<div class="input-group-item">
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
 												</span>
 											</span>
-										</span>
-										<span class="label-item label-item-expand">wall</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-												</span>
+											<span class="label-item label-item-expand">wall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
 											</span>
 										</span>
-										<span class="label-item label-item-expand">wallpaper</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
 												</span>
 											</span>
+											<span class="label-item label-item-expand">wallpaper</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
 										</span>
-										<span class="label-item label-item-expand">wonderwall</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wonderwall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
 										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-expand">winterfell</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-expand">winterfell</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
 										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
 										</span>
-									</span>
-									<span class="autofit-row">
-										<span class="autofit-col autofit-col-expand">
-											<input class="form-control-inset" id="tagsField2" type="text" value="some value">
-										</span>
-									</span>
+										<input class="form-control-inset" id="tagsField2" type="text" value="some value">
+									</div>
 								</div>
 								<ul class="autocomplete-dropdown-menu dropdown-menu">
 									<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
@@ -163,7 +159,294 @@ section: Components
 					<div class="input-group input-group-stacked-sm-down">
 						<div class="input-group-item">
 							<div class="dropdown">
-								<div class="form-control form-control-tag-group">
+								<div class="form-control form-control-tag-group input-group">
+									<div class="input-group-item">
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wallpaper</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wonderwall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-expand">winterfell</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<input class="form-control-inset" id="tagsField2" type="text" value="some value">
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<span class="inline-item">
+											<span class="loading-animation" role="presentation"></span>
+										</span>
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<a class="component-action" href="#1" role="button">
+											<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+											</svg>
+										</a>
+									</div>
+								</div>
+								<ul class="autocomplete-dropdown-menu dropdown-menu show">
+									<li><span class="disabled dropdown-item">Loading...</span></li>
+								</ul>
+							</div>
+
+							<div class="form-feedback-group">
+								<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
+							</div>
+						</div>
+						<div class="input-group-item input-group-item-shrink">
+							<button class="btn btn-secondary" type="button">Select All the Things</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Clay Multiselect with Other Things</h3>
+
+		<div class="sheet">
+			<div class="form-group">
+				<div class="clay-multiselect">
+					<label for="tagsField3">Tags</label>
+					<div class="input-group input-group-stacked-sm-down">
+						<div class="input-group-item">
+							<div class="dropdown">
+								<div class="form-control form-control-tag-group input-group">
+									<div class="input-group-item input-group-item-shrink">
+										<button class="btn btn-warning" type="button">Warning</button>
+									</div>
+									<div class="input-group-item">
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wallpaper</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wonderwall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+
+										<span class="autofit-row">
+											<span class="autofit-col">
+												<button class="btn btn-primary" type="button">Button</button>
+											</span>
+											<span class="autofit-col autofit-col-expand">
+												<input class="form-control-inset" id="tagsField3" type="text" value="some value">
+											</span>
+											<span class="autofit-col">
+												<span class="inline-item">
+													<a href="#1">link</a>
+												</span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced btn-secondary" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<span class="inline-item">
+											<span class="loading-animation" role="presentation"></span>
+										</span>
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<a class="component-action" href="#1" role="button">
+											<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+											</svg>
+										</a>
+									</div>
+								</div>
+								<ul class="autocomplete-dropdown-menu dropdown-menu">
+									<li><span class="disabled dropdown-item">Loading...</span></li>
+								</ul>
+							</div>
+
+							<div class="form-feedback-group">
+								<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
+							</div>
+						</div>
+						<div class="input-group-item input-group-item-shrink">
+							<button class="btn btn-secondary" type="button">Select All the Things</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Clay Multiselect with Contenteditable Elements</h3>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label for="formControlContentEditable1">Label (Content Editable)</label>
+
+				<div class="input-group input-group-stacked-sm-down">
+					<div class="input-group-item">
+						<div class="dropdown">
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
+									<textarea aria-hidden="true" class="form-control-hidden" id="formControlContentEditable1" tabindex="-1"></textarea>
+									<div class="form-control-inset" contenteditable="true"></div>
+								</div>
+							</div>
+							<ul class="autocomplete-dropdown-menu dropdown-menu">
+								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
+								<li><a class="dropdown-item" href="#1"><strong>some value</strong> meal</a></li>
+							</ul>
+						</div>
+						<div class="form-feedback-group">
+							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
+						</div>
+					</div>
+
+					<div class="input-group-item input-group-item-shrink">
+						<button class="btn btn-secondary" type="submit">Select</button>
+					</div>
+				</div>
+			</div>
+
+			<div class="form-group">
+				<label for="tagsContentEditableField2">Tags (Content Editable)</label>
+
+				<div class="input-group input-group-stacked-sm-down">
+					<div class="input-group-item">
+						<div class="dropdown">
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
 									<span class="label label-dismissible label-secondary" tabindex="0">
 										<span class="label-item label-item-before">
 											<span class="sticker">
@@ -198,239 +481,9 @@ section: Components
 											</button>
 										</span>
 									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-												</span>
-											</span>
-										</span>
-										<span class="label-item label-item-expand">wonderwall</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-expand">winterfell</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="autofit-row">
-										<span class="autofit-col autofit-col-expand">
-											<input class="form-control-inset" id="tagsField2" type="text" value="some value">
-										</span>
-										<span class="autofit-col">
-											<span class="inline-item">
-												<span class="loading-animation" role="presentation"></span>
-											</span>
-										</span>
-									</span>
+									<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableField2" tabindex="-1" type="text">
+									<span class="form-control-inset" contenteditable>some value</span>
 								</div>
-								<ul class="autocomplete-dropdown-menu dropdown-menu show">
-									<li><span class="disabled dropdown-item">Loading...</span></li>
-								</ul>
-							</div>
-
-							<div class="form-feedback-group">
-								<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
-							</div>
-						</div>
-						<div class="input-group-item input-group-item-shrink">
-							<button class="btn btn-secondary" type="button">Select All the Things</button>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-
-	</div>
-</div>
-
-<div class="clay-site-row-spacer row">
-	<div class="col-md-12">
-		<h3>Clay Multiselect with Other Things</h3>
-
-		<div class="sheet">
-			<div class="form-group">
-				<div class="clay-multiselect">
-					<label for="tagsField3">Tags</label>
-					<div class="input-group input-group-stacked-sm-down">
-						<div class="input-group-item">
-							<div class="dropdown">
-								<div class="form-control form-control-tag-group">
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-												</span>
-											</span>
-										</span>
-										<span class="label-item label-item-expand">wall</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="autofit-row">
-										<span class="autofit-col">
-											<a class="component-action" href="#1" role="button">
-												<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
-												</svg>
-											</a>
-										</span>
-										<span class="autofit-col autofit-col-expand">
-											<input class="form-control-inset" id="tagsField3" type="text" value="some value">
-										</span>
-										<span class="autofit-col">
-											<span class="inline-item">
-												<span class="loading-animation" role="presentation"></span>
-											</span>
-										</span>
-										<span class="autofit-col">
-											<span class="inline-item">
-												<a href="#1">link</a>
-											</span>
-										</span>
-										<span class="autofit-col">
-											<button class="btn btn-monospaced btn-secondary" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-										<span class="autofit-col">
-											<button class="btn btn-primary" type="button">Button</button>
-										</span>
-									</span>
-								</div>
-								<ul class="autocomplete-dropdown-menu dropdown-menu">
-									<li><span class="disabled dropdown-item">Loading...</span></li>
-								</ul>
-							</div>
-
-							<div class="form-feedback-group">
-								<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
-							</div>
-						</div>
-						<div class="input-group-item input-group-item-shrink">
-							<button class="btn btn-secondary" type="button">Select All the Things</button>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-
-	</div>
-</div>
-
-<div class="clay-site-row-spacer row">
-	<div class="col-md-12">
-		<h3>Clay Multiselect with Contenteditable Elements</h3>
-
-		<div class="sheet">
-			<div class="form-group">
-				<label for="formControlContentEditable1">Label (Content Editable)</label>
-
-				<div class="input-group input-group-stacked-sm-down">
-					<div class="input-group-item">
-						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<textarea aria-hidden="true" class="form-control-hidden" id="formControlContentEditable1" tabindex="-1"></textarea>
-										<div class="form-control-inset" contenteditable="true"></div>
-									</span>
-								</span>
-							</div>
-							<ul class="autocomplete-dropdown-menu dropdown-menu">
-								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
-								<li><a class="dropdown-item" href="#1"><strong>some value</strong> meal</a></li>
-							</ul>
-						</div>
-						<div class="form-feedback-group">
-							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
-						</div>
-					</div>
-
-					<div class="input-group-item input-group-item-shrink">
-						<button class="btn btn-secondary" type="submit">Select</button>
-					</div>
-				</div>
-			</div>
-
-			<div class="form-group">
-				<label for="tagsContentEditableField2">Tags (Content Editable)</label>
-
-				<div class="input-group input-group-stacked-sm-down">
-					<div class="input-group-item">
-						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
-								<span class="label label-dismissible label-secondary" tabindex="0">
-									<span class="label-item label-item-before">
-										<span class="sticker">
-											<span class="sticker-overlay">
-												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-											</span>
-										</span>
-									</span>
-									<span class="label-item label-item-expand">wall</span>
-									<span class="label-item label-item-after">
-										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-											</svg>
-										</button>
-									</span>
-								</span>
-								<span class="label label-dismissible label-secondary" tabindex="0">
-									<span class="label-item label-item-before">
-										<span class="sticker">
-											<span class="sticker-overlay">
-												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-											</span>
-										</span>
-									</span>
-									<span class="label-item label-item-expand">wallpaper</span>
-									<span class="label-item label-item-after">
-										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-											</svg>
-										</button>
-									</span>
-								</span>
-
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableField2" tabindex="-1" type="text">
-										<span class="form-control-inset" contenteditable>some value</span>
-									</span>
-								</span>
 							</div>
 							<ul class="autocomplete-dropdown-menu dropdown-menu">
 								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
@@ -454,18 +507,16 @@ section: Components
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
 						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<input aria-hidden="true" class="form-control-hidden" id="formControlContentEditableLoading1" tabindex="-1" type="text">
-										<div class="form-control-inset" contenteditable="true"></div>
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
+									<input aria-hidden="true" class="form-control-hidden" id="formControlContentEditableLoading1" tabindex="-1" type="text">
+									<div class="form-control-inset" contenteditable="true"></div>
+								</div>
+								<div class="input-group-item input-group-item-shrink">
+									<span class="inline-item">
+										<span class="loading-animation" role="presentation"></span>
 									</span>
-									<span class="autofit-col">
-										<span class="inline-item">
-											<span class="loading-animation" role="presentation"></span>
-										</span>
-									</span>
-								</span>
+								</div>
 							</div>
 							<ul class="autocomplete-dropdown-menu dropdown-menu">
 								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
@@ -489,53 +540,51 @@ section: Components
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
 						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
-								<span class="label label-dismissible label-secondary" tabindex="0">
-									<span class="label-item label-item-before">
-										<span class="sticker">
-											<span class="sticker-overlay">
-												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
 											</span>
 										</span>
-									</span>
-									<span class="label-item label-item-expand">wall</span>
-									<span class="label-item label-item-after">
-										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-											</svg>
-										</button>
-									</span>
-								</span>
-								<span class="label label-dismissible label-secondary" tabindex="0">
-									<span class="label-item label-item-before">
-										<span class="sticker">
-											<span class="sticker-overlay">
-												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-											</span>
+										<span class="label-item label-item-expand">wall</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
 										</span>
 									</span>
-									<span class="label-item label-item-expand">wallpaper</span>
-									<span class="label-item label-item-after">
-										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-											</svg>
-										</button>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
+											</span>
+										</span>
+										<span class="label-item label-item-expand">wallpaper</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
 									</span>
-								</span>
 
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableLoading2" tabindex="-1" type="text">
-										<span class="form-control-inset" contenteditable>some value</span>
+									<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableLoading2" tabindex="-1" type="text">
+									<span class="form-control-inset" contenteditable>some value</span>
+								</div>
+								<div class="input-group-item input-group-item-shrink">
+									<span class="inline-item">
+										<span class="loading-animation" role="presentation"></span>
 									</span>
-									<span class="autofit-col">
-										<span class="inline-item">
-											<span class="loading-animation" role="presentation"></span>
-										</span>
-									</span>
-								</span>
+								</div>
 							</div>
 							<ul class="autocomplete-dropdown-menu dropdown-menu">
 								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -194,6 +194,10 @@ div {
 		@include clay-container($form-control-tag-group-autofit-col);
 	}
 
+	.input-group-item {
+		@include clay-container($form-control-tag-group-input-group-item);
+	}
+
 	.inline-item {
 		@include clay-container($form-control-tag-group-inline-item);
 	}

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -87,7 +87,7 @@ $form-control-tag-group: map-merge((
 
 $form-control-tag-group-autofit-row: () !default;
 $form-control-tag-group-autofit-row: map-merge((
-		align-items: flex-end,
+		align-items: center,
 		flex-grow: 1,
 		margin-left: -0.5rem,
 		margin-right: -0.5rem,
@@ -99,6 +99,11 @@ $form-control-tag-group-autofit-col: map-merge((
 	padding-left: 0.5rem,
 	padding-right: 0.5rem,
 ), $form-control-tag-group-autofit-col);
+
+$form-control-tag-group-input-group-item: () !default;
+$form-control-tag-group-input-group-item: map-merge((
+	align-items: flex-start,
+), $form-control-tag-group-input-group-item);
 
 $form-control-tag-group-inline-item: () !default;
 $form-control-tag-group-inline-item: map-merge((

--- a/packages/clay-form/src/__tests__/InputWithMultiSelect.tsx
+++ b/packages/clay-form/src/__tests__/InputWithMultiSelect.tsx
@@ -5,7 +5,6 @@
  */
 
 import * as React from 'react';
-import * as TestRenderer from 'react-test-renderer';
 import {ClayInputWithMultiSelect} from '../InputWithMultiSelect';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 
@@ -26,30 +25,32 @@ const ClayInputWithMultiSelectWithState = (props: any) => {
 };
 
 describe('ClayInputWithMultiSelect', () => {
+	afterEach(cleanup);
+
 	it('renders', () => {
-		const testRenderer = TestRenderer.create(
+		render(
 			<ClayInputWithMultiSelectWithState
 				items={[]}
 				spritemap="/foo/bar"
 			/>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(document.body).toMatchSnapshot();
 	});
 
 	it('renders with items', () => {
-		const testRenderer = TestRenderer.create(
+		render(
 			<ClayInputWithMultiSelectWithState
 				items={['foo', 'bar', 'baz']}
 				spritemap="/foo/bar"
 			/>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(document.body).toMatchSnapshot();
 	});
 
 	it('renders as not valid', () => {
-		const testRenderer = TestRenderer.create(
+		render(
 			<ClayInputWithMultiSelectWithState
 				errorMessage="WRONG"
 				isValid={false}
@@ -58,7 +59,21 @@ describe('ClayInputWithMultiSelect', () => {
 			/>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(document.body).toMatchSnapshot();
+	});
+
+	it('renders as disabled', () => {
+		render(
+			<ClayInputWithMultiSelectWithState
+				disabled
+				errorMessage="WRONG"
+				isValid={false}
+				items={['foo', 'bar', 'baz']}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		expect(document.body).toMatchSnapshot();
 	});
 });
 
@@ -173,5 +188,50 @@ describe('Interactions', () => {
 		);
 
 		expect(onItemsChangeFn).toHaveBeenCalled();
+	});
+
+	it('clicking the Clear All button removes items and text in the input', () => {
+		const onItemsChangeFn = jest.fn();
+		const onInputChangeFn = jest.fn();
+
+		const {getByTitle} = render(
+			<ClayInputWithMultiSelectWithState
+				inputValue="foo"
+				items={['foo']}
+				onInputChange={onInputChangeFn}
+				onItemsChange={onItemsChangeFn}
+				sourceItems={['one', 'two', 'three', 'four']}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		const clearButton = getByTitle('Clear All');
+
+		fireEvent.click(clearButton, {});
+
+		expect(onItemsChangeFn).toHaveBeenCalledWith([]);
+		expect(onInputChangeFn).toHaveBeenCalledWith('');
+	});
+
+	it('clicking the Clear All button should move the focus to the input', () => {
+		const {container, getByTitle} = render(
+			<ClayInputWithMultiSelectWithState
+				inputValue="foo"
+				items={['foo']}
+				onInputChange={jest.fn()}
+				onItemsChange={jest.fn()}
+				sourceItems={['one', 'two', 'three', 'four']}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		const clearButton = getByTitle('Clear All');
+		const input = container.querySelector('.form-control-inset');
+
+		expect(document.activeElement).not.toBe(input);
+
+		fireEvent.click(clearButton, {});
+
+		expect(document.activeElement).toBe(input);
 	});
 });

--- a/packages/clay-form/src/__tests__/__snapshots__/InputWithMultiSelect.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/InputWithMultiSelect.tsx.snap
@@ -1,316 +1,499 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ClayInputWithMultiSelect renders 1`] = `
-<div
-  className="form-group"
->
-  <div
-    className="input-group input-group-stacked-sm-down"
-  >
+<body>
+  <div>
     <div
-      className="input-group-item"
+      class="form-group"
     >
       <div
-        className="form-control form-control-tag-group"
-        onKeyDown={[Function]}
-      >
-        <input
-          className="form-control-inset"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
-          type="text"
-          value=""
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`ClayInputWithMultiSelect renders as not valid 1`] = `
-<div
-  className="form-group has-error"
->
-  <div
-    className="input-group input-group-stacked-sm-down"
-  >
-    <div
-      className="input-group-item"
-    >
-      <div
-        className="form-control form-control-tag-group"
-        onKeyDown={[Function]}
-      >
-        <span
-          className="label label-dismissible label-secondary"
-          onKeyDown={[Function]}
-          tabIndex={0}
-        >
-          <span
-            className="label-item label-item-expand"
-          >
-            foo
-          </span>
-          <span
-            className="label-item label-item-after"
-          >
-            <button
-              className="close"
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="lexicon-icon lexicon-icon-times"
-                role="presentation"
-              >
-                <use
-                  xlinkHref="/foo/bar#times"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <input
-          name=""
-          type="hidden"
-          value="foo"
-        />
-        <span
-          className="label label-dismissible label-secondary"
-          onKeyDown={[Function]}
-          tabIndex={0}
-        >
-          <span
-            className="label-item label-item-expand"
-          >
-            bar
-          </span>
-          <span
-            className="label-item label-item-after"
-          >
-            <button
-              className="close"
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="lexicon-icon lexicon-icon-times"
-                role="presentation"
-              >
-                <use
-                  xlinkHref="/foo/bar#times"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <input
-          name=""
-          type="hidden"
-          value="bar"
-        />
-        <span
-          className="label label-dismissible label-secondary"
-          onKeyDown={[Function]}
-          tabIndex={0}
-        >
-          <span
-            className="label-item label-item-expand"
-          >
-            baz
-          </span>
-          <span
-            className="label-item label-item-after"
-          >
-            <button
-              className="close"
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="lexicon-icon lexicon-icon-times"
-                role="presentation"
-              >
-                <use
-                  xlinkHref="/foo/bar#times"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <input
-          name=""
-          type="hidden"
-          value="baz"
-        />
-        <input
-          className="form-control-inset"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        className="form-feedback-group"
+        class="input-group input-group-stacked-sm-down"
       >
         <div
-          className="form-feedback-item"
+          class="input-group-item"
         >
-          <span
-            className="form-feedback-indicator"
+          <div
+            class="form-control form-control-tag-group input-group"
           >
-            <svg
-              className="lexicon-icon lexicon-icon-info-circle"
-              role="presentation"
+            <div
+              class="input-group-item"
             >
-              <use
-                xlinkHref="/foo/bar#info-circle"
+              <input
+                class="form-control-inset"
+                type="text"
+                value=""
               />
-            </svg>
-          </span>
-          WRONG
+            </div>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
+</body>
 `;
 
-exports[`ClayInputWithMultiSelect renders with items 1`] = `
-<div
-  className="form-group"
->
-  <div
-    className="input-group input-group-stacked-sm-down"
-  >
+exports[`ClayInputWithMultiSelect renders as disabled 1`] = `
+<body>
+  <div>
     <div
-      className="input-group-item"
+      class="form-group has-error"
     >
       <div
-        className="form-control form-control-tag-group"
-        onKeyDown={[Function]}
+        class="input-group input-group-stacked-sm-down"
       >
-        <span
-          className="label label-dismissible label-secondary"
-          onKeyDown={[Function]}
-          tabIndex={0}
+        <div
+          class="input-group-item"
         >
-          <span
-            className="label-item label-item-expand"
+          <div
+            class="form-control form-control-tag-group input-group"
           >
-            foo
-          </span>
-          <span
-            className="label-item label-item-after"
-          >
-            <button
-              className="close"
-              onClick={[Function]}
-              type="button"
+            <div
+              class="input-group-item"
             >
-              <svg
-                className="lexicon-icon lexicon-icon-times"
-                role="presentation"
+              <span
+                class="label label-dismissible label-secondary"
+                tabindex="0"
               >
-                <use
-                  xlinkHref="/foo/bar#times"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <input
-          name=""
-          type="hidden"
-          value="foo"
-        />
-        <span
-          className="label label-dismissible label-secondary"
-          onKeyDown={[Function]}
-          tabIndex={0}
-        >
-          <span
-            className="label-item label-item-expand"
+                <span
+                  class="label-item label-item-expand"
+                >
+                  foo
+                </span>
+                <span
+                  class="label-item label-item-after"
+                >
+                  <button
+                    class="close"
+                    disabled=""
+                    type="button"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-times"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#times"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </span>
+              <input
+                name=""
+                type="hidden"
+                value="foo"
+              />
+              <span
+                class="label label-dismissible label-secondary"
+                tabindex="0"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  bar
+                </span>
+                <span
+                  class="label-item label-item-after"
+                >
+                  <button
+                    class="close"
+                    disabled=""
+                    type="button"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-times"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#times"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </span>
+              <input
+                name=""
+                type="hidden"
+                value="bar"
+              />
+              <span
+                class="label label-dismissible label-secondary"
+                tabindex="0"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  baz
+                </span>
+                <span
+                  class="label-item label-item-after"
+                >
+                  <button
+                    class="close"
+                    disabled=""
+                    type="button"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-times"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#times"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </span>
+              <input
+                name=""
+                type="hidden"
+                value="baz"
+              />
+              <input
+                class="form-control-inset"
+                disabled=""
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="form-feedback-group"
           >
-            bar
-          </span>
-          <span
-            className="label-item label-item-after"
-          >
-            <button
-              className="close"
-              onClick={[Function]}
-              type="button"
+            <div
+              class="form-feedback-item"
             >
-              <svg
-                className="lexicon-icon lexicon-icon-times"
-                role="presentation"
+              <span
+                class="form-feedback-indicator"
               >
-                <use
-                  xlinkHref="/foo/bar#times"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <input
-          name=""
-          type="hidden"
-          value="bar"
-        />
-        <span
-          className="label label-dismissible label-secondary"
-          onKeyDown={[Function]}
-          tabIndex={0}
-        >
-          <span
-            className="label-item label-item-expand"
-          >
-            baz
-          </span>
-          <span
-            className="label-item label-item-after"
-          >
-            <button
-              className="close"
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="lexicon-icon lexicon-icon-times"
-                role="presentation"
-              >
-                <use
-                  xlinkHref="/foo/bar#times"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <input
-          name=""
-          type="hidden"
-          value="baz"
-        />
-        <input
-          className="form-control-inset"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onPaste={[Function]}
-          type="text"
-          value=""
-        />
+                <svg
+                  class="lexicon-icon lexicon-icon-info-circle"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/foo/bar#info-circle"
+                  />
+                </svg>
+              </span>
+              WRONG
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</div>
+</body>
+`;
+
+exports[`ClayInputWithMultiSelect renders as not valid 1`] = `
+<body>
+  <div>
+    <div
+      class="form-group has-error"
+    >
+      <div
+        class="input-group input-group-stacked-sm-down"
+      >
+        <div
+          class="input-group-item"
+        >
+          <div
+            class="form-control form-control-tag-group input-group"
+          >
+            <div
+              class="input-group-item"
+            >
+              <span
+                class="label label-dismissible label-secondary"
+                tabindex="0"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  foo
+                </span>
+                <span
+                  class="label-item label-item-after"
+                >
+                  <button
+                    class="close"
+                    type="button"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-times"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#times"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </span>
+              <input
+                name=""
+                type="hidden"
+                value="foo"
+              />
+              <span
+                class="label label-dismissible label-secondary"
+                tabindex="0"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  bar
+                </span>
+                <span
+                  class="label-item label-item-after"
+                >
+                  <button
+                    class="close"
+                    type="button"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-times"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#times"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </span>
+              <input
+                name=""
+                type="hidden"
+                value="bar"
+              />
+              <span
+                class="label label-dismissible label-secondary"
+                tabindex="0"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  baz
+                </span>
+                <span
+                  class="label-item label-item-after"
+                >
+                  <button
+                    class="close"
+                    type="button"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-times"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#times"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </span>
+              <input
+                name=""
+                type="hidden"
+                value="baz"
+              />
+              <input
+                class="form-control-inset"
+                type="text"
+                value=""
+              />
+            </div>
+            <div
+              class="input-group-item input-group-item-shrink"
+            >
+              <button
+                class="component-action"
+                title="Clear All"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-times-circle"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/foo/bar#times-circle"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            class="form-feedback-group"
+          >
+            <div
+              class="form-feedback-item"
+            >
+              <span
+                class="form-feedback-indicator"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-info-circle"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/foo/bar#info-circle"
+                  />
+                </svg>
+              </span>
+              WRONG
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ClayInputWithMultiSelect renders with items 1`] = `
+<body>
+  <div>
+    <div
+      class="form-group"
+    >
+      <div
+        class="input-group input-group-stacked-sm-down"
+      >
+        <div
+          class="input-group-item"
+        >
+          <div
+            class="form-control form-control-tag-group input-group"
+          >
+            <div
+              class="input-group-item"
+            >
+              <span
+                class="label label-dismissible label-secondary"
+                tabindex="0"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  foo
+                </span>
+                <span
+                  class="label-item label-item-after"
+                >
+                  <button
+                    class="close"
+                    type="button"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-times"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#times"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </span>
+              <input
+                name=""
+                type="hidden"
+                value="foo"
+              />
+              <span
+                class="label label-dismissible label-secondary"
+                tabindex="0"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  bar
+                </span>
+                <span
+                  class="label-item label-item-after"
+                >
+                  <button
+                    class="close"
+                    type="button"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-times"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#times"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </span>
+              <input
+                name=""
+                type="hidden"
+                value="bar"
+              />
+              <span
+                class="label label-dismissible label-secondary"
+                tabindex="0"
+              >
+                <span
+                  class="label-item label-item-expand"
+                >
+                  baz
+                </span>
+                <span
+                  class="label-item label-item-after"
+                >
+                  <button
+                    class="close"
+                    type="button"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-times"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="/foo/bar#times"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </span>
+              <input
+                name=""
+                type="hidden"
+                value="baz"
+              />
+              <input
+                class="form-control-inset"
+                type="text"
+                value=""
+              />
+            </div>
+            <div
+              class="input-group-item input-group-item-shrink"
+            >
+              <button
+                class="component-action"
+                title="Clear All"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-times-circle"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/foo/bar#times-circle"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
 `;

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -94,6 +94,8 @@ storiesOf('ClayForm', module)
 	.add('default', () => <ClayForm />)
 	.add('InputWithMultiSelect', () => (
 		<ClayMultiSelectWithState
+			disabled={boolean('Disabled all', false)}
+			disabledClearAll={boolean('Disabled Clear All', false)}
 			errorMessage="you done goofed up"
 			helpText="You can use a comma to enter tags."
 			isValid={boolean('isValid', true)}

--- a/packages/clay-label/src/index.tsx
+++ b/packages/clay-label/src/index.tsx
@@ -86,6 +86,6 @@ const ClayLabel: React.FunctionComponent<IProps> = ({
 	);
 };
 
-export default React.forwardRef((props: IProps, ref?) => (
-	<ClayLabel {...props} forwardRef={ref} />
-));
+export default React.forwardRef<HTMLAnchorElement | HTMLSpanElement, IProps>(
+	(props: IProps, ref?) => <ClayLabel {...props} forwardRef={ref} />
+);


### PR DESCRIPTION
Fixes #2335

This follows the [new specifications in the document for MultiSelect](https://docs.google.com/document/d/1LJ8yiO8V5mSEGOjaYzHd5Nex_De_8fMRQAEKQoHMiiM/edit).

It still remains to cover the tab order that looks different here, I will have to make some changes in `useFocusManagement` to respect the `tabindex`, I will work on that in another PR.