### PR TITLE
feat(@clayui/drop-down): add new prop to pass element attributes to DropDown.Menu

### DIFF
--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -45,6 +45,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement | HTMLLIElement> {
 	hasLeftSymbols?: boolean;
 
 	/**
+	 * Prop to pass DOM element attributes to <DropDown.Menu />.
+	 */
+	menuElementAttrs?: React.HTMLAttributes<HTMLDivElement>;
+
+	/**
 	 * Callback for when the active state changes.
 	 */
 	onActiveChange: (val: boolean) => void;
@@ -77,6 +82,7 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 	containerElement: ContainerElement = 'div',
 	hasLeftSymbols,
 	hasRightSymbols,
+	menuElementAttrs,
 	onActiveChange,
 	trigger,
 	...otherProps
@@ -116,6 +122,7 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 				})}
 
 				<Menu
+					{...menuElementAttrs}
 					active={active}
 					alignElementRef={triggerElementRef}
 					alignmentPosition={alignmentPosition}

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -82,6 +82,13 @@ interface IProps extends IDropDownContentProps {
 	helpText?: string;
 
 	/**
+	 * Prop to pass DOM element attributes to <DropDown.Menu />.
+	 */
+	menuElementAttrs?: React.ComponentProps<
+		typeof ClayDropDown
+	>['menuElementAttrs'];
+
+	/**
 	 * Callback will always be called when the user is interacting with search.
 	 */
 	onSearchValueChange?: (newValue: string) => void;
@@ -258,6 +265,7 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 	footerContent,
 	helpText,
 	items,
+	menuElementAttrs,
 	onSearchValueChange = () => {},
 	searchable,
 	searchProps,
@@ -279,6 +287,7 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 			containerElement={containerElement}
 			hasLeftSymbols={hasLeftSymbols}
 			hasRightSymbols={hasRightSymbols}
+			menuElementAttrs={menuElementAttrs}
 			onActiveChange={setActive}
 			trigger={trigger}
 		>


### PR DESCRIPTION
Fixes #2674

@bryceosterhaus I ended up choosing `menuElementAttrs` instead of `menuProps`, since we already have `DropDown.Menu` specific props in DropDown root.