### PR TITLE
feat(clay-css): Adds pattern `.c-inner` for highjacking focus state on click

### DIFF
--- a/packages/clay-css/src/content/utilities_c_inner.html
+++ b/packages/clay-css/src/content/utilities_c_inner.html
@@ -1,0 +1,5109 @@
+---
+title: Utilities (C Inner)
+section: Components
+---
+
+<div class="alert alert-danger">
+	Before using this pattern, make sure to enable it by setting <code>$enable-c-inner: true;</code>.
+</div>
+
+<blockquote class="blockquote">
+	<p>A utility to help manage focus styles in an interactive component. Wrap the contents of your component in <code>```<span class="c-inner" tabindex="-1">Text</span>```</code> or <code>```<div class="c-inner" tabindex="-1">Text</div>```</code> to only show focus styles on keyboard interaction and not click.</p>
+	<p>See <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus</a> for more details about <code>button</code> and focus.</p>
+</blockquote>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Buttons with C Inner</h3>
+
+		<h6>Buttons and Anchor</h6>
+		<button class="btn btn-unstyled" type="button">
+			<span class="c-inner" tabindex="-1">.btn.btn-unstyled</span>
+		</button>
+		<button class="btn btn-primary" type="button">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item inline-item-before"><svg class="lexicon-icon lexicon-icon-share" focusable="false" role="presentation"><use xlink:href="{{rootPath}}/images/icons/icons.svg#share" /></svg></span><span class="inline-item inline-item-before"><svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation"><use xlink:href="{{rootPath}}/images/icons/icons.svg#plus" /></svg></span>Primary<span class="inline-item inline-item-after"><svg class="lexicon-icon lexicon-icon-camera" focusable="false" role="presentation"><use xlink:href="{{rootPath}}/images/icons/icons.svg#camera" /></svg></span><span class="inline-item inline-item-after"><svg class="lexicon-icon lexicon-icon-picture" focusable="false" role="presentation"><use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" /></svg></span>
+			</span>
+		</button>
+		<button class="btn btn-secondary" type="button">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item inline-item-before"><svg class="lexicon-icon lexicon-icon-share" focusable="false" role="presentation"><use xlink:href="{{rootPath}}/images/icons/icons.svg#share" /></svg></span>Secondary<span class="inline-item inline-item-after"><svg class="lexicon-icon lexicon-icon-picture" focusable="false" role="presentation"><use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" /></svg></span>
+			</span>
+		</button>
+		<a class="btn btn-success" href="#1" role="button">
+			<span class="c-inner" tabindex="-1">Anchor</span>
+		</a>
+		<a class="btn btn-warning" href="#1" role="button">
+			<span class="c-inner" tabindex="-1">Anchor</span>
+		</a>
+		<a class="btn btn-danger" href="#1" role="button">
+			<span class="c-inner" tabindex="-1">Anchor</span>
+		</a>
+		<div class="clay-site-light-container">
+			<a class="btn btn-light" href="#1" role="button">
+				<span class="c-inner" tabindex="-1">Anchor</span>
+			</a>
+		</div>
+		<a class="btn btn-dark" href="#1" role="button">
+			<span class="c-inner" tabindex="-1">Anchor</span>
+		</a>
+		<a class="btn btn-link" href="#1" role="button">
+			<span class="c-inner" tabindex="-1">Anchor</span>
+		</a>
+		<button class="btn btn-secondary btn-sm" type="button">
+			<span class="c-inner" tabindex="-1">Small</span>
+		</button>
+		<button class="btn btn-secondary btn-lg" type="button">
+			<span class="c-inner" tabindex="-1">Large</span>
+		</button>
+
+		<h6>Input</h6>
+
+		<div class="alert alert-warning">
+			This pattern doesn't apply to buttons using <code>input</code> because elements can't be nested inside them. This pattern only works with <code>anchor</code>s in IE11.
+		</div>
+
+		<input class="btn btn-primary" type="button" value="Input" />
+		<input class="btn btn-info" type="submit" value="Submit" />
+
+		<h6>Button Monospaced</h6>
+		<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-blogs" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#blogs"></use>
+					</svg>
+				</span>
+			</span>
+		</button>
+		<button class="btn btn-monospaced btn-secondary" type="button">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#plus"></use>
+					</svg>
+				</span>
+			</span>
+		</button>
+		<button class="btn btn-monospaced btn-secondary btn-lg" type="button">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-share" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#share"></use>
+					</svg>
+				</span>
+			</span>
+		</button>
+		<a class="btn btn-monospaced btn-secondary btn-sm" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+					</svg>
+				</span>
+				<span class="btn-section">es-ES</span>
+			</span>
+		</a>
+		<a class="btn btn-monospaced btn-secondary" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+					</svg>
+				</span>
+				<span class="btn-section">es-ES</span>
+			</span>
+		</a>
+		<a class="btn btn-monospaced btn-secondary btn-lg" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+					</svg>
+				</span>
+				<span class="btn-section">es-ES</span>
+			</span>
+		</a>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Links with C Inner</h3>
+
+		<div><a href="#1"><span class="c-inner" tabindex="-1">Regular Anchor Tag</span></a></div>
+		<div><a class="link-primary" href="#1"><span class="c-inner" tabindex="-1">.link-primary</span></a></div>
+		<div><a class="link-secondary" href="#1"><span class="c-inner" tabindex="-1">.link-secondary</span></a></div>
+		<div><a class="link-primary single-link" href="#1"><span class="c-inner" tabindex="-1">.link-primary.single-link</span></a></div>
+		<div><a class="link-secondary single-link" href="#1"><span class="c-inner" tabindex="-1">.link-secondary.single-link</span></a></div>
+		<div><a class="component-link" href="#1"><span class="c-inner" tabindex="-1">.component-link</span></a></div>
+		<h4 class="component-title"><a href="#1"><span class="c-inner" tabindex="-1">.component-title a</span></a></h4>
+		<p class="component-subtitle"><a href="#1"><span class="c-inner" tabindex="-1">.component-subtitle a</span></a></p>
+
+		<h6>Component Action</h6>
+		<a class="component-action" href="#1" role="button">
+			<span class="c-inner" tabindex="-1">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</span>
+		</a>
+		<a class="component-action disabled" href="#disabled" role="button" tabindex="-1">
+			<span class="c-inner" tabindex="-1">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</span>
+		</a>
+		<button class="component-action" type="button">
+			<span class="c-inner" tabindex="-1">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</span>
+		</button>
+		<button class="component-action" disabled type="button">
+			<span class="c-inner" tabindex="-1">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</span>
+		</button>
+
+		<h6>Link Outline</h6>
+		<a class="link-outline link-outline-primary" href="#1"><span class="c-inner" tabindex="-1">Primary</span></a>
+		<a class="link-outline link-outline-secondary" href="#1"><span class="c-inner" tabindex="-1">Secondary</span></a>
+		<a class="link-outline link-outline-borderless link-outline-primary" href="#1"><span class="c-inner" tabindex="-1">Primary</span></a>
+		<a class="link-outline link-outline-borderless link-outline-secondary" href="#1"><span class="c-inner" tabindex="-1">Secondary</span></a>
+
+		<h6>Link Monospaced</h6>
+		<a class="link-monospaced link-outline link-outline-primary" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-add-cell" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell" />
+					</svg>
+				</span>
+			</span>
+		</a>
+		<a class="link-monospaced link-outline link-outline-borderless link-outline-primary" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-add-cell" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell" />
+					</svg>
+				</span>
+			</span>
+		</a>
+		<a class="link-monospaced link-outline link-outline-secondary" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-picture" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
+					</svg>
+				</span>
+			</span>
+		</a>
+		<a class="link-monospaced link-outline link-outline-borderless link-outline-secondary" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-picture" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture" />
+					</svg>
+				</span>
+			</span>
+		</a>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Close with C Inner</h3>
+
+		<h6>Anchor</h6>
+		<a aria-label="Close" class="close" href="#1" role="button">
+			<span class="c-inner" tabindex="-1">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</span>
+		</a>
+		<a aria-label="Close" class="close disabled" href="#1" role="button" tabindex="-1">
+			<span class="c-inner" tabindex="-1">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</span>
+		</a>
+		<a aria-label="Close" class="close" href="#1" role="button">
+			<span class="c-inner" tabindex="-1">
+				<span aria-hidden="true">×</span>
+			</span>
+		</a>
+		<a aria-label="Close" class="close disabled" href="#1" role="button" tabindex="-1">
+			<span class="c-inner" tabindex="-1">
+				<span aria-hidden="true">×</span>
+			</span>
+		</a>
+
+
+		<h6>Button</h6>
+		<button aria-label="Close" class="close" type="button">
+			<span class="c-inner" tabindex="-1">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</span>
+		</button>
+		<button aria-label="Close" class="close" disabled type="button">
+			<span class="c-inner" tabindex="-1">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</span>
+		</button>
+		<button aria-label="Close" class="close" type="button">
+			<span class="c-inner" tabindex="-1">
+				<span aria-hidden="true">×</span>
+			</span>
+		</button>
+		<button aria-label="Close" class="close" disabled type="button">
+			<span class="c-inner" tabindex="-1">
+				<span aria-hidden="true">×</span>
+			</span>
+		</button>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Badges with C Inner</h3>
+
+		<h6>Badge as Anchor</h6>
+		<a class="badge badge-primary" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="badge-item badge-item-expand">Primary</span>
+			</span>
+		</a>
+
+		<h6>Badge with Links Inside</h6>
+		<span class="badge badge-danger">
+			<span class="badge-item badge-item-before">
+				<a href="#1">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+						</svg>
+					</span>
+				</a>
+			</span>
+			<span class="badge-item badge-item-before">
+				<button class="btn btn-unstyled" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-picture" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#picture"></use>
+						</svg>
+					</span>
+				</button>
+			</span>
+			<span class="badge-item badge-item-expand">
+				<a href="#1">
+					<span class="c-inner" tabindex="-1">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
+				</a>
+			</span>
+			<span class="badge-item badge-item-after">
+				<svg class="lexicon-icon lexicon-icon-camera" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#camera"></use>
+				</svg>
+			</span>
+			<span class="badge-item badge-item-after">
+				<button aria-label="Close" class="close" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+						</svg>
+					</span>
+				</button>
+			</span>
+		</span>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Labels with C Inner</h3>
+
+		<h6>Label as Anchor</h6>
+		<a class="label label-primary" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="label-item label-item-expand">Primary</span>
+			</span>
+		</a>
+		<a class="label label-lg label-secondary" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="label-item label-item-expand">Secondary</span>
+			</span>
+		</a>
+
+		<h6>Label Dismissible</h6>
+		<span class="label label-dismissible label-secondary">
+			<span class="label-item label-item-before">
+				<span class="sticker">
+					<span class="sticker-overlay">
+						<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+					</span>
+				</span>
+			</span>
+			<span class="label-item label-item-before">
+				<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+				</svg>
+			</span>
+			<span class="label-item label-item-before">
+				<button class="btn btn-unstyled" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-add-cell" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell"></use>
+						</svg>
+					</span>
+				</button>
+			</span>
+			<span class="label-item label-item-expand">
+				<a href="#1">
+					<span class="c-inner" tabindex="-1">Normal Label</span>
+				</a>
+			</span>
+			<span class="label-item label-item-after">
+				<button aria-label="Close" class="close" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+						</svg>
+					</span>
+				</button>
+			</span>
+		</span>
+		<span class="label label-dismissible label-lg label-success">
+			<span class="label-item label-item-before">
+				<span class="sticker">
+					<span class="sticker-overlay">
+						<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+					</span>
+				</span>
+			</span>
+			<span class="label-item label-item-before">
+				<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+				</svg>
+			</span>
+			<span class="label-item label-item-before">
+				<svg class="lexicon-icon lexicon-icon-add-cell" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell"></use>
+				</svg>
+			</span>
+			<span class="label-item label-item-expand">
+				<a href="#1">
+					<span class="c-inner" tabindex="-1">Label Lg</span>
+				</a>
+			</span>
+			<span class="label-item label-item-after">
+				<button aria-label="Close" class="close" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+						</svg>
+					</span>
+				</button>
+			</span>
+		</span>
+
+		<h6>Interactive Label</h6>
+		<span class="label label-dismissible label-secondary" tabindex="0">
+			<span class="c-inner" tabindex="-1">
+				<span class="label-item label-item-before">
+					<span class="sticker">
+						<span class="sticker-overlay">
+							<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+						</span>
+					</span>
+				</span>
+				<span class="label-item label-item-before">
+					<button class="btn btn-unstyled" type="button" tabindex="-1">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+							</svg>
+						</span>
+					</button>
+				</span>
+				<span class="label-item label-item-before">
+					<a href="#1" role="button" tabindex="-1">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-add-cell" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell"></use>
+							</svg>
+						</span>
+					</a>
+				</span>
+				<span class="label-item label-item-expand">
+					<a href="#1" tabindex="-1">
+						<span class="c-inner" tabindex="-1">Label Secondary</span>
+					</a>
+				</span>
+				<span class="label-item label-item-after">
+					<button aria-label="Close" class="close" tabindex="-1" type="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+							</svg>
+						</span>
+					</button>
+				</span>
+			</span>
+		</span>
+		<span class="label label-dismissible label-lg label-primary" tabindex="0">
+			<span class="c-inner" tabindex="-1">
+				<span class="label-item label-item-before">
+					<span class="sticker">
+						<span class="sticker-overlay">
+							<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+						</span>
+					</span>
+				</span>
+				<span class="label-item label-item-before">
+					<button class="btn btn-unstyled" type="button" tabindex="-1">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+							</svg>
+						</span>
+					</button>
+				</span>
+				<span class="label-item label-item-before">
+					<a href="#1" role="button" tabindex="-1">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-add-cell" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#add-cell"></use>
+							</svg>
+						</span>
+					</a>
+				</span>
+				<span class="label-item label-item-expand">
+					<a href="#1" tabindex="-1">
+						<span class="c-inner" tabindex="-1">Label Primary</span>
+					</a>
+				</span>
+				<span class="label-item label-item-after">
+					<button aria-label="Close" class="close" tabindex="-1" type="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+							</svg>
+						</span>
+					</button>
+				</span>
+			</span>
+		</span>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Breadcrumb with C Inner</h3>
+
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item dropdown">
+				<a aria-expanded="false" aria-haspopup="true" class="breadcrumb-link dropdown-toggle" data-toggle="dropdown" href="" id="breadcrumb2Dropdown1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-h"></use>
+						</svg>
+						<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom"></use>
+						</svg>
+					</span>
+				</a>
+				<ul aria-labelledby="breadcrumb2Dropdown1" class="dropdown-menu">
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">Home</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">Components</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">Breadcrumbs and Paginations</span>
+						</a>
+					</li>
+				</ul>
+			</li>
+			<li class="breadcrumb-item">
+				<a class="breadcrumb-link" href="#1" title="Page">
+					<span class="c-inner" tabindex="-1">
+						<span class="breadcrumb-text-truncate">Page</span>
+					</span>
+				</a>
+			</li>
+			<li class="breadcrumb-item">
+				<a class="breadcrumb-link" href="#1" title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual">
+					<span class="c-inner" tabindex="-1">
+						<span class="breadcrumb-text-truncate">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+					</span>
+				</a>
+			</li>
+			<li class="active breadcrumb-item">
+				<span class="breadcrumb-text-truncate" title="Active">Active</span>
+			</li>
+		</ol>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Card Interactive with C Inner</h3>
+	</div>
+
+	<div class="col-md-4">
+		<div class="card card-interactive card-type-template template-card" tabindex="0">
+			<div class="c-inner" tabindex="-1">
+				<div class="aspect-ratio">
+					<div class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-flush">
+						<img src="{{rootPath}}/content/site-images/portlet.svg" />
+					</div>
+				</div>
+				<div class="card-body">
+					<h3 class="card-title">Widget Page</h3>
+					<div class="card-text">Build a page by adding widgets and content.</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col-md-4">
+		<div class="card card-interactive card-interactive-primary card-type-template template-card" tabindex="0">
+			<div class="c-inner" tabindex="-1">
+				<div class="aspect-ratio">
+					<div class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-flush">
+						<img src="{{rootPath}}/content/site-images/portlet.svg" />
+					</div>
+				</div>
+				<div class="card-body">
+					<h3 class="card-title">Widget Page</h3>
+					<div class="card-text">Build a page by adding widgets and content.</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col-md-4">
+		<a class="card card-interactive card-interactive-secondary" href="#1">
+			<span class="c-inner" tabindex="-1">
+				<span class="card-body">
+					<label>Textarea</label>
+					<span class="form-control form-control-textarea"></span>
+				</span>
+			</span>
+		</a>
+	</div>
+
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown with C Inner</h3>
+
+		<div class="alert alert-warning">
+			Bootstrap's Dropdown Plugin focuses <code>dropdown-toggle</code> on show. You will need to manually undo the focus via blur or focus <code>c-inner</code> on show.
+		</div>
+
+		<div class="d-inline-block">
+			<div class="dropdown">
+				<button aria-expanded="false" aria-haspopup="true" class="link-outline link-outline-primary dropdown-toggle" data-toggle="dropdown" id="dropdownSites1" type="button">
+					<span class="c-inner" tabindex="-1">
+						Dropdown
+						<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+						</svg>
+					</span>
+				</button>
+				<ul aria-labelledby="dropdownSites1" class="dropdown-menu">
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Download</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Edit</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Move</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Checkout</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Permissions</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Move to Recycle Bin</span></a></li>
+				</ul>
+			</div>
+		</div>
+
+		<div class="d-inline-block">
+			<div class="dropdown">
+				<a aria-expanded="false" aria-haspopup="true" class="link-outline link-outline-borderless link-outline-primary dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownSitesAnchor2" role="button">
+					<span class="c-inner" tabindex="-1">
+						Dropdown
+						<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+						</svg>
+					</span>
+				</a>
+				<ul aria-labelledby="dropdownSitesAnchor2" class="dropdown-menu">
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Download</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Edit</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Move</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Checkout</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Permissions</span></a></li>
+					<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Move to Recycle Bin</span></a></li>
+				</ul>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-dropdown-display clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown Menu with C Inner</h3>
+
+		<div class="clay-site-dropdown-menu-container">
+			<ul aria-labelledby="theDropdownToggleId" class="dropdown-menu">
+				<li class="dropdown-subheader">Order by</li>
+				<li>
+					<a class="active dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">Author</span>
+					</a>
+				</li>
+				<li>
+					<a class="disabled dropdown-item" href="#1" tabindex="-1">
+						<span class="c-inner" tabindex="-1">Title Entry</span>
+					</a>
+				</li>
+				<li class="dropdown-divider"></li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">Date</span>
+					</a>
+				</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">Description</span>
+					</a>
+				</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">Status</span>
+					</a>
+				</li>
+			</ul>
+		</div>
+
+		<div class="clay-site-dropdown-menu-container">
+			<ul aria-labelledby="theDropdownToggleId" class="dropdown-menu dropdown-menu-indicator-start">
+				<li class="dropdown-header">Dropdown Header</li>
+				<li class="dropdown-divider"></li>
+				<li class="dropdown-subheader">Dropdown Sub Header</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">
+							<span class="dropdown-item-indicator-start">
+								<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+								</svg>
+							</span>
+							Ticket Buyer Information
+						</span>
+					</a>
+				</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">
+							<span class="dropdown-item-indicator-start">
+								<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+								</svg>
+							</span>
+							Attendee Information
+						</span>
+					</a>
+				</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">
+							<span class="dropdown-item-indicator-start">
+								<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+								</svg>
+							</span>
+							Seat Assignment
+						</span>
+					</a>
+				</li>
+				<li>
+					<a class="active dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">Dinner Preference</span>
+					</a>
+				</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">Submit Payment</span>
+					</a>
+				</li>
+				<li class="dropdown-caption">Dropdown Caption</li>
+			</ul>
+		</div>
+
+		<div class="clay-site-dropdown-menu-container">
+			<ul aria-labelledby="theDropdownToggleId" class="dropdown-menu dropdown-menu-indicator-end dropdown-menu-indicator-start">
+				<li class="dropdown-header">Dropdown Header</li>
+				<li class="dropdown-divider"></li>
+				<li class="dropdown-subheader">Dropdown Sub Header</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">
+							<span class="dropdown-item-indicator-start">
+								<svg class="lexicon-icon lexicon-icon-pencil" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#pencil" />
+								</svg>
+							</span>
+							ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+							<span class="dropdown-item-indicator-end">
+								<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+						</span>
+					</a>
+				</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">
+							<span class="dropdown-item-indicator-start">
+								<svg class="lexicon-icon lexicon-icon-view" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#view" />
+								</svg>
+							</span>
+							Attendee Information
+						</span>
+					</a>
+				</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">
+							<span class="dropdown-item-indicator">
+								<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+								</svg>
+							</span>
+							Seat Assignment
+						</span>
+					</a>
+				</li>
+				<li>
+					<a class="active dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">Dinner Preference</span>
+					</a>
+				</li>
+				<li>
+					<a class="dropdown-item" href="#1">
+						<span class="c-inner" tabindex="-1">Submit Payment</span>
+					</a>
+				</li>
+				<li class="dropdown-caption">Dropdown Caption</li>
+			</ul>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row clay-site-dropdown-display">
+	<div class="col-md-12">
+		<h3>Dropdown Menu Drill Down</h3>
+
+		<div class="clay-site-dropdown-menu-container">
+			<div aria-labelledby="theDropdownToggleId" class="drilldown dropdown-menu dropdown-menu-indicator-end">
+				<div class="drilldown-inner">
+					<div class="drilldown-current drilldown-item" id="demoFirstDrillDownItem">
+						<div class="drilldown-item-inner">
+							<ul class="inline-scroller">
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Folder</span></a></li>
+								<li>
+									<a class="dropdown-item" data-drilldown="next" href="#demoDocumentId">
+										<span class="c-inner" tabindex="-1">
+											Document
+											<span class="dropdown-item-indicator-end">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+										</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" data-drilldown="next" href="#demoShortcutId">
+										<span class="c-inner" tabindex="-1">
+											Shortcut
+											<span class="dropdown-item-indicator-end">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+										</span>
+									</a>
+								</li>
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Repository</span></a></li>
+								<li><a class="disabled dropdown-item" href="#1" tabindex="-1"><span class="c-inner" tabindex="-1">Disabled</span></a></li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="drilldown-item" id="demoDocumentId">
+						<div class="drilldown-item-inner">
+							<a class="drilldown-item-header dropdown-item" data-drilldown="prev" href="#demoFirstDrillDownItem">
+								<span class="c-inner" tabindex="-1">
+									<span class="dropdown-item-indicator-start">
+										<svg class="lexicon-icon lexicon-icon-caret-left" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-left" />
+										</svg>
+									</span>
+									Document
+								</span>
+							</a>
+							<div class="dropdown-divider"></div>
+
+							<ul class="inline-scroller">
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Basic Document</span></a></li>
+								<li>
+									<a class="dropdown-item" data-drilldown="next" href="#demoContractId">
+										<span class="c-inner" tabindex="-1">
+											Contract
+											<span class="dropdown-item-indicator-end">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+										</span>
+									</a>
+								</li>
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Marketing Banner</span></a></li>
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Online Training</span></a></li>
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Sales Presentation</span></a></li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="drilldown-item" id="demoContractId">
+						<div class="drilldown-item-inner">
+							<a class="drilldown-item-header dropdown-item" data-drilldown="prev" href="#demoDocumentId">
+								<span class="c-inner" tabindex="-1">
+									<span class="dropdown-item-indicator-start">
+										<svg class="lexicon-icon lexicon-icon-caret-left" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-left" />
+										</svg>
+									</span>
+									Contract
+								</span>
+							</a>
+							<div class="dropdown-divider"></div>
+							<ul class="inline-scroller">
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Contract Document #1</span></a></li>
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Contract Document #2</span></a></li>
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Contract Document #3</span></a></li>
+							</ul>
+						</div>
+					</div>
+
+					<div class="drilldown-item" id="demoShortcutId">
+						<div class="drilldown-item-inner">
+							<a class="drilldown-item-header dropdown-item" data-drilldown="prev" href="#demoFirstDrillDownItem">
+								<span class="c-inner" tabindex="-1">
+									<span class="dropdown-item-indicator-start">
+										<svg class="lexicon-icon lexicon-icon-caret-left" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-left" />
+										</svg>
+									</span>
+									Shortcut
+								</span>
+							</a>
+							<div class="dropdown-divider"></div>
+							<ul class="inline-scroller">
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Shortcut #1</span></a></li>
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Shortcut #2</span></a></li>
+								<li><a class="dropdown-item" href="#1"><span class="c-inner" tabindex="-1">Shortcut #3</span></a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Input Group Inset</h3>
+
+		<div class="sheet">
+			<form>
+				<div class="form-group-autofit">
+					<div class="form-group-item">
+						<div class="input-group">
+							<div class="input-group-item">
+								<input aria-label="Search for" class="form-control input-group-inset input-group-inset-after" placeholder="Search..." type="text">
+								<div class="input-group-inset-item input-group-inset-item-after">
+									<button class="btn btn-unstyled d-md-none" type="button">
+										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+										</svg>
+									</button>
+									<button class="btn btn-unstyled d-none d-md-inline-block" type="button">
+										<span class="c-inner" tabindex="-1">
+											<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="form-group-item">
+						<div class="input-group">
+							<div class="input-group-item">
+								<input aria-label="Search for" class="form-control input-group-inset input-group-inset-after" placeholder="Search..." type="text">
+								<div class="input-group-inset-item input-group-inset-item-after">
+									<button class="btn btn-unstyled" type="button">
+										<span class="c-inner" tabindex="-1">
+											<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle" />
+											</svg>
+										</span>
+									</button>
+									<button class="btn btn-unstyled" type="button">
+										<span class="c-inner" tabindex="-1">
+											<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="form-group-item">
+						<div class="input-group">
+							<div class="input-group-item">
+								<input aria-label="Enter email" class="form-control input-group-inset input-group-inset-after" placeholder="Enter Email..." type="email">
+								<div class="input-group-inset-item input-group-inset-item-after">
+									<button class="btn btn-secondary" type="button">
+										<span class="c-inner" tabindex="-1">Submit</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="form-group-autofit">
+					<div class="form-group-item">
+						<div class="input-group">
+							<div class="input-group-item">
+								<input aria-label="Search for" class="form-control input-group-inset input-group-inset-before" placeholder="Search..." type="text">
+								<div class="input-group-inset-item input-group-inset-item-before">
+									<button class="btn btn-unstyled" type="button">
+										<span class="c-inner" tabindex="-1">
+											<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="form-group-item">
+						<div class="input-group">
+							<div class="input-group-item">
+								<input aria-label="Enter email" class="form-control input-group-inset input-group-inset-before" placeholder="Enter Email..." type="email">
+								<div class="input-group-inset-item input-group-inset-item-before">
+									<button class="btn btn-secondary" type="button">
+										<span class="c-inner" tabindex="-1">Submit</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</form>
+		</div>
+
+	</div>
+</div>
+
+<style>
+#colorPickerView2 { display: none; }
+</style>
+
+<div class="clay-site-row-spacer row" style="margin-bottom: 5rem;">
+	<div class="col-md-12">
+		<h3>Clay Color</h3>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label for="clayColor1DropdownToggle">Background Color</label>
+				<div class="clay-color input-group">
+					<div class="input-group-item input-group-item-shrink input-group-prepend">
+						<div class="input-group-text">
+							<button aria-expanded="false" aria-haspopup="true" aria-label="Select a color" class="btn clay-color-btn dropdown-toggle" data-toggle="dropdown" id="clayColor1DropdownToggle" title="#B2EDFF" type="button" style="background-color:#B2EDFF;"><span class="c-inner" tabindex="-1"></span></button>
+
+							<div aria-labelledby="clayColor1DropdownToggle" class="clay-color-dropdown-menu dropdown-menu">
+								<div id="colorPickerView1">
+									<div class="clay-color-swatch">
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#000000" style="background-color:#000000;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#5F5F5F" style="background-color:#5F5F5F;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#9A9A9A" style="background-color:#9A9A9A;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#CBCBCB" style="background-color:#CBCBCB;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#E1E1E1" style="background-color:#E1E1E1;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FF0D0D" style="background-color:#FF0D0D;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FF8A1C" style="background-color:#FF8A1C;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#2BA676" style="background-color:#2BA676;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#006EF8" style="background-color:#006EF8;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#7F26FF" style="background-color:#7F26FF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FF21A0" style="background-color:#FF21A0;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FF5F5F" style="background-color:#FF5F5F;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FFB46E" style="background-color:#FFB46E;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#50D2A0" style="background-color:#50D2A0;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#4B9BFF" style="background-color:#4B9BFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#AF78FF" style="background-color:#AF78FF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FF73C3" style="background-color:#FF73C3;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FFB1B1" style="background-color:#FFB1B1;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FFDEC0" style="background-color:#FFDEC0;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#91E3C3" style="background-color:#91E3C3;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#9DC8FF" style="background-color:#9DC8FF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#DFCAFF" style="background-color:#DFCAFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FFC5E6" style="background-color:#FFC5E6;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FFD9D9" style="background-color:#FFD9D9;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FFF3E8" style="background-color:#FFF3E8;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#B1EBD5" style="background-color:#B1EBD5;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#C5DFFF" style="background-color:#C5DFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#F8F2FF" style="background-color:#F8F2FF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#FFEDF7" style="background-color:#FFEDF7;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+									</div>
+
+									<div class="clay-color-header">
+										<span class="component-title">Custom Colors</span>
+										<button class="component-action" id="claySiteShowView2" type="button">
+											<span class="c-inner" tabindex="-1">
+												<svg class="lexicon-icon lexicon-icon-drop" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#drop" />
+												</svg>
+											</span>
+										</button>
+									</div>
+
+									<div class="clay-color-swatch">
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn focus" title="#B2EDFF" style="background-color:#B2EDFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#45EDC5" style="background-color:#45EDC5;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#BEDA70" style="background-color:#BEDA70;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#DB5959" style="background-color:#DB5959;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#36466D" style="background-color:#36466D;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#55ADFF" style="background-color:#55ADFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+									</div>
+								</div>
+
+								<div id="colorPickerView2">
+									<div class="clay-color-header">
+										<span class="component-title">Custom Colors</span>
+										<button class="close" id="claySiteShowView1" type="button">
+											<span class="c-inner" tabindex="-1">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+												</svg>
+											</span>
+										</button>
+									</div>
+
+									<div class="clay-color-swatch">
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn focus" title="#B2EDFF" style="background-color:#B2EDFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#45EDC5" style="background-color:#45EDC5;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#BEDA70" style="background-color:#BEDA70;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#DB5959" style="background-color:#DB5959;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#36466D" style="background-color:#36466D;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn" title="#55ADFF" style="background-color:#55ADFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+										<div class="clay-color-swatch-item">
+											<button class="btn clay-color-btn clay-color-btn-bordered" title="#FFFFFF" style="background-color:#FFFFFF;"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+									</div>
+
+									<div class="clay-color-map-group">
+										<div class="clay-color-map-hsb clay-color-map" style="background-color:rgb(180,237,254);">
+											<button class="clay-color-pointer clay-color-map-pointer" style="top: 0px; left: 130px;background-color: rgb(180,237,254);" type="button"><span class="c-inner" tabindex="-1"></span></button>
+										</div>
+
+										<div class="clay-color-map-values">
+											<div class="form-group">
+												<div class="input-group">
+													<div class="input-group-item">
+														<input class="form-control input-group-inset input-group-inset-before" id="clayColor1Red" type="text" value="180">
+														<label class="input-group-inset-item input-group-inset-item-before" for="clayColor1Red">
+															R
+														</label>
+													</div>
+												</div>
+											</div>
+											<div class="form-group">
+												<div class="input-group">
+													<div class="input-group-item">
+														<input class="form-control input-group-inset input-group-inset-before" id="clayColor1Green" type="text" value="237">
+														<label class="input-group-inset-item input-group-inset-item-before" for="clayColor1Green">
+															G
+														</label>
+													</div>
+												</div>
+											</div>
+											<div class="form-group">
+												<div class="input-group">
+													<div class="input-group-item">
+														<input class="form-control input-group-inset input-group-inset-before" id="clayColor1Blue" type="text" value="254">
+														<label class="input-group-inset-item input-group-inset-item-before" for="clayColor1Blue">
+															B
+														</label>
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+
+									<div class="clay-color-range clay-color-range-hue">
+										<button class="clay-color-pointer clay-color-range-pointer" type="button" style="left: 98px; background-color: rgb(180,237,254);"><span class="c-inner" tabindex="-1"></span></button>
+									</div>
+
+									<div class="clay-color-footer">
+										<input class="form-control" type="text" value="#B2EDFF">
+									</div>
+								</div>
+
+							</div>
+						</div>
+					</div>
+					<div class="input-group-append input-group-item">
+						<input aria-label="Color selection is #B2EDFF" class="form-control" id="clayColor1" type="text" value="#B2EDFF">
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Clay Time with Seconds and Extra Controls</h3>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label for="timePicker12hSeconds">Time Picker (12H)</label>
+				<div class="clay-time">
+					<div class="input-group">
+						<div class="input-group-item input-group-item-shrink">
+							<div class="form-control">
+								<div class="clay-time-edit">
+									<input class="clay-time-hours form-control-inset" id="timePicker12hSeconds" maxlength="2" name="hours" type="text" value="--">
+									<span class="clay-time-divider">:</span>
+									<input class="clay-time-minutes form-control-inset" maxlength="2" name="minutes" type="text" value="--">
+									<span class="clay-time-divider">:</span>
+									<input class="clay-time-seconds form-control-inset" maxlength="2" name="seconds" type="text" value="--">
+									<input class="clay-time-ampm form-control-inset" maxlength="2" name="ampm" type="text" value="--">
+								</div>
+								<div class="clay-time-action-group">
+									<div class="clay-time-action-group-item">
+										<button class="btn clay-time-clear-btn" type="button">
+											<span class="c-inner" tabindex="-1">
+												<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="clay-time-action-group-item">
+										<div class="btn-group-vertical clay-time-inner-spin" role="group">
+											<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc" type="button">
+												<span class="c-inner" tabindex="-1">
+													<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-up"></use>
+													</svg>
+												</span>
+											</button>
+											<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" type="button">
+												<span class="c-inner" tabindex="-1">
+													<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down"></use>
+													</svg>
+												</span>
+											</button>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row" style="margin-bottom: 400px;">
+	<div class="col-md-12">
+		<h3>Date Picker with C Inner</h3>
+
+		<div class="sheet">
+			<div class="form-group">
+				<div class="date-picker">
+					<div class="input-group">
+						<div class="input-group-item">
+							<input name="datePicker" type="hidden" value="">
+							<input class="form-control input-group-inset input-group-inset-after" placeholder="YYYY-MM-DD" type="text" value="">
+							<div class="input-group-inset-item input-group-inset-item-after">
+								<button class="btn btn-unstyled date-picker-dropdown-toggle" type="button">
+									<span class="c-inner" tabindex="-1">
+										<svg class="lexicon-icon lexicon-icon-calendar" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#calendar"></use>
+										</svg>
+									</span>
+								</button>
+							</div>
+						</div>
+						<div class="input-group-item input-group-item-shrink">
+							<span class="input-group-text">(GMT+01:00)</span>
+						</div>
+					</div>
+
+					<div class="date-picker-dropdown-menu dropdown-menu show">
+						<div class="date-picker-calendar">
+							<div class="date-picker-calendar-header">
+								<div class="date-picker-nav">
+									<div class="date-picker-nav-item input-date-picker-month">
+										<select class="form-control" disabled name="month">
+											<option value="0">January</option>
+											<option value="1">February</option>
+											<option value="2">March</option>
+											<option value="3">April</option>
+											<option value="4">May</option>
+											<option value="5">June</option>
+											<option value="6">July</option>
+											<option value="7">August</option>
+											<option value="8">September</option>
+											<option value="9">October</option>
+											<option value="10">November</option>
+											<option value="11">December</option>
+										</select>
+									</div>
+									<div class="date-picker-nav-item input-date-picker-year">
+										<select class="form-control" name="year">
+											<option value="1997">1997</option>
+											<option value="1998">1998</option>
+											<option value="1999">1999</option>
+											<option value="2000">2000</option>
+											<option value="2001">2001</option>
+											<option value="2002">2002</option>
+											<option value="2003">2003</option>
+											<option value="2004">2004</option>
+											<option value="2005">2005</option>
+											<option value="2006">2006</option>
+											<option value="2007">2007</option>
+											<option value="2008">2008</option>
+											<option value="2009">2009</option>
+											<option value="2010">2010</option>
+											<option value="2011">2011</option>
+											<option value="2012">2012</option>
+											<option value="2013">2013</option>
+											<option value="2014">2014</option>
+											<option value="2015">2015</option>
+											<option value="2016">2016</option>
+											<option value="2017">2017</option>
+											<option value="2018">2018</option>
+											<option value="2019">2019</option>
+											<option value="2020">2020</option>
+											<option value="2021">2021</option>
+											<option value="2022">2022</option>
+											<option value="2023">2023</option>
+										</select>
+									</div>
+
+									<div class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls">
+										<button aria-label="Select the previous month" class="btn nav-btn nav-btn-monospaced" disabled type="button">
+											<span class="c-inner" tabindex="-1">
+												<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-left"></use>
+												</svg>
+											</span>
+										</button>
+										<button aria-label="Select current date" class="btn nav-btn nav-btn-monospaced" type="button">
+											<span class="c-inner" tabindex="-1">
+												<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#simple-circle"></use>
+												</svg>
+											</span>
+										</button>
+										<button aria-label="Select the next month" class="btn nav-btn nav-btn-monospaced" type="button">
+											<span class="c-inner" tabindex="-1">
+												<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right"></use>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+
+							<div class="date-picker-calendar-body">
+								<div class="date-picker-days-row date-picker-row">
+									<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+									<div class="date-picker-day date-picker-calendar-item"><abbr>M</abbr></div>
+									<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
+									<div class="date-picker-day date-picker-calendar-item"><abbr>W</abbr></div>
+									<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
+									<div class="date-picker-day date-picker-calendar-item"><abbr>F</abbr></div>
+									<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+								</div>
+
+								<div class="date-picker-date-row date-picker-row">
+									<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button">
+										<span class="c-inner" tabindex="-1">27</span>
+									</button>
+									<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button">
+										<span class="c-inner" tabindex="-1">28</span>
+									</button>
+									<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button">
+										<span class="c-inner" tabindex="-1">29</span>
+									</button>
+									<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" type="button">
+										<span class="c-inner" tabindex="-1">30</span>
+									</button>
+									<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button">
+										<span class="c-inner" tabindex="-1">31</span>
+									</button>
+									<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">1</span>
+									</button>
+									<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">2</span>
+									</button>
+								</div>
+
+								<div class="date-picker-date-row date-picker-row">
+									<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">3</span>
+									</button>
+									<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">4</span>
+									</button>
+									<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">5</span>
+									</button>
+									<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">6</span>
+									</button>
+									<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">7</span>
+									</button>
+									<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">8</span>
+									</button>
+									<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">9</span>
+									</button>
+								</div>
+
+								<div class="date-picker-date-row date-picker-row">
+									<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">10</span>
+									</button>
+									<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">11</span>
+									</button>
+									<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">12</span>
+									</button>
+									<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item active" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-1">13</span>
+									</button>
+									<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">14</span>
+									</button>
+									<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">15</span>
+									</button>
+									<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">16</span>
+									</button>
+								</div>
+
+								<div class="date-picker-date-row date-picker-row">
+									<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">17</span>
+									</button>
+									<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">18</span>
+									</button>
+									<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">19</span>
+									</button>
+									<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">20</span>
+									</button>
+									<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">21</span>
+									</button>
+									<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">22</span>
+									</button>
+									<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">23</span>
+									</button>
+								</div>
+
+								<div class="date-picker-date-row date-picker-row">
+									<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">24</span>
+									</button>
+									<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">25</span>
+									</button>
+									<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">26</span>
+									</button>
+									<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">27</span>
+									</button>
+									<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button">
+										<span class="c-inner" tabindex="-1">28</span>
+									</button>
+									<button aria-label="2019 03 01" class="active date-picker-date date-picker-calendar-item next-month-date" type="button">
+										<span class="c-inner" tabindex="-1">1</span>
+									</button>
+									<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button">
+										<span class="c-inner" tabindex="-1">2</span>
+									</button>
+								</div>
+							</div>
+
+							<div class="date-picker-calendar-footer">
+								<div class="clay-time">
+									<div class="input-group">
+										<div class="input-group-item input-group-item-shrink">
+											<div class="input-group-text">
+												<svg class="lexicon-icon lexicon-icon-time" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#time"></use>
+												</svg>
+											</div>
+										</div>
+										<div class="input-group-item">
+											<div class="form-control">
+												<div class="clay-time-edit">
+													<input class="clay-time-hours form-control-inset" id="timePicker12hTimeZoneIcon" maxlength="2" name="uniqueNameHours" type="text" value="12">
+													<span class="clay-time-divider">:</span>
+													<input class="clay-time-minutes form-control-inset" maxlength="2" name="uniqueNameMinutes" type="text" value="00">
+													<input class="clay-time-ampm form-control-inset" maxlength="2" name="uniqueNameAmpm" type="text" value="PM">
+												</div>
+
+												<div class="clay-time-action-group">
+													<div class="clay-time-action-group-item">
+														<div class="btn-group-vertical clay-time-inner-spin" role="group">
+															<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc" type="button">
+																<span class="c-inner" tabindex="-1">
+																	<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-up"></use>
+																	</svg>
+																</span>
+															</button>
+															<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" type="button">
+																<span class="c-inner" tabindex="-1">
+																	<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down"></use>
+																	</svg>
+																</span>
+															</button>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+										<div class="input-group-item input-group-item-shrink">
+											<span class="input-group-text">(GMT+01:00)</span>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>List Group with C Inner</h3>
+
+<ul class="list-group show-quick-actions-on-hover">
+	<li class="list-group-header">
+		<h3 class="list-group-header-title">List Group Header 1</h3>
+	</li>
+	<li class="list-group-item list-group-item-flex">
+		<div class="autofit-col autofit-col-expand">
+			<section class="autofit-section">
+				<div class="list-group-title">
+					<span class="text-truncate-inline">
+						<a class="text-truncate" href="#1">
+							<span class="c-inner" tabindex="-1">List Item 1</span>
+						</a>
+					</span>
+				</div>
+			</section>
+		</div>
+	</li>
+	<li class="list-group-item list-group-item-flex">
+		<div class="autofit-col autofit-col-expand">
+			<section class="autofit-section">
+				<div class="list-group-title">
+					<span class="text-truncate-inline">
+						<a class="text-truncate" href="#1">
+							<span class="c-inner" tabindex="-1">List Item 2</span>
+						</a>
+					</span>
+				</div>
+			</section>
+		</div>
+	</li>
+	<li class="list-group-item list-group-item-flex">
+		<div class="autofit-col autofit-col-expand">
+			<section class="autofit-section">
+				<div class="list-group-title">
+					<span class="text-truncate-inline">
+						<a class="text-truncate" href="#1">
+							<span class="c-inner" tabindex="-1">List Item 3</span>
+						</a>
+					</span>
+				</div>
+			</section>
+		</div>
+	</li>
+	<li class="list-group-item list-group-item-flex">
+		<div class="autofit-col autofit-col-expand">
+			<section class="autofit-section">
+				<div class="list-group-title">
+					<span class="text-truncate-inline">
+						<a class="text-truncate" href="#1">
+							<span class="c-inner" tabindex="-1">List Item 4</span>
+						</a>
+					</span>
+				</div>
+			</section>
+		</div>
+	</li>
+	<li class="list-group-header">
+		<h3 class="list-group-header-title">List Group Header 2</h3>
+	</li>
+	<li class="list-group-item list-group-item-flex">
+		<div class="autofit-col">
+			<div class="custom-control custom-checkbox">
+				<label>
+					<input class="custom-control-input" type="checkbox">
+					<span class="custom-control-label"></span>
+				</label>
+			</div>
+		</div>
+		<div class="autofit-col">
+			<div class="sticker sticker-secondary">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
+			</div>
+		</div>
+		<div class="autofit-col autofit-col-expand">
+			<section class="autofit-section">
+				<div class="list-group-title">
+					<span class="text-truncate-inline">
+						<a class="text-truncate" href="#1">
+							<span class="c-inner" tabindex="-1">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+						</a>
+					</span>
+				</div>
+				<p class="list-group-subtext">
+					<span class="text-truncate-inline">
+						<span class="text-truncate">List Group Subtext</span>
+					</span>
+				</p>
+				<div class="list-group-detail">
+					<span class="label label-success">
+						<span class="label-item label-item-expand">Approved</span>
+					</span>
+				</div>
+			</section>
+		</div>
+		<div class="autofit-col">
+			<div class="quick-action-menu">
+				<a class="component-action quick-action-item" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+						</svg>
+					</span>
+				</a>
+				<a class="component-action quick-action-item" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+						</svg>
+					</span>
+				</a>
+				<a class="component-action quick-action-item" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+						</svg>
+					</span>
+				</a>
+			</div>
+			<div class="dropdown dropdown-action">
+				<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</span>
+				</a>
+				<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+					<li>
+						<a class="dropdown-item" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">Remove</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">Download</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">Checkout</span>
+						</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</li>
+	<li class="list-group-item list-group-item-flex">
+		<div class="autofit-col">
+			<div class="custom-control custom-checkbox">
+				<label>
+					<input class="custom-control-input" type="checkbox">
+					<span class="custom-control-label"></span>
+				</label>
+			</div>
+		</div>
+		<div class="autofit-col">
+			<div class="sticker sticker-secondary">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
+			</div>
+		</div>
+		<div class="autofit-col autofit-col-expand">
+			<section class="autofit-section">
+				<div class="list-group-title">
+					<a href="#1">
+						<span class="c-inner" tabindex="-1">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</span>
+					</a>
+				</div>
+				<p class="list-group-subtext">List Group Subtext</p>
+				<div class="list-group-detail">
+					<span class="label label-success">
+						<span class="label-item label-item-expand">Approved</span>
+					</span>
+				</div>
+			</section>
+		</div>
+		<div class="autofit-col">
+			<div class="quick-action-menu">
+				<a class="component-action quick-action-item" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+						</svg>
+					</span>
+				</a>
+				<a class="component-action quick-action-item" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+						</svg>
+					</span>
+				</a>
+				<a class="component-action quick-action-item" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+						</svg>
+					</span>
+				</a>
+			</div>
+			<div class="dropdown dropdown-action">
+				<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</span>
+				</a>
+				<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+					<li>
+						<a class="dropdown-item" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">Remove</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">Download</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">Checkout</span>
+						</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</li>
+	<li class="list-group-item list-group-item-flex">
+		<div class="autofit-col">
+			<div class="custom-control custom-checkbox">
+				<label>
+					<input class="custom-control-input" type="checkbox">
+					<span class="custom-control-label"></span>
+				</label>
+			</div>
+		</div>
+		<div class="autofit-col">
+			<div class="sticker sticker-secondary">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
+			</div>
+		</div>
+		<div class="autofit-col autofit-col-expand">
+			<section class="autofit-section">
+				<div class="list-group-title">
+					<span class="text-truncate-inline">
+						<a class="text-truncate" href="#1">
+							<span class="c-inner" tabindex="-1">Account Example One</span>
+						</a>
+					</span>
+				</div>
+				<p class="list-group-subtext">
+					<span class="text-truncate-inline">
+						<span class="text-truncate">List Group Subtext</span>
+					</span>
+				</p>
+			</section>
+		</div>
+		<div class="autofit-col">
+			<div class="quick-action-menu">
+				<button class="component-action quick-action-item" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+						</svg>
+					</span>
+				</button>
+				<button class="component-action quick-action-item" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+						</svg>
+					</span>
+				</button>
+				<button class="component-action quick-action-item" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+						</svg>
+					</span>
+				</button>
+			</div>
+			<div class="dropdown dropdown-action">
+				<button aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" id="dropdownAction1" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</span>
+				</button>
+				<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+					<li>
+						<button class="dropdown-item" type="button">
+							<span class="c-inner" tabindex="-1">Remove</span>
+						</button>
+					</li>
+					<li>
+						<button class="dropdown-item" type="button">
+							<span class="c-inner" tabindex="-1">Download</span>
+						</button>
+					</li>
+					<li>
+						<button class="dropdown-item" type="button">
+							<span class="c-inner" tabindex="-1">Checkout</span>
+						</button>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</li>
+	<li class="list-group-item list-group-item-flex">
+		<div class="autofit-col">
+			<div class="custom-control custom-checkbox">
+				<label>
+					<input class="custom-control-input" type="checkbox">
+					<span class="custom-control-label"></span>
+				</label>
+			</div>
+		</div>
+		<div class="autofit-col">
+			<div class="sticker sticker-secondary">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</span>
+			</div>
+		</div>
+		<div class="autofit-col autofit-col-expand">
+			<section class="autofit-section">
+				<div class="list-group-title">
+					<a href="#1">
+						<span class="c-inner" tabindex="-1">Account Example Two</span>
+					</a>
+				</div>
+				<p class="list-group-text">List Group Text</p>
+				<p class="list-group-subtext">List Group Subtext</p>
+			</section>
+		</div>
+		<div class="autofit-col">
+			<div class="quick-action-menu">
+				<button class="component-action quick-action-item" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+						</svg>
+					</span>
+				</button>
+				<button class="component-action quick-action-item" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+						</svg>
+					</span>
+				</button>
+				<button class="component-action quick-action-item" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+						</svg>
+					</span>
+				</button>
+			</div>
+			<div class="dropdown dropdown-action">
+				<button aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" id="dropdownAction1" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</span>
+				</button>
+				<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+					<li>
+						<a class="dropdown-item" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">Remove</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">Download</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">Checkout</span>
+						</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</li>
+</ul>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>List Group with Links and Buttons C Inner</h3>
+
+		<div class="list-group">
+			<a class="list-group-item list-group-item-action" href="#1">
+				<span class="c-inner" tabindex="-1">List Item 1</span>
+			</a>
+			<a class="list-group-item list-group-item-action" href="#1">
+				<span class="c-inner" tabindex="-1">List Item 2</span>
+			</a>
+			<button class="list-group-item list-group-item-action" type="button">
+				<span class="c-inner" tabindex="-1">List Item 3</span>
+			</button>
+			<a class="list-group-item list-group-item-action" href="#1">
+				<span class="c-inner" tabindex="-1">List Item 4</span>
+			</a>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Base Nav with C Inner</h3>
+
+		<ul class="nav">
+			<li class="nav-item">
+				<a class="active nav-link" href="#1">
+					<span class="c-inner" tabindex="-1">Details</span>
+				</a>
+			</li>
+			<li class="nav-item">
+				<a class="nav-link" href="#1">
+					<span class="c-inner" tabindex="-1">Categorization</span>
+				</a>
+			</li>
+			<li class="nav-item">
+				<a class="disabled nav-link" href="#1" tabindex="-1">
+					<span class="c-inner" tabindex="-1">Documents and Media</span>
+				</a>
+			</li>
+			<li class="nav-item">
+				<a class="nav-link" href="#1">
+					<span class="c-inner" tabindex="-1">Site Template</span>
+				</a>
+			</li>
+		</ul>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Nav Stacked with Buttons C Inner</h3>
+	</div>
+
+	<div class="col-md-4">
+		<ul class="nav nav-stacked">
+			<li class="nav-item">
+				<button class="active btn btn-unstyled nav-link" type="button">
+					<span class="c-inner" tabindex="-1">Details</span>
+				</button>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-unstyled nav-link" type="button">
+					<span class="c-inner" tabindex="-1">Categorization</span>
+				</button>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-unstyled nav-link" disabled type="button">
+					<span class="c-inner" tabindex="-1">Documents and Media</span>
+				</button>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-unstyled nav-link" type="button">
+					<span class="c-inner" tabindex="-1">Site Template</span>
+				</button>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-unstyled nav-link" type="button">
+					<span class="c-inner" tabindex="-1">Configuration</span>
+				</button>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-unstyled nav-link" type="button">
+					<span class="c-inner" tabindex="-1">Identification</span>
+				</button>
+			</li>
+		</ul>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Nav Nested with Buttons C Inner</h3>
+	</div>
+
+	<div class="col-md-6">
+		<ul class="nav nav-nested">
+			<li class="nav-item">
+				<button aria-controls="navCollapseButton01" aria-expanded="true" class="btn btn-unstyled collapse-icon nav-link" data-toggle="collapse" data-target="#navCollapseButton01" type="button">
+					<span class="c-inner" tabindex="-1">
+						Basic Information
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</button>
+				<div class="collapse show" id="navCollapseButton01">
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="active nav-link" href="#1">
+								<span class="c-inner" tabindex="-1">Details</span>
+							</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1">
+								<span class="c-inner" tabindex="-1">Categorization</span>
+							</a>
+						</li>
+						<li class="nav-item">
+							<button aria-controls="navCollapseButton02" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#navCollapseButton02" type="button">
+								<span class="c-inner" tabindex="-1">
+									Documents and Media
+									<span class="collapse-icon-closed">
+										<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+										</svg>
+									</span>
+									<span class="collapse-icon-open">
+										<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+										</svg>
+									</span>
+								</span>
+							</button>
+							<div class="collapse" id="navCollapseButton02">
+								<ul class="nav nav-stacked">
+									<li class="nav-item">
+										<a class="nav-link" href="#1">
+											<span class="c-inner" tabindex="-1">Details</span>
+										</a>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1">
+											<span class="c-inner" tabindex="-1">Categorization</span>
+										</a>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1">
+											<span class="c-inner" tabindex="-1">Documents and Media</span>
+										</a>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1">
+											<span class="c-inner" tabindex="-1">Site Template</span>
+										</a>
+									</li>
+								</ul>
+							</div>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1">
+								<span class="c-inner" tabindex="-1">Site Template</span>
+							</a>
+						</li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<button aria-controls="navCollapseButton03" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#navCollapseButton03" type="button">
+					<span class="c-inner" tabindex="-1">
+						SEO
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</button>
+				<div class="collapse" id="navCollapseButton03">
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="nav-link" href="#1">
+								<span class="c-inner" tabindex="-1">Sitemap</span>
+							</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1">
+								<span class="c-inner" tabindex="-1">Robots</span>
+							</a>
+						</li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<button aria-controls="navCollapseButton04" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" href="#navCollapseButton04" type="button">
+					<span class="c-inner" tabindex="-1">
+						Advanced
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</button>
+				<div class="collapse" id="navCollapseButton04">
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="nav-link" href="#1">
+								<span class="c-inner" tabindex="-1">Default User Associations</span>
+							</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1">
+								<span class="c-inner" tabindex="-1">Staging</span>
+							</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1">
+								<span class="c-inner" tabindex="-1">Analytics</span>
+							</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1">
+								<span class="c-inner" tabindex="-1">Maps</span>
+							</a>
+						</li>
+					</ul>
+				</div>
+			</li>
+		</ul>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Nav Link and Button Helpers with C Inner</h3>
+
+		<ul class="nav">
+			<li class="nav-item">
+				<a class="active nav-link" href="#1">
+					<span class="c-inner" tabindex="-1">Basic Information</span>
+				</a>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-unstyled nav-link" type="button">
+					<span class="c-inner" tabindex="-1">Details</span>
+				</button>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-primary nav-btn" type="button">
+					<span class="c-inner" tabindex="-1">Details</span>
+				</button>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-link nav-btn" type="button">
+					<span class="c-inner" tabindex="-1">Details</span>
+				</button>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-primary nav-btn nav-btn-monospaced" type="button">
+					<span class="c-inner" tabindex="-1">De</span>
+				</button>
+			</li>
+			<li class="nav-item">
+				<a class="disabled nav-link" href="#1" tabindex="-1">
+					<span class="c-inner" tabindex="-1">Categorization</span>
+				</a>
+			</li>
+			<li class="dropdown nav-item">
+				<button aria-expanded="false" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle nav-link" data-toggle="dropdown" type="button">
+					<span class="c-inner" tabindex="-1">
+						More
+						<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+						</svg>
+					</span>
+				</button>
+				<ul aria-labelledby="" class="dropdown-menu">
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">App Section 4</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">App Section 5</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">App Section 6</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">App Section 7</span>
+						</a>
+					</li>
+				</ul>
+			</li>
+			<li class="nav-item">
+				<a class="nav-link nav-link-monospaced" href="#1">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-cog" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#cog" />
+						</svg>
+					</span>
+				</a>
+			</li>
+			<li class="nav-item">
+				<a class="btn btn-primary nav-btn nav-btn-monospaced" href="#1">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-cog" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#cog" />
+						</svg>
+					</span>
+				</a>
+			</li>
+			<li class="nav-item">
+				<button class="btn btn-unstyled nav-btn nav-btn-monospaced" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-cog" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#cog" />
+						</svg>
+					</span>
+				</button>
+			</li>
+		</ul>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Menubar Vertical Expand Md with Buttons C Inner</h3>
+	</div>
+
+	<div class="col-md-6">
+		<nav class="menubar menubar-transparent menubar-vertical-expand-md">
+			<button aria-controls="menubarVerticalMdCollapseButton01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" data-target="#menubarVerticalMdCollapseButton01" role="button">
+				<span class="c-inner" tabindex="-1">
+					Details
+					<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+					</svg>
+				</span>
+			</button>
+			<div class="collapse menubar-collapse" id="menubarVerticalMdCollapseButton01">
+				<ul class="nav nav-nested">
+					<li class="nav-item">
+						<button aria-controls="menubarVerticalMdNestedCollapseButton01" aria-expanded="true" class="btn btn-unstyled collapse-icon nav-link" data-toggle="collapse" data-target="#menubarVerticalMdNestedCollapseButton01" type="button">
+							<span class="c-inner" tabindex="-1">
+								Basic Information
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
+							</span>
+						</button>
+						<div class="collapse show" id="menubarVerticalMdNestedCollapseButton01">
+							<ul class="nav nav-stacked">
+								<li class="nav-item">
+									<a class="active nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Details</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Categorization</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<button aria-controls="menubarVerticalMdNestedCollapseButton02" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#menubarVerticalMdNestedCollapseButton02" type="button">
+										<span class="c-inner" tabindex="-1">
+											Documents and Media
+											<span class="collapse-icon-closed">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+											<span class="collapse-icon-open">
+												<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+												</svg>
+											</span>
+										</span>
+									</button>
+									<div class="collapse" id="menubarVerticalMdNestedCollapseButton02">
+										<ul class="nav nav-stacked">
+											<li class="nav-item">
+												<a class="nav-link" href="#1">
+													<span class="c-inner" tabindex="-1">Details</span>
+												</a>
+											</li>
+											<li class="nav-item">
+												<a class="nav-link" href="#1">
+													<span class="c-inner" tabindex="-1">Categorization</span>
+												</a>
+											</li>
+											<li class="nav-item">
+												<a class="nav-link" href="#1">
+													<span class="c-inner" tabindex="-1">Documents and Media</span>
+												</a>
+											</li>
+											<li class="nav-item">
+												<a class="nav-link" href="#1">
+													<span class="c-inner" tabindex="-1">Site Template</span>
+												</a>
+											</li>
+										</ul>
+									</div>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Site Template</span>
+									</a>
+								</li>
+							</ul>
+						</div>
+					</li>
+					<li class="nav-item">
+						<button aria-controls="menubarVerticalMdNestedCollapseButton03" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#menubarVerticalMdNestedCollapseButton03" type="button">
+							<span class="c-inner" tabindex="-1">
+								SEO
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
+							</span>
+						</button>
+						<div class="collapse" id="menubarVerticalMdNestedCollapseButton03">
+							<ul class="nav nav-stacked">
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Sitemap</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Robots</span>
+									</a>
+								</li>
+							</ul>
+						</div>
+					</li>
+					<li class="nav-item">
+						<button aria-controls="menubarVerticalMdNestedCollapseButton04" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#menubarVerticalMdNestedCollapseButton04" type="button">
+							<span class="c-inner" tabindex="-1">
+								Advanced
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
+							</span>
+						</button>
+						<div class="collapse" id="menubarVerticalMdNestedCollapseButton04">
+							<ul class="nav nav-stacked">
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Default User Associations</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Staging</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Analytics</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Maps</span>
+									</a>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Menubar Decorated Menubar Vertical Expand Md with Buttons C Inner</h3>
+	</div>
+
+	<div class="col-md-6">
+		<nav class="menubar menubar-decorated menubar-transparent menubar-vertical-expand-md">
+			<button aria-controls="menubarDecoratedVerticalMdCollapseButton01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" data-target="#menubarDecoratedVerticalMdCollapseButton01" role="button">
+				<span class="c-inner" tabindex="-1">
+					Details
+					<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+					</svg>
+				</span>
+			</button>
+			<div class="collapse menubar-collapse" id="menubarDecoratedVerticalMdCollapseButton01">
+				<ul class="nav nav-nested">
+					<li class="nav-item">
+						<button aria-controls="menubarDecoratedVerticalMdNestedCollapseButton01" aria-expanded="true" class="btn btn-unstyled collapse-icon nav-link" data-toggle="collapse" data-target="#menubarDecoratedVerticalMdNestedCollapseButton01" type="button">
+							<span class="c-inner" tabindex="-1">
+								Basic Information
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
+							</span>
+						</button>
+						<div class="collapse show" id="menubarDecoratedVerticalMdNestedCollapseButton01">
+							<ul class="nav nav-stacked">
+								<li class="nav-item">
+									<a class="active nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Details</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Categorization</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<button aria-controls="menubarDecoratedVerticalMdNestedCollapseButton02" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#menubarDecoratedVerticalMdNestedCollapseButton02" type="button">
+										<span class="c-inner" tabindex="-1">
+											Documents and Media
+											<span class="collapse-icon-closed">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+											<span class="collapse-icon-open">
+												<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+												</svg>
+											</span>
+										</span>
+									</button>
+									<div class="collapse" id="menubarDecoratedVerticalMdNestedCollapseButton02">
+										<ul class="nav nav-stacked">
+											<li class="nav-item">
+												<a class="nav-link" href="#1">
+													<span class="c-inner" tabindex="-1">Details</span>
+												</a>
+											</li>
+											<li class="nav-item">
+												<a class="nav-link" href="#1">
+													<span class="c-inner" tabindex="-1">Categorization</span>
+												</a>
+											</li>
+											<li class="nav-item">
+												<a class="nav-link" href="#1">
+													<span class="c-inner" tabindex="-1">Documents and Media</span>
+												</a>
+											</li>
+											<li class="nav-item">
+												<a class="nav-link" href="#1">
+													<span class="c-inner" tabindex="-1">Site Template</span>
+												</a>
+											</li>
+										</ul>
+									</div>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Site Template</span>
+									</a>
+								</li>
+							</ul>
+						</div>
+					</li>
+					<li class="nav-item">
+						<button aria-controls="menubarDecoratedVerticalMdNestedCollapseButton03" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#menubarDecoratedVerticalMdNestedCollapseButton03" type="button">
+							<span class="c-inner" tabindex="-1">
+								SEO
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
+							</span>
+						</button>
+						<div class="collapse" id="menubarDecoratedVerticalMdNestedCollapseButton03">
+							<ul class="nav nav-stacked">
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Sitemap</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Robots</span>
+									</a>
+								</li>
+							</ul>
+						</div>
+					</li>
+					<li class="nav-item">
+						<button aria-controls="menubarDecoratedVerticalMdNestedCollapseButton04" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#menubarDecoratedVerticalMdNestedCollapseButton04" type="button">
+							<span class="c-inner" tabindex="-1">
+								Advanced
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
+							</span>
+						</button>
+						<div class="collapse" id="menubarDecoratedVerticalMdNestedCollapseButton04">
+							<ul class="nav nav-stacked">
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Default User Associations</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Staging</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Analytics</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="c-inner" tabindex="-1">Maps</span>
+									</a>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Multi Step Nav</h3>
+
+		<div class="sheet">
+			<ol class="multi-step-nav">
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<a class="multi-step-icon" data-multi-step-icon="1" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<a class="multi-step-icon" data-multi-step-icon="2" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="active complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="dropdown multi-step-indicator">
+						<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle multi-step-icon" data-toggle="dropdown" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
+									<use xlink:href="../../images/icons/icons.svg#ellipsis-h"></use>
+								</svg>
+							</span>
+						</a>
+						<ul class="dropdown-menu dropdown-menu-indicator-end">
+							<li>
+								<a class="complete dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										1. Step One
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										2. Step Two
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="multi-step-item">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<a class="multi-step-icon" data-multi-step-icon="Fin" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+			</ol>
+			<ol class="multi-step-nav multi-step-indicator-label-top">
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">Step 01</div>
+						<a class="multi-step-icon" data-multi-step-icon="1" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="dropdown multi-step-indicator">
+						<button aria-expanded="false" aria-haspopup="true" class="dropdown-toggle multi-step-icon" data-toggle="dropdown" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
+									<use xlink:href="../../images/icons/icons.svg#ellipsis-h"></use>
+								</svg>
+							</span>
+						</button>
+						<ul class="dropdown-menu dropdown-menu-indicator-end">
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										5. Step Five
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="complete dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										6. Step Six
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										7. Step Seven
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										8. Step Eight
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="dropdown multi-step-indicator">
+						<button aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle multi-step-icon" data-toggle="dropdown" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
+									<use xlink:href="../../images/icons/icons.svg#ellipsis-h"></use>
+								</svg>
+							</span>
+						</button>
+						<ul class="dropdown-menu dropdown-menu-indicator-end">
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										5. Step Five
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										6. Step Six
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										7. Step Seven
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										8. Step Eight
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="dropdown multi-step-indicator">
+						<button aria-expanded="false" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle multi-step-icon" data-toggle="dropdown" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
+									<use xlink:href="../../images/icons/icons.svg#ellipsis-h"></use>
+								</svg>
+							</span>
+						</button>
+						<ul class="dropdown-menu dropdown-menu-indicator-end">
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										5. Step Five
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										6. Step Six
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										7. Step Seven
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										8. Step Eight
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="dropdown multi-step-indicator">
+						<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle multi-step-icon" data-toggle="dropdown" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
+									<use xlink:href="../../images/icons/icons.svg#ellipsis-h"></use>
+								</svg>
+							</span>
+						</a>
+						<ul class="dropdown-menu dropdown-menu-indicator-end">
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										5. Step Five
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										6. Step Six
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										7. Step Seven
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										8. Step Eight
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">Step 09</div>
+						<a class="multi-step-icon" data-multi-step-icon="9" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="multi-step-item">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">Step 10</div>
+						<a class="multi-step-icon" data-multi-step-icon="10" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+			</ol>
+			<ol class="multi-step-nav multi-step-indicator-label-bottom">
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">01</div>
+						<a class="multi-step-icon" data-multi-step-icon="1" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">02</div>
+						<a class="multi-step-icon" data-multi-step-icon="2" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">03</div>
+						<a class="multi-step-icon" data-multi-step-icon="3" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">04</div>
+						<a class="multi-step-icon" data-multi-step-icon="4" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">05</div>
+						<a class="multi-step-icon" data-multi-step-icon="5" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="active multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">06</div>
+						<a class="multi-step-icon" data-multi-step-icon="6" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="multi-step-item">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">07</div>
+						<a class="multi-step-icon" data-multi-step-icon="7" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+			</ol>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Multi Step Nav Collapse (sm, md, lg, xl)</h3>
+
+		<div class="sheet">
+
+	<ol class="multi-step-nav multi-step-nav-collapse-sm multi-step-indicator-label-top">
+		<li class="complete multi-step-item multi-step-item-expand">
+			<div class="multi-step-divider"></div>
+			<div class="multi-step-indicator">
+				<div class="multi-step-indicator-label">Step 01</div>
+				<a class="multi-step-icon" data-multi-step-icon="1" href="#1">
+					<span class="c-inner" tabindex="-1"></span>
+				</a>
+			</div>
+		</li>
+		<li class="complete multi-step-item multi-step-item-expand">
+			<div class="multi-step-divider"></div>
+			<div class="multi-step-indicator">
+				<div class="multi-step-indicator-label">Step 02</div>
+				<a class="multi-step-icon" data-multi-step-icon="2" href="#1">
+					<span class="c-inner" tabindex="-1"></span>
+				</a>
+			</div>
+		</li>
+		<li class="complete multi-step-item multi-step-item-expand">
+			<div class="multi-step-divider"></div>
+			<div class="multi-step-indicator">
+				<div class="multi-step-indicator-label">Step 03</div>
+				<a class="multi-step-icon" data-multi-step-icon="3" href="#1">
+					<span class="c-inner" tabindex="-1"></span>
+				</a>
+			</div>
+		</li>
+		<li class="complete multi-step-item multi-step-item-expand">
+			<div class="multi-step-divider"></div>
+			<div class="multi-step-indicator">
+				<div class="multi-step-indicator-label">Step 04</div>
+				<a class="multi-step-icon" data-multi-step-icon="4" href="#1">
+					<span class="c-inner" tabindex="-1"></span>
+				</a>
+			</div>
+		</li>
+		<li class="active multi-step-item multi-step-item-expand">
+			<div class="multi-step-divider"></div>
+			<div class="dropdown multi-step-indicator">
+				<div class="multi-step-indicator-label">Step 05</div>
+				<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle multi-step-icon" data-toggle="dropdown" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-h"></use>
+						</svg>
+					</span>
+				</a>
+				<ul class="dropdown-menu dropdown-menu-indicator-end">
+					<li>
+						<a class="active complete dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">
+								5. Step Five
+								<span aria-hidden="true" class="dropdown-item-indicator-end">
+									<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+									</svg>
+								</span>
+							</span>
+						</a>
+					</li>
+					<li>
+						<a class="complete dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">
+								6. Step Six
+								<span aria-hidden="true" class="dropdown-item-indicator-end">
+									<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+									</svg>
+								</span>
+							</span>
+						</a>
+					</li>
+					<li>
+						<a class="complete dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">
+								7. Step Seven
+								<span aria-hidden="true" class="dropdown-item-indicator-end">
+									<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+									</svg>
+								</span>
+							</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">
+								8. Step Eight
+								<span aria-hidden="true" class="dropdown-item-indicator-end">
+									<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+									</svg>
+								</span>
+							</span>
+						</a>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="disabled multi-step-item multi-step-item-expand">
+			<div class="multi-step-divider"></div>
+			<div class="multi-step-indicator">
+				<div class="multi-step-indicator-label">Step 09</div>
+				<a class="multi-step-icon" data-multi-step-icon="9" href="#1" tabindex="-1">
+					<span class="c-inner" tabindex="-1"></span>
+				</a>
+			</div>
+		</li>
+		<li class="multi-step-item">
+			<div class="multi-step-divider"></div>
+			<div class="multi-step-indicator">
+				<div class="multi-step-indicator-label">Step 10</div>
+				<a class="multi-step-icon" data-multi-step-icon="10" href="#1">
+					<span class="c-inner" tabindex="-1"></span>
+				</a>
+			</div>
+		</li>
+	</ol>
+
+			<ol class="multi-step-nav multi-step-nav-collapse-sm multi-step-indicator-label-bottom">
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-title">Ticket Buyer Information</div>
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">Step 01</div>
+						<a class="multi-step-icon" data-multi-step-icon="1" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-title">Attendee Information</div>
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">Step 02</div>
+						<a class="multi-step-icon" data-multi-step-icon="2" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="complete multi-step-item multi-step-item-expand">
+					<div class="multi-step-title">Seat Assignment</div>
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">Step 03</div>
+						<a class="multi-step-icon" data-multi-step-icon="3" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="active multi-step-item multi-step-item-expand">
+					<div class="multi-step-title">Dinner Preference</div>
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">Step 04</div>
+						<a class="multi-step-icon" data-multi-step-icon="4" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="multi-step-item multi-step-item-expand">
+					<div class="multi-step-divider"></div>
+					<div class="dropdown multi-step-indicator">
+						<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle multi-step-icon" data-toggle="dropdown" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
+									<use xlink:href="../../images/icons/icons.svg#ellipsis-h"></use>
+								</svg>
+							</span>
+						</a>
+						<ul class="dropdown-menu dropdown-menu-indicator-end">
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										5. Step Five
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										6. Step Six
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										7. Step Seven
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										8. Step Eight
+										<span aria-hidden="true" class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#check" />
+											</svg>
+										</span>
+									</span>
+								</a>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="multi-step-item multi-step-item-expand">
+					<div class="multi-step-title">Payment Information</div>
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">Step 09</div>
+						<a class="multi-step-icon" data-multi-step-icon="9" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+				<li class="multi-step-item">
+					<div class="multi-step-divider"></div>
+					<div class="multi-step-indicator">
+						<div class="multi-step-indicator-label">Step 10</div>
+						<a class="multi-step-icon" data-multi-step-icon="Fin" href="#1">
+							<span class="c-inner" tabindex="-1"></span>
+						</a>
+					</div>
+				</li>
+			</ol>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Navbar (Application Bar) with C Inner</h3>
+	</div>
+
+	<div class="col-md-12">
+		<nav class="application-bar application-bar-dark navbar navbar-expand-md">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="navbar-nav">
+					<li class="nav-item">
+						<button class="btn btn-unstyled nav-btn nav-btn-monospaced" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-closed" />
+								</svg>
+							</span>
+						</button>
+					</li>
+					<li class="nav-item">
+						<button class="btn btn-unstyled nav-btn nav-btn-monospaced" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-left" />
+								</svg>
+							</span>
+						</button>
+					</li>
+				</ul>
+				<div class="navbar-title navbar-text-truncate">My Application Name</div>
+				<ul class="navbar-nav">
+					<li class="nav-item">
+						<a class="nav-link nav-link-monospaced" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-cog" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#cog" />
+								</svg>
+							</span>
+						</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link nav-link-monospaced" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#plus" />
+								</svg>
+							</span>
+						</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link nav-link-monospaced" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-simulation-menu-closed" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#simulation-menu-closed" />
+								</svg>
+							</span>
+						</a>
+					</li>
+					<li class="dropdown nav-item">
+						<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced" data-toggle="dropdown" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</a>
+						<ul aria-labelledby="navbarDropdownMenuLink" class="dropdown-menu dropdown-menu-right">
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">Action</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">Another action</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">Something else here</span>
+								</a>
+							</li>
+							<li class="dropdown-divider"></li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">Separated link</span>
+								</a>
+							</li>
+						</ul>
+					</li>
+				</ul>
+			</div>
+		</nav>
+
+	</div>
+</div>
+
+<div class="clay-site-open-overlay clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Navbar (Management Bar) with C Inner</h3>
+	</div>
+
+	<div class="col-md-12">
+		<nav class="management-bar management-bar-light navbar navbar-expand-md">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="navbar-nav">
+					<li class="nav-item">
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input class="custom-control-input" type="checkbox">
+								<span class="custom-control-label"></span>
+							</label>
+						</div>
+					</li>
+					<li class="dropdown nav-item">
+						<button aria-expanded="false" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle nav-link navbar-breakpoint-down-d-none" data-toggle="dropdown" type="button">
+							<span class="c-inner" tabindex="-1">
+								<span class="navbar-text-truncate">Filter and Order</span>
+								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+								</svg>
+							</span>
+						</button>
+						<button aria-expanded="false" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle nav-btn nav-btn-monospaced navbar-breakpoint-d-none" data-toggle="dropdown" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-filter" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#filter" />
+								</svg>
+							</span>
+						</button>
+						<ul class="dropdown-menu">
+							<li>
+								<button class="dropdown-item" type="button">
+									<span class="c-inner" tabindex="-1">Filter Action 1</span>
+								</button>
+							</li>
+							<li>
+								<button class="dropdown-item" type="button">
+									<span class="c-inner" tabindex="-1">Filter Action 2</span>
+								</button>
+							</li>
+							<li>
+								<button class="dropdown-item" type="button">
+									<span class="c-inner" tabindex="-1">Filter Action 3</span>
+								</button>
+							</li>
+						</ul>
+					</li>
+					<li class="nav-item">
+						<button class="btn btn-unstyled nav-btn nav-btn-monospaced order-arrow-down-active" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-order-arrow" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#order-arrow" />
+								</svg>
+							</span>
+						</button>
+					</li>
+				</ul>
+				<div class="navbar-form navbar-form-autofit navbar-overlay navbar-overlay-sm-down">
+					<div class="container-fluid container-fluid-max-xl">
+						<form role="search">
+							<div class="input-group">
+								<div class="input-group-item">
+									<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
+									<span class="input-group-inset-item input-group-inset-item-after">
+										<button class="btn btn-unstyled" type="submit">
+											<span class="c-inner" tabindex="-1">
+												<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+												</svg>
+											</span>
+										</button>
+										<button class="btn btn-unstyled d-none" type="button">
+											<span class="c-inner" tabindex="-1">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</div>
+							</div>
+						</form>
+					</div>
+				</div>
+				<ul class="navbar-nav">
+					<li class="nav-item navbar-breakpoint-d-none">
+						<button class="btn btn-unstyled nav-btn nav-btn-monospaced" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+								</svg>
+							</span>
+						</button>
+					</li>
+					<li class="dropdown nav-item">
+						<button aria-expanded="false" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle nav-btn nav-btn-monospaced" data-toggle="dropdown" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-list" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
+								</svg>
+							</span>
+						</button>
+						<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
+							<li>
+								<a class="active dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-list" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
+											</svg>
+										</span>
+										List View
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-table" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
+											</svg>
+										</span>
+										Table View
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-cards2" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
+											</svg>
+										</span>
+										Card View
+									</span>
+								</a>
+							</li>
+						</ul>
+					</li>
+					<li class="nav-item">
+						<button class="btn btn-secondary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#plus" />
+								</svg>
+							</span>
+						</button>
+					</li>
+					<li class="nav-item">
+						<button class="btn btn-primary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#plus" />
+								</svg>
+							</span>
+						</button>
+					</li>
+				</ul>
+			</div>
+		</nav>
+
+		<nav class="management-bar management-bar-primary navbar navbar-expand-md navbar-nowrap">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="navbar-nav navbar-nav-expand">
+					<li class="nav-item">
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input checked class="custom-control-input" type="checkbox">
+								<span class="custom-control-label"></span>
+							</label>
+						</div>
+					</li>
+					<li class="nav-item nav-item-shrink">
+						<span class="navbar-text">
+							20,000,000 of 200,000,000
+							<span class="navbar-breakpoint-down-d-none">items selected</span>
+						</span>
+					</li>
+					<li class="nav-item nav-item-shrink">
+						<button class="btn btn-unstyled nav-link" type="button">
+							<span class="c-inner" tabindex="-1">
+								<span class="text-truncate-inline">
+									<span class="text-truncate">Clear</span>
+								</span>
+							</span>
+						</button>
+					</li>
+					<li class="nav-item nav-item-shrink">
+						<button class="btn btn-link nav-btn" type="button">
+							<span class="c-inner" tabindex="-1">
+								<span class="text-truncate-inline">
+									<span class="text-truncate">Select All</span>
+								</span>
+							</span>
+						</button>
+					</li>
+				</ul>
+				<ul class="navbar-nav">
+					<li class="nav-item">
+						<a class="nav-link nav-link-monospaced" href="#uniqueSidenavCollapseId3" id="uniqueSidenavToggler3" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-info-circle-open" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#info-circle-open" />
+								</svg>
+							</span>
+						</a>
+					</li>
+					<li class="nav-item navbar-breakpoint-down-d-none">
+						<a class="nav-link nav-link-monospaced" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+								</svg>
+							</span>
+						</a>
+					</li>
+					<li class="nav-item navbar-breakpoint-down-d-none">
+						<a class="nav-link nav-link-monospaced" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-paste" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#paste" />
+								</svg>
+							</span>
+						</a>
+					</li>
+					<li class="dropdown nav-item">
+						<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced" data-toggle="dropdown" href="#1" role="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</a>
+						<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
+							<li>
+								<a class="active dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-list" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
+											</svg>
+										</span>
+										List View
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-table" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
+											</svg>
+										</span>
+										Table View
+									</span>
+								</a>
+							</li>
+							<li>
+								<a class="dropdown-item" href="#1">
+									<span class="c-inner" tabindex="-1">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-cards2" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
+											</svg>
+										</span>
+										Card View
+									</span>
+								</a>
+							</li>
+						</ul>
+					</li>
+				</ul>
+			</div>
+		</nav>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Navbar Navigation Bar</h3>
+
+		<nav class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-light">
+			<div class="container-fluid container-fluid-max-xl">
+				<a aria-controls="navigationBarCollapse00" aria-expanded="false" aria-label="Toggle Navigation" class="collapsed navbar-toggler navbar-toggler-link" data-toggle="collapse" href="#navigationBarCollapse00" role="button">
+					<span class="c-inner" tabindex="-1">
+						<span class="navbar-text-truncate">App Section 2</span>
+						<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+						</svg>
+					</span>
+				</a>
+				<div class="collapse navbar-collapse" id="navigationBarCollapse00" style="z-index: 505;">
+					<div class="container-fluid container-fluid-max-xl">
+						<ul class="navbar-nav">
+							<li class="nav-item">
+								<a class="nav-link" href="#1">
+									<span class="c-inner" tabindex="-1">
+										<span class="navbar-text-truncate">App Section 1</span>
+									</span>
+								</a>
+							</li>
+							<li aria-label="Current Page" class="nav-item">
+								<a class="active nav-link" href="#1">
+									<span class="c-inner" tabindex="-1">
+										<span class="navbar-text-truncate">App Section 2</span>
+									</span>
+								</a>
+							</li>
+							<li class="nav-item">
+								<a class="nav-link" href="#1">
+									<span class="c-inner" tabindex="-1">
+										<span class="navbar-text-truncate">App Section 3</span>
+									</span>
+								</a>
+							</li>
+							<li class="dropdown nav-item show-dropdown-on-collapse">
+								<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link" data-toggle="dropdown" href="#1" role="button">
+									<span class="c-inner" tabindex="-1">
+										<span class="navbar-text-truncate">More</span>
+										<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+										</svg>
+									</span>
+								</a>
+								<ul aria-labelledby="" class="dropdown-menu">
+									<li>
+										<a class="dropdown-item" href="#1">
+											<span class="c-inner" tabindex="-1">App Section 4</span>
+										</a>
+									</li>
+									<li>
+										<a class="dropdown-item" href="#1">
+											<span class="c-inner" tabindex="-1">App Section 5</span>
+										</a>
+									</li>
+									<li>
+										<a class="dropdown-item" href="#1">
+											<span class="c-inner" tabindex="-1">App Section 6</span>
+										</a>
+									</li>
+									<li>
+										<a class="dropdown-item" href="#1">
+											<span class="c-inner" tabindex="-1">App Section 7</span>
+										</a>
+									</li>
+								</ul>
+							</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</nav>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Tbar</h3>
+
+		<nav class="tbar">
+			<ul class="tbar-nav">
+				<li class="tbar-item">
+					<a class="component-action disabled" href="#1" role="button" tabindex="-1">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-left" />
+							</svg>
+						</span>
+					</a>
+				</li>
+				<li class="tbar-item tbar-item-expand">
+					<div class="tbar-section">
+						<span class="text-truncate-inline">
+							<span class="text-truncate">Item 1 of 3,138,732,873,467,182,321,341,231,234,342,559,827,334,424</span>
+						</span>
+					</div>
+				</li>
+				<li class="tbar-item">
+					<a class="component-link" href="#1">
+						<span class="c-inner" tabindex="-1">Component Link</span>
+					</a>
+				</li>
+				<li class="tbar-item">
+					<a class="component-action" href="#1" role="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+							</svg>
+						</span>
+					</a>
+				</li>
+				<li class="tbar-item">
+					<a class="component-action" href="#1" role="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+							</svg>
+						</span>
+					</a>
+				</li>
+			</ul>
+		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Subnav Tbar Primary</h3>
+
+		<nav class="tbar tbar-inline-md-down subnav-tbar subnav-tbar-primary">
+			<div class="container-fluid container-fluid-max-xl">
+				<ul class="tbar-nav tbar-nav-wrap">
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-text">10,000 results for "<strong>ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</strong>"</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Category: <strong>Productivity</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<span class="c-inner" tabindex="-1">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Status: <strong>Approved</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<span class="c-inner" tabindex="-1">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item tbar-item-expand">
+						<div class="tbar-section">
+							<span class="component-label label label-dismissible tbar-label">
+								<span class="label-item label-item-expand">
+									<div class="label-section">Type: <strong>png</strong></div>
+								</span>
+								<span class="label-item label-item-after">
+									<button aria-label="Close" class="close" type="button">
+										<span class="c-inner" tabindex="-1">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<a class="component-link tbar-link tbar-link-monospaced" href="#1" role="button">
+								<span class="c-inner" tabindex="-1">A</span>
+							</a>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<button class="btn btn-unstyled tbar-btn tbar-btn-monospaced" type="button">
+								<span class="c-inner" tabindex="-1">B</span>
+							</button>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<a class="component-link tbar-link" href="#1" role="button">
+								<span class="c-inner" tabindex="-1">Apply to Root</span>
+							</a>
+						</div>
+					</li>
+					<li class="tbar-item">
+						<div class="tbar-section">
+							<button class="btn btn-unstyled component-link tbar-link" type="button">
+								<span class="c-inner" tabindex="-1">Clear All</span>
+							</button>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</nav>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+
+		<h3>Pagination Sizes</h3>
+
+		<h5>Small</h5>
+
+		<div class="pagination-bar pagination-sm">
+			<div class="dropdown pagination-items-per-page">
+				<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						10 entries
+						<svg class="lexicon-icon lexicon-icon-caret-double-l" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-double-l" />
+						</svg>
+					</span>
+				</a>
+				<ul class="dropdown-menu dropdown-menu-top">
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">5</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">10</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">20</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">30</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">50</span>
+						</a>
+					</li>
+				</ul>
+			</div>
+			<div class="pagination-results">Showing 1 to 20 of 203 entries.</div>
+			<ul class="pagination">
+				<li class="disabled page-item">
+					<a class="page-link" href="#1" role="button" tabindex="-1">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-left" />
+							</svg>
+							<span class="sr-only">Previous</span>
+						</span>
+					</a>
+				</li>
+				<li class="active page-item">
+					<a class="page-link" href="#1" tabindex="-1">
+						<span class="c-inner" tabindex="-1">1</span>
+					</a>
+				</li>
+				<li class="page-item">
+					<a class="page-link" href="#1">
+						<span class="c-inner" tabindex="-1">2</span>
+					</a>
+				</li>
+				<li class="dropdown page-item">
+					<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">
+						<span class="c-inner" tabindex="-1">...</span>
+					</a>
+					<ul class="dropdown-menu dropdown-menu-top-center">
+						<li>
+							<ul class="inline-scroller">
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">3</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">4</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">5</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">6</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">7</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">8</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">9</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">10</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">11</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">12</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">13</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">14</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">15</span>
+									</a>
+								</li>
+							</ul>
+						</li>
+					</ul>
+				</li>
+				<li class="page-item">
+					<a class="page-link" href="#1">
+						<span class="c-inner" tabindex="-1">16</span>
+					</a>
+				</li>
+				<li class="page-item">
+					<a class="page-link" href="#1" role="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+							</svg>
+							<span class="sr-only">Next</span>
+						</span>
+					</a>
+				</li>
+			</ul>
+		</div>
+
+		<h5>Default</h5>
+
+		<div class="pagination-bar">
+			<div class="dropdown pagination-items-per-page">
+				<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						10 entries
+						<svg class="lexicon-icon lexicon-icon-caret-double-l" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-double-l" />
+						</svg>
+					</span>
+				</a>
+				<ul class="dropdown-menu dropdown-menu-top">
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">5</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">10</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">20</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">30</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">50</span>
+						</a>
+					</li>
+				</ul>
+			</div>
+			<div class="pagination-results">Showing 1 to 20 of 203 entries.</div>
+			<ul class="pagination">
+				<li class="disabled page-item">
+					<a class="page-link" href="#1" role="button" tabindex="-1">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-left" />
+							</svg>
+							<span class="sr-only">Previous</span>
+						</span>
+					</a>
+				</li>
+				<li class="active page-item">
+					<a class="page-link" href="#1" tabindex="-1">
+						<span class="c-inner" tabindex="-1">1</span>
+					</a>
+				</li>
+				<li class="page-item">
+					<a class="page-link" href="#1">
+						<span class="c-inner" tabindex="-1">2</span>
+					</a>
+				</li>
+				<li class="dropdown page-item">
+					<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">
+						<span class="c-inner" tabindex="-1">...</span>
+					</a>
+					<ul class="dropdown-menu dropdown-menu-top-center">
+						<li>
+							<ul class="inline-scroller">
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">3</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">4</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">5</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">6</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">7</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">8</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">9</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">10</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">11</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">12</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">13</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">14</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">15</span>
+									</a>
+								</li>
+							</ul>
+						</li>
+					</ul>
+				</li>
+				<li class="page-item">
+					<a class="page-link" href="#1">
+						<span class="c-inner" tabindex="-1">16</span>
+					</a>
+				</li>
+				<li class="page-item">
+					<a class="page-link" href="#1" role="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+							</svg>
+							<span class="sr-only">Next</span>
+						</span>
+					</a>
+				</li>
+			</ul>
+		</div>
+
+		<h5>Large</h5>
+
+		<div class="pagination-bar pagination-lg">
+			<div class="dropdown pagination-items-per-page">
+				<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+					<span class="c-inner" tabindex="-1">
+						10 entries
+						<svg class="lexicon-icon lexicon-icon-caret-double-l" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-double-l" />
+						</svg>
+					</span>
+				</a>
+				<ul class="dropdown-menu dropdown-menu-top">
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">5</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">10</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">20</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">30</span>
+						</a>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1">
+							<span class="c-inner" tabindex="-1">50</span>
+						</a>
+					</li>
+				</ul>
+			</div>
+			<div class="pagination-results">Showing 1 to 20 of 203 entries.</div>
+			<ul class="pagination">
+				<li class="disabled page-item">
+					<a class="page-link" href="#1" role="button" tabindex="-1">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-left" />
+							</svg>
+							<span class="sr-only">Previous</span>
+						</span>
+					</a>
+				</li>
+				<li class="active page-item">
+					<a class="page-link" href="#1" tabindex="-1">
+						<span class="c-inner" tabindex="-1">1</span>
+					</a>
+				</li>
+				<li class="page-item">
+					<a class="page-link" href="#1">
+						<span class="c-inner" tabindex="-1">2</span>
+					</a>
+				</li>
+				<li class="dropdown page-item">
+					<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">
+						<span class="c-inner" tabindex="-1">...</span>
+					</a>
+					<ul class="dropdown-menu dropdown-menu-top-center">
+						<li>
+							<ul class="inline-scroller">
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">3</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">4</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">5</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">6</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">7</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">8</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">9</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">10</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">11</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">12</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">13</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">14</span>
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="c-inner" tabindex="-1">15</span>
+									</a>
+								</li>
+							</ul>
+						</li>
+					</ul>
+				</li>
+				<li class="page-item">
+					<a class="page-link" href="#1">
+						<span class="c-inner" tabindex="-1">16</span>
+					</a>
+				</li>
+				<li class="page-item">
+					<a class="page-link" href="#1" role="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+							</svg>
+							<span class="sr-only">Next</span>
+						</span>
+					</a>
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Accordions with Open and Close Icon</h3>
+
+<div aria-orientation="vertical" class="panel-group" id="accordion03" role="tablist">
+	<div class="panel panel-secondary">
+		<a aria-controls="collapseTwo" aria-expanded="false" class="collapse-icon collapsed panel-header panel-header-link" data-toggle="collapse" href="#accordion03CollapseTwo" id="accordion03HeadingTwo" role="tab">
+			<span class="c-inner" tabindex="-1">
+				<span class="panel-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+				<span class="collapse-icon-closed">
+					<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+					</svg>
+				</span>
+				<span class="collapse-icon-open">
+					<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+					</svg>
+				</span>
+			</span>
+		</a>
+		<div aria-labelledby="accordion03HeadingTwo" class="panel-collapse collapse" data-parent="#accordion03" id="accordion03CollapseTwo" role="tabpanel">
+			<div class="panel-body">
+				Flavour filter fair trade kopi-luwak robusta viennese, trifecta grinder, grounds lungo beans, half and half cup steamed cappuccino cinnamon. Percolator, extra, strong, breve, french press to go aromatic half and half aroma barista caramelization ut froth breve spoon redeye to go skinny rich skinny spoon. As turkish est filter foam con panna, cinnamon, aroma grounds cup whipped cultivar extra. Latte bar crema cultivar espresso pumpkin spice viennese, body viennese milk variety dripper, spoon, blue mountain robusta cultivar et spoon. Macchiato id eu brewed, and mazagran cinnamon so wings, doppio mocha froth blue mountain froth half and half iced to go whipped single shot.
+			</div>
+		</div>
+	</div>
+	<div class="panel panel-secondary">
+		<a aria-controls="accordion03CollapseOne" aria-expanded="true" class="collapse-icon collapse-icon-middle panel-header panel-header-link" data-toggle="collapse" href="#accordion03CollapseOne" id="accordion03HeadingOne" role="tab">
+			<span class="c-inner" tabindex="-1">
+				<span class="panel-title">Collapsible Group Item #2 (Flavour to go strong steamed mazagran trifecta decaffeinated percolator crema, aged americano rich chicory frappuccino foam white.)</span>
+				<span class="collapse-icon-closed">
+					<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+					</svg>
+				</span>
+				<span class="collapse-icon-open">
+					<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+					</svg>
+				</span>
+			</span>
+		</a>
+		<div aria-labelledby="accordion03HeadingOne" class="panel-collapse collapse show" data-parent="#accordion03" id="accordion03CollapseOne" role="tabpanel">
+			<div class="panel-body">
+				In organic dripper so, body, robust medium pumpkin spice cup, in aged dripper latte extra cup white. And viennese redeye carajillo, beans, mug viennese, carajillo id breve decaffeinated americano crema chicory whipped arabica variety aged robusta. Affogato lungo eu, cultivar at, aged breve and blue mountain roast breve americano aged. Sugar acerbic sweet variety aged café au lait chicory, java, single shot percolator aromatic brewed wings, a, sugar, body, aftertaste organic barista espresso dripper to go. Flavour to go strong steamed mazagran trifecta decaffeinated percolator crema, aged americano rich chicory frappuccino foam white.
+			</div>
+		</div>
+	</div>
+	<div class="panel panel-secondary">
+		<a aria-controls="collapseThree" aria-expanded="false" class="collapse-icon collapsed panel-header panel-header-link" data-toggle="collapse" href="#accordion03CollapseThree" id="accordion03HeadingThree" role="tab">
+			<span class="c-inner" tabindex="-1">
+				<span class="panel-title">Collapsible Group Item #3</span>
+				<span class="collapse-icon-closed">
+					<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+					</svg>
+				</span>
+				<span class="collapse-icon-open">
+					<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+					</svg>
+				</span>
+			</span>
+		</a>
+		<div aria-labelledby="accordion03HeadingThree" class="panel-collapse collapse" data-parent="#accordion03" id="accordion03CollapseThree" role="tabpanel">
+			<div class="panel-body">
+				Flavour filter fair trade kopi-luwak robusta viennese, trifecta grinder, grounds lungo beans, half and half cup steamed cappuccino cinnamon. Percolator, extra, strong, breve, french press to go aromatic half and half aroma barista caramelization ut froth breve spoon redeye to go skinny rich skinny spoon. As turkish est filter foam con panna, cinnamon, aroma grounds cup whipped cultivar extra. Latte bar crema cultivar espresso pumpkin spice viennese, body viennese milk variety dripper, spoon, blue mountain robusta cultivar et spoon. Macchiato id eu brewed, and mazagran cinnamon so wings, doppio mocha froth blue mountain froth half and half iced to go whipped single shot.
+			</div>
+		</div>
+	</div>
+	<div class="panel panel-secondary">
+		<a aria-controls="accordion03CollapseFour" aria-expanded="false" class="collapse-icon collapsed panel-header panel-header-link" data-toggle="collapse" href="#accordion03CollapseFour" id="accordion03HeadingFour" role="tab">
+			<span class="c-inner" tabindex="-1">
+				<span class="panel-title">Collapsible Group Item #4</span>
+				<span class="collapse-icon-closed">
+					<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+					</svg>
+				</span>
+				<span class="collapse-icon-open">
+					<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+					</svg>
+				</span>
+			</span>
+		</a>
+		<div aria-labelledby="accordion03HeadingFour" class="panel-collapse collapse" data-parent="#accordion03" id="accordion03CollapseFour" role="tabpanel">
+			<div class="panel-body">
+				Eu ristretto ut sugar rich saucer milk aftertaste, froth dark, cultivar blue mountain as coffee cappuccino. Saucer grounds mocha, aroma, half and half coffee eu robusta roast, doppio skinny galão, extraction, frappuccino aromatic breve crema frappuccino aroma. Froth half and half so java, grounds half and half, macchiato at est sugar mug redeye, strong, cream seasonal qui doppio robusta. Wings, at, cup dark, a, breve french press decaffeinated acerbic, black extra, and, saucer barista rich seasonal barista blue mountain. Roast mazagran a and id mug in est trifecta pumpkin spice coffee and mug trifecta, ut breve, mug frappuccino mug, breve mocha qui aged aftertaste.
+			</div>
+		</div>
+	</div>
+	<div class="panel panel-secondary">
+		<a aria-controls="accordion03CollapseFive" aria-expanded="false" class="collapse-icon collapsed panel-header panel-header-link" data-toggle="collapse" href="#accordion03CollapseFive" id="accordion03HeadingFive" role="tab">
+			<span class="c-inner" tabindex="-1">
+				<span class="panel-title">Collapsible Group Item #5</span>
+				<span class="collapse-icon-closed">
+					<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+					</svg>
+				</span>
+				<span class="collapse-icon-open">
+					<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+					</svg>
+				</span>
+			</span>
+		</a>
+		<div aria-labelledby="accordion03HeadingFive" class="panel-collapse collapse" data-parent="#accordion03" id="accordion03CollapseFive" role="tabpanel">
+			<div class="panel-body">
+				In organic dripper so, body, robust medium pumpkin spice cup, in aged dripper latte extra cup white. And viennese redeye carajillo, beans, mug viennese, carajillo id breve decaffeinated americano crema chicory whipped arabica variety aged robusta. Affogato lungo eu, cultivar at, aged breve and blue mountain roast breve americano aged. Sugar acerbic sweet variety aged café au lait chicory, java, single shot percolator aromatic brewed wings, a, sugar, body, aftertaste organic barista espresso dripper to go. Flavour to go strong steamed mazagran trifecta decaffeinated percolator crema, aged americano rich chicory frappuccino foam white.
+			</div>
+		</div>
+	</div>
+	<div class="panel panel-secondary">
+		<a aria-controls="accordion03CollapseSix" aria-expanded="false" class="collapse-icon collapsed panel-header panel-header-link" data-toggle="collapse" href="#accordion03CollapseSix" id="accordion03HeadingSix" role="tab">
+			<span class="c-inner" tabindex="-1">
+				<span class="panel-title">Collapsible Group Item #6</span>
+				<span class="collapse-icon-closed">
+					<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+					</svg>
+				</span>
+				<span class="collapse-icon-open">
+					<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+					</svg>
+				</span>
+			</span>
+		</a>
+		<div aria-labelledby="accordion03HeadingSix" class="panel-collapse collapse" data-parent="#accordion03" id="accordion03CollapseSix" role="tabpanel">
+			<div class="panel-body">
+				In organic dripper so, body, robust medium pumpkin spice cup, in aged dripper latte extra cup white. And viennese redeye carajillo, beans, mug viennese, carajillo id breve decaffeinated americano crema chicory whipped arabica variety aged robusta. Affogato lungo eu, cultivar at, aged breve and blue mountain roast breve americano aged. Sugar acerbic sweet variety aged café au lait chicory, java, single shot percolator aromatic brewed wings, a, sugar, body, aftertaste organic barista espresso dripper to go. Flavour to go strong steamed mazagran trifecta decaffeinated percolator crema, aged americano rich chicory frappuccino foam white.
+			</div>
+		</div>
+	</div>
+</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Panel Group Flush</h3>
+
+		<div class="sheet">
+			<div aria-orientation="vertical" class="panel-group panel-group-flush" role="tablist">
+				<div class="panel">
+					<a aria-controls="accordion04CollapseTwo" aria-expanded="true" class="collapse-icon sheet-subtitle" data-toggle="collapse" href="#accordion04CollapseTwo" id="accordion04HeadingTwo" role="tab">
+						<span class="c-inner" tabindex="-1">
+							<span>Password</span>
+							<span class="collapse-icon-closed">
+								<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+							<span class="collapse-icon-open">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+								</svg>
+							</span>
+						</span>
+					</a>
+					<div aria-labelledby="accordion04HeadingTwo" class="panel-collapse collapse show" id="accordion04CollapseTwo" role="tabpanel">
+						<div class="panel-body">
+							<div class="form-group">
+								<label>
+									Current Password
+									<span class="reference-mark">
+										<svg class="lexicon-icon lexicon-icon-asterisk" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+										</svg>
+									</span>
+								</label>
+								<input class="form-control" placeholder="Current Password" type="password" value="my-secret">
+							</div>
+							<div class="form-group">
+								<label>
+									New Password
+									<span class="reference-mark">
+										<svg class="lexicon-icon lexicon-icon-asterisk" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+										</svg>
+									</span>
+								</label>
+								<input class="form-control" placeholder="New Password" type="password" value="my-new-secret">
+							</div>
+							<div class="form-group">
+								<label>
+									Confirm New Password
+									<span class="reference-mark">
+										<svg class="lexicon-icon lexicon-icon-asterisk" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+										</svg>
+									</span>
+								</label>
+								<input class="form-control" placeholder="Confirm New Password" type="password" value="my-new-secret">
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="panel">
+					<a aria-controls="accordion04CollapseOne" aria-expanded="false" class="collapse-icon collapsed sheet-subtitle" data-toggle="collapse" href="#accordion04CollapseOne" id="accordion04HeadingOne" role="tab">
+						<span class="c-inner" tabindex="-1">
+							<span>Organizations</span>
+							<span class="collapse-icon-closed">
+								<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+							<span class="collapse-icon-open">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+								</svg>
+							</span>
+						</span>
+					</a>
+					<div aria-labelledby="accordion04HeadingOne" class="panel-collapse collapse" id="accordion04CollapseOne" role="tabpanel">
+						<div class="panel-body">
+							In organic dripper so, body, robust medium pumpkin spice cup, in aged dripper latte extra cup white. And viennese redeye carajillo, beans, mug viennese, carajillo id breve decaffeinated americano crema chicory whipped arabica variety aged robusta. Affogato lungo eu, cultivar at, aged breve and blue mountain roast breve americano aged. Sugar acerbic sweet variety aged café au lait chicory, java, single shot percolator aromatic brewed wings, a, sugar, body, aftertaste organic barista espresso dripper to go. Flavour to go strong steamed mazagran trifecta decaffeinated percolator crema, aged americano rich chicory frappuccino foam white.
+						</div>
+					</div>
+				</div>
+				<div class="panel">
+					<a aria-controls="accordion04CollapseThree" aria-expanded="false" class="collapse-icon collapsed sheet-subtitle" data-toggle="collapse" href="#accordion04CollapseThree" id="accordion04HeadingThree" role="tab">
+						<span class="c-inner" tabindex="-1">
+							<span>ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual User Groups</span>
+							<span class="collapse-icon-closed">
+								<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+							<span class="collapse-icon-open">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+								</svg>
+							</span>
+						</span>
+					</a>
+					<div aria-labelledby="accordion04HeadingThree" class="panel-collapse collapse" id="accordion04CollapseThree" role="tabpanel">
+						<div class="panel-body">
+							Flavour filter fair trade kopi-luwak robusta viennese, trifecta grinder, grounds lungo beans, half and half cup steamed cappuccino cinnamon. Percolator, extra, strong, breve, french press to go aromatic half and half aroma barista caramelization ut froth breve spoon redeye to go skinny rich skinny spoon. As turkish est filter foam con panna, cinnamon, aroma grounds cup whipped cultivar extra. Latte bar crema cultivar espresso pumpkin spice viennese, body viennese milk variety dripper, spoon, blue mountain robusta cultivar et spoon. Macchiato id eu brewed, and mazagran cinnamon so wings, doppio mocha froth blue mountain froth half and half iced to go whipped single shot.
+						</div>
+					</div>
+				</div>
+				<div class="panel">
+					<a aria-controls="accordion04CollapseFour" aria-expanded="false" class="collapse-icon collapsed sheet-subtitle" data-toggle="collapse" href="#accordion04CollapseFour" id="accordion04HeadingFour" role="tab">
+						<span class="c-inner" tabindex="-1">
+							<span>Roles</span>
+							<span class="collapse-icon-closed">
+								<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+							<span class="collapse-icon-open">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+								</svg>
+							</span>
+						</span>
+					</a>
+					<div aria-labelledby="accordion04HeadingFour" class="panel-collapse collapse" id="accordion04CollapseFour" role="tabpanel">
+						<div class="panel-body">
+							Eu ristretto ut sugar rich saucer milk aftertaste, froth dark, cultivar blue mountain as coffee cappuccino. Saucer grounds mocha, aroma, half and half coffee eu robusta roast, doppio skinny galão, extraction, frappuccino aromatic breve crema frappuccino aroma. Froth half and half so java, grounds half and half, macchiato at est sugar mug redeye, strong, cream seasonal qui doppio robusta. Wings, at, cup dark, a, breve french press decaffeinated acerbic, black extra, and, saucer barista rich seasonal barista blue mountain. Roast mazagran a and id mug in est trifecta pumpkin spice coffee and mug trifecta, ut breve, mug frappuccino mug, breve mocha qui aged aftertaste.
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Panel Group Flush Panel Group Sm</h3>
+
+		<div aria-orientation="vertical" class="panel-group panel-group-flush panel-group-sm" role="tablist">
+			<div class="panel panel-unstyled">
+				<a aria-controls="panelGroupSmCollapseOne" aria-expanded="true" class="collapse-icon panel-header panel-header-link" data-toggle="collapse" href="#panelGroupSmCollapseOne" id="panelGroupSmHeadingOne" role="tab">
+					<span class="c-inner" tabindex="-1">
+						<span class="panel-title">Collapsible Group Item #1</span>
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div aria-labelledby="panelGroupSmHeadingOne" class="panel-collapse collapse show" id="panelGroupSmCollapseOne" role="tabpanel">
+					<div class="panel-body">
+						In organic dripper so, body, robust medium pumpkin spice cup, in aged dripper latte extra cup white. And viennese redeye carajillo, beans, mug viennese, carajillo id breve decaffeinated americano crema chicory whipped arabica variety aged robusta. Affogato lungo eu, cultivar at, aged breve and blue mountain roast breve americano aged. Sugar acerbic sweet variety aged café au lait chicory, java, single shot percolator aromatic brewed wings, a, sugar, body, aftertaste organic barista espresso dripper to go. Flavour to go strong steamed mazagran trifecta decaffeinated percolator crema, aged americano rich chicory frappuccino foam white.
+					</div>
+				</div>
+			</div>
+			<div class="panel panel-unstyled">
+				<a aria-controls="panelGroupSmCollapseTwo" aria-expanded="false" class="collapse-icon collapsed panel-header panel-header-link" data-toggle="collapse" href="#panelGroupSmCollapseTwo" id="panelGroupSmHeadingTwo" role="tab">
+					<span class="c-inner" tabindex="-1">
+						<span class="panel-title">Collapsible Group Item #2</span>
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div aria-labelledby="panelGroupSmHeadingTwo" class="panel-collapse collapse" id="panelGroupSmCollapseTwo" role="tabpanel">
+					<div class="panel-body">
+						Flavour filter fair trade kopi-luwak robusta viennese, trifecta grinder, grounds lungo beans, half and half cup steamed cappuccino cinnamon. Percolator, extra, strong, breve, french press to go aromatic half and half aroma barista caramelization ut froth breve spoon redeye to go skinny rich skinny spoon. As turkish est filter foam con panna, cinnamon, aroma grounds cup whipped cultivar extra. Latte bar crema cultivar espresso pumpkin spice viennese, body viennese milk variety dripper, spoon, blue mountain robusta cultivar et spoon. Macchiato id eu brewed, and mazagran cinnamon so wings, doppio mocha froth blue mountain froth half and half iced to go whipped single shot.
+					</div>
+				</div>
+			</div>
+			<div class="panel panel-unstyled">
+				<a aria-controls="panelGroupSmCollapseThree" aria-expanded="false" class="collapse-icon collapsed panel-header panel-header-link" data-toggle="collapse" href="#panelGroupSmCollapseThree" id="panelGroupSmHeadingThree" role="tab">
+					<span class="c-inner" tabindex="-1">
+						<span class="panel-title">Collapsible Group Item #3</span>
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div aria-labelledby="panelGroupSmHeadingThree" class="panel-collapse collapse" id="panelGroupSmCollapseThree" role="tabpanel">
+					<div class="panel-body">
+						Eu ristretto ut sugar rich saucer milk aftertaste, froth dark, cultivar blue mountain as coffee cappuccino. Saucer grounds mocha, aroma, half and half coffee eu robusta roast, doppio skinny galão, extraction, frappuccino aromatic breve crema frappuccino aroma. Froth half and half so java, grounds half and half, macchiato at est sugar mug redeye, strong, cream seasonal qui doppio robusta. Wings, at, cup dark, a, breve french press decaffeinated acerbic, black extra, and, saucer barista rich seasonal barista blue mountain. Roast mazagran a and id mug in est trifecta pumpkin spice coffee and mug trifecta, ut breve, mug frappuccino mug, breve mocha qui aged aftertaste.
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<script>
+var drilldownKeypress = false;
+
+$(document).on('keydown', '[data-drilldown]', function(event) {
+	drilldownKeypress = event.which;
+});
+
+$(document).on('click', '[data-drilldown]', function(event) {
+	var drilldownItemArr = [];
+
+	var dataDrilldown = $(this).data('drilldown');
+
+	var drilldownInner = $(this).closest('.drilldown-inner');
+
+	var currentDrilldownItemId = '#' + $(this).closest('.drilldown-item').attr('id');
+	var currentDrilldownItem = $(currentDrilldownItemId);
+
+	var nextDrilldownItemId = $(this).attr('href');
+	var nextDrilldownItem = $(nextDrilldownItemId);
+
+	event.preventDefault();
+	event.stopPropagation();
+
+	drilldownInner.find('.drilldown-item').each(function(index, item) {
+		drilldownItemArr.push('#' + $(this).attr('id'));
+	});
+
+	var currentItemPos = drilldownItemArr.indexOf(currentDrilldownItemId);
+	var nextItemPos = drilldownItemArr.indexOf(nextDrilldownItemId);
+
+	drilldownInner.css('height', drilldownInner.height());
+
+	function drilldownItemTransitionend(element, focus) {
+		element.on('transitionend.clay', function(event) {
+			$(this)
+				.removeClass('transitioning')
+				.removeClass('drilldown-transition')
+				.removeClass('drilldown-next')
+				.css('transform', '')
+				.off('transitionend.clay');
+
+			if (focus) {
+				$(this).find('.dropdown-item')[0].focus();
+
+				if (drilldownKeypress !== 13) {
+					$(this).find('.dropdown-item')[0].blur();
+				}
+
+				drilldownKeypress = false;
+			}
+		});
+	}
+
+	if (dataDrilldown === 'next') {
+		// slides to the left
+		if (currentItemPos < nextItemPos) { // in order
+			currentDrilldownItem
+				.addClass('transitioning')
+				.removeClass('drilldown-current');
+
+			nextDrilldownItem
+				.addClass('transitioning')
+				.addClass('drilldown-current');
+
+			drilldownInner.css('height', nextDrilldownItem.find('.drilldown-item-inner').height());
+
+			drilldownInner.on('transitionend.clay', function(event) {
+				currentDrilldownItem
+					.addClass('drilldown-transition')
+					.css('transform', 'translateX(-100%)');
+
+				nextDrilldownItem
+					.addClass('drilldown-transition')
+					.css('transform', 'translateX(-100%)');
+
+				$(this).css('height', '').off('transitionend.clay');
+			});
+
+			drilldownItemTransitionend(currentDrilldownItem);
+			drilldownItemTransitionend(nextDrilldownItem, true);
+		}
+		else if (currentItemPos > nextItemPos) { // out of order
+			currentDrilldownItem
+				.addClass('transitioning')
+				.removeClass('drilldown-current')
+				.css('transform', 'translateX(-100%)');
+
+			nextDrilldownItem
+				.addClass('transitioning')
+				.addClass('drilldown-current')
+				.css('transform', 'translateX(100%)');
+
+			drilldownInner.css('height', nextDrilldownItem.find('.drilldown-item-inner').height());
+
+			drilldownInner.on('transitionend.clay', function(event) {
+				currentDrilldownItem
+					.addClass('drilldown-transition')
+					.css('transform', 'translateX(-200%)');
+
+				nextDrilldownItem
+					.addClass('drilldown-transition')
+					.css('transform', '');
+
+				$(this).css('height', '');
+				$(this).off('transitionend.clay');
+			});
+
+			drilldownItemTransitionend(currentDrilldownItem);
+			drilldownItemTransitionend(nextDrilldownItem, true);
+		}
+	}
+
+	if (dataDrilldown === 'prev') {
+		// slides to the right
+		if (currentItemPos > nextItemPos) { // in order
+			currentDrilldownItem
+				.addClass('transitioning')
+				.removeClass('drilldown-current')
+				.css('transform', 'translateX(-100%)');
+
+			nextDrilldownItem
+				.addClass('transitioning')
+				.addClass('drilldown-current')
+				.css('transform', 'translateX(-100%)');
+
+			drilldownInner.css('height', nextDrilldownItem.find('.drilldown-item-inner').height());
+
+			drilldownInner.on('transitionend.clay', function(event) {
+				currentDrilldownItem
+					.addClass('drilldown-transition')
+					.css('transform', '');
+
+				nextDrilldownItem
+					.addClass('drilldown-transition')
+					.css('transform', '');
+
+				$(this).css('height', '');
+				$(this).off('transitionend.clay');
+			});
+
+			drilldownItemTransitionend(currentDrilldownItem);
+			drilldownItemTransitionend(nextDrilldownItem, true);
+		}
+		else if (currentItemPos < nextItemPos) { // out of order
+			currentDrilldownItem
+				.addClass('transitioning')
+				.removeClass('drilldown-current');
+
+			nextDrilldownItem
+				.addClass('transitioning')
+				.addClass('drilldown-current')
+				.css('transform', 'translateX(-200%)');
+
+			drilldownInner.css('height', nextDrilldownItem.find('.drilldown-item-inner').height());
+
+			drilldownInner.on('transitionend.clay', function(event) {
+				currentDrilldownItem
+					.addClass('drilldown-transition')
+					.css('transform', 'translateX(100%)');
+
+				nextDrilldownItem
+					.addClass('drilldown-transition')
+					.css('transform', 'translateX(-100%)');
+
+				$(this).css('height', '');
+				$(this).off('transitionend.clay');
+			});
+
+			drilldownItemTransitionend(currentDrilldownItem);
+			drilldownItemTransitionend(nextDrilldownItem, true);
+		}
+	}
+});
+
+// Color Picker
+
+	$('.input-group-inset').on('focusin', function(event) {
+		$(this).closest('.input-group-item').addClass('focus');
+	});
+
+	$('.input-group-inset').on('focusout', function(event) {
+		$(this).closest('.input-group-item').removeClass('focus');
+	});
+
+	$('#claySiteShowView2').on('click', function(event) {
+		$('#colorPickerView1').css('display', 'none');
+		$('#colorPickerView2').css('display', 'block');
+	});
+
+	$('#claySiteShowView1').on('click', function(event) {
+		$('#colorPickerView1').css('display', 'block');
+		$('#colorPickerView2').css('display', 'none');
+	});
+
+	$('.clay-color-dropdown-menu').on('click', function(event) {
+		event.stopPropagation();
+	});
+
+// Date Picker
+
+	$('.input-group-inset').on('focusin', function(event) {
+		$(this).closest('.input-group-item').addClass('focus');
+	});
+
+	$('.input-group-inset').on('focusout', function(event) {
+		$(this).closest('.input-group-item').removeClass('focus');
+	});
+
+// List Group
+
+	$('.list-group .list-group-item input[type="checkbox"]').on(
+		'click',
+		function(event) {
+			$(this).closest('.list-group-item').toggleClass('active');
+		}
+	);
+
+	$(document).on('focus', '.heading-anchor', function(event) {
+		$('.list-group').find('.list-group-item-flex').removeClass('focus');
+	});
+
+	$(document).on('click', 'body', function(event) {
+		$('.list-group').find('.list-group-item-flex').removeClass('focus');
+	});
+
+	$('.list-group').on('focus', '.list-group-item-flex', function(event) {
+		var $this = $(this);
+		$this.closest('.list-group').find('.list-group-item-flex').removeClass('focus');
+		$this.closest('.list-group-item-flex').addClass('focus');
+	});
+</script>

--- a/packages/clay-css/src/scss/components/_badges.scss
+++ b/packages/clay-css/src/scss/components/_badges.scss
@@ -85,7 +85,7 @@
 	}
 
 	.close {
-		@include clay-link($badge-close);
+		@include clay-close($badge-close);
 	}
 
 	.lexicon-icon {
@@ -114,6 +114,20 @@
 	margin-left: $badge-item-spacer-x;
 }
 
+// Badge C Inner
+
+@if ($enable-c-inner) {
+	.badge > .c-inner {
+		margin: -#{$badge-padding-y} -#{$badge-padding-x};
+		padding: $badge-padding-y $badge-padding-x;
+	}
+
+	.badge-item .c-inner {
+		.lexicon-icon {
+			display: block;
+		}
+	}
+}
 
 // Badge Variants
 

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -223,6 +223,72 @@
 	}
 }
 
+// Button C Inner
+
+@if ($enable-c-inner) {
+	.btn .c-inner {
+		display: block;
+		margin: -#{$btn-padding-y} -#{$btn-padding-x};
+		padding: $btn-padding-y $btn-padding-x;
+
+		@include clay-scale-component {
+			margin: -#{$btn-padding-y-mobile} -#{$btn-padding-x-mobile};
+			padding: $btn-padding-y-mobile $btn-padding-x-mobile;
+		}
+	}
+
+	.btn-unstyled .c-inner {
+		margin: 0;
+		padding: 0;
+	}
+
+	.btn-monospaced .c-inner {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		height: calc(100% + #{$btn-monospaced-padding-y * 2});
+		justify-content: center;
+		margin: -#{$btn-monospaced-padding-y} 0;
+		padding: 0;
+	}
+
+	.btn-sm {
+		.c-inner {
+			margin: -#{$btn-padding-y-sm} -#{$btn-padding-x-sm};
+			padding: $btn-padding-y-sm $btn-padding-x-sm;
+
+			@include clay-scale-component {
+				margin: -#{$btn-padding-y-sm-mobile} -#{$btn-padding-x-sm-mobile};
+				padding: $btn-padding-y-sm-mobile $btn-padding-x-sm-mobile;
+			}
+		}
+
+		&.btn-monospaced .c-inner {
+			height: calc(100% + #{$btn-monospaced-padding-y-sm * 2});
+			margin: -#{$btn-monospaced-padding-y-sm} 0;
+			padding: 0;
+		}
+	}
+
+	.btn-lg {
+		.c-inner {
+			margin: -#{$btn-padding-y-lg} -#{$btn-padding-x-lg};
+			padding: $btn-padding-y-lg $btn-padding-x-lg;
+
+			@include clay-scale-component {
+				margin: -#{$btn-padding-y-lg-mobile} -#{$btn-padding-x-lg-mobile};
+				padding: $btn-padding-y-lg-mobile $btn-padding-x-lg-mobile;
+			}
+		}
+
+		&.btn-monospaced .c-inner {
+			height: calc(100% + #{$btn-monospaced-padding-y-lg * 2});
+			margin: -#{$btn-monospaced-padding-y-lg} 0;
+			padding: 0;
+		}
+	}
+}
+
 // Button Variants
 
 @each $color, $value in $btn-palette {

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -228,11 +228,11 @@
 @if ($enable-c-inner) {
 	.btn .c-inner {
 		display: block;
-		margin: -#{$btn-padding-y} -#{$btn-padding-x};
+		margin: #{math-sign($btn-padding-y)} #{math-sign($btn-padding-x)};
 		padding: $btn-padding-y $btn-padding-x;
 
 		@include clay-scale-component {
-			margin: -#{$btn-padding-y-mobile} -#{$btn-padding-x-mobile};
+			margin: #{math-sign($btn-padding-y-mobile)} #{math-sign($btn-padding-x-mobile)};
 			padding: $btn-padding-y-mobile $btn-padding-x-mobile;
 		}
 	}
@@ -248,42 +248,42 @@
 		flex-direction: column;
 		height: calc(100% + #{$btn-monospaced-padding-y * 2});
 		justify-content: center;
-		margin: -#{$btn-monospaced-padding-y} 0;
+		margin: #{math-sign($btn-monospaced-padding-y)} 0;
 		padding: 0;
 	}
 
 	.btn-sm {
 		.c-inner {
-			margin: -#{$btn-padding-y-sm} -#{$btn-padding-x-sm};
+			margin: #{math-sign($btn-padding-y-sm)} #{math-sign($btn-padding-x-sm)};
 			padding: $btn-padding-y-sm $btn-padding-x-sm;
 
 			@include clay-scale-component {
-				margin: -#{$btn-padding-y-sm-mobile} -#{$btn-padding-x-sm-mobile};
+				margin: #{math-sign($btn-padding-y-sm-mobile)} #{math-sign($btn-padding-x-sm-mobile)};
 				padding: $btn-padding-y-sm-mobile $btn-padding-x-sm-mobile;
 			}
 		}
 
 		&.btn-monospaced .c-inner {
 			height: calc(100% + #{$btn-monospaced-padding-y-sm * 2});
-			margin: -#{$btn-monospaced-padding-y-sm} 0;
+			margin: #{math-sign($btn-monospaced-padding-y-sm)} 0;
 			padding: 0;
 		}
 	}
 
 	.btn-lg {
 		.c-inner {
-			margin: -#{$btn-padding-y-lg} -#{$btn-padding-x-lg};
+			margin: #{math-sign($btn-padding-y-lg)} #{math-sign($btn-padding-x-lg)};
 			padding: $btn-padding-y-lg $btn-padding-x-lg;
 
 			@include clay-scale-component {
-				margin: -#{$btn-padding-y-lg-mobile} -#{$btn-padding-x-lg-mobile};
+				margin: #{math-sign($btn-padding-y-lg-mobile)} #{math-sign($btn-padding-x-lg-mobile)};
 				padding: $btn-padding-y-lg-mobile $btn-padding-x-lg-mobile;
 			}
 		}
 
 		&.btn-monospaced .c-inner {
 			height: calc(100% + #{$btn-monospaced-padding-y-lg * 2});
-			margin: -#{$btn-monospaced-padding-y-lg} 0;
+			margin: #{math-sign($btn-monospaced-padding-y-lg)} 0;
 			padding: 0;
 		}
 	}

--- a/packages/clay-css/src/scss/components/_cards.scss
+++ b/packages/clay-css/src/scss/components/_cards.scss
@@ -21,6 +21,12 @@
 			}
 		}
 	}
+
+	@if ($enable-c-inner) {
+		> .c-inner {
+			display: block;
+		}
+	}
 }
 
 .card-body {

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -231,6 +231,15 @@
 	.dropdown-item {
 		padding-left: $dropdown-item-padding-x + $dropdown-item-indicator-size + $dropdown-item-indicator-spacer-x;
 	}
+
+	@if ($enable-c-inner) {
+		.dropdown-item {
+			.c-inner {
+				margin-left: math-sign($dropdown-item-padding-x + $dropdown-item-indicator-size + $dropdown-item-indicator-spacer-x);
+				padding-left: $dropdown-item-padding-x + $dropdown-item-indicator-size + $dropdown-item-indicator-spacer-x;
+			}
+		}
+	}
 }
 
 .dropdown-menu-indicator-end {
@@ -251,6 +260,13 @@
 
 	.dropdown-item {
 		padding-right: $dropdown-item-padding-x + $dropdown-item-indicator-size + $dropdown-item-indicator-spacer-x;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				margin-right: math-sign($dropdown-item-padding-x + $dropdown-item-indicator-size + $dropdown-item-indicator-spacer-x);
+				padding-right: $dropdown-item-padding-x + $dropdown-item-indicator-size + $dropdown-item-indicator-spacer-x;
+			}
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_icons.scss
+++ b/packages/clay-css/src/scss/components/_icons.scss
@@ -33,9 +33,19 @@
 
 // Collapse Icon
 
-a.collapse-icon {
+a.collapse-icon,
+button.collapse-icon {
 	padding-left: $collapse-icon-padding-left;
 	padding-right: $collapse-icon-padding-right;
+
+	@if ($enable-c-inner) {
+		.c-inner {
+			margin-left: math-sign($collapse-icon-padding-left);
+			margin-right: math-sign($collapse-icon-padding-right);
+			padding-left: $collapse-icon-padding-left;
+			padding-right: $collapse-icon-padding-right;
+		}
+	}
 }
 
 .collapse-icon-closed,

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -246,11 +246,6 @@
 
 		@if ($enable-c-inner) {
 			.c-inner {
-				align-items: center;
-				display: flex;
-				height: 100%;
-				justify-content: center;
-
 				.lexicon-icon {
 					margin-top: 0;
 				}

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -243,6 +243,19 @@
 
 	.btn {
 		@include clay-button-size($input-group-inset-item-btn);
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				align-items: center;
+				display: flex;
+				height: 100%;
+				justify-content: center;
+
+				.lexicon-icon {
+					margin-top: 0;
+				}
+			}
+		}
 	}
 
 	.form-file {

--- a/packages/clay-css/src/scss/components/_labels.scss
+++ b/packages/clay-css/src/scss/components/_labels.scss
@@ -37,6 +37,20 @@
 		}
 	}
 
+	@if ($enable-c-inner) {
+		> .c-inner {
+			display: inline-flex;
+			margin-bottom: math-sign($label-padding-y);
+			margin-left: math-sign($label-padding-x);
+			margin-right: math-sign($label-padding-x);
+			margin-top: math-sign($label-padding-y);
+			padding-bottom: $label-padding-y;
+			padding-left: $label-padding-x;
+			padding-right: $label-padding-x;
+			padding-top: $label-padding-y;
+		}
+	}
+
 	// Inline Item in Labels are deprecated in v2.0.0-rc.11 use .label-item
 	// pattern instead
 	.inline-item {
@@ -124,6 +138,14 @@ button.label {
 	.btn-unstyled {
 		color: inherit;
 		display: inline-flex;
+	}
+
+	@if ($enable-c-inner) {
+		.c-inner {
+			.lexicon-icon {
+				display: block;
+			}
+		}
 	}
 
 	.close {

--- a/packages/clay-css/src/scss/components/_links.scss
+++ b/packages/clay-css/src/scss/components/_links.scss
@@ -103,6 +103,4 @@ button.link-outline {
 
 .component-action {
 	@include clay-link($component-action);
-
-	@extend %link-monospaced;
 }

--- a/packages/clay-css/src/scss/components/_links.scss
+++ b/packages/clay-css/src/scss/components/_links.scss
@@ -37,19 +37,7 @@ button.link-outline {
 }
 
 %link-monospaced {
-	align-items: center;
-	display: inline-flex;
-	height: $link-monospaced-size;
-	justify-content: center;
-	overflow: hidden;
-	padding: 0;
-	vertical-align: middle;
-	width: $link-monospaced-size;
-
-	.inline-item .lexicon-icon,
-	.lexicon-icon {
-		margin-top: 0;
-	}
+	@include clay-link($link-monospaced);
 }
 
 .link-monospaced {

--- a/packages/clay-css/src/scss/components/_links.scss
+++ b/packages/clay-css/src/scss/components/_links.scss
@@ -21,34 +21,7 @@ button.link-outline {
 }
 
 .link-outline {
-	align-items: center;
-	background-color: transparent;
-	border-color: transparent;
-
-	@include border-radius($link-outline-border-radius);
-
-	border-style: solid;
-	border-width: $link-outline-border-width;
-	display: inline-flex;
-	font-size: $link-outline-font-size;
-	font-weight: $link-outline-font-weight;
-	justify-content: center;
-	line-height: $link-outline-line-height;
-	padding-bottom: $link-outline-padding-y;
-	padding-left: $link-outline-padding-x;
-	padding-right: $link-outline-padding-x;
-	padding-top: $link-outline-padding-y;
-	transition: $link-outline-transition;
-	vertical-align: middle;
-
-	&:hover {
-		text-decoration: none;
-	}
-
-	.inline-item .lexicon-icon,
-	.lexicon-icon {
-		margin-top: 0;
-	}
+	@include clay-link($link-outline);
 }
 
 .link-outline-primary {

--- a/packages/clay-css/src/scss/components/_list-group.scss
+++ b/packages/clay-css/src/scss/components/_list-group.scss
@@ -216,6 +216,16 @@
 	}
 }
 
+.list-group-item-action {
+	@if ($enable-c-inner){
+		.c-inner {
+			display: block;
+			margin: #{math-sign($list-group-item-padding-y)} #{math-sign($list-group-item-padding-x)};
+			padding: $list-group-item-padding-y $list-group-item-padding-x;
+		}
+	}
+}
+
 .list-group-item-action:focus {
 	z-index: 1;
 }

--- a/packages/clay-css/src/scss/components/_multi-step-nav.scss
+++ b/packages/clay-css/src/scss/components/_multi-step-nav.scss
@@ -246,6 +246,25 @@
 		width: $multi-step-icon-size;
 	}
 
+	@if ($enable-c-inner) {
+		.c-inner {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+			height: $multi-step-icon-size;
+			margin-bottom: #{math-sign($multi-step-icon-padding-bottom)};
+			margin-left: #{math-sign($multi-step-icon-padding-left)};
+			margin-right: #{math-sign($multi-step-icon-padding-right)};
+			margin-top: #{math-sign($multi-step-icon-padding-top)};
+			padding-bottom: $multi-step-icon-padding-bottom;
+			padding-left: $multi-step-icon-padding-left;
+			padding-right: $multi-step-icon-padding-right;
+			padding-top: $multi-step-icon-padding-top;
+			position: absolute;
+			width: $multi-step-icon-size;
+		}
+	}
+
 	.btn-link {
 		vertical-align: baseline;
 	}

--- a/packages/clay-css/src/scss/components/_navs.scss
+++ b/packages/clay-css/src/scss/components/_navs.scss
@@ -15,57 +15,22 @@
 // Nav Btn
 
 .nav-btn {
-	align-items: center;
-	display: flex;
-	height: $nav-item-monospaced-size;
-	justify-content: center;
-	line-height: $line-height-base;
-	margin: $nav-btn-margin-y $nav-btn-margin-x;
-	min-width: $nav-item-monospaced-size;
-	padding-bottom: $nav-btn-padding-y;
-	padding-left: $nav-btn-padding-x;
-	padding-right: $nav-btn-padding-x;
-	padding-top: $nav-btn-padding-y;
-	position: relative;
-	text-align: center;
-	width: auto;
-
-	&:focus {
-		z-index: 1;
-	}
-
-	&.disabled {
-		opacity: 1;
-	}
+	@include clay-button-variant($nav-btn);
 
 	&.btn-link {
 		margin-left: 0;
 		margin-right: 0;
-	}
-
-	.lexicon-icon {
-		margin-top: 0;
 	}
 }
 
 // Nav Item Monospaced
 
 .nav-btn-monospaced {
-	padding: 0;
+	@include clay-button-variant($nav-btn-monospaced);
 }
 
 .nav-link-monospaced {
-	align-items: center;
-	display: flex;
-	height: $nav-item-monospaced-size;
-	justify-content: center;
-	margin: $nav-btn-margin-y $nav-btn-margin-x;
-	min-width: $nav-item-monospaced-size;
-	padding: 0;
-
-	.lexicon-icon {
-		margin-top: 0;
-	}
+	@include clay-link($nav-link-monospaced);
 }
 
 // Nav Item

--- a/packages/clay-css/src/scss/components/_pagination.scss
+++ b/packages/clay-css/src/scss/components/_pagination.scss
@@ -163,6 +163,14 @@
 		height: $pagination-item-height-sm;
 		line-height: $pagination-line-height-sm;
 		padding: $pagination-padding-y-sm $pagination-padding-x;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				height: $pagination-item-height-sm;
+				margin: #{math-sign($pagination-padding-y-sm)} #{math-sign($pagination-padding-x)};
+				padding: $pagination-padding-y-sm $pagination-padding-x;
+			}
+		}
 	}
 
 	.pagination-results {
@@ -175,6 +183,14 @@
 		font-size: $pagination-font-size-sm;
 		height: $pagination-item-height-sm;
 		line-height: $pagination-line-height-sm;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				height: $pagination-item-height-sm;
+				margin: #{math-sign($pagination-padding-y-sm)} #{math-sign($pagination-padding-x-sm)};
+				padding: $pagination-padding-y-sm $pagination-padding-x-sm;
+			}
+		}
 
 		&.btn-unstyled {
 			padding: $pagination-padding-y-sm $pagination-padding-x-sm;
@@ -198,6 +214,14 @@
 		height: $pagination-item-height-lg;
 		line-height: $pagination-line-height-lg;
 		padding: $pagination-padding-y-lg $pagination-padding-x;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				height: $pagination-item-height-lg;
+				margin: #{math-sign($pagination-padding-y-lg)} #{math-sign($pagination-padding-x)};
+				padding: $pagination-padding-y-lg $pagination-padding-x;
+			}
+		}
 	}
 
 	.pagination-results {
@@ -210,6 +234,14 @@
 		font-size: $pagination-font-size-lg;
 		height: $pagination-item-height-lg;
 		line-height: $pagination-line-height-lg;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				height: $pagination-item-height-lg;
+				margin: #{math-sign($pagination-padding-y-lg)} #{math-sign($pagination-padding-x-lg)};
+				padding: $pagination-padding-y-lg $pagination-padding-x-lg;
+			}
+		}
 
 		&.btn-unstyled {
 			padding: $pagination-padding-y-lg $pagination-padding-x-lg;

--- a/packages/clay-css/src/scss/components/_panels.scss
+++ b/packages/clay-css/src/scss/components/_panels.scss
@@ -24,6 +24,13 @@
 	position: relative;
 	width: 100%;
 
+	@if ($enable-c-inner) {
+		.c-inner {
+			margin: #{math-sign($panel-header-padding-y)} #{math-sign($panel-header-padding-x)};
+			padding: $panel-header-padding-y $panel-header-padding-x;
+		}
+	}
+
 	&.collapsed {
 		@if not ($panel-header-offset-border-radius == 0) {
 			@include border-bottom-radius($panel-header-offset-border-radius);
@@ -33,6 +40,15 @@
 	&.collapse-icon {
 		padding-left: $panel-header-collapse-icon-padding-left;
 		padding-right: $panel-header-collapse-icon-padding-right;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				margin-left: #{math-sign($panel-header-collapse-icon-padding-left)};
+				margin-right: #{math-sign($panel-header-collapse-icon-padding-right)};
+				padding-left: $panel-header-collapse-icon-padding-left;
+				padding-right: $panel-header-collapse-icon-padding-right;
+			}
+		}
 	}
 
 	.collapse-icon-closed,
@@ -241,6 +257,15 @@
 	.panel-header-link {
 		padding-left: 0;
 		padding-right: 0;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				margin-left: 0;
+				margin-right: 0;
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
 	}
 
 	.panel-body {
@@ -251,6 +276,15 @@
 	.collapse-icon {
 		padding-left: $panel-group-flush-collapse-icon-padding-left;
 		padding-right: $panel-group-flush-collapse-icon-padding-right;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				margin-left: #{math-sign($panel-group-flush-collapse-icon-padding-left)};
+				margin-right: #{math-sign($panel-group-flush-collapse-icon-padding-right)};
+				padding-left: $panel-group-flush-collapse-icon-padding-left;
+				padding-right: $panel-group-flush-collapse-icon-padding-right;
+			}
+		}
 	}
 
 	.collapse-icon-closed,

--- a/packages/clay-css/src/scss/components/_sheets.scss
+++ b/packages/clay-css/src/scss/components/_sheets.scss
@@ -166,6 +166,20 @@ fieldset {
 		margin-bottom: $sheet-subtitle-margin-bottom-mobile;
 	}
 
+	@if ($enable-c-inner) {
+		.c-inner {
+			display: block;
+			margin-bottom: #{math-sign($sheet-subtitle-padding-y)};
+			margin-left: #{math-sign($sheet-subtitle-padding-x)};
+			margin-right: #{math-sign($sheet-subtitle-padding-x)};
+			margin-top: #{math-sign($sheet-subtitle-padding-y)};
+			padding-bottom: $sheet-subtitle-padding-y;
+			padding-left: $sheet-subtitle-padding-x;
+			padding-right: $sheet-subtitle-padding-x;
+			padding-top: $sheet-subtitle-padding-y;
+		}
+	}
+
 	&.autofit-row {
 		padding-bottom: 0;
 
@@ -177,6 +191,15 @@ fieldset {
 	&.collapse-icon {
 		padding-left: $sheet-subtitle-collapse-icon-padding-left;
 		padding-right: $sheet-subtitle-collapse-icon-padding-right;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				margin-left: #{math-sign($sheet-subtitle-collapse-icon-padding-left)};
+				margin-right: #{math-sign($sheet-subtitle-collapse-icon-padding-right)};
+				padding-left: $sheet-subtitle-collapse-icon-padding-left;
+				padding-right: $sheet-subtitle-collapse-icon-padding-right;
+			}
+		}
 	}
 
 	.collapse-icon-closed,

--- a/packages/clay-css/src/scss/components/_tbar.scss
+++ b/packages/clay-css/src/scss/components/_tbar.scss
@@ -63,6 +63,12 @@
 
 .tbar-link {
 	display: inline-block;
+
+	@if ($enable-c-inner) {
+		.c-inner {
+			display: inline-block;
+		}
+	}
 }
 
 .tbar-btn-monospaced,
@@ -74,6 +80,15 @@
 	overflow: hidden;
 	padding: 0;
 	text-align: center;
+
+	@if ($enable-c-inner) {
+		.c-inner {
+			align-items: center;
+			display: inline-flex;
+			flex-direction: column;
+			justify-content: center;
+		}
+	}
 
 	.inline-item .lexicon-icon,
 	.lexicon-icon {

--- a/packages/clay-css/src/scss/components/_utilities.scss
+++ b/packages/clay-css/src/scss/components/_utilities.scss
@@ -229,6 +229,14 @@
 	@extend %autofit-float-end-md-down;
 }
 
+// C Inner 
+
+@if ($enable-c-inner) {
+	.c-inner {
+		outline: 0;
+	}
+}
+
 // Headings (h1-6)
 
 .heading-start {

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -46,6 +46,12 @@
 	$section-font-weight: map-get($map, section-font-weight);
 	$section-line-height: map-get($map, section-line-height);
 
+	$lexicon-icon-font-size: map-get($map, lexicon-icon-font-size);
+	$lexicon-icon-margin-bottom: map-get($map, lexicon-icon-margin-bottom);
+	$lexicon-icon-margin-right: map-get($map, lexicon-icon-margin-right);
+	$lexicon-icon-margin-left: map-get($map, lexicon-icon-margin-left);
+	$lexicon-icon-margin-top: map-get($map, lexicon-icon-margin-top);
+
 	$font-size-mobile: map-get($map, font-size-mobile);
 	$height-mobile: map-get($map, height-mobile);
 	$padding-bottom-mobile: map-get($map, padding-bottom-mobile);
@@ -105,6 +111,24 @@
 		cursor: $disabled-cursor;
 	}
 
+	@if ($enable-c-inner) {
+		.c-inner {
+			align-items: $align-items;
+			display: $display;
+			height: $height;
+			justify-content: $justify-content;
+			margin-bottom: math-sign($padding-bottom);
+			margin-left: math-sign($padding-left);
+			margin-right: math-sign($padding-right);
+			margin-top: math-sign($padding-top);
+			padding-bottom: $padding-bottom;
+			padding-left: $padding-left;
+			padding-right: $padding-right;
+			padding-top: $padding-top;
+			width: $width;
+		}
+	}
+
 	.inline-item {
 		font-size: $inline-item-font-size;
 	}
@@ -113,6 +137,14 @@
 		font-size: $section-font-size;
 		font-weight: $section-font-weight;
 		line-height: $section-line-height;
+	}
+
+	.lexicon-icon {
+		font-size: $lexicon-icon-font-size;
+		margin-bottom: $lexicon-icon-margin-bottom;
+		margin-right: $lexicon-icon-margin-right;
+		margin-left: $lexicon-icon-margin-left;
+		margin-top: $lexicon-icon-margin-top;
 	}
 }
 
@@ -180,6 +212,11 @@
 /// active-color: {Color | String | Null},
 /// active-opacity: {Number | String | Null},
 /// active-focus-box-shadow: {String | List}, // Default: $focus-box-shadow
+/// lexicon-icon-font-size: {Number | String | Null},
+/// lexicon-icon-margin-bottom: {Number | String | Null},
+/// lexicon-icon-margin-right: {Number | String | Null},
+/// lexicon-icon-margin-left: {Number | String | Null},
+/// lexicon-icon-margin-top: {Number | String | Null},
 /// inline-item-font-size: {Number | String | Null},
 /// section-font-size: {Number | String | Null},
 /// section-font-weight: {Number | String | Null},
@@ -263,6 +300,12 @@
 	$active-color: map-get($map, active-color);
 	$active-opacity: map-get($map, active-opacity);
 	$active-focus-box-shadow: setter(map-get($map, active-focus-box-shadow), $focus-box-shadow);
+
+	$lexicon-icon-font-size: map-get($map, lexicon-icon-font-size);
+	$lexicon-icon-margin-bottom: map-get($map, lexicon-icon-margin-bottom);
+	$lexicon-icon-margin-right: map-get($map, lexicon-icon-margin-right);
+	$lexicon-icon-margin-left: map-get($map, lexicon-icon-margin-left);
+	$lexicon-icon-margin-top: map-get($map, lexicon-icon-margin-top);
 
 	$inline-item-font-size: map-get($map, inline-item-font-size);
 
@@ -376,6 +419,32 @@
 		&:focus {
 			box-shadow: $active-focus-box-shadow;
 		}
+	}
+
+	@if ($enable-c-inner) {
+		.c-inner {
+			align-items: $align-items;
+			display: $display;
+			height: $height;
+			justify-content: $justify-content;
+			margin-bottom: math-sign($padding-bottom);
+			margin-left: math-sign($padding-left);
+			margin-right: math-sign($padding-right);
+			margin-top: math-sign($padding-top);
+			padding-bottom: $padding-bottom;
+			padding-left: $padding-left;
+			padding-right: $padding-right;
+			padding-top: $padding-top;
+			width: $width;
+		}
+	}
+
+	.lexicon-icon {
+		font-size: $lexicon-icon-font-size;
+		margin-bottom: $lexicon-icon-margin-bottom;
+		margin-right: $lexicon-icon-margin-right;
+		margin-left: $lexicon-icon-margin-left;
+		margin-top: $lexicon-icon-margin-top;
 	}
 
 	.inline-item {

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -60,6 +60,23 @@
 	$padding-top-mobile: map-get($map, padding-top-mobile);
 	$width-mobile: map-get($map, width-mobile);
 
+	$c-inner: setter(map-get($map, c-inner), ());
+	$c-inner: map-deep-merge((
+		align-items: $align-items,
+		display: $display,
+		height: $height,
+		justify-content: $justify-content,
+		margin-bottom: math-sign($padding-bottom),
+		margin-left: math-sign($padding-left),
+		margin-right: math-sign($padding-right),
+		margin-top: math-sign($padding-top),
+		padding-bottom: $padding-bottom,
+		padding-left: $padding-left,
+		padding-right: $padding-right,
+		padding-top: $padding-top,
+		width: $width,
+	), $c-inner);
+
 	align-items: $align-items;
 	border-color: $border-color;
 	border-radius: $border-radius;
@@ -113,19 +130,7 @@
 
 	@if ($enable-c-inner) {
 		.c-inner {
-			align-items: $align-items;
-			display: $display;
-			height: $height;
-			justify-content: $justify-content;
-			margin-bottom: math-sign($padding-bottom);
-			margin-left: math-sign($padding-left);
-			margin-right: math-sign($padding-right);
-			margin-top: math-sign($padding-top);
-			padding-bottom: $padding-bottom;
-			padding-left: $padding-left;
-			padding-right: $padding-right;
-			padding-top: $padding-top;
-			width: $width;
+			@include clay-css($c-inner);
 		}
 	}
 
@@ -229,6 +234,7 @@
 /// padding-top-mobile: {Number | String | Null},
 /// width-mobile: {Number | String | Null},
 /// loading-animation: {String | Null}, // The placeholder name 'loading-animation' or 'loading-animation-light'
+/// c-inner: {Map | Null}, // Pass parameters to `clay-css` mixin
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
@@ -322,6 +328,23 @@
 	$width-mobile: map-get($map, width-mobile);
 
 	$loading-animation: setter(map-get($map, loading-animation), $clay-unset-placeholder);
+
+	$c-inner: setter(map-get($map, c-inner), ());
+	$c-inner: map-deep-merge((
+		align-items: $align-items,
+		display: $display,
+		height: $height,
+		justify-content: $justify-content,
+		margin-bottom: math-sign($padding-bottom),
+		margin-left: math-sign($padding-left),
+		margin-right: math-sign($padding-right),
+		margin-top: math-sign($padding-top),
+		padding-bottom: $padding-bottom,
+		padding-left: $padding-left,
+		padding-right: $padding-right,
+		padding-top: $padding-top,
+		width: $width,
+	), $c-inner);
 
 	align-items: $align-items;
 	background-color: $bg;
@@ -423,19 +446,7 @@
 
 	@if ($enable-c-inner) {
 		.c-inner {
-			align-items: $align-items;
-			display: $display;
-			height: $height;
-			justify-content: $justify-content;
-			margin-bottom: math-sign($padding-bottom);
-			margin-left: math-sign($padding-left);
-			margin-right: math-sign($padding-right);
-			margin-top: math-sign($padding-top);
-			padding-bottom: $padding-bottom;
-			padding-left: $padding-left;
-			padding-right: $padding-right;
-			padding-top: $padding-top;
-			width: $width;
+			@include clay-css($c-inner);
 		}
 	}
 

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -175,11 +175,17 @@
 /// justify-content: {String | Null},
 /// left: {Number | String | Null},
 /// line-height: {Number | String | Null},
+/// margin: {Number | String | List | Null},
 /// margin-bottom: {Number | String | Null},
 /// margin-left: {Number | String | Null},
 /// margin-right: {Number | String | Null},
 /// margin-top: {Number | String | Null},
+/// max-height: {Number | String | Null},
+/// max-width: {Number | String | Null},
+/// min-height: {Number | String | Null},
+/// min-width: {Number | String | Null},
 /// opacity: {Number | String | Null},
+/// padding: {Number | String | List | Null},
 /// padding-bottom: {Number | String | Null},
 /// padding-left: {Number | String | Null},
 /// padding-right: {Number | String | Null},
@@ -194,28 +200,33 @@
 /// white-space: {String | Null},
 /// width: {Number | String | Null},
 /// word-wrap: {String | Null},
+/// z-index: {Number | String | Null},
 /// hover-bg: {Color | String | Null},
 /// hover-border-color: {Color | String | List | Null},
 /// hover-color: {Color | String | Null},
 /// hover-opacity: {Number | String | Null},
 /// hover-text-decoration: {String | Null},
+/// hover-z-index: {Number | String | Null},
 /// focus-bg: {Color | String | Null},
 /// focus-border-color: {Color | String | List | Null},
 /// focus-box-shadow: {String | List | Null}
 /// focus-color: {Color | String | Null},
 /// focus-opacity: {Number | String | Null},
 /// focus-outline: {Number | String | Null},
+/// focus-z-index: {Number | String | Null},
 /// disabled-bg: {Color | String | Null},
 /// disabled-border-color: {Color | String | List | Null},
 /// disabled-box-shadow: {String | List | Null},
 /// disabled-color: {Color | String | Null},
 /// disabled-cursor: {String | Null},
 /// disabled-opacity: {Number | String | Null},
+/// disabled-z-index: {Number | String | Null},
 /// active-bg: {Color | String | Null},
 /// active-border-color: {Color | String | List | Null},
 /// active-box-shadow: {String | List | Null},
 /// active-color: {Color | String | Null},
 /// active-opacity: {Number | String | Null},
+/// active-z-index: {Number | String | Null},
 /// active-focus-box-shadow: {String | List}, // Default: $focus-box-shadow
 /// lexicon-icon-font-size: {Number | String | Null},
 /// lexicon-icon-margin-bottom: {Number | String | Null},
@@ -260,11 +271,17 @@
 	$justify-content: map-get($map, justify-content);
 	$left: map-get($map, left);
 	$line-height: map-get($map, line-height);
+	$margin: map-get($map, margin);
 	$margin-bottom: map-get($map, margin-bottom);
 	$margin-left: map-get($map, margin-left);
 	$margin-right: map-get($map, margin-right);
 	$margin-top: map-get($map, margin-top);
+	$max-height: map-get($map, max-height);
+	$max-width: map-get($map, max-width);
+	$min-height: map-get($map, min-height);
+	$min-width: map-get($map, min-width);
 	$opacity: map-get($map, opacity);
+	$padding: map-get($map, padding);
 	$padding-bottom: map-get($map, padding-bottom);
 	$padding-left: map-get($map, padding-left);
 	$padding-right: map-get($map, padding-right);
@@ -279,12 +296,14 @@
 	$white-space: map-get($map, white-space);
 	$width: map-get($map, width);
 	$word-wrap: map-get($map, word-wrap);
+	$z-index: map-get($map, z-index);
 
 	$hover-bg: map-get($map, hover-bg);
 	$hover-border-color: map-get($map, hover-border-color);
 	$hover-color: map-get($map, hover-color);
 	$hover-opacity: map-get($map, hover-opacity);
 	$hover-text-decoration: map-get($map, hover-text-decoration);
+	$hover-z-index: map-get($map, hover-z-index);
 
 	$focus-bg: map-get($map, focus-bg);
 	$focus-border-color: map-get($map, focus-border-color);
@@ -292,6 +311,7 @@
 	$focus-color: map-get($map, focus-color);
 	$focus-opacity: map-get($map, focus-opacity);
 	$focus-outline: map-get($map, focus-outline);
+	$focus-z-index: map-get($map, focus-z-index);
 
 	$disabled-bg: map-get($map, disabled-bg);
 	$disabled-border-color: map-get($map, disabled-border-color);
@@ -299,12 +319,14 @@
 	$disabled-color: map-get($map, disabled-color);
 	$disabled-cursor: map-get($map, disabled-cursor);
 	$disabled-opacity: map-get($map, disabled-opacity);
+	$disabled-z-index: map-get($map, disabled-z-index);
 
 	$active-bg: map-get($map, active-bg);
 	$active-border-color: map-get($map, active-border-color);
 	$active-box-shadow: map-get($map, active-box-shadow);
 	$active-color: map-get($map, active-color);
 	$active-opacity: map-get($map, active-opacity);
+	$active-z-index: map-get($map, active-z-index);
 	$active-focus-box-shadow: setter(map-get($map, active-focus-box-shadow), $focus-box-shadow);
 
 	$lexicon-icon-font-size: map-get($map, lexicon-icon-font-size);
@@ -339,6 +361,8 @@
 		margin-left: math-sign($padding-left),
 		margin-right: math-sign($padding-right),
 		margin-top: math-sign($padding-top),
+		min-height: $min-height,
+		min-width: $min-width,
 		padding-bottom: $padding-bottom,
 		padding-left: $padding-left,
 		padding-right: $padding-right,
@@ -363,11 +387,17 @@
 	justify-content: $justify-content;
 	left: $left;
 	line-height: $line-height;
+	margin: $margin;
 	margin-bottom: $margin-bottom;
 	margin-left: $margin-left;
 	margin-right: $margin-right;
 	margin-top: $margin-top;
+	max-height: $max-height;
+	max-width: $max-width;
+	min-height: $min-height;
+	min-width: $min-width;
 	opacity: $opacity;
+	padding: $padding;
 	padding-bottom: $padding-bottom;
 	padding-left: $padding-left;
 	padding-right: $padding-right;
@@ -382,6 +412,7 @@
 	white-space: $white-space;
 	width: $width;
 	word-wrap: $word-wrap;
+	z-index: $z-index;
 
 	@at-root {
 		a#{&},
@@ -408,6 +439,7 @@
 		color: $hover-color;
 		opacity: $hover-opacity;
 		text-decoration: $hover-text-decoration;
+		z-index: $hover-z-index;
 	}
 
 	&:focus,
@@ -418,6 +450,7 @@
 		color: $focus-color;
 		opacity: $focus-opacity;
 		outline: $focus-outline;
+		z-index: $focus-z-index;
 	}
 
 	&:disabled,
@@ -428,6 +461,7 @@
 		color: $disabled-color;
 		cursor: $disabled-cursor;
 		opacity: $disabled-opacity;
+		z-index: $disabled-z-index;
 	}
 
 	&:not([disabled]):not(.disabled):active,
@@ -438,6 +472,7 @@
 		box-shadow: $active-box-shadow;
 		color: $active-color;
 		opacity: $active-opacity;
+		z-index: $active-z-index;
 
 		&:focus {
 			box-shadow: $active-focus-box-shadow;

--- a/packages/clay-css/src/scss/mixins/_close.scss
+++ b/packages/clay-css/src/scss/mixins/_close.scss
@@ -64,6 +64,7 @@
 /// lexicon-icon-margin-left: {Number | String | Null},
 /// lexicon-icon-margin-right: {Number | String | Null},
 /// lexicon-icon-margin-top: {Number | String | Null},
+/// c-inner: {Map | Null}, // Pass parameters to `clay-css` mixin
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
@@ -136,6 +137,23 @@
 	$lexicon-icon-margin-left: map-get($map, lexicon-icon-margin-left);
 	$lexicon-icon-margin-right: map-get($map, lexicon-icon-margin-right);
 	$lexicon-icon-margin-top: map-get($map, lexicon-icon-margin-top);
+
+	$c-inner: setter(map-get($map, c-inner), ());
+	$c-inner: map-deep-merge((
+			align-items: $align-items,
+			display: $display,
+			height: $height,
+			justify-content: $justify-content,
+			margin-bottom: math-sign($padding-bottom),
+			margin-left: math-sign($padding-left),
+			margin-right: math-sign($padding-right),
+			margin-top: math-sign($padding-top),
+			padding-bottom: $padding-bottom,
+			padding-left: $padding-left,
+			padding-right: $padding-right,
+			padding-top: $padding-top,
+			width: $width,
+	), $c-inner);
 
 	align-items: $align-items;
 	background-color: $bg;
@@ -228,19 +246,7 @@
 
 	@if ($enable-c-inner) {
 		.c-inner {
-			align-items: $align-items;
-			display: $display;
-			height: $height;
-			justify-content: $justify-content;
-			margin-bottom: math-sign($padding-bottom);
-			margin-left: math-sign($padding-left);
-			margin-right: math-sign($padding-right);
-			margin-top: math-sign($padding-top);
-			padding-bottom: $padding-bottom;
-			padding-left: $padding-left;
-			padding-right: $padding-right;
-			padding-top: $padding-top;
-			width: $width;
+			@include clay-css($c-inner);
 		}
 	}
 

--- a/packages/clay-css/src/scss/mixins/_close.scss
+++ b/packages/clay-css/src/scss/mixins/_close.scss
@@ -226,6 +226,24 @@
 		text-decoration: $disabled-text-decoration;
 	}
 
+	@if ($enable-c-inner) {
+		.c-inner {
+			align-items: $align-items;
+			display: $display;
+			height: $height;
+			justify-content: $justify-content;
+			margin-bottom: math-sign($padding-bottom);
+			margin-left: math-sign($padding-left);
+			margin-right: math-sign($padding-right);
+			margin-top: math-sign($padding-top);
+			padding-bottom: $padding-bottom;
+			padding-left: $padding-left;
+			padding-right: $padding-right;
+			padding-top: $padding-top;
+			width: $width;
+		}
+	}
+
 	.lexicon-icon {
 		margin-bottom: $lexicon-icon-margin-bottom;
 		margin-right: $lexicon-icon-margin-right;

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -366,6 +366,20 @@
 			}
 		}
 
+		@if ($enable-c-inner) {
+			.c-inner {
+				display: $display;
+				margin-bottom: math-sign($padding-bottom);
+				margin-left: math-sign($padding-left);
+				margin-right: math-sign($padding-right);
+				margin-top: math-sign($padding-top);
+				padding-bottom: $padding-bottom;
+				padding-left: $padding-left;
+				padding-right: $padding-right;
+				padding-top: $padding-top;
+			}
+		}
+
 		.form-check-label {
 			font-weight: $font-weight;
 		}

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -184,6 +184,7 @@
 /// disabled-pointer-events: {String | Null},
 /// disabled-text-decoration: {String | Null},
 /// disabled-active-pointer-events: {String | Null},
+/// c-inner: {Map | Null}, // Pass parameters to `clay-css` mixin
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
@@ -248,6 +249,19 @@
 	$disabled-text-decoration: map-get($map, disabled-text-decoration);
 
 	$disabled-active-pointer-events: map-get($map, disabled-active-pointer-events);
+
+	$c-inner: setter(map-get($map, c-inner), ());
+	$c-inner: map-deep-merge((
+		display: $display,
+		margin-bottom: math-sign($padding-bottom),
+		margin-left: math-sign($padding-left),
+		margin-right: math-sign($padding-right),
+		margin-top: math-sign($padding-top),
+		padding-bottom: $padding-bottom,
+		padding-left: $padding-left,
+		padding-right: $padding-right,
+		padding-top: $padding-top,
+	), $c-inner);
 
 	@if ($enabled) {
 		background-color: $bg; // For `<button>`s set to `transparent` in Bootstrap
@@ -368,15 +382,7 @@
 
 		@if ($enable-c-inner) {
 			.c-inner {
-				display: $display;
-				margin-bottom: math-sign($padding-bottom);
-				margin-left: math-sign($padding-left);
-				margin-right: math-sign($padding-right);
-				margin-top: math-sign($padding-top);
-				padding-bottom: $padding-bottom;
-				padding-left: $padding-left;
-				padding-right: $padding-right;
-				padding-top: $padding-top;
+				@include clay-css($c-inner);
 			}
 		}
 

--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -25,6 +25,7 @@
 /// sticker-border-radius: {Number | String | List | Null},
 /// sticker-size: {Number | String | Null},
 /// close: {Map | Null}, // Pass parameters to `clay-close` mixin
+/// c-inner: {Map | Null}, // Pass parameters to `clay-css` mixin
 
 @mixin clay-label-size($map) {
 	$border-width: setter(map-get($map, border-width), $label-border-width);
@@ -50,6 +51,18 @@
 	$sticker-size: map-get($map, sticker-size);
 
 	$close: setter(map-get($map, close), ());
+
+	$c-inner: setter(map-get($map, c-inner), ());
+	$c-inner: map-deep-merge((
+		margin-bottom: math-sign($padding-y),
+		margin-left: math-sign($padding-x),
+		margin-right: math-sign($padding-x),
+		margin-top: math-sign($padding-y),
+		padding-bottom: $padding-y,
+		padding-left: $padding-x,
+		padding-right: $padding-x,
+		padding-top: $padding-y,
+	), $c-inner);
 
 	border-width: $border-width;
 	font-size: $font-size;
@@ -118,14 +131,7 @@
 
 	@if ($enable-c-inner) {
 		> .c-inner {
-			margin-bottom: math-sign($padding-y);
-			margin-left: math-sign($padding-x);
-			margin-right: math-sign($padding-x);
-			margin-top: math-sign($padding-y);
-			padding-bottom: $padding-y;
-			padding-left: $padding-x;
-			padding-right: $padding-x;
-			padding-top: $padding-y;
+			@include clay-css($c-inner);
 		}
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -115,6 +115,19 @@
 	.sticker-overlay {
 		border-radius: $sticker-border-radius;
 	}
+
+	@if ($enable-c-inner) {
+		> .c-inner {
+			margin-bottom: math-sign($padding-y);
+			margin-left: math-sign($padding-x);
+			margin-right: math-sign($padding-x);
+			margin-top: math-sign($padding-y);
+			padding-bottom: $padding-y;
+			padding-left: $padding-x;
+			padding-right: $padding-x;
+			padding-top: $padding-y;
+		}
+	}
 }
 
 /// A mixin for creating `.label` color variants.

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -28,6 +28,7 @@
 /// max-width: {Number | String | Null},
 /// opacity: {Number | String | Null},
 /// outline: {Number | String | Null},
+/// overflow: {String | Null},
 /// padding-bottom: {Number | String | Null},
 /// padding-left: {Number | String | Null},
 /// padding-right: {Number | String | Null},
@@ -108,6 +109,7 @@
 	$max-width: map-get($map, max-width);
 	$opacity: map-get($map, opacity);
 	$outline: map-get($map, outline);
+	$overflow: map-get($map, overflow);
 	$padding: map-get($map, padding);
 	$padding-bottom: map-get($map, padding-bottom);
 	$padding-left: map-get($map, padding-left);
@@ -197,6 +199,7 @@
 	max-width: $max-width;
 	opacity: $opacity;
 	outline: $outline;
+	overflow: $overflow;
 	padding: $padding;
 	padding-bottom: $padding-bottom;
 	padding-left: $padding-left;
@@ -277,7 +280,10 @@
 
 	@if ($enable-c-inner) {
 		> .c-inner {
+			align-items: $align-items;
 			display: $display;
+			height: $height;
+			justify-content: $justify-content;
 			margin-bottom: math-sign($padding-bottom);
 			margin-left: math-sign($padding-left);
 			margin-right: math-sign($padding-right);
@@ -286,6 +292,7 @@
 			padding-left: $padding-left;
 			padding-right: $padding-right;
 			padding-top: $padding-top;
+			width: $width;
 		}
 	}
 

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -81,6 +81,7 @@
 /// lexicon-icon-margin-left: {Number | String | Null},
 /// lexicon-icon-margin-right: {Number | String | Null},
 /// lexicon-icon-margin-top: {Number | String | Null},
+/// c-inner: {Map | Null}, // Pass parameters to `clay-css` mixin
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
@@ -173,6 +174,24 @@
 	$lexicon-icon-margin-left: map-get($map, lexicon-icon-margin-left);
 	$lexicon-icon-margin-right: map-get($map, lexicon-icon-margin-right);
 	$lexicon-icon-margin-top: map-get($map, lexicon-icon-margin-top);
+
+	$c-inner: setter(map-get($map, c-inner),());
+	$c-inner: map-deep-merge((
+		align-items: $align-items,
+		display: $display,
+		height: $height,
+		justify-content: $justify-content,
+		margin-bottom: math-sign($padding-bottom),
+		margin-left: math-sign($padding-left),
+		margin-right: math-sign($padding-right),
+		margin-top: math-sign($padding-top),
+		max-width: $max-width,
+		padding-bottom: $padding-bottom,
+		padding-left: $padding-left,
+		padding-right: $padding-right,
+		padding-top: $padding-top,
+		width: $width,
+	), $c-inner);
 
 	align-items: $align-items;
 	background-color: $bg;
@@ -280,20 +299,7 @@
 
 	@if ($enable-c-inner) {
 		> .c-inner {
-			align-items: $align-items;
-			display: $display;
-			height: $height;
-			justify-content: $justify-content;
-			margin-bottom: math-sign($padding-bottom);
-			margin-left: math-sign($padding-left);
-			margin-right: math-sign($padding-right);
-			margin-top: math-sign($padding-top);
-			max-width: $max-width;
-			padding-bottom: $padding-bottom;
-			padding-left: $padding-left;
-			padding-right: $padding-right;
-			padding-top: $padding-top;
-			width: $width;
+			@include clay-css($c-inner);
 		}
 	}
 

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -21,14 +21,19 @@
 /// height: {Number | String | Null},
 /// justify-content: {String | Null},
 /// line-height: {Number | String | Null},
+/// margin: {Number | String | List | Null},
 /// margin-bottom: {Number | String | Null},
 /// margin-left: {Number | String | Null},
 /// margin-right: {Number | String | Null},
 /// margin-top: {Number | String | Null},
+/// max-height: {Number | String | Null},
 /// max-width: {Number | String | Null},
+/// min-height: {Number | String | Null},
+/// min-width: {Number | String | Null},
 /// opacity: {Number | String | Null},
 /// outline: {Number | String | Null},
 /// overflow: {String | Null},
+/// padding: {Number | String | List | Null},
 /// padding-bottom: {Number | String | Null},
 /// padding-left: {Number | String | Null},
 /// padding-right: {Number | String | Null},
@@ -103,11 +108,15 @@
 	$height: map-get($map, height);
 	$justify-content: map-get($map, justify-content);
 	$line-height: map-get($map, line-height);
+	$margin: map-get($map, margin);
 	$margin-bottom: map-get($map, margin-bottom);
 	$margin-left: map-get($map, margin-left);
 	$margin-right: map-get($map, margin-right);
 	$margin-top: map-get($map, margin-top);
+	$max-height: map-get($map, max-height);
 	$max-width: map-get($map, max-width);
+	$min-height: map-get($map, min-height);
+	$min-width: map-get($map, min-width);
 	$opacity: map-get($map, opacity);
 	$outline: map-get($map, outline);
 	$overflow: map-get($map, overflow);
@@ -186,6 +195,8 @@
 		margin-right: math-sign($padding-right),
 		margin-top: math-sign($padding-top),
 		max-width: $max-width,
+		min-height: $min-height,
+		min-width: $min-width,
 		padding-bottom: $padding-bottom,
 		padding-left: $padding-left,
 		padding-right: $padding-right,
@@ -211,11 +222,15 @@
 	height: $height;
 	justify-content: $justify-content;
 	line-height: $line-height;
+	margin: $margin;
 	margin-bottom: $margin-bottom;
 	margin-left: $margin-left;
 	margin-right: $margin-right;
 	margin-top: $margin-top;
+	max-height: $max-height;
 	max-width: $max-width;
+	min-height: $min-height;
+	min-width: $min-width;
 	opacity: $opacity;
 	outline: $outline;
 	overflow: $overflow;

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -288,6 +288,7 @@
 			margin-left: math-sign($padding-left);
 			margin-right: math-sign($padding-right);
 			margin-top: math-sign($padding-top);
+			max-width: $max-width;
 			padding-bottom: $padding-bottom;
 			padding-left: $padding-left;
 			padding-right: $padding-right;

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -275,6 +275,20 @@
 		}
 	}
 
+	@if ($enable-c-inner) {
+		> .c-inner {
+			display: $display;
+			margin-bottom: math-sign($padding-bottom);
+			margin-left: math-sign($padding-left);
+			margin-right: math-sign($padding-right);
+			margin-top: math-sign($padding-top);
+			padding-bottom: $padding-bottom;
+			padding-left: $padding-left;
+			padding-right: $padding-right;
+			padding-top: $padding-top;
+		}
+	}
+
 	.lexicon-icon {
 		font-size: $lexicon-icon-font-size;
 		margin-bottom: $lexicon-icon-margin-bottom;

--- a/packages/clay-css/src/scss/mixins/_menubar.scss
+++ b/packages/clay-css/src/scss/mixins/_menubar.scss
@@ -38,6 +38,7 @@
 /// toggler-height-mobile: {Number | String}, // Default: 2rem
 /// toggler-padding-x-mobile: {Number | String}, // Default: 0.5rem
 /// toggler-padding-y-mobile: {Number | String | Null},
+/// toggler-c-inner: {Map | Null}, // Pass parameters to `clay-css` mixin
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
@@ -86,6 +87,21 @@
 	$toggler-height-mobile: setter(map-get($map, toggler-height-mobile), 2rem); // 32px
 	$toggler-padding-x-mobile: setter(map-get($map, toggler-padding-x-mobile), 0.5rem); // 8px
 	$toggler-padding-y-mobile: map-get($map, toggler-padding-y-mobile);
+
+	$toggler-c-inner: setter(map-get($map, toggler-c-inner), ());
+	$toggler-c-inner: map-deep-merge((
+		align-items: center,
+		display: flex,
+		height: $toggler-height-mobile,
+		margin-bottom: math-sign($toggler-padding-y-mobile),
+		margin-left: math-sign($toggler-padding-x-mobile),
+		margin-right: math-sign($toggler-padding-x-mobile),
+		margin-top: math-sign($toggler-padding-y-mobile),
+		padding-bottom: $toggler-padding-y-mobile,
+		padding-left: $toggler-padding-x-mobile,
+		padding-right: $toggler-padding-x-mobile,
+		padding-top: $toggler-padding-y-mobile,
+	), $toggler-c-inner);
 
 	@if ($enabled) {
 		border-color: $border-color;
@@ -153,6 +169,12 @@
 				padding-left: $toggler-padding-x-mobile;
 				padding-right: $toggler-padding-x-mobile;
 				padding-top: $toggler-padding-y-mobile;
+
+				@if ($enable-c-inner) {
+					.c-inner {
+						@include clay-css($toggler-c-inner);
+					}
+				}
 
 				.lexicon-icon {
 					margin-top: 0;

--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -112,11 +112,25 @@
 			padding-left: $toggler-padding-x;
 			padding-right: $toggler-padding-x;
 			padding-top: $toggler-padding-y;
+
+			@if ($enable-c-inner) {
+				.c-inner {
+					height: $toggler-height;
+					margin-bottom: math-sign($toggler-padding-y);
+					margin-left: math-sign($toggler-padding-x);
+					margin-right: math-sign($toggler-padding-x);
+					margin-top: math-sign($toggler-padding-y);
+					padding-bottom: $toggler-padding-y;
+					padding-left: $toggler-padding-x;
+					padding-right: $toggler-padding-x;
+					padding-top: $toggler-padding-y;
+				}
+			}
 		}
 
 		.navbar-toggler-link {
-			height: $toggler-link-height;
 			font-size: $toggler-link-font-size;
+			height: $toggler-link-height;
 			line-height: $toggler-link-line-height;
 			margin-bottom: $toggler-link-margin-y;
 			margin-left: $toggler-link-margin-x;
@@ -126,6 +140,20 @@
 			padding-left: $toggler-link-padding-x;
 			padding-right: $toggler-link-padding-x;
 			padding-top: $toggler-link-padding-y;
+
+			@if ($enable-c-inner) {
+				.c-inner {
+					height: $toggler-link-height;
+					margin-bottom: math-sign($toggler-link-padding-y);
+					margin-left: math-sign($toggler-link-padding-x);
+					margin-right: math-sign($toggler-link-padding-x);
+					margin-top: math-sign($toggler-link-padding-y);
+					padding-bottom: $toggler-link-padding-y;
+					padding-left: $toggler-link-padding-x;
+					padding-right: $toggler-link-padding-x;
+					padding-top: $toggler-link-padding-y;
+				}
+			}
 		}
 
 		.navbar-brand {
@@ -136,6 +164,20 @@
 			padding-left: $brand-padding-x-mobile;
 			padding-right: $brand-padding-x-mobile;
 			padding-top: $brand-padding-y-mobile;
+
+			@if ($enable-c-inner) {
+				.c-inner {
+					margin-bottom: math-sign($brand-padding-y-mobile);
+					margin-left: math-sign($brand-padding-x-mobile);
+					margin-right: math-sign($brand-padding-x-mobile);
+					margin-top: math-sign($brand-padding-y-mobile);
+					max-width: $brand-max-width;
+					padding-bottom: $brand-padding-y-mobile;
+					padding-left: $brand-padding-x-mobile;
+					padding-right: $brand-padding-x-mobile;
+					padding-top: $brand-padding-y-mobile;
+				}
+			}
 		}
 
 		.navbar-title {
@@ -158,11 +200,33 @@
 				padding-right: $btn-padding-x-mobile;
 				padding-top: $btn-padding-y-mobile;
 				min-width: $btn-monospaced-size-mobile;
+
+				@if ($enable-c-inner) {
+					.c-inner {
+						height: $btn-monospaced-size-mobile;
+						margin-bottom: math-sign($btn-padding-y-mobile);
+						margin-left: math-sign($btn-padding-x-mobile);
+						margin-right: math-sign($btn-padding-x-mobile);
+						margin-top: math-sign($btn-padding-y-mobile);
+						padding-bottom: $btn-padding-y-mobile;
+						padding-left: $btn-padding-x-mobile;
+						padding-right: $btn-padding-x-mobile;
+						padding-top: $btn-padding-y-mobile;
+						min-width: $btn-monospaced-size-mobile;
+					}
+				}
 			}
 
 			.nav-btn-monospaced {
 				font-size: $btn-monospaced-font-size-mobile;
 				padding: 0;
+
+				@if ($enable-c-inner) {
+					.c-inner {
+						margin: 0;
+						padding: 0;
+					}
+				}
 			}
 
 			.nav-item {
@@ -183,6 +247,19 @@
 				padding-left: $link-padding-x-mobile;
 				padding-right: $link-padding-x-mobile;
 				padding-top: $link-padding-y-mobile;
+
+				@if ($enable-c-inner) {
+					.c-inner {
+						margin-bottom: math-sign($link-padding-y-mobile);
+						margin-left: math-sign($link-padding-x-mobile);
+						margin-right: math-sign($link-padding-x-mobile);
+						margin-top: math-sign($link-padding-y-mobile);
+						padding-bottom: $link-padding-y-mobile;
+						padding-left: $link-padding-x-mobile;
+						padding-right: $link-padding-x-mobile;
+						padding-top: $link-padding-y-mobile;
+					}
+				}
 			}
 
 			.nav-link-monospaced {
@@ -192,6 +269,13 @@
 				margin-right: $btn-margin-x-mobile;
 				margin-top: $btn-margin-y-mobile;
 				padding: 0;
+
+				@if ($enable-c-inner) {
+					.c-inner {
+						margin: 0;
+						padding: 0;
+					}
+				}
 			}
 		}
 
@@ -276,6 +360,19 @@
 								padding-left: $brand-padding-x;
 								padding-right: $brand-padding-x;
 								padding-top: $brand-padding-y;
+
+								@if ($enable-c-inner) {
+									.c-inner {
+										margin-bottom: math-sign($brand-padding-y);
+										margin-left: math-sign($brand-padding-x);
+										margin-right: math-sign($brand-padding-x);
+										margin-top: math-sign($brand-padding-y);
+										padding-bottom: $brand-padding-y;
+										padding-left: $brand-padding-x;
+										padding-right: $brand-padding-x;
+										padding-top: $brand-padding-y;
+									}
+								}
 							}
 						}
 
@@ -310,6 +407,21 @@
 								padding-right: $btn-padding-x;
 								padding-top: $btn-padding-y;
 								min-width: $btn-monospaced-size;
+
+								@if ($enable-c-inner) {
+									.c-inner {
+										height: $btn-monospaced-size;
+										margin-bottom: math-sign($btn-padding-y);
+										margin-left: math-sign($btn-padding-x);
+										margin-right: math-sign($btn-padding-x);
+										margin-top: math-sign($btn-padding-y);
+										padding-bottom: $btn-padding-y;
+										padding-left: $btn-padding-x;
+										padding-right: $btn-padding-x;
+										padding-top: $btn-padding-y;
+										min-width: $btn-monospaced-size;
+									}
+								}
 							}
 						}
 
@@ -317,6 +429,13 @@
 							@if ($scaling-navbar) {
 								font-size: $btn-monospaced-font-size;
 								padding: 0;
+
+								@if ($enable-c-inner) {
+									.c-inner {
+										margin: 0;
+										padding: 0;
+									}
+								}
 							}
 						}
 
@@ -341,6 +460,19 @@
 								padding-left: $link-padding-x;
 								padding-right: $link-padding-x;
 								padding-top: $link-padding-y;
+
+								@if ($enable-c-inner) {
+									.c-inner {
+										margin-bottom: math-sign($link-padding-y);
+										margin-left: math-sign($link-padding-x);
+										margin-right: math-sign($link-padding-x);
+										margin-top: math-sign($link-padding-y);
+										padding-bottom: $link-padding-y;
+										padding-left: $link-padding-x;
+										padding-right: $link-padding-x;
+										padding-top: $link-padding-y;
+									}
+								}
 							}
 						}
 
@@ -352,6 +484,13 @@
 								margin-right: $btn-margin-x;
 								margin-top: $btn-margin-y;
 								padding: 0;
+
+								@if ($enable-c-inner) {
+									.c-inner {
+										margin: 0;
+										padding: 0;
+									}
+								}
 							}
 						}
 					}

--- a/packages/clay-css/src/scss/mixins/_panels.scss
+++ b/packages/clay-css/src/scss/mixins/_panels.scss
@@ -126,6 +126,19 @@
 		padding-top: $header-padding-top;
 		transition: $header-transition;
 
+		@if ($enable-c-inner) {
+			.c-inner {
+				margin-bottom: #{math-sign($header-padding-bottom)};
+				margin-left: #{math-sign($header-padding-left)};
+				margin-right: #{math-sign($header-padding-right)};
+				margin-top: #{math-sign($header-padding-top)};
+				padding-bottom: $header-padding-bottom;
+				padding-left: $header-padding-left;
+				padding-right: $header-padding-right;
+				padding-top: $header-padding-top;
+			}
+		}
+
 		&.collapsed {
 			border-color: $header-collapsed-border-color;
 		}

--- a/packages/clay-css/src/scss/mixins/_tbar.scss
+++ b/packages/clay-css/src/scss/mixins/_tbar.scss
@@ -161,6 +161,20 @@
 		padding-left: $btn-padding-x;
 		padding-right: $btn-padding-x;
 		padding-top: $btn-padding-y;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				height: $btn-height;
+				margin-bottom: #{math-sign($btn-padding-y)};
+				margin-left: #{math-sign($btn-padding-x)};
+				margin-right: #{math-sign($btn-padding-x)};
+				margin-top: #{math-sign($btn-padding-y)};
+				padding-bottom: $btn-padding-y;
+				padding-left: $btn-padding-x;
+				padding-right: $btn-padding-x;
+				padding-top: $btn-padding-y;
+			}
+		}
 	}
 
 	.tbar-link {
@@ -172,6 +186,19 @@
 		padding-left: $link-padding-x;
 		padding-right: $link-padding-x;
 		padding-top: $link-padding-y;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				margin-bottom: #{math-sign($link-padding-y)};
+				margin-left: #{math-sign($link-padding-x)};
+				margin-right: #{math-sign($link-padding-x)};
+				margin-top: #{math-sign($link-padding-y)};
+				padding-bottom: $link-padding-y;
+				padding-left: $link-padding-x;
+				padding-right: $link-padding-x;
+				padding-top: $link-padding-y;
+			}
+		}
 	}
 
 	.tbar-btn-monospaced {
@@ -185,6 +212,15 @@
 		margin-top: $btn-monospaced-margin-y;
 		padding: $btn-monospaced-padding;
 		width: $btn-monospaced-size;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				height: $btn-monospaced-size;
+				margin: #{math-sign($btn-monospaced-padding)};
+				padding: $btn-monospaced-padding;
+				width: $btn-monospaced-size;
+			}
+		}
 
 		.inline-item {
 			font-size: $btn-monospaced-font-size;
@@ -202,6 +238,15 @@
 		margin-top: $link-monospaced-margin-y;
 		padding: $link-monospaced-padding;
 		width: $link-monospaced-size;
+
+		@if ($enable-c-inner) {
+			.c-inner {
+				height: $link-monospaced-size;
+				margin: #{math-sign($link-monospaced-padding)};
+				padding: $link-monospaced-padding;
+				width: $link-monospaced-size;
+			}
+		}
 
 		.inline-item {
 			font-size: $link-monospaced-font-size;

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -48,6 +48,7 @@ $dropdown-item-indicator-spacer-x: 1rem !default;
 $dropdown-item-base: () !default;
 $dropdown-item-base: map-deep-merge((
 	border-radius: 0,
+	display: block,
 	overflow: hidden,
 	padding-bottom: $dropdown-item-padding-y,
 	padding-left: $dropdown-item-padding-x,

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -328,6 +328,12 @@ $input-group-inset-item-btn: map-deep-merge((
 	padding-left: 0.5rem,
 	padding-right: 0.5rem,
 	padding-top: 0,
+	c-inner: (
+		align-items: center,
+		display: flex,
+		height: 100%,
+		justify-content: center,
+	),
 ), $input-group-inset-item-btn);
 
 $input-group-inset-form-file-btn: () !default;

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -319,6 +319,7 @@ $input-group-inset-item-padding-right: 5px !default;
 
 $input-group-inset-item-btn: () !default;
 $input-group-inset-item-btn: map-deep-merge((
+	display: block,
 	height: 75%,
 	line-height: 1,
 	margin-left: 0.125rem,

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -50,6 +50,7 @@ $dark-l1: lighten($dark, 22.94) !default;
 $dark-l2: lighten($dark, 32.94) !default;
 
 $enable-scaling-components: false !default;
+$enable-c-inner: false !default;
 $scaling-breakpoint-down: sm !default;
 
 $rounded-border-radius: $border-radius !default;

--- a/packages/clay-css/src/scss/variables/_links.scss
+++ b/packages/clay-css/src/scss/variables/_links.scss
@@ -18,59 +18,6 @@ $link-secondary: map-deep-merge((
 	hover-color: darken($secondary, 15%)
 ), $link-secondary);
 
-// Component Title
-
-$component-title: () !default;
-$component-title: map-deep-merge((
-	color: $gray-900,
-	font-size: 1.125rem,
-	font-weight: $headings-font-weight,
-	line-height: $headings-line-height,
-	margin-bottom: calc((#{$dropdown-action-toggle-size} - (1em * #{$headings-line-height})) / 2),
-	margin-top: calc((#{$dropdown-action-toggle-size} - (1em * #{$headings-line-height})) / 2)
-), $component-title);
-
-$component-title-link: () !default;
-$component-title-link: map-deep-merge((
-	color: $gray-900,
-	hover-color: darken($gray-900, 15%)
-), $component-title-link);
-
-// Component Subtitle
-
-$component-subtitle: () !default;
-$component-subtitle: map-deep-merge((
-	color: $gray-600,
-	margin-bottom: 0
-), $component-subtitle);
-
-$component-subtitle-link: () !default;
-$component-subtitle-link: map-deep-merge((
-	color: $gray-600,
-	hover-color: darken($gray-600, 15%)
-), $component-subtitle-link);
-
-// Component Action
-
-$component-action: () !default;
-$component-action: map-deep-merge((
-	bg: transparent,
-	border-color: transparent,
-	border-radius: $border-radius,
-	color: $secondary,
-	hover-bg: $secondary,
-	hover-color: $white,
-	btn-focus-box-shadow: 0 0 0 $btn-focus-width rgba($secondary, 0.5),
-	btn-focus-outline: 0,
-	active-bg: $secondary,
-	active-color: $white,
-	disabled-bg: transparent,
-	disabled-color: $secondary,
-	disabled-cursor: $disabled-cursor,
-	disabled-opacity: $btn-disabled-opacity,
-	transition: $btn-transition
-), $component-action);
-
 // Link Outline
 
 $link-outline-border-radius: $btn-border-radius !default;
@@ -117,3 +64,66 @@ $link-outline-secondary: map-deep-merge((
 // Link Monospaced
 
 $link-monospaced-size: $btn-monospaced-size-sm !default;
+
+// Component Title
+
+$component-title: () !default;
+$component-title: map-deep-merge((
+	color: $gray-900,
+	font-size: 1.125rem,
+	font-weight: $headings-font-weight,
+	line-height: $headings-line-height,
+	margin-bottom: calc((#{$dropdown-action-toggle-size} - (1em * #{$headings-line-height})) / 2),
+	margin-top: calc((#{$dropdown-action-toggle-size} - (1em * #{$headings-line-height})) / 2)
+), $component-title);
+
+$component-title-link: () !default;
+$component-title-link: map-deep-merge((
+	color: $gray-900,
+	hover-color: darken($gray-900, 15%)
+), $component-title-link);
+
+// Component Subtitle
+
+$component-subtitle: () !default;
+$component-subtitle: map-deep-merge((
+	color: $gray-600,
+	margin-bottom: 0
+), $component-subtitle);
+
+$component-subtitle-link: () !default;
+$component-subtitle-link: map-deep-merge((
+	color: $gray-600,
+	hover-color: darken($gray-600, 15%)
+), $component-subtitle-link);
+
+// Component Action
+
+$component-action: () !default;
+$component-action: map-deep-merge((
+	align-items: center,
+	bg: transparent,
+	border-color: transparent,
+	border-radius: $border-radius,
+	border-width: 0,
+	color: $secondary,
+	display: inline-flex,
+	height: $link-monospaced-size,
+	justify-content: center,
+	overflow: hidden,
+	padding: 0,
+	vertical-align: middle,
+	width: $link-monospaced-size,
+	hover-bg: $secondary,
+	hover-color: $white,
+	btn-focus-box-shadow: 0 0 0 $btn-focus-width rgba($secondary, 0.5),
+	btn-focus-outline: 0,
+	active-bg: $secondary,
+	active-color: $white,
+	disabled-bg: transparent,
+	disabled-color: $secondary,
+	disabled-cursor: $disabled-cursor,
+	disabled-opacity: $btn-disabled-opacity,
+	transition: $btn-transition,
+	lexicon-icon-margin-top: 0,
+), $component-action);

--- a/packages/clay-css/src/scss/variables/_links.scss
+++ b/packages/clay-css/src/scss/variables/_links.scss
@@ -1,3 +1,7 @@
+////
+/// @group Links
+////
+
 $single-link-font-weight: $font-weight-semi-bold !default;
 
 $component-link: () !default;
@@ -20,14 +24,60 @@ $link-secondary: map-deep-merge((
 
 // Link Outline
 
+/// @deprecated as of v3.4.0 use the Sass map `$link-outline` instead
+
 $link-outline-border-radius: $btn-border-radius !default;
+
+/// @deprecated as of v3.4.0 use the Sass map `$link-outline` instead
+
 $link-outline-border-width: $btn-border-width !default;
+
+/// @deprecated as of v3.4.0 use the Sass map `$link-outline` instead
+
 $link-outline-font-size: $btn-font-size-sm !default;
+
+/// @deprecated as of v3.4.0 use the Sass map `$link-outline` instead
+
 $link-outline-font-weight: $font-weight-semi-bold !default;
+
+/// @deprecated as of v3.4.0 use the Sass map `$link-outline` instead
+
 $link-outline-line-height: $btn-line-height-sm !default;
+
+/// @deprecated as of v3.4.0 use the Sass map `$link-outline` instead
+
 $link-outline-padding-x: $btn-padding-x-sm !default;
+
+/// @deprecated as of v3.4.0 use the Sass map `$link-outline` instead
+
 $link-outline-padding-y: $btn-padding-y-sm !default;
+
+/// @deprecated as of v3.4.0 use the Sass map `$link-outline` instead
+
 $link-outline-transition: $btn-transition !default;
+
+$link-outline: () !default;
+$link-outline: map-deep-merge((
+	align-items: center,
+	bg: transparent,
+	border-color: transparent,
+	border-radius: $link-outline-border-radius,
+	border-style: solid,
+	border-width: $link-outline-border-width,
+	display: inline-flex,
+	font-size: $link-outline-font-size,
+	font-weight: $link-outline-font-weight,
+	justify-content: center,
+	line-height: $link-outline-line-height,
+	padding-bottom: $link-outline-padding-y,
+	padding-left: $link-outline-padding-x,
+	padding-right: $link-outline-padding-x,
+	padding-top: $link-outline-padding-y,
+	transition: $link-outline-transition,
+	vertical-align: middle,
+	hover-text-decoration: none,
+	lexicon-icon-margin-top: 0,
+), $link-outline);
 
 $link-outline-primary: () !default;
 $link-outline-primary: map-deep-merge((

--- a/packages/clay-css/src/scss/variables/_links.scss
+++ b/packages/clay-css/src/scss/variables/_links.scss
@@ -113,7 +113,25 @@ $link-outline-secondary: map-deep-merge((
 
 // Link Monospaced
 
+/// @deprecated as of v3.4.0 use the Sass map `$link-monospaced` instead
+
 $link-monospaced-size: $btn-monospaced-size-sm !default;
+
+$link-monospaced: () !default;
+$link-monospaced: map-deep-merge((
+	align-items: center,
+	display: inline-flex,
+	height: $link-monospaced-size,
+	justify-content: center,
+	overflow: hidden,
+	padding-bottom: 0,
+	padding-left: 0,
+	padding-right: 0,
+	padding-top: 0,
+	vertical-align: middle,
+	width: $link-monospaced-size,
+	lexicon-icon-margin-top: 0,
+), $link-monospaced);
 
 // Component Title
 
@@ -158,12 +176,12 @@ $component-action: map-deep-merge((
 	border-width: 0,
 	color: $secondary,
 	display: inline-flex,
-	height: $link-monospaced-size,
+	height: map-get($link-monospaced, height),
 	justify-content: center,
 	overflow: hidden,
 	padding: 0,
 	vertical-align: middle,
-	width: $link-monospaced-size,
+	width: map-get($link-monospaced, width),
 	hover-bg: $secondary,
 	hover-color: $white,
 	btn-focus-box-shadow: 0 0 0 $btn-focus-width rgba($secondary, 0.5),

--- a/packages/clay-css/src/scss/variables/_navs.scss
+++ b/packages/clay-css/src/scss/variables/_navs.scss
@@ -28,10 +28,72 @@ $nav-link-btn-unstyled: map-deep-merge((
 
 $nav-item-monospaced-size: 2rem !default; // 32px
 
+/// @deprecated after v3.4.0 use the Sass map `$nav-btn` instead
+
 $nav-btn-margin-x: 0.25rem !default; // 4px
+
+/// @deprecated after v3.4.0 use the Sass map `$nav-btn` instead
+
 $nav-btn-margin-y: (($line-height-base * $font-size-base) + ($nav-link-padding-y * 2) - $nav-item-monospaced-size) / 2 !default;
+
+/// @deprecated after v3.4.0 use the Sass map `$nav-btn` instead
+
 $nav-btn-padding-x: $btn-padding-x-sm !default;
+
+/// @deprecated after v3.4.0 use the Sass map `$nav-btn` instead
+
 $nav-btn-padding-y: 0 !default;
+
+$nav-btn: () !default;
+$nav-btn: map-deep-merge((
+	align-items: center,
+	display: flex,
+	height: $nav-item-monospaced-size,
+	justify-content: center,
+	line-height: $line-height-base,
+	margin: $nav-btn-margin-y $nav-btn-margin-x,
+	min-width: $nav-item-monospaced-size,
+	padding: $nav-btn-padding-y $nav-btn-padding-x,
+	position: relative,
+	text-align: center,
+	width: auto,
+	focus-z-index: 1,
+	disabled-opacity: 1,
+	c-inner: (
+		margin-bottom: 0,
+		margin-left: math-sign($nav-btn-padding-x),
+		margin-right: math-sign($nav-btn-padding-x),
+		margin-top: math-sign($btn-border-width),
+		padding: $nav-btn-padding-y $nav-btn-padding-x,
+	),
+	lexicon-icon-margin-top: 0,
+), $nav-btn);
+
+$nav-btn-monospaced: () !default;
+$nav-btn-monospaced: map-deep-merge((
+	padding: 0,
+	c-inner: (
+		margin-left: math-sign($btn-border-width),
+		margin-right: math-sign($btn-border-width),
+		padding-left: 0,
+		padding-right: 0,
+	),
+), $nav-btn-monospaced);
+
+$nav-link-monospaced: () !default;
+$nav-link-monospaced: map-deep-merge((
+	align-items: center,
+	display: flex,
+	height: $nav-item-monospaced-size,
+	justify-content: center,
+	margin: $nav-btn-margin-y $nav-btn-margin-x,
+	min-width: $nav-item-monospaced-size,
+	padding: 0,
+	lexicon-icon-margin-top: 0,
+	c-inner: (
+		padding: 0,
+	),
+), $nav-link-monospaced);
 
 $nav-form-padding-bottom: 0 !default;
 $nav-form-padding-left: $nav-link-padding-x !default;

--- a/packages/clay-css/src/scss/variables/_navs.scss
+++ b/packages/clay-css/src/scss/variables/_navs.scss
@@ -4,7 +4,11 @@ $nav-link-disabled-cursor: $disabled-cursor !default;
 
 $nav-link: () !default;
 $nav-link: map-deep-merge((
-	padding: $nav-link-padding-y $nav-link-padding-x,
+	display: block,
+	padding-bottom: $nav-link-padding-y,
+	padding-left: $nav-link-padding-x,
+	padding-right: $nav-link-padding-x,
+	padding-top: $nav-link-padding-y,
 	position: relative,
 	focus-z-index: 1,
 	disabled-color: $nav-link-disabled-color,
@@ -17,6 +21,9 @@ $nav-link-btn-unstyled: () !default;
 $nav-link-btn-unstyled: map-deep-merge((
 	width: 100%,
 	disabled-opacity: 1,
+	c-inner: (
+		width: auto,
+	),
 ), $nav-link-btn-unstyled);
 
 $nav-item-monospaced-size: 2rem !default; // 32px


### PR DESCRIPTION
This is a big change, but doesn't change the existing behavior even if this setting is enabled. This is disabled by default and can be enabled by setting `$enable-c-inner: true;` in your Clay CSS variable overwrites.

Once enabled the markup follows the pattern:
```
<button class="btn btn-primary" type="button">
    <span class="c-inner" tabindex="-1">Primary</span>
</button>
```

Let me know if this is a feature we want to enable by default.