### PR TITLE
chore: update stale snapshots

### DIFF
--- a/packages/clay-alert/src/__tests__/__snapshots__/ClayAlert.tsx.snap
+++ b/packages/clay-alert/src/__tests__/__snapshots__/ClayAlert.tsx.snap
@@ -476,7 +476,7 @@ exports[`ClayAlert renders with an icon for closing with autoClose 1`] = `
     className="alert-autofit-row autofit-row"
   >
     <div
-      className="autofit-col"
+      className="autofit-col inline-item-before"
     >
       <div
         className="autofit-section"
@@ -538,7 +538,7 @@ exports[`ClayAlert renders with autoClose and without icon 1`] = `
     className="alert-autofit-row autofit-row"
   >
     <div
-      className="autofit-col"
+      className="autofit-col inline-item-before"
     >
       <div
         className="autofit-section"


### PR DESCRIPTION
Looks like e393c07f3f9b21bb7f146037d7372e1b updated some but not all of the snapshots.