### PR TITLE
feat(clay-css): Sizes for Dropdowns

### DIFF
--- a/packages/clay-css/src/content/dropdowns.html
+++ b/packages/clay-css/src/content/dropdowns.html
@@ -745,6 +745,264 @@ section: Components
 	</div>
 </div>
 
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown Menu with Sheet</h3>
+
+		<div class="dropdown-menu dropdown-menu-fluid show" style="position:static;">
+			<div class="sheet">
+				<div class="sheet-title">
+					<div class="autofit-float-sm-down autofit-row autofit-padded-no-gutters">
+						<div class="autofit-col autofit-col-expand">
+							<div class="heading-text">
+								ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+							</div>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-secondary btn-sm" type="button">
+								New Experience
+							</button>
+						</div>
+					</div>
+				</div>
+
+				<div class="sheet-text">Mazagran, affogato sugar crema café au lait grounds sugar fair trade acerbic. Robust saucer est in fair trade barista aftertaste et saucer. Rich barista irish lungo aroma turkish whipped. Americano, ristretto variety dripper single shot rich pumpkin spice robust. Arabica, robusta, irish sweet froth, café au lait id chicory so et decaffeinated siphon.</div>
+
+				<div class="alert alert-warning" role="alert">
+					<span class="alert-indicator">
+						<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#warning-full"></use>
+						</svg>
+					</span>
+					<strong class="lead">Warning:</strong> This alert is a <a href="#1" class="alert-link">warning message</a>.
+				</div>
+
+				<ul class="list-group show-quick-actions-on-hover">
+					<li class="list-group-item list-group-item-flex">
+						<div class="autofit-col autofit-col-expand">
+							<section class="autofit-section">
+								<div class="list-group-title">
+									<a href="#1">Experience 1</a>
+								</div>
+								<span class="list-group-subtext">Audience</span>
+								<span class="list-group-text">MMM</span>
+							</section>
+						</div>
+						<div class="autofit-col">
+							<div class="quick-action-menu">
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+									</svg>
+								</a>
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+									</svg>
+								</a>
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+									</svg>
+								</a>
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle" />
+									</svg>
+								</a>
+							</div>
+						</div>
+					</li>
+					<li class="list-group-item list-group-item-flex">
+						<div class="autofit-col autofit-col-expand">
+							<section class="autofit-section">
+								<div class="list-group-title">
+									<a href="#1">Experience 2</a>
+								</div>
+								<span class="list-group-subtext">Audience</span>
+								<span class="list-group-text">Cositas</span>
+							</section>
+						</div>
+						<div class="autofit-col">
+							<div class="quick-action-menu">
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+									</svg>
+								</a>
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+									</svg>
+								</a>
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+									</svg>
+								</a>
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle" />
+									</svg>
+								</a>
+							</div>
+						</div>
+					</li>
+					<li class="list-group-item list-group-item-flex">
+						<div class="autofit-col autofit-col-expand">
+							<section class="autofit-section">
+								<div class="list-group-title">
+									<a href="#1">Default</a>
+								</div>
+								<span class="list-group-subtext">Audience</span>
+								<span class="list-group-text">Anyone</span>
+							</section>
+						</div>
+						<div class="autofit-col">
+							<div class="quick-action-menu">
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+									</svg>
+								</a>
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+									</svg>
+								</a>
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+									</svg>
+								</a>
+								<a class="component-action quick-action-item" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle" />
+									</svg>
+								</a>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown Menu Fluid</h3>
+
+		<blockquote class="blockquote">
+			<p>Bootstrap 4's dropdown plugin add <code>dropdown-fluid</code> to <code>dropdown</code> to expand the <code>dropdown-menu</code> 100% relative to its nearest position relative/absolute container. This does not work with <a href="#dropdown-alignment">Clay CSS Dropdown Alignment</a>.</p>
+
+			<p>Clay Components Dropdown add <code>dropdown-menu-fluid</code> to <code>dropdown-menu</code>.</p>
+		</blockquote>
+
+		<div class="alert alert-warning">
+			Bootstrap 4's Dropdown plugin closes the <code>dropdown-menu</code> on click unless it is wrapped in a <code>form</code> or <code>stopPropagation()</code> is called on your click handler.
+		</div>
+
+		<div class="dropdown-menu dropdown-menu-fluid show" style="position:static;">
+			<div class="sheet">
+				<div class="c-mb-4">Fluid</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown Menu Fluid Xl</h3>
+
+		<blockquote class="blockquote">
+			<p>Bootstrap 4 Dropdown plugin add <code>dropdown-fluid dropdown-fluid-xl</code> to <code>dropdown</code> to cap the <code>dropdown-menu</code> width at the <code>container-fluid-max-xl</code> max-width.</p>
+
+			<p>Clay Components Dropdown add <code>dropdown-menu-fluid dropdown-menu-fluid-xl</code> to <code>dropdown-menu</code>.</p>
+		</blockquote>
+
+		<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-xl show" style="position:static;">
+			<div class="sheet">
+				<div class="c-mb-4">XL</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown Menu Fluid Lg</h3>
+
+		<blockquote class="blockquote">
+			<p>Bootstrap 4 Dropdown plugin add <code>dropdown-fluid dropdown-fluid-lg</code> to <code>dropdown</code> to cap the <code>dropdown-menu</code> width at the <code>container-fluid-max-lg</code> max-width.</p>
+
+			<p>Clay Components Dropdown add <code>dropdown-menu-fluid dropdown-menu-fluid-lg</code> to <code>dropdown-menu</code>.</p>
+		</blockquote>
+
+		<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-lg show" style="position:static;">
+			<div class="sheet">
+				<div class="c-mb-4">LG</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown Menu Fluid Md</h3>
+
+		<blockquote class="blockquote">
+			<p>Bootstrap 4 Dropdown plugin add <code>dropdown-fluid dropdown-fluid-md</code> to <code>dropdown</code> to cap the <code>dropdown-menu</code> width at the <code>container-fluid-max-md</code> max-width.</p>
+
+			<p>Clay Components Dropdown add <code>dropdown-menu-fluid dropdown-menu-fluid-md</code> to <code>dropdown-menu</code>.</p>
+		</blockquote>
+
+		<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-md show" style="position:static;">
+			<div class="sheet">
+				<div class="c-mb-4">MD</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown Menu Fluid Sm</h3>
+
+		<blockquote class="blockquote">
+			<p>Bootstrap 4 Dropdown plugin add <code>dropdown-fluid dropdown-fluid-sm</code> to <code>dropdown</code> to cap the <code>dropdown-menu</code> width at the <code>container-fluid-max-sm</code> max-width.</p>
+
+			<p>Clay Components Dropdown add <code>dropdown-menu-fluid dropdown-menu-fluid-sm</code> to <code>dropdown-menu</code>.</p>
+		</blockquote>
+
+		<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-sm show" style="position:static;">
+			<div class="sheet">
+				<div class="c-mb-4">SM</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown Menu Fluid Xs</h3>
+
+		<blockquote class="blockquote">
+			<p>Bootstrap 4 Dropdown plugin add <code>dropdown-fluid dropdown-fluid-xs</code> to <code>dropdown</code> to cap the <code>dropdown-menu</code> width at <code>max-width: 240px</code>.</p>
+
+			<p>Clay Components Dropdown add <code>dropdown-menu-fluid dropdown-menu-fluid-xs</code> to <code>dropdown-menu</code>.</p>
+		</blockquote>
+
+		<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-xs show" style="position:static;">
+			<div class="sheet">
+				<div class="c-mb-4">XS</div>
+			</div>
+		</div>
+	</div>
+</div>
+
 <div class="clay-site-row-spacer row clay-site-dropdown-display">
 	<div class="col-md-12">
 		<h3>Dropdown wide / full</h3>
@@ -752,6 +1010,10 @@ section: Components
 		<blockquote class="blockquote">
 			<p>Use <code>.dropdown-wide</code> with <code>.dropdown</code> to make the dropdown menu big. The default width is 500px. Use <code class="code">.dropdown-full</code> to create a dropdown menu as wide as its relative parent. See dropdown examples.</p>
 		</blockquote>
+
+		<div class="alert alert-danger">
+			<code>.dropdown-wide</code> and <code>.dropdown-full</code> have been deprecated in favor of <code>.dropdown-fluid</code> / <code>dropdown-menu-fluid</code>.
+		</div>
 
 		<div aria-labelledby="" class="dropdown-wide dropdown-wide-container">
 			<div class="dropdown-menu">
@@ -1186,7 +1448,7 @@ section: Components
 								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
 							</svg>
 						</a>
-						<ul aria-labelledby="navbarDropdownMenuLink3" class="dropdown-menu">
+						<div aria-labelledby="navbarDropdownMenuLink3" class="dropdown-menu">
 							<div class="row">
 								<div class="col-sm-4">
 									<ul class="list-unstyled">
@@ -1230,7 +1492,7 @@ section: Components
 									</ul>
 								</div>
 							</div>
-						</ul>
+						</div>
 					</li>
 				</ul>
 				<div class="navbar-form navbar-form-autofit">

--- a/packages/clay-css/src/content/popovers.html
+++ b/packages/clay-css/src/content/popovers.html
@@ -151,7 +151,7 @@ section: Components
 
 <div class="clay-site-row-spacer row">
 	<div class="col-md-12">
-		<h3>Bootstrap Tooltips</h3>
+		<h3>Bootstrap Popovers</h3>
 
 		<div class="form-group">
 			<button class="btn btn-secondary" data-container="body" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." data-placement="top" data-toggle="popover" type="button">

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -106,7 +106,8 @@
 		font-size: $dropdown-font-size-mobile;
 	}
 
-	.alert {
+	.dropdown-item-alert,
+	li.alert {
 		font-size: $dropdown-alert-font-size;
 		line-height: $dropdown-alert-line-height;
 		margin: $dropdown-alert-margin;
@@ -121,7 +122,8 @@
 		}
 	}
 
-	.alert-fluid {
+	.dropdown-item-alert.alert-fluid,
+	li.alert-fluid {
 		margin-left: 0;
 		margin-right: 0;
 

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -1,3 +1,7 @@
+////
+/// @group dropdowns
+////
+
 .dropdown-header {
 	font-size: $dropdown-header-font-size;
 	margin-bottom: $dropdown-header-margin-bottom;
@@ -144,6 +148,10 @@
 
 	> .list-unstyled {
 		margin-bottom: 0;
+	}
+
+	.sheet {
+		@include clay-container($dropdown-menu-sheet);
 	}
 }
 
@@ -348,6 +356,8 @@
 
 // Dropdown wide / full
 
+/// @deprecated as of v3.2.0 and v2.19.0 use `.dropdown-fluid` or `.dropdown-menu-fluid` instead
+
 %dropdown-full-wide-dropdown-menu {
 	max-width: none;
 	width: 100%;
@@ -357,6 +367,8 @@
 		width: 100%;
 	}
 }
+
+/// @deprecated as of v3.2.0 and v2.19.0 use `.dropdown-fluid` or `.dropdown-menu-fluid` instead
 
 .dropdown-full,
 .dropdown-wide {
@@ -375,6 +387,8 @@
 	}
 }
 
+/// @deprecated as of v3.2.0 and v2.19.0 use `.dropdown-fluid` or `.dropdown-menu-fluid` instead
+
 .dropdown-wide .dropdown-menu {
 	@include media-breakpoint-up(lg) { // min-width 992px
 		min-width: $dropdown-wide-width;
@@ -382,6 +396,8 @@
 }
 
 // Dropdown Menu Autocomplete
+
+/// @deprecated as of v3.2.0 and v2.19.0 use `.dropdown-fluid` or `.dropdown-menu-fluid` instead
 
 .dropdown-full .autocomplete-dropdown-menu,
 .dropdown-full .dropdown-menu-autocomplete {
@@ -397,11 +413,71 @@
 	@include clay-dropdown-menu-variant($autocomplete-dropdown-menu);
 }
 
+// Dropdown Fluid
+
+.dropdown-fluid {
+	@include clay-container($dropdown-fluid);
+}
+
+.dropdown-fluid .dropdown-menu {
+	@include clay-container($dropdown-fluid-dropdown-menu);
+}
+
+.dropdown-fluid-xs .dropdown-menu {
+	@include clay-container($dropdown-fluid-xs-dropdown-menu);
+}
+
+.dropdown-fluid-sm .dropdown-menu {
+	@include clay-container($dropdown-fluid-sm-dropdown-menu);
+}
+
+.dropdown-fluid-md .dropdown-menu {
+	@include clay-container($dropdown-fluid-md-dropdown-menu);
+}
+
+.dropdown-fluid-lg .dropdown-menu {
+	@include clay-container($dropdown-fluid-lg-dropdown-menu);
+}
+
+.dropdown-fluid-xl .dropdown-menu {
+	@include clay-container($dropdown-fluid-xl-dropdown-menu);
+}
+
+// Dropdown Menu Fluid
+
+.dropdown-menu-fluid {
+	@include clay-container($dropdown-menu-fluid);
+}
+
+.dropdown-menu-fluid-xs {
+	@include clay-container($dropdown-menu-fluid-xs);
+}
+
+.dropdown-menu-fluid-sm {
+	@include clay-container($dropdown-menu-fluid-sm);
+}
+
+.dropdown-menu-fluid-md {
+	@include clay-container($dropdown-menu-fluid-md);
+}
+
+.dropdown-menu-fluid-lg {
+	@include clay-container($dropdown-menu-fluid-lg);
+}
+
+.dropdown-menu-fluid-xl {
+	@include clay-container($dropdown-menu-fluid-xl);
+}
+
 // Navbar Component Dropdowns
+
+/// @deprecated as of v3.2.0 and v2.19.0 use `.dropdown-fluid` or `.dropdown-menu-fluid` instead
 
 .nav-item.dropdown-full {
 	position: static;
 }
+
+/// @deprecated as of v3.2.0 and v2.19.0 use `.dropdown-fluid` or `.dropdown-menu-fluid` instead
 
 .nav-item.dropdown-wide {
 	@include media-breakpoint-down(md) { // max-width 991px

--- a/packages/clay-css/src/scss/components/_popovers.scss
+++ b/packages/clay-css/src/scss/components/_popovers.scss
@@ -43,6 +43,16 @@
 	@include border-bottom-radius($popover-offset-border-width);
 }
 
+// Popover Fluid
+
+.popover-fluid {
+	@include clay-container($popover-fluid);
+
+	> .dropdown-menu {
+		@include clay-container($popover-fluid-dropdown-menu);
+	}
+}
+
 // Top
 
 .clay-popover-top,

--- a/packages/clay-css/src/scss/mixins/_grid.scss
+++ b/packages/clay-css/src/scss/mixins/_grid.scss
@@ -49,6 +49,7 @@
 /// height: {Number | String | Null},
 /// justify-content: {String | Null},
 /// line-height: {Number | String | Null},
+/// margin: {Number | List | Null},
 /// margin-bottom: {Number | String | Null},
 /// margin-left: {Number | String | Null},
 /// margin-right: {Number | String | Null},
@@ -59,6 +60,7 @@
 /// min-width: {Number | String | Null},
 /// opacity: {Number | String | Null},
 /// order: {Number | String | Null},
+/// padding: {Number | List | Null},
 /// padding-bottom: {Number | String | Null},
 /// padding-left: {Number | String | Null},
 /// padding-right: {Number | String | Null},
@@ -110,6 +112,7 @@
 	$height: map-get($map, height);
 	$justify-content: map-get($map, justify-content);
 	$line-height: map-get($map, line-height);
+	$margin: map-get($map, margin);
 	$margin-bottom: map-get($map, margin-bottom);
 	$margin-left: map-get($map, margin-left);
 	$margin-right: map-get($map, margin-right);
@@ -120,6 +123,7 @@
 	$min-width: map-get($map, min-width);
 	$opacity: map-get($map, opacity);
 	$order: map-get($map, order);
+	$padding: map-get($map, padding);
 	$padding-bottom: map-get($map, padding-bottom);
 	$padding-left: map-get($map, padding-left);
 	$padding-right: map-get($map, padding-right);
@@ -166,6 +170,7 @@
 	justify-content: $justify-content;
 	height: $height;
 	line-height: $line-height;
+	margin: $margin;
 	margin-bottom: $margin-bottom;
 	margin-left: $margin-left;
 	margin-right: $margin-right;
@@ -176,6 +181,7 @@
 	min-width: $min-width;
 	opacity: $opacity;
 	order: $order;
+	padding: $padding;
 	padding-bottom: $padding-bottom;
 	padding-left: $padding-left;
 	padding-right: $padding-right;

--- a/packages/clay-css/src/scss/mixins/_grid.scss
+++ b/packages/clay-css/src/scss/mixins/_grid.scss
@@ -35,6 +35,7 @@
 /// border-radius: {Number | String | List | Null},
 /// border-style: {String | List | Null},
 /// border-width: {Number | String | List | Null},
+/// box-shadow: {String | List | Null},
 /// color: {Color | String | Null},
 /// display: {String | Null},
 /// flex-basis: {Number | String | Null},
@@ -98,6 +99,7 @@
 	$border-radius: map-get($map, border-radius);
 	$border-style: map-get($map, border-style);
 	$border-width: map-get($map, border-width);
+	$box-shadow: map-get($map, box-shadow);
 	$color: map-get($map, color);
 	$display: map-get($map, display);
 	$flex-basis: map-get($map, flex-basis);
@@ -156,6 +158,7 @@
 	border-radius: $border-radius;
 	border-style: $border-style;
 	border-width: $border-width;
+	box-shadow: $box-shadow;
 	color: $color;
 	display: $display;
 	font-family: $font-family;

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -1,6 +1,14 @@
+////
+/// @group dropdowns
+////
+
 $dropdown-border-style: null !default;
 
+/// @deprecated as of v3.2.0 and v2.19.0 use `$dropdown-fluid` or `$dropdown-menu-fluid` instead
+
 $dropdown-full-wide-header-spacer-y: 20px !default;
+
+/// @deprecated as of v3.2.0 and v2.19.0 use `$dropdown-fluid` or `$dropdown-menu-fluid` instead
 
 $dropdown-wide-width: 500px !default;
 
@@ -90,3 +98,85 @@ $dropdown-alert-line-height: normal !default;
 $dropdown-alert-margin: ($spacer / 2) !default;
 $dropdown-alert-padding-x: $dropdown-header-padding-x !default;
 $dropdown-alert-padding-y: $dropdown-header-padding-y !default;
+
+// Sheet inside Dropdowns
+
+$dropdown-menu-sheet: () !default;
+$dropdown-menu-sheet: map-deep-merge((
+	border-radius: 0,
+	border-width: 0,
+	box-shadow: none,
+), $dropdown-menu-sheet);
+
+// Dropdown Fluid
+
+$dropdown-fluid: () !default;
+$dropdown-fluid: map-deep-merge((
+	position: static,
+), $dropdown-fluid);
+
+$dropdown-fluid-dropdown-menu: () !default;
+$dropdown-fluid-dropdown-menu: map-deep-merge((
+	max-height: none,
+	max-width: 100%,
+	width: 100%,
+), $dropdown-fluid-dropdown-menu);
+
+$dropdown-fluid-xs-dropdown-menu: () !default;
+$dropdown-fluid-xs-dropdown-menu: map-deep-merge((
+	max-width: 240px,
+), $dropdown-fluid-xs-dropdown-menu);
+
+$dropdown-fluid-sm-dropdown-menu: () !default;
+$dropdown-fluid-sm-dropdown-menu: map-deep-merge((
+	max-width: map-get($container-max-widths, sm),
+), $dropdown-fluid-sm-dropdown-menu);
+
+$dropdown-fluid-md-dropdown-menu: () !default;
+$dropdown-fluid-md-dropdown-menu: map-deep-merge((
+	max-width: map-get($container-max-widths, md),
+), $dropdown-fluid-md-dropdown-menu);
+
+$dropdown-fluid-lg-dropdown-menu: () !default;
+$dropdown-fluid-lg-dropdown-menu: map-deep-merge((
+	max-width: map-get($container-max-widths, lg),
+), $dropdown-fluid-lg-dropdown-menu);
+
+$dropdown-fluid-xl-dropdown-menu: () !default;
+$dropdown-fluid-xl-dropdown-menu: map-deep-merge((
+	max-width: map-get($container-max-widths, xl),
+), $dropdown-fluid-xl-dropdown-menu);
+
+// Dropdown Menu Fluid
+
+$dropdown-menu-fluid: () !default;
+$dropdown-menu-fluid: map-deep-merge((
+	max-height: none,
+	max-width: 100%,
+	width: calc(100% - 2rem),
+), $dropdown-menu-fluid);
+
+$dropdown-menu-fluid-xs: () !default;
+$dropdown-menu-fluid-xs: map-deep-merge((
+	max-width: calc(240px - 2rem),
+), $dropdown-menu-fluid-xs);
+
+$dropdown-menu-fluid-sm: () !default;
+$dropdown-menu-fluid-sm: map-deep-merge((
+	max-width: calc(#{map-get($container-max-widths, sm)} - 2rem),
+), $dropdown-menu-fluid-sm);
+
+$dropdown-menu-fluid-md: () !default;
+$dropdown-menu-fluid-md: map-deep-merge((
+	max-width: calc(#{map-get($container-max-widths, md)} - 2rem),
+), $dropdown-menu-fluid-md);
+
+$dropdown-menu-fluid-lg: () !default;
+$dropdown-menu-fluid-lg: map-deep-merge((
+	max-width: calc(#{map-get($container-max-widths, lg)} - 2rem),
+), $dropdown-menu-fluid-lg);
+
+$dropdown-menu-fluid-xl: () !default;
+$dropdown-menu-fluid-xl: map-deep-merge((
+	max-width: calc(#{map-get($container-max-widths, xl)} - 2rem),
+), $dropdown-menu-fluid-xl);

--- a/packages/clay-css/src/scss/variables/_popovers.scss
+++ b/packages/clay-css/src/scss/variables/_popovers.scss
@@ -22,3 +22,21 @@ $popover-header-margin-x: null !default;
 $popover-header-margin-y: null !default;
 
 $popover-offset-border-width: calc(#{$popover-border-radius} - #{$popover-border-width}) !default;
+
+$popover-fluid: () !default;
+$popover-fluid: map-deep-merge((
+	align-items: center,
+	bg: transparent,
+	border-width: 0,
+	box-shadow: none,
+	display: flex,
+	flex-direction: column,
+	margin-top: 0,
+	max-width: calc(100% - 2rem),
+), $popover-fluid);
+
+$popover-fluid-dropdown-menu: () !default;
+$popover-fluid-dropdown-menu: map-deep-merge((
+	display: block,
+	position: static,
+), $popover-fluid-dropdown-menu);


### PR DESCRIPTION
fixes #2631 

This adds 6 different dropdown sizes. The markup is:
```
<div class="dropdown-menu dropdown-menu-fluid"></div>
<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-xl"></div>
<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-lg"></div>
<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-md"></div>
<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-sm"></div>
<div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-xs"></div>
```
You can toss in whatever you want in `dropdown-menu-fluid`. I tried to mimic the screenshot in #2631 by using `sheet` inside the `dropdown-menu`. I got close, but not exact.

I also added `popover-fluid` modifier that removes the default `popover` style. You can toss whatever you want in there too. From my tinkering, I concluded:
```
<div class="popover popover-fluid fade show">
    <div class="dropdown-menu dropdown-menu-fluid dropdown-menu-fluid-xl"></div>
</div>
```
should work best if it's decided to go the popover route.

I'm also thinking this is too big of a change for 2.x.

/cc @bryceosterhaus @andresfulla @jbalsas 