### PR TITLE
chore(@clayui/popover): Adds a missing property knob on ClayPopover storybook example

### DIFF
--- a/packages/clay-popover/stories/index.tsx
+++ b/packages/clay-popover/stories/index.tsx
@@ -33,6 +33,7 @@ storiesOf('Components|ClayPopover', module).add('popover', () => (
 		}
 		disableScroll={boolean('Disable Scroll', false)}
 		header="Popover"
+		show={boolean('Show', true)}
 	>
 		{`Viennese flavour cup eu, percolator froth ristretto mazagran
 				caffeine. White roast seasonal, mocha trifecta, dripper caffeine


### PR DESCRIPTION
Related to #2738
