### PR TITLE
docs(icon): Remove next subdomain from clayui.com icon download link

### DIFF
--- a/clayui.com/content/docs/components/icon.mdx
+++ b/clayui.com/content/docs/components/icon.mdx
@@ -37,7 +37,7 @@ import {Icon, IconWithContext} from '../../../src/components/clay/Icon';
 ## Best Pratices
 
 For Icons, we use SVG elements that link to an SVG sprite. So, it becomes necessary to pass a parameter that points to a path where this [`spritemap`](#api-spritemap) is located.
-If you are using the spritemap from `@clayui/css` you can download that svg [here](https://github.com/liferay/clay/blob/master/next.clayui.com/static/images/icons/icons.svg).
+If you are using the spritemap from `@clayui/css` you can download that svg [here](https://github.com/liferay/clay/blob/master/clayui.com/static/images/icons/icons.svg).
 
 -   See the complete list of symbols and flags that are offered by Clay's spritemap [here](/docs/components/icons.html)
 


### PR DESCRIPTION
Reading through documentation when I came across a broken link. Haven't kept up with the developments around this project, but I'm guessing the location for this svg was correct during the v2 versions and `next` was v3 before release.

Please let me know if you have any questions. Thanks!

Fixes #2771 
