### PR TITLE
fix(panel): collapsing doesn't work well when there is more than one child element

### DIFF
--- a/packages/clay-panel/stories/index.tsx
+++ b/packages/clay-panel/stories/index.tsx
@@ -49,7 +49,9 @@ storiesOf('Components|ClayPanel', module)
 			showCollapseIcon={boolean('Show Collapse Icon', true)}
 			spritemap={spritemap}
 		>
-			<ClayPanel.Body>{'Here is some content inside.'}</ClayPanel.Body>
+			<ClayPanel.Header>{'Header!'}</ClayPanel.Header>
+			<ClayPanel.Body>{'Body!'}</ClayPanel.Body>
+			<ClayPanel.Footer>{'Footer!'}</ClayPanel.Footer>
 		</ClayPanel>
 	))
 	.add('groups', () => (

--- a/packages/clay-shared/src/useTransitionHeight.ts
+++ b/packages/clay-shared/src/useTransitionHeight.ts
@@ -22,10 +22,13 @@ function removeCollapseHeight(collapseElementRef: React.RefObject<any>) {
  */
 function setCollapseHeight(collapseElementRef: React.RefObject<any>) {
 	if (collapseElementRef && collapseElementRef.current) {
-		collapseElementRef.current.setAttribute(
-			'style',
-			`height: ${collapseElementRef.current.children[0].clientHeight}px`
+		// Cloned into a new array since `.reduce` is not a method on an HTMLCollection
+		const height = [...collapseElementRef.current.children].reduce(
+			(acc: number, child: HTMLElement) => acc + child.clientHeight,
+			0
 		);
+
+		collapseElementRef.current.setAttribute('style', `height: ${height}px`);
 	}
 }
 


### PR DESCRIPTION
this is a necessary fix for panel, we will have to make sure to release a new version of shared before as well.