### PR TITLE
fix(@clayui/shared): use another method to create a new array from an HTMLCollection

### DIFF
--- a/packages/clay-shared/src/useTransitionHeight.ts
+++ b/packages/clay-shared/src/useTransitionHeight.ts
@@ -23,10 +23,12 @@ function removeCollapseHeight(collapseElementRef: React.RefObject<any>) {
 function setCollapseHeight(collapseElementRef: React.RefObject<any>) {
 	if (collapseElementRef && collapseElementRef.current) {
 		// Cloned into a new array since `.reduce` is not a method on an HTMLCollection
-		const height = [...collapseElementRef.current.children].reduce(
-			(acc: number, child: HTMLElement) => acc + child.clientHeight,
-			0
-		);
+		const height = Array.prototype.slice
+			.call(collapseElementRef.current.children)
+			.reduce(
+				(acc: number, child: HTMLElement) => acc + child.clientHeight,
+				0
+			);
 
 		collapseElementRef.current.setAttribute('style', `height: ${height}px`);
 	}


### PR DESCRIPTION
In different builds, the spread is transformed differently, causing errors on the next.clayui.com site but it worked fine on the Storybook. Converting to something "older" to make sure transpilations don't cause consistency.

This affects `ClayPanel` but there is no need for a patch release, we can hold back a bit and release later.