### PR TITLE
feat(@clayui/data-provider): WIP Suspense Support

### DIFF
--- a/packages/clay-data-provider/src/types.ts
+++ b/packages/clay-data-provider/src/types.ts
@@ -169,6 +169,11 @@ export interface IDataProvider {
 	storageMaxSize?: number;
 
 	/**
+	 * Flag to enable `useResource` integration with suspense.
+	 */
+	suspense?: boolean;
+
+	/**
 	 * Variables are analyzed and converted to be passed as parameters
 	 * to the query of a GET request, for example.
 	 *

--- a/packages/clay-data-provider/src/useCache.ts
+++ b/packages/clay-data-provider/src/useCache.ts
@@ -72,6 +72,7 @@ const useCache = (
 			shouldUseCache,
 			partial(readFromCache, getCacheKey(link, variables))
 		),
+		getCacheKey,
 		reset: cache.reset,
 		set: ifVal(
 			shouldUseCache,

--- a/packages/clay-data-provider/stories/index.tsx
+++ b/packages/clay-data-provider/stories/index.tsx
@@ -6,7 +6,7 @@
 
 import {number} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
-import React, {useContext, useState} from 'react';
+import React, {useContext, useState, Suspense} from 'react';
 
 import ClayDataProvider, {useResource} from '../src';
 import {FetchPolicy} from '../src/types';
@@ -105,6 +105,47 @@ const ClayDataProviderWithVariablesAndStorage = () => {
 			</ClayDataProvider>
 		</div>
 	);
+};
+
+class ErrorBoundary extends React.Component {
+	state = {
+		hasError: false,
+		errorMessage: null,
+	};
+
+	static getDerivedStateFromError(error: Error) {
+		return {hasError: true, errorMessage: error.message};
+	}
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<>
+					<h3>Something went wrong.</h3>
+					<p>{this.state.errorMessage}</p>
+				</>
+			);
+		}
+
+		return this.props.children;
+	}
+}
+
+const RickAndMortyList = () => {
+	const {resource} = useResource({
+		link: 'https://rickandmortyapi.com/api/character/',
+		suspense: true,
+		variables: {limit: 10},
+	});
+
+	return resource.results.map((item: any) => (
+		<li className="list-group-item list-group-item-flex" key={item.id}>
+			<div className="autofit-col autofit-col-expand">
+				<p className="list-group-title text-truncate">{'Name'}</p>
+				<p className="list-group-subtitle text-truncate">{item.name}</p>
+			</div>
+		</li>
+	));
 };
 
 storiesOf('Components|ClayDataProvider', module)
@@ -239,4 +280,11 @@ storiesOf('Components|ClayDataProvider', module)
 				</div>
 			</div>
 		);
-	});
+	})
+	.add('with Suspense', () => (
+		<ErrorBoundary>
+			<Suspense fallback={<h1>Loading...</h1>}>
+				<RickAndMortyList />
+			</Suspense>
+		</ErrorBoundary>
+	));


### PR DESCRIPTION
This is experimental is just a WIP, but I've been doing some testing to see what we need to change to add support for `<Suspense />`. See the demo in the Storybook, try turning off the network to see other states.

> 🚨: The tests are broken! Once we reach some conclusion about this I will have to refactor some of them. 

To work better with our cache engine, having a `link` that accepts a function greatly undermines our cache validator and prevents us from making further improvements. I've been thinking of depreciating this functionality and adding a new prop that passes the function that will replace the default `fetch`.

```js
import {fetch} from 'frontend-js-web';

useResource({
    link: 'https://clay.data/',
    fetcher: fetch
})
```

In addition it can help us get better support for `Suspense` as we need to catalog promises so we can retrieve when making the request. The `link` and `variables` are important for generating a key for this.

There are still some changes that need to be made to this code to work well with the other use cases. The vast majority is still supported here. Leave your thoughts.