### PR TITLE
docs: add warning to point to 2.x on homepage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,12 +2,12 @@
 bower_components
 build
 clay-css
-clayui.com
 copyright.js
 coverage
 lib
-next.clayui.com/public
-next.clayui.com/static
+clayui.com/.cache
+clayui.com/public
+clayui.com/static
 node_modules
 package-lock.json
 packages/generator-clay-component/app/templates

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,12 +2,12 @@
 bower_components
 build
 clay-css
-clayui.com
 copyright.js
 coverage
 lib
-next.clayui.com/public
-next.clayui.com/static
+clayui.com/.cache
+clayui.com/public
+clayui.com/static
 node_modules
 package-lock.json
 packages/generator-clay-component/app/templates

--- a/clayui.com/src/components/LayoutNav/LayoutNav.js
+++ b/clayui.com/src/components/LayoutNav/LayoutNav.js
@@ -16,10 +16,10 @@ export default () => (
 				<Search placeholder="Search..." />
 			</div>
 			<div className="autofit-col">
-				<ul className="navbar-nav ml-auto">
+				<ul className="ml-auto navbar-nav">
 					<li className="nav-item">
 						<Link
-							className="nav-link ml-3"
+							className="ml-3 nav-link"
 							to="/docs/get-started/what-is-clay.html"
 						>
 							{'Docs'}
@@ -42,7 +42,7 @@ export default () => (
 					</li>
 					<li className="nav-item">
 						<a
-							className="nav-link ml-3"
+							className="ml-3 nav-link"
 							href="https://github.com/liferay/clay"
 							rel="noopener noreferrer"
 							target="_blank"

--- a/clayui.com/src/components/Sidebar/Sidebar.js
+++ b/clayui.com/src/components/Sidebar/Sidebar.js
@@ -29,7 +29,7 @@ const SideNavScroll = props => {
 
 	return (
 		<div
-			className="sidebar sidebar-clay-site sidenav-menu d-flex flex-column p-3"
+			className="d-flex flex-column p-3 sidebar sidebar-clay-site sidenav-menu"
 			onScroll={onScroll}
 			ref={SideNavRef}
 		>
@@ -41,32 +41,32 @@ const SideNavScroll = props => {
 export default props => (
 	<>
 		<nav
-			className="sidebar-toggler-content sidenav-sticky sidenav-menu-slider"
+			className="sidebar-toggler-content sidenav-menu-slider sidenav-sticky"
 			id="clay-sidebar"
 			ref={SidebarRef}
 		>
 			<SideNavScroll>
-				<div className="sidebar-header d-flex justify-content-between align-items-center p-0">
+				<div className="align-items-center d-flex justify-content-between p-0 sidebar-header">
 					<Link
-						className="sidebar-logo text-reset text-decoration-none d-inline-block p-2"
+						className="d-inline-block p-2 sidebar-logo text-decoration-none text-reset"
 						to="/"
 					>
 						<img
 							alt="Clay"
-							className="sidebar-logo-image align-middle"
+							className="align-middle sidebar-logo-image"
 							src="/images/clay_logo_w.png"
 						/>
-						<span className="sidebar-logo-title align-middle h3 font-weight-700 ml-2">
+						<span className="align-middle font-weight-700 h3 ml-2 sidebar-logo-title">
 							{'Clay'}
 						</span>
 					</Link>
 
-					<div className="sidebar-icon-links d-flex align-items-center">
+					<div className="align-items-center d-flex sidebar-icon-links">
 						<button
 							aria-controls="navbarSupportedContent"
 							aria-expanded="false"
 							aria-label="Toggle navigation"
-							className="btn sidebar-toggler mx-2 px-2 py-1"
+							className="btn mx-2 px-2 py-1 sidebar-toggler"
 							data-target="#navbarSupportedContent"
 							data-toggle="collapse"
 							onClick={onClick}
@@ -87,7 +87,7 @@ export default props => (
 						</button>
 					</div>
 				</div>
-				<div className="sidebar-body p-0">
+				<div className="p-0 sidebar-body">
 					<div className="mt-3">
 						<Navigation
 							location={props.location}

--- a/clayui.com/src/components/TrackingIssues/Tracking.js
+++ b/clayui.com/src/components/TrackingIssues/Tracking.js
@@ -22,7 +22,7 @@ const Tracking = ({query}) => {
 				<thead>
 					<tr>
 						<th>{'ID'}</th>
-						<th className="table-cell-minw-300 table-cell-expand">
+						<th className="table-cell-expand table-cell-minw-300">
 							{'Title'}
 						</th>
 						<th className="table-cell-expand-small table-cell-ws-nowrap">
@@ -63,7 +63,7 @@ const TableItem = ({comments, date, id, title, url}) => {
 	return (
 		<tr>
 			<td>{id}</td>
-			<td className="table-cell-minw-300 table-cell-expand">
+			<td className="table-cell-expand table-cell-minw-300">
 				<div className="table-title">
 					<a
 						className="text-truncate-inline"

--- a/clayui.com/src/components/clay/Editor.js
+++ b/clayui.com/src/components/clay/Editor.js
@@ -6,8 +6,8 @@
 
 import parserBabylon from 'prettier/parser-babylon';
 import prettier from 'prettier/standalone';
-import {LiveEditor, LiveError, LivePreview, LiveProvider} from 'react-live';
 import React from 'react';
+import {LiveEditor, LiveError, LivePreview, LiveProvider} from 'react-live';
 
 const theme = {
 	plain: {

--- a/clayui.com/src/components/clay/PaginationBar.js
+++ b/clayui.com/src/components/clay/PaginationBar.js
@@ -6,10 +6,10 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import {ClayPaginationWithBasicItems} from '@clayui/pagination';
 import ClayPaginationBar, {
 	ClayPaginationBarWithBasicItems,
 } from '@clayui/pagination-bar';
-import {ClayPaginationWithBasicItems} from '@clayui/pagination';
 import React, {useState} from 'react';
 
 import Editor from './Editor';

--- a/clayui.com/src/pages/index.js
+++ b/clayui.com/src/pages/index.js
@@ -17,6 +17,24 @@ export default () => {
 
 	return (
 		<div className="home">
+			<div
+				className="alert alert-warning alert-dismissible alert-fluid"
+				role="alert"
+			>
+				<div className="container">
+					{
+						'This site is for version 3.x. If you are looking for version 2.x documentation, it has been moved to '
+					}
+					<a
+						href="https://v2.clayui.com"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						{'v2.clayui.com.'}
+					</a>
+				</div>
+			</div>
+
 			<Helmet>
 				<title>{'Clay'}</title>
 				<meta content={description} name="description" />

--- a/clayui.com/src/pages/index.js
+++ b/clayui.com/src/pages/index.js
@@ -5,8 +5,8 @@
  */
 
 import {Link} from 'gatsby';
-import Helmet from 'react-helmet';
 import React from 'react';
+import Helmet from 'react-helmet';
 
 /**
  * @return {React.Component}
@@ -18,7 +18,7 @@ export default () => {
 	return (
 		<div className="home">
 			<div
-				className="alert alert-warning alert-dismissible alert-fluid"
+				className="alert alert-dismissible alert-fluid alert-warning"
 				role="alert"
 			>
 				<div className="container">
@@ -46,7 +46,7 @@ export default () => {
 				<header className="header">
 					<div className="container-fluid">
 						<div className="row">
-							<div className="intro text-left col">
+							<div className="col intro text-left">
 								<div className="container-fluid container-fluid-max-lg">
 									<Link className="brand" to="/">
 										<img
@@ -54,7 +54,7 @@ export default () => {
 											className="logo"
 											src="/images/home/clay_logo.svg"
 										/>
-										<span className="title align-middle">
+										<span className="align-middle title">
 											{'Clay'}
 										</span>
 									</Link>
@@ -64,7 +64,7 @@ export default () => {
 										}
 									</h2>
 									<div className="navbar-nav-scroll">
-										<ul className="navbar-nav ml-auto">
+										<ul className="ml-auto navbar-nav">
 											<li className="nav-item">
 												<Link
 													className="nav-link-intro"
@@ -143,11 +143,11 @@ export default () => {
 					</div>
 				</header>
 
-				<section className="warning hr" id="warning">
-					<div className="container-fluid container-fluid-max-lg text-center spacing">
+				<section className="hr warning" id="warning">
+					<div className="container-fluid container-fluid-max-lg spacing text-center">
 						<div className="row">
 							<div className="col-md-12">
-								<h1 className="title-section orange">
+								<h1 className="orange title-section">
 									<svg className="lexicon-icon lexicon-icon-megaphone-full">
 										<use xlinkHref="/images/icons/icons.svg#megaphone-full" />
 									</svg>
@@ -166,7 +166,7 @@ export default () => {
 						<div className="row">
 							<div className="col-md-12">
 								<a
-									className="btn btn-warning-borderless btn-borderless mr-3"
+									className="btn btn-borderless btn-warning-borderless mr-3"
 									href="https://v2.clayui.com"
 									rel="noopener noreferrer"
 									target="_blank"
@@ -185,11 +185,11 @@ export default () => {
 				</section>
 
 				<section className="components hr" id="components">
-					<div className="container-fluid container-fluid-max-lg text-center spacing">
+					<div className="container-fluid container-fluid-max-lg spacing text-center">
 						<div className="row">
 							<div className="col-md-12">
 								<img alt="" src="/images/react_logo.svg" />
-								<h1 className="title-section mb-2">
+								<h1 className="mb-2 title-section">
 									{'Clay Components'}
 								</h1>
 								<h2 className="version-section">{'v3.0.0'}</h2>
@@ -207,7 +207,7 @@ export default () => {
 						<div className="row">
 							<div className="col-md-12">
 								<Link
-									className="btn btn-warning-borderless btn-borderless mr-3"
+									className="btn btn-borderless btn-warning-borderless mr-3"
 									to="/docs/components/alerts.html"
 								>
 									{'Documentation'}
@@ -219,7 +219,7 @@ export default () => {
 									target="_blank"
 								>
 									{'Storybook'}
-									<span className="inline-item inline-item-after fs-12">
+									<span className="fs-12 inline-item inline-item-after">
 										<svg
 											className="lexicon-icon lexicon-icon-angle-right"
 											focusable="false"
@@ -235,7 +235,7 @@ export default () => {
 				</section>
 
 				<section className="css hr" id="css">
-					<div className="container-fluid container-fluid-max-lg text-left spacing">
+					<div className="container-fluid container-fluid-max-lg spacing text-left">
 						<div className="row">
 							<div className="col-md-5">
 								<img
@@ -262,7 +262,7 @@ export default () => {
 								<div className="row">
 									<div className="col-md-12">
 										<Link
-											className="btn btn-warning-borderless btn-borderless mr-3"
+											className="btn btn-borderless btn-warning-borderless mr-3"
 											to="/docs/components/alerts.html"
 										>
 											{'Documentation'}
@@ -274,7 +274,7 @@ export default () => {
 											target="_blank"
 										>
 											{'View Documentation v2'}
-											<span className="inline-item inline-item-after fs-12">
+											<span className="fs-12 inline-item inline-item-after">
 												<svg
 													className="lexicon-icon lexicon-icon-angle-right"
 													focusable="false"
@@ -317,11 +317,11 @@ export default () => {
 				<section className="link-blocks text-center">
 					<div className="container-fluid container-fluid-max-lg">
 						<div className="row">
-							<div className="body ml-auto col-md-9 mr-auto">
+							<div className="body col-md-9 ml-auto mr-auto">
 								<h2 className="title-section">
 									{'A web implementation of Lexicon'}
 								</h2>
-								<p className="subtitle-section pb-5">
+								<p className="pb-5 subtitle-section">
 									{`There's always been a distinction between Lexicon as a design system, and Lexicon as a web implementation. Naming them like this didn't help with the distinction, so `}
 									<b>
 										{
@@ -333,7 +333,7 @@ export default () => {
 							</div>
 						</div>
 						<div className="row">
-							<div className="col-md-5 ml-auto mb-4">
+							<div className="col-md-5 mb-4 ml-auto">
 								<div className="card h-100">
 									<div className="card-body mx-5">
 										<img
@@ -357,7 +357,7 @@ export default () => {
 									</div>
 								</div>
 							</div>
-							<div className="col-md-5 mr-auto mb-4">
+							<div className="col-md-5 mb-4 mr-auto">
 								<div className="card h-100">
 									<div className="card-body mx-5">
 										<img
@@ -388,7 +388,7 @@ export default () => {
 				<div className="footer">
 					<div className="container-fluid container-fluid-max-lg">
 						<div className="row">
-							<div className="col-lg text-center text-lg-left mb-4 mb-lg-0">
+							<div className="col-lg mb-4 mb-lg-0 text-center text-lg-left">
 								<a
 									className="font-weight-bold"
 									href="https://github.com/liferay/clay/graphs/contributors"

--- a/clayui.com/src/templates/blog.js
+++ b/clayui.com/src/templates/blog.js
@@ -5,8 +5,8 @@
  */
 
 import {graphql} from 'gatsby';
-import Helmet from 'react-helmet';
 import React from 'react';
+import Helmet from 'react-helmet';
 
 import LayoutNav from '../components/LayoutNav';
 import Sidebar from '../components/Sidebar';
@@ -38,7 +38,7 @@ export default ({data, location}) => {
 			</Helmet>
 			<main className="content">
 				<div className="container-fluid">
-					<div className="row flex-xl-nowrap">
+					<div className="flex-xl-nowrap row">
 						<Sidebar data={list} location={location} />
 						<div className="col-xl sidebar-offset">
 							<LayoutNav />

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -5,10 +5,10 @@
  */
 
 import {MDXProvider} from '@mdx-js/react';
-import MDXRenderer from 'gatsby-mdx/mdx-renderer';
 import {Link, graphql} from 'gatsby';
-import Helmet from 'react-helmet';
+import MDXRenderer from 'gatsby-mdx/mdx-renderer';
 import React, {useEffect} from 'react';
+import Helmet from 'react-helmet';
 
 import CodeClipboard from '../components/CodeClipboard';
 import LayoutNav from '../components/LayoutNav';
@@ -85,7 +85,7 @@ export default props => {
 			</Helmet>
 			<main className="content">
 				<div className="container-fluid">
-					<div className="row flex-xl-nowrap">
+					<div className="flex-xl-nowrap row">
 						<Sidebar
 							data={getSection(
 								[...allMarkdownRemark.edges, ...allMdx.edges],
@@ -123,7 +123,7 @@ export default props => {
 										{hasTabs && (
 											<div className="col-12">
 												<ul
-													className="nav nav-clay nav-underline border-bottom"
+													className="border-bottom nav nav-clay nav-underline"
 													role="tablist"
 												>
 													<li className="nav-item">
@@ -274,7 +274,7 @@ export default props => {
 								</div>
 							</div>
 							<footer className="clay-site-container container-fluid">
-								<div className="row border-top py-5">
+								<div className="border-top py-5 row">
 									<div className="col-6">
 										<p className="legal">
 											{


### PR DESCRIPTION
I added an alert to the homepage to point to v2. I think this will help anyone who might be confused at the design change and who didn't scroll to see the deprecation warning. This helps keep the alert above the scroll line and will help inform users of knowing where v2 docs are at, as well as knowing this is a v3 site.

We can eventually remove it, but I think itd be good to keep around for a bit.

![Screen Shot 2019-10-25 at 12 01 16 PM](https://user-images.githubusercontent.com/6843530/67597115-2ea31f80-f71f-11e9-83d7-79cddf828cce.png)
