### PR TITLE
chore: update for compliance with current Outbound Licensing Policy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,30 @@
+Valid-License-Identifier: LicenseRef-BSD-3-Clause-Liferay
+Valid-License-Identifier: BSD-3-Clause
+License-Text:
+
+Copyright (c) 2014, Liferay Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/gatsby-browser.js
+++ b/clayui.com/gatsby-browser.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/gatsby-config.js
+++ b/clayui.com/gatsby-config.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/gatsby-node.js
+++ b/clayui.com/gatsby-node.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/gatsby/createPages.js
+++ b/clayui.com/gatsby/createPages.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/gatsby/onCreateNode.js
+++ b/clayui.com/gatsby/onCreateNode.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/gatsby/onCreateWebpackConfig.js
+++ b/clayui.com/gatsby/onCreateWebpackConfig.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/plugins/gatsby-plugin-meta-redirect/gatsby-node.js
+++ b/clayui.com/plugins/gatsby-plugin-meta-redirect/gatsby-node.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/plugins/gatsby-plugin-meta-redirect/getMetaRedirect.js
+++ b/clayui.com/plugins/gatsby-plugin-meta-redirect/getMetaRedirect.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/plugins/gatsby-remark-api-table/index.js
+++ b/clayui.com/plugins/gatsby-remark-api-table/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/plugins/gatsby-remark-typography/index.js
+++ b/clayui.com/plugins/gatsby-remark-typography/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/plugins/gatsby-remark-use-clipboard/index.js
+++ b/clayui.com/plugins/gatsby-remark-use-clipboard/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/plugins/gatsby-transformer-authors-yaml/gatsby-node.js
+++ b/clayui.com/plugins/gatsby-transformer-authors-yaml/gatsby-node.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/CodeClipboard/CodeClipboard.js
+++ b/clayui.com/src/components/CodeClipboard/CodeClipboard.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/CodeClipboard/index.js
+++ b/clayui.com/src/components/CodeClipboard/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/Hooks/index.js
+++ b/clayui.com/src/components/Hooks/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/Hooks/useResource.js
+++ b/clayui.com/src/components/Hooks/useResource.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/IconSearch/index.js
+++ b/clayui.com/src/components/IconSearch/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2020 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/LayoutNav/LayoutNav.js
+++ b/clayui.com/src/components/LayoutNav/LayoutNav.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/LayoutNav/Search.js
+++ b/clayui.com/src/components/LayoutNav/Search.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/LayoutNav/index.js
+++ b/clayui.com/src/components/LayoutNav/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/Sidebar/Navigation.js
+++ b/clayui.com/src/components/Sidebar/Navigation.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/Sidebar/Sidebar.js
+++ b/clayui.com/src/components/Sidebar/Sidebar.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/Sidebar/index.js
+++ b/clayui.com/src/components/Sidebar/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/TrackingIssues/Tracking.js
+++ b/clayui.com/src/components/TrackingIssues/Tracking.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/TrackingIssues/index.js
+++ b/clayui.com/src/components/TrackingIssues/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/Typography/Typography.js
+++ b/clayui.com/src/components/Typography/Typography.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/Typography/index.js
+++ b/clayui.com/src/components/Typography/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Alerts.js
+++ b/clayui.com/src/components/clay/Alerts.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Autocomplete.js
+++ b/clayui.com/src/components/clay/Autocomplete.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Badge.js
+++ b/clayui.com/src/components/clay/Badge.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Breadcrumb.js
+++ b/clayui.com/src/components/clay/Breadcrumb.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Button.js
+++ b/clayui.com/src/components/clay/Button.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Card.js
+++ b/clayui.com/src/components/clay/Card.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Chart.js
+++ b/clayui.com/src/components/clay/Chart.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Checkbox.js
+++ b/clayui.com/src/components/clay/Checkbox.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/ColorPicker.js
+++ b/clayui.com/src/components/clay/ColorPicker.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/DataProvider.js
+++ b/clayui.com/src/components/clay/DataProvider.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/DatePicker.js
+++ b/clayui.com/src/components/clay/DatePicker.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/DropDown.js
+++ b/clayui.com/src/components/clay/DropDown.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Editor.js
+++ b/clayui.com/src/components/clay/Editor.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Form.js
+++ b/clayui.com/src/components/clay/Form.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Icon.js
+++ b/clayui.com/src/components/clay/Icon.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Input.js
+++ b/clayui.com/src/components/clay/Input.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Label.js
+++ b/clayui.com/src/components/clay/Label.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Link.js
+++ b/clayui.com/src/components/clay/Link.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/List.js
+++ b/clayui.com/src/components/clay/List.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/LoadingIndicator.js
+++ b/clayui.com/src/components/clay/LoadingIndicator.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/ManagementToolbar.js
+++ b/clayui.com/src/components/clay/ManagementToolbar.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Modal.js
+++ b/clayui.com/src/components/clay/Modal.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/MultiSelect.js
+++ b/clayui.com/src/components/clay/MultiSelect.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/MultiStepNav.js
+++ b/clayui.com/src/components/clay/MultiStepNav.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/NavigationBar.js
+++ b/clayui.com/src/components/clay/NavigationBar.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Pagination.js
+++ b/clayui.com/src/components/clay/Pagination.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/PaginationBar.js
+++ b/clayui.com/src/components/clay/PaginationBar.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Panel.js
+++ b/clayui.com/src/components/clay/Panel.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Popover.js
+++ b/clayui.com/src/components/clay/Popover.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/ProgressBar.js
+++ b/clayui.com/src/components/clay/ProgressBar.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/RadioGroup.js
+++ b/clayui.com/src/components/clay/RadioGroup.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Select.js
+++ b/clayui.com/src/components/clay/Select.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Slider.js
+++ b/clayui.com/src/components/clay/Slider.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Sticker.js
+++ b/clayui.com/src/components/clay/Sticker.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Table.js
+++ b/clayui.com/src/components/clay/Table.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Tabs.js
+++ b/clayui.com/src/components/clay/Tabs.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/TimePicker.js
+++ b/clayui.com/src/components/clay/TimePicker.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/Tooltip.js
+++ b/clayui.com/src/components/clay/Tooltip.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/components/clay/VerticalNavigation.js
+++ b/clayui.com/src/components/clay/VerticalNavigation.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/html.js
+++ b/clayui.com/src/html.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/pages/index.js
+++ b/clayui.com/src/pages/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/templates/blog.js
+++ b/clayui.com/src/templates/blog.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/utils/getPackageConfig.js
+++ b/clayui.com/src/utils/getPackageConfig.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/clayui.com/src/utils/getSection.js
+++ b/clayui.com/src/utils/getSection.js
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/copyright.js
+++ b/copyright.js
@@ -1,5 +1,5 @@
 /**
- * © <%= YEAR %> Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © <%= YEAR %> Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/browserslist-config-clay/index.js
+++ b/packages/browserslist-config-clay/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-alert/src/Footer.tsx
+++ b/packages/clay-alert/src/Footer.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-alert/src/ToastContainer.tsx
+++ b/packages/clay-alert/src/ToastContainer.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-alert/src/__tests__/ClayAlert.tsx
+++ b/packages/clay-alert/src/__tests__/ClayAlert.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-alert/src/index.tsx
+++ b/packages/clay-alert/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-alert/stories/index.tsx
+++ b/packages/clay-alert/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-autocomplete/src/Context.ts
+++ b/packages/clay-autocomplete/src/Context.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-autocomplete/src/Input.tsx
+++ b/packages/clay-autocomplete/src/Input.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-autocomplete/src/LoadingIndicator.tsx
+++ b/packages/clay-autocomplete/src/LoadingIndicator.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-autocomplete/src/__tests__/index.tsx
+++ b/packages/clay-autocomplete/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-autocomplete/stories/index.tsx
+++ b/packages/clay-autocomplete/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-badge/src/__tests__/index.tsx
+++ b/packages/clay-badge/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-badge/src/index.tsx
+++ b/packages/clay-badge/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-badge/stories/index.tsx
+++ b/packages/clay-badge/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-breadcrumb/src/Ellipsis.tsx
+++ b/packages/clay-breadcrumb/src/Ellipsis.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-breadcrumb/src/Item.tsx
+++ b/packages/clay-breadcrumb/src/Item.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-breadcrumb/src/__tests__/index.tsx
+++ b/packages/clay-breadcrumb/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-breadcrumb/src/index.tsx
+++ b/packages/clay-breadcrumb/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-breadcrumb/stories/index.tsx
+++ b/packages/clay-breadcrumb/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-button/src/Button.tsx
+++ b/packages/clay-button/src/Button.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-button/src/ButtonWithIcon.tsx
+++ b/packages/clay-button/src/ButtonWithIcon.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-button/src/Group.tsx
+++ b/packages/clay-button/src/Group.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-button/src/__tests__/index.tsx
+++ b/packages/clay-button/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-button/src/index.tsx
+++ b/packages/clay-button/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-button/stories/index.tsx
+++ b/packages/clay-button/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/AspectRatio.tsx
+++ b/packages/clay-card/src/AspectRatio.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/Body.tsx
+++ b/packages/clay-card/src/Body.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/Caption.tsx
+++ b/packages/clay-card/src/Caption.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/Card.tsx
+++ b/packages/clay-card/src/Card.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/Context.ts
+++ b/packages/clay-card/src/Context.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/Description.tsx
+++ b/packages/clay-card/src/Description.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/Group.tsx
+++ b/packages/clay-card/src/Group.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/Row.tsx
+++ b/packages/clay-card/src/Row.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/src/index.tsx
+++ b/packages/clay-card/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-card/stories/index.tsx
+++ b/packages/clay-card/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-charts/src/BillboardWrapper.tsx
+++ b/packages/clay-charts/src/BillboardWrapper.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-charts/src/GeoMap.tsx
+++ b/packages/clay-charts/src/GeoMap.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-charts/src/Predictive.tsx
+++ b/packages/clay-charts/src/Predictive.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-charts/src/__tests__/ClayCharts.tsx
+++ b/packages/clay-charts/src/__tests__/ClayCharts.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-charts/src/config.ts
+++ b/packages/clay-charts/src/config.ts
@@ -1,8 +1,8 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 export const DEFAULT_COLORS = [
 	'#4B9BFF',
 	'#FFB46E',

--- a/packages/clay-charts/src/index.tsx
+++ b/packages/clay-charts/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-charts/stories/index.tsx
+++ b/packages/clay-charts/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/src/Basic.tsx
+++ b/packages/clay-color-picker/src/Basic.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/src/GradientSelector.tsx
+++ b/packages/clay-color-picker/src/GradientSelector.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/src/Hue.tsx
+++ b/packages/clay-color-picker/src/Hue.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/src/Splotch.tsx
+++ b/packages/clay-color-picker/src/Splotch.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/src/hooks.ts
+++ b/packages/clay-color-picker/src/hooks.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/src/util.ts
+++ b/packages/clay-color-picker/src/util.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/stories/index.tsx
+++ b/packages/clay-color-picker/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-color-picker/tests-util.ts
+++ b/packages/clay-color-picker/tests-util.ts
@@ -1,8 +1,8 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 interface IFakeMouseEventInit {
 	bubbles?: boolean;
 	cancelable?: boolean;

--- a/packages/clay-data-provider/src/LRUCache.ts
+++ b/packages/clay-data-provider/src/LRUCache.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-data-provider/src/__tests__/LRUCache.ts
+++ b/packages/clay-data-provider/src/__tests__/LRUCache.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-data-provider/src/__tests__/index.tsx
+++ b/packages/clay-data-provider/src/__tests__/index.tsx
@@ -1,9 +1,9 @@
-/*global fetchMock*/
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
+/*global fetchMock*/
 
 import {cleanup, render, wait} from '@testing-library/react';
 import {FetchMock} from 'jest-fetch-mock'; // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/clay-data-provider/src/index.tsx
+++ b/packages/clay-data-provider/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-data-provider/src/types.ts
+++ b/packages/clay-data-provider/src/types.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-data-provider/src/useCache.ts
+++ b/packages/clay-data-provider/src/useCache.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-data-provider/src/useResource.ts
+++ b/packages/clay-data-provider/src/useResource.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-data-provider/src/util.ts
+++ b/packages/clay-data-provider/src/util.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-data-provider/stories/index.tsx
+++ b/packages/clay-data-provider/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/DaysTable.tsx
+++ b/packages/clay-date-picker/src/DaysTable.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/Helpers.ts
+++ b/packages/clay-date-picker/src/Helpers.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/InputDate.tsx
+++ b/packages/clay-date-picker/src/InputDate.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/Select.tsx
+++ b/packages/clay-date-picker/src/Select.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/TimePicker.tsx
+++ b/packages/clay-date-picker/src/TimePicker.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/Weekday.tsx
+++ b/packages/clay-date-picker/src/Weekday.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/WeekdayHeader.tsx
+++ b/packages/clay-date-picker/src/WeekdayHeader.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
+++ b/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/__tests__/Internationalization.tsx
+++ b/packages/clay-date-picker/src/__tests__/Internationalization.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/src/types.ts
+++ b/packages/clay-date-picker/src/types.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-date-picker/stories/index.tsx
+++ b/packages/clay-date-picker/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/Action.tsx
+++ b/packages/clay-drop-down/src/Action.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/Caption.tsx
+++ b/packages/clay-drop-down/src/Caption.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/Divider.tsx
+++ b/packages/clay-drop-down/src/Divider.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/Group.tsx
+++ b/packages/clay-drop-down/src/Group.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/Help.tsx
+++ b/packages/clay-drop-down/src/Help.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/ItemList.tsx
+++ b/packages/clay-drop-down/src/ItemList.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/Search.tsx
+++ b/packages/clay-drop-down/src/Search.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/__tests__/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/__tests__/DropDownWithItems.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/__tests__/index.tsx
+++ b/packages/clay-drop-down/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/hooks.ts
+++ b/packages/clay-drop-down/src/hooks.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/src/index.tsx
+++ b/packages/clay-drop-down/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-drop-down/stories/index.tsx
+++ b/packages/clay-drop-down/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/Checkbox.tsx
+++ b/packages/clay-form/src/Checkbox.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/Form.tsx
+++ b/packages/clay-form/src/Form.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/Input.tsx
+++ b/packages/clay-form/src/Input.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/Radio.tsx
+++ b/packages/clay-form/src/Radio.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/RadioGroup.tsx
+++ b/packages/clay-form/src/RadioGroup.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/Select.tsx
+++ b/packages/clay-form/src/Select.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/SelectWithOption.tsx
+++ b/packages/clay-form/src/SelectWithOption.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/Toggle.tsx
+++ b/packages/clay-form/src/Toggle.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/__tests__/Checkbox.tsx
+++ b/packages/clay-form/src/__tests__/Checkbox.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/__tests__/RadioGroup.tsx
+++ b/packages/clay-form/src/__tests__/RadioGroup.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/__tests__/Select.tsx
+++ b/packages/clay-form/src/__tests__/Select.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/__tests__/Toggle.tsx
+++ b/packages/clay-form/src/__tests__/Toggle.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/__tests__/index.tsx
+++ b/packages/clay-form/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/src/index.tsx
+++ b/packages/clay-form/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-icon/src/__tests__/index.tsx
+++ b/packages/clay-icon/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-icon/src/index.tsx
+++ b/packages/clay-icon/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-icon/stories/index.tsx
+++ b/packages/clay-icon/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-label/src/__tests__/index.tsx
+++ b/packages/clay-label/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-label/src/index.tsx
+++ b/packages/clay-label/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-label/stories/index.tsx
+++ b/packages/clay-label/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-link/src/Context.tsx
+++ b/packages/clay-link/src/Context.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-link/src/__tests__/index.tsx
+++ b/packages/clay-link/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-link/src/index.tsx
+++ b/packages/clay-link/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-link/stories/index.tsx
+++ b/packages/clay-link/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/Header.tsx
+++ b/packages/clay-list/src/Header.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/Item.tsx
+++ b/packages/clay-list/src/Item.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/ItemField.tsx
+++ b/packages/clay-list/src/ItemField.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/ItemText.tsx
+++ b/packages/clay-list/src/ItemText.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/ItemTitle.tsx
+++ b/packages/clay-list/src/ItemTitle.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/List.tsx
+++ b/packages/clay-list/src/List.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/ListWithItems.tsx
+++ b/packages/clay-list/src/ListWithItems.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/QuickActionMenu.tsx
+++ b/packages/clay-list/src/QuickActionMenu.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/QuickActionMenuItem.tsx
+++ b/packages/clay-list/src/QuickActionMenuItem.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/__tests__/index.tsx
+++ b/packages/clay-list/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/src/index.tsx
+++ b/packages/clay-list/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-list/stories/index.tsx
+++ b/packages/clay-list/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-loading-indicator/src/__tests__/index.tsx
+++ b/packages/clay-loading-indicator/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-loading-indicator/src/index.tsx
+++ b/packages/clay-loading-indicator/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-loading-indicator/stories/index.tsx
+++ b/packages/clay-loading-indicator/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-management-toolbar/src/Item.tsx
+++ b/packages/clay-management-toolbar/src/Item.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-management-toolbar/src/ItemList.tsx
+++ b/packages/clay-management-toolbar/src/ItemList.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-management-toolbar/src/ManagementToolbar.tsx
+++ b/packages/clay-management-toolbar/src/ManagementToolbar.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-management-toolbar/src/ResultsBar.tsx
+++ b/packages/clay-management-toolbar/src/ResultsBar.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-management-toolbar/src/ResultsBarItem.tsx
+++ b/packages/clay-management-toolbar/src/ResultsBarItem.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-management-toolbar/src/Search.tsx
+++ b/packages/clay-management-toolbar/src/Search.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-management-toolbar/src/__tests__/BasicRendering.tsx
+++ b/packages/clay-management-toolbar/src/__tests__/BasicRendering.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-management-toolbar/src/index.tsx
+++ b/packages/clay-management-toolbar/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-management-toolbar/stories/index.tsx
+++ b/packages/clay-management-toolbar/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/Body.tsx
+++ b/packages/clay-modal/src/Body.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/Context.ts
+++ b/packages/clay-modal/src/Context.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/Footer.tsx
+++ b/packages/clay-modal/src/Footer.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/Header.tsx
+++ b/packages/clay-modal/src/Header.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/Hook.ts
+++ b/packages/clay-modal/src/Hook.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/Provider.tsx
+++ b/packages/clay-modal/src/Provider.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -1,10 +1,9 @@
-/*eslint no-console: 0 */
-/* eslint-disable no-sparse-arrays */
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
+/* eslint-disable no-sparse-arrays */
 
 import ClayModal, {ClayModalProvider, Context, useModal} from '..';
 import Button from '@clayui/button';

--- a/packages/clay-modal/src/__tests__/index.tsx
+++ b/packages/clay-modal/src/__tests__/index.tsx
@@ -1,7 +1,5 @@
-/*eslint no-console: 0 */
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/index.tsx
+++ b/packages/clay-modal/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/types.ts
+++ b/packages/clay-modal/src/types.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/src/useModal.tsx
+++ b/packages/clay-modal/src/useModal.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-modal/stories/index.tsx
+++ b/packages/clay-modal/stories/index.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable no-sparse-arrays */
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
+/* eslint-disable no-sparse-arrays */
 
 import '@clayui/css/lib/css/atlas.css';
 import ClayButton from '@clayui/button';

--- a/packages/clay-multi-select/src/__tests__/index.tsx
+++ b/packages/clay-multi-select/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-select/stories/index.tsx
+++ b/packages/clay-multi-select/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-step-nav/src/Divider.tsx
+++ b/packages/clay-multi-step-nav/src/Divider.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-step-nav/src/Indicator.tsx
+++ b/packages/clay-multi-step-nav/src/Indicator.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-step-nav/src/Item.tsx
+++ b/packages/clay-multi-step-nav/src/Item.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-step-nav/src/MultiStepNav.tsx
+++ b/packages/clay-multi-step-nav/src/MultiStepNav.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
+++ b/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-step-nav/src/Title.tsx
+++ b/packages/clay-multi-step-nav/src/Title.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-step-nav/src/__tests__/index.tsx
+++ b/packages/clay-multi-step-nav/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-step-nav/src/index.tsx
+++ b/packages/clay-multi-step-nav/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-multi-step-nav/stories/index.tsx
+++ b/packages/clay-multi-step-nav/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-nav/src/Nav.tsx
+++ b/packages/clay-nav/src/Nav.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-nav/src/NavItem.tsx
+++ b/packages/clay-nav/src/NavItem.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-nav/src/NavLink.tsx
+++ b/packages/clay-nav/src/NavLink.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-nav/src/__tests__/index.tsx
+++ b/packages/clay-nav/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-nav/src/index.tsx
+++ b/packages/clay-nav/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-nav/stories/index.tsx
+++ b/packages/clay-nav/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-navigation-bar/src/__tests__/index.tsx
+++ b/packages/clay-navigation-bar/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-navigation-bar/stories/index.tsx
+++ b/packages/clay-navigation-bar/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination-bar/src/DropDown.tsx
+++ b/packages/clay-pagination-bar/src/DropDown.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination-bar/src/PaginationBar.tsx
+++ b/packages/clay-pagination-bar/src/PaginationBar.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
+++ b/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination-bar/src/Results.tsx
+++ b/packages/clay-pagination-bar/src/Results.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination-bar/src/__tests__/index.tsx
+++ b/packages/clay-pagination-bar/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination-bar/src/index.tsx
+++ b/packages/clay-pagination-bar/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination-bar/stories/index.tsx
+++ b/packages/clay-pagination-bar/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination/src/Item.tsx
+++ b/packages/clay-pagination/src/Item.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination/src/Pagination.tsx
+++ b/packages/clay-pagination/src/Pagination.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination/src/PaginationWithBasicItems.tsx
+++ b/packages/clay-pagination/src/PaginationWithBasicItems.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination/src/__tests__/index.tsx
+++ b/packages/clay-pagination/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination/src/index.tsx
+++ b/packages/clay-pagination/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-pagination/stories/index.tsx
+++ b/packages/clay-pagination/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-panel/src/Body.tsx
+++ b/packages/clay-panel/src/Body.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-panel/src/Footer.tsx
+++ b/packages/clay-panel/src/Footer.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-panel/src/Group.tsx
+++ b/packages/clay-panel/src/Group.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-panel/src/Header.tsx
+++ b/packages/clay-panel/src/Header.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-panel/src/__tests__/index.tsx
+++ b/packages/clay-panel/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-panel/src/index.tsx
+++ b/packages/clay-panel/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-panel/stories/index.tsx
+++ b/packages/clay-panel/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-popover/src/__tests__/index.tsx
+++ b/packages/clay-popover/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-popover/stories/index.tsx
+++ b/packages/clay-popover/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-progress-bar/src/__tests__/index.tsx
+++ b/packages/clay-progress-bar/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-progress-bar/src/index.tsx
+++ b/packages/clay-progress-bar/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-progress-bar/stories/index.tsx
+++ b/packages/clay-progress-bar/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-shared/src/LinkOrButton.tsx
+++ b/packages/clay-shared/src/LinkOrButton.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-shared/src/Portal.tsx
+++ b/packages/clay-shared/src/Portal.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-shared/src/__tests__/Portal.tsx
+++ b/packages/clay-shared/src/__tests__/Portal.tsx
@@ -1,7 +1,5 @@
-/*eslint no-console: 0 */
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-shared/src/getEllipsisItems.tsx
+++ b/packages/clay-shared/src/getEllipsisItems.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-shared/src/sub.ts
+++ b/packages/clay-shared/src/sub.ts
@@ -1,8 +1,8 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 const SPLIT_REGEX = /({\d+})/g;
 
 /**

--- a/packages/clay-shared/src/useDebounce.ts
+++ b/packages/clay-shared/src/useDebounce.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-shared/src/useTransitionHeight.ts
+++ b/packages/clay-shared/src/useTransitionHeight.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-slider/src/__tests__/index.tsx
+++ b/packages/clay-slider/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-slider/src/index.tsx
+++ b/packages/clay-slider/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-slider/stories/index.tsx
+++ b/packages/clay-slider/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-sticker/src/__tests__/index.tsx
+++ b/packages/clay-sticker/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-sticker/src/index.tsx
+++ b/packages/clay-sticker/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-sticker/stories/index.tsx
+++ b/packages/clay-sticker/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-table/src/Body.tsx
+++ b/packages/clay-table/src/Body.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-table/src/Cell.tsx
+++ b/packages/clay-table/src/Cell.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-table/src/Head.tsx
+++ b/packages/clay-table/src/Head.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-table/src/Row.tsx
+++ b/packages/clay-table/src/Row.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-table/src/__tests__/index.tsx
+++ b/packages/clay-table/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-table/src/index.tsx
+++ b/packages/clay-table/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-table/src/types.ts
+++ b/packages/clay-table/src/types.ts
@@ -1,6 +1,6 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 export type TDelimiter = 'start' | 'end';

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tabs/src/Content.tsx
+++ b/packages/clay-tabs/src/Content.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tabs/src/Item.tsx
+++ b/packages/clay-tabs/src/Item.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tabs/src/TabPane.tsx
+++ b/packages/clay-tabs/src/TabPane.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tabs/src/__tests__/index.tsx
+++ b/packages/clay-tabs/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tabs/src/index.tsx
+++ b/packages/clay-tabs/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tabs/stories/index.tsx
+++ b/packages/clay-tabs/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-time-picker/src/__tests__/index.tsx
+++ b/packages/clay-time-picker/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-time-picker/src/index.tsx
+++ b/packages/clay-time-picker/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-time-picker/stories/index.tsx
+++ b/packages/clay-time-picker/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tooltip/src/Tooltip.tsx
+++ b/packages/clay-tooltip/src/Tooltip.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tooltip/src/__tests__/index.tsx
+++ b/packages/clay-tooltip/src/__tests__/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tooltip/src/index.tsx
+++ b/packages/clay-tooltip/src/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/clay-tooltip/stories/index.tsx
+++ b/packages/clay-tooltip/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/demos/src/recharts/Tooltip.tsx
+++ b/packages/demos/src/recharts/Tooltip.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/demos/src/recharts/config.ts
+++ b/packages/demos/src/recharts/config.ts
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/demos/src/recharts/index.tsx
+++ b/packages/demos/src/recharts/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2018 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2018 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/demos/stories/DragDrop.tsx
+++ b/packages/demos/stories/DragDrop.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2020 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/demos/stories/FilesPage.tsx
+++ b/packages/demos/stories/FilesPage.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/demos/stories/FormPage.tsx
+++ b/packages/demos/stories/FormPage.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/demos/stories/ListPage.tsx
+++ b/packages/demos/stories/ListPage.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/demos/stories/Recharts.tsx
+++ b/packages/demos/stories/Recharts.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/demos/stories/index.tsx
+++ b/packages/demos/stories/index.tsx
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/generator-clay-component/__tests__/test-app.js
+++ b/packages/generator-clay-component/__tests__/test-app.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/packages/generator-clay-component/app/index.js
+++ b/packages/generator-clay-component/app/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/scripts/check-deps/check-dependencies.js
+++ b/scripts/check-deps/check-dependencies.js
@@ -1,10 +1,9 @@
-/* eslint no-for-of-loops/no-for-of-loops: 0 */
-
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
+/* eslint no-for-of-loops/no-for-of-loops: 0 */
 
 /**
  * Checks built packages prior to publishing to make sure their dependencies are

--- a/scripts/check-deps/src/forEachPackage.js
+++ b/scripts/check-deps/src/forEachPackage.js
@@ -1,10 +1,9 @@
-/* eslint no-for-of-loops/no-for-of-loops: 0 */
-
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
+/* eslint no-for-of-loops/no-for-of-loops: 0 */
 
 const {readdir} = require('fs');
 const {promisify} = require('util');

--- a/scripts/check-deps/src/getPackageConfig.js
+++ b/scripts/check-deps/src/getPackageConfig.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/scripts/check-deps/src/main.js
+++ b/scripts/check-deps/src/main.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/scripts/check-deps/src/print.js
+++ b/scripts/check-deps/src/print.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/scripts/jest-clay-lerna-resolver.js
+++ b/scripts/jest-clay-lerna-resolver.js
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/scripts/setupTests.ts
+++ b/scripts/setupTests.ts
@@ -1,6 +1,5 @@
 /**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 


### PR DESCRIPTION
This change is analogous to the one I made in:

- https://github.com/liferay/eslint-config-liferay/pull/151
- https://github.com/liferay/liferay-npm-tools/pull/394
- https://github.com/liferay/liferay-js-themes-toolkit/pull/441

It updates the license header format to match the latest policy:

https://grow.liferay.com/excellence/Liferay+Outbound+Licensing+Policy

Did this by updating `copyright.js` and running `yarn lint:fix`. I used a Vim macro to strip out the original headers. Note some files required manual fixing because they had ESLint or other comments at the top of the file (this is bad; the header should always be at the top). Some of the comments I could just remove (eg. unnecessary lint suppressions), but the others I moved below the header.

Adds a copy of the license to `LICENSES/MIT.txt` as required by the policy too.