### PR TITLE
docs: add prettier for react-live editor

### DIFF
--- a/next.clayui.com/package.json
+++ b/next.clayui.com/package.json
@@ -63,6 +63,7 @@
 		"metal-dom": "^2.16.5",
 		"metal-tabs": "^2.3.1",
 		"node-sass": "^4.11.0",
+		"prettier": "^1.16.4",
 		"prismjs": "^1.15.0",
 		"react": "^16.8.1",
 		"react-docgen": "5.0.0-beta.1",

--- a/next.clayui.com/src/components/clay/DataProvider.js
+++ b/next.clayui.com/src/components/clay/DataProvider.js
@@ -63,16 +63,19 @@ const DataProviderWithNetworkStatus = () => {
 const dataProviderWithCacheRootLevelImportsCode = `import ClayDataProvider from '@clayui/data-provider';
 import React, {useContext} from 'react';`;
 
-const dataProviderWithCacheRootLevelCode = `const Component = () => (
+const dataProviderWithCacheRootLevelCode = `const Component = () => {
 	const storageContext = useContext(Store);
-	<ClayDataProvider
-		link="https://rickandmortyapi.com/api/character"
-		fetchPolicy="cache-first"
-		storage={storageContext}
-	>
-		{({data, error, loading, refetch}) => {}}
-	</ClayDataProvider>
-);
+
+	return (
+		<ClayDataProvider
+			link="https://rickandmortyapi.com/api/character"
+			fetchPolicy="cache-first"
+			storage={storageContext}
+		>
+			{({data, error, loading, refetch}) => {}}
+		</ClayDataProvider>
+	);
+};
 
 render(<Component />)`;
 

--- a/next.clayui.com/src/components/clay/Editor.js
+++ b/next.clayui.com/src/components/clay/Editor.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import parserBabylon from 'prettier/parser-babylon';
+import prettier from 'prettier/standalone';
 import {LiveEditor, LiveError, LivePreview, LiveProvider} from 'react-live';
 import React from 'react';
 
@@ -82,27 +84,39 @@ const theme = {
 	],
 };
 
-const Editor = ({code, disabled = false, imports, preview = true, scope}) => (
-	<LiveProvider
-		code={code}
-		disabled={disabled}
-		noInline
-		scope={scope}
-		theme={theme}
-	>
-		{preview && (
-			<div className="sheet-example">
-				<LivePreview />
-				<LiveError />
+const Editor = ({code, disabled = false, imports, preview = true, scope}) => {
+	try {
+		code = prettier.format(code, {
+			parser: 'babylon',
+			plugins: [parserBabylon],
+		});
+	} catch (e) {
+		// eslint-disable-next-line
+		console.log(e);
+	}
+
+	return (
+		<LiveProvider
+			code={code}
+			disabled={disabled}
+			noInline
+			scope={scope}
+			theme={theme}
+		>
+			{preview && (
+				<div className="sheet-example">
+					<LivePreview />
+					<LiveError />
+				</div>
+			)}
+			<div className="gatsby-highlight">
+				<div style={{padding: '10px'}}>
+					{imports && <LiveEditor disabled value={imports} />}
+					<LiveEditor />
+				</div>
 			</div>
-		)}
-		<div className="gatsby-highlight">
-			<div style={{padding: '10px'}}>
-				{imports && <LiveEditor disabled value={imports} />}
-				<LiveEditor />
-			</div>
-		</div>
-	</LiveProvider>
-);
+		</LiveProvider>
+	);
+};
 
 export default Editor;


### PR DESCRIPTION
In regards to https://github.com/liferay/clay/issues/2554

This was the quickest way to keep formatting consistent in the docs. I think we can later iterate on this, but I think this provides a quick and helpful formatting for our examples that utilize react-live