### PR TITLE
chore: use fragments instead of empty args

### DIFF
--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -268,8 +268,8 @@ describe('ModalProvider -> IncrementalInteractions', () => {
 							payload: {
 								body: <h1>{'Hello world!'}</h1>,
 								footer: [
-									,
-									,
+									<></>,
+									<></>,
 									<Button key={3} onClick={state.onClose}>
 										{'Primary'}
 									</Button>,
@@ -312,8 +312,8 @@ describe('ModalProvider -> IncrementalInteractions', () => {
 					payload: {
 						body: <h1>{'Hello world!'}</h1>,
 						footer: [
-							,
-							,
+							<></>,
+							<></>,
 							<Button key={3} onClick={state.onClose}>
 								{'Primary'}
 							</Button>,

--- a/packages/clay-modal/stories/index.tsx
+++ b/packages/clay-modal/stories/index.tsx
@@ -26,8 +26,8 @@ const MyApp: React.FunctionComponent<any> = () => {
 					payload: {
 						body: <h1>{'Hello world!'}</h1>,
 						footer: [
-							,
-							,
+							<></>,
+							<></>,
 							<ClayButton key={3} onClick={state.onClose}>
 								{'Primary'}
 							</ClayButton>,


### PR DESCRIPTION
After looking at https://github.com/liferay/clay/pull/2668, I think it's a bit more clear to use fragments instead of empty arguments. This should at least help readability.