### PR TITLE
fix(@clayui/drop-down): fixes DropDown.Menu component error blinks when aligning

### DIFF
--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -109,7 +109,6 @@ exports[`Rendering default 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
-        style="top: 0px; left: 0px;"
       >
         <div
           class="clay-color-header"

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -7,7 +7,7 @@
 import {ClayPortal} from '@clayui/shared';
 import classNames from 'classnames';
 import {Align} from 'metal-position';
-import React, {useEffect, useRef} from 'react';
+import React, {useLayoutEffect, useRef} from 'react';
 
 import {useDropdownCloseInteractions} from './hooks';
 
@@ -81,7 +81,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 
 	useDropdownCloseInteractions([alignElementRef, subPortalRef], onSetActive);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (
 			alignElementRef.current &&
 			(ref as React.RefObject<HTMLDivElement>).current


### PR DESCRIPTION
Fixes #2579

This causes the alignment to be done before the browser can paint.