### PR TITLE
feat(@clayui/sidebar): Creates a new sidebar component

### DIFF
--- a/packages/clay-sidebar/.yarnrc
+++ b/packages/clay-sidebar/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/sidebar@"
+version-git-message "chore: prepare @clayui/sidebar@%s"

--- a/packages/clay-sidebar/README.md
+++ b/packages/clay-sidebar/README.md
@@ -1,0 +1,17 @@
+# clay-sidebar
+
+My awesome Clay component
+
+## Setup
+
+1. Install `yarn`
+
+2. Install local dependencies:
+
+```
+yarn
+```
+
+## Contribute
+
+We'd love to get contributions from you! Please, check our [Contributing Guidelines](https://github.com/liferay/clay/blob/master/CONTRIBUTING.md) to see how you can help us improve.

--- a/packages/clay-sidebar/package.json
+++ b/packages/clay-sidebar/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@clayui/sidebar",
+	"version": "3.0.0",
+	"description": "ClaySidebar component",
+	"license": "BSD-3-Clause",
+	"repository": "https://github.com/liferay/clay/tree/master/packages/clay-sidebar",
+	"engines": {
+		"node": ">=0.12.0",
+		"npm": ">=3.0.0"
+	},
+	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
+	"scripts": {
+		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
+		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
+		"prepublishOnly": "yarn build && yarn build:types",
+		"test": "jest --config ../../jest.config.js"
+	},
+	"keywords": [
+		"clay",
+		"react"
+	],
+	"dependencies": {
+		"classnames": "^2.2.6"
+	},
+	"peerDependencies": {
+		"@clayui/css": "3.x",
+		"react": "^16.8.1",
+		"react-dom": "^16.8.1"
+	},
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
+}

--- a/packages/clay-sidebar/src/Divider.tsx
+++ b/packages/clay-sidebar/src/Divider.tsx
@@ -1,0 +1,17 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+interface IDividerProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const Divider: React.FunctionComponent<IDividerProps> = ({...otherProps}) => {
+	return <div {...otherProps}>{'Should be a divider'}</div>;
+};
+
+Divider.displayName = 'Divider';
+
+export default Divider;

--- a/packages/clay-sidebar/src/Panel.tsx
+++ b/packages/clay-sidebar/src/Panel.tsx
@@ -1,0 +1,31 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+interface IPanelProps extends React.HTMLAttributes<HTMLDivElement> {
+	show?: boolean;
+}
+
+const Panel: React.FunctionComponent<IPanelProps> = ({
+	children,
+	show = false,
+	...otherProps
+}) => {
+	if (show) {
+		return (
+			<div className="sidebar sidebar-light" {...otherProps}>
+				{children}
+			</div>
+		);
+	}
+
+	return null;
+};
+
+Panel.displayName = 'Panel';
+
+export default Panel;

--- a/packages/clay-sidebar/src/Search.tsx
+++ b/packages/clay-sidebar/src/Search.tsx
@@ -1,0 +1,49 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import React from 'react';
+
+interface ISearchProps extends React.HTMLAttributes<HTMLDivElement> {
+	spritemap: string;
+}
+
+const Search: React.FunctionComponent<ISearchProps> = ({
+	className,
+	placeholder,
+	spritemap,
+	...otherProps
+}) => {
+	return (
+		<ClayForm.Group
+			className={classNames('cm-panel-search', className)}
+			{...otherProps}
+		>
+			<ClayInput.Group>
+				<ClayInput.GroupItem prepend>
+					<ClayInput
+						placeholder={placeholder}
+						sizing="sm"
+						type="search"
+					/>
+				</ClayInput.GroupItem>
+
+				<ClayInput.GroupItem append shrink>
+					<ClayButton small type="submit">
+						<ClayIcon spritemap={spritemap} symbol="search" />
+					</ClayButton>
+				</ClayInput.GroupItem>
+			</ClayInput.Group>
+		</ClayForm.Group>
+	);
+};
+
+Search.displayName = 'Search';
+
+export default Search;

--- a/packages/clay-sidebar/src/Toolbar.tsx
+++ b/packages/clay-sidebar/src/Toolbar.tsx
@@ -1,0 +1,24 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+interface IToolbarProps extends React.HTMLAttributes<HTMLElement> {}
+
+const Toolbar: React.FunctionComponent<IToolbarProps> = ({
+	children,
+	...otherProps
+}) => {
+	return (
+		<nav className="tbar tbar-dark-l2 tbar-stacked" {...otherProps}>
+			{children}
+		</nav>
+	);
+};
+
+Toolbar.displayName = 'Toolbar';
+
+export default Toolbar;

--- a/packages/clay-sidebar/src/ToolbarItem.tsx
+++ b/packages/clay-sidebar/src/ToolbarItem.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable no-console */
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+interface IToolbarItemProps
+	extends React.HTMLAttributes<HTMLAnchorElement | HTMLButtonElement> {
+	active?: boolean;
+	expand?: boolean;
+}
+
+const ToolbarItem: React.FunctionComponent<IToolbarItemProps> = ({
+	active,
+	children,
+	expand = false,
+}) => {
+	return (
+		<li
+			className={classNames('tbar-item', {
+				active,
+				'tbar-item-expand': expand,
+			})}
+		>
+			{children}
+		</li>
+	);
+};
+
+ToolbarItem.displayName = 'ToolbarItem';
+
+export default ToolbarItem;

--- a/packages/clay-sidebar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-sidebar/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClaySidebar renders 1`] = `
+<div>
+  <div
+    class="sidenav-fixed sidenav-fixed-end"
+  >
+    <ul
+      class="tbar-nav"
+    />
+  </div>
+</div>
+`;

--- a/packages/clay-sidebar/src/__tests__/index.tsx
+++ b/packages/clay-sidebar/src/__tests__/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClaySidebar from '..';
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+describe('ClaySidebar', () => {
+	afterEach(cleanup);
+
+	it('renders', () => {
+		const {container} = render(<ClaySidebar />);
+
+		expect(container).toMatchSnapshot();
+	});
+});

--- a/packages/clay-sidebar/src/index.tsx
+++ b/packages/clay-sidebar/src/index.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable no-console */
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+import Divider from './Divider';
+import Panel from './Panel';
+import Search from './Search';
+import Toolbar from './Toolbar';
+import ToolbarItem from './ToolbarItem';
+
+type TDirection = 'left' | 'right';
+
+type TDisplayType = 'dark' | 'light';
+
+type TOpeningMode = 'overlay' | 'hover';
+
+interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+	direction?: TDirection;
+	displayType?: TDisplayType;
+	openingMode?: TOpeningMode;
+}
+
+const ClaySidebar: React.FunctionComponent<IProps> = ({
+	children,
+	direction = 'left',
+	displayType = 'light',
+	openingMode = 'overlay',
+	...otherProps
+}) => {
+	console.log({direction, displayType, openingMode});
+
+	return (
+		<div className="sidenav-fixed sidenav-fixed-end" {...otherProps}>
+			<ul className="tbar-nav">{children}</ul>
+		</div>
+	);
+};
+
+export default Object.assign(ClaySidebar, {
+	Divider,
+	Panel,
+	Search,
+	Toolbar,
+	ToolbarItem,
+});

--- a/packages/clay-sidebar/stories/index.tsx
+++ b/packages/clay-sidebar/stories/index.tsx
@@ -1,0 +1,84 @@
+/**
+ * © 2019 Liferay, Inc. <https://liferay.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import '@clayui/css/lib/css/atlas.css';
+import {ClayButtonWithIcon} from '@clayui/button';
+const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import {storiesOf} from '@storybook/react';
+import React, {useState} from 'react';
+
+import ClaySidebar from '../src';
+
+const panels = [
+	{
+		expand: true,
+		icon: 'chip',
+		label: 'Infrastructure',
+		panelId: 'infra',
+	},
+	{
+		icon: 'calendar',
+		label: 'Calendar',
+		panelId: 'cal',
+	},
+	{
+		expand: true,
+		icon: 'bolt',
+		label: 'Speed',
+		panelId: 'speed',
+	},
+];
+
+storiesOf('Components|ClaySidebar', module).add('default', () => {
+	const [activePanelId, setActivePanelId] = useState<string>('');
+
+	return (
+		<ClaySidebar>
+			<ClaySidebar.Panel show={activePanelId === 'infra'}>
+				<h1>{'Panel 1'}</h1>
+				<ClaySidebar.Search
+					placeholder="Search on Panel 1"
+					spritemap={spritemap}
+				/>
+			</ClaySidebar.Panel>
+			<ClaySidebar.Panel show={activePanelId === 'cal'}>
+				<h1>{'Panel 2'}</h1>
+				<ClaySidebar.Search
+					placeholder="Search on Panel 2"
+					spritemap={spritemap}
+				/>
+			</ClaySidebar.Panel>
+			<ClaySidebar.Panel show={activePanelId === 'speed'}>
+				<h1>{'Panel 3'}</h1>
+				<ClaySidebar.Search
+					placeholder="Search on Panel 3"
+					spritemap={spritemap}
+				/>
+			</ClaySidebar.Panel>
+			<ClaySidebar.Toolbar>
+				{panels.map(({expand, icon, label, panelId}) => (
+					<ClaySidebar.ToolbarItem
+						expand={expand}
+						key={`ToolbarItem${panelId}`}
+					>
+						<ClayButtonWithIcon
+							aria-label={label}
+							onClick={() => {
+								if (activePanelId === panelId) {
+									setActivePanelId('');
+									return;
+								}
+								setActivePanelId(panelId);
+							}}
+							spritemap={spritemap}
+							symbol={icon}
+						/>
+					</ClaySidebar.ToolbarItem>
+				))}
+			</ClaySidebar.Toolbar>
+		</ClaySidebar>
+	);
+});

--- a/packages/clay-sidebar/tsconfig.declarations.json
+++ b/packages/clay-sidebar/tsconfig.declarations.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"declarationDir": "./lib"
+	},
+	"extends": "../../tsconfig.declarations.json",
+	"include": ["src"]
+}

--- a/packages/clay-sidebar/tsconfig.json
+++ b/packages/clay-sidebar/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}


### PR DESCRIPTION
**Attention:** Markup is missing and this is a WIP

This is the current API Design:

```tsx
const panels = [
	{
		expand: true,
		icon: 'chip',
		label: 'Infrastructure',
		panelId: 'infra',
	},
	{
		icon: 'calendar',
		label: 'Calendar',
		panelId: 'cal',
	},
	{
		expand: true,
		icon: 'bolt',
		label: 'Speed',
		panelId: 'speed',
	},
];

<ClaySidebar>
    <ClaySidebar.Panel show={activePanelId === 'infra'}>
        <h1>{'Panel 1'}</h1>
        <ClaySidebar.Search
            placeholder="Search on Panel 1"
            spritemap={spritemap}
        />
    </ClaySidebar.Panel>
    <ClaySidebar.Panel show={activePanelId === 'cal'}>
        <h1>{'Panel 2'}</h1>
        <ClaySidebar.Search
            placeholder="Search on Panel 2"
            spritemap={spritemap}
        />
    </ClaySidebar.Panel>
    <ClaySidebar.Panel show={activePanelId === 'speed'}>
        <h1>{'Panel 3'}</h1>
        <ClaySidebar.Search
            placeholder="Search on Panel 3"
            spritemap={spritemap}
        />
    </ClaySidebar.Panel>
    <ClaySidebar.Toolbar>
        {panels.map(({expand, icon, label, panelId}) => (
            <ClaySidebar.ToolbarItem
                expand={expand}
                key={`ToolbarItem${panelId}`}
            >
                <ClayButtonWithIcon
                    aria-label={label}
                    onClick={() => {
                        if (activePanelId === panelId) {
                            setActivePanelId('');
                            return;
                        }
                        setActivePanelId(panelId);
                    }}
                    spritemap={spritemap}
                    symbol={icon}
                />
            </ClaySidebar.ToolbarItem>
        ))}
    </ClaySidebar.Toolbar>
</ClaySidebar>
```
I left `ClaySidebar.ToolbarItem` for wrapping the `HTMLLIElement` and it receives children for rendering anything.

For a single Panel like Data Engine and Product Menu we can just place one `.Panel` component and control the visible state of it.

What are your thoughts on this?


/cc @bryceosterhaus @jbalsas @matuzalemsteles @pat270