### PR TITLE
fix(@clayui/popover): make 'show' prop actually usable

### DIFF
--- a/packages/clay-popover/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-popover/src/__tests__/__snapshots__/index.tsx.snap
@@ -28,6 +28,34 @@ exports[`ClayPopover renders 1`] = `
 </div>
 `;
 
+exports[`ClayPopover renders with \`show\` 1`] = `
+<div>
+  <div
+    class="popover clay-popover-bottom show"
+  >
+    <div
+      class="arrow"
+    />
+    <div
+      class="inline-scroller"
+    >
+      <div
+        class="popover-header"
+      >
+        Popover
+      </div>
+      <div
+        class="popover-body"
+      >
+        Viennese flavour cup eu, percolator froth ristretto mazagran
+					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+					spoon acerbic to go macchiato strong.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ClayPopover renders without scroll 1`] = `
 <div>
   <div

--- a/packages/clay-popover/src/__tests__/index.tsx
+++ b/packages/clay-popover/src/__tests__/index.tsx
@@ -34,4 +34,16 @@ describe('ClayPopover', () => {
 
 		expect(container).toMatchSnapshot();
 	});
+
+	it('renders with `show`', () => {
+		const {container} = render(
+			<ClayPopover header="Popover" show>
+				{`Viennese flavour cup eu, percolator froth ristretto mazagran
+					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+					spoon acerbic to go macchiato strong.`}
+			</ClayPopover>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
 });

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -56,6 +56,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	show?: boolean;
 
 	/**
+	 * Callback for when the `show` prop changes.
+	 */
+	onShowChange?: (val: boolean) => void;
+
+	/**
 	 * React element that the popover will align to when clicked.
 	 */
 	trigger?: React.ReactElement & {
@@ -76,12 +81,14 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 			className,
 			disableScroll = false,
 			header,
+			onShowChange,
+			show: externalShow = false,
 			trigger,
 			...otherProps
 		}: IProps,
 		ref
 	) => {
-		const [show, setShow] = React.useState(false);
+		const [internalShow, internalSetShow] = React.useState(externalShow);
 
 		const triggerRef = React.useRef<HTMLElement | null>(null);
 		const popoverRef = React.useRef<HTMLElement | null>(null);
@@ -89,6 +96,9 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 		if (!ref) {
 			ref = popoverRef as React.Ref<HTMLDivElement>;
 		}
+
+		const show = externalShow ? externalShow : internalShow;
+		const setShow = onShowChange ? onShowChange : internalSetShow;
 
 		React.useEffect(() => {
 			if (

--- a/packages/clay-popover/stories/index.tsx
+++ b/packages/clay-popover/stories/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import '@clayui/css/lib/css/atlas.css';
-import {ClayButtonWithIcon} from '@clayui/button';
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
 import {boolean, select} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
@@ -64,5 +64,41 @@ storiesOf('Components|ClayPopover', module)
 				spoon acerbic to go macchiato strong.`}
 				</ClayPopover>
 			</div>
+		);
+	})
+	.add('popover w/ manual show', () => {
+		const [show, setShow] = React.useState(false);
+
+		return (
+			<>
+				<ClayButton
+					onClick={() => setShow(!show)}
+					style={{marginRight: 40}}
+				>
+					{'additional trigger'}
+				</ClayButton>
+
+				<ClayPopover
+					header="Popover"
+					onShowChange={setShow}
+					show={show}
+					trigger={
+						<ClayButtonWithIcon
+							spritemap={spritemap}
+							symbol="info-circle-open"
+						/>
+					}
+				>
+					{`Viennese flavour cup eu, percolator froth ristretto mazagran
+				caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+				spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+				caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+				spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+				caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+				spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+				caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+				spoon acerbic to go macchiato strong.`}
+				</ClayPopover>
+			</>
 		);
 	});


### PR DESCRIPTION
fixes #2738

This fix may look a little odd, and here is my line of thinking...

1. We initially released and documented a `show` prop on the components interface.
2. However, we don't use it for anything and handle all show/hide internally.
3. Since we initially released it on the interface and because we typically release "controlled" components, we should provide a full controllable API.
4. In order to keep current functionality and not break the internal show/hide, make it so we can do both.
5. Conclusion: make it usable via both controlled and uncontrolled.

Any concerns with this?


The other option would be to just remove it from the interface since it doesnt actually do anything and act like nothing happened
 ![](https://media.giphy.com/media/13d2jHlSlxklVe/giphy.gif)