### PR TITLE
fix(clay-css): Deprecate `.sheet-lg` and `$sheet-lg-max-width` in fav…

### DIFF
--- a/packages/clay-css/src/scss/components/_sheets.scss
+++ b/packages/clay-css/src/scss/components/_sheets.scss
@@ -1,3 +1,7 @@
+////
+/// @group sheet
+////
+
 .sheet {
 	background-color: $sheet-bg;
 	border-color: $sheet-border-color;
@@ -111,6 +115,8 @@ fieldset {
 }
 
 // Sheet Sizes
+
+/// @deprecated as of v3.x use `.container .sheet` instead
 
 .sheet-lg {
 	margin-left: auto;

--- a/packages/clay-css/src/scss/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/variables/_sheets.scss
@@ -1,3 +1,7 @@
+////
+/// @group sheet
+////
+
 $sheet-bg: $body-bg !default;
 $sheet-border-color: $gray-300 !default;
 $sheet-border-style: solid !default;
@@ -47,6 +51,8 @@ $sheet-footer-btn-block-sm-down: map-deep-merge((
 ), $sheet-footer-btn-block-sm-down);
 
 // Sheet Sizes
+
+/// @deprecated as of 3.x.
 
 $sheet-lg-max-width: ceil(map-get($container-max-widths, lg) * 0.83333) !default; // 800px
 


### PR DESCRIPTION
…or of `.container .sheet` pattern

fixes #2655