### PR TITLE
fix: ref callbacks are first calling with null. https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs

### DIFF
--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -54,11 +54,14 @@ const ClayAutocomplete = React.forwardRef(
 				{...otherProps}
 				className={className}
 				ref={(r: any) => {
-					containerElementRef.current = r;
-					if (typeof ref === 'function') {
-						ref(r);
-					} else if (ref !== null) {
-						(ref.current as React.MutableRefObject<any>) = r;
+					if (r) {
+						containerElementRef.current = r;
+
+						if (typeof ref === 'function') {
+							ref(r);
+						} else if (ref !== null) {
+							(ref.current as React.MutableRefObject<any>) = r;
+						}
 					}
 				}}
 			>

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -104,11 +104,13 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 					),
 					onClick: () => onActiveChange(!active),
 					ref: (node: HTMLButtonElement) => {
-						triggerElementRef.current = node;
-						// Call the original ref, if any.
-						const {ref} = trigger;
-						if (typeof ref === 'function') {
-							ref(node);
+						if (node) {
+							triggerElementRef.current = node;
+							// Call the original ref, if any.
+							const {ref} = trigger;
+							if (typeof ref === 'function') {
+								ref(node);
+							}
 						}
 					},
 				})}

--- a/packages/clay-multi-select/src/__tests__/index.tsx
+++ b/packages/clay-multi-select/src/__tests__/index.tsx
@@ -160,6 +160,37 @@ describe('Interactions', () => {
 		expect(onItemsChangeFn).toHaveBeenCalled();
 	});
 
+	it('autocomplete menu renders with left and top styles', () => {
+		const onItemsChangeFn = jest.fn();
+
+		render(
+			<ClayMultiSelectWithState
+				items={[items[0]]}
+				onItemsChange={onItemsChangeFn}
+				sourceItems={items}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		expect(document.querySelectorAll('.dropdown-item').length).toEqual(0);
+
+		fireEvent.change(
+			document.querySelectorAll(
+				'input[type=text]'
+			)[0] as HTMLInputElement,
+			{target: {value: 'bar'}}
+		);
+
+		expect(document.querySelectorAll('.dropdown-item').length).toEqual(1);
+
+		const menuStyles = (document.querySelector(
+			'.autocomplete-dropdown-menu'
+		) as HTMLElement).style;
+
+		expect(menuStyles.left).not.toEqual('');
+		expect(menuStyles.top).not.toEqual('');
+	});
+
 	it('clicking on autocomplete item calls onItemsChange', () => {
 		const onItemsChangeFn = jest.fn();
 

--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -76,11 +76,13 @@ export const FocusScope: React.FunctionComponent<IProps> = ({
 			}
 		},
 		ref: (r: HTMLElement) => {
-			elRef.current = r;
-			const {ref} = children;
-			if (ref) {
-				if (typeof ref === 'object') {
-					ref.current = r;
+			if (r) {
+				elRef.current = r;
+				const {ref} = children;
+				if (ref) {
+					if (typeof ref === 'object') {
+						ref.current = r;
+					}
 				}
 			}
 		},


### PR DESCRIPTION
Fixes: https://github.com/liferay/clay/issues/2592
So it turned out we were running into issues with callback refs for dropdown. It wasn't properly aligning due to the ref being null. See reacts doc for info on callback refs, https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs