### PR TITLE
fix(@clayui/modal): change the default size of the `modal-dialog` wrapping div

### DIFF
--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -65,7 +65,7 @@ const ClayModal: FunctionComponent<IProps> & {
 	useEffect(() => observer.dispatch(ObserverType.Open), []);
 
 	// Defines a default Modal size when size is not set.
-	const maxWidth = size ? {} : {maxWidth: '500px'};
+	const maxWidth = size ? {} : {maxWidth: '600px'};
 
 	return (
 		<ClayPortal subPortalRef={modalBodyElementRef}>

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -13,7 +13,7 @@ exports[`ClayModal renders 1`] = `
     >
       <div
         class=""
-        style="margin: auto; max-width: 500px;"
+        style="margin: auto; max-width: 600px;"
       >
         <div
           class="modal-dialog"
@@ -94,7 +94,7 @@ exports[`ClayModal renders a body component with url 1`] = `
     >
       <div
         class=""
-        style="margin: auto; max-width: 500px;"
+        style="margin: auto; max-width: 600px;"
       >
         <div
           class="modal-dialog"
@@ -133,7 +133,7 @@ exports[`ClayModal renders a footer component with buttons 1`] = `
     >
       <div
         class=""
-        style="margin: auto; max-width: 500px;"
+        style="margin: auto; max-width: 600px;"
       >
         <div
           class="modal-dialog"
@@ -198,7 +198,7 @@ exports[`ClayModal renders with Header 1`] = `
     >
       <div
         class=""
-        style="margin: auto; max-width: 500px;"
+        style="margin: auto; max-width: 600px;"
       >
         <div
           class="modal-dialog"
@@ -282,7 +282,7 @@ exports[`ClayModal renders with status 1`] = `
     >
       <div
         class=""
-        style="margin: auto; max-width: 500px;"
+        style="margin: auto; max-width: 600px;"
       >
         <div
           class="modal-dialog modal-success"


### PR DESCRIPTION
Related #2367