### PR TITLE
feat(@clayui/table): Adds ClayTableWithQuickActions and ClayTableWithEditableRow

### DIFF
--- a/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClayNavigationBar collapses the dropdown expanded when trigger element is clicked 1`] = `
+exports[`ClayNavigationBar collapses the previously expanded dropdown when trigger element is clicked 1`] = `
 <div
   class="navbar-collapse collapse"
   data-testid="NavigationBarDropdown"
@@ -46,90 +46,91 @@ exports[`ClayNavigationBar collapses the dropdown expanded when trigger element 
 `;
 
 exports[`ClayNavigationBar renders 1`] = `
-<nav
-  className="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
->
-  <div
-    className="container-fluid container-fluid-max-xl"
+<div>
+  <nav
+    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
   >
-    <a
-      aria-expanded={false}
-      className="navbar-toggler navbar-toggler-link collapsed link-secondary"
-      onClick={[Function]}
-    >
-      Item 1
-      <svg
-        className="lexicon-icon lexicon-icon-caret-bottom"
-        role="presentation"
-      >
-        <use
-          xlinkHref="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
-        />
-      </svg>
-    </a>
     <div
-      className="navbar-collapse collapse"
-      data-testid="NavigationBarDropdown"
-      onTransitionEnd={[Function]}
+      class="container-fluid container-fluid-max-xl"
     >
-      <div
-        className="container-fluid container-fluid-max-xl"
+      <a
+        aria-expanded="false"
+        class="navbar-toggler navbar-toggler-link collapsed link-secondary"
+        data-testid="navbarToggler"
       >
-        <ul
-          className="navbar-nav"
+        Item 1
+        <svg
+          class="lexicon-icon lexicon-icon-caret-bottom"
+          role="presentation"
         >
-          <li
-            className="nav-item"
+          <use
+            xlink:href="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
+          />
+        </svg>
+      </a>
+      <div
+        class="navbar-collapse collapse"
+        data-testid="NavigationBarDropdown"
+      >
+        <div
+          class="container-fluid container-fluid-max-xl"
+        >
+          <ul
+            class="navbar-nav"
           >
-            <a
-              className="nav-link active link-secondary"
-              href="#1"
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <a
+                class="nav-link active link-secondary"
+                href="#1"
               >
-                Item 1
-              </span>
-            </a>
-          </li>
-          <li
-            className="nav-item"
-          >
-            <button
-              className="nav-link btn btn-block btn-sm btn-unstyled"
-              type="button"
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 1
+                </span>
+              </a>
+            </li>
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <button
+                class="nav-link btn btn-block btn-sm btn-unstyled"
+                type="button"
               >
-                Item 2
-              </span>
-            </button>
-          </li>
-          <li
-            className="nav-item"
-          >
-            <a
-              className="nav-link link-secondary"
-              href="#3"
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 2
+                </span>
+              </button>
+            </li>
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <a
+                class="nav-link link-secondary"
+                href="#3"
               >
-                Item 3
-              </span>
-            </a>
-          </li>
-        </ul>
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 3
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 `;
 
-exports[`ClayNavigationBar renders a dropdown when clicking the collapsed element from NavigationBar 1`] = `
+exports[`ClayNavigationBar renders a dropdown when clicking the trigger element from NavigationBar 1`] = `
 <div
-  class="navbar-collapse collapse"
+  class="navbar-collapse collapse show"
   data-testid="NavigationBarDropdown"
   style=""
 >
@@ -173,85 +174,153 @@ exports[`ClayNavigationBar renders a dropdown when clicking the collapsed elemen
 `;
 
 exports[`ClayNavigationBar renders when passing more than one active item 1`] = `
-<nav
-  className="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
->
-  <div
-    className="container-fluid container-fluid-max-xl"
+<div>
+  <nav
+    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
   >
-    <a
-      aria-expanded={false}
-      className="navbar-toggler navbar-toggler-link collapsed link-secondary"
-      onClick={[Function]}
-    >
-      Item 1
-      <svg
-        className="lexicon-icon lexicon-icon-caret-bottom"
-        role="presentation"
-      >
-        <use
-          xlinkHref="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
-        />
-      </svg>
-    </a>
     <div
-      className="navbar-collapse collapse"
-      data-testid="NavigationBarDropdown"
-      onTransitionEnd={[Function]}
+      class="container-fluid container-fluid-max-xl"
     >
-      <div
-        className="container-fluid container-fluid-max-xl"
+      <a
+        aria-expanded="false"
+        class="navbar-toggler navbar-toggler-link collapsed link-secondary"
+        data-testid="navbarToggler"
       >
-        <ul
-          className="navbar-nav"
+        Item 1
+        <svg
+          class="lexicon-icon lexicon-icon-caret-bottom"
+          role="presentation"
         >
-          <li
-            className="nav-item"
+          <use
+            xlink:href="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
+          />
+        </svg>
+      </a>
+      <div
+        class="navbar-collapse collapse"
+        data-testid="NavigationBarDropdown"
+      >
+        <div
+          class="container-fluid container-fluid-max-xl"
+        >
+          <ul
+            class="navbar-nav"
           >
-            <a
-              className="nav-link link-secondary"
-              href="#1"
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <a
+                class="nav-link link-secondary"
+                href="#1"
               >
-                Item 1
-              </span>
-            </a>
-          </li>
-          <li
-            className="nav-item"
-          >
-            <button
-              className="nav-link active btn btn-block btn-sm btn-unstyled"
-              type="button"
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 1
+                </span>
+              </a>
+            </li>
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <button
+                class="nav-link active btn btn-block btn-sm btn-unstyled"
+                type="button"
               >
-                Item 2
-              </span>
-            </button>
-          </li>
-          <li
-            className="nav-item"
-          >
-            <a
-              className="nav-link link-secondary"
-              href="#3"
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 2
+                </span>
+              </button>
+            </li>
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <a
+                class="nav-link link-secondary"
+                href="#3"
               >
-                Item 3
-              </span>
-            </a>
-          </li>
-        </ul>
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 3
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 `;
 
-exports[`ClayNavigationBar should throw a warning when passing more than one active prop to child 1`] = `[Function]`;
+exports[`ClayNavigationBar should throw a warning when passing more than one active prop to child 1`] = `
+<div>
+  <nav
+    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
+  >
+    <div
+      class="container-fluid container-fluid-max-xl"
+    >
+      <a
+        aria-expanded="false"
+        class="navbar-toggler navbar-toggler-link collapsed link-secondary"
+        data-testid="navbarToggler"
+      >
+        Item 1
+        <svg
+          class="lexicon-icon lexicon-icon-caret-bottom"
+          role="presentation"
+        >
+          <use
+            xlink:href="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
+          />
+        </svg>
+      </a>
+      <div
+        class="navbar-collapse collapse"
+        data-testid="NavigationBarDropdown"
+      >
+        <div
+          class="container-fluid container-fluid-max-xl"
+        >
+          <ul
+            class="navbar-nav"
+          >
+            <li
+              class="nav-item"
+            >
+              <a
+                class="nav-link active link-secondary"
+                href="#1"
+              >
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 1
+                </span>
+              </a>
+            </li>
+            <li
+              class="nav-item"
+            >
+              <button
+                class="nav-link active btn btn-block btn-sm btn-unstyled"
+                type="button"
+              >
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 2
+                </span>
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </nav>
+</div>
+`;

--- a/packages/clay-navigation-bar/src/__tests__/index.tsx
+++ b/packages/clay-navigation-bar/src/__tests__/index.tsx
@@ -4,16 +4,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import * as TestRenderer from 'react-test-renderer';
+import '@testing-library/jest-dom/extend-expect';
 import ClayButton from '@clayui/button';
 import ClayLink from '@clayui/link';
 import ClayNavigationBar from '..';
 import React from 'react';
 import {
 	act,
+	cleanup,
 	fireEvent,
-	getByTestId,
-	getByText,
 	render,
 	waitForElement,
 } from '@testing-library/react';
@@ -21,10 +20,12 @@ import {
 const spritemap = 'node_modules/clay-css/lib/images/icons/icons.svg';
 
 describe('ClayNavigationBar', () => {
+	afterEach(cleanup);
+
 	it('renders', () => {
 		const label = 'Item 1';
 
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -63,7 +64,7 @@ describe('ClayNavigationBar', () => {
 			</ClayNavigationBar>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a dropdown when clicking the collapsed element from NavigationBar', async () => {
@@ -175,7 +176,7 @@ describe('ClayNavigationBar', () => {
 	it('renders when passing more than one active item', () => {
 		const label = 'Item 1';
 
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -214,7 +215,7 @@ describe('ClayNavigationBar', () => {
 			</ClayNavigationBar>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('should throw a warning when passing more than one active prop to child', () => {
@@ -224,7 +225,7 @@ describe('ClayNavigationBar', () => {
 
 		const label = 'Item 1';
 
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -257,7 +258,7 @@ describe('ClayNavigationBar', () => {
 		expect(mockWarnings.mock.calls[0][0]).toBe(
 			'Warning: ClayNavigationBar expects 0 or 1 active children, but received 2'
 		);
-		expect(testRenderer.toJSON).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 		jest.resetAllMocks();
 	});
 });

--- a/packages/clay-navigation-bar/src/__tests__/index.tsx
+++ b/packages/clay-navigation-bar/src/__tests__/index.tsx
@@ -67,8 +67,8 @@ describe('ClayNavigationBar', () => {
 		expect(container).toMatchSnapshot();
 	});
 
-	it('renders a dropdown when clicking the collapsed element from NavigationBar', async () => {
-		const {container} = render(
+	it('renders a dropdown when clicking the trigger element from NavigationBar', async () => {
+		const {container, getByTestId, getByText} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -97,21 +97,14 @@ describe('ClayNavigationBar', () => {
 			</ClayNavigationBar>
 		);
 
-		fireEvent.click(getByText(container, 'Trigger Label'));
-		fireEvent.transitionEnd(
-			getByTestId(container, 'NavigationBarDropdown')
-		);
-
-		fireEvent.click(getByText(container, 'Trigger Label'));
-		fireEvent.transitionEnd(
-			getByTestId(container, 'NavigationBarDropdown')
-		);
+		fireEvent.click(getByText('Trigger Label'));
+		fireEvent.transitionEnd(getByTestId('NavigationBarDropdown'));
 
 		let navigationBarDropdown;
 
 		await act(async () => {
 			navigationBarDropdown = await waitForElement(() =>
-				getByTestId(container, 'NavigationBarDropdown')
+				container.querySelector('.navbar-collapse.collapse.show')
 			);
 		});
 
@@ -120,8 +113,8 @@ describe('ClayNavigationBar', () => {
 		expect(navigationBarDropdown).toMatchSnapshot();
 	});
 
-	it('collapses the dropdown expanded when trigger element is clicked', async () => {
-		const {container} = render(
+	it('collapses the previously expanded dropdown when trigger element is clicked', async () => {
+		const {container, getByTestId} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -150,25 +143,23 @@ describe('ClayNavigationBar', () => {
 			</ClayNavigationBar>
 		);
 
-		fireEvent.click(getByText(container, 'Trigger Label'));
-		fireEvent.transitionEnd(
-			getByTestId(container, 'NavigationBarDropdown')
-		);
+		fireEvent.click(getByTestId('navbarToggler'), 'Trigger Label');
+		fireEvent.transitionEnd(getByTestId('NavigationBarDropdown'));
 
-		fireEvent.click(getByText(container, 'Trigger Label'));
-		fireEvent.transitionEnd(
-			getByTestId(container, 'NavigationBarDropdown')
-		);
+		fireEvent.click(getByTestId('navbarToggler'), 'Trigger Label');
+		fireEvent.transitionEnd(getByTestId('NavigationBarDropdown'));
 
 		let navigationBarDropdown;
 
 		await act(async () => {
 			navigationBarDropdown = await waitForElement(() =>
-				getByTestId(container, 'NavigationBarDropdown')
+				container.querySelector('.navbar-collapse.collapse')
 			);
 		});
 
 		expect(navigationBarDropdown).toBeDefined();
+
+		expect(navigationBarDropdown).not.toHaveClass('show');
 
 		expect(navigationBarDropdown).toMatchSnapshot();
 	});

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -86,6 +86,7 @@ const ClayNavigationBar: React.FunctionComponent<IProps> & {
 							collapsed: !visible,
 						}
 					)}
+					data-testid="navbarToggler"
 					displayType="secondary"
 					onClick={handleClickToggler}
 				>

--- a/packages/clay-navigation-bar/stories/index.tsx
+++ b/packages/clay-navigation-bar/stories/index.tsx
@@ -14,36 +14,50 @@ import {storiesOf} from '@storybook/react';
 
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
 
-storiesOf('ClayNavigationBar', module).add('default', () => (
-	<ClayNavigationBar
-		inverted={boolean('Inverted: ', false)}
-		spritemap={spritemap}
-		triggerLabel={text('triggerLabel: ', 'Item 1')}
-	>
-		<ClayNavigationBar.Item active={boolean('Active 1: ', true)}>
-			<ClayLink className="nav-link" displayType="secondary" href="#1">
-				<span className="navbar-text-truncate">{`Item 1`}</span>
-			</ClayLink>
-		</ClayNavigationBar.Item>
+storiesOf('ClayNavigationBar', module).add('default', () => {
+	const [triggerName, setTriggerName] = React.useState<string>('Item 1');
+	return (
+		<ClayNavigationBar
+			inverted={boolean('Inverted: ', false)}
+			spritemap={spritemap}
+			triggerLabel={text('triggerLabel: ', triggerName)}
+		>
+			<ClayNavigationBar.Item active={boolean('Active 1: ', true)}>
+				<ClayLink
+					className="nav-link"
+					displayType="secondary"
+					href="#1"
+				>
+					<span className="navbar-text-truncate">{`Item 1`}</span>
+				</ClayLink>
+			</ClayNavigationBar.Item>
 
-		<ClayNavigationBar.Item active={boolean('Active 2: ', false)}>
-			<ClayButton block className="nav-link" displayType="unstyled" small>
-				<span className="navbar-text-truncate">{`Item 2`}</span>
-			</ClayButton>
-		</ClayNavigationBar.Item>
+			<ClayNavigationBar.Item active={boolean('Active 2: ', false)}>
+				<ClayButton
+					block
+					className="nav-link"
+					displayType="unstyled"
+					onClick={() => setTriggerName('Item 2')}
+					small
+				>
+					<span className="navbar-text-truncate">{`Item 2`}</span>
+				</ClayButton>
+			</ClayNavigationBar.Item>
 
-		<ClayNavigationBar.Item active={boolean('Active 3: ', false)}>
-			<a className="nav-link link-secondary" href="#1">
-				<span className="navbar-text-truncate">{`Item 3`}</span>
-			</a>
-		</ClayNavigationBar.Item>
-		<ClayNavigationBar.Item active={boolean('Active 4: ', false)}>
-			<button
-				className="nav-link btn btn-unstyled btn-block btn-sm"
-				type="button"
-			>
-				<span className="navbar-text-truncate">{`Item 4`}</span>
-			</button>
-		</ClayNavigationBar.Item>
-	</ClayNavigationBar>
-));
+			<ClayNavigationBar.Item active={boolean('Active 3: ', false)}>
+				<a className="nav-link link-secondary" href="#1">
+					<span className="navbar-text-truncate">{`Item 3`}</span>
+				</a>
+			</ClayNavigationBar.Item>
+			<ClayNavigationBar.Item active={boolean('Active 4: ', false)}>
+				<button
+					className="nav-link btn btn-unstyled btn-block btn-sm"
+					onClick={() => setTriggerName('Item 4')}
+					type="button"
+				>
+					<span className="navbar-text-truncate">{`Item 4`}</span>
+				</button>
+			</ClayNavigationBar.Item>
+		</ClayNavigationBar>
+	);
+});

--- a/packages/clay-table/package.json
+++ b/packages/clay-table/package.json
@@ -26,6 +26,7 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/shared": "^3.0.0-milestone.3",
 		"classnames": "^2.2.6"
 	},
 	"devDependencies": {

--- a/packages/clay-table/src/ActionsMenu.tsx
+++ b/packages/clay-table/src/ActionsMenu.tsx
@@ -1,0 +1,69 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import React from 'react';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
+import {LinkOrButton} from '@clayui/shared';
+
+interface IActionItem {
+	href?: string;
+	onClick?: (event: React.SyntheticEvent) => void;
+	symbol: string;
+}
+
+interface IActionItemsProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * List of actions to include in actions items.
+	 */
+	actionItems: Array<IActionItem>;
+
+	/**
+	 * List of actions to include in dropdown.
+	 */
+	dropdownActions?: React.ComponentProps<
+		typeof ClayDropDownWithItems
+	>['items'];
+
+	spritemap?: string;
+}
+
+const ClayTableActionsMenu: React.FunctionComponent<IActionItemsProps> = ({
+	actionItems,
+	dropdownActions,
+	spritemap,
+	...otherProps
+}: IActionItemsProps) => (
+	<>
+		<div className="quick-action-menu" {...otherProps}>
+			{actionItems.map(({href, onClick, symbol}, index) => (
+				<LinkOrButton
+					buttonDisplayType="unstyled"
+					className="component-action quick-action-item"
+					href={href}
+					key={index}
+					onClick={onClick}
+				>
+					<ClayIcon spritemap={spritemap} symbol={symbol} />
+				</LinkOrButton>
+			))}
+		</div>
+		{dropdownActions && (
+			<ClayDropDownWithItems
+				items={dropdownActions}
+				spritemap={spritemap}
+				trigger={
+					<ClayButton className="component-action" monospaced>
+						<ClayIcon spritemap={spritemap} symbol="ellipsis-v" />
+					</ClayButton>
+				}
+			/>
+		)}
+	</>
+);
+
+export default ClayTableActionsMenu;

--- a/packages/clay-table/src/ClayTableWithEditableRow.tsx
+++ b/packages/clay-table/src/ClayTableWithEditableRow.tsx
@@ -1,0 +1,126 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Cell from './Cell';
+import ClayButton from '@clayui/button';
+import React from 'react';
+import Row, {IRowProps} from './Row';
+import {ClayCheckbox, ClayInput} from '@clayui/form';
+
+interface IEditableCell {
+	cellProps?: Object;
+	editable?: boolean;
+	value: string;
+}
+
+interface IEditableRowProps extends IRowProps {
+	/**
+	 * Defines the Cell.
+	 */
+	cells: Array<IEditableCell>;
+
+	/**
+	 * Callback function for when the selectable checkbox state changes.
+	 */
+	onCheckboxChange?: (isChecked: boolean) => void;
+
+	/**
+	 * Callback function for when the `Save` button is clicked.
+	 */
+	onRowUpdated?: (
+		newEntries: Array<IEditableCell>,
+		oldEntries: Array<IEditableCell>
+	) => void;
+
+	/**
+	 * Flag to indicate if the Row is selectable.
+	 */
+	selectable?: boolean;
+}
+
+export const ClayTableWithEditableRow: React.FunctionComponent<IEditableRowProps> = ({
+	cells,
+	onCheckboxChange = () => {},
+	onRowUpdated = () => {},
+	selectable = false,
+	...otherProps
+}: IEditableRowProps) => {
+	const [check, setCheck] = React.useState<boolean>(false);
+	const [editing, setEditing] = React.useState<boolean>(false);
+
+	const oldCells = React.useMemo(
+		() => cells.map(cell => Object.assign(cell)),
+		[cells]
+	);
+
+	// Pular o foco para o Row inteiro quando o Edit mode for triggado!
+
+	return (
+		<Row active={check} {...otherProps}>
+			{selectable && (
+				<Cell>
+					<ClayCheckbox
+						checked={check}
+						onChange={() => {
+							setCheck(val => !val);
+							onCheckboxChange(!check);
+						}}
+					/>
+				</Cell>
+			)}
+			{cells.map(({cellProps, editable = false, value}, index) => (
+				<Cell expanded key={index} {...cellProps}>
+					{editable && editing ? (
+						<ClayInput
+							className="form-control-sm"
+							defaultValue={value}
+							onChange={event => {
+								cells[index].value = event.target.value;
+							}}
+							placeholder={value}
+							type="text"
+						/>
+					) : (
+						value
+					)}
+				</Cell>
+			))}
+			<Cell columnTextAlignment="end" key="actionsCell">
+				{editing ? (
+					<ClayButton.Group className="btn-group-nowrap" spaced>
+						<ClayButton
+							displayType="primary"
+							onClick={() => {
+								onRowUpdated(cells, oldCells);
+								setEditing(false);
+							}}
+							small
+						>
+							{'Save'}
+						</ClayButton>
+						<ClayButton
+							displayType="secondary"
+							onClick={() => setEditing(val => !val)}
+							small
+						>
+							{'Cancel'}
+						</ClayButton>
+					</ClayButton.Group>
+				) : (
+					<ClayButton.Group className="btn-group-nowrap">
+						<ClayButton
+							displayType="secondary"
+							onClick={() => setEditing(val => !val)}
+							small
+						>
+							{'Edit'}
+						</ClayButton>
+					</ClayButton.Group>
+				)}
+			</Cell>
+		</Row>
+	);
+};

--- a/packages/clay-table/src/ClayTableWithEditableRow.tsx
+++ b/packages/clay-table/src/ClayTableWithEditableRow.tsx
@@ -13,7 +13,7 @@ import {ClayCheckbox, ClayInput} from '@clayui/form';
 interface IEditableCell {
 	cellProps?: Object;
 	editable?: boolean;
-	value: string;
+	title: string;
 }
 
 interface IEditableRowProps extends IRowProps {
@@ -71,20 +71,20 @@ export const ClayTableWithEditableRow: React.FunctionComponent<IEditableRowProps
 					/>
 				</Cell>
 			)}
-			{cells.map(({cellProps, editable = false, value}, index) => (
+			{cells.map(({cellProps, editable = false, title}, index) => (
 				<Cell expanded key={index} {...cellProps}>
 					{editable && editing ? (
 						<ClayInput
 							className="form-control-sm"
-							defaultValue={value}
+							defaultValue={title}
 							onChange={event => {
-								cells[index].value = event.target.value;
+								cells[index].title = event.target.value;
 							}}
-							placeholder={value}
+							placeholder={title}
 							type="text"
 						/>
 					) : (
-						value
+						title
 					)}
 				</Cell>
 			))}

--- a/packages/clay-table/src/ClayTableWithEditableRow.tsx
+++ b/packages/clay-table/src/ClayTableWithEditableRow.tsx
@@ -41,7 +41,9 @@ interface IEditableRowProps extends IRowProps {
 	selectable?: boolean;
 }
 
-export const ClayTableWithEditableRow: React.FunctionComponent<IEditableRowProps> = ({
+export const ClayTableWithEditableRow: React.FunctionComponent<
+	IEditableRowProps
+> = ({
 	cells,
 	onCheckboxChange = () => {},
 	onRowUpdated = () => {},
@@ -55,8 +57,6 @@ export const ClayTableWithEditableRow: React.FunctionComponent<IEditableRowProps
 		() => cells.map(cell => Object.assign(cell)),
 		[cells]
 	);
-
-	// Pular o foco para o Row inteiro quando o Edit mode for triggado!
 
 	return (
 		<Row active={check} {...otherProps}>

--- a/packages/clay-table/src/ClayTableWithQuickActions.tsx
+++ b/packages/clay-table/src/ClayTableWithQuickActions.tsx
@@ -12,20 +12,38 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 interface IQuickActions {
 	href: string;
 
+	/**
+	 * Name of icon symbol
+	 */
 	symbol: string;
 }
 
 interface IColumnItem {
+	/**
+	 * Props to be added on each Cell for Heading Cells.
+	 */
 	cellProps?: Object;
 
+	/**
+	 * Unique key for a column. Used to describe a column specification.
+	 */
 	dataIndex: string;
 
-	render?: Function;
+	/**
+	 * Renderer of the table cell. The return value should be a ReactNode.
+	 */
+	render?: (title: string) => React.ReactNode;
 
+	/**
+	 * Title of the column.
+	 */
 	title: string;
 }
 
 interface IRowItem {
+	/**
+	 * Props to be added on each Cell for Row Cells.
+	 */
 	cellProps?: Object;
 
 	dropdownActions: React.ComponentProps<
@@ -34,8 +52,14 @@ interface IRowItem {
 
 	quickActions: Array<IQuickActions>;
 
+	/**
+	 * Renderer of the table cell. The return value should be a ReactNode.
+	 */
 	render?: Function;
 
+	/**
+	 * Title of the column.
+	 */
 	title: string;
 
 	[key: string]: any;

--- a/packages/clay-table/src/ClayTableWithQuickActions.tsx
+++ b/packages/clay-table/src/ClayTableWithQuickActions.tsx
@@ -74,7 +74,7 @@ export const ClayTableWithQuickActions: React.FunctionComponent<
 		<ClayTable hover {...otherProps}>
 			<ClayTable.Head>
 				<ClayTable.Row>
-					{columns.map(({cellProps, render, title}, index) => {
+					{columns.map(({cellProps = {}, render, title}, index) => {
 						return (
 							<ClayTable.Cell
 								headingCell

--- a/packages/clay-table/src/ClayTableWithQuickActions.tsx
+++ b/packages/clay-table/src/ClayTableWithQuickActions.tsx
@@ -1,0 +1,138 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayTable, {IProps} from './index';
+import React from 'react';
+import {ClayDropDownWithBasicItems} from '@clayui/drop-down';
+
+interface IDropdownItem {
+	label: string;
+
+	onClick?: (event: React.SyntheticEvent) => void;
+}
+
+interface IQuickActions {
+	href: string;
+
+	symbol: string;
+}
+
+interface IColumnItem {
+	cellProps?: Object;
+
+	dataIndex: string;
+
+	render?: Function;
+
+	title: string;
+}
+
+interface IRowItem {
+	cellProps?: Object;
+
+	dropdownActions: Array<IDropdownItem>;
+
+	quickActions: Array<IQuickActions>;
+
+	render?: Function;
+
+	title: string;
+
+	[key: string]: any;
+}
+
+interface ITableProps extends IProps {
+	columns: Array<IColumnItem>;
+
+	rows: Array<IRowItem>;
+
+	spritemap?: string;
+}
+
+export const ClayTableWithQuickActions: React.FunctionComponent<
+	ITableProps
+> = ({columns, rows, spritemap, ...otherProps}: ITableProps) => {
+	const hasQuickActions =
+		rows.findIndex(row => row.dropdownActions || row.dropdownActions) > -1;
+
+	return (
+		<ClayTable hover {...otherProps}>
+			<ClayTable.Head>
+				<ClayTable.Row>
+					{columns.map(({cellProps, render, title}, index) => {
+						return (
+							<ClayTable.Cell
+								headingCell
+								headingTitle
+								key={index}
+								{...cellProps}
+							>
+								{render ? render(title) : title}
+							</ClayTable.Cell>
+						);
+					})}
+					{hasQuickActions && <ClayTable.Cell headingCell />}
+				</ClayTable.Row>
+			</ClayTable.Head>
+			<ClayTable.Body>
+				{rows.map((row, index) => {
+					const values = columns.map(({dataIndex}) => row[dataIndex]);
+
+					return (
+						<ClayTable.Row key={index}>
+							{row.render
+								? row.render(values)
+								: values.map((value, index) => (
+										<ClayTable.Cell
+											{...row.cellProps}
+											key={index}
+										>
+											{value}
+										</ClayTable.Cell>
+								  ))}
+							<ClayTable.Cell {...row.cellProps} key={index}>
+								{row.quickActions && (
+									<div className="quick-action-menu">
+										{row.quickActions.map(
+											({href, symbol}, index) => (
+												<a
+													className="component-action quick-action-item"
+													href={href}
+													key={index}
+													role="button"
+												>
+													<ClayIcon
+														spritemap={spritemap}
+														symbol={symbol}
+													/>
+												</a>
+											)
+										)}
+									</div>
+								)}
+								{row.dropdownActions && (
+									<ClayDropDownWithBasicItems
+										items={row.dropdownActions}
+										spritemap={spritemap}
+										trigger={
+											<button className="component-action">
+												<ClayIcon
+													spritemap={spritemap}
+													symbol="ellipsis-v"
+												/>
+											</button>
+										}
+									/>
+								)}
+							</ClayTable.Cell>
+						</ClayTable.Row>
+					);
+				})}
+			</ClayTable.Body>
+		</ClayTable>
+	);
+};

--- a/packages/clay-table/src/ClayTableWithQuickActions.tsx
+++ b/packages/clay-table/src/ClayTableWithQuickActions.tsx
@@ -4,19 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayIcon from '@clayui/icon';
+import ActionsMenu from '../src/ActionsMenu';
 import ClayTable, {IProps} from './index';
 import React from 'react';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
-
-interface IQuickActions {
-	href: string;
-
-	/**
-	 * Name of icon symbol
-	 */
-	symbol: string;
-}
 
 interface IColumnItem {
 	/**
@@ -50,7 +41,7 @@ interface IRowItem {
 		typeof ClayDropDownWithItems
 	>['items'];
 
-	quickActions: Array<IQuickActions>;
+	quickActions: React.ComponentProps<typeof ActionsMenu>['actionItems'];
 
 	/**
 	 * Renderer of the table cell. The return value should be a ReactNode.
@@ -115,39 +106,11 @@ export const ClayTableWithQuickActions: React.FunctionComponent<
 										</ClayTable.Cell>
 								  ))}
 							<ClayTable.Cell {...row.cellProps} key={index}>
-								{row.quickActions && (
-									<div className="quick-action-menu">
-										{row.quickActions.map(
-											({href, symbol}, index) => (
-												<a
-													className="component-action quick-action-item"
-													href={href}
-													key={index}
-													role="button"
-												>
-													<ClayIcon
-														spritemap={spritemap}
-														symbol={symbol}
-													/>
-												</a>
-											)
-										)}
-									</div>
-								)}
-								{row.dropdownActions && (
-									<ClayDropDownWithItems
-										items={row.dropdownActions}
-										spritemap={spritemap}
-										trigger={
-											<button className="component-action">
-												<ClayIcon
-													spritemap={spritemap}
-													symbol="ellipsis-v"
-												/>
-											</button>
-										}
-									/>
-								)}
+								<ActionsMenu
+									actionItems={row.quickActions}
+									dropdownActions={row.dropdownActions}
+									spritemap={spritemap}
+								/>
 							</ClayTable.Cell>
 						</ClayTable.Row>
 					);

--- a/packages/clay-table/src/ClayTableWithQuickActions.tsx
+++ b/packages/clay-table/src/ClayTableWithQuickActions.tsx
@@ -7,13 +7,7 @@
 import ClayIcon from '@clayui/icon';
 import ClayTable, {IProps} from './index';
 import React from 'react';
-import {ClayDropDownWithBasicItems} from '@clayui/drop-down';
-
-interface IDropdownItem {
-	label: string;
-
-	onClick?: (event: React.SyntheticEvent) => void;
-}
+import {ClayDropDownWithItems} from '@clayui/drop-down';
 
 interface IQuickActions {
 	href: string;
@@ -34,7 +28,9 @@ interface IColumnItem {
 interface IRowItem {
 	cellProps?: Object;
 
-	dropdownActions: Array<IDropdownItem>;
+	dropdownActions: React.ComponentProps<
+		typeof ClayDropDownWithItems
+	>['items'];
 
 	quickActions: Array<IQuickActions>;
 
@@ -115,7 +111,7 @@ export const ClayTableWithQuickActions: React.FunctionComponent<
 									</div>
 								)}
 								{row.dropdownActions && (
-									<ClayDropDownWithBasicItems
+									<ClayDropDownWithItems
 										items={row.dropdownActions}
 										spritemap={spritemap}
 										trigger={

--- a/packages/clay-table/src/Row.tsx
+++ b/packages/clay-table/src/Row.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import React from 'react';
 import {TDelimiter} from './types';
 
-interface IRowProps extends React.HTMLAttributes<HTMLTableRowElement> {
+export interface IRowProps extends React.HTMLAttributes<HTMLTableRowElement> {
 	/**
 	 * Forces the active state inside the row.
 	 */

--- a/packages/clay-table/src/index.tsx
+++ b/packages/clay-table/src/index.tsx
@@ -15,7 +15,7 @@ type ResposiveSizeType = 'lg' | 'md' | 'sm' | 'xl';
 
 type VerticalAlignmentType = 'bottom' | 'middle' | 'top';
 
-interface IProps extends React.HTMLAttributes<HTMLTableElement> {
+export interface IProps extends React.HTMLAttributes<HTMLTableElement> {
 	/**
 	 * This property vertically align the contents
 	 * inside the table body according a given position.

--- a/packages/clay-table/src/index.tsx
+++ b/packages/clay-table/src/index.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import ActionsMenu from './ActionsMenu';
 import Body from './Body';
 import Cell from './Cell';
 import classNames from 'classnames';
@@ -71,6 +72,7 @@ export interface IProps extends React.HTMLAttributes<HTMLTableElement> {
 }
 
 const ClayTable: React.FunctionComponent<IProps> & {
+	ActionsMenu: typeof ActionsMenu;
 	Body: typeof Body;
 	Cell: typeof Cell;
 	Head: typeof Head;
@@ -121,6 +123,7 @@ const ClayTable: React.FunctionComponent<IProps> & {
 	);
 };
 
+ClayTable.ActionsMenu = ActionsMenu;
 ClayTable.Body = Body;
 ClayTable.Cell = Cell;
 ClayTable.Head = Head;

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -14,6 +14,7 @@ import ClayTable from '../src';
 import React from 'react';
 import {boolean, select} from '@storybook/addon-knobs';
 import {ClayCheckbox} from '@clayui/form';
+import {ClayTableWithEditableRow} from '../src/ClayTableWithEditableRow';
 import {storiesOf} from '@storybook/react';
 
 function ClayCheckboxWithState(props: any) {
@@ -538,4 +539,67 @@ storiesOf('ClayTable', module)
 				</ClayTable.Body>
 			</ClayTable>
 		</form>
-	));
+	))
+	.add('using EditableRow', () => {
+		const [state, setState] = React.useState({
+			cells: [
+				{
+					value: 'White and Red',
+				},
+				{
+					editable: true,
+					value: 'South America',
+				},
+				{
+					editable: true,
+					value: 'Brazil',
+				},
+			],
+		});
+
+		const onRowUpdated = (cellsUpdated: any, oldCells: any) => {
+			const cells = [...state.cells];
+			cells[cells.indexOf(oldCells)] = cellsUpdated;
+			setState({...state, cells});
+		};
+
+		return (
+			<ClayTable responsive>
+				<ClayTable.Head>
+					<ClayTable.Row>
+						{['', 'Teams', 'Region', 'Country', ''].map(
+							(cell, index) => (
+								<ClayTable.Cell
+									columnTextAlignment={
+										['', 'Teams', 'Region', 'Country', '']
+											.length === index
+											? 'end'
+											: undefined
+									}
+									expanded={index > 0}
+									headingCell
+									key={index}
+								>
+									{cell}
+								</ClayTable.Cell>
+							)
+						)}
+					</ClayTable.Row>
+				</ClayTable.Head>
+				<ClayTable.Body>
+					<ClayTableWithEditableRow
+						cells={state.cells}
+						onRowUpdated={onRowUpdated}
+						selectable
+					/>
+					<ClayTable.Row>
+						<ClayTable.Cell />
+						<ClayTable.Cell>{'Purple and Yellow'}</ClayTable.Cell>
+						<ClayTable.Cell>{'North America'}</ClayTable.Cell>
+						<ClayTable.Cell>{'U.S.A'}</ClayTable.Cell>
+						<ClayTable.Cell />
+					</ClayTable.Row>
+				</ClayTable.Body>
+			</ClayTable>
+		);
+	});

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -604,12 +604,15 @@ storiesOf('ClayTable', module)
 			</ClayTable>
 		);
 	})
-	.add('using high-level', () => {
+	.add('using ClayTableWithQuickActions', () => {
 		const columns = [
 			{
+				cellProps: {
+					headingTitle: false,
+				},
 				dataIndex: 'author',
 				render: (title: string) => (
-					<p className="table-list-title">{title}</p>
+					<div className="bg-secondary text-white">{title}</div>
 				),
 				title: 'Author',
 			},
@@ -618,10 +621,16 @@ storiesOf('ClayTable', module)
 					expanded: true,
 				},
 				dataIndex: 'description',
+				render: (title: string) => (
+					<div className="bg-secondary text-white">{title}</div>
+				),
 				title: 'Description',
 			},
 			{
 				dataIndex: 'title',
+				render: (title: string) => (
+					<div className="bg-secondary text-white">{title}</div>
+				),
 				title: 'Title',
 			},
 		];
@@ -647,16 +656,21 @@ storiesOf('ClayTable', module)
 						label: 'Edit',
 						onClick: () =>
 							alert('Edit event from Estrela da Manhã'),
+						symbolRight: 'edit',
 					},
 					{
 						label: 'Share',
 						onClick: () =>
 							alert('Share event from Estrela da Manhã'),
+						symbolRight: 'edit',
 					},
 				],
 				quickActions: [
 					{
-						href: '#1',
+						onClick: () =>
+							alert(
+								'Event of trash action from Estrela da Manhã'
+							),
 						symbol: 'trash',
 					},
 					{
@@ -664,15 +678,16 @@ storiesOf('ClayTable', module)
 						symbol: 'download',
 					},
 					{
-						href: '#3',
+						onClick: () =>
+							alert(
+								'Event of expand action from Estrela da Manhã'
+							),
 						symbol: 'expand',
 					},
 				],
 				render: (values: any) => {
 					return values.map((value: any, index: number) => (
-						<ClayTable.Cell className="bg-light" key={index}>
-							{value}
-						</ClayTable.Cell>
+						<ClayTable.Cell key={index}>{value}</ClayTable.Cell>
 					));
 				},
 				title: 'Estrela da Manhã',
@@ -706,7 +721,8 @@ storiesOf('ClayTable', module)
 				],
 				quickActions: [
 					{
-						href: '#1',
+						onClick: () =>
+							alert('Event of trash action from Libertinagem'),
 						symbol: 'trash',
 					},
 					{
@@ -714,7 +730,8 @@ storiesOf('ClayTable', module)
 						symbol: 'download',
 					},
 					{
-						href: '#3',
+						onClick: () =>
+							alert('Event of expand action from Libertinagem'),
 						symbol: 'expand',
 					},
 				],
@@ -751,7 +768,10 @@ storiesOf('ClayTable', module)
 				],
 				quickActions: [
 					{
-						href: '#1',
+						onClick: () =>
+							alert(
+								'Event of trash action from Morte e Vida Severina'
+							),
 						symbol: 'trash',
 					},
 					{
@@ -759,15 +779,16 @@ storiesOf('ClayTable', module)
 						symbol: 'download',
 					},
 					{
-						href: '#3',
+						onClick: () =>
+							alert(
+								'Event of expand action from Morte e Vida Severina'
+							),
 						symbol: 'expand',
 					},
 				],
 				render: (values: any) => {
 					return values.map((value: any, index: number) => (
-						<ClayTable.Cell className="bg-light" key={index}>
-							{value}
-						</ClayTable.Cell>
+						<ClayTable.Cell key={index}>{value}</ClayTable.Cell>
 					));
 				},
 				title: 'Morte e Vida Severina',

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -673,7 +673,7 @@ storiesOf('ClayTable', module)
 						<ClayTable.Cell className="bg-light" key={index}>
 							{value}
 						</ClayTable.Cell>
-					))
+					));
 				},
 				title: 'Estrela da Manhã',
 			},
@@ -768,7 +768,7 @@ storiesOf('ClayTable', module)
 						<ClayTable.Cell className="bg-light" key={index}>
 							{value}
 						</ClayTable.Cell>
-					))
+					));
 				},
 				title: 'Morte e Vida Severina',
 			},

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -608,6 +608,9 @@ storiesOf('ClayTable', module)
 		const columns = [
 			{
 				dataIndex: 'author',
+				render: (title: string) => (
+					<p className="table-list-title">{title}</p>
+				),
 				title: 'Author',
 			},
 			{
@@ -665,6 +668,13 @@ storiesOf('ClayTable', module)
 						symbol: 'expand',
 					},
 				],
+				render: (values: any) => {
+					return values.map((value: any, index: number) => (
+						<ClayTable.Cell className="bg-light" key={index}>
+							{value}
+						</ClayTable.Cell>
+					))
+				},
 				title: 'Estrela da Manhã',
 			},
 			{
@@ -753,6 +763,13 @@ storiesOf('ClayTable', module)
 						symbol: 'expand',
 					},
 				],
+				render: (values: any) => {
+					return values.map((value: any, index: number) => (
+						<ClayTable.Cell className="bg-light" key={index}>
+							{value}
+						</ClayTable.Cell>
+					))
+				},
 				title: 'Morte e Vida Severina',
 			},
 		];

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -544,15 +544,15 @@ storiesOf('ClayTable', module)
 		const [state, setState] = React.useState({
 			cells: [
 				{
-					value: 'White and Red',
+					title: 'White and Red',
 				},
 				{
 					editable: true,
-					value: 'South America',
+					title: 'South America',
 				},
 				{
 					editable: true,
-					value: 'Brazil',
+					title: 'Brazil',
 				},
 			],
 		});

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import {boolean, select} from '@storybook/addon-knobs';
 import {ClayCheckbox} from '@clayui/form';
 import {ClayTableWithEditableRow} from '../src/ClayTableWithEditableRow';
+import {ClayTableWithQuickActions} from '../src/ClayTableWithQuickActions';
 import {storiesOf} from '@storybook/react';
 
 function ClayCheckboxWithState(props: any) {
@@ -601,5 +602,166 @@ storiesOf('ClayTable', module)
 					</ClayTable.Row>
 				</ClayTable.Body>
 			</ClayTable>
+		);
+	})
+	.add('using high-level', () => {
+		const columns = [
+			{
+				dataIndex: 'author',
+				title: 'Author',
+			},
+			{
+				cellProps: {
+					expanded: true,
+				},
+				dataIndex: 'description',
+				title: 'Description',
+			},
+			{
+				dataIndex: 'title',
+				title: 'Title',
+			},
+		];
+
+		const rows = [
+			{
+				author: 'Manuel Bandeira',
+				description: (
+					<div className="autofit-row">
+						<div className="autofit-col-expand">
+							{`Estrela da Manhã is the title of a poem that gives name to a book by the Brazilian poet Manuel Bandeira of 1936.`}
+						</div>
+						<div className="autofit-col">
+							<img
+								className="table-img"
+								src="https://upload.wikimedia.org/wikipedia/commons/9/9a/Estrela_da_Manh%C3%A3_Manuel_Bandeira_1936.jpg"
+							/>
+						</div>
+					</div>
+				),
+				dropdownActions: [
+					{
+						label: 'Edit',
+						onClick: () =>
+							alert('Edit event from Estrela da Manhã'),
+					},
+					{
+						label: 'Share',
+						onClick: () =>
+							alert('Share event from Estrela da Manhã'),
+					},
+				],
+				quickActions: [
+					{
+						href: '#1',
+						symbol: 'trash',
+					},
+					{
+						href: '#2',
+						symbol: 'download',
+					},
+					{
+						href: '#3',
+						symbol: 'expand',
+					},
+				],
+				title: 'Estrela da Manhã',
+			},
+			{
+				author: 'Manuel Bandeira',
+				description: (
+					<div className="autofit-row">
+						<div className="autofit-col-expand">
+							{`Libertinagem is the fourth book of poetry by Brazilian writer Manuel Bandeira, published in 1930. It is composed of 38 poems, among which stand out Pneumothorax, Family Pension, Deeply and I'm Leaving for Pasargada.`}
+						</div>
+						<div className="autofit-col">
+							<img
+								className="table-img"
+								src="https://d3swacfcujrr1g.cloudfront.net/img/uploads/2000/01/002670084013.jpg"
+							/>
+						</div>
+					</div>
+				),
+				dropdownActions: [
+					{
+						label: 'Edit',
+						onClick: () => alert('Edit event from Libertinagem'),
+						symbolRight: 'edit',
+					},
+					{
+						label: 'Share',
+						onClick: () => alert('Share event from Libertinagem'),
+						symbolRight: 'edit',
+					},
+				],
+				quickActions: [
+					{
+						href: '#1',
+						symbol: 'trash',
+					},
+					{
+						href: '#2',
+						symbol: 'download',
+					},
+					{
+						href: '#3',
+						symbol: 'expand',
+					},
+				],
+				title: 'Libertinagem',
+			},
+			{
+				author: 'João Cabral de Melo Neto',
+				description: (
+					<div className="autofit-row">
+						<div className="autofit-col-expand">
+							{`Published in 1955 and written between 1954 and 1955, the play is divided into 18 sections and written in heptasyllabic meter, recalling the popular poetry of northeastern Brazil, where Melo Neto was born and lived for most of his life, the cordel.`}
+						</div>
+						<div className="autofit-col">
+							<img
+								className="table-img"
+								src="https://upload.wikimedia.org/wikipedia/pt/thumb/0/0d/Morte-e-vida-severina-joo-cabral-de-melo-neto.jpg/230px-Morte-e-vida-severina-joo-cabral-de-melo-neto.jpg"
+							/>
+						</div>
+					</div>
+				),
+				dropdownActions: [
+					{
+						label: 'Edit',
+						onClick: () =>
+							alert('Edit event from Morte e Vida Severina'),
+						symbolRight: 'edit',
+					},
+					{
+						label: 'Share',
+						onClick: () =>
+							alert('Share event from Morte e Vida Severina'),
+						symbolRight: 'edit',
+					},
+				],
+				quickActions: [
+					{
+						href: '#1',
+						symbol: 'trash',
+					},
+					{
+						href: '#2',
+						symbol: 'download',
+					},
+					{
+						href: '#3',
+						symbol: 'expand',
+					},
+				],
+				title: 'Morte e Vida Severina',
+			},
+		];
+
+		return (
+			<ClayTableWithQuickActions
+				columns={columns}
+				rows={rows}
+				spritemap={spritemap}
+			/>
 		);
 	});


### PR DESCRIPTION
- Was created a high-level component for using Rows with inline edit called ClayTableWithEditableRow. 
- Another component is ClayTableWithQuickActions(I'm open for better names)

Fixes: #2212