### PR TITLE
fix(@clayui/form): pressing enter on label with focus should remove

### DIFF
--- a/packages/clay-form/src/InputWithMultiSelect.tsx
+++ b/packages/clay-form/src/InputWithMultiSelect.tsx
@@ -187,13 +187,17 @@ const ClayMultiSelect: React.FunctionComponent<IProps> = ({
 										}}
 										key={i}
 										onKeyDown={({keyCode}) => {
-											if (keyCode !== BACKSPACE_KEY) {
-												return;
+											switch (keyCode) {
+												case ENTER_KEY:
+												case BACKSPACE_KEY:
+													if (inputRef.current) {
+														inputRef.current.focus();
+													}
+													removeItem();
+													break;
+												default:
+													break;
 											}
-											if (inputRef.current) {
-												inputRef.current.focus();
-											}
-											removeItem();
 										}}
 										ref={(ref: HTMLSpanElement) => {
 											focusManager.createScope(

--- a/packages/clay-form/src/__tests__/InputWithMultiSelect.tsx
+++ b/packages/clay-form/src/__tests__/InputWithMultiSelect.tsx
@@ -142,6 +142,36 @@ describe('Interactions', () => {
 		expect(onItemsChangeFn).toHaveBeenCalled();
 	});
 
+	it('hitting enter on label with focus should call onItemsChange', () => {
+		const onItemsChangeFn = jest.fn();
+
+		const {container} = render(
+			<ClayInputWithMultiSelectWithState
+				items={['foo', 'bar']}
+				onItemsChange={onItemsChangeFn}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		expect(container.querySelectorAll('.label').length).toEqual(2);
+
+		expect(document.activeElement!.tagName).toEqual('BODY');
+
+		fireEvent.keyDown(
+			container.querySelector('input') as HTMLInputElement,
+			{keyCode: 8}
+		);
+
+		expect(document.activeElement!.tagName).toEqual('SPAN');
+		expect(document.activeElement!.classList).toContain('label');
+
+		fireEvent.keyDown(document.activeElement as HTMLSpanElement, {
+			keyCode: 13,
+		});
+
+		expect(onItemsChangeFn).toHaveBeenCalled();
+	});
+
 	it('clicking on autocomplete item calls onItemsChange', () => {
 		const onItemsChangeFn = jest.fn();
 


### PR DESCRIPTION
This is related to #2376