### PR TITLE
chore(@clayui/navigation): improve types

### DIFF
--- a/packages/clay-navigation/src/BreadcrumbEllipsis.tsx
+++ b/packages/clay-navigation/src/BreadcrumbEllipsis.tsx
@@ -9,7 +9,8 @@ import ClayIcon from '@clayui/icon';
 import React, {useState} from 'react';
 import {IBreadcrumbItem} from './BreadcrumbItem';
 
-export interface IBreadcrumbEllipsisProps {
+export interface IBreadcrumbEllipsisProps
+	extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Property to define BreadcrumbEllipsis's items.
 	 */

--- a/packages/clay-navigation/src/BreadcrumbItem.tsx
+++ b/packages/clay-navigation/src/BreadcrumbItem.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import ClayButton from '@clayui/button';
 import React from 'react';
 
-export interface IBreadcrumbItem {
+export interface IBreadcrumbItem extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Flag to indicate if the Breadcrumb item is active or not.
 	 */


### PR DESCRIPTION
This is just a subtle improvement, since we allow `otherProps` in this component we must say what other props can be passed to it.