### PR TITLE
fix(@clayui/data-provider): replace setInterval in favor of setTimeout and polling engine improvements

### DIFF
--- a/packages/clay-data-provider/stories/index.tsx
+++ b/packages/clay-data-provider/stories/index.tsx
@@ -6,7 +6,7 @@
 
 import {number} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
-import React, {useContext, useState, useRef} from 'react';
+import React, {useContext, useState} from 'react';
 
 import ClayDataProvider, {useResource} from '../src';
 import {FetchPolicy} from '../src/types';
@@ -213,25 +213,18 @@ storiesOf('Components|ClayDataProvider', module)
 	.add('toggle poll', () => {
 		const [poll, setPoll] = useState(false);
 
-		const {resource} = useResource({
-			link:
-				'https://api-public.sandbox.pro.coinbase.com/products/BTC-USD/trades',
+		useResource({
+			link: 'https://rickandmortyapi.com/api/character',
 			pollInterval: poll ? 1000 : 0,
 			variables: {limit: 10},
 		});
 
-		console.log(resource);
-
 		return (
-			<div className="sheet pb-4">
-				<h3>Polling {poll ? 'enable' : 'disable'}</h3>
+			<div className="pb-4 sheet">
+				<h3>{`Polling  ${poll ? 'enable' : 'disable'}`}</h3>
 				<div className="row">
 					<div className="col-md-5">
-						<p>
-							{
-								'Open your console to see the data and see the network tab.'
-							}
-						</p>
+						<p>{'Open your console to see the network tab.'}</p>
 					</div>
 				</div>
 				<div className="row">
@@ -240,7 +233,7 @@ storiesOf('Components|ClayDataProvider', module)
 							className="btn btn-primary"
 							onClick={() => setPoll(!poll)}
 						>
-							Toggle Poll
+							{'Toggle Poll'}
 						</button>
 					</div>
 				</div>

--- a/packages/clay-data-provider/stories/index.tsx
+++ b/packages/clay-data-provider/stories/index.tsx
@@ -6,9 +6,9 @@
 
 import {number} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
-import React, {useContext, useState} from 'react';
+import React, {useContext, useState, useRef} from 'react';
 
-import ClayDataProvider from '../src';
+import ClayDataProvider, {useResource} from '../src';
 import {FetchPolicy} from '../src/types';
 
 import '@clayui/css/lib/css/atlas.css';
@@ -209,4 +209,41 @@ storiesOf('Components|ClayDataProvider', module)
 	))
 	.add('with variables change and storage', () => (
 		<ClayDataProviderWithVariablesAndStorage />
-	));
+	))
+	.add('toggle poll', () => {
+		const [poll, setPoll] = useState(false);
+
+		const {resource} = useResource({
+			link:
+				'https://api-public.sandbox.pro.coinbase.com/products/BTC-USD/trades',
+			pollInterval: poll ? 1000 : 0,
+			variables: {limit: 10},
+		});
+
+		console.log(resource);
+
+		return (
+			<div className="sheet pb-4">
+				<h3>Polling {poll ? 'enable' : 'disable'}</h3>
+				<div className="row">
+					<div className="col-md-5">
+						<p>
+							{
+								'Open your console to see the data and see the network tab.'
+							}
+						</p>
+					</div>
+				</div>
+				<div className="row">
+					<div className="col-md-5">
+						<button
+							className="btn btn-primary"
+							onClick={() => setPoll(!poll)}
+						>
+							Toggle Poll
+						</button>
+					</div>
+				</div>
+			</div>
+		);
+	});


### PR DESCRIPTION
Fixes #2679

Replace the use of `setInterval` to `setTimeout` is safer for now, because we may have cases when `pollInterval` is set to 1000ms and the request may take longer than this time and we may have more than one request being made. and that number can accumulate. So we will always wait for the request to succeed in scheduling the next one.

Such a change means that `pollInterval` is not always executed every 1000ms for example, it also contains the time of the previous request. In a way, we already had this when we were using `setInterval`... but we are preventing more than one request from being made at the same time and possibly creating some kind of server overload.

A change to `pollInterval` also to enable you to make a mechanism to enable and disable `poll` by setting to some value above 0, enable and equal to 0/false disable.