### PR TITLE
chore(demos): add recharts examples to storybook

### DIFF
--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -18,7 +18,11 @@
 		"@clayui/panel": "*",
 		"classnames": "^2.2.6",
 		"react-dnd": "^10.0.2",
-		"react-dnd-html5-backend": "^10.0.2"
+		"react-dnd-html5-backend": "^10.0.2",
+		"recharts": "1.8.5"
+	},
+	"devDependencies": {
+		"@types/recharts": "1.8.5"
 	},
 	"version": "0.0.1"
 }

--- a/packages/demos/src/recharts/Tooltip.tsx
+++ b/packages/demos/src/recharts/Tooltip.tsx
@@ -1,0 +1,59 @@
+/**
+ * © 2018 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as React from 'react';
+import {TooltipPayload, TooltipProps} from 'recharts';
+
+const defaultRenderer = (item: TooltipPayload) => {
+	if (item.payload) {
+		item = item.payload;
+	}
+
+	return (
+		<div key={item.name}>
+			<span
+				style={{
+					backgroundColor: item.fill || (item as any).stroke,
+					display: 'inline-block',
+					height: 10,
+					marginRight: 6,
+					width: 10,
+				}}
+			/>
+
+			{`${item.name}: ${item.value}`}
+		</div>
+	);
+};
+
+interface IProps extends TooltipProps {
+	labelRenderer?: (val?: string | number) => React.ReactNode;
+	itemRenderer?: (val: any) => React.ReactNode;
+}
+
+const ClayRechartsTooltip: React.FunctionComponent<IProps> = ({
+	active,
+	label,
+	payload,
+	labelRenderer = val => val,
+	itemRenderer = defaultRenderer,
+}) => {
+	if (active) {
+		return (
+			<div className="popover" style={{position: 'static'}}>
+				<div className="popover-header">{labelRenderer(label)}</div>
+
+				<div className="popover-body">
+					{payload && payload.map(itemRenderer)}
+				</div>
+			</div>
+		);
+	}
+
+	return null;
+};
+
+export default ClayRechartsTooltip;

--- a/packages/demos/src/recharts/config.ts
+++ b/packages/demos/src/recharts/config.ts
@@ -1,0 +1,28 @@
+/**
+ * © 2018 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const COLOR_MAP = {
+	Dothraki: '#AF78FF',
+	Kashtark: '#FFD76E',
+	Lannister: '#FF5F5F',
+	Martell: '#50D2A0',
+	Mormont: '#FFB46E',
+	Stark: '#4B9BFF',
+	Targaryen: '#9CE269',
+	Tarly: '#5FC8FF',
+	Tyrell: '#FF73C3',
+};
+export const COLORS = [
+	COLOR_MAP.Stark,
+	COLOR_MAP.Mormont,
+	COLOR_MAP.Lannister,
+	COLOR_MAP.Martell,
+	COLOR_MAP.Tyrell,
+	COLOR_MAP.Targaryen,
+	COLOR_MAP.Dothraki,
+	COLOR_MAP.Kashtark,
+	COLOR_MAP.Tarly,
+];

--- a/packages/demos/src/recharts/index.tsx
+++ b/packages/demos/src/recharts/index.tsx
@@ -1,0 +1,10 @@
+/**
+ * © 2018 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayRechartsTooltip from './Tooltip';
+import {COLORS} from './config';
+
+export {COLORS, ClayRechartsTooltip};

--- a/packages/demos/stories/Recharts.tsx
+++ b/packages/demos/stories/Recharts.tsx
@@ -1,0 +1,756 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import '@clayui/css/lib/css/atlas.css';
+import {ClayRadioGroup, ClayRadio} from '@clayui/form';
+import {storiesOf} from '@storybook/react';
+import moment from 'moment';
+import * as React from 'react';
+import {
+	BarChart,
+	Bar,
+	ReferenceArea as ReferenceAreaTest,
+	CartesianGrid,
+	ComposedChart,
+	Legend,
+	Line,
+	LineChart,
+	XAxis,
+	YAxis,
+	Tooltip,
+	Cell,
+	RadialBarChart,
+	RadialBar,
+	PieChart,
+	Pie,
+	PolarAngleAxis as PolarAngleAxisTest,
+	Scatter,
+	ScatterChart,
+	Area,
+	AreaChart,
+} from 'recharts';
+
+import {ClayRechartsTooltip, COLORS} from '../src/recharts';
+
+// Temporary hack until Recharts gets proper types exported
+const PolarAngleAxis = PolarAngleAxisTest as any;
+const ReferenceArea = ReferenceAreaTest as any;
+
+const DATA = [
+	{
+		amt: 2400,
+		name: 'Page A',
+		pv: 2400,
+		uv: 4000,
+	},
+	{
+		amt: 2210,
+		name: 'Page B',
+		pv: 1398,
+		uv: 3000,
+	},
+	{
+		amt: 2290,
+		name: 'Page C',
+		pv: 9800,
+		uv: 2000,
+	},
+	{
+		amt: 2000,
+		name: 'Page D',
+		pv: 3908,
+		uv: 2780,
+	},
+	{
+		amt: 2181,
+		name: 'Page E',
+		pv: 4800,
+		uv: 1890,
+	},
+	{
+		amt: 2500,
+		name: 'Page F',
+		pv: 3800,
+		uv: 2390,
+	},
+	{
+		amt: 2100,
+		name: 'Page G',
+		pv: 4300,
+		uv: 3490,
+	},
+];
+
+storiesOf('Demos|Recharts', module)
+	.add('line', () => (
+		<LineChart data={DATA} height={300} width={500}>
+			<CartesianGrid />
+			<XAxis dataKey="name" />
+			<YAxis />
+			<Tooltip />
+			<Legend />
+			<Line dataKey="pv" stroke={COLORS[0]} />
+			<Line dataKey="uv" stroke={COLORS[1]} />
+		</LineChart>
+	))
+	.add('bar', () => (
+		<BarChart data={DATA} height={300} width={500}>
+			<CartesianGrid />
+			<XAxis dataKey="name" />
+			<YAxis />
+			<Tooltip content={<ClayRechartsTooltip />} />
+			<Legend />
+			<Bar dataKey="pv" fill={COLORS[0]} />
+			<Bar dataKey="uv" fill={COLORS[1]} />
+		</BarChart>
+	))
+	.add('combo', () => (
+		<ComposedChart data={DATA} height={300} width={500}>
+			<CartesianGrid />
+			<XAxis dataKey="name" />
+			<YAxis />
+			<Tooltip content={<ClayRechartsTooltip />} />
+
+			<Legend
+				align="right"
+				layout="vertical"
+				verticalAlign="middle"
+				wrapperStyle={{paddingLeft: 24}}
+			/>
+
+			<Bar dataKey="uv" fill={COLORS[1]} />
+			<Line dataKey="pv" stroke={COLORS[0]} type="monotone" />
+		</ComposedChart>
+	))
+	.add('pie', () => {
+		const data = [{name: 'A', value: 30}, {name: 'B', value: 70}];
+
+		const customLabel = ({percent}: any) =>
+			`${(percent * 100).toFixed(0)}%`;
+
+		return (
+			<PieChart height={400} width={400}>
+				<Legend />
+				<Tooltip content={<ClayRechartsTooltip />} />
+				<Pie
+					data={data}
+					dataKey="value"
+					label={customLabel}
+					labelLine={false}
+				>
+					{data.map((entry, index) => (
+						<Cell fill={COLORS[index]} key={entry.name} />
+					))}
+				</Pie>
+			</PieChart>
+		);
+	})
+	.add('donut', () => {
+		const data = [{name: 'A', value: 30}, {name: 'B', value: 70}];
+
+		const customLabel = ({percent}: any) =>
+			`${(percent * 100).toFixed(0)}%`;
+
+		return (
+			<PieChart height={400} width={400}>
+				<Pie
+					data={data}
+					dataKey="value"
+					innerRadius={60}
+					label={customLabel}
+					labelLine={false}
+					outerRadius={100}
+				>
+					{data.map((entry, index) => (
+						<Cell fill={COLORS[index]} key={entry.name} />
+					))}
+				</Pie>
+			</PieChart>
+		);
+	})
+	.add('guage', () => {
+		const data = [{name: 'A', value: 70}];
+
+		return (
+			<RadialBarChart
+				barSize={40}
+				data={data}
+				endAngle={0}
+				height={400}
+				innerRadius="60%"
+				outerRadius="100%"
+				startAngle={180}
+				width={400}
+			>
+				<PolarAngleAxis domain={[0, 100]} tick={false} type="number" />
+				<RadialBar
+					background
+					dataKey="value"
+					fill={COLORS[0]}
+					label={{position: 'center'}}
+				/>
+			</RadialBarChart>
+		);
+	})
+	.add('scatter', () => {
+		const data = [
+			{x: 100, y: 200},
+			{x: 120, y: 100},
+			{x: 170, y: 300},
+			{x: 140, y: 250},
+			{x: 150, y: 400},
+			{x: 110, y: 280},
+		];
+
+		const data2 = [
+			{x: 200, y: 100},
+			{x: 100, y: 120},
+			{x: 300, y: 170},
+			{x: 250, y: 140},
+			{x: 400, y: 150},
+			{x: 280, y: 110},
+		];
+
+		return (
+			<ScatterChart height={400} width={400}>
+				<CartesianGrid />
+				<XAxis dataKey="x" type="number" />
+				<YAxis dataKey="y" type="number" />
+				<Tooltip cursor={{strokeDasharray: '3 3'}} />
+
+				<Scatter data={data} fill={COLORS[0]} />
+				<Scatter data={data2} fill={COLORS[1]} shape="square" />
+			</ScatterChart>
+		);
+	})
+	.add('spline', () => (
+		<LineChart data={DATA} height={300} width={500}>
+			<CartesianGrid />
+			<XAxis dataKey="name" />
+			<YAxis />
+			<Legend />
+			<Line dataKey="pv" stroke={COLORS[0]} type="monotone" />
+			<Line dataKey="uv" stroke={COLORS[1]} type="monotone" />
+		</LineChart>
+	))
+	.add('area Step', () => (
+		<AreaChart
+			data={[
+				{a: 100, b: 200},
+				{a: 50, b: 100},
+				{a: 170, b: 300},
+				{a: 140, b: 250},
+				{a: 150, b: 400},
+				{a: 110, b: 280},
+			]}
+			height={400}
+			width={500}
+		>
+			<CartesianGrid />
+			<XAxis />
+			<YAxis />
+			<Tooltip />
+			<Area dataKey="b" fill={COLORS[1]} stroke={COLORS[1]} type="step" />
+			<Area dataKey="a" fill={COLORS[0]} stroke={COLORS[0]} type="step" />
+		</AreaChart>
+	))
+	.add('w/ custom tooltip', () => (
+		<LineChart data={DATA} height={300} width={500}>
+			<XAxis />
+			<YAxis />
+			<Tooltip content={<ClayRechartsTooltip />} />
+			<Line dataKey="pv" stroke={COLORS[0]} />
+			<Line dataKey="uv" stroke={COLORS[1]} />
+		</LineChart>
+	))
+	.add('w/ custom+interactive legend', () => {
+		const [active, setActive] = React.useState('');
+
+		return (
+			<LineChart data={DATA} height={300} width={500}>
+				<XAxis />
+				<YAxis />
+				<Legend
+					align="right"
+					layout="vertical"
+					onMouseEnter={({dataKey}) => setActive(dataKey)}
+					onMouseLeave={() => setActive('')}
+					verticalAlign="middle"
+					wrapperStyle={{paddingLeft: 24}}
+				/>
+				<Line
+					dataKey="pv"
+					dot={false}
+					onMouseOut={() => setActive('')}
+					onMouseOver={() => setActive('pv')}
+					stroke={COLORS[0]}
+					strokeWidth={active === 'pv' ? 3 : 1}
+				/>
+				<Line
+					dataKey="uv"
+					dot={false}
+					onMouseOut={() => setActive('')}
+					onMouseOver={() => setActive('uv')}
+					stroke={COLORS[1]}
+					strokeWidth={active === 'uv' ? 3 : 1}
+				/>
+			</LineChart>
+		);
+	})
+	.add('w/ custom axis label', () => (
+		<LineChart data={DATA} height={300} width={500}>
+			<XAxis
+				label={{
+					value: 'X-Axis',
+				}}
+				tick={false}
+			/>
+			<YAxis label={{angle: -90, value: 'Y-Axis'}} tick={false} />
+			<Line dataKey="pv" stroke={COLORS[0]} />
+			<Line dataKey="uv" stroke={COLORS[1]} />
+		</LineChart>
+	))
+	.add('w/ time axis label', () => (
+		<LineChart
+			data={[
+				{date: '1/1/1990', val: 4},
+				{date: '1/1/1995', val: 15},
+				{date: '1/1/2000', val: 20},
+				{date: '1/1/2005', val: 18},
+			]}
+			height={300}
+			width={500}
+		>
+			<Tooltip />
+			<YAxis label={{angle: -90, value: 'Y-Axis'}} tick={false} />
+			<XAxis tickFormatter={val => moment(val).year()} />
+
+			<Line dataKey="val" stroke={COLORS[0]} />
+		</LineChart>
+	))
+	.add('predictive', () => {
+		const data = [
+			{
+				date: '2018-01-01',
+				val: [130],
+			},
+			{
+				date: '2018-02-01',
+				val: [340],
+			},
+			{
+				date: '2018-03-01',
+				val: [200],
+			},
+			{
+				date: '2018-04-01',
+				val: [100],
+			},
+			{
+				date: '2018-05-01',
+				val: [40],
+			},
+			{
+				date: '2018-06-01',
+				val: [300],
+			},
+			{
+				date: '2018-07-01',
+				range: [140, 240],
+				val: [170],
+			},
+			{
+				date: '2018-08-01',
+				range: [300, 380],
+				val: [320],
+			},
+			{
+				date: '2018-09-01',
+				range: [320, 480],
+				val: [400],
+			},
+			{
+				date: '2018-10-01',
+				range: [140, 240],
+				val: [200],
+			},
+		];
+
+		return (
+			<ComposedChart data={data} height={300} width={500}>
+				<Tooltip />
+				<XAxis dataKey="date" scale="point" />
+				<YAxis />
+
+				<ReferenceArea
+					label={{position: 'insideTop', value: 'Forecast'}}
+					x1="2018-07-01"
+				/>
+
+				<Area dataKey="val" fill={COLORS[0]} stroke={COLORS[0]} />
+
+				<Area
+					dataKey="range"
+					fill={COLORS[0]}
+					opacity={0.2}
+					strokeWidth={0}
+				/>
+			</ComposedChart>
+		);
+	})
+	.add('histogram', () => {
+		const BIN_DATA = [
+			{
+				bin: '10-20',
+				val: 15,
+			},
+			{
+				bin: '20-30',
+				val: 80,
+			},
+			{
+				bin: '30-40',
+				val: 60,
+			},
+			{
+				bin: '50-60',
+				val: 30,
+			},
+			{
+				bin: '70-80',
+				val: 40,
+			},
+		];
+
+		const AC_DATA = [
+			{count: 25, values: [296, 327]},
+			{count: 23, values: [327, 358]},
+			{count: 16, values: [358, 389]},
+			{count: 19, values: [389, 420]},
+			{count: 35, values: [420, 451]},
+			{count: 7, values: [451, 482]},
+		];
+
+		const ticksACData = [
+			...AC_DATA.map(item => item.values[0]),
+			AC_DATA[AC_DATA.length - 1].values[1],
+		];
+
+		const modifiedACData = AC_DATA.map(({count, values}) => ({
+			rangeMid: (values[0] + values[1]) / 2,
+			val: count,
+		}));
+
+		return (
+			<>
+				<BarChart data={BIN_DATA} height={300} width={500}>
+					<XAxis
+						dataKey="bin"
+						height={70}
+						label={{value: 'Age'}}
+						tickLine={false}
+						type="category"
+					/>
+
+					<YAxis
+						dataKey="val"
+						label={{angle: -90, value: '# of Employees'}}
+						type="number"
+						width={150}
+					/>
+
+					<Bar dataKey="val" fill={COLORS[0]} />
+				</BarChart>
+
+				<BarChart
+					data={modifiedACData}
+					height={300}
+					layout="vertical"
+					width={500}
+				>
+					<YAxis
+						dataKey="rangeMid"
+						domain={[296, 482]}
+						interval={0}
+						label={{angle: -90, value: 'Sales Total'}}
+						padding={{bottom: 10, top: 10}}
+						scale="linear"
+						tickFormatter={val => `$${val}M`}
+						ticks={ticksACData}
+						type="number"
+						width={150}
+					/>
+
+					<XAxis
+						dataKey="val"
+						height={70}
+						label={{value: '# of Accounts'}}
+						type="number"
+					/>
+
+					<Bar dataKey="val" fill={COLORS[0]} />
+				</BarChart>
+			</>
+		);
+	})
+	.add('performance test', () => {
+		const [dataPoints, setDataPoints] = React.useState(10);
+
+		const DATA = Array(dataPoints)
+			.fill(0)
+			.map(() => ({
+				pv: Math.floor(Math.random() * 1000),
+				uv: Math.floor(Math.random() * 1000),
+			}));
+
+		return (
+			<>
+				<div className="sheet sheet-lg">
+					<div className="sheet-subtitle">
+						<label htmlFor="mySelectId">
+							{'Select Number of Data Points'}
+						</label>
+
+						<ClayRadioGroup
+							inline
+							onSelectedValueChange={val =>
+								setDataPoints(Number(val))
+							}
+							selectedValue={dataPoints}
+						>
+							{[5, 10, 25, 50].map(item => (
+								<ClayRadio
+									key={item}
+									label={item}
+									value={item}
+								/>
+							))}
+						</ClayRadioGroup>
+					</div>
+				</div>
+
+				<div className="container-fluid container-view">
+					<ul className="card-page">
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<LineChart
+										data={DATA}
+										height={300}
+										width={300}
+									>
+										<CartesianGrid />
+										<XAxis dataKey="uv" />
+										<YAxis />
+										<Tooltip />
+										<Line dataKey="pv" stroke={COLORS[0]} />
+										<Line dataKey="uv" stroke={COLORS[1]} />
+									</LineChart>
+								</div>
+							</div>
+						</li>
+
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<LineChart
+										data={DATA}
+										height={300}
+										width={300}
+									>
+										<Line dataKey="pv" stroke={COLORS[0]} />
+									</LineChart>
+								</div>
+							</div>
+						</li>
+
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<BarChart
+										data={DATA}
+										height={300}
+										width={300}
+									>
+										<CartesianGrid />
+										<XAxis dataKey="uv" />
+										<YAxis />
+										<Tooltip
+											content={<ClayRechartsTooltip />}
+										/>
+										<Bar dataKey="uv" fill={COLORS[1]} />
+									</BarChart>
+								</div>
+							</div>
+						</li>
+
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<BarChart
+										data={DATA}
+										height={300}
+										width={300}
+									>
+										<CartesianGrid />
+										<XAxis dataKey="pv" />
+										<YAxis />
+										<Tooltip
+											content={<ClayRechartsTooltip />}
+										/>
+										<Bar dataKey="pv" fill={COLORS[0]} />
+									</BarChart>
+								</div>
+							</div>
+						</li>
+
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<ComposedChart
+										data={DATA}
+										height={300}
+										width={300}
+									>
+										<CartesianGrid />
+										<XAxis dataKey="uv" />
+										<YAxis />
+										<Tooltip
+											content={<ClayRechartsTooltip />}
+										/>
+										<Bar dataKey="uv" fill={COLORS[1]} />
+										<Line
+											dataKey="pv"
+											stroke={COLORS[0]}
+											type="monotone"
+										/>
+									</ComposedChart>
+								</div>
+							</div>
+						</li>
+
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<ComposedChart
+										data={DATA}
+										height={300}
+										width={300}
+									>
+										<Bar dataKey="uv" fill={COLORS[0]} />
+										<Line
+											dataKey="pv"
+											stroke={COLORS[1]}
+											type="monotone"
+										/>
+									</ComposedChart>
+								</div>
+							</div>
+						</li>
+
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<LineChart
+										data={DATA}
+										height={300}
+										width={300}
+									>
+										<Line
+											dataKey="uv"
+											stroke={COLORS[1]}
+											type="monotone"
+										/>
+									</LineChart>
+								</div>
+							</div>
+						</li>
+
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<LineChart
+										data={DATA}
+										height={300}
+										width={300}
+									>
+										<CartesianGrid />
+										<XAxis dataKey="pv" />
+										<YAxis />
+										<Legend />
+										<Line
+											dataKey="pv"
+											stroke={COLORS[0]}
+											type="monotone"
+										/>
+										<Line
+											dataKey="uv"
+											stroke={COLORS[1]}
+											type="monotone"
+										/>
+									</LineChart>
+								</div>
+							</div>
+						</li>
+
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<AreaChart
+										data={DATA}
+										height={400}
+										width={300}
+									>
+										<CartesianGrid />
+										<XAxis />
+										<YAxis />
+										<Tooltip />
+										<Area
+											dataKey="uv"
+											fill={COLORS[1]}
+											stroke={COLORS[1]}
+											type="step"
+										/>
+										<Area
+											dataKey="pv"
+											fill={COLORS[0]}
+											stroke={COLORS[0]}
+											type="step"
+										/>
+									</AreaChart>
+								</div>
+							</div>
+						</li>
+
+						<li className="card-page-item card-page-item-asset">
+							<div className="card">
+								<div className="card-body">
+									<AreaChart
+										data={DATA}
+										height={400}
+										width={300}
+									>
+										<Area
+											dataKey="uv"
+											fill={COLORS[1]}
+											stroke={COLORS[1]}
+											type="monotone"
+										/>
+										<Area
+											dataKey="pv"
+											fill={COLORS[0]}
+											stroke={COLORS[0]}
+											type="monotone"
+										/>
+									</AreaChart>
+								</div>
+							</div>
+						</li>
+					</ul>
+				</div>
+			</>
+		);
+	});

--- a/packages/demos/stories/index.tsx
+++ b/packages/demos/stories/index.tsx
@@ -15,6 +15,8 @@ import FilesPage from './FilesPage';
 import FormPage from './FormPage';
 import ListPage from './ListPage';
 
+import './Recharts';
+
 storiesOf('Demos|Templates', module)
 	.add('List Page', () => <ListPage />)
 	.add('Files Page', () => <FilesPage />)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,6 +3017,20 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/recharts-scale@*":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/recharts-scale/-/recharts-scale-1.0.0.tgz#348c9220d6d9062c44a9d585d686644a97f7e25d"
+  integrity sha512-HR/PrCcxYb2YHviTqH7CMdL1TUhUZLTUKzfrkMhxm1HTa5mg/QtP8XMiuSPz6dZ6wecazAOu8aYZ5DqkNlgHHQ==
+
+"@types/recharts@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@types/recharts/-/recharts-1.8.5.tgz#5436ae742485cd033910c611eeb9e4c13cbf55f7"
+  integrity sha512-3h/hVNnyOxDyAGhzRpa5y/QBp30vqDw7mUyV0JNoxWnjKM1h8SdgoYru3robamxsXkVa18rz/SVJ+MWDQw8GLg==
+  dependencies:
+    "@types/d3-shape" "*"
+    "@types/react" "*"
+    "@types/recharts-scale" "*"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -4749,6 +4763,11 @@ bail@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.4.tgz#7181b66d508aa3055d3f6c13f0a0c720641dde9b"
   integrity sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==
+
+balanced-match@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+  integrity sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -6585,6 +6604,11 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
+core-js@^2.6.10:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -7216,6 +7240,13 @@ d3-interpolate@1:
   dependencies:
     d3-color "1"
 
+d3-interpolate@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
 d3-path@1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.7.tgz#8de7cd693a75ac0b5480d3abaccd94793e58aae8"
@@ -7244,7 +7275,7 @@ d3-scale-chromatic@1:
     d3-color "1"
     d3-interpolate "1"
 
-d3-scale@2:
+d3-scale@2, d3-scale@^2.1.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
   integrity sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==
@@ -7265,6 +7296,13 @@ d3-shape@1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.5.tgz#e81aea5940f59f0a79cfccac012232a8987c6033"
   integrity sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==
+  dependencies:
+    d3-path "1"
+
+d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
   dependencies:
     d3-path "1"
 
@@ -7463,6 +7501,11 @@ decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, deca
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decimal.js-light@^2.4.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.0.tgz#ca7faf504c799326df94b0ab920424fdfc125348"
+  integrity sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -14467,7 +14510,7 @@ lodash.values@~2.4.1:
   dependencies:
     lodash.keys "~2.4.1"
 
-lodash@>=2.4.0, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10:
+lodash@>=2.4.0, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10, lodash@~4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -14762,6 +14805,11 @@ material-colors@^1.2.1:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
   integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
+
+math-expression-evaluator@^1.2.14:
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
+  integrity sha1-3oGf282E3M2PrlnGrreWFbnSZqw=
 
 math-random@^1.0.1:
   version "1.0.4"
@@ -18163,6 +18211,16 @@ react-reconciler@^0.20.0:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
+react-resize-detector@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-2.3.0.tgz#57bad1ae26a28a62a2ddb678ba6ffdf8fa2b599c"
+  integrity sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==
+  dependencies:
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    prop-types "^15.6.0"
+    resize-observer-polyfill "^1.5.0"
+
 react-resize-detector@^3.2.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-3.4.0.tgz#2ccd399958a0efe9b7c52c5db5a13d87e47cd585"
@@ -18199,6 +18257,16 @@ react-simple-code-editor@^0.9.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.9.10.tgz#1ab5ea7215687ed918c6d0dae90736cf01890905"
   integrity sha512-80LJwRQS7Wi9Ugh/e6FRHWdcg4oQOpMBDFxyDpORILffrHdV3EIQ1IeX5x7488r05iFgLbVDV4nQ1LRKjgCm0g==
 
+react-smooth@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-1.0.5.tgz#94ae161d7951cdd893ccb7099d031d342cb762ad"
+  integrity sha512-eW057HT0lFgCKh8ilr0y2JaH2YbNcuEdFpxyg7Gf/qDKk9hqGMyXryZJ8iMGJEuKH0+wxS0ccSsBBB3W8yCn8w==
+  dependencies:
+    lodash "~4.17.4"
+    prop-types "^15.6.0"
+    raf "^3.4.0"
+    react-transition-group "^2.5.0"
+
 react-syntax-highlighter@^8.0.1:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-8.1.0.tgz#59103ff17a828a27ed7c8f035ae2558f09b6b78c"
@@ -18228,7 +18296,7 @@ react-textarea-autosize@^7.0.4:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-transition-group@^2.2.1:
+react-transition-group@^2.2.1, react-transition-group@^2.5.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
@@ -18499,6 +18567,30 @@ recast@^0.16.0:
     private "~0.1.5"
     source-map "~0.6.1"
 
+recharts-scale@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.4.3.tgz#040b4f638ed687a530357292ecac880578384b59"
+  integrity sha512-t8p5sccG9Blm7c1JQK/ak9O8o95WGhNXD7TXg/BW5bYbVlr6eCeRBNpgyigD4p6pSSMehC5nSvBUPj6F68rbFA==
+  dependencies:
+    decimal.js-light "^2.4.1"
+
+recharts@1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-1.8.5.tgz#ca94a3395550946334a802e35004ceb2583fdb12"
+  integrity sha512-tM9mprJbXVEBxjM7zHsIy6Cc41oO/pVYqyAsOHLxlJrbNBuLs0PHB3iys2M+RqCF0//k8nJtZF6X6swSkWY3tg==
+  dependencies:
+    classnames "^2.2.5"
+    core-js "^2.6.10"
+    d3-interpolate "^1.3.0"
+    d3-scale "^2.1.0"
+    d3-shape "^1.2.0"
+    lodash "^4.17.5"
+    prop-types "^15.6.0"
+    react-resize-detector "^2.3.0"
+    react-smooth "^1.0.5"
+    recharts-scale "^0.4.2"
+    reduce-css-calc "^1.3.0"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -18562,6 +18654,22 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+reduce-css-calc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
+  integrity sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=
+  dependencies:
+    balanced-match "^0.4.2"
+    math-expression-evaluator "^1.2.14"
+    reduce-function-call "^1.0.1"
+
+reduce-function-call@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.3.tgz#60350f7fb252c0a67eb10fd4694d16909971300f"
+  integrity sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==
+  dependencies:
+    balanced-match "^1.0.0"
 
 redux-thunk@^2.3.0:
   version "2.3.0"
@@ -19011,7 +19119,7 @@ requires-port@1.x.x, requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==


### PR DESCRIPTION
I spent some time re-creating our existing charts using `recharts` and overall the experience was really nice. Recharts was super easy to use and highly configurable. I haven't approached the predictive or geomap charts yet, I am going to look into those now.

One question I have for people, is how would you expect us to offer the "clay" portion of charts? Is exporting colors and potentially custom components such as tooltips, legends, and axis enough? Or do you expect something else? I am hesitant to wrap rechart components and export them with our own default config. Check out the storybook for clay-recharts(name subject to change) and let me know what you all think. 

