### PR TITLE
fix(css): allow newline characters to display properly for tooltips

### DIFF
--- a/packages/clay-css/src/scss/components/_tooltip.scss
+++ b/packages/clay-css/src/scss/components/_tooltip.scss
@@ -1,5 +1,7 @@
 .tooltip-inner {
 	@include box-shadow($tooltip-box-shadow);
+
+	white-space: pre-line;
 }
 
 .tooltip-arrow {

--- a/packages/clay-tooltip/stories/index.tsx
+++ b/packages/clay-tooltip/stories/index.tsx
@@ -37,6 +37,9 @@ storiesOf('Components|ClayTooltip', module)
 			{'Tooltip'}
 		</ClayTooltip>
 	))
+	.add('tooltip w/ newline', () => (
+		<ClayTooltip show>{'Tooltip\nwith\nnew\n\nlines'}</ClayTooltip>
+	))
 	.add('ClayTooltipProvider', () => (
 		<div style={{padding: 50}}>
 			<button title="Default">{'No Tooltip'}</button>
@@ -44,6 +47,11 @@ storiesOf('Components|ClayTooltip', module)
 			<ClayTooltipProvider>
 				<div>
 					<button title="Default">{'Default'}</button>
+
+					{/* Note that the newline has to be a string within braces. */}
+					<button title={'Line1\nLine2'}>
+						{'With a line Break'}
+					</button>
 
 					<button data-tooltip-align="left" title="Left">
 						{'Left'}


### PR DESCRIPTION
fixes #2836