### PR TITLE
feat(@clayui/modal): does not close Modal when document click event is prevented

### DIFF
--- a/packages/clay-modal/src/Hook.ts
+++ b/packages/clay-modal/src/Hook.ts
@@ -79,6 +79,10 @@ const useUserInteractions = (
 	};
 
 	const handleDocumentClick = (event: Event) => {
+		if (event.defaultPrevented) {
+			return;
+		}
+
 		if (
 			elementRef.current &&
 			event.target !== null &&

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -104,7 +104,7 @@ describe('Modal -> IncrementalInteractions', () => {
 		const ModalWithEventPrevented = () => {
 			const handleDocumentClick = (event: Event) => {
 				event.preventDefault();
-			}
+			};
 
 			useEffect(() => {
 				document.addEventListener('click', handleDocumentClick);
@@ -114,9 +114,7 @@ describe('Modal -> IncrementalInteractions', () => {
 				};
 			}, []);
 
-			return (
-				<ModalWithState />
-			);
+			return <ModalWithState />;
 		};
 
 		const {getByLabelText} = render(<ModalWithEventPrevented />);

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -100,6 +100,45 @@ describe('Modal -> IncrementalInteractions', () => {
 		expect(document.querySelector(modalElSelector)).toBeNull();
 	});
 
+	it('do not close modal when event is prevented by clicking on overlay', () => {
+		const ModalWithEventPrevented = () => {
+			const handleDocumentClick = (event: Event) => {
+				event.preventDefault();
+			}
+
+			useEffect(() => {
+				document.addEventListener('click', handleDocumentClick);
+
+				return () => {
+					document.removeEventListener('click', handleDocumentClick);
+				};
+			}, []);
+
+			return (
+				<ModalWithState />
+			);
+		};
+
+		const {getByLabelText} = render(<ModalWithEventPrevented />);
+
+		fireEvent.click(getByLabelText('button'), {});
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		const backdropElSelector = '.modal-backdrop.fade.show';
+		const modalElSelector = '.fade.modal.d-block.show';
+
+		const backdropEl = document.querySelector(backdropElSelector);
+
+		fireEvent.click(backdropEl!, {});
+
+		expect(document.body.classList).toContain('modal-open');
+		expect(document.querySelector(backdropElSelector)).toBeDefined();
+		expect(document.querySelector(modalElSelector)).toBeDefined();
+	});
+
 	it('close the modal when pressing ESC', () => {
 		const {container} = render(<ModalWithState initialVisible />);
 


### PR DESCRIPTION
Fixes #2165

This adds the ability for the person to control Modal closing when clicking outside Modal occurs. Since it is a generic click event within `document`, it may happen that other Portal methods can prevent this, so it is a bit dangerous, adding that we will be assuming that people will control. This also enables Portal to implement the option to open more than one modal on the screen.

cc @julien 