### PR TITLE
feat(clay-css): Atlas Global Variables make `h1` - `h6` font sizes th…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -50,6 +50,13 @@ $font-family-sans-serif: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI
 
 $headings-font-weight: $font-weight-bold !default;
 
+$h1-font-size: 1.625rem !default; // 26px
+$h2-font-size: 1.375rem !default; // 22px
+$h3-font-size: 1.1875rem !default; // 19px
+$h4-font-size: 1rem !default; // 16px
+$h5-font-size: 0.875rem !default; // 14px
+$h6-font-size: 0.8125rem !default; // 13px
+
 // Theme Base Colors
 
 $white: #FFF !default;


### PR DESCRIPTION
…e same as 2.x

fixes #2864