### PR TITLE
fix(card): prevent unwanted DOM thrash in ClayCard (#2916)

### DIFF
--- a/packages/clay-card/src/Card.tsx
+++ b/packages/clay-card/src/Card.tsx
@@ -53,12 +53,6 @@ const ClayCard: React.FunctionComponent<IProps> & {
 	selectable = false,
 	...otherProps
 }: IProps) => {
-	const Content: React.FunctionComponent<IProps> = ({children}) => (
-		<Context.Provider value={{horizontal, interactive}}>
-			{children}
-		</Context.Provider>
-	);
-
 	const isCardType = {
 		file: displayType === 'file',
 		image: displayType === 'image',
@@ -70,40 +64,40 @@ const ClayCard: React.FunctionComponent<IProps> & {
 	const TagName = interactive ? 'span' : 'div';
 
 	return (
-		<TagHeaderName
-			{...otherProps}
-			className={classNames(className, {
-				card: !selectable,
-				'card-interactive card-interactive-primary card-type-template':
-					(horizontal && interactive) || interactive,
-				'card-type-asset':
-					isCardType.file || isCardType.image || isCardType.user,
-				'card-type-directory form-check form-check-card form-check-middle-left':
-					selectable && horizontal,
-				'file-card': isCardType.file,
-				'form-check form-check-card form-check-top-left':
-					(selectable && isCardType.file) ||
-					isCardType.image ||
-					isCardType.user,
-				'image-card': isCardType.image,
-				'template-card': interactive && !horizontal,
-				'template-card-horizontal': horizontal && interactive,
-				'user-card': isCardType.user,
-			})}
-			href={interactive ? href : undefined}
-			onClick={onClick}
-			role={onClick ? 'button' : undefined}
-		>
-			{(selectable && !horizontal) ||
-			(selectable && isCardType.image) ||
-			isCardType.user ? (
-				<TagName className="card">
-					<Content>{children}</Content>
-				</TagName>
-			) : (
-				<Content>{children}</Content>
-			)}
-		</TagHeaderName>
+		<Context.Provider value={{horizontal, interactive}}>
+			<TagHeaderName
+				{...otherProps}
+				className={classNames(className, {
+					card: !selectable,
+					'card-interactive card-interactive-primary card-type-template':
+						(horizontal && interactive) || interactive,
+					'card-type-asset':
+						isCardType.file || isCardType.image || isCardType.user,
+					'card-type-directory form-check form-check-card form-check-middle-left':
+						selectable && horizontal,
+					'file-card': isCardType.file,
+					'form-check form-check-card form-check-top-left':
+						(selectable && isCardType.file) ||
+						isCardType.image ||
+						isCardType.user,
+					'image-card': isCardType.image,
+					'template-card': interactive && !horizontal,
+					'template-card-horizontal': horizontal && interactive,
+					'user-card': isCardType.user,
+				})}
+				href={interactive ? href : undefined}
+				onClick={onClick}
+				role={onClick ? 'button' : undefined}
+			>
+				{(selectable && !horizontal) ||
+				(selectable && isCardType.image) ||
+				isCardType.user ? (
+					<TagName className="card">{children}</TagName>
+				) : (
+					<>{children}</>
+				)}
+			</TagHeaderName>
+		</Context.Provider>
 	);
 };
 


### PR DESCRIPTION
Not sure if this is a React bug or we were just doing it wrong, but using [the `<Content>` component inside the `ClayCard` implementation](https://github.com/liferay/clay/blob/1fbdfa21e64e623f9470fa50e5d242c0743a0809/packages/clay-card/src/Card.tsx#L56-L60) was causing React to remove one of the descendent elements from the DOM and re-insert it, even though there was no actual diff. When the descendent element is an `<img>`, this is bad and can cause a visual flicker (maybe something we haven't noticed before because we tend not to re-render cards much; but @boton noticed it now because he is rendering a progress bar inside the card that updates frequently).

To see this in action, see this demo:

https://codesandbox.io/s/blissful-shaw-xrekn

There is a fork of `ClayCard` in there called `ClayCardFork` so that you can edit it. When you turn off the browser cache, and use the `<Content>` component, you'll see a new image request going out over the network every second, even though nothing in the DOM is actually changing.

If we avoid the `<Content>` component and just inline the `Context.Provider` directly, no DOM mutations occur and no bogus network requests happen. Fortunately, the solution actually looks a bit less repetitive than what we had before, so there is no downside to this workaround.

Closes: https://github.com/liferay/clay/issues/2916