### PR TITLE
feat(@clayui/table)!: `bordered` property was renamed to `borderedColumns` due consistency and `borderless` property was added (#2387)

### DIFF
--- a/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
@@ -6,7 +6,7 @@ exports[`ClayTable renders 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     />
   </div>
 </div>
@@ -18,7 +18,7 @@ exports[`ClayTable renders a Cell delimited 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead>
         <tr
@@ -65,7 +65,7 @@ exports[`ClayTable renders a Cell with text alignment set to center 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead>
         <tr
@@ -94,7 +94,7 @@ exports[`ClayTable renders a full bottom vertical aligned table 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover thead-valign-bottom table-valign-bottom"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list thead-valign-bottom table-valign-bottom"
     >
       <thead />
       <tbody />
@@ -109,7 +109,7 @@ exports[`ClayTable renders a no wrapped table 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-heading-nowrap table-hover table-nowrap"
+      class="table table-autofit show-quick-actions-on-hover table-heading-nowrap table-hover table-list table-nowrap"
     >
       <thead />
       <tbody />
@@ -124,7 +124,7 @@ exports[`ClayTable renders a responsive table 1`] = `
     class="table-responsive table-responsive-sm"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <thead />
       <tbody />
@@ -139,7 +139,7 @@ exports[`ClayTable renders a responsive table 2`] = `
     class="table-responsive table-responsive-sm"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <thead />
       <tbody />
@@ -154,7 +154,7 @@ exports[`ClayTable renders a table bordered 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-bordered table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <thead />
       <tbody />
@@ -169,7 +169,7 @@ exports[`ClayTable renders a table hover 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <thead />
       <tbody />
@@ -184,7 +184,7 @@ exports[`ClayTable renders a table striped 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover table-striped"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list table-striped"
     >
       <thead />
       <tbody />
@@ -199,7 +199,7 @@ exports[`ClayTable renders a table with a Body 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <tbody />
     </table>
@@ -213,7 +213,7 @@ exports[`ClayTable renders a table with a Head 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <thead />
     </table>
@@ -227,7 +227,7 @@ exports[`ClayTable renders a table with a Head and Body 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <thead />
       <tbody />
@@ -242,7 +242,7 @@ exports[`ClayTable renders a table with an active row 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <tbody>
         <tr
@@ -260,7 +260,7 @@ exports[`ClayTable renders a table with multiple Cells into Row 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <tbody>
         <tr
@@ -298,7 +298,7 @@ exports[`ClayTable renders a table with multiple rows into Body 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <tbody>
         <tr
@@ -322,7 +322,7 @@ exports[`ClayTable renders a table with multiple rows into Head 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <thead>
         <tr
@@ -346,7 +346,7 @@ exports[`ClayTable renders with a headingTitle 1`] = `
     class="table-responsive"
   >
     <table
-      class="table table-autofit table-list show-quick-actions-on-hover table-hover"
+      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
     >
       <tbody>
         <tr

--- a/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
@@ -148,21 +148,6 @@ exports[`ClayTable renders a responsive table 2`] = `
 </div>
 `;
 
-exports[`ClayTable renders a table bordered 1`] = `
-<div>
-  <div
-    class="table-responsive"
-  >
-    <table
-      class="table table-autofit show-quick-actions-on-hover table-hover table-list"
-    >
-      <thead />
-      <tbody />
-    </table>
-  </div>
-</div>
-`;
-
 exports[`ClayTable renders a table hover 1`] = `
 <div>
   <div
@@ -249,6 +234,21 @@ exports[`ClayTable renders a table with an active row 1`] = `
           class="table-active"
         />
       </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`ClayTable renders a table with columns bordered 1`] = `
+<div>
+  <div
+    class="table-responsive"
+  >
+    <table
+      class="table table-autofit show-quick-actions-on-hover table-bordered table-hover table-list"
+    >
+      <thead />
+      <tbody />
     </table>
   </div>
 </div>

--- a/packages/clay-table/src/__tests__/index.tsx
+++ b/packages/clay-table/src/__tests__/index.tsx
@@ -100,9 +100,9 @@ describe('ClayTable', () => {
 
 		expect(container).toMatchSnapshot();
 	});
-	it('renders a table bordered', () => {
+	it('renders a table with columns bordered', () => {
 		const {container} = render(
-			<ClayTable bordered>
+			<ClayTable borderedColumns>
 				<ClayTable.Head />
 				<ClayTable.Body />
 			</ClayTable>

--- a/packages/clay-table/src/index.tsx
+++ b/packages/clay-table/src/index.tsx
@@ -23,9 +23,14 @@ interface IProps extends React.HTMLAttributes<HTMLTableElement> {
 	bodyVerticalAlignment?: VerticalAlignmentType;
 
 	/**
-	 * Applies a Bordered style on Table.
+	 * Applies a Bordered style on Table's columns.
 	 */
-	bordered?: boolean;
+	borderedColumns?: boolean;
+
+	/**
+	 * Removes the default border and rounded corners from table.
+	 */
+	borderless?: boolean;
 
 	/**
 	 * This property keeps all the headings on one line.
@@ -77,7 +82,8 @@ const ClayTable: React.FunctionComponent<IProps> & {
 	Row: typeof Row;
 } = ({
 	bodyVerticalAlignment,
-	bordered,
+	borderedColumns,
+	borderless,
 	children,
 	className,
 	headVerticalAlignment,
@@ -99,12 +105,13 @@ const ClayTable: React.FunctionComponent<IProps> & {
 		>
 			<table
 				className={classNames(
-					'table table-autofit table-list',
+					'table table-autofit',
 					{
 						'show-quick-actions-on-hover': hover,
-						'table-bordered': bordered,
+						'table-bordered': borderedColumns,
 						'table-heading-nowrap': headingNoWrap,
 						'table-hover': hover,
+						'table-list': !borderless,
 						'table-nowrap': noWrap,
 						'table-striped': striped,
 						[`tbody-valign-${bodyVerticalAlignment}`]: bodyVerticalAlignment,

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -177,7 +177,8 @@ storiesOf('ClayTable', module)
 						{bottom: 'bottom', middle: 'middle', top: 'top'},
 						'middle'
 					)}
-					bordered={boolean('bordered', false)}
+					borderedColumns={boolean('borderedColumns', false)}
+					borderless={boolean('borderless', false)}
 					headVerticalAlignment={select(
 						'head vertical alignment',
 						{bottom: 'bottom', middle: 'middle', top: 'top'},
@@ -365,7 +366,8 @@ storiesOf('ClayTable', module)
 						{bottom: 'bottom', middle: 'middle', top: 'top'},
 						'middle'
 					)}
-					bordered={boolean('bordered', false)}
+					borderedColumns={boolean('bordered', false)}
+					borderless={boolean('borderless', false)}
 					headVerticalAlignment={select(
 						'head vertical alignment',
 						{bottom: 'bottom', middle: 'middle', top: 'top'},
@@ -444,7 +446,8 @@ storiesOf('ClayTable', module)
 					{bottom: 'bottom', middle: 'middle', top: 'top'},
 					'middle'
 				)}
-				bordered={boolean('bordered', false)}
+				borderedColumns={boolean('bordered columns', false)}
+				borderless={boolean('bordeless', false)}
 				headVerticalAlignment={select(
 					'head vertical alignment',
 					{bottom: 'bottom', middle: 'middle', top: 'top'},

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -177,7 +177,7 @@ storiesOf('ClayTable', module)
 						{bottom: 'bottom', middle: 'middle', top: 'top'},
 						'middle'
 					)}
-					borderedColumns={boolean('borderedColumns', false)}
+					borderedColumns={boolean('bordered columns', false)}
 					borderless={boolean('borderless', false)}
 					headVerticalAlignment={select(
 						'head vertical alignment',
@@ -366,7 +366,7 @@ storiesOf('ClayTable', module)
 						{bottom: 'bottom', middle: 'middle', top: 'top'},
 						'middle'
 					)}
-					borderedColumns={boolean('bordered', false)}
+					borderedColumns={boolean('bordered columns', false)}
 					borderless={boolean('borderless', false)}
 					headVerticalAlignment={select(
 						'head vertical alignment',


### PR DESCRIPTION
Fixes: #2387