### PR TITLE
Revert "fix(clay-css): Use `selector-unify` to combine parent selecto…

### DIFF
--- a/packages/clay-css/src/scss/components/_utilities.scss
+++ b/packages/clay-css/src/scss/components/_utilities.scss
@@ -40,7 +40,7 @@
 	width: 100%;
 
 	@at-root {
-		#{selector-unify(&, ul)} {
+		ul#{&} {
 			@include list-unstyled;
 		}
 	}

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -82,8 +82,8 @@
 	width: $width;
 
 	@at-root {
-		#{selector-unify(&, a)},
-		#{selector-unify(&, button)} {
+		a#{&},
+		button#{&} {
 			cursor: $cursor;
 		}
 	}
@@ -318,8 +318,8 @@
 	word-wrap: $word-wrap;
 
 	@at-root {
-		#{selector-unify(&, a)},
-		#{selector-unify(&, button)} {
+		a#{&},
+		button#{&} {
 			cursor: $cursor;
 		}
 	}

--- a/packages/clay-css/src/scss/mixins/_close.scss
+++ b/packages/clay-css/src/scss/mixins/_close.scss
@@ -179,7 +179,7 @@
 	}
 
 	@at-root {
-		#{selector-unify(&, button)} {
+		button#{&} {
 			&:focus {
 				box-shadow: $btn-focus-box-shadow;
 				outline: $btn-focus-outline;

--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -181,8 +181,8 @@
 	transition: $transition;
 
 	@at-root {
-		#{selector-unify(&, a)},
-		#{selector-unify(&, button)} {
+		a#{&},
+		button#{&} {
 			&:hover {
 				background-color: $hover-bg;
 				border-color: $hover-border-color;

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -216,8 +216,7 @@
 	}
 
 	@at-root {
-		#{selector-unify(&, a)},
-		#{selector-unify(&, button)} {
+		button#{&} {
 			&:focus {
 				box-shadow: $btn-focus-box-shadow;
 				outline: $btn-focus-outline;


### PR DESCRIPTION
…rs with nested element selectors in mixins and components"

This reverts commit f5bf8efa7abf25c8761790e551e72aac657bc59b.