### PR TITLE
chore(next.clayui.com): remove redirect from landing page and show blog menu

### DIFF
--- a/next.clayui.com/gatsby/createPages.js
+++ b/next.clayui.com/gatsby/createPages.js
@@ -125,13 +125,6 @@ module.exports = async ({actions, graphql}) => {
 		toPath: '/',
 	});
 
-	// temporary redirect for the milestone version
-	actions.createRedirect({
-		fromPath: '/',
-		redirectInBrowser: true,
-		toPath: '/docs/get-started/what-is-clay.html',
-	});
-
 	return graphql(`
 		{
 			allMdx {

--- a/next.clayui.com/src/components/LayoutNav/LayoutNav.js
+++ b/next.clayui.com/src/components/LayoutNav/LayoutNav.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import {Link} from 'gatsby';
 
 import Search from './Search';
 
@@ -17,6 +18,19 @@ export default () => (
 			<div className="autofit-col">
 				<ul className="navbar-nav ml-auto">
 					<li className="nav-item">
+						<Link
+							className="nav-link ml-3"
+							to="/docs/get-started/what-is-clay.html"
+						>
+							{'Docs'}
+						</Link>
+					</li>
+					<li className="nav-item">
+						<Link className="nav-link" to="/blog">
+							{'Blog'}
+						</Link>
+					</li>
+					<li className="nav-item">
 						<a
 							className="nav-link"
 							href="http://storybook.clayui.com"
@@ -26,11 +40,6 @@ export default () => (
 							{'Storybook'}
 						</a>
 					</li>
-					{/* <li className="nav-item">
-						<Link className="nav-link ml-3" to="/blog">
-							{'Blog'}
-						</Link>
-					</li> */}
 					<li className="nav-item">
 						<a
 							className="nav-link ml-3"

--- a/next.clayui.com/src/pages/index.js
+++ b/next.clayui.com/src/pages/index.js
@@ -50,7 +50,7 @@ export default () => {
 											<li className="nav-item">
 												<Link
 													className="nav-link-intro"
-													to="/docs/get-started/introduction.html"
+													to="/docs/get-started/what-is-clay.html"
 												>
 													{'Get Started'}
 												</Link>
@@ -58,7 +58,7 @@ export default () => {
 											<li className="nav-item">
 												<Link
 													className="nav-link-intro"
-													to="/docs/css"
+													to="/docs/css/scss.html"
 												>
 													{'Style Guide'}
 												</Link>
@@ -66,7 +66,7 @@ export default () => {
 											<li className="nav-item">
 												<Link
 													className="nav-link-intro"
-													to="/docs/components"
+													to="/docs/components/alerts.html"
 												>
 													{'Components Library'}
 												</Link>
@@ -130,8 +130,8 @@ export default () => {
 						<div className="row">
 							<div className="col-md-12">
 								<h1 className="title-section orange">
-									<svg className="lexicon-icon lexicon-icon-announcement">
-										<use xlinkHref="/images/icons/icons.svg#announcement" />
+									<svg className="lexicon-icon lexicon-icon-megaphone-full">
+										<use xlinkHref="/images/icons/icons.svg#megaphone-full" />
 									</svg>
 									{'Deprecation warnings'}
 								</h1>
@@ -174,9 +174,7 @@ export default () => {
 								<h1 className="title-section mb-2">
 									{'Clay Components'}
 								</h1>
-								<h2 className="version-section">
-									{'v3.0.0 Beta'}
-								</h2>
+								<h2 className="version-section">{'v3.0.0'}</h2>
 								<p className="subtitle-section">
 									{
 										'Lexicon follows the approach of Atomic Design and Clay follows '
@@ -192,7 +190,7 @@ export default () => {
 							<div className="col-md-12">
 								<Link
 									className="btn btn-warning-borderless btn-borderless mr-3"
-									to="/docs/components"
+									to="/docs/components/alerts.html"
 								>
 									{'Documentation'}
 								</Link>
@@ -247,7 +245,7 @@ export default () => {
 									<div className="col-md-12">
 										<Link
 											className="btn btn-warning-borderless btn-borderless mr-3"
-											to="/docs/css"
+											to="/docs/components/alerts.html"
 										>
 											{'Documentation'}
 										</Link>

--- a/next.clayui.com/src/templates/blog.js
+++ b/next.clayui.com/src/templates/blog.js
@@ -40,7 +40,7 @@ export default ({data, location}) => {
 				<div className="container-fluid">
 					<div className="row flex-xl-nowrap">
 						<Sidebar data={list} location={location} />
-						<div className="col-xl-9 sidebar-offset">
+						<div className="col-xl sidebar-offset">
 							<LayoutNav />
 							<header>
 								<div className="clay-site-container container-fluid">


### PR DESCRIPTION
This is a start to preparing the site launch by removing the redirect from the landing page and adding the blog to the menu.

I'm working on submitting the introduction content and components documentation.