### PR TITLE
feat(@clayui.com): Icon Filtering

### DIFF
--- a/clayui.com/content/docs/components/css-icons.mdx
+++ b/clayui.com/content/docs/components/css-icons.mdx
@@ -3,10 +3,15 @@ title: 'Icons'
 description: 'Icons are a visual representation of an idea and/or action.'
 ---
 
+import IconSearch from '../../../src/components/IconSearch';
+import icons from '../../../static/js/icons.json';
+import flags from '../../../static/js/flags.json';
+
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
 -   [Usage](#usage)
+-   [Icon List](#icon-list)
 -   [Language Flags](#language-flags)
 -   [SVG Icons as Background Images](#svg-icons-as-background-images)
 -   [Clay-SVG-url()](<#clay-svg-url()>)
@@ -16,11 +21,22 @@ description: 'Icons are a visual representation of an idea and/or action.'
 </div>
 
 <div class="clay-site-alert alert alert-info">
-	Check the <a href="https://liferay.design/lexicon">Lexicon</a> <a href="https://liferay.design/lexicon/core-components/icons/">Icons Pattern</a> for a more in-depth look at the motivations and proper usage of this component.
+	Check the <a href="https://liferay.design/lexicon">Lexicon</a>{' '}
+	<a href="https://liferay.design/lexicon/core-components/icons/">
+		Icons Pattern
+	</a>{' '}
+	for a more in-depth look at the motivations and proper usage of this
+	component.
 </div>
 
 <div class="clay-site-alert alert alert-warning">
-	See the implementation of the <a href="/docs/components/icons.html">Icons component in React</a> following the Lexicon <a href="https://liferay.design/lexicon/core-components/icons/">Icons Pattern</a>.
+	See the implementation of the{' '}
+	<a href="/docs/components/icons.html">Icons component in React</a> following
+	the Lexicon{' '}
+	<a href="https://liferay.design/lexicon/core-components/icons/">
+		Icons Pattern
+	</a>
+	.
 </div>
 
 ## Usage
@@ -39,9 +55,9 @@ We use SVG elements that link to an SVG sprite, like so:
 
 Note that the ID after the # symbol is the ID of the icon to use, so if you wanted to use plus icon, you would do change the href to `path/to/icons.svg#plus`.
 
-<ul class="lexicon-icon-list list-unstyled">
-	[foreach Icons]
-</ul>
+## Icon List
+
+<IconSearch source={icons} />
 
 ## Language Flags
 
@@ -53,9 +69,12 @@ Or, to paraphrase Winston Churchill, "Using flags is the worst system for indica
 
 To use the flags below, follow the same process as you would for a standard icon, and use the locale and country code indicated in parenthesis for the icon's name (e.g. to use the Japanese icon, you would use `ja-jp`)
 
-<ul class="lexicon-icon-list list-unstyled">
-	[foreach Flags]
-</ul>
+<IconSearch
+	label="Search Flags"
+	placeholder="Search Flags..."
+	source={flags}
+	type="flags"
+/>
 
 ### SVG Icons as Background Images
 
@@ -75,7 +94,8 @@ We have created a Sass function to turn Lexicon SVG icon's into data uri schemes
 You can turn your custom SVG into a data uri using the Sass function `clay-svg-url($svg)`, where `$svg` is the code for your inline SVG. The function returns `url(your_svg_as_data_uri)`.
 
 <div class="alert alert-info">
-	When using `clay-svg-url()`, wrap your inline SVG code with single quotes if your SVG's attributes are delimited with double quotes.
+	When using `clay-svg-url()`, wrap your inline SVG code with single quotes if
+	your SVG's attributes are delimited with double quotes.
 </div>
 
 <span class="clay-site-linux-tux clay-site-svg-bg">Linux Tux</span>
@@ -83,9 +103,11 @@ You can turn your custom SVG into a data uri using the Sass function `clay-svg-u
 ## Why do we use SVG
 
 <p id="lexicon-icon-explanation">
-  Font icons, while fairly simple, suffer drawbacks, such as sub-pixel aliasing. This results in a lower quality than we would like.
-	SVG gives us and you a greater amount of freedom in styling the icons, as well as a higher level of fidelity and clarity in the icons.
-	Also, SVG supports multi-color icons, as shown below:
+	Font icons, while fairly simple, suffer drawbacks, such as sub-pixel
+	aliasing. This results in a lower quality than we would like. SVG gives us
+	and you a greater amount of freedom in styling the icons, as well as a
+	higher level of fidelity and clarity in the icons. Also, SVG supports
+	multi-color icons, as shown below:
 </p>
 
 <div class="lexicon-icon-examples">

--- a/clayui.com/content/docs/components/css-icons.mdx
+++ b/clayui.com/content/docs/components/css-icons.mdx
@@ -69,12 +69,8 @@ Or, to paraphrase Winston Churchill, "Using flags is the worst system for indica
 
 To use the flags below, follow the same process as you would for a standard icon, and use the locale and country code indicated in parenthesis for the icon's name (e.g. to use the Japanese icon, you would use `ja-jp`)
 
-export function flagLabelFormatter(icon) {
-	return icon.aliases.join(' - ');
-}
-
 <IconSearch
-	iconLabelFormatter={flagLabelFormatter}
+	iconLabelFormatter={icon => icon.aliases.join(' - ')}
 	label="Search Flags"
 	placeholder="Search Flags..."
 	source={flags}

--- a/clayui.com/content/docs/components/css-icons.mdx
+++ b/clayui.com/content/docs/components/css-icons.mdx
@@ -69,11 +69,15 @@ Or, to paraphrase Winston Churchill, "Using flags is the worst system for indica
 
 To use the flags below, follow the same process as you would for a standard icon, and use the locale and country code indicated in parenthesis for the icon's name (e.g. to use the Japanese icon, you would use `ja-jp`)
 
+export function flagLabelFormatter(icon) {
+	return icon.aliases.join(' - ');
+}
+
 <IconSearch
+	iconLabelFormatter={flagLabelFormatter}
 	label="Search Flags"
 	placeholder="Search Flags..."
 	source={flags}
-	type="flags"
 />
 
 ### SVG Icons as Background Images

--- a/clayui.com/content/docs/components/icon.mdx
+++ b/clayui.com/content/docs/components/icon.mdx
@@ -6,6 +6,8 @@ sibling: 'docs/components/css-icons.html'
 ---
 
 import {Icon, IconWithContext} from '../../../src/components/clay/Icon';
+import IconSearch from '../../../src/components/IconSearch';
+import icons from '../../../static/js/icons.json';
 
 <div class="nav-toc-absolute">
 <div class="nav-toc">
@@ -16,6 +18,8 @@ import {Icon, IconWithContext} from '../../../src/components/clay/Icon';
 
 </div>
 </div>
+
+<IconSearch source={icons} />
 
 <div class="clay-site-alert alert alert-warning">
 	Take a look at our{' '}

--- a/clayui.com/src/components/IconSearch/index.js
+++ b/clayui.com/src/components/IconSearch/index.js
@@ -1,0 +1,84 @@
+/**
+ * © 2020 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayForm, {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import React, {useMemo, useState} from 'react';
+
+const spritemap = '/images/icons/icons.svg';
+
+/**
+ * Component that allows searching through icons
+ * @param {string} label - Label of the search input field.
+ * @param {string} placeholder - Placeholder of the search input field.
+ * @param {Array[Object]} source - Path to the source JSON. Needs to follow pattern of [{name: String, aliases: Array<String>}]
+ * @param {string} type - Type of icons being provided, supports "icons" and "flags"
+ */
+const IconSearch = ({
+	label = 'Search Icons',
+	placeholder = 'Search Icons...',
+	source,
+	type = 'icons',
+}) => {
+	const [searchQuery, setSearchQuery] = useState('');
+	let list = [];
+
+	const filteredIcons = useMemo(() => {
+		const query = searchQuery.toLowerCase();
+
+		return source.filter(
+			({aliases, name}) =>
+				name.toLowerCase().includes(query) ||
+				aliases.some(alias => alias.toLowerCase().includes(query))
+		);
+	}, [searchQuery]);
+
+	if (filteredIcons.length) {
+		list = filteredIcons;
+	} else {
+		list = searchQuery ? [] : source;
+	}
+
+	return (
+		<>
+			<ClayForm.Group>
+				<label style={{width: '100%'}}>
+					{label}
+
+					<ClayInput
+						onChange={event => setSearchQuery(event.target.value)}
+						placeholder={placeholder}
+						type="text"
+						value={searchQuery}
+					/>
+				</label>
+
+				<ul className="lexicon-icon-list list-unstyled">
+					{list.map(icon => (
+						<li key={icon.name}>
+							<ClayIcon
+								spritemap={spritemap}
+								symbol={icon.name}
+							/>
+
+							<span>
+								{type === 'flags'
+									? icon.aliases.join(' - ')
+									: icon.name}
+							</span>
+						</li>
+					))}
+				</ul>
+
+				{!list.length && (
+					<span>{`No results found for ${searchQuery}`}</span>
+				)}
+			</ClayForm.Group>
+		</>
+	);
+};
+
+export default IconSearch;

--- a/clayui.com/src/components/IconSearch/index.js
+++ b/clayui.com/src/components/IconSearch/index.js
@@ -24,7 +24,6 @@ const IconSearch = ({
 	iconLabelFormatter = icon => icon.name,
 }) => {
 	const [searchQuery, setSearchQuery] = useState('');
-	let list = [];
 
 	const filteredIcons = useMemo(() => {
 		const query = searchQuery.toLowerCase();
@@ -36,11 +35,7 @@ const IconSearch = ({
 		);
 	}, [searchQuery, source]);
 
-	if (filteredIcons.length) {
-		list = filteredIcons;
-	} else {
-		list = searchQuery ? [] : source;
-	}
+	const list = searchQuery ? filteredIcons : source;
 
 	return (
 		<>

--- a/clayui.com/src/components/IconSearch/index.js
+++ b/clayui.com/src/components/IconSearch/index.js
@@ -21,7 +21,7 @@ const IconSearch = ({
 	label = 'Search Icons',
 	placeholder = 'Search Icons...',
 	source,
-	type = 'icons',
+	iconLabelFormatter = icon => icon.name,
 }) => {
 	const [searchQuery, setSearchQuery] = useState('');
 	let list = [];
@@ -34,7 +34,7 @@ const IconSearch = ({
 				name.toLowerCase().includes(query) ||
 				aliases.some(alias => alias.toLowerCase().includes(query))
 		);
-	}, [searchQuery]);
+	}, [searchQuery, source]);
 
 	if (filteredIcons.length) {
 		list = filteredIcons;
@@ -64,11 +64,7 @@ const IconSearch = ({
 								symbol={icon.name}
 							/>
 
-							<span>
-								{type === 'flags'
-									? icon.aliases.join(' - ')
-									: icon.name}
-							</span>
+							<span>{iconLabelFormatter(icon)}</span>
 						</li>
 					))}
 				</ul>

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -254,15 +254,15 @@ export default props => {
 															}
 														</p>
 													)}
-													{tab.html && (
+													{tab && tab.html && (
 														<div
 															dangerouslySetInnerHTML={{
 																__html:
-																	mdTab.html,
+																	tab.html,
 															}}
 														/>
 													)}
-													{tab.code && (
+													{tab && tab.code && (
 														<article>
 															<CodeClipboard>
 																<MDXProvider
@@ -294,7 +294,7 @@ export default props => {
 																>
 																	<MDXRenderer>
 																		{
-																			mdxTab
+																			tab
 																				.code
 																				.body
 																		}

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -23,11 +23,18 @@ export default props => {
 		location,
 		pageContext: {blacklist = [], markdownJsx},
 	} = props;
-	const {allMarkdownRemark, allMdx, markdownRemark, mdx, tabs} = data;
+	const {
+		allMarkdownRemark,
+		allMdx,
+		markdownRemark,
+		mdTab,
+		mdx,
+		mdxTab,
+	} = data;
 	const {code, excerpt, fields, frontmatter, html, timeToRead} =
 		mdx || markdownRemark;
 
-	const hasTabs = tabs.edges.length > 0;
+	const tab = mdTab || mdxTab;
 
 	const title = `${frontmatter.title} - Clay`;
 
@@ -99,13 +106,8 @@ export default props => {
 													</p>
 												)}
 											</div>
-											{!hasTabs && (
-												<div className="col-12">
-													<hr className="clay-site-separator" />
-												</div>
-											)}
-											{hasTabs && (
-												<div className="col-12">
+											<div className="col-12">
+												{tab ? (
 													<ul
 														className="border-bottom nav nav-clay nav-underline"
 														role="tablist"
@@ -138,8 +140,10 @@ export default props => {
 															</a>
 														</li>
 													</ul>
-												</div>
-											)}
+												) : (
+													<hr className="clay-site-separator" />
+												)}
+											</div>
 										</div>
 									</div>
 								</header>
@@ -250,16 +254,54 @@ export default props => {
 															}
 														</p>
 													)}
-													{hasTabs && (
+													{tab.html && (
 														<div
 															dangerouslySetInnerHTML={{
 																__html:
-																	tabs
-																		.edges[0]
-																		.node
-																		.html,
+																	mdTab.html,
 															}}
 														/>
+													)}
+													{tab.code && (
+														<article>
+															<CodeClipboard>
+																<MDXProvider
+																	components={{
+																		h1:
+																			Typography.H1,
+																		h2:
+																			Typography.H2,
+																		h3:
+																			Typography.H3,
+																		h4:
+																			Typography.H4,
+																		p:
+																			Typography.P,
+																		ul: props => (
+																			<ul
+																				className={
+																					props.className
+																						? props.className
+																						: 'clay-ul'
+																				}
+																			>
+																				{
+																					props.children
+																				}
+																			</ul>
+																		),
+																	}}
+																>
+																	<MDXRenderer>
+																		{
+																			mdxTab
+																				.code
+																				.body
+																		}
+																	</MDXRenderer>
+																</MDXProvider>
+															</CodeClipboard>
+														</article>
 													)}
 												</div>
 											</div>
@@ -369,11 +411,12 @@ export const pageQuery = graphql`
 				}
 			}
 		}
-		tabs: allMarkdownRemark(filter: {fields: {slug: {eq: $sibling}}}) {
-			edges {
-				node {
-					html
-				}
+		mdTab: markdownRemark(fields: {slug: {eq: $sibling}}) {
+			html
+		}
+		mdxTab: mdx(fields: {slug: {eq: $sibling}}) {
+			code {
+				body
 			}
 		}
 	}

--- a/clayui.com/static/js/flags.json
+++ b/clayui.com/static/js/flags.json
@@ -2,393 +2,393 @@
 	{
 		"name": "ar-sa",
 		"aliases": [
-            "Arabic",
+			"Arabic",
 			"Saudi Arabia",
 			"ar-sa"
-        ]
+		]
 	},
 	{
 		"name": "bg-bg",
 		"aliases": [
-            "Bulgarian",
+			"Bulgarian",
 			"Bulgaria",
 			"bg-bg"
-        ]
+		]
 	},
 	{
 		"name": "ca-ad",
 		"aliases": [
-            "Catalan",
+			"Catalan",
 			"Andorra",
 			"ca-ad"
-        ]
+		]
 	},
 	{
 		"name": "ca-es",
 		"aliases": [
-            "Catalan",
+			"Catalan",
 			"Spain",
 			"ca-es"
-        ]
+		]
 	},
 	{
 		"name": "cs-cz",
 		"aliases": [
-            "Czech",
+			"Czech",
 			"Czech Republic",
 			"cs-cz"
-        ]
+		]
 	},
 	{
 		"name": "da-dk",
 		"aliases": [
-            "Danish",
+			"Danish",
 			"Denmark",
 			"da-dk"
-        ]
+		]
 	},
 	{
 		"name": "de-de",
 		"aliases": [
-            "German",
+			"German",
 			"Germany",
 			"de-de"
-        ]
+		]
 	},
 	{
 		"name": "el-gr",
 		"aliases": [
-            "Greek",
+			"Greek",
 			"Greece",
 			"el-gr"
-        ]
+		]
 	},
 	{
 		"name": "en-au",
 		"aliases": [
-            "English",
+			"English",
 			"Australia",
 			"en-au"
-        ]
+		]
 	},
 	{
 		"name": "en-gb",
 		"aliases": [
-            "English",
+			"English",
 			"United Kingdom",
 			"en-gb"
-        ]
+		]
 	},
 	{
 		"name": "en-us",
 		"aliases": [
-            "English",
+			"English",
 			"United States",
 			"en-us"
-        ]
+		]
 	},
 	{
 		"name": "es-es",
 		"aliases": [
-            "Spanish",
+			"Spanish",
 			"Spain",
 			"es-es"
-        ]
+		]
 	},
 	{
 		"name": "et-ee",
 		"aliases": [
-            "Estonian",
+			"Estonian",
 			"Estonia",
 			"et-ee"
-        ]
+		]
 	},
 	{
 		"name": "eu-es",
 		"aliases": [
-            "Basque",
+			"Basque",
 			"Spain",
 			"eu-es"
-        ]
+		]
 	},
 	{
 		"name": "fa-ir",
 		"aliases": [
-            "Persian",
+			"Persian",
 			"Iran",
 			"fa-ir"
-        ]
+		]
 	},
 	{
 		"name": "fi-fi",
 		"aliases": [
-            "Finnish",
+			"Finnish",
 			"Finland",
 			"fi-fi"
-        ]
+		]
 	},
 	{
 		"name": "fr-ca",
 		"aliases": [
-            "French",
+			"French",
 			"Canada",
 			"fr-ca"
-        ]
+		]
 	},
 	{
 		"name": "fr-fr",
 		"aliases": [
-            "French",
+			"French",
 			"France",
 			"fr-fr"
-        ]
+		]
 	},
 	{
 		"name": "gl-es",
 		"aliases": [
-            "Galician",
+			"Galician",
 			"Spain",
 			"gl-es"
-        ]
+		]
 	},
 	{
 		"name": "hi-in",
 		"aliases": [
-            "Hindi",
+			"Hindi",
 			"India",
 			"hi-in"
-        ]
+		]
 	},
 	{
 		"name": "hr-hr",
 		"aliases": [
-            "Croatian",
+			"Croatian",
 			"Croatia",
 			"hr-hr"
-        ]
+		]
 	},
 	{
 		"name": "hu-hu",
 		"aliases": [
-            "Hungarian",
+			"Hungarian",
 			"Hungary",
 			"hu-hu"
-        ]
+		]
 	},
 	{
 		"name": "in-id",
 		"aliases": [
-            "Indonesian",
+			"Indonesian",
 			"Indonesia",
 			"in-id"
-        ]
+		]
 	},
 	{
 		"name": "it-it",
 		"aliases": [
-            "Italian",
+			"Italian",
 			"Italy",
 			"it-it"
-        ]
+		]
 	},
 	{
 		"name": "iw-il",
 		"aliases": [
-            "Hebrew",
+			"Hebrew",
 			"Israel",
 			"iw-il"
-        ]
+		]
 	},
 	{
 		"name": "ja-jp",
 		"aliases": [
-            "Japanese",
+			"Japanese",
 			"Japan",
 			"ja-jp"
-        ]
+		]
 	},
 	{
 		"name": "kk-kz",
 		"aliases": [
-            "Kazakh",
+			"Kazakh",
 			"Kazakhstan",
 			"kk-kz"
-        ]
+		]
 	},
 	{
 		"name": "ko-kr",
 		"aliases": [
-            "Korean",
-		"South Korea",
-		"ko-kr"
-        ]
+			"Korean",
+			"South Korea",
+			"ko-kr"
+		]
 	},
 	{
 		"name": "lo-la",
 		"aliases": [
-            "Laotian",
+			"Laotian",
 			"Laos",
 			"lo-la"
-        ]
+		]
 	},
 	{
 		"name": "lt-lt",
 		"aliases": [
-            "Lithuanian",
+			"Lithuanian",
 			"Lithuania",
 			"lt-lt"
-        ]
+		]
 	},
 	{
 		"name": "nb-no",
 		"aliases": [
-            "Norwegian",
+			"Norwegian",
 			"Norway",
 			"nb-no"
-        ]
+		]
 	},
 	{
 		"name": "nl-be",
 		"aliases": [
-            "Dutch",
+			"Dutch",
 			"Belgium",
 			"nl-be"
-        ]
+		]
 	},
 	{
 		"name": "nl-nl",
 		"aliases": [
-            "Dutch",
+			"Dutch",
 			"Netherlands",
 			"nl-nl"
-        ]
+		]
 	},
 	{
 		"name": "pl-pl",
 		"aliases": [
-            "Polish",
+			"Polish",
 			"Poland",
 			"pl-pl"
-        ]
+		]
 	},
 	{
 		"name": "pt-br",
 		"aliases": [
-            "Portuguese",
+			"Portuguese",
 			"Brazil",
 			"pt-br"
-        ]
+		]
 	},
 	{
 		"name": "pt-pt",
 		"aliases": [
-            "Portuguese",
+			"Portuguese",
 			"Portugal",
 			"pt-pt"
-        ]
+		]
 	},
 	{
 		"name": "ro-ro",
 		"aliases": [
-            "Romanian",
+			"Romanian",
 			"Romania",
 			"ro-ro"
-        ]
+		]
 	},
 	{
 		"name": "ru-ru",
 		"aliases": [
-            "Russian",
+			"Russian",
 			"Russia",
 			"ru-ru"
-        ]
+		]
 	},
 	{
 		"name": "sk-sk",
 		"aliases": [
-            "Slovak",
+			"Slovak",
 			"Slovakia",
 			"sk-sk"
-        ]
+		]
 	},
 	{
 		"name": "sl-si",
 		"aliases": [
-            "Slovenian",
+			"Slovenian",
 			"Slovenia",
 			"sl-si"
-        ]
+		]
 	},
 	{
 		"name": "sr-rs",
 		"aliases": [
-            "Serbian",
+			"Serbian",
 			"Serbia",
 			"sr-rs"
-        ]
+		]
 	},
 	{
 		"name": "sv-se",
 		"aliases": [
-            "Swedish",
+			"Swedish",
 			"Sweden",
 			"sv-se"
-        ]
+		]
 	},
 	{
 		"name": "ta-in",
 		"aliases": [
-            "Tamil",
+			"Tamil",
 			"India",
 			"ta-in"
-        ]
+		]
 	},
 	{
 		"name": "th-th",
 		"aliases": [
-            "Thai",
+			"Thai",
 			"Thailand",
 			"th-th"
-        ]
+		]
 	},
 	{
 		"name": "tr-tr",
 		"aliases": [
-            "Turkish",
+			"Turkish",
 			"Turkey",
 			"tr-tr"
-        ]
+		]
 	},
 	{
 		"name": "uk-ua",
 		"aliases": [
-            "Ukrainian",
+			"Ukrainian",
 			"Ukraine",
 			"uk-ua"
-        ]
+		]
 	},
 	{
 		"name": "vi-vn",
 		"aliases": [
-            "Vietnamese",
+			"Vietnamese",
 			"Vietnam",
 			"vi-vn"
-        ]
+		]
 	},
 	{
 		"name": "zh-cn",
 		"aliases": [
-            "Chinese",
+			"Chinese",
 			"China",
 			"zh-cn"
-        ]
+		]
 	},
 	{
 		"name": "zh-tw",
 		"aliases": [
-            "Chinese",
+			"Chinese",
 			"Taiwan",
 			"zh-tw"
-        ]
+		]
 	}
 ]

--- a/clayui.com/static/js/flags.json
+++ b/clayui.com/static/js/flags.json
@@ -1,0 +1,394 @@
+[
+	{
+		"name": "ar-sa",
+		"aliases": [
+            "Arabic",
+			"Saudi Arabia",
+			"ar-sa"
+        ]
+	},
+	{
+		"name": "bg-bg",
+		"aliases": [
+            "Bulgarian",
+			"Bulgaria",
+			"bg-bg"
+        ]
+	},
+	{
+		"name": "ca-ad",
+		"aliases": [
+            "Catalan",
+			"Andorra",
+			"ca-ad"
+        ]
+	},
+	{
+		"name": "ca-es",
+		"aliases": [
+            "Catalan",
+			"Spain",
+			"ca-es"
+        ]
+	},
+	{
+		"name": "cs-cz",
+		"aliases": [
+            "Czech",
+			"Czech Republic",
+			"cs-cz"
+        ]
+	},
+	{
+		"name": "da-dk",
+		"aliases": [
+            "Danish",
+			"Denmark",
+			"da-dk"
+        ]
+	},
+	{
+		"name": "de-de",
+		"aliases": [
+            "German",
+			"Germany",
+			"de-de"
+        ]
+	},
+	{
+		"name": "el-gr",
+		"aliases": [
+            "Greek",
+			"Greece",
+			"el-gr"
+        ]
+	},
+	{
+		"name": "en-au",
+		"aliases": [
+            "English",
+			"Australia",
+			"en-au"
+        ]
+	},
+	{
+		"name": "en-gb",
+		"aliases": [
+            "English",
+			"United Kingdom",
+			"en-gb"
+        ]
+	},
+	{
+		"name": "en-us",
+		"aliases": [
+            "English",
+			"United States",
+			"en-us"
+        ]
+	},
+	{
+		"name": "es-es",
+		"aliases": [
+            "Spanish",
+			"Spain",
+			"es-es"
+        ]
+	},
+	{
+		"name": "et-ee",
+		"aliases": [
+            "Estonian",
+			"Estonia",
+			"et-ee"
+        ]
+	},
+	{
+		"name": "eu-es",
+		"aliases": [
+            "Basque",
+			"Spain",
+			"eu-es"
+        ]
+	},
+	{
+		"name": "fa-ir",
+		"aliases": [
+            "Persian",
+			"Iran",
+			"fa-ir"
+        ]
+	},
+	{
+		"name": "fi-fi",
+		"aliases": [
+            "Finnish",
+			"Finland",
+			"fi-fi"
+        ]
+	},
+	{
+		"name": "fr-ca",
+		"aliases": [
+            "French",
+			"Canada",
+			"fr-ca"
+        ]
+	},
+	{
+		"name": "fr-fr",
+		"aliases": [
+            "French",
+			"France",
+			"fr-fr"
+        ]
+	},
+	{
+		"name": "gl-es",
+		"aliases": [
+            "Galician",
+			"Spain",
+			"gl-es"
+        ]
+	},
+	{
+		"name": "hi-in",
+		"aliases": [
+            "Hindi",
+			"India",
+			"hi-in"
+        ]
+	},
+	{
+		"name": "hr-hr",
+		"aliases": [
+            "Croatian",
+			"Croatia",
+			"hr-hr"
+        ]
+	},
+	{
+		"name": "hu-hu",
+		"aliases": [
+            "Hungarian",
+			"Hungary",
+			"hu-hu"
+        ]
+	},
+	{
+		"name": "in-id",
+		"aliases": [
+            "Indonesian",
+			"Indonesia",
+			"in-id"
+        ]
+	},
+	{
+		"name": "it-it",
+		"aliases": [
+            "Italian",
+			"Italy",
+			"it-it"
+        ]
+	},
+	{
+		"name": "iw-il",
+		"aliases": [
+            "Hebrew",
+			"Israel",
+			"iw-il"
+        ]
+	},
+	{
+		"name": "ja-jp",
+		"aliases": [
+            "Japanese",
+			"Japan",
+			"ja-jp"
+        ]
+	},
+	{
+		"name": "kk-kz",
+		"aliases": [
+            "Kazakh",
+			"Kazakhstan",
+			"kk-kz"
+        ]
+	},
+	{
+		"name": "ko-kr",
+		"aliases": [
+            "Korean",
+		"South Korea",
+		"ko-kr"
+        ]
+	},
+	{
+		"name": "lo-la",
+		"aliases": [
+            "Laotian",
+			"Laos",
+			"lo-la"
+        ]
+	},
+	{
+		"name": "lt-lt",
+		"aliases": [
+            "Lithuanian",
+			"Lithuania",
+			"lt-lt"
+        ]
+	},
+	{
+		"name": "nb-no",
+		"aliases": [
+            "Norwegian",
+			"Norway",
+			"nb-no"
+        ]
+	},
+	{
+		"name": "nl-be",
+		"aliases": [
+            "Dutch",
+			"Belgium",
+			"nl-be"
+        ]
+	},
+	{
+		"name": "nl-nl",
+		"aliases": [
+            "Dutch",
+			"Netherlands",
+			"nl-nl"
+        ]
+	},
+	{
+		"name": "pl-pl",
+		"aliases": [
+            "Polish",
+			"Poland",
+			"pl-pl"
+        ]
+	},
+	{
+		"name": "pt-br",
+		"aliases": [
+            "Portuguese",
+			"Brazil",
+			"pt-br"
+        ]
+	},
+	{
+		"name": "pt-pt",
+		"aliases": [
+            "Portuguese",
+			"Portugal",
+			"pt-pt"
+        ]
+	},
+	{
+		"name": "ro-ro",
+		"aliases": [
+            "Romanian",
+			"Romania",
+			"ro-ro"
+        ]
+	},
+	{
+		"name": "ru-ru",
+		"aliases": [
+            "Russian",
+			"Russia",
+			"ru-ru"
+        ]
+	},
+	{
+		"name": "sk-sk",
+		"aliases": [
+            "Slovak",
+			"Slovakia",
+			"sk-sk"
+        ]
+	},
+	{
+		"name": "sl-si",
+		"aliases": [
+            "Slovenian",
+			"Slovenia",
+			"sl-si"
+        ]
+	},
+	{
+		"name": "sr-rs",
+		"aliases": [
+            "Serbian",
+			"Serbia",
+			"sr-rs"
+        ]
+	},
+	{
+		"name": "sv-se",
+		"aliases": [
+            "Swedish",
+			"Sweden",
+			"sv-se"
+        ]
+	},
+	{
+		"name": "ta-in",
+		"aliases": [
+            "Tamil",
+			"India",
+			"ta-in"
+        ]
+	},
+	{
+		"name": "th-th",
+		"aliases": [
+            "Thai",
+			"Thailand",
+			"th-th"
+        ]
+	},
+	{
+		"name": "tr-tr",
+		"aliases": [
+            "Turkish",
+			"Turkey",
+			"tr-tr"
+        ]
+	},
+	{
+		"name": "uk-ua",
+		"aliases": [
+            "Ukrainian",
+			"Ukraine",
+			"uk-ua"
+        ]
+	},
+	{
+		"name": "vi-vn",
+		"aliases": [
+            "Vietnamese",
+			"Vietnam",
+			"vi-vn"
+        ]
+	},
+	{
+		"name": "zh-cn",
+		"aliases": [
+            "Chinese",
+			"China",
+			"zh-cn"
+        ]
+	},
+	{
+		"name": "zh-tw",
+		"aliases": [
+            "Chinese",
+			"Taiwan",
+			"zh-tw"
+        ]
+	}
+]

--- a/clayui.com/static/js/icons.json
+++ b/clayui.com/static/js/icons.json
@@ -1,0 +1,1855 @@
+﻿[
+    {
+        "name": "add-cell",
+        "aliases": [
+            "squares",
+            "grid",
+            "table",
+            "center",
+            "excel"
+        ]
+    },
+    {
+        "name": "add-column",
+        "aliases": [
+            "cell",
+            "squares",
+            "grid",
+            "table",
+            "center",
+            "vertical",
+            "excel"
+        ]
+    },
+    {
+        "name": "add-row",
+        "aliases": [
+            "cell",
+            "squares",
+            "grid",
+            "table",
+            "center",
+            "horizontal",
+            "excel"
+        ]
+    },
+    {
+        "name": "adjust",
+        "aliases": [
+            "circle",
+            "half",
+            "effects",
+            "contrast",
+            "settings",
+            "editor"
+        ]
+    },
+    {
+        "name": "align-center",
+        "aliases": [
+            "texts",
+            "lines",
+            "editor"
+        ]
+    },
+    {
+        "name": "align-justify",
+        "aliases": [
+            "texts",
+            "lines",
+            "editor"
+        ]
+    },
+    {
+        "name": "align-left",
+        "aliases": [
+            "texts",
+            "lines",
+            "editor"
+        ]
+    },
+    {
+        "name": "align-right",
+        "aliases": [
+            "texts",
+            "lines",
+            "editor"
+        ]
+    },
+    {
+        "name": "analytics",
+        "aliases": [
+            "grow",
+            "arrow",
+            "increase",
+            "bar",
+            "data",
+            "expand"
+        ]
+    },
+    {
+        "name": "angle-down",
+        "aliases": [
+            "arrow",
+            "bottom",
+            "chevron"
+        ]
+    },
+    {
+        "name": "angle-left",
+        "aliases": [
+            "arrow",
+            "chevron"
+        ]
+    },
+    {
+        "name": "angle-right",
+        "aliases": [
+            "arrow",
+            "chevron"
+        ]
+    },
+    {
+        "name": "angle-up",
+        "aliases": [
+            "arrow",
+            "top",
+            "chevron"
+        ]
+    },
+    {
+        "name": "api-lock",
+        "aliases": [
+            "security",
+            "access",
+            "login"
+        ]
+    },
+    {
+        "name": "api-web",
+        "aliases": [
+            "world",
+            "globe"
+        ]
+    },
+    {
+        "name": "archive",
+        "aliases": [
+            "box",
+            "stock"
+        ]
+    },
+    {
+        "name": "asterisk",
+        "aliases": [
+            "required",
+            "*",
+            "mandatory"
+        ]
+    },
+    {
+        "name": "audio",
+        "aliases": [
+            "sound",
+            "music",
+            "note"
+        ]
+    },
+    {
+        "name": "autosize",
+        "aliases": [
+            "resize",
+            "fullscreen",
+            "expand",
+            "arrows",
+            "box"
+        ]
+    },
+    {
+        "name": "bars",
+        "aliases": [
+            "menu",
+            "lines",
+            "horizontal",
+            "more"
+        ]
+    },
+    {
+        "name": "bell-off",
+        "aliases": [
+            "sound",
+            "music",
+            "audio",
+            "notification",
+            "alert"
+        ]
+    },
+    {
+        "name": "bell-on",
+        "aliases": [
+            "sound",
+            "music",
+            "audio",
+            "notification",
+            "alert"
+        ]
+    },
+    {
+        "name": "blogs",
+        "aliases": [
+            "journal"
+        ]
+    },
+    {
+        "name": "bold",
+        "aliases": [
+            "texts",
+            "editor",
+            "style"
+        ]
+    },
+    {
+        "name": "bolt",
+        "aliases": [
+            "thunder",
+            "trigger",
+            "mapping",
+            "bind"
+        ]
+    },
+    {
+        "name": "bookmarks",
+        "aliases": [
+            "clip",
+            "holder",
+            "marker",
+            "tag"
+        ]
+    },
+    {
+        "name": "box-container",
+        "aliases": [
+            "chest",
+            "package",
+            "collection"
+        ]
+    },
+    {
+        "name": "breadcrumb",
+        "aliases": [
+            "steps",
+            "path",
+            "navigation",
+            "sequence"
+        ]
+    },
+    {
+        "name": "calendar",
+        "aliases": [
+            "date",
+            "days",
+            "agenda",
+            "time",
+            "picker"
+        ]
+    },
+    {
+        "name": "camera",
+        "aliases": [
+            "photo",
+            "picture",
+            "image"
+        ]
+    },
+    {
+        "name": "cards",
+        "aliases": [
+            "box",
+            "squares",
+            "grid",
+            "rectangle"
+        ]
+    },
+    {
+        "name": "cards-full",
+        "aliases": [
+            "box",
+            "squares",
+            "grid",
+            "rectangle"
+        ]
+    },
+    {
+        "name": "cards2",
+        "aliases": [
+            "box",
+            "squares",
+            "grid",
+            "rectangle"
+        ]
+    },
+    {
+        "name": "caret-bottom",
+        "aliases": [
+            "down",
+            "arrow"
+        ]
+    },
+    {
+        "name": "caret-bottom-l",
+        "aliases": [
+            "down",
+            "arrow"
+        ]
+    },
+    {
+        "name": "caret-double",
+        "aliases": [
+            "up",
+            "top",
+            "bottom",
+            "down",
+            "arrow",
+            "double",
+            "select"
+        ]
+    },
+    {
+        "name": "caret-double-l",
+        "aliases": [
+            "up",
+            "top",
+            "bottom",
+            "down",
+            "arrow",
+            "double",
+            "select"
+        ]
+    },
+    {
+        "name": "caret-left",
+        "aliases": [
+            "arrow"
+        ]
+    },
+    {
+        "name": "caret-left-l",
+        "aliases": [
+            "arrow"
+        ]
+    },
+    {
+        "name": "caret-right",
+        "aliases": [
+            "arrow"
+        ]
+    },
+    {
+        "name": "caret-right-l",
+        "aliases": [
+            "arrow"
+        ]
+    },
+    {
+        "name": "caret-top",
+        "aliases": [
+            "up",
+            "arrow"
+        ]
+    },
+    {
+        "name": "caret-top-l",
+        "aliases": [
+            "up",
+            "arrow"
+        ]
+    },
+    {
+        "name": "categories",
+        "aliases": [
+            "tag",
+            "product"
+        ]
+    },
+    {
+        "name": "chain-broken",
+        "aliases": [
+            "link"
+        ]
+    },
+    {
+        "name": "change",
+        "aliases": [
+            "reload",
+            "update",
+            "arrows",
+            "repeat"
+        ]
+    },
+    {
+        "name": "check",
+        "aliases": [
+            "done",
+            "boolean",
+            "active",
+            "select",
+            "approve",
+            "success"
+        ]
+    },
+    {
+        "name": "check-circle",
+        "aliases": [
+            "done",
+            "boolean",
+            "active",
+            "select",
+            "approve",
+            "success"
+        ]
+    },
+    {
+        "name": "check-circle-full",
+        "aliases": [
+            "done",
+            "boolean",
+            "active",
+            "select",
+            "approve",
+            "success"
+        ]
+    },
+    {
+        "name": "chip",
+        "aliases": [
+            "technology",
+            "processor",
+            "infrastructure"
+        ]
+    },
+    {
+        "name": "code",
+        "aliases": [
+            "text",
+            "editor",
+            "script"
+        ]
+    },
+    {
+        "name": "cog",
+        "aliases": [
+            "settings",
+            "change"
+        ]
+    },
+    {
+        "name": "color-picker",
+        "aliases": [
+            "drop",
+            "paint",
+            "hue",
+            "bucket",
+            "can"
+        ]
+    },
+    {
+        "name": "columns",
+        "aliases": [
+            "table",
+            "grid"
+        ]
+    },
+    {
+        "name": "community",
+        "aliases": [
+            "user",
+            "people"
+        ]
+    },
+    {
+        "name": "compress",
+        "aliases": [
+            "reduce",
+            "arrows",
+            "small",
+            "resize",
+            "decrease"
+        ]
+    },
+    {
+        "name": "control-panel",
+        "aliases": [
+            "settings",
+            "change",
+            "effects"
+        ]
+    },
+    {
+        "name": "custom-size",
+        "aliases": [
+            "arrows",
+            "increase",
+            "sides",
+            "box"
+        ]
+    },
+    {
+        "name": "cut",
+        "aliases": [
+            "scissors",
+            "paste",
+            "copy",
+            "text",
+            "editor"
+        ]
+    },
+    {
+        "name": "change-list",
+        "aliases": [
+            "arrows",
+            "box",
+            "move",
+            "update"
+        ]
+    },
+    {
+        "name": "date",
+        "aliases": [
+            "calendar",
+            "day",
+            "time",
+            "agenda",
+            "picker"
+        ]
+    },
+    {
+        "name": "decimal",
+        "aliases": [
+            "0",
+            "number",
+            "zero"
+        ]
+    },
+    {
+        "name": "desktop",
+        "aliases": [
+            "computer",
+            "display",
+            "screen"
+        ]
+    },
+    {
+        "name": "diagram",
+        "aliases": [
+            "map",
+            "structure",
+            "schema"
+        ]
+    },
+    {
+        "name": "diary",
+        "aliases": [
+            "book",
+            "library",
+            "agenda"
+        ]
+    },
+    {
+        "name": "document",
+        "aliases": [
+            "file",
+            "text"
+        ]
+    },
+    {
+        "name": "documents-and-media",
+        "aliases": [
+            "file",
+            "video",
+            "music",
+            "audio"
+        ]
+    },
+    {
+        "name": "document-code",
+        "aliases": [
+            "file",
+            "script"
+        ]
+    },
+    {
+        "name": "document-compressed",
+        "aliases": [
+            "file",
+            "zip",
+            "rar"
+        ]
+    },
+    {
+        "name": "document-default",
+        "aliases": [
+            "file"
+        ]
+    },
+    {
+        "name": "document-image",
+        "aliases": [
+            "file",
+            "picture",
+            "photo"
+        ]
+    },
+    {
+        "name": "document-multimedia",
+        "aliases": [
+            "file",
+            "video",
+            "music",
+            "audio",
+            "play"
+        ]
+    },
+    {
+        "name": "document-pdf",
+        "aliases": [
+            "file",
+            "text"
+        ]
+    },
+    {
+        "name": "document-presentation",
+        "aliases": [
+            "file",
+            "slide",
+            "keynote",
+            "powerpoint"
+        ]
+    },
+    {
+        "name": "document-table",
+        "aliases": [
+            "file",
+            "spreadsheet",
+            "excel"
+        ]
+    },
+    {
+        "name": "document-text",
+        "aliases": [
+            "file",
+            "write"
+        ]
+    },
+    {
+        "name": "download",
+        "aliases": [
+            "arrow",
+            "down"
+        ]
+    },
+    {
+        "name": "drop",
+        "aliases": [
+            "color",
+            "picker",
+            "hue",
+            "paint"
+        ]
+    },
+    {
+        "name": "dynamic-data-list",
+        "aliases": [
+            "grid",
+            "thunder",
+            "action",
+            "change",
+            "update",
+            "reload",
+            "active"
+        ]
+    },
+    {
+        "name": "edit-layout",
+        "aliases": [
+            "structure",
+            "grid"
+        ]
+    },
+    {
+        "name": "effects",
+        "aliases": [
+            "settings",
+            "dots"
+        ]
+    },
+    {
+        "name": "ellipsis-h",
+        "aliases": [
+            "horizontal",
+            "more",
+            "dots",
+            "menu"
+        ]
+    },
+    {
+        "name": "ellipsis-v",
+        "aliases": [
+            "vertical",
+            "more",
+            "dots",
+            "menu"
+        ]
+    },
+    {
+        "name": "embed",
+        "aliases": [
+            "duplicated icon (deleted) - use \"code\" instead"
+        ]
+    },
+    {
+        "name": "envelope-open",
+        "aliases": [
+            "email",
+            "postal",
+            "message"
+        ]
+    },
+    {
+        "name": "exclamation-circle",
+        "aliases": [
+            "alert",
+            "error",
+            "attention",
+            "validation"
+        ]
+    },
+    {
+        "name": "exclamation-full",
+        "aliases": [
+            "alert",
+            "error",
+            "attention",
+            "validation"
+        ]
+    },
+    {
+        "name": "expand",
+        "aliases": [
+            "fullscreen",
+            "increase"
+        ]
+    },
+    {
+        "name": "file-script",
+        "aliases": [
+            "document",
+            "code"
+        ]
+    },
+    {
+        "name": "file-template",
+        "aliases": [
+            "document",
+            "structure",
+            "layout",
+            "page"
+        ]
+    },
+    {
+        "name": "file-xsl",
+        "aliases": [
+            "document"
+        ]
+    },
+    {
+        "name": "filter",
+        "aliases": [
+            "sort",
+            "order"
+        ]
+    },
+    {
+        "name": "flag-empty",
+        "aliases": [
+            "report",
+            "banner"
+        ]
+    },
+    {
+        "name": "flag-full",
+        "aliases": [
+            "report",
+            "banner"
+        ]
+    },
+    {
+        "name": "folder",
+        "aliases": [
+            "file",
+            "container",
+            "box"
+        ]
+    },
+    {
+        "name": "format",
+        "aliases": [
+            "text",
+            "editor",
+            "style",
+            "paint"
+        ]
+    },
+    {
+        "name": "forms",
+        "aliases": [
+            "layout",
+            "list",
+            "inputs",
+            "structure"
+        ]
+    },
+    {
+        "name": "full-size",
+        "aliases": [
+            "fullscreen",
+            "expand",
+            "increase"
+        ]
+    },
+    {
+        "name": "geolocation",
+        "aliases": [
+            "pin",
+            "place"
+        ]
+    },
+    {
+        "name": "globe",
+        "aliases": [
+            "world",
+            "web",
+            "location",
+            "earth"
+        ]
+    },
+    {
+        "name": "grid",
+        "aliases": [
+            "apps",
+            "squares",
+            "rectangle",
+            "layout",
+            "structure"
+        ]
+    },
+    {
+        "name": "h1",
+        "aliases": [
+            "heading",
+            "title",
+            "editor",
+            "text"
+        ]
+    },
+    {
+        "name": "h2",
+        "aliases": [
+            "heading",
+            "title",
+            "editor",
+            "text"
+        ]
+    },
+    {
+        "name": "hashtag",
+        "aliases": [
+            "number",
+            "mark"
+        ]
+    },
+    {
+        "name": "heart",
+        "aliases": [
+            "like",
+            "love",
+            "emotion"
+        ]
+    },
+    {
+        "name": "hidden",
+        "aliases": [
+            "eye",
+            "see",
+            "view",
+            "hide",
+            "show"
+        ]
+    },
+    {
+        "name": "home",
+        "aliases": [
+            "house"
+        ]
+    },
+    {
+        "name": "horizontal-scroll",
+        "aliases": [
+            "arrows",
+            "expand"
+        ]
+    },
+    {
+        "name": "hr",
+        "aliases": [
+            "line",
+            "minus",
+            "rectangle"
+        ]
+    },
+    {
+        "name": "import-export",
+        "aliases": [
+            "duplicated icon (deleted) - use \"order-arrows\" instead"
+        ]
+    },
+    {
+        "name": "indent-less",
+        "aliases": [
+            "text",
+            "editor",
+            "align",
+            "right",
+            "arrow"
+        ]
+    },
+    {
+        "name": "indent-more",
+        "aliases": [
+            "text",
+            "editor",
+            "align",
+            "left",
+            "arrow"
+        ]
+    },
+    {
+        "name": "info-book",
+        "aliases": [
+            "help",
+            "library"
+        ]
+    },
+    {
+        "name": "info-circle-open",
+        "aliases": [
+            "i",
+            "help",
+            "validation"
+        ]
+    },
+    {
+        "name": "information-live",
+        "aliases": [
+            "i",
+            "help",
+            "instruction"
+        ]
+    },
+    {
+        "name": "integer",
+        "aliases": [
+            "number",
+            "10"
+        ]
+    },
+    {
+        "name": "italic",
+        "aliases": [
+            "text",
+            "editor"
+        ]
+    },
+    {
+        "name": "link",
+        "aliases": [
+            "connection",
+            "chain"
+        ]
+    },
+    {
+        "name": "list",
+        "aliases": [
+            "order",
+            "sequence"
+        ]
+    },
+    {
+        "name": "list-ol",
+        "aliases": [
+            "order",
+            "number",
+            "sequence"
+        ]
+    },
+    {
+        "name": "list-ul",
+        "aliases": [
+            "order",
+            "sequence",
+            "dots"
+        ]
+    },
+    {
+        "name": "live",
+        "aliases": [
+            "circle"
+        ]
+    },
+    {
+        "name": "lock",
+        "aliases": [
+            "close",
+            "security",
+            "access"
+        ]
+    },
+    {
+        "name": "lock-dots",
+        "aliases": [
+            "close",
+            "security",
+            "access",
+            "multiple"
+        ]
+    },
+    {
+        "name": "logout",
+        "aliases": [
+            "turn",
+            "on",
+            "off"
+        ]
+    },
+    {
+        "name": "magic",
+        "aliases": [
+            "wand",
+            "effects",
+            "select"
+        ]
+    },
+    {
+        "name": "mark-as-answer",
+        "aliases": [
+            "question",
+            "list",
+            "lines"
+        ]
+    },
+    {
+        "name": "mark-as-question",
+        "aliases": [
+            "list",
+            "lines"
+        ]
+    },
+    {
+        "name": "merge",
+        "aliases": [
+            "combine",
+            "incorporate",
+            "branch"
+        ]
+    },
+    {
+        "name": "message",
+        "aliases": [
+            "discussion",
+            "text",
+            "word",
+            "chat"
+        ]
+    },
+    {
+        "name": "message-boards",
+        "aliases": [
+            "discussion",
+            "text",
+            "word",
+            "chat"
+        ]
+    },
+    {
+        "name": "mobile-landscape",
+        "aliases": [
+            "smartphone",
+            "technology"
+        ]
+    },
+    {
+        "name": "mobile-portrait",
+        "aliases": [
+            "smartphone",
+            "technology"
+        ]
+    },
+    {
+        "name": "moon",
+        "aliases": [
+            "night",
+            "light"
+        ]
+    },
+    {
+        "name": "move",
+        "aliases": [
+            "arrows",
+            "change",
+            "position"
+        ]
+    },
+    {
+        "name": "move-folder",
+        "aliases": [
+            "file",
+            "location",
+            "change"
+        ]
+    },
+    {
+        "name": "myspace",
+        "aliases": [
+            "social"
+        ]
+    },
+    {
+        "name": "number",
+        "aliases": [
+            "counter",
+            "order",
+            "sequence"
+        ]
+    },
+    {
+        "name": "order-arrow-down",
+        "aliases": [
+            "bottom"
+        ]
+    },
+    {
+        "name": "order-arrow-up",
+        "aliases": [
+            "top"
+        ]
+    },
+    {
+        "name": "organizations",
+        "aliases": [
+            "connection",
+            "multiple",
+            "structure"
+        ]
+    },
+    {
+        "name": "page",
+        "aliases": [
+            "paper"
+        ]
+    },
+    {
+        "name": "page-template",
+        "aliases": [
+            "layout",
+            "paper"
+        ]
+    },
+    {
+        "name": "paperclip",
+        "aliases": [
+            "attachment",
+            "file",
+            "editor"
+        ]
+    },
+    {
+        "name": "paragraph",
+        "aliases": [
+            "text",
+            "editor",
+            "p"
+        ]
+    },
+    {
+        "name": "password-policies",
+        "aliases": [
+            "user",
+            "login",
+            "access",
+            "security"
+        ]
+    },
+    {
+        "name": "paste",
+        "aliases": [
+            "copy",
+            "duplicate"
+        ]
+    },
+    {
+        "name": "pause",
+        "aliases": [
+            "play",
+            "multimedia",
+            "control"
+        ]
+    },
+    {
+        "name": "pencil",
+        "aliases": [
+            "edit",
+            "write",
+            "draft"
+        ]
+    },
+    {
+        "name": "phone",
+        "aliases": [
+            "call",
+            "contact"
+        ]
+    },
+    {
+        "name": "picture",
+        "aliases": [
+            "image",
+            "photo"
+        ]
+    },
+    {
+        "name": "play",
+        "aliases": [
+            "multimedia",
+            "control"
+        ]
+    },
+    {
+        "name": "plug",
+        "aliases": [
+            "connect",
+            "electricity"
+        ]
+    },
+    {
+        "name": "plus",
+        "aliases": [
+            "add",
+            "create",
+            "new"
+        ]
+    },
+    {
+        "name": "plus-squares",
+        "aliases": [
+            "add",
+            "create",
+            "multiple",
+            "new"
+        ]
+    },
+    {
+        "name": "polls",
+        "aliases": [
+            "statistics",
+            "bars",
+            "results"
+        ]
+    },
+    {
+        "name": "print",
+        "aliases": [
+            "paper"
+        ]
+    },
+    {
+        "name": "product-menu",
+        "aliases": [
+            "sidebar",
+            "list",
+            "navigation"
+        ]
+    },
+    {
+        "name": "product-menu-closed",
+        "aliases": [
+            "sidebar",
+            "list",
+            "navigation"
+        ]
+    },
+    {
+        "name": "product-menu-open",
+        "aliases": [
+            "sidebar",
+            "list",
+            "navigation"
+        ]
+    },
+    {
+        "name": "propagation",
+        "aliases": [
+            "circle",
+            "arrows",
+            "multiplication",
+            "publish"
+        ]
+    },
+    {
+        "name": "pin",
+        "aliases": [
+            "fix"
+        ]
+    },
+    {
+        "name": "question-circle",
+        "aliases": [
+            "mark",
+            "help"
+        ]
+    },
+    {
+        "name": "question-circle-full",
+        "aliases": [
+            "mark",
+            "help"
+        ]
+    },
+    {
+        "name": "quote-left",
+        "aliases": [
+            "\"",
+            "commas"
+        ]
+    },
+    {
+        "name": "quote-right",
+        "aliases": [
+            "\"",
+            "commas"
+        ]
+    },
+    {
+        "name": "radio-button",
+        "aliases": [
+            "circle",
+            "on",
+            "off",
+            "check"
+        ]
+    },
+    {
+        "name": "redo",
+        "aliases": [
+            "action",
+            "control",
+            "editor",
+            "arrow",
+            "right"
+        ]
+    },
+    {
+        "name": "reload",
+        "aliases": [
+            "cicle",
+            "change",
+            "update"
+        ]
+    },
+    {
+        "name": "remove-style",
+        "aliases": [
+            "text",
+            "editor"
+        ]
+    },
+    {
+        "name": "reply",
+        "aliases": [
+            "answer",
+            "respond",
+            "arrow",
+            "left"
+        ]
+    },
+    {
+        "name": "repository",
+        "aliases": [
+            "folder",
+            "connection"
+        ]
+    },
+    {
+        "name": "restore",
+        "aliases": [
+            "history",
+            "time",
+            "back"
+        ]
+    },
+    {
+        "name": "rss",
+        "aliases": [
+            "notification",
+            "updates"
+        ]
+    },
+    {
+        "name": "rules",
+        "aliases": [
+            "condition"
+        ]
+    },
+    {
+        "name": "search",
+        "aliases": [
+            "lens",
+            "inspect",
+            "zoom"
+        ]
+    },
+    {
+        "name": "select",
+        "aliases": [
+            "options",
+            "multiple",
+            "input"
+        ]
+    },
+    {
+        "name": "select-from-list",
+        "aliases": [
+            "options",
+            "multiple",
+            "input"
+        ]
+    },
+    {
+        "name": "separator",
+        "aliases": [
+            "divider",
+            "line",
+            "group"
+        ]
+    },
+    {
+        "name": "share",
+        "aliases": [
+            "social"
+        ]
+    },
+    {
+        "name": "sheets",
+        "aliases": [
+            "layers",
+            "assets"
+        ]
+    },
+    {
+        "name": "shopping-cart",
+        "aliases": [
+            "commerce",
+            "buy"
+        ]
+    },
+    {
+        "name": "shortcut",
+        "aliases": [
+            "external",
+            "window"
+        ]
+    },
+    {
+        "name": "simple-circle",
+        "aliases": [
+            "dot",
+            "point"
+        ]
+    },
+    {
+        "name": "simulation-menu",
+        "aliases": [
+            "target"
+        ]
+    },
+    {
+        "name": "simulation-menu-closed",
+        "aliases": [
+            "target"
+        ]
+    },
+    {
+        "name": "simulation-menu-open",
+        "aliases": [
+            "target"
+        ]
+    },
+    {
+        "name": "site-template",
+        "aliases": [
+            "navigation",
+            "compass"
+        ]
+    },
+    {
+        "name": "sites",
+        "aliases": [
+            "navigation",
+            "compass"
+        ]
+    },
+    {
+        "name": "social-facebook",
+        "aliases": [
+            "share"
+        ]
+    },
+    {
+        "name": "social-linkedin",
+        "aliases": [
+            "share"
+        ]
+    },
+    {
+        "name": "spacer",
+        "aliases": [
+            "padding",
+            "margin"
+        ]
+    },
+    {
+        "name": "staging",
+        "aliases": [
+            "changes",
+            "loading",
+            "circle"
+        ]
+    },
+    {
+        "name": "star",
+        "aliases": [
+            "rating",
+            "favorite"
+        ]
+    },
+    {
+        "name": "star-half",
+        "aliases": [
+            "rating",
+            "favorite"
+        ]
+    },
+    {
+        "name": "star-o",
+        "aliases": [
+            "rating",
+            "favorite"
+        ]
+    },
+    {
+        "name": "strikethrough",
+        "aliases": [
+            "text",
+            "editor",
+            "style"
+        ]
+    },
+    {
+        "name": "subscript",
+        "aliases": [
+            "text",
+            "editor",
+            "style"
+        ]
+    },
+    {
+        "name": "suitcase",
+        "aliases": [
+            "business"
+        ]
+    },
+    {
+        "name": "sun",
+        "aliases": [
+            "light",
+            "day"
+        ]
+    },
+    {
+        "name": "superscript",
+        "aliases": [
+            "text",
+            "editor",
+            "style"
+        ]
+    },
+    {
+        "name": "table",
+        "aliases": [
+            "grid",
+            "column",
+            "row"
+        ]
+    },
+    {
+        "name": "table2",
+        "aliases": [
+            "grid",
+            "column",
+            "row"
+        ]
+    },
+    {
+        "name": "tablet-landscape",
+        "aliases": [
+            "device",
+            "mobile"
+        ]
+    },
+    {
+        "name": "tablet-portrait",
+        "aliases": [
+            "device",
+            "mobile"
+        ]
+    },
+    {
+        "name": "tag",
+        "aliases": [
+            "product",
+            "category"
+        ]
+    },
+    {
+        "name": "test",
+        "aliases": [
+            "lab",
+            "experiment"
+        ]
+    },
+    {
+        "name": "text",
+        "aliases": [
+            "a",
+            "editor"
+        ]
+    },
+    {
+        "name": "text-editor",
+        "aliases": [
+            "style"
+        ]
+    },
+    {
+        "name": "thumbs-down",
+        "aliases": [
+            "dislike",
+            "social"
+        ]
+    },
+    {
+        "name": "thumbs-up",
+        "aliases": [
+            "like",
+            "social"
+        ]
+    },
+    {
+        "name": "time",
+        "aliases": [
+            "hour",
+            "day",
+            "clock"
+        ]
+    },
+    {
+        "name": "times",
+        "aliases": [
+            "x",
+            "close",
+            "cancel"
+        ]
+    },
+    {
+        "name": "times-circle",
+        "aliases": [
+            "x",
+            "remove"
+        ]
+    },
+    {
+        "name": "transform",
+        "aliases": [
+            "editor",
+            "image"
+        ]
+    },
+    {
+        "name": "trash",
+        "aliases": [
+            "recycle",
+            "bin"
+        ]
+    },
+    {
+        "name": "twitter",
+        "aliases": [
+            "social"
+        ]
+    },
+    {
+        "name": "underline",
+        "aliases": [
+            "text",
+            "style",
+            "editor"
+        ]
+    },
+    {
+        "name": "undo",
+        "aliases": [
+            "back",
+            "arrow",
+            "control",
+            "cancel"
+        ]
+    },
+    {
+        "name": "unlock",
+        "aliases": [
+            "open",
+            "security",
+            "access",
+            "login"
+        ]
+    },
+    {
+        "name": "unpin",
+        "aliases": [
+            "fix",
+            "move"
+        ]
+    },
+    {
+        "name": "upload",
+        "aliases": [
+            "arrow",
+            "top",
+            "up"
+        ]
+    },
+    {
+        "name": "upload-multiple",
+        "aliases": [
+            "arrow",
+            "top",
+            "up"
+        ]
+    },
+    {
+        "name": "user",
+        "aliases": [
+            "client",
+            "contact"
+        ]
+    },
+    {
+        "name": "user-plus",
+        "aliases": [
+            "people",
+            "client",
+            "add",
+            "create"
+        ]
+    },
+    {
+        "name": "users",
+        "aliases": [
+            "people",
+            "client",
+            "contacts"
+        ]
+    },
+    {
+        "name": "vertical-scroll",
+        "aliases": [
+            "arrows",
+            "expand"
+        ]
+    },
+    {
+        "name": "video",
+        "aliases": [
+            "multimedia",
+            "play"
+        ]
+    },
+    {
+        "name": "view",
+        "aliases": [
+            "eye",
+            "show",
+            "see"
+        ]
+    },
+    {
+        "name": "vocabulary",
+        "aliases": [
+            "abc",
+            "text",
+            "editor",
+            "order"
+        ]
+    },
+    {
+        "name": "warning",
+        "aliases": [
+            "attention",
+            "alert",
+            "validation",
+            "exclamation"
+        ]
+    },
+    {
+        "name": "warning-full",
+        "aliases": [
+            "attention",
+            "alert",
+            "validation",
+            "exclamation"
+        ]
+    },
+    {
+        "name": "web-content",
+        "aliases": [
+            "assets"
+        ]
+    },
+    {
+        "name": "wiki",
+        "aliases": [
+            "knowledge"
+        ]
+    },
+    {
+        "name": "wiki-page",
+        "aliases": [
+            "knowledge"
+        ]
+    },
+    {
+        "name": "workflow",
+        "aliases": [
+            "function",
+            "progress"
+        ]
+    }
+]


### PR DESCRIPTION
Hey @bryceosterhaus here's my draft of the Icon Filtering feature we talked about in [the issue](https://github.com/liferay/clay/issues/2029).

A couple notes:
- The filtering via the search input and the icon rendering is in the React component
- I couldn't figure out how to import that React component in the `css-icons.md` file, I did convert it into an `mdx` file but then it wasn't considered a sibling of `icon.mdx` as defined in [icon.mdx:5](https://github.com/liferay/clay/blob/master/clayui.com/content/docs/components/icon.mdx#L5)
- Gonna have to do a cleanup of the `icons.json` file because there are some icons that don't have a file associated with them

I doubt that putting the `<IconSearch />` in the `icon.mdx` is the best place to do it because it duplicates the icon list found in the `CSS/Markup` page. What do I have to do to get it in the proper place, I assume the `css-icons.md`?