### PR TITLE
fix(@clayui/card): add prop `tag` to make Description configurable

### DIFF
--- a/packages/clay-card/src/Description.tsx
+++ b/packages/clay-card/src/Description.tsx
@@ -29,16 +29,15 @@ interface ICardDescriptionProps
 	href?: string;
 
 	/**
+	 * Define the name of the container element.
+	 */
+	tag?: 'p' | 'span' | 'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+	/**
 	 * Truncates the text inside a description.
 	 */
 	truncate?: boolean;
 }
-
-const CARD_TYPE_ELEMENTS = {
-	subtitle: 'p',
-	text: 'p',
-	title: 'h3',
-} as const;
 
 const ClayCardDescription: React.FunctionComponent<ICardDescriptionProps> = ({
 	children,
@@ -46,14 +45,14 @@ const ClayCardDescription: React.FunctionComponent<ICardDescriptionProps> = ({
 	disabled,
 	displayType,
 	href,
+	tag: Tag = 'p',
 	truncate = true,
 	...otherProps
 }: ICardDescriptionProps) => {
-	const OuterTag = CARD_TYPE_ELEMENTS[displayType];
 	const InnerTag = href && !disabled ? 'a' : 'span';
 
 	return (
-		<OuterTag
+		<Tag
 			className={classNames(className, `card-${displayType}`)}
 			title={children ? children.toString() : undefined}
 			{...otherProps}
@@ -67,7 +66,7 @@ const ClayCardDescription: React.FunctionComponent<ICardDescriptionProps> = ({
 			) : (
 				children
 			)}
-		</OuterTag>
+		</Tag>
 	);
 };
 

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -40,7 +40,7 @@ exports[`ClayCard renders a ClayCard as a directory 1`] = `
             <div
               class="autofit-section"
             >
-              <h3
+              <p
                 class="card-title"
                 title="Very Large Folder"
               >
@@ -53,7 +53,7 @@ exports[`ClayCard renders a ClayCard as a directory 1`] = `
                     Very Large Folder
                   </span>
                 </span>
-              </h3>
+              </p>
             </div>
           </div>
         </div>
@@ -105,7 +105,7 @@ exports[`ClayCard renders a ClayCard as a file card 1`] = `
           <section
             class="autofit-section"
           >
-            <h3
+            <p
               class="card-title"
               title="deliverable.doc"
             >
@@ -118,7 +118,7 @@ exports[`ClayCard renders a ClayCard as a file card 1`] = `
                   deliverable.doc
                 </span>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
               title="Stevie Ray Vaughn"
@@ -212,7 +212,7 @@ exports[`ClayCard renders a ClayCard as a selectable file card 1`] = `
             <section
               class="autofit-section"
             >
-              <h3
+              <p
                 class="card-title"
                 title="deliverable.doc"
               >
@@ -225,7 +225,7 @@ exports[`ClayCard renders a ClayCard as a selectable file card 1`] = `
                     deliverable.doc
                   </span>
                 </span>
-              </h3>
+              </p>
               <p
                 class="card-subtitle"
                 title="Stevie Ray Vaughn"
@@ -310,7 +310,7 @@ exports[`ClayCard renders a ClayCard as a selectable folder 1`] = `
               <div
                 class="autofit-col autofit-col-expand autofit-col-gutters"
               >
-                <h3
+                <p
                   class="card-title"
                   title="Very Large Folder"
                 >
@@ -323,7 +323,7 @@ exports[`ClayCard renders a ClayCard as a selectable folder 1`] = `
                       Very Large Folder
                     </span>
                   </span>
-                </h3>
+                </p>
               </div>
             </div>
           </div>
@@ -393,7 +393,7 @@ exports[`ClayCard renders a ClayCard as a selectable image card 1`] = `
           <div
             class="autofit-col autofit-col-expand"
           >
-            <h3
+            <p
               class="card-title"
               title="thumbnail_coffee.jpg"
             >
@@ -406,7 +406,7 @@ exports[`ClayCard renders a ClayCard as a selectable image card 1`] = `
                   thumbnail_coffee.jpg
                 </span>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
               title="Author Action"
@@ -463,7 +463,7 @@ exports[`ClayCard renders a ClayCard as a template navigation card truncating te
     <span
       class="card-body"
     >
-      <h3
+      <p
         class="card-title"
         title="Content Page"
       >
@@ -476,7 +476,7 @@ exports[`ClayCard renders a ClayCard as a template navigation card truncating te
             Content Page
           </span>
         </span>
-      </h3>
+      </p>
       <p
         class="card-text"
         title="This is an example of card-type-template using an anchor tag."
@@ -527,7 +527,7 @@ exports[`ClayCard renders a ClayCard as image card 1`] = `
         <div
           class="autofit-col autofit-col-expand"
         >
-          <h3
+          <p
             class="card-title"
             title="thumbnail_coffee.jpg"
           >
@@ -540,7 +540,7 @@ exports[`ClayCard renders a ClayCard as image card 1`] = `
                 thumbnail_coffee.jpg
               </span>
             </span>
-          </h3>
+          </p>
           <p
             class="card-subtitle"
             title="Author Action"
@@ -596,7 +596,7 @@ exports[`ClayCard renders a ClayCard as template navigation card 1`] = `
     <span
       class="card-body"
     >
-      <h3
+      <p
         class="card-title"
         title="Widget Page"
       >
@@ -609,7 +609,7 @@ exports[`ClayCard renders a ClayCard as template navigation card 1`] = `
             Widget Page
           </span>
         </span>
-      </h3>
+      </p>
       <p
         class="card-text"
         title="Build a page by adding widgets and content."
@@ -667,7 +667,7 @@ exports[`ClayCard renders a ClayCard as template navigation card as horizontal c
           <span
             class="autofit-section"
           >
-            <h3
+            <p
               class="card-title"
               title="Full Page Application"
             >
@@ -680,7 +680,7 @@ exports[`ClayCard renders a ClayCard as template navigation card as horizontal c
                   Full Page Application
                 </span>
               </span>
-            </h3>
+            </p>
           </span>
         </span>
       </span>
@@ -714,7 +714,7 @@ exports[`ClayCard renders a ClayCard as template navigation card with icon inste
     <span
       class="card-body"
     >
-      <h3
+      <p
         class="card-title"
         title="Blog"
       >
@@ -727,7 +727,7 @@ exports[`ClayCard renders a ClayCard as template navigation card with icon inste
             Blog
           </span>
         </span>
-      </h3>
+      </p>
     </span>
   </a>
 </div>
@@ -774,7 +774,7 @@ exports[`ClayCard renders a ClayCard as user card 1`] = `
           <div
             class="autofit-col autofit-col-expand"
           >
-            <h3
+            <p
               class="card-title"
               title="Adélaide"
             >
@@ -787,7 +787,7 @@ exports[`ClayCard renders a ClayCard as user card 1`] = `
                   Adélaide
                 </span>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
               title="Author Action"
@@ -881,7 +881,7 @@ exports[`ClayCard renders a ClayCard as user selectable card 1`] = `
           <div
             class="autofit-col autofit-col-expand"
           >
-            <h3
+            <p
               class="card-title"
               title="Adélaide"
             >
@@ -894,7 +894,7 @@ exports[`ClayCard renders a ClayCard as user selectable card 1`] = `
                   Adélaide
                 </span>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
               title="Author Action"
@@ -987,7 +987,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
               <section
                 class="autofit-section"
               >
-                <h3
+                <p
                   class="card-title"
                   title="deliverable.doc"
                 >
@@ -1000,7 +1000,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
                       deliverable.doc
                     </span>
                   </span>
-                </h3>
+                </p>
                 <p
                   class="card-subtitle"
                   title="Stevie Ray Vaughn"
@@ -1077,7 +1077,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
               <section
                 class="autofit-section"
               >
-                <h3
+                <p
                   class="card-title"
                   title="deliverable.doc"
                 >
@@ -1090,7 +1090,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
                       deliverable.doc
                     </span>
                   </span>
-                </h3>
+                </p>
                 <p
                   class="card-subtitle"
                   title="Stevie Ray Vaughn"
@@ -1179,7 +1179,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
               <div
                 class="autofit-col autofit-col-expand"
               >
-                <h3
+                <p
                   class="card-title"
                   title="Adélaide"
                 >
@@ -1192,7 +1192,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
                       Adélaide
                     </span>
                   </span>
-                </h3>
+                </p>
                 <p
                   class="card-subtitle"
                   title="Author Action"
@@ -1268,7 +1268,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
               <div
                 class="autofit-col autofit-col-expand"
               >
-                <h3
+                <p
                   class="card-title"
                   title="Adélaide"
                 >
@@ -1281,7 +1281,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
                       Adélaide
                     </span>
                   </span>
-                </h3>
+                </p>
                 <p
                   class="card-subtitle"
                   title="Author Action"
@@ -1368,7 +1368,7 @@ exports[`ClayCardWithHorizontal renders as disabled 1`] = `
               <div
                 class="autofit-col autofit-col-expand autofit-col-gutters"
               >
-                <h3
+                <p
                   class="card-title"
                   title="Foo Bar"
                 >
@@ -1382,7 +1382,7 @@ exports[`ClayCardWithHorizontal renders as disabled 1`] = `
                       Foo Bar
                     </span>
                   </span>
-                </h3>
+                </p>
               </div>
             </div>
           </div>
@@ -1430,7 +1430,7 @@ exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
           <div
             class="autofit-col autofit-col-expand autofit-col-gutters"
           >
-            <h3
+            <p
               class="card-title"
               title="Foo Bar"
             >
@@ -1444,7 +1444,7 @@ exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
                   Foo Bar
                 </a>
               </span>
-            </h3>
+            </p>
           </div>
         </div>
       </div>
@@ -1501,7 +1501,7 @@ exports[`ClayCardWithHorizontal renders as selectable 1`] = `
               <div
                 class="autofit-col autofit-col-expand autofit-col-gutters"
               >
-                <h3
+                <p
                   class="card-title"
                   title="Foo Bar"
                 >
@@ -1515,7 +1515,7 @@ exports[`ClayCardWithHorizontal renders as selectable 1`] = `
                       Foo Bar
                     </a>
                   </span>
-                </h3>
+                </p>
               </div>
             </div>
           </div>
@@ -1589,7 +1589,7 @@ exports[`ClayCardWithInfo renders as disabled 1`] = `
           <div
             class="autofit-col autofit-col-expand"
           >
-            <h3
+            <p
               class="card-title"
               title="Foo Bar"
             >
@@ -1603,7 +1603,7 @@ exports[`ClayCardWithInfo renders as disabled 1`] = `
                   Foo Bar
                 </span>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
             >
@@ -1669,7 +1669,7 @@ exports[`ClayCardWithInfo renders as not selectable 1`] = `
         <div
           class="autofit-col autofit-col-expand"
         >
-          <h3
+          <p
             class="card-title"
             title="Very Large File"
           >
@@ -1683,7 +1683,7 @@ exports[`ClayCardWithInfo renders as not selectable 1`] = `
                 Very Large File
               </a>
             </span>
-          </h3>
+          </p>
           <p
             class="card-subtitle"
             title="A cool description"
@@ -1780,7 +1780,7 @@ exports[`ClayCardWithInfo renders as selectable 1`] = `
           <div
             class="autofit-col autofit-col-expand"
           >
-            <h3
+            <p
               class="card-title"
               title="Foo Bar"
             >
@@ -1794,7 +1794,7 @@ exports[`ClayCardWithInfo renders as selectable 1`] = `
                   Foo Bar
                 </a>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
             >
@@ -1836,7 +1836,7 @@ exports[`ClayCardWithUser renders ClayCardWithNavigation with image 1`] = `
     <span
       class="card-body"
     >
-      <h3
+      <p
         class="card-title"
         title="Layout Page"
       >
@@ -1849,7 +1849,7 @@ exports[`ClayCardWithUser renders ClayCardWithNavigation with image 1`] = `
             Layout Page
           </span>
         </span>
-      </h3>
+      </p>
       <p
         class="card-text"
         title="Pick and choose your layout..."
@@ -1924,7 +1924,7 @@ exports[`ClayCardWithUser renders as disabled 1`] = `
           <div
             class="autofit-col autofit-col-expand"
           >
-            <h3
+            <p
               class="card-title"
               title="Foo Bar"
             >
@@ -1938,7 +1938,7 @@ exports[`ClayCardWithUser renders as disabled 1`] = `
                   Foo Bar
                 </span>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
               title="Test"
@@ -2028,7 +2028,7 @@ exports[`ClayCardWithUser renders as selectable 1`] = `
           <div
             class="autofit-col autofit-col-expand"
           >
-            <h3
+            <p
               class="card-title"
               title="Foo Bar"
             >
@@ -2042,7 +2042,7 @@ exports[`ClayCardWithUser renders as selectable 1`] = `
                   Foo Bar
                 </a>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
               title="Test"
@@ -2119,7 +2119,7 @@ exports[`ClayCardWithUser renders with icon 1`] = `
           <div
             class="autofit-col autofit-col-expand"
           >
-            <h3
+            <p
               class="card-title"
               title="Foo Bar"
             >
@@ -2133,7 +2133,7 @@ exports[`ClayCardWithUser renders with icon 1`] = `
                   Foo Bar
                 </a>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
               title="Test"
@@ -2207,7 +2207,7 @@ exports[`ClayCardWithUser renders with image 1`] = `
           <div
             class="autofit-col autofit-col-expand"
           >
-            <h3
+            <p
               class="card-title"
               title="Foo Bar"
             >
@@ -2221,7 +2221,7 @@ exports[`ClayCardWithUser renders with image 1`] = `
                   Foo Bar
                 </a>
               </span>
-            </h3>
+            </p>
             <p
               class="card-subtitle"
               title="Test"


### PR DESCRIPTION
Fixes #2607

I'm leaving the `p` tag pattern to follow the same pattern we did in 2.x. #1733