### PR TITLE
feat(clay-css): 2.x Atlas Forms input readonly should have white backgrou…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -65,7 +65,21 @@ $input-placeholder-disabled-color: $input-disabled-color !default;
 
 $input-label-disabled-color: $gray-500 !default;
 
-$input-readonly-bg: $input-border-color !default;
+// @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
+
+$input-readonly-bg: $white !default;
+
+$input-readonly: () !default;
+$input-readonly: map-deep-merge((
+	bg: $input-readonly-bg,
+	focus-box-shadow: none,
+), $input-readonly);
+
+$input-plaintext-readonly: () !default;
+$input-plaintext-readonly: map-deep-merge((
+	focus-border-color: $input-focus-border-color,
+	focus-box-shadow: none,
+), $input-plaintext-readonly);
 
 $input-danger-bg: $danger-l2 !default;
 $input-danger-border-color: $danger-l1 !default;

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -377,16 +377,11 @@ fieldset[disabled] label {
 // Readonly State
 
 .form-control[readonly] {
-	background-color: $input-readonly-bg;
-	border-color: $input-readonly-border-color;
-	color: $input-readonly-color;
-	cursor: $input-readonly-cursor;
+	@include clay-form-control-variant($input-readonly);
+}
 
-	&:focus {
-		background-color: $input-readonly-focus-bg;
-		border-color: $input-readonly-focus-border-color;
-		color: $input-readonly-focus-color;
-	}
+.form-control-plaintext[readonly] {
+	@include clay-form-control-variant($input-plaintext-readonly);
 }
 
 // Input Sizes

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -60,14 +60,14 @@
 /// focus-box-shadow: {String | List | Null},
 /// focus-color: {Color | String | Null},
 /// focus-placeholder-color: {Color | String | Null},
-/// readonly-bg: {Color | String | Null},
-/// readonly-bg-image: {String | List | Null},
-/// readonly-border-color: {Color | String | List | Null},
-/// readonly-box-shadow: {String | List | Null},
-/// readonly-color: {Color | String | Null},
-/// readonly-cursor: {String | Null},
-/// readonly-opacity: {Number | String | Null},
-/// readonly-placeholder-color: {Color | String | Null},
+/// readonly-bg: {Color | String | Null}, // deprecated after v2.18.0
+/// readonly-bg-image: {String | List | Null}, // deprecated after v2.18.0
+/// readonly-border-color: {Color | String | List | Null}, // deprecated after v2.18.0
+/// readonly-box-shadow: {String | List | Null}, // deprecated after v2.18.0
+/// readonly-color: {Color | String | Null}, // deprecated after v2.18.0
+/// readonly-cursor: {String | Null}, // deprecated after v2.18.0
+/// readonly-opacity: {Number | String | Null}, // deprecated after v2.18.0
+/// readonly-placeholder-color: {Color | String | Null}, // deprecated after v2.18.0
 /// disabled-bg: {Color | String | Null},
 /// disabled-bg-image: {String | List | Null},
 /// disabled-border-color: {Color | String | List | Null},
@@ -133,6 +133,8 @@
 	$focus-box-shadow: map-get($map, focus-box-shadow);
 	$focus-color: map-get($map, focus-color);
 	$focus-placeholder-color: map-get($map, focus-placeholder-color);
+
+	// deprecated after v2.18.0 [readonly] can have hover focus styles, declare a separate selector and use `clay-form-control-variant` mixin (e.g., `.form-control[readonly] { @include clay-form-control-variant($the-readonly-map); }`).
 
 	$readonly-bg: map-get($map, readonly-bg);
 	$readonly-bg-image: map-get($map, readonly-bg-image);
@@ -225,6 +227,8 @@
 				color: $focus-placeholder-color;
 			}
 		}
+
+		// @deprecated after v2.18.0 [readonly] can have hover focus styles, declare a separate selector and use `clay-form-control-variant` mixin (e.g., `.form-control[readonly] { @include clay-form-control-variant($the-readonly-map); }`).
 
 		&[readonly] {
 			background-color: $readonly-bg;

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -45,13 +45,52 @@ $input-label-reference-mark-font-size: null !default;
 $input-label-reference-mark-spacer: null !default;
 $input-label-reference-mark-vertical-align: null !default;
 
+/// @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
+
 $input-readonly-bg: null !default;
-$input-readonly-focus-bg: null !default;
+
+/// @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
+
 $input-readonly-border-color: null !default;
-$input-readonly-focus-border-color: null !default;
+
+/// @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
+
 $input-readonly-color: null !default;
-$input-readonly-focus-color: null !default;
+
+/// @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
+
 $input-readonly-cursor: null !default;
+
+/// @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
+
+$input-readonly-focus-bg: null !default;
+
+/// @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
+
+$input-readonly-focus-border-color: null !default;
+
+/// @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
+
+$input-readonly-focus-color: null !default;
+
+$input-readonly: () !default;
+$input-readonly: map-deep-merge((
+	bg: $input-readonly-bg,
+	border-color: $input-readonly-border-color,
+	color: $input-readonly-color,
+	cursor: $input-readonly-cursor,
+	focus-bg: $input-readonly-focus-bg,
+	focus-border-color: $input-readonly-focus-border-color,
+	focus-color: $input-readonly-focus-color,
+), $input-readonly);
+
+$input-plaintext-readonly: () !default;
+$input-plaintext-readonly: map-deep-merge((
+	border-radius: $input-border-radius,
+	outline: 0,
+	transition: $input-transition,
+	focus-box-shadow: $input-focus-box-shadow,
+), $input-plaintext-readonly);
 
 $input-textarea-height: 150px !default;
 $input-textarea-height-lg: 190px !default;


### PR DESCRIPTION
…nd and no focus box shadow

feat(clay-css): Forms input readonly added Sass maps `$input-readonly`, `$input-plaintext-readonly` and use `clay-form-control-variant` mixin for both

fix(clay-css): Forms deprecated variables `$input-readonly-bg`, `$input-readonly-border-color`, `$input-readonly-color`, `$input-readonly-cursor`, `$input-readonly-focus-bg`, `$input-readonly-focus-border-color`, `$input-readonly-focus-color`

fix(clay-css): Mixins `clay-form-control-variant` deprecate all readonly items

fixes #2425