### PR TITLE
fix(clay-css): Adds `!optional` flag to `@extend` for components that…

### DIFF
--- a/packages/clay-css/src/scss/components/_button-groups.scss
+++ b/packages/clay-css/src/scss/components/_button-groups.scss
@@ -45,7 +45,7 @@
 
 .btn-group-lg {
 	.btn-group > .btn {
-		@extend .btn-lg;
+		@extend .btn-lg !optional;
 	}
 
 	.btn-monospaced {
@@ -55,7 +55,7 @@
 
 .btn-group-sm {
 	.btn-group > .btn {
-		@extend .btn-sm;
+		@extend .btn-sm !optional;
 	}
 
 	.btn-monospaced {

--- a/packages/clay-css/src/scss/components/_cards.scss
+++ b/packages/clay-css/src/scss/components/_cards.scss
@@ -419,7 +419,7 @@
 // Card Page
 
 .card-page {
-	@extend %clay-custom-grid-wrapper;
+	@extend %clay-custom-grid-wrapper !optional;
 
 	&.card-page-equal-height {
 		.card-page-item,

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -589,7 +589,7 @@ textarea.form-control-sm,
 	}
 
 	.btn {
-		@extend %clay-btn-sm;
+		@extend %clay-btn-sm !optional;
 	}
 
 	.form-control,

--- a/packages/clay-css/src/scss/components/_menubar.scss
+++ b/packages/clay-css/src/scss/components/_menubar.scss
@@ -3,7 +3,7 @@
 }
 
 .menubar-toggler {
-	@extend %btn-unstyled;
+	@extend %btn-unstyled !optional;
 
 	display: none;
 }

--- a/packages/clay-css/src/scss/components/_stickers.scss
+++ b/packages/clay-css/src/scss/components/_stickers.scss
@@ -42,8 +42,8 @@
 }
 
 .sticker-img {
-	@extend %aspect-ratio-item-center-middle;
-	@extend %aspect-ratio-item-fluid;
+	@extend %aspect-ratio-item-center-middle !optional;
+	@extend %aspect-ratio-item-fluid !optional;
 }
 
 .sticker-overlay {

--- a/packages/clay-css/src/scss/components/_tbar.scss
+++ b/packages/clay-css/src/scss/components/_tbar.scss
@@ -34,7 +34,7 @@
 }
 
 .tbar-item {
-	@extend %autofit-col;
+	@extend %autofit-col !optional;
 
 	max-width: 100%;
 	padding-bottom: $tbar-item-padding-y;
@@ -52,13 +52,13 @@
 }
 
 .tbar-item-expand {
-	@extend %autofit-col-expand;
+	@extend %autofit-col-expand !optional;
 
 	text-align: center;
 }
 
 .tbar-section {
-	@extend %autofit-section;
+	@extend %autofit-section !optional;
 }
 
 .tbar-link {


### PR DESCRIPTION
… are extending selectors/placeholders outside of their respective component file

fixes #2881