### PR TITLE
fix(clay-css): 2.x Atlas Dropdown change `.dropdown-header` and `.dropdow…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -10,12 +10,14 @@ $dropdown-min-width: 240px !default;
 $dropdown-max-width: 240px !default;
 $dropdown-spacer: 0.3125rem !default; // 5px
 
-$dropdown-header-color: $gray-600 !default;
+$dropdown-header-color: $gray-900 !default;
 $dropdown-header-font-size: 0.875rem !default; // 14px
 $dropdown-header-margin-top: 0.625rem !default; // 10px
 
 $dropdown-subheader-font-size: 0.75rem !default; // 12px
 $dropdown-subheader-margin-top: 0.625rem !default; // 10px
+
+$dropdown-caption-color: $gray-600 !default;
 
 $dropdown-link-color: $gray-600 !default;
 $dropdown-link-font-weight: $font-weight-normal !default;


### PR DESCRIPTION
…n-subheader` color to #272833

fixes #2812