### PR TITLE
chore: adds yarnrc to each package

### DIFF
--- a/packages/browserslist-config-clay/.yarnrc
+++ b/packages/browserslist-config-clay/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "browserslist-config-clay@"
+version-git-message "browserslist-config-clay@%s"

--- a/packages/clay-alert/.yarnrc
+++ b/packages/clay-alert/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/alert@"
+version-git-message "@clayui/alert@%s"

--- a/packages/clay-autocomplete/.yarnrc
+++ b/packages/clay-autocomplete/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/autocomplete@"
+version-git-message "@clayui/autocomplete@%s"

--- a/packages/clay-badge/.yarnrc
+++ b/packages/clay-badge/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/badge@"
+version-git-message "@clayui/badge@%s"

--- a/packages/clay-button/.yarnrc
+++ b/packages/clay-button/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/button@"
+version-git-message "@clayui/button@%s"

--- a/packages/clay-card/.yarnrc
+++ b/packages/clay-card/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/card@"
+version-git-message "@clayui/card@%s"

--- a/packages/clay-charts/.yarnrc
+++ b/packages/clay-charts/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/charts@"
+version-git-message "@clayui/charts@%s"

--- a/packages/clay-color-picker/.yarnrc
+++ b/packages/clay-color-picker/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/color-picker@"
+version-git-message "@clayui/color-picker@%s"

--- a/packages/clay-css/.yarnrc
+++ b/packages/clay-css/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/css@"
+version-git-message "@clayui/css@%s"

--- a/packages/clay-data-provider/.yarnrc
+++ b/packages/clay-data-provider/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/data-provider@"
+version-git-message "@clayui/data-provider@%s"

--- a/packages/clay-date-picker/.yarnrc
+++ b/packages/clay-date-picker/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/date-picker@"
+version-git-message "@clayui/date-picker@%s"

--- a/packages/clay-drop-down/.yarnrc
+++ b/packages/clay-drop-down/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/drop-down@"
+version-git-message "@clayui/drop-down@%s"

--- a/packages/clay-form/.yarnrc
+++ b/packages/clay-form/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/form@"
+version-git-message "@clayui/form@%s"

--- a/packages/clay-icon/.yarnrc
+++ b/packages/clay-icon/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/icon@"
+version-git-message "@clayui/icon@%s"

--- a/packages/clay-label/.yarnrc
+++ b/packages/clay-label/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/label@"
+version-git-message "@clayui/label@%s"

--- a/packages/clay-link/.yarnrc
+++ b/packages/clay-link/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/link@"
+version-git-message "@clayui/link@%s"

--- a/packages/clay-list/.yarnrc
+++ b/packages/clay-list/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/list@"
+version-git-message "@clayui/list@%s"

--- a/packages/clay-loading-indicator/.yarnrc
+++ b/packages/clay-loading-indicator/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/loading-indicator@"
+version-git-message "@clayui/loading-indicator@%s"

--- a/packages/clay-management-toolbar/.yarnrc
+++ b/packages/clay-management-toolbar/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/management-toolbar@"
+version-git-message "@clayui/management-toolbar@%s"

--- a/packages/clay-modal/.yarnrc
+++ b/packages/clay-modal/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/modal@"
+version-git-message "@clayui/modal@%s"

--- a/packages/clay-multi-step-nav/.yarnrc
+++ b/packages/clay-multi-step-nav/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/multi-step-nav@"
+version-git-message "@clayui/multi-step-nav@%s"

--- a/packages/clay-navigation-bar/.yarnrc
+++ b/packages/clay-navigation-bar/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/navigation-bar@"
+version-git-message "@clayui/navigation-bar@%s"

--- a/packages/clay-navigation/.yarnrc
+++ b/packages/clay-navigation/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/navigation@"
+version-git-message "@clayui/navigation@%s"

--- a/packages/clay-pagination/.yarnrc
+++ b/packages/clay-pagination/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/pagination@"
+version-git-message "@clayui/pagination@%s"

--- a/packages/clay-panel/.yarnrc
+++ b/packages/clay-panel/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/panel@"
+version-git-message "@clayui/panel@%s"

--- a/packages/clay-popover/.yarnrc
+++ b/packages/clay-popover/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/popover@"
+version-git-message "@clayui/popover@%s"

--- a/packages/clay-progress-bar/.yarnrc
+++ b/packages/clay-progress-bar/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/progress-bar@"
+version-git-message "@clayui/progress-bar@%s"

--- a/packages/clay-select/.yarnrc
+++ b/packages/clay-select/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/select@"
+version-git-message "@clayui/select@%s"

--- a/packages/clay-shared/.yarnrc
+++ b/packages/clay-shared/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/shared@"
+version-git-message "@clayui/shared@%s"

--- a/packages/clay-slider/.yarnrc
+++ b/packages/clay-slider/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/slider@"
+version-git-message "@clayui/slider@%s"

--- a/packages/clay-sticker/.yarnrc
+++ b/packages/clay-sticker/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/sticker@"
+version-git-message "@clayui/sticker@%s"

--- a/packages/clay-table/.yarnrc
+++ b/packages/clay-table/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/table@"
+version-git-message "@clayui/table@%s"

--- a/packages/clay-tabs/.yarnrc
+++ b/packages/clay-tabs/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/tabs@"
+version-git-message "@clayui/tabs@%s"

--- a/packages/clay-time-picker/.yarnrc
+++ b/packages/clay-time-picker/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/time-picker@"
+version-git-message "@clayui/time-picker@%s"

--- a/packages/clay-tooltip/.yarnrc
+++ b/packages/clay-tooltip/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/tooltip@"
+version-git-message "@clayui/tooltip@%s"


### PR DESCRIPTION
So I was looking into release processes and there isn't exactly a clear way forward in starting this process. For this first release, I think we may have to publish packages individually as they are ready by running the `yarn version` and `yarn publish` commands in the specified package. Lerna doesn't exactly help us yet, since not all of the components are ready at this point. Once the majority of packages are released, I _believe_ lerna should be beneficial at that point. Otherwise, if we start with lerna right off the bat, we end up having to skip every package in the `lerna version` command except the one we intend to publish, so its sort of messy.

I am still going to investigate this, but I wanted to send this first in case anyone has experience with this.