### PR TITLE
chore: scrape API table for a specific specific named component

### DIFF
--- a/clayui.com/content/docs/components/forms/form.mdx
+++ b/clayui.com/content/docs/components/forms/form.mdx
@@ -62,4 +62,26 @@ Use `ClayForm.Text` for creating a caption on Form Groups.
 
 ## API
 
+### Form
+
 <div>[APITable "clay-form/src/Form.tsx"]</div>
+
+### Form.FeedbackGroup
+
+<div>[APITable "clay-form/src/Form.tsx#FeedbackGroup"]</div>
+
+### Form.FeedbackIndicator
+
+<div>[APITable "clay-form/src/Form.tsx#FeedbackIndicator"]</div>
+
+### Form.FeedbackItem
+
+<div>[APITable "clay-form/src/Form.tsx#FeedbackItem"]</div>
+
+### Form.Group
+
+<div>[APITable "clay-form/src/Form.tsx#Group"]</div>
+
+### Form.Text
+
+<div>[APITable "clay-form/src/Form.tsx#Text"]</div>

--- a/packages/clay-form/src/Form.tsx
+++ b/packages/clay-form/src/Form.tsx
@@ -16,7 +16,7 @@ interface IGroup extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const Group = React.forwardRef<HTMLDivElement, IGroup>(
-	({children, className, small, ...otherProps}, ref) => (
+	({children, className, small, ...otherProps}: IGroup, ref) => (
 		<div
 			{...otherProps}
 			className={classNames(
@@ -33,6 +33,8 @@ const Group = React.forwardRef<HTMLDivElement, IGroup>(
 	)
 );
 
+Group.displayName = 'Group';
+
 const Text = React.forwardRef<
 	HTMLDivElement,
 	React.HTMLAttributes<HTMLDivElement>
@@ -45,6 +47,8 @@ const Text = React.forwardRef<
 		{children}
 	</div>
 ));
+
+Text.displayName = 'Text';
 
 const FeedbackGroup = React.forwardRef<
 	HTMLDivElement,
@@ -59,6 +63,8 @@ const FeedbackGroup = React.forwardRef<
 	</div>
 ));
 
+FeedbackGroup.displayName = 'FeedbackGroup';
+
 const FeedbackItem = React.forwardRef<
 	HTMLDivElement,
 	React.HTMLAttributes<HTMLDivElement>
@@ -71,6 +77,8 @@ const FeedbackItem = React.forwardRef<
 		{children}
 	</div>
 ));
+
+FeedbackItem.displayName = 'FeedbackItem';
 
 interface IFeedbackIndicatorProps
 	extends React.HTMLAttributes<HTMLSpanElement> {
@@ -103,6 +111,8 @@ const FeedbackIndicator = React.forwardRef<
 	)
 );
 
+FeedbackIndicator.displayName = 'FeedbackIndicator';
+
 const ClayForm = React.forwardRef<
 	HTMLFormElement,
 	React.HTMLAttributes<HTMLFormElement>
@@ -111,6 +121,8 @@ const ClayForm = React.forwardRef<
 		{children}
 	</form>
 ));
+
+ClayForm.displayName = 'ClayForm';
 
 export default Object.assign(ClayForm, {
 	FeedbackGroup,


### PR DESCRIPTION
Fixes https://github.com/liferay/clay/issues/2716

Note, we specify the component by using its name via `some/file.tsx#FooBar`


Also, `react-docgen` doesn't seem to accurately pick up displayName of some components. This may be because of using arrow functions, but im not quite sure. This is why I explicitly added displayName to the form components