### PR TITLE
fix(clay-dropdown): escape special characters in label

### DIFF
--- a/packages/clay-dropdown/demos/index.html
+++ b/packages/clay-dropdown/demos/index.html
@@ -211,7 +211,7 @@
 				items: [
 					{
 						href: '#1',
-						label: 'Item 1',
+						label: '&lt;Item 1&gt;',
 						title: 'Item 1',
 					},
 					{

--- a/packages/clay-dropdown/src/ClayDropdownItem.js
+++ b/packages/clay-dropdown/src/ClayDropdownItem.js
@@ -1,3 +1,4 @@
+import './ClayDropdownLabel.soy.js';
 import 'clay-button';
 import 'clay-checkbox';
 import 'clay-icon';

--- a/packages/clay-dropdown/src/ClayDropdownItem.soy
+++ b/packages/clay-dropdown/src/ClayDropdownItem.soy
@@ -119,7 +119,9 @@
 				{/if}
 			{/if}
 
-			{$label}
+			{call ClayDropdownLabel.render}
+				{param label: $label /}
+			{/call}
 
 			{if $icons and $icons.right and $spritemap}
 				<span class="dropdown-item-indicator-end">

--- a/packages/clay-dropdown/src/ClayDropdownLabel.soy
+++ b/packages/clay-dropdown/src/ClayDropdownLabel.soy
@@ -1,0 +1,11 @@
+{namespace ClayDropdownLabel}
+
+/**
+ * Just a hack to force the label to be treated as HTML so
+ * it can escape special characters.
+ */
+{template .render}
+	{@param label: string|html}
+
+	{$label}
+{/template}

--- a/packages/clay-isomorphic/fixtures/expected/ClayDropdownLabel.render
+++ b/packages/clay-isomorphic/fixtures/expected/ClayDropdownLabel.render
@@ -1,0 +1,1 @@
+&amp;lt;Item 1&amp;gt;

--- a/packages/clay-isomorphic/fixtures/input/ClayDropdownLabel.render
+++ b/packages/clay-isomorphic/fixtures/input/ClayDropdownLabel.render
@@ -1,0 +1,3 @@
+{
+    "label": "&lt;Item 1&gt;"
+}


### PR DESCRIPTION
Fixes #2856

Just a hack to force the label to be treated as HTML so it can escape special characters.