### PR TITLE
feat(@clayui/autocomplete): add high-level Autocomplete component

### DIFF
--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -29,11 +29,11 @@
 		"@clayui/drop-down": "^3.0.0",
 		"@clayui/form": "^3.0.0",
 		"@clayui/loading-indicator": "^3.0.0",
+		"@clayui/shared": "^3.0.1",
 		"fuzzy": "^0.1.3"
 	},
 	"devDependencies": {
-		"@clayui/data-provider": "^3.0.0",
-		"@clayui/shared": "^3.0.1"
+		"@clayui/data-provider": "^3.0.0"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -1,0 +1,85 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ClayInput} from '@clayui/form';
+import React, {useRef, useState} from 'react';
+
+import Context from './Context';
+import DropDown from './DropDown';
+import Input from './Input';
+import Item from './Item';
+import LoadingIndicator from './LoadingIndicator';
+
+const AutocompleteMarkup = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
+>(({children, ...otherProps}, ref) => (
+	<ClayInput.Group {...otherProps} ref={ref}>
+		<ClayInput.GroupItem>{children}</ClayInput.GroupItem>
+	</ClayInput.Group>
+));
+
+interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Div component to render. It can be a one component that will replace the markup.
+	 */
+	component?: React.ForwardRefExoticComponent<any>;
+}
+
+type Autocomplete = React.ForwardRefExoticComponent<IProps> & {
+	DropDown: typeof DropDown;
+	Input: typeof Input;
+	Item: typeof Item;
+	LoadingIndicator: typeof LoadingIndicator;
+};
+
+const ClayAutocomplete = React.forwardRef(
+	(
+		{
+			children,
+			className,
+			component: Component = AutocompleteMarkup,
+			...otherProps
+		}: IProps,
+		ref
+	) => {
+		const containerElementRef = useRef<null | HTMLDivElement>(null);
+		const [loading, setLoading] = useState(false);
+
+		return (
+			<Component
+				{...otherProps}
+				className={className}
+				ref={(r: any) => {
+					containerElementRef.current = r;
+					if (typeof ref === 'function') {
+						ref(r);
+					} else if (ref !== null) {
+						(ref.current as React.MutableRefObject<any>) = r;
+					}
+				}}
+			>
+				<Context.Provider
+					value={{
+						containerElementRef,
+						loading,
+						onLoadingChange: (loading: boolean) =>
+							setLoading(loading),
+					}}
+				>
+					{children}
+				</Context.Provider>
+			</Component>
+		);
+	}
+) as Autocomplete;
+
+ClayAutocomplete.DropDown = DropDown;
+ClayAutocomplete.Input = Input;
+ClayAutocomplete.Item = Item;
+ClayAutocomplete.LoadingIndicator = LoadingIndicator;
+
+export default ClayAutocomplete;

--- a/packages/clay-autocomplete/src/InputWithAutocomplete.tsx
+++ b/packages/clay-autocomplete/src/InputWithAutocomplete.tsx
@@ -1,0 +1,128 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import {FocusScope} from '@clayui/shared';
+import React, {useEffect, useState} from 'react';
+
+import ClayAutocomplete from './Autocomplete';
+
+interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
+	containerRenderer?: React.ForwardRefExoticComponent<any>;
+
+	/**
+	 * Flag to indicate is loading indicator should be shown.
+	 */
+	loading?: boolean;
+
+	/**
+	 * Message displayed in dropdown when laoding is indicated.
+	 */
+	loadingMessage?: string;
+
+	/**
+	 * Items that will show up in the dropdown list
+	 */
+	items: Array<string> | Array<Object>;
+
+	/**
+	 * Function that returns the value that should be showed in the list.
+	 */
+	itemSelector?: (val: string | Object) => string;
+
+	/**
+	 * Callback for when input value changes
+	 */
+	onItemSelect: (val: string | Object) => void;
+
+	/**
+	 * Callback for when input value changes
+	 */
+	onValueChange: (val: string | Object) => void;
+
+	/**
+	 * Flag to indicate if loading message should show in drop down
+	 */
+	showLoadingMessage?: boolean;
+}
+
+const ENTER_KEY_CODE = 13;
+
+export const ClayInputWithAutocomplete: React.FunctionComponent<IProps> = ({
+	containerRenderer,
+	items = [],
+	itemSelector = val => val as string,
+	loading,
+	loadingMessage = 'Loading...',
+	onItemSelect,
+	onValueChange,
+	showLoadingMessage = true,
+	value = '',
+	...otherProps
+}) => {
+	const [active, setActive] = useState(!!value);
+
+	const handleKeyEnter = (
+		event: React.KeyboardEvent<HTMLSpanElement | HTMLAnchorElement>,
+		item: string | object
+	) => {
+		if (event.keyCode === ENTER_KEY_CODE) {
+			onItemSelect(item);
+		}
+	};
+
+	useEffect(() => {
+		setActive(!!value);
+	}, [value]);
+
+	return (
+		<FocusScope>
+			<ClayAutocomplete component={containerRenderer}>
+				<ClayAutocomplete.Input
+					{...otherProps}
+					onChange={e => onValueChange(e.target.value)}
+					value={value}
+				/>
+
+				{((loading && showLoadingMessage) || !!items.length) && (
+					<ClayAutocomplete.DropDown
+						active={active}
+						onSetActive={setActive}
+					>
+						<ClayDropDown.ItemList>
+							{!loading &&
+								items.map(item => (
+									<ClayAutocomplete.Item
+										key={itemSelector(item)}
+										match={value.toString()}
+										onClick={() =>
+											onItemSelect(itemSelector(item))
+										}
+										onKeyDown={event =>
+											handleKeyEnter(
+												event,
+												itemSelector(item)
+											)
+										}
+										value={itemSelector(item)}
+									/>
+								))}
+
+							{loading && showLoadingMessage && (
+								<ClayAutocomplete.Item
+									disabled
+									value={loadingMessage}
+								/>
+							)}
+						</ClayDropDown.ItemList>
+					</ClayAutocomplete.DropDown>
+				)}
+
+				{loading && <ClayAutocomplete.LoadingIndicator />}
+			</ClayAutocomplete>
+		</FocusScope>
+	);
+};

--- a/packages/clay-autocomplete/src/__tests__/InputWithAutocomplete.tsx
+++ b/packages/clay-autocomplete/src/__tests__/InputWithAutocomplete.tsx
@@ -1,0 +1,74 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import * as React from 'react';
+
+import {ClayInputWithAutocomplete} from '../InputWithAutocomplete';
+
+describe('InputWithAutocomplete', () => {
+	afterEach(cleanup);
+
+	it('hitting enter calls onItemSelect', () => {
+		const itemSelectFn = jest.fn();
+		const valueChangeFn = jest.fn();
+
+		const {container} = render(
+			<ClayInputWithAutocomplete
+				autoFocus
+				items={['one', 'two', 'three']}
+				onItemSelect={itemSelectFn}
+				onValueChange={valueChangeFn}
+				value="one"
+			/>
+		);
+
+		fireEvent.keyDown(
+			container.querySelector('input') as HTMLInputElement,
+			{
+				keyCode: 40,
+			}
+		);
+
+		fireEvent.keyDown(
+			document.querySelector('.dropdown-item') as HTMLButtonElement,
+			{
+				keyCode: 13,
+			}
+		);
+
+		expect(itemSelectFn).toHaveBeenCalledWith('one');
+	});
+
+	it('clicking item calls onItemSelect', () => {
+		const itemSelectFn = jest.fn();
+		const valueChangeFn = jest.fn();
+
+		const {container} = render(
+			<ClayInputWithAutocomplete
+				autoFocus
+				items={['one']}
+				onItemSelect={itemSelectFn}
+				onValueChange={valueChangeFn}
+				value="one"
+			/>
+		);
+
+		fireEvent.keyDown(
+			container.querySelector('input') as HTMLInputElement,
+			{
+				keyCode: 40,
+			}
+		);
+
+		fireEvent.click(
+			document.querySelector('.dropdown-item') as HTMLElement,
+			{}
+		);
+
+		expect(itemSelectFn).toHaveBeenCalledWith('one');
+	});
+});

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -4,82 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayInput} from '@clayui/form';
-import React, {useRef, useState} from 'react';
+import ClayAutocomplete from './Autocomplete';
+import {ClayInputWithAutocomplete} from './InputWithAutocomplete';
 
-import Context from './Context';
-import DropDown from './DropDown';
-import Input from './Input';
-import Item from './Item';
-import LoadingIndicator from './LoadingIndicator';
-
-const AutocompleteMarkup = React.forwardRef<
-	HTMLDivElement,
-	React.HTMLAttributes<HTMLDivElement>
->(({children, ...otherProps}, ref) => (
-	<ClayInput.Group {...otherProps} ref={ref}>
-		<ClayInput.GroupItem>{children}</ClayInput.GroupItem>
-	</ClayInput.Group>
-));
-
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
-	/**
-	 * Div component to render. It can be a one component that will replace the markup.
-	 */
-	component?: React.ForwardRefExoticComponent<any>;
-}
-
-type Autocomplete = React.ForwardRefExoticComponent<IProps> & {
-	DropDown: typeof DropDown;
-	Input: typeof Input;
-	Item: typeof Item;
-	LoadingIndicator: typeof LoadingIndicator;
-};
-
-const ClayAutocomplete = React.forwardRef(
-	(
-		{
-			children,
-			className,
-			component: Component = AutocompleteMarkup,
-			...otherProps
-		}: IProps,
-		ref
-	) => {
-		const containerElementRef = useRef<null | HTMLDivElement>(null);
-		const [loading, setLoading] = useState(false);
-
-		return (
-			<Component
-				{...otherProps}
-				className={className}
-				ref={(r: any) => {
-					containerElementRef.current = r;
-					if (typeof ref === 'function') {
-						ref(r);
-					} else if (ref !== null) {
-						(ref.current as React.MutableRefObject<any>) = r;
-					}
-				}}
-			>
-				<Context.Provider
-					value={{
-						containerElementRef,
-						loading,
-						onLoadingChange: (loading: boolean) =>
-							setLoading(loading),
-					}}
-				>
-					{children}
-				</Context.Provider>
-			</Component>
-		);
-	}
-) as Autocomplete;
-
-ClayAutocomplete.DropDown = DropDown;
-ClayAutocomplete.Input = Input;
-ClayAutocomplete.Item = Item;
-ClayAutocomplete.LoadingIndicator = LoadingIndicator;
-
+export {ClayInputWithAutocomplete};
 export default ClayAutocomplete;

--- a/packages/clay-autocomplete/stories/index.tsx
+++ b/packages/clay-autocomplete/stories/index.tsx
@@ -8,10 +8,11 @@ import {FetchPolicy, NetworkStatus} from '@clayui/data-provider/src/types';
 import {useResource} from '@clayui/data-provider';
 import ClayDropDown from '@clayui/drop-down';
 import {FocusScope, useDebounce} from '@clayui/shared';
+import {boolean} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React, {useEffect, useRef, useState} from 'react';
 
-import ClayAutocomplete from '../src';
+import ClayAutocomplete, {ClayInputWithAutocomplete} from '../src';
 
 import '@clayui/css/lib/css/atlas.css';
 
@@ -165,6 +166,38 @@ const AutocompleteWithAsyncData = () => {
 	);
 };
 
+const AutoCompleteWithState = ({items, ...otherProps}: any) => {
+	const [value, setValue] = React.useState('');
+
+	const filteredItems = items.filter((val: any) =>
+		(typeof val === 'string'
+			? val
+			: `${val.firstName} ${val.lastName}`
+		).match(new RegExp(value, 'gi'))
+	);
+
+	return (
+		<div className="sheet">
+			<div className="form-group">
+				<ClayInputWithAutocomplete
+					{...otherProps}
+					items={filteredItems}
+					loading={boolean('Loading', false)}
+					onItemSelect={(val: any) =>
+						setValue(
+							typeof val === 'string'
+								? val
+								: `${val.firstName} ${val.lastName}`
+						)
+					}
+					onValueChange={setValue}
+					value={value}
+				/>
+			</div>
+		</div>
+	);
+};
+
 storiesOf('Components|ClayAutocomplete', module)
 	.add('basic', () => (
 		<div className="row">
@@ -201,4 +234,19 @@ storiesOf('Components|ClayAutocomplete', module)
 				</div>
 			</div>
 		</div>
+	))
+	.add('InputWithAutocomplete', () => (
+		<AutoCompleteWithState items={['one', 'two', 'three', 'four']} />
+	))
+	.add('InputWithAutocomplete w/ objects', () => (
+		<AutoCompleteWithState
+			itemSelector={(person: any) =>
+				`${person.firstName} ${person.lastName}`
+			}
+			items={[
+				{firstName: 'Abraham', lastName: 'Kuyper'},
+				{firstName: 'Joe', lastName: 'Bloggs'},
+				{firstName: 'Steve', lastName: 'Nash'},
+			]}
+		/>
 	));


### PR DESCRIPTION
@bryceosterhaus I am adding the high-level Autocomplete back to the `@clayui/autocomplete` package, we just have to decide if we are going to release this package with `minor` or `patch`, which is likely to be a `minor` (v3.1.0) since It is a new component but maintains compatibility.