### PR TITLE
fix(clay-css): 2.x Mixin `clay-input-group-stacked` should use child comb…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_input-groups.scss
+++ b/packages/clay-css/src/scss/mixins/_input-groups.scss
@@ -31,7 +31,7 @@
 	$shrink-margin-top: map-get($map, shrink-margin-top);
 
 	@include media-breakpoint-down($breakpoint-down) {
-		.input-group-item {
+		> .input-group-item {
 			margin-bottom: $item-margin-bottom;
 			margin-left: $item-margin-left;
 			margin-right: $item-margin-right;
@@ -39,7 +39,7 @@
 			width: 100%;
 		}
 
-		.input-group-item-shrink {
+		> .input-group-item-shrink {
 			margin-bottom: $shrink-margin-bottom;
 			margin-left: $shrink-margin-left;
 			margin-right: $shrink-margin-right;


### PR DESCRIPTION
…inator styles only apply direct descendants

fixes #2384