### PR TITLE
fix(drop-down): automatically close dropdown when clicking on item

### DIFF
--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -25,7 +25,7 @@ interface IItem {
 	label?: string;
 	name?: string;
 	onChange?: Function;
-	onClick?: () => void;
+	onClick?: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 	symbolLeft?: string;
 	symbolRight?: string;
 	type?: TType;
@@ -117,9 +117,29 @@ const Checkbox: React.FunctionComponent<IItem> = ({
 	);
 };
 
-const Item: React.FunctionComponent<Omit<IItem, 'onChange'>> = props => (
-	<ClayDropDown.Item {...props}>{props.label}</ClayDropDown.Item>
-);
+const ClayDropDownContext = React.createContext({close: () => {}});
+
+const Item: React.FunctionComponent<Omit<IItem, 'onChange'>> = ({
+	onClick,
+	...props
+}) => {
+	const {close} = React.useContext(ClayDropDownContext);
+
+	return (
+		<ClayDropDown.Item
+			onClick={e => {
+				if (onClick) {
+					onClick(e);
+				}
+
+				close();
+			}}
+			{...props}
+		>
+			{props.label}
+		</ClayDropDown.Item>
+	);
+};
 
 const Group: React.FunctionComponent<IItem & {spritemap?: string}> = ({
 	items,
@@ -249,32 +269,41 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 			onActiveChange={setActive}
 			trigger={trigger}
 		>
-			{helpText && <Help>{helpText}</Help>}
+			<ClayDropDownContext.Provider
+				value={{close: () => setActive(false)}}
+			>
+				{helpText && <Help>{helpText}</Help>}
 
-			{searchable && (
-				<Search
-					{...searchProps}
-					onChange={event => onSearchValueChange(event.target.value)}
-					spritemap={spritemap}
-					value={searchValue}
-				/>
-			)}
+				{searchable && (
+					<Search
+						{...searchProps}
+						onChange={event =>
+							onSearchValueChange(event.target.value)
+						}
+						spritemap={spritemap}
+						value={searchValue}
+					/>
+				)}
 
-			<Wrap>
-				{footerContent ? (
-					<div className="inline-scroller">
+				<Wrap>
+					{footerContent ? (
+						<div className="inline-scroller">
+							<DropDownContent
+								items={items}
+								spritemap={spritemap}
+							/>
+						</div>
+					) : (
 						<DropDownContent items={items} spritemap={spritemap} />
-					</div>
-				) : (
-					<DropDownContent items={items} spritemap={spritemap} />
-				)}
+					)}
 
-				{caption && <Caption>{caption}</Caption>}
+					{caption && <Caption>{caption}</Caption>}
 
-				{footerContent && (
-					<div className="dropdown-section">{footerContent}</div>
-				)}
-			</Wrap>
+					{footerContent && (
+						<div className="dropdown-section">{footerContent}</div>
+					)}
+				</Wrap>
+			</ClayDropDownContext.Provider>
 		</ClayDropDown>
 	);
 };

--- a/packages/clay-pagination/src/PaginationWithBar.tsx
+++ b/packages/clay-pagination/src/PaginationWithBar.tsx
@@ -8,9 +8,9 @@ import classNames from 'classnames';
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayPagination from './Pagination';
-import React, {useState} from 'react';
+import React from 'react';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
-import {noop, sub} from '@clayui/shared';
+import {sub} from '@clayui/shared';
 
 const defaultDeltas = [
 	{
@@ -42,6 +42,7 @@ interface IDelta {
 }
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+	activeDelta?: number;
 	/**
 	 * Possible values of items per page.
 	 */
@@ -79,18 +80,18 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * Callback for when the number of elements per page changes. This is only used if
 	 * an href is not provided.
 	 */
-	onDeltaChange?: (page?: number) => void;
+	onDeltaChange?: (page: number) => void;
 
 	/**
 	 * Callback for when the active page changes. This is only used if
 	 * an href is not provided.
 	 */
-	onPageChange?: (page?: number) => void;
+	onPageChange?: (page: number) => void;
 
 	/**
 	 * Initialize the page that is currently active. The first page is `1`.
 	 */
-	initialActivePage?: number;
+	activePage?: number;
 
 	/**
 	 * Initializes delta. Default is `10`.
@@ -120,24 +121,24 @@ const DEFAULT_LABELS = {
 };
 
 export const ClayPaginationWithBar: React.FunctionComponent<IProps> = ({
+	activeDelta,
+	activePage = 1,
 	deltas = defaultDeltas,
 	disabledPages,
 	ellipsisBuffer,
 	hrefConstructor,
 	labels = DEFAULT_LABELS,
-	onDeltaChange = noop,
-	onPageChange = noop,
-	initialSelectedDelta = deltas[0],
-	initialActivePage = 1,
+	onDeltaChange,
+	onPageChange,
 	size,
 	spritemap,
 	totalItems,
 	...otherProps
 }: IProps) => {
-	const [activePage, setActivePage] = useState<number>(initialActivePage);
-	const [perPage, setPerPage] = useState<number>(
-		initialSelectedDelta.label as number
-	);
+	if (!activeDelta) {
+		activeDelta = deltas[0].label;
+	}
+
 	const items: Items = deltas.map(({href, label}) => {
 		const item: {
 			href?: string;
@@ -150,7 +151,6 @@ export const ClayPaginationWithBar: React.FunctionComponent<IProps> = ({
 
 		if (!href) {
 			item.onClick = () => {
-				setPerPage(label as number);
 				if (onDeltaChange) {
 					onDeltaChange(label as number);
 				}
@@ -175,7 +175,8 @@ export const ClayPaginationWithBar: React.FunctionComponent<IProps> = ({
 						data-testid="selectPaginationBar"
 						displayType="unstyled"
 					>
-						{sub(labels.perPageItems, [perPage])}
+						{sub(labels.perPageItems, [activeDelta])}
+
 						<ClayIcon
 							spritemap={spritemap}
 							symbol="caret-double-l"
@@ -186,9 +187,9 @@ export const ClayPaginationWithBar: React.FunctionComponent<IProps> = ({
 
 			<div className="pagination-results">
 				{sub(labels.paginationResults, [
-					(activePage - 1) * perPage + 1,
-					activePage * perPage < totalItems
-						? activePage * perPage
+					(activePage - 1) * activeDelta + 1,
+					activePage * activeDelta < totalItems
+						? activePage * activeDelta
 						: totalItems,
 					totalItems,
 				])}
@@ -200,15 +201,12 @@ export const ClayPaginationWithBar: React.FunctionComponent<IProps> = ({
 				ellipsisBuffer={ellipsisBuffer}
 				hrefConstructor={hrefConstructor}
 				onPageChange={page => {
-					if (page) {
-						setActivePage(page);
-						if (onPageChange) {
-							onPageChange(page);
-						}
+					if (page && onPageChange) {
+						onPageChange(page);
 					}
 				}}
 				spritemap={spritemap}
-				totalPages={Math.ceil(totalItems / perPage)}
+				totalPages={Math.ceil(totalItems / activeDelta)}
 			/>
 		</div>
 	);

--- a/packages/clay-pagination/src/__tests__/index.tsx
+++ b/packages/clay-pagination/src/__tests__/index.tsx
@@ -129,7 +129,7 @@ describe('ClayPaginationWithBar', () => {
 
 		const {getByTestId} = render(
 			<ClayPaginationWithBar
-				initialActivePage={12}
+				activePage={12}
 				onPageChange={changeMock}
 				spritemap={spritemap}
 				totalItems={100}
@@ -142,7 +142,7 @@ describe('ClayPaginationWithBar', () => {
 
 		fireEvent.click(getByTestId('nextArrow'), {});
 
-		expect(changeMock).toHaveBeenLastCalledWith(12);
+		expect(changeMock).toHaveBeenLastCalledWith(13);
 	});
 
 	it('calls onDeltaChange when select is expanded', () => {
@@ -150,7 +150,7 @@ describe('ClayPaginationWithBar', () => {
 
 		const {getByTestId} = render(
 			<ClayPaginationWithBar
-				initialActivePage={12}
+				activePage={12}
 				onDeltaChange={deltaChangeMock}
 				spritemap={spritemap}
 				totalItems={100}
@@ -167,7 +167,7 @@ describe('ClayPaginationWithBar', () => {
 	it('shows dropdown when pagination dropdown is clicked', () => {
 		const {getByTestId} = render(
 			<ClayPaginationWithBar
-				initialActivePage={12}
+				activePage={12}
 				spritemap={spritemap}
 				totalItems={100}
 			/>

--- a/packages/clay-pagination/stories/index.tsx
+++ b/packages/clay-pagination/stories/index.tsx
@@ -164,7 +164,10 @@ storiesOf('ClayPagination', module)
 
 		return <PaginationBar numberOfItems={500} />;
 	})
-	.add('using ClayPaginationWithBar component', () => {
+	.add('ClayPaginationWithBar', () => {
+		const [activePage, setActivePage] = useState<number>(1);
+		const [delta, setDelta] = useState<number>(5);
+
 		const deltas = [
 			{
 				href: '#1',
@@ -184,9 +187,12 @@ storiesOf('ClayPagination', module)
 
 		return (
 			<ClayPaginationWithBar
+				activeDelta={delta}
+				activePage={activePage}
 				deltas={deltas}
 				ellipsisBuffer={number('Ellipsis Buffer: ', 3)}
-				initialActivePage={number('Selected page: ', 1)}
+				onDeltaChange={setDelta}
+				onPageChange={setActivePage}
 				spritemap={spritemap}
 				totalItems={number('Number of items: ', 21)}
 			/>


### PR DESCRIPTION
Two issues here:

1) `<ClayPaginationWithBar />` was an uncontrolled component. We should default our components to be controlled(both a value and onChange). This gives users a flexibility provide a specific value in reaction to some other change.

2) `<ClayDropDownWithItems />` isn't currently closing the dropdown after clicking an item. I added a context here so that it will automatically close when item is clicked.

Both of these issues arose from chatting with @thektan and @oliv-yu as they tried to use `<ClayPaginationWithBar />`