### PR TITLE
feat(clay-css): Dropdown Section add specific styles for nested `custom-control`s

### DIFF
--- a/packages/clay-css/src/content/dropdowns.html
+++ b/packages/clay-css/src/content/dropdowns.html
@@ -403,7 +403,17 @@ section: Components
 			</li>
 			<li class="dropdown-subheader">Filter by</li>
 			<li>
-				<div class="active dropdown-item">
+				<div class="dropdown-section">
+					<div class="custom-control custom-checkbox">
+						<label>
+							<input class="custom-control-input" type="checkbox">
+							<span class="custom-control-label"></span>
+						</label>
+					</div>
+				</div>
+			</li>
+			<li>
+				<div class="active dropdown-section">
 					<div class="custom-control custom-checkbox">
 						<label>
 							<input checked class="custom-control-input" type="checkbox">
@@ -415,7 +425,7 @@ section: Components
 				</div>
 			</li>
 			<li>
-				<div class="dropdown-item">
+				<div class="dropdown-section">
 					<div class="custom-control custom-checkbox">
 						<label>
 							<input class="custom-control-input" type="checkbox">
@@ -427,7 +437,7 @@ section: Components
 				</div>
 			</li>
 			<li>
-				<div class="disabled dropdown-item">
+				<div class="disabled dropdown-section">
 					<div class="custom-control custom-checkbox">
 						<label>
 							<input disabled class="custom-control-input" type="checkbox">
@@ -447,7 +457,7 @@ section: Components
 		<ul aria-labelledby="theDropdownToggleId" class="dropdown-menu">
 			<li class="dropdown-subheader">Order by</li>
 			<li>
-				<div class="active dropdown-item">
+				<div class="active dropdown-section">
 					<div class="custom-control custom-radio">
 						<label>
 							<input checked class="custom-control-input" id="dropdownRadio1" name="dropdownRadio" type="radio">
@@ -459,7 +469,7 @@ section: Components
 				</div>
 			</li>
 			<li>
-				<div class="dropdown-item">
+				<div class="dropdown-section">
 					<div class="custom-control custom-radio">
 						<label>
 							<input class="custom-control-input" id="dropdownRadio2" name="dropdownRadio" type="radio">
@@ -471,7 +481,7 @@ section: Components
 				</div>
 			</li>
 			<li>
-				<div class="disabled dropdown-item">
+				<div class="disabled dropdown-section">
 					<div class="custom-control custom-radio">
 						<label>
 							<input disabled class="custom-control-input" id="dropdownRadio3" name="dropdownRadio" type="radio">
@@ -1061,7 +1071,7 @@ section: Components
 									<input type="email" class="form-control form-control-sm" id="exampleInputEmail3" placeholder="Email">
 								</li>
 								<li>
-									<div class="dropdown-item">
+									<div class="dropdown-section">
 										<div class="custom-control custom-checkbox">
 											<label>
 												<input class="custom-control-input" type="checkbox">
@@ -1073,7 +1083,7 @@ section: Components
 									</div>
 								</li>
 								<li>
-									<div class="dropdown-item">
+									<div class="dropdown-section">
 										<div class="custom-control custom-checkbox">
 											<label>
 												<input class="custom-control-input" type="checkbox">
@@ -1085,7 +1095,7 @@ section: Components
 									</div>
 								</li>
 								<li>
-									<div class="dropdown-item">
+									<div class="dropdown-section">
 										<div class="custom-control custom-checkbox">
 											<label>
 												<input class="custom-control-input" type="checkbox">
@@ -1097,7 +1107,7 @@ section: Components
 									</div>
 								</li>
 								<li>
-									<div class="dropdown-item">
+									<div class="dropdown-section">
 										<div class="custom-control custom-checkbox">
 											<label>
 												<input class="custom-control-input" type="checkbox">
@@ -1109,7 +1119,7 @@ section: Components
 									</div>
 								</li>
 								<li>
-									<div class="dropdown-item">
+									<div class="dropdown-section">
 										<div class="custom-control custom-checkbox">
 											<label>
 												<input class="custom-control-input" type="checkbox">
@@ -1121,7 +1131,7 @@ section: Components
 									</div>
 								</li>
 								<li>
-									<div class="dropdown-item">
+									<div class="dropdown-section">
 										<div class="custom-control custom-checkbox">
 											<label>
 												<input class="custom-control-input" type="checkbox">
@@ -1283,12 +1293,15 @@ section: Components
 	$('input[type="checkbox"]').change(
 		function(event) {
 			$(this).closest('.dropdown-item').toggleClass('active', this.checked);
+			$(this).closest('.dropdown-section').toggleClass('active', this.checked);
 		}
 	);
 
 	$('input[type="radio"]').change(function(event) {
 		$(this).closest('.dropdown-menu').find('.dropdown-item').removeClass('active');
 		$(this).closest('.dropdown-item').toggleClass('active', this.checked);
+		$(this).closest('.dropdown-menu').find('.dropdown-section').removeClass('active');
+		$(this).closest('.dropdown-section').toggleClass('active', this.checked);
 	});
 
 	$('.input-group-inset').on('focusin', function(event) {

--- a/packages/clay-css/src/content/form_custom.html
+++ b/packages/clay-css/src/content/form_custom.html
@@ -216,7 +216,7 @@ section: Components
 		<h3>Custom Control Primary</h3>
 
 		<blockquote class="blockquote">
-			<p>Add <code>custom-control-primary</code> to a <code>custom-control</code> to increase the visual hierarchy of a <code>custom-control</code>? See <a href="https://github.com/liferay/clay/issues/2813" noreferrer noopener target="_blank">https://github.com/liferay/clay/issues/2813</a></p>
+			<p>Add <code>custom-control-primary</code> to a <code>custom-control</code> to increase the visual hierarchy (makes text bold) of a <code>custom-control</code>? See <a href="https://github.com/liferay/clay/issues/2813" noreferrer noopener target="_blank">https://github.com/liferay/clay/issues/2813</a></p>
 		</blockquote>
 
 <div class="sheet">

--- a/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
@@ -61,9 +61,10 @@ $custom-control-description-font-size: $input-label-font-size !default; // 13px
 
 $custom-control-description-font-weight: $font-weight-normal !default;
 
-/// @deprecated as of v2.19.0 use the Sass map `$custom-control-label-disabled` instead. This variable is not used in Clay CSS.
+/// @deprecated as of v2.19.0 use the Sass map `$custom-control-label-disabled-color` instead. This variable is not used in Clay CSS.
 
 $custom-control-description-disabled-color: $input-label-disabled-color !default;
+$custom-control-label-disabled-color: $custom-control-description-disabled-color !default;
 
 // @deprecated as of v2.19.0 use the Sass map `$custom-control-label-text-small` instead
 

--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -41,6 +41,21 @@ $dropdown-item-base: map-deep-merge((
 	disabled-box-shadow: none,
 ), $dropdown-item-base);
 
+$dropdown-section-custom-control-label: () !default;
+$dropdown-section-custom-control-label: map-deep-merge((
+	color: $secondary,
+), $dropdown-section-custom-control-label);
+
+$dropdown-section-active-custom-control-label: () !default;
+$dropdown-section-active-custom-control-label: map-deep-merge((
+	color: $gray-900,
+), $dropdown-section-active-custom-control-label);
+
+$dropdown-section-custom-control-label-text: () !default;
+$dropdown-section-custom-control-label-text: map-deep-merge((
+	padding-left: 1rem,
+), $dropdown-section-custom-control-label-text);
+
 $dropdown-divider-bg: $dropdown-border-color !default;
 
 // Autocomplete Dropdown Menu

--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -38,6 +38,7 @@ $dropdown-item-base: map-deep-merge((
 	focus-box-shadow: inset 0 0 0 0.125rem $primary-l1#{','} inset 0 0 0 0.25rem $white,
 	focus-outline: 0,
 	focus-text-decoration: none,
+	disabled-box-shadow: none,
 ), $dropdown-item-base);
 
 $dropdown-divider-bg: $dropdown-border-color !default;

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -73,6 +73,24 @@
 	.form-group + .form-group {
 		margin-top: $dropdown-item-padding-y * 2;
 	}
+
+	.custom-control {
+		@include clay-css($dropdown-section-custom-control);
+	}
+
+	.custom-control-label {
+		@include clay-css($dropdown-section-custom-control-label);
+	}
+
+	.custom-control-label-text {
+		@include clay-css($dropdown-section-custom-control-label-text);
+	}
+
+	&.active {
+		.custom-control-label {
+			@include clay-css($dropdown-section-active-custom-control-label);
+		}
+	}
 }
 
 .dropdown-menu {

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -180,8 +180,10 @@
 /// disabled-color: {Color | String | Null},
 /// disabled-cursor: {String | Null},
 /// disabled-opacity: {Number | String | Null},
+/// disabled-outline: {Number | String | Null},
 /// disabled-pointer-events: {String | Null},
 /// disabled-text-decoration: {String | Null},
+/// disabled-active-pointer-events: {String | Null},
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
@@ -241,8 +243,11 @@
 	$disabled-color: map-get($map, disabled-color);
 	$disabled-cursor: map-get($map, disabled-cursor);
 	$disabled-opacity: map-get($map, disabled-opacity);
+	$disabled-outline: map-get($map, disabled-outline);
 	$disabled-pointer-events: map-get($map, disabled-pointer-events);
 	$disabled-text-decoration: map-get($map, disabled-text-decoration);
+
+	$disabled-active-pointer-events: map-get($map, disabled-active-pointer-events);
 
 	@if ($enabled) {
 		background-color: $bg; // For `<button>`s set to `transparent` in Bootstrap
@@ -347,12 +352,17 @@
 			color: $disabled-color;
 			cursor: $disabled-cursor;
 			opacity: $disabled-opacity;
+			outline: $disabled-outline;
 			pointer-events: $disabled-pointer-events;
 			text-decoration: $disabled-text-decoration;
 
 			label,
 			.form-check-label {
 				color: $disabled-color;
+			}
+
+			&:active {
+				pointer-events: $disabled-active-pointer-events;
 			}
 		}
 

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -63,6 +63,9 @@ $dropdown-item-base: map-deep-merge((
 	disabled-color: $dropdown-link-disabled-color,
 	disabled-cursor: $dropdown-item-disabled-cursor,
 	disabled-opacity: 1,
+	disabled-outline: 0,
+	disabled-pointer-events: auto,
+	disabled-active-pointer-events: none,
 ), $dropdown-item-base);
 
 // Autocomplete Dropdown Menu

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -68,6 +68,17 @@ $dropdown-item-base: map-deep-merge((
 	disabled-active-pointer-events: none,
 ), $dropdown-item-base);
 
+$dropdown-section-custom-control: () !default;
+$dropdown-section-custom-control: map-deep-merge((
+	margin-bottom: 0,
+), $dropdown-section-custom-control);
+
+$dropdown-section-custom-control-label: () !default;
+
+$dropdown-section-custom-control-label-text: () !default;
+
+$dropdown-section-active-custom-control-label: () !default;
+
 // Autocomplete Dropdown Menu
 
 $autocomplete-dropdown-menu: () !default;


### PR DESCRIPTION
The only thing that needs to happen in Clay Dropdown is changing `dropdown-item` to `dropdown-section` for any `custom-control` components.