### PR TITLE
fix(@clayui/icon): forces React not to reuse node when symbol changes

### DIFF
--- a/packages/clay-icon/src/index.tsx
+++ b/packages/clay-icon/src/index.tsx
@@ -43,6 +43,7 @@ const ClayIcon = React.forwardRef<SVGSVGElement, IProps>(
 					`lexicon-icon lexicon-icon-${symbol}`,
 					className
 				)}
+				key={symbol}
 				ref={ref}
 				role="presentation"
 			>


### PR DESCRIPTION
Fixes #2642

As suggested by @jbalsas, it was the same solution in Metal. Forces to change the `key` of the element so that React does not reuse the node, so `svg4everybody` will re-capture the node to make its changes.

I am adding this straight to `ClayIcon` because it is common for someone to do this and so we can support it directly, I don't see a real problem with that so please let me know if you see anything.

Once we get on with this, we will need to release some fix patches for the components that use the ClayIcon. I'm eyeing ColorPicker that symbol change...