### PR TITLE
feat(clay-css): 2.x Form Validation add Sass maps `$input-danger-readonly`, `$input-success-readonly`, and `$input-warning-readonly`

### DIFF
--- a/packages/clay-css/src/content/form_validation.html
+++ b/packages/clay-css/src/content/form_validation.html
@@ -384,36 +384,108 @@ section: Components
 				<div class="form-group">
 					<label for="readonlySuccess">Text Input (Read Only) with Success</label>
 					<input class="form-control" id="readonlySuccess" placeholder="Placeholder" readonly type="text" value="Con panna aroma, pumpkin spice to go, wings, aromatic single shot, aged single shot to go extraction java.">
+					<div class="form-feedback-group">
+						<div class="form-feedback-item">This is a form-feedback-item.</div>
+						<div class="form-feedback-item">
+							<span class="form-feedback-indicator">
+								<svg class="lexicon-icon lexicon-icon-check-circle-full" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check-circle-full" />
+								</svg>
+							</span>
+							This is a form-feedback-indicator.
+						</div>
+						<div class="form-text">This is form-text.</div>
+					</div>
 				</div>
 			</div>
 			<div class="has-warning">
 				<div class="form-group">
 					<label for="readonlyWarning">Text Input (Read Only) with Warning</label>
 					<input class="form-control" id="readonlyWarning" placeholder="Placeholder" readonly type="text" value="Con panna aroma, pumpkin spice to go, wings, aromatic single shot, aged single shot to go extraction java.">
+					<div class="form-feedback-group">
+						<div class="form-feedback-item">This is a form-feedback-item.</div>
+						<div class="form-feedback-item">
+							<span class="form-feedback-indicator">
+								<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#warning-full" />
+								</svg>
+							</span>
+							This is a form-feedback-indicator.
+						</div>
+						<div class="form-text">This is form-text.</div>
+					</div>
 				</div>
 			</div>
 			<div class="has-error">
 				<div class="form-group">
 					<label for="readonlyError">Text Input (Read Only) with Error</label>
 					<input class="form-control" id="readonlyError" placeholder="Placeholder" readonly type="text" value="Con panna aroma, pumpkin spice to go, wings, aromatic single shot, aged single shot to go extraction java.">
+					<div class="form-feedback-group">
+						<div class="form-feedback-item">This is a form-feedback-item.</div>
+						<div class="form-feedback-item">
+							<span class="form-feedback-indicator">
+								<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#exclamation-full" />
+								</svg>
+							</span>
+							This is a form-feedback-indicator.
+						</div>
+						<div class="form-text">This is form-text.</div>
+					</div>
 				</div>
 			</div>
 			<div class="has-success">
 				<div class="form-group">
 					<label for="readonlyTextareaSuccess">Textarea (Read Only) with Success</label>
 					<textarea class="form-control" id="readonlyTextareaSuccess" placeholder="Placeholder" readonly>Plunger pot, extra siphon latte, as americano aromatic roast cultivar cup cup frappuccino. To go, strong, half and half foam single origin, cultivar affogato black grounds shop ut plunger pot. Con panna aroma, pumpkin spice to go, wings, aromatic single shot, aged single shot to go extraction java. Percolator americano at cultivar grinder est java percolator plunger pot shop con panna.</textarea>
+					<div class="form-feedback-group">
+						<div class="form-feedback-item">This is a form-feedback-item.</div>
+						<div class="form-feedback-item">
+							<span class="form-feedback-indicator">
+								<svg class="lexicon-icon lexicon-icon-check-circle-full" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check-circle-full" />
+								</svg>
+							</span>
+							This is a form-feedback-indicator.
+						</div>
+						<div class="form-text">This is form-text.</div>
+					</div>
 				</div>
 			</div>
 			<div class="has-warning">
 				<div class="form-group">
 					<label for="readonlyTextareaWarning">Textarea (Read Only) with Warning</label>
 					<textarea class="form-control" id="readonlyTextareaWarning" placeholder="Placeholder" readonly>Plunger pot, extra siphon latte, as americano aromatic roast cultivar cup cup frappuccino. To go, strong, half and half foam single origin, cultivar affogato black grounds shop ut plunger pot. Con panna aroma, pumpkin spice to go, wings, aromatic single shot, aged single shot to go extraction java. Percolator americano at cultivar grinder est java percolator plunger pot shop con panna.</textarea>
+					<div class="form-feedback-group">
+						<div class="form-feedback-item">This is a form-feedback-item.</div>
+						<div class="form-feedback-item">
+							<span class="form-feedback-indicator">
+								<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#warning-full" />
+								</svg>
+							</span>
+							This is a form-feedback-indicator.
+						</div>
+						<div class="form-text">This is form-text.</div>
+					</div>
 				</div>
 			</div>
 			<div class="has-error">
 				<div class="form-group">
 					<label for="readonlyTextareaError">Textarea (Read Only) with Error</label>
 					<textarea class="form-control" id="readonlyTextareaError" placeholder="Placeholder" readonly>Plunger pot, extra siphon latte, as americano aromatic roast cultivar cup cup frappuccino. To go, strong, half and half foam single origin, cultivar affogato black grounds shop ut plunger pot. Con panna aroma, pumpkin spice to go, wings, aromatic single shot, aged single shot to go extraction java. Percolator americano at cultivar grinder est java percolator plunger pot shop con panna.</textarea>
+					<div class="form-feedback-group">
+						<div class="form-feedback-item">This is a form-feedback-item.</div>
+						<div class="form-feedback-item">
+							<span class="form-feedback-indicator">
+								<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#exclamation-full" />
+								</svg>
+							</span>
+							This is a form-feedback-indicator.
+						</div>
+						<div class="form-text">This is form-text.</div>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -72,6 +72,7 @@ $input-readonly-bg: $white !default;
 $input-readonly: () !default;
 $input-readonly: map-deep-merge((
 	bg: $input-readonly-bg,
+	border-color: $input-border-color,
 	focus-box-shadow: none,
 ), $input-readonly);
 
@@ -87,6 +88,14 @@ $input-danger-border-color: $danger-l1 !default;
 $input-danger-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
 $input-danger-focus-box-shadow: $input-focus-box-shadow !default;
 $input-danger-color: $input-color !default;
+
+$input-danger-readonly: () !default;
+$input-danger-readonly: map-deep-merge((
+	bg: map-get($input-readonly, bg),
+	border-color: map-get($input-readonly, border-color),
+	focus-border-color: $input-focus-border-color,
+), $input-danger-readonly);
+
 $input-danger-checkbox-label-color: $danger !default;
 $input-danger-select-icon-color: $input-danger-border-color !default;
 $input-danger-select-icon: clay-icon(caret-double-l, $input-danger-select-icon-color) !default;
@@ -97,6 +106,14 @@ $input-success-border-color: $success-l1 !default;
 $input-success-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
 $input-success-focus-box-shadow: $input-focus-box-shadow !default;
 $input-success-color: $input-color !default;
+
+$input-success-readonly: () !default;
+$input-success-readonly: map-deep-merge((
+	bg: map-get($input-readonly, bg),
+	border-color: map-get($input-readonly, border-color),
+	focus-border-color: $input-focus-border-color,
+), $input-success-readonly);
+
 $input-success-checkbox-label-color: $success !default;
 $input-success-select-icon-color: $input-success-border-color !default;
 $input-success-select-icon: clay-icon(caret-double-l, $input-success-select-icon-color) !default;
@@ -106,6 +123,14 @@ $input-warning-border-color: $warning-l1 !default;
 // Will need to be revisited if https://github.com/twbs/bootstrap/pull/24821 merge error is fixed
 $input-warning-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
 $input-warning-focus-box-shadow: $input-focus-box-shadow !default;
+
+$input-warning-readonly: () !default;
+$input-warning-readonly: map-deep-merge((
+	bg: map-get($input-readonly, bg),
+	border-color: map-get($input-readonly, border-color),
+	focus-border-color: $input-focus-border-color,
+), $input-warning-readonly);
+
 $input-warning-color: $input-color !default;
 $input-warning-checkbox-label-color: $warning !default;
 $input-warning-select-icon-color: $input-warning-border-color !default;

--- a/packages/clay-css/src/scss/components/_form-validation.scss
+++ b/packages/clay-css/src/scss/components/_form-validation.scss
@@ -92,6 +92,10 @@
 		}
 	}
 
+	.form-control[readonly] {
+		@include clay-button-variant($input-danger-readonly);
+	}
+
 	.form-feedback-item {
 		color: $form-feedback-invalid-color;
 	}
@@ -152,6 +156,10 @@
 		}
 	}
 
+	.form-control[readonly] {
+		@include clay-button-variant($input-warning-readonly);
+	}
+
 	.form-feedback-item {
 		color: $form-feedback-warning-color;
 	}
@@ -210,6 +218,10 @@
 			box-shadow: $input-success-focus-box-shadow;
 			color: $input-success-focus-color;
 		}
+	}
+
+	.form-control[readonly] {
+		@include clay-button-variant($input-success-readonly);
 	}
 
 	.form-feedback-item {

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -215,6 +215,8 @@ $input-danger-focus-box-shadow: 0 0 0 $input-focus-width rgba($form-feedback-inv
 $input-danger-color: null !default;
 $input-danger-focus-color: null !default;
 
+$input-danger-readonly: () !default;
+
 $input-danger-checkbox-label-color: $form-feedback-invalid-color !default;
 $input-danger-label-color: null !default;
 $input-danger-select-icon-color: $input-danger-border-color !default;
@@ -229,6 +231,8 @@ $input-success-focus-box-shadow: 0 0 0 $input-focus-width rgba($form-feedback-va
 $input-success-color: null !default;
 $input-success-focus-color: null !default;
 
+$input-success-readonly: () !default;
+
 $input-success-checkbox-label-color: $form-feedback-valid-color !default;
 $input-success-label-color: null !default;
 $input-success-select-icon-color: $input-success-border-color !default;
@@ -242,6 +246,8 @@ $input-warning-box-shadow: null !default;
 $input-warning-focus-box-shadow: 0 0 0 $input-focus-width rgba($form-feedback-warning-color, 0.25) !default;
 $input-warning-color: null !default;
 $input-warning-focus-color: null !default;
+
+$input-warning-readonly: () !default;
 
 $input-warning-checkbox-label-color: $form-feedback-warning-color !default;
 $input-warning-label-color: null !default;


### PR DESCRIPTION
fixes #2715