### PR TITLE
fix(@clayui/navigation): fixes focus problem on elements with DropDown

### DIFF
--- a/packages/clay-navigation/package.json
+++ b/packages/clay-navigation/package.json
@@ -26,11 +26,11 @@
 		"react"
 	],
 	"dependencies": {
-		"@clayui/button": "^3.0.0-alpha.1",
-		"@clayui/drop-down": "^3.0.0-alpha.1",
-		"@clayui/icon": "^3.0.0-alpha.1",
-		"@clayui/link": "^3.0.0-alpha.1",
-		"@clayui/shared": "^3.0.0-alpha.1",
+		"@clayui/button": "^3.0.0",
+		"@clayui/drop-down": "^3.0.0",
+		"@clayui/icon": "^3.0.0",
+		"@clayui/link": "^3.0.0",
+		"@clayui/shared": "^3.0.1",
 		"classnames": "^2.2.6",
 		"warning": "^4.0.3"
 	},

--- a/packages/clay-navigation/src/NavLink.tsx
+++ b/packages/clay-navigation/src/NavLink.tsx
@@ -5,7 +5,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
+import {LinkOrButton} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -41,8 +41,10 @@ export const NavLink: React.FunctionComponent<IProps> = ({
 	...otherProps
 }) => {
 	return (
-		<ClayLink
+		<LinkOrButton
 			{...otherProps}
+			buttonDisplayType="unstyled"
+			buttonType="button"
 			className={classNames('nav-link', className, {
 				active,
 				['collapse-icon']: showIcon,
@@ -72,6 +74,6 @@ export const NavLink: React.FunctionComponent<IProps> = ({
 					</span>
 				</>
 			)}
-		</ClayLink>
+		</LinkOrButton>
 	);
 };

--- a/packages/clay-navigation/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation/src/__tests__/__snapshots__/index.tsx.snap
@@ -314,9 +314,10 @@ exports[`ClayVerticalNav renders 1`] = `
         <li
           class="nav-item"
         >
-          <a
-            class="nav-link collapse-icon"
+          <button
+            class="nav-link collapse-icon btn btn-unstyled"
             role="button"
+            type="button"
           >
             Home
             <span
@@ -345,7 +346,7 @@ exports[`ClayVerticalNav renders 1`] = `
                 />
               </svg>
             </span>
-          </a>
+          </button>
           <div
             class="collapse show"
           >


### PR DESCRIPTION
Fixes #2456

Once this is merged I think we can release Navigation to a stable release, let me know if you see anything that might prevent it from being released.

Importantly we also make a patch release of `@clayui/css` which contains the changes to this #2597, we will also need to make a patch release for 2.x, because the portal is still using 2.x css.