### PR TITLE
feat(clay-css): Modal additional components in Modal Header

### DIFF
--- a/packages/clay-css/src/content/modals.html
+++ b/packages/clay-css/src/content/modals.html
@@ -16,7 +16,13 @@ section: Components
 	<div class="modal-dialog modal-sm">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="claySmallModalLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="claySmallModalLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -58,7 +64,13 @@ section: Components
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayDefaultModalLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayDefaultModalLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -102,7 +114,13 @@ section: Components
 	<div class="modal-dialog modal-lg">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayLargeModalLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayLargeModalLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -146,7 +164,13 @@ section: Components
 	<div class="modal-dialog modal-xl">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayExtraLargeModalLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayExtraLargeModalLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -188,7 +212,13 @@ section: Components
 	<div class="modal-dialog modal-sm">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="claySmallModalInlineScrollerLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="claySmallModalInlineScrollerLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -250,7 +280,13 @@ section: Components
 	<div class="modal-dialog modal-full-screen">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayLargeModalLabel">Add Picture to Documents and Media Library in Liferay Seven</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayLargeModalLabel">Add Picture to Documents and Media Library in Liferay Seven</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -372,7 +408,13 @@ section: Components
 	<div class="modal-dialog modal-full-screen-sm-down">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayModalFullScreenSmDownLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayModalFullScreenSmDownLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -433,7 +475,13 @@ section: Components
 	<div class="modal-dialog modal-full-screen modal-full-screen-sm-down">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayFullScreenModalIframeLabel">Add Picture to Documents and Media Library in Liferay Seven</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayFullScreenModalIframeLabel">Add Picture to Documents and Media Library in Liferay Seven</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -467,7 +515,7 @@ section: Components
 		<h3>Modal Variants</h3>
 
 		<blockquote class="blockquote">
-			<p><code>modal-danger</code>, <code>modal-info</code>, <code>modal-success</code>, or <code>modal-warning</code> are helper classes that style a modal based on that state, add it to modal-dialog.</p>
+			<p><code>modal-danger</code>, <code>modal-info</code>, <code>modal-success</code>, or <code>modal-warning</code> are helper classes that style a modal based on that state, add it to <code>modal-dialog</code>.</p>
 		</blockquote>
 
 <button class="btn btn-danger" data-target="#clayModalDanger" data-toggle="modal" type="button">Modal Danger</button>
@@ -475,13 +523,30 @@ section: Components
 	<div class="modal-danger modal-dialog modal-full-screen-sm-down">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayModalDangerLabel">
-					<span class="modal-title-indicator">
-						<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#exclamation-full" />
-						</svg>
-					</span>
-					Modal Title
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayModalDangerLabel">
+								<span class="modal-title-indicator">
+									<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#exclamation-full" />
+									</svg>
+								</span>
+								Modal Title
+							</div>
+						</div>
+					</div>
+					<div class="modal-item modal-item-shrink">
+						<div class="modal-subtitle-section">
+							<div class="text-truncate-inline">
+								<div class="text-truncate">
+									<div class="modal-subtitle">Step 1 of 2</div>
+									<div class="modal-subtitle-divider">/</div>
+									<strong>Details</strong>
+								</div>
+							</div>
+						</div>
+					</div>
 				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
@@ -518,19 +583,36 @@ section: Components
 	<div class="modal-info modal-dialog modal-full-screen-sm-down">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayModalInfoLabel">
-					<span class="modal-title-indicator">
-						<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#info-circle" />
-						</svg>
-					</span>
-					Modal Title
-				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 					</svg>
 				</button>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayModalInfoLabel">
+								<span class="modal-title-indicator">
+									<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#info-circle" />
+									</svg>
+								</span>
+								ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+							</div>
+						</div>
+					</div>
+					<div class="modal-item modal-item-shrink">
+						<div class="modal-subtitle-section">
+							<div class="text-truncate-inline">
+								<div class="text-truncate">
+									<span class="modal-subtitle">Step 10,000,000,000 of 2,000,000,000,000,000</span>
+									<span class="modal-subtitle-divider">/</span>
+									<strong>Details</strong>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
 			</div>
 			<div class="modal-body">
 				<h4>Modal Body</h4>
@@ -555,13 +637,19 @@ section: Components
 	<div class="modal-success modal-dialog modal-full-screen-sm-down">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayModalSuccessLabel">
-					<span class="modal-title-indicator">
-						<svg class="lexicon-icon lexicon-icon-check-circle-full" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#check-circle-full" />
-						</svg>
-					</span>
-					Modal Title
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayModalSuccessLabel">
+								<span class="modal-title-indicator">
+									<svg class="lexicon-icon lexicon-icon-check-circle-full" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#check-circle-full" />
+									</svg>
+								</span>
+								Modal Title
+							</div>
+						</div>
+					</div>
 				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
@@ -595,13 +683,19 @@ section: Components
 	<div class="modal-warning modal-dialog modal-full-screen-sm-down">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="clayModalWarningLabel">
-					<span class="modal-title-indicator">
-						<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#warning-full" />
-						</svg>
-					</span>
-					Modal Title
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="clayModalWarningLabel">
+								<span class="modal-title-indicator">
+									<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#warning-full" />
+									</svg>
+								</span>
+								Modal Title
+							</div>
+						</div>
+					</div>
 				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
@@ -633,11 +727,139 @@ section: Components
 
 <div class="clay-site-row-spacer row">
 	<div class="col-md-12">
+		<h3>Modal Title</h3>
+
+		<div class="modal-header">
+			<div class="modal-item-group">
+				<div class="modal-item">
+					<div class="modal-title-section">
+						<div class="modal-title" id="modalLabel">
+							Modal Title
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Modal Subtitle</h3>
+
+		<div class="modal-header">
+			<div class="modal-item-group">
+				<div class="modal-item">
+					<div class="modal-subtitle-section">
+						<div class="text-truncate-inline">
+							<div class="text-truncate">
+								<div class="modal-subtitle">Step 1 of 2</div>
+								<div class="modal-subtitle-divider">/</div>
+								<strong>Details</strong>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Modal Header with Modal Item</h3>
+
+		<blockquote class="blockquote">
+			<p>Use a combination of <code>.modal-item-group</code>, <code>.modal-item</code>, and <code>.modal-item.modal-item-shrink</code> to make content fill remaining space.</p>
+		</blockquote>
+
+		<div class="modal-header">
+			<div class="modal-item-group">
+				<div class="modal-item">
+					<div class="modal-title-section">
+						<div class="modal-title" id="modalLabel">
+							Modal Title
+						</div>
+					</div>
+				</div>
+				<div class="modal-item modal-item-shrink">
+					<div class="modal-subtitle-section">
+						<div class="text-truncate-inline">
+							<div class="text-truncate">
+								<div class="modal-subtitle">Step 1 of 2</div>
+								<div class="modal-subtitle-divider">/</div>
+								<strong>Details</strong>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<button aria-label="Close" class="close" data-dismiss="modal" type="button">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</button>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Modal Header with Modal Item and Hidden Buttons</h3>
+
+		<blockquote class="blockquote">
+			<p>Additionally, there are <code>modal-group-first</code>, <code>modal-group-last</code>, and <code>modal-group-only</code> classes to force spacing between <code>modal-item-group</code> and other siblings if there are hidden items in the header. The example below has <code>display: none;</code> on the <code>close</code> button.</p>
+		</blockquote>
+
+		<div class="modal-header">
+			<button class="btn btn-secondary btn-monospaced btn-sm" type="button">
+				<span class="inline-item">
+					<svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#plus" />
+					</svg>
+				</span>
+			</button>
+			<div class="modal-item-group modal-item-group-last">
+				<div class="modal-item">
+					<div class="modal-title-section">
+						<div class="modal-title" id="modalLabel">
+							ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+						</div>
+					</div>
+				</div>
+				<div class="modal-item modal-item-shrink">
+					<div class="modal-subtitle-section">
+						<div class="text-truncate-inline">
+							<div class="text-truncate">
+								<div class="modal-subtitle">Step 10,000,000 of 20,000,000,000,000</div>
+								<div class="modal-subtitle-divider">/</div>
+								<strong>ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</strong>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<button aria-label="Close" class="close" data-dismiss="modal" type="button" style="display:none;">
+				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+				</svg>
+			</button>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
 		<h3>Modal Helpers</h3>
 
 		<blockquote class="blockquote">
-			<p>Use classes <code>modal-item-first</code>, <code>modal-item</code>, and <code>modal-item-last</code> inside <code>modal-footer</code> to align content left, middle, and right.</p>
+			<p>Use classes <code>modal-item-group</code>, <code>modal-item-first</code>, <code>modal-item</code>, and <code>modal-item-last</code> inside <code>modal-footer</code> to align content left, middle, and right.</p>
 		</blockquote>
+
 	</div>
 </div>
 
@@ -654,7 +876,13 @@ section: Components
 	<div class="modal-dialog modal-sm">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="claySmallModalModalHeightFullLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="claySmallModalModalHeightFullLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -696,7 +924,13 @@ section: Components
 	<div class="modal-dialog modal-sm">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="claySmallModalModalHeightXlLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="claySmallModalModalHeightXlLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -738,7 +972,13 @@ section: Components
 	<div class="modal-dialog modal-sm">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="claySmallModalModalHeightLgLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="claySmallModalModalHeightLgLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -780,7 +1020,13 @@ section: Components
 	<div class="modal-dialog modal-sm">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="claySmallModalModalHeightMdLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="claySmallModalModalHeightMdLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
@@ -822,7 +1068,13 @@ section: Components
 	<div class="modal-dialog modal-sm">
 		<div class="modal-content">
 			<div class="modal-header">
-				<div class="modal-title" id="claySmallModalModalHeightSmLabel">Modal Title</div>
+				<div class="modal-item-group">
+					<div class="modal-item">
+						<div class="modal-title-section">
+							<div class="modal-title" id="claySmallModalModalHeightSmLabel">Modal Title</div>
+						</div>
+					</div>
+				</div>
 				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />

--- a/packages/clay-css/src/content/test_upload_documents.html
+++ b/packages/clay-css/src/content/test_upload_documents.html
@@ -9,7 +9,13 @@ section: Visual Tests
 			<div class="modal-dialog modal-lg">
 				<div class="modal-content">
 					<div class="modal-header">
-						<div class="modal-title">Documents Upload</div>
+						<div class="modal-item-group">
+							<div class="modal-item">
+								<div class="modal-title-section">
+									<div class="modal-title">Documents Upload</div>
+								</div>
+							</div>
+						</div>
 						<button aria-label="Close" class="close" data-dismiss="modal" type="button">
 							<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />

--- a/packages/clay-css/src/scss/components/_modals.scss
+++ b/packages/clay-css/src/scss/components/_modals.scss
@@ -59,6 +59,33 @@
 
 // Modal Item
 
+.modal-item-group {
+	@include clay-css($modal-item-group);
+
+	&:first-child,
+	&.modal-item-group-first {
+		@include clay-css($modal-item-group-first-child);
+	}
+
+	&:last-child,
+	&.modal-item-group-last {
+		@include clay-css($modal-item-group-last-child);
+	}
+
+	&:only-child,
+	&.modal-item-group-only {
+		@include clay-css($modal-item-group-only-child);
+	}
+}
+
+.modal-item {
+	@include clay-css($modal-item);
+}
+
+.modal-item-shrink {
+	@include clay-css($modal-item-shrink);
+}
+
 .modal-item-first,
 .modal-item,
 .modal-item-last {
@@ -72,10 +99,6 @@
 	margin-left: auto;
 }
 
-.modal-item {
-	flex-grow: 1;
-}
-
 .modal-footer {
 	> .modal-item-last {
 		margin-left: auto;
@@ -85,12 +108,13 @@
 // Modal Title
 
 .modal-title {
+	flex-grow: 1;
 	font-size: $modal-title-font-size;
 	font-weight: $modal-title-font-weight;
-	flex-grow: 1;
+	overflow: hidden;
 	text-align: $modal-title-text-align;
-
-	@include text-truncate;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 
 	@include clay-scale-component {
 		font-size: $modal-title-font-size-mobile;
@@ -103,6 +127,20 @@
 	margin-right: $modal-title-indicator-spacer-x;
 	margin-top: -0.2em;
 	vertical-align: middle;
+}
+
+// Modal Subtitle
+
+.modal-subtitle {
+	@include clay-css($modal-subtitle);
+
+	strong {
+		@include clay-css($modal-subtitle-strong);
+	}
+}
+
+.modal-subtitle-divider {
+	@include clay-css($modal-subtitle-divider);
 }
 
 // Modal Close

--- a/packages/clay-css/src/scss/variables/_modals.scss
+++ b/packages/clay-css/src/scss/variables/_modals.scss
@@ -17,6 +17,54 @@ $modal-footer-height-mobile: null !default;
 $modal-item-padding-x: null !default;
 $modal-item-padding-y: null !default;
 
+$modal-item-group: () !default;
+$modal-item-group: map-deep-merge((
+	align-items: center,
+	display: flex,
+	flex-wrap: wrap,
+	min-width: 3rem,
+	padding-left: 0.5rem,
+	padding-right: 0.5rem,
+	width: 100%,
+), $modal-item-group);
+
+$modal-item-group-first-child: () !default;
+$modal-item-group-first-child: map-deep-merge((
+	padding-left: 0,
+), $modal-item-group-first-child);
+
+$modal-item-group-last-child: () !default;
+$modal-item-group-last-child: map-deep-merge((
+	padding-right: 0,
+), $modal-item-group-last-child);
+
+$modal-item-group-only-child: () !default;
+$modal-item-group-only-child: map-deep-merge((
+	padding-left: 0,
+	padding-right: 0,
+), $modal-item-group-only-child);
+
+$modal-item: () !default;
+$modal-item: map-deep-merge((
+	display: flex,
+	flex-direction: column,
+	flex-grow: 1,
+	flex-shrink: 1,
+	max-width: 100%,
+	min-height: 0,
+	min-width: 3.125rem,
+	padding: 0,
+	position: relative,
+	word-wrap: break-word,
+), $modal-item);
+
+$modal-item-shrink: () !default;
+$modal-item-shrink: map-deep-merge((
+	flex-grow: 0,
+), $modal-item-shrink);
+
+// Modal Title
+
 $modal-title-font-size: 1.25rem !default; // 20px
 $modal-title-font-weight: $font-weight-semi-bold !default;
 $modal-title-text-align: null !default;
@@ -24,6 +72,22 @@ $modal-title-font-size-mobile: null !default;
 
 $modal-title-indicator-font-size: 0.875rem !default; // 14px
 $modal-title-indicator-spacer-x: 0.5rem !default; // 8px
+
+// Modal Subtitle
+
+$modal-subtitle: () !default;
+$modal-subtitle: map-deep-merge((
+	display: inline-block,
+), $modal-subtitle);
+
+$modal-subtitle-divider: () !default;
+$modal-subtitle-divider: map-deep-merge((
+	display: inline-block,
+	margin-left: 0.25rem,
+	margin-right: 0.25rem,
+), $modal-subtitle-divider);
+
+$modal-subtitle-strong: () !default;
 
 // Modal Close
 


### PR DESCRIPTION
fixes #2844 
The autofit pattern was the most robust when it came to tossing in additional components into the header. I piggy backed off the `modal-item` class. The markup for additional items is below:

```
<div class="modal-header">
    <div class="modal-item-group">
        <div class="modal-item">
            <div class="modal-title-section">
                <div class="modal-title" id="modalLabel">
                    Modal Title
                </div>
            </div>
        </div>
        <div class="modal-item modal-item-shrink">
            <div class="modal-subtitle-section">
                <div class="text-truncate-inline">
                    <div class="text-truncate">
                        <div class="modal-subtitle">Step 1 of 2</div>
                        <div class="modal-subtitle-divider">/</div>
                        <strong>Details</strong>
                    </div>
                </div>
            </div>
        </div>
    </div>
    <button aria-label="Close" class="close" data-dismiss="modal" type="button">
        x
    </button>
</div>
```

The markup for `modal-title` and `close`:
```
<div class="modal-header">
    <div class="modal-item-group">
        <div class="modal-item">
            <div class="modal-title-section">
                <div class="modal-title" id="modalLabel">
                    Modal Title
                </div>
            </div>
        </div>
    </div>
    <button aria-label="Close" class="close" data-dismiss="modal" type="button">
        x
    </button>
</div>
```

The old markup still works.