### PR TITLE
chore(next.clayui.com): add guide to install components and quick start

### DIFF
--- a/next.clayui.com/content/docs/foundations/composing.md
+++ b/next.clayui.com/content/docs/foundations/composing.md
@@ -1,0 +1,6 @@
+---
+title: "Composing"
+description: "Component composition philosophy"
+---
+
+This is a stub. Help our community expand it.

--- a/next.clayui.com/content/docs/foundations/index.md
+++ b/next.clayui.com/content/docs/foundations/index.md
@@ -3,5 +3,4 @@ layout: "redirect"
 redirect: "/docs/foundations/grid.html"
 title: "Foundations"
 order: 2
-draft: true
 ---

--- a/next.clayui.com/content/docs/get-started/how-to-use-clay.md
+++ b/next.clayui.com/content/docs/get-started/how-to-use-clay.md
@@ -27,7 +27,7 @@ Clay follows some fundamentals and we recommend that you read more about this be
 ### Install with NPM or Yarn
 
 
-Clay makes the components and CSS available in its own `@clayui` scope package, in some packages we have component aggregation, something like the `@clayui/form` package that aggregates components `Checkbox`, `Radio`, `Input`, `Select`...
+Clay makes the components and CSS available in its own `@clayui` scope, for example the card package is available through `@clayui/card` and the css is available through `@clayui/css`. In some packages we expose multiple components, for example the `@clayui/form` package contains components `Checkbox`, `Radio`, `Input`, `Select`...
 
 You can check out the full list of [packages available in NPM](https://www.npmjs.com/search?q=%40clayui).
 

--- a/next.clayui.com/content/docs/get-started/how-to-use-clay.md
+++ b/next.clayui.com/content/docs/get-started/how-to-use-clay.md
@@ -1,47 +1,186 @@
 ---
 title: "How to use clay"
-description: "Practical guidelines to start using Clay"
+description: "Practical guidelines to start using Clay, a quick guide on how to install components and css to get started."
 order: 2
 ---
 
-## Versions
+<div class="nav-toc-absolute">
+<div class="nav-toc">
 
-- how many versions exist
-- differences between version (changelog?)
-- what to choose and why
+- [Install with NPM or Yarn](#install-with-npm-or-yarn)
+    - [NPM](#npm)
+	- [Yarn](#yarn)
+- [Install via Clay CSS CDN](#install-via-clay-css-cdn)
+- [Quick start](#quick-start)
 
-## NPM
+</div>
+</div>
 
-- how to install Clay in your project with NPM
+Clay follows some fundamentals and we recommend that you read more about this before you start using it in your application.
+
+<div class="nav-toc">
+
+- [Composing](/foundations/composing.html)
+
+</div>
+
+### Install with NPM or Yarn
+
+
+Clay makes the components and CSS available in its own `@clayui` scope package, in some packages we have component aggregation, something like the `@clayui/form` package that aggregates components `Checkbox`, `Radio`, `Input`, `Select`...
+
+You can check out the full list of [packages available in NPM](https://www.npmjs.com/search?q=%40clayui).
+
+#### NPM
 
 ```shell
-npm i clay
+npm install @clayui/css @clayui/*
 ```
 
-## GitHub
+#### Yarn
 
-- how to clone or download
-- how to contribute [internal-link]
-- why contribute
+```shell
+yarn add @clayui/css @clayui/*
+```
 
-## CDN
+### Install via Clay CSS CDN
 
-- how to include Clay in your project with CDN
+We provide Clay CSS via CDN, which is an option when you do not want to install the clay package via NPM or Yarn.
 
-## Clay-CSS
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@clayui/css/lib/css/atlas.css">
+```
 
-- what is it, how to use it and why
+If you want a specific version of CSS, specify the desired version.
 
-## Storybook
+Example:
 
-- what is it, how to use it and why
+```diff
+- https://cdn.jsdelivr.net/npm/@clayui/css/lib/css/atlas.css
++ https://cdn.jsdelivr.net/npm/@clayui/css@3.0.0/lib/css/atlas.css
+```
 
-## SCSS
+### Quick start
 
-- before starting [read this](https://github.com/liferay/clay/blob/master/packages/clay-css/CONTRIBUTING.md)
-- structure map (external link to the css map)
-- how to create a Clay "skin" (like Atlas)
+<div class="clay-site-alert alert alert-warning">
+	<strong class="lead">Warning</strong>
+	Before you get started with this quick start, read about Clay's fundamentals of composition to move on. The information below is assuming you have read about Clay's compositional philosophy and learned about the terms.
+</div>
 
-## Paver
+<div class="clay-site-alert alert alert-warning">
+	<strong class="lead">Warning</strong>
+	This quick start requires that you have a minimum knowledge of <a href="https://reactjs.org/docs/hooks-intro.html" target="_blank">React Hooks</a>, not much of your API's will be used but just <a href="https://reactjs.org/docs/hooks-reference.html#usestate" target="_blank"><b>useState</b></a> to control the component.
+</div>
 
-- what is it, how to use it and why
+For this quick start we will use [codesandbox](https://codesandbox.io/) which does not need to install an environment on your machine.
+
+Use the **codesandbox** below as your text editor and environment so we can follow through with the examples.
+
+<iframe src="https://codesandbox.io/embed/intelligent-resonance-dlpgp?fontsize=14&view=editor" title="quick-start-clay" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+
+Let's use the **DropDown** component (`@clayui/drop-down`) and understand how the compositing philosophy works for this component so you can start replicating on other components.
+
+<div class="clay-site-alert alert alert-info">
+	<strong class="lead">Info</strong>
+	You can check the <a href="/docs/components/drop-down.html" target="_blank">ClayDropDown</a> package documentation for its API and usage philosophy.
+</div>
+
+Before we get started, let's import the main packages that we will use to create a low-level Drop Down with Clay components.
+
+```js
+import {ClayCheckbox, ClayRadio} from '@clayui/form';
+import ClayButton from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
+```
+
+<div class="clay-site-alert alert alert-info">
+	<strong class="lead">Info</strong>
+	These packages are installed in the sandbox environment, so feel free to fork the environment if you want to test with other Clay components.
+</div>
+
+
+As you learned from [Clay's compositional philosophy]((/foundations/composing.html)), we are using a low-level DropDown component, as its essence is a controlled component and for that you need to control DropDown's expand state. Let's use React's [`useState`](https://reactjs.org/docs/hooks-reference.html#usestate) to control the state.
+
+```js
+const [expand, setExpand] = useState(false);
+```
+
+Soon after we can add the components to see rendered on the screen.
+
+```jsx
+<ClayDropDown
+	active={expand}
+	onActiveChange={setExpand}
+	trigger={<ClayButton>{'Click Me'}</ClayButton>}
+/>
+```
+
+At first we are seeing only ClayButton being rendered with empty DropDown, as it is a low-level component we need to compose DropDown content with other components to see a list of actions or add whatever you want inside.
+
+Try this:
+
+```jsx
+<ClayDropDown
+	active={expand}
+	onActiveChange={setExpand}
+	trigger={<ClayButton>{'Click Me'}</ClayButton>}
+>
+	<h1>Menu</h1>
+</ClayDropDown>
+```
+
+Now we can compose with other Clay components and add a Checkbox and Radio to the content.
+
+```jsx
+<ClayDropDown
+	active={expand}
+	onActiveChange={setExpand}
+	trigger={<ClayButton>{'Click Me'}</ClayButton>}
+>
+	<ClayDropDown.ItemList>
+		<ClayDropDown.Item href="#1">
+            Linkable
+		</ClayDropDown.Item>
+		<ClayDropDown.Item>
+			<ClayCheckbox checked label="Checkbox" onChange={() => {}} />
+		</ClayDropDown.Item>
+		<ClayDropDown.Item>
+			<ClayRadio checked label="Radio" value="radio" />
+        </ClayDropDown.Item>
+	</ClayDropDown.ItemList>
+</ClayDropDown>
+```
+
+Low-level components in Clay allow you to compose and add your own rules, allowing you to achieve your design standards that are tied to Lexicon fundamentals. A team that follows the Lexicon team's predicted behaviors and cases can use the high-level components that help you code faster.
+
+See the same example above being reflected in a high-level component.
+
+```js
+import ClayDropDown, {ClayDropDownWithItems} from '@clayui/drop-down';
+```
+
+```jsx
+<ClayDropDownWithItems
+	items={[
+		{
+			href: '#linkable',
+			label: 'linkable',
+		},
+		{
+			checked: true,
+			label: 'Checkbox',
+			type: 'checkbox',
+		},
+		{
+			label: 'Radio',
+			type: 'radio',
+			value: 'radio',
+		}
+	]}
+	trigger={<ClayButton>{'Click Me'}</ClayButton>}
+/>
+```
+
+If you had problems, this is the final sandbox with all the examples described above.
+
+<iframe src="https://codesandbox.io/embed/quick-start-clay-23xtz?fontsize=14" title="quick-start-clay-finale" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>

--- a/next.clayui.com/content/docs/get-started/what-is-clay.md
+++ b/next.clayui.com/content/docs/get-started/what-is-clay.md
@@ -4,8 +4,6 @@ description: "A Web Implementation of Lexicon Experience Language"
 order: 1
 ---
 
-## What is Clay?
-
 Clay is an extensive Component Library, where you'll find useful components—with extensive code examples—for your web application.
 
 It is composed by 3 different layers, each one easy to understand and designed to fit different needs, allowing the developer to choose what to use without limitations
@@ -29,18 +27,18 @@ It is composed by 3 different layers, each one easy to understand and designed t
     </table>
 </div>
 
-## Bootstrap
+#### Bootstrap
 
 Clay is based on [Bootstrap](https://getbootstrap.com). This means it has a very solid foundation and it is easy to use because you are already familiar with it and it follows the same general patterns.
 
-## Lexicon
+#### Lexicon
 
 Because Clay is modeled after [Lexicon](https://liferay.design/lexicon/)'s experience language, you can rest assured that your web application will have a consistent style and user experience.
 
-## Customizable 100%
+#### Customizable 100%
 
 Clay's powerful [SCSS foundation](https://next.clayui.com/docs/css/scss.html) allows you to create your own customizations easily.
 
-## React
+#### React
 
 Built with [React](https://reactjs.org) to reduce the learning curve and simplify the integration with your other React projects.

--- a/next.clayui.com/src/styles/_guide.scss
+++ b/next.clayui.com/src/styles/_guide.scss
@@ -40,7 +40,7 @@
 			margin: 0;
 		}
 
-		.docs-package-npm {
+		.docs-subtitle {
 			color: #6B6C7E;
 			font-size: 22px;
 			font-weight: 400;
@@ -142,6 +142,10 @@
 			position: absolute;
 			right: -50%;
 			top: 0;
+
+			.nav-toc {
+				position: sticky;
+			}
 		}
 	}
 
@@ -172,7 +176,6 @@
 			margin-bottom: 0;
 			max-height: 100vh;
 			overflow-y: auto;
-			position: sticky;
 			top: 84px;
 			width: 280px;
 			z-index: 1;

--- a/next.clayui.com/src/templates/docs.js
+++ b/next.clayui.com/src/templates/docs.js
@@ -39,6 +39,8 @@ export default props => {
 		stable: 'success',
 	};
 
+	const showDescTop = !frontmatter.packageNpm && frontmatter.description;
+
 	useEffect(() => {
 		document
 			.querySelectorAll('.clay-site-custom-checkbox-indeterminate')
@@ -79,10 +81,15 @@ export default props => {
 												{frontmatter.title}
 											</h1>
 											{frontmatter.packageNpm && (
-												<p className="docs-package-npm">
+												<p className="docs-subtitle">
 													{`yarn add ${
 														frontmatter.packageNpm
 													}`}
+												</p>
+											)}
+											{showDescTop && (
+												<p className="docs-subtitle">
+													{frontmatter.description}
 												</p>
 											)}
 										</div>
@@ -168,7 +175,7 @@ export default props => {
 														)}
 													</Link>
 												)}
-												{frontmatter.description && (
+												{!showDescTop && (
 													<p className="docs-description">
 														{
 															frontmatter.description


### PR DESCRIPTION
This will most likely fix issues #2474, #2209, and #2478

I have added leaner documentation to the "How to use clay" document, if we need more information we can add it elsewhere.

I just added the document I'll work on tomorrow for "Composing" to explain how composing works for Clay components and low-level and high-level philosophy.