### PR TITLE
feat(@clay-components): Input Move Boxes - Draft implementation

### DIFF
--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -33,6 +33,8 @@
 @import "components/_form-validation";
 @import "components/_icons";
 @import "components/_input-groups";
+@import "components/_input-move-boxes";
+@import "components/_select-box";
 @import "components/_list-group";
 @import "components/_modals";
 @import "components/_multi-step-nav";

--- a/packages/clay-css/src/scss/components/_input-move-boxes.scss
+++ b/packages/clay-css/src/scss/components/_input-move-boxes.scss
@@ -1,0 +1,23 @@
+.input-move-boxes {
+    display: flex;
+    max-width: 768px;
+    width: 100%;
+
+    .select-box {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        width: 40%;
+    }
+}
+
+.transfer-buttons {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: 0 24px;
+
+    .btn {
+        flex: 0 1 auto;
+    }
+}

--- a/packages/clay-css/src/scss/components/_select-box.scss
+++ b/packages/clay-css/src/scss/components/_select-box.scss
@@ -1,0 +1,6 @@
+.select-box-order-buttons {
+    bottom: 8px;
+    right: 8px;
+    position: absolute;
+    z-index: 9;
+}

--- a/packages/clay-empty-state/src/__tests__/index.tsx
+++ b/packages/clay-empty-state/src/__tests__/index.tsx
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
- * SPDX-License-Identifier: BSD-3-Clause
- */
-
 import ClayEmptyState from '..';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';

--- a/packages/clay-form/package.json
+++ b/packages/clay-form/package.json
@@ -26,6 +26,7 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/button": "^3.3.0",
 		"@clayui/icon": "^3.0.4",
 		"classnames": "^2.2.6"
 	},

--- a/packages/clay-form/src/DualListbox.tsx
+++ b/packages/clay-form/src/DualListbox.tsx
@@ -1,0 +1,255 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import classNames from 'classnames';
+import React from 'react';
+
+import ClaySelectBox from './SelectBox';
+
+function swapArrayItems(
+	arrays: [
+		Array<{
+			label: string;
+			value: string;
+		}>,
+		Array<{
+			label: string;
+			value: string;
+		}>
+	],
+	selectedIndexes: Array<number>
+) {
+	const [sourceArray, targetArray] = arrays;
+
+	const newTargetArray = [...targetArray];
+
+	const newSourceArray: Array<{
+		label: string;
+		value: string;
+	}> = sourceArray.filter(
+		(
+			item: {
+				label: string;
+				value: string;
+			},
+			index: number
+		) => {
+			if (selectedIndexes.includes(index)) {
+				newTargetArray.push(item);
+
+				return false;
+			}
+
+			return true;
+		}
+	);
+
+	return [newSourceArray, newTargetArray];
+}
+
+interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Items spread across two arrays that will be displayed in the two Select Boxes.
+	 */
+	items: Array<
+		Array<{
+			label: string;
+			value: string;
+		}>
+	>;
+
+	/**
+	 * Handler that triggers when the content of the items prop are changed. Caused by either reordering or transfering of items.
+	 */
+	onItemsChange: (
+		val: Array<
+			Array<{
+				label: string;
+				value: string;
+			}>
+		>
+	) => void;
+
+	/**
+	 * Props for the left Select Box.
+	 */
+	left: {
+		/**
+		 * Label of the left Select Box.
+		 */
+		label: string;
+
+		/**
+		 * Handler that triggers when a new item is selected in the left Select Box.
+		 */
+		onSelectChange?: (val: Array<string>) => void;
+
+		/**
+		 * Array of selected items in the left Select Box.
+		 */
+		selected?: Array<string>;
+	};
+
+	/**
+	 * Props for the right Select Box.
+	 */
+	right: {
+		/**
+		 * Label of the right Select Box.
+		 */
+		label: string;
+
+		/**
+		 * Handler that triggers when a new item is selected in the right Select Box.
+		 */
+		onSelectChange?: (val: Array<string>) => void;
+
+		/**
+		 * Array of selected items in the right Select Box.
+		 */
+		selected?: Array<string>;
+	};
+
+	/**
+	 * Amount of items that can fit inside the both Select Boxes before a scrollbar is introduced.
+	 */
+	size?: number;
+
+	/**
+	 * Path to the spritemap that Icon should use when referencing symbols.
+	 */
+	spritemap?: string;
+}
+
+const ClayDualListbox: React.FunctionComponent<IProps> = ({
+	className,
+	items,
+	left,
+	onItemsChange,
+	right,
+	size,
+	spritemap,
+	...otherProps
+}) => {
+	const [internalLeftSelected, setInternalLeftSelected] = React.useState(
+		left.selected || []
+	);
+	const [internalRightSelected, setInternalRightSelected] = React.useState(
+		right.selected || []
+	);
+
+	const handleLeftSelectedChange =
+		left.onSelectChange || setInternalLeftSelected;
+	const handleRightSelectedChange =
+		right.onSelectChange || setInternalRightSelected;
+
+	const leftSelected = left.selected || internalLeftSelected;
+	const rightSelected = right.selected || internalRightSelected;
+
+	const [leftItems, rightItems] = items;
+
+	const selectedIndexesLeft = leftItems.reduce(
+		(acc: any, item: any, index: number) => {
+			if (leftSelected.includes(item.value)) {
+				return [...acc, index];
+			}
+
+			return acc;
+		},
+		[]
+	);
+
+	const selectedIndexesRight = rightItems.reduce(
+		(acc: any, item: any, index: number) => {
+			if (rightSelected.includes(item.value)) {
+				return [...acc, index];
+			}
+
+			return acc;
+		},
+		[]
+	);
+
+	return (
+		<div {...otherProps} className={classNames(className, 'form-group')}>
+			<div className="clay-dual-listbox">
+				<ClaySelectBox
+					className="clay-dual-listbox-item clay-dual-listbox-item-expand listbox-left"
+					items={leftItems}
+					label={left.label}
+					multiple
+					onItemsChange={(
+						newLeftItems: Array<{
+							label: string;
+							value: string;
+						}>
+					) => {
+						onItemsChange([newLeftItems, rightItems]);
+					}}
+					onSelectChange={handleLeftSelectedChange}
+					showArrows
+					size={size}
+					spritemap={spritemap}
+					value={leftSelected}
+				/>
+
+				<ClayButton.Group className="clay-dual-listbox-actions clay-dual-listbox-item">
+					<ClayButtonWithIcon
+						className="transfer-button-ltr"
+						data-testid="ltr"
+						disabled={!leftSelected.length}
+						displayType="secondary"
+						onClick={() => {
+							const [arrayLeft, arrayRight] = swapArrayItems(
+								[leftItems, rightItems],
+								selectedIndexesLeft
+							);
+
+							onItemsChange([arrayLeft, arrayRight]);
+						}}
+						spritemap={spritemap}
+						symbol="caret-right"
+					/>
+
+					<ClayButtonWithIcon
+						className="transfer-button-rtl"
+						data-testid="rtl"
+						disabled={!rightSelected.length}
+						displayType="secondary"
+						onClick={() => {
+							const [arrayRight, arrayLeft] = swapArrayItems(
+								[rightItems, leftItems],
+								selectedIndexesRight
+							);
+
+							onItemsChange([arrayLeft, arrayRight]);
+						}}
+						spritemap={spritemap}
+						symbol="caret-left"
+					/>
+				</ClayButton.Group>
+
+				<ClaySelectBox
+					className="clay-dual-listbox-item clay-dual-listbox-item-expand listbox-right"
+					items={rightItems}
+					label={right.label}
+					multiple
+					onItemsChange={(
+						newRightItems: Array<{
+							label: string;
+							value: string;
+						}>
+					) => onItemsChange([leftItems, newRightItems])}
+					onSelectChange={handleRightSelectedChange}
+					size={size}
+					value={rightSelected}
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default ClayDualListbox;

--- a/packages/clay-form/src/SelectBox.tsx
+++ b/packages/clay-form/src/SelectBox.tsx
@@ -1,0 +1,225 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import classNames from 'classnames';
+import React from 'react';
+
+function arrayMove(
+	arrayToMove: Array<{
+		label: string;
+		value: string;
+	}>,
+	oldIndex: number,
+	newIndex: number
+) {
+	arrayToMove.splice(newIndex, 0, arrayToMove.splice(oldIndex, 1)[0]);
+
+	return arrayToMove;
+}
+
+function reorderUp(
+	array: Array<{
+		label: string;
+		value: string;
+	}>,
+	selectedIndexes: Array<number>
+) {
+	let clonedArray = [...array];
+
+	for (let i = 0; i < selectedIndexes.length; i++) {
+		const item = selectedIndexes[i];
+
+		if (item === 0) {
+			return clonedArray;
+		}
+
+		clonedArray = arrayMove(clonedArray, item, item - 1);
+	}
+
+	return clonedArray;
+}
+
+function reorderDown(
+	array: Array<{
+		label: string;
+		value: string;
+	}>,
+	selectedIndexes: Array<number>
+) {
+	let clonedArray = [...array];
+
+	for (let i = 0; i < selectedIndexes.length; i++) {
+		const item = selectedIndexes[i];
+
+		if (selectedIndexes.includes(clonedArray.length - 1)) {
+			return clonedArray;
+		}
+
+		clonedArray = arrayMove(clonedArray, item, item + 1);
+	}
+
+	return clonedArray;
+}
+
+interface IProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+	/**
+	 * Aligns the buttons used to reorder items relative to the Select Box.
+	 */
+	buttonAlignment?: 'center' | 'end';
+
+	/**
+	 * Items to be displayed in the Select Box.
+	 */
+	items: Array<{
+		label: string;
+		value: string;
+	}>;
+
+	/**
+	 * Label to be displayed above the Select Box.
+	 */
+	label?: string;
+
+	/**
+	 * Defines whether the Select Box supports selection of multiple items.
+	 */
+	multiple?: boolean;
+
+	/**
+	 * Handler that triggers when the content of the items prop are changed caused by reordering of items.
+	 */
+	onItemsChange?: (
+		items: Array<{
+			label: string;
+			value: string;
+		}>
+	) => void;
+
+	/**
+	 * Handler that triggers when a new item is selected.
+	 */
+	onSelectChange: (val: Array<string>) => void;
+
+	/**
+	 *  Selected indexes, most commonly used in combination with the  Dual Listbox component
+	 */
+	selectedIndexes?: Array<number>;
+
+	/**
+	 * Amount of items that can fit inside the both Select Boxes before a scrollbar is introduced.
+	 */
+	size?: number;
+
+	/**
+	 * Defines whether the component should render buttons that allow reordering of items.
+	 */
+	showArrows?: boolean;
+
+	/**
+	 * Value of the component.
+	 */
+	value: string | Array<string>;
+
+	/**
+	 * Path to the spritemap that Icon should use when referencing symbols.
+	 */
+	spritemap?: string;
+}
+
+const ClaySelectBox: React.FunctionComponent<IProps> = ({
+	buttonAlignment = 'right',
+	className,
+	items,
+	label,
+	multiple,
+	onItemsChange,
+	onSelectChange,
+	showArrows,
+	size,
+	spritemap,
+	value,
+}) => {
+	const selectedIndexes = items.reduce(
+		(acc: any, item: any, index: number) => {
+			if (value.includes(item.value)) {
+				return [...acc, index];
+			}
+
+			return acc;
+		},
+		[]
+	);
+
+	return (
+		<div className={classNames(className, 'form-group')}>
+			{label && <label className="reorder-label">{label}</label>}
+
+			<div
+				className={`clay-reorder clay-reorder-footer-${buttonAlignment}`}
+			>
+				<select
+					className="form-control form-control-inset"
+					multiple={multiple}
+					onChange={event => {
+						const selectedItems = [...event.target.options]
+							.filter(({selected}) => selected)
+							.map(item => item.value);
+
+						onSelectChange(selectedItems);
+					}}
+					size={size}
+					value={value}
+				>
+					{items.map((option: {label: string; value: string}) => (
+						<option
+							className="reorder-option"
+							key={option.value}
+							value={option.value}
+						>
+							{option.label}
+						</option>
+					))}
+				</select>
+
+				<div className="clay-reorder-underlay form-control" />
+
+				{showArrows && onItemsChange && (
+					<div className="clay-reorder-footer">
+						<ClayButton.Group className="reorder-order-buttons">
+							<ClayButtonWithIcon
+								className="reorder-button reorder-button-up"
+								disabled={value.length ? false : true}
+								displayType="secondary"
+								onClick={() =>
+									onItemsChange(
+										reorderUp(items, selectedIndexes)
+									)
+								}
+								spritemap={spritemap}
+								symbol="caret-top"
+							/>
+
+							<ClayButtonWithIcon
+								className="reorder-button reorder-button-down"
+								disabled={value.length ? false : true}
+								displayType="secondary"
+								onClick={() =>
+									onItemsChange(
+										reorderDown(items, selectedIndexes)
+									)
+								}
+								spritemap={spritemap}
+								symbol="caret-bottom"
+							/>
+						</ClayButton.Group>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+};
+
+export default ClaySelectBox;

--- a/packages/clay-form/src/__tests__/DualListbox.tsx
+++ b/packages/clay-form/src/__tests__/DualListbox.tsx
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import ClayDualListbox from '../DualListbox';
+
+const options = [
+	[
+		{
+			label: 'Option 1',
+			value: '1',
+		},
+		{
+			label: 'Option 2',
+			value: '2',
+		},
+		{
+			label: 'Option 3',
+			value: '3',
+		},
+	],
+	[
+		{
+			label: 'Option 4',
+			value: '4',
+		},
+		{
+			label: 'Option 5',
+			value: '5',
+		},
+	],
+];
+
+describe('Rendering', () => {
+	afterEach(cleanup);
+
+	it('renders ClayDualListbox', () => {
+		const {container} = render(
+			<ClayDualListbox
+				items={options}
+				left={{
+					label: 'In Use',
+					onSelectChange: () => {},
+					selected: [''],
+				}}
+				onItemsChange={() => {}}
+				right={{
+					label: 'Available',
+					onSelectChange: () => {},
+					selected: [''],
+				}}
+				size={8}
+				spritemap="/path/to/some/resource.svg"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+});
+
+describe('Interactions', () => {
+	afterEach(cleanup);
+
+	it('calls onChange event when transfering items', () => {
+		const handleChange = jest.fn();
+
+		const {getByTestId} = render(
+			<ClayDualListbox
+				items={options}
+				left={{
+					label: 'In Use',
+					onSelectChange: () => {},
+					selected: ['2'],
+				}}
+				onItemsChange={handleChange}
+				right={{
+					label: 'Available',
+					onSelectChange: () => {},
+					selected: ['5'],
+				}}
+				size={8}
+				spritemap="/path/to/some/resource.svg"
+			/>
+		);
+
+		expect(handleChange).not.toHaveBeenCalled();
+
+		fireEvent.click(getByTestId('ltr') as HTMLButtonElement, {});
+
+		expect(handleChange).toHaveBeenCalledWith([
+			[
+				{
+					label: 'Option 1',
+					value: '1',
+				},
+				{
+					label: 'Option 3',
+					value: '3',
+				},
+			],
+			[
+				{
+					label: 'Option 4',
+					value: '4',
+				},
+				{
+					label: 'Option 5',
+					value: '5',
+				},
+				{
+					label: 'Option 2',
+					value: '2',
+				},
+			],
+		]);
+
+		fireEvent.click(getByTestId('rtl') as HTMLButtonElement, {});
+
+		expect(handleChange).toHaveBeenCalledWith([
+			[
+				{
+					label: 'Option 1',
+					value: '1',
+				},
+				{
+					label: 'Option 2',
+					value: '2',
+				},
+				{
+					label: 'Option 3',
+					value: '3',
+				},
+				{
+					label: 'Option 5',
+					value: '5',
+				},
+			],
+			[
+				{
+					label: 'Option 4',
+					value: '4',
+				},
+			],
+		]);
+	});
+});

--- a/packages/clay-form/src/__tests__/SelectBox.tsx
+++ b/packages/clay-form/src/__tests__/SelectBox.tsx
@@ -1,0 +1,126 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React from 'react';
+
+import ClaySelectBox from '../SelectBox';
+
+const options = [
+	{
+		label: 'Option 1',
+		value: '1',
+	},
+	{
+		label: 'Option 2',
+		value: '2',
+	},
+	{
+		label: 'Option 3',
+		value: '3',
+	},
+];
+
+describe('Rendering', () => {
+	afterEach(cleanup);
+
+	it('renders ClaySelectBox', () => {
+		const {container} = render(
+			<ClaySelectBox
+				aria-label="Select Box Label"
+				items={options}
+				onSelectChange={() => {}}
+				value={'1'}
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders ClaySelectBox with multiple options selected', () => {
+		const {container} = render(
+			<ClaySelectBox
+				aria-label="Select Box Label"
+				items={options}
+				multiple
+				onSelectChange={() => {}}
+				value={['1', '2']}
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders ClaySelectBox with buttons to reorder options', () => {
+		const {container} = render(
+			<ClaySelectBox
+				aria-label="Select Box Label"
+				items={options}
+				multiple
+				onItemsChange={() => {}}
+				onSelectChange={() => {}}
+				showArrows
+				spritemap="/path/to/some/resource.svg"
+				value={['1']}
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+});
+
+describe('Interactions', () => {
+	afterEach(cleanup);
+
+	it('changes order of options in ClaySelectBox when reorder up button is clicked', () => {
+		const handleOnItemsChange = jest.fn();
+		const {container} = render(
+			<ClaySelectBox
+				aria-label="Select Box Label"
+				items={options}
+				multiple
+				onItemsChange={handleOnItemsChange}
+				onSelectChange={() => {}}
+				showArrows
+				spritemap="/path/to/some/resource.svg"
+				value={['2']}
+			/>
+		);
+
+		const reorderUpButton = container.querySelector('.reorder-button-up');
+
+		expect(handleOnItemsChange).not.toHaveBeenCalled();
+
+		fireEvent.click(reorderUpButton as HTMLButtonElement, {});
+
+		expect(handleOnItemsChange).toHaveBeenCalledWith([
+			{label: 'Option 2', value: '2'},
+			{label: 'Option 1', value: '1'},
+			{label: 'Option 3', value: '3'},
+		]);
+	});
+
+	it('selects multiple options', () => {
+		const {container} = render(
+			<ClaySelectBox
+				aria-label="Select Box Label"
+				items={options}
+				multiple
+				onSelectChange={() => {}}
+				showArrows
+				spritemap="/path/to/some/resource.svg"
+				value={[]}
+			/>
+		);
+
+		const optionElement = container.querySelector('option');
+
+		fireEvent.change(optionElement as HTMLOptionElement, {
+			target: {value: ['1', '2']},
+		});
+
+		expect(container.querySelector('select')!.value).toEqual('1,2');
+	});
+});

--- a/packages/clay-form/src/__tests__/__snapshots__/DualListbox.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/DualListbox.tsx.snap
@@ -1,0 +1,156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rendering renders ClayDualListbox 1`] = `
+<div>
+  <div
+    class="form-group"
+  >
+    <div
+      class="clay-dual-listbox"
+    >
+      <div
+        class="clay-dual-listbox-item clay-dual-listbox-item-expand listbox-left form-group"
+      >
+        <label
+          class="reorder-label"
+        >
+          In Use
+        </label>
+        <div
+          class="clay-reorder clay-reorder-footer-right"
+        >
+          <select
+            class="form-control form-control-inset"
+            multiple=""
+            size="8"
+          >
+            <option
+              class="reorder-option"
+              value="1"
+            >
+              Option 1
+            </option>
+            <option
+              class="reorder-option"
+              value="2"
+            >
+              Option 2
+            </option>
+            <option
+              class="reorder-option"
+              value="3"
+            >
+              Option 3
+            </option>
+          </select>
+          <div
+            class="clay-reorder-underlay form-control"
+          />
+          <div
+            class="clay-reorder-footer"
+          >
+            <div
+              class="reorder-order-buttons btn-group"
+              role="group"
+            >
+              <button
+                class="reorder-button reorder-button-up btn btn-monospaced btn-secondary"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-top"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#caret-top"
+                  />
+                </svg>
+              </button>
+              <button
+                class="reorder-button reorder-button-down btn btn-monospaced btn-secondary"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-bottom"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#caret-bottom"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="clay-dual-listbox-actions clay-dual-listbox-item btn-group"
+        role="group"
+      >
+        <button
+          class="transfer-button-ltr btn btn-monospaced btn-secondary"
+          data-testid="ltr"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-caret-right"
+            role="presentation"
+          >
+            <use
+              xlink:href="/path/to/some/resource.svg#caret-right"
+            />
+          </svg>
+        </button>
+        <button
+          class="transfer-button-rtl btn btn-monospaced btn-secondary"
+          data-testid="rtl"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-caret-left"
+            role="presentation"
+          >
+            <use
+              xlink:href="/path/to/some/resource.svg#caret-left"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="clay-dual-listbox-item clay-dual-listbox-item-expand listbox-right form-group"
+      >
+        <label
+          class="reorder-label"
+        >
+          Available
+        </label>
+        <div
+          class="clay-reorder clay-reorder-footer-right"
+        >
+          <select
+            class="form-control form-control-inset"
+            multiple=""
+            size="8"
+          >
+            <option
+              class="reorder-option"
+              value="4"
+            >
+              Option 4
+            </option>
+            <option
+              class="reorder-option"
+              value="5"
+            >
+              Option 5
+            </option>
+          </select>
+          <div
+            class="clay-reorder-underlay form-control"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/clay-form/src/__tests__/__snapshots__/SelectBox.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/SelectBox.tsx.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rendering renders ClaySelectBox 1`] = `
+<div>
+  <div
+    class="form-group"
+  >
+    <div
+      class="clay-reorder clay-reorder-footer-right"
+    >
+      <select
+        class="form-control form-control-inset"
+      >
+        <option
+          class="reorder-option"
+          value="1"
+        >
+          Option 1
+        </option>
+        <option
+          class="reorder-option"
+          value="2"
+        >
+          Option 2
+        </option>
+        <option
+          class="reorder-option"
+          value="3"
+        >
+          Option 3
+        </option>
+      </select>
+      <div
+        class="clay-reorder-underlay form-control"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Rendering renders ClaySelectBox with buttons to reorder options 1`] = `
+<div>
+  <div
+    class="form-group"
+  >
+    <div
+      class="clay-reorder clay-reorder-footer-right"
+    >
+      <select
+        class="form-control form-control-inset"
+        multiple=""
+      >
+        <option
+          class="reorder-option"
+          value="1"
+        >
+          Option 1
+        </option>
+        <option
+          class="reorder-option"
+          value="2"
+        >
+          Option 2
+        </option>
+        <option
+          class="reorder-option"
+          value="3"
+        >
+          Option 3
+        </option>
+      </select>
+      <div
+        class="clay-reorder-underlay form-control"
+      />
+      <div
+        class="clay-reorder-footer"
+      >
+        <div
+          class="reorder-order-buttons btn-group"
+          role="group"
+        >
+          <button
+            class="reorder-button reorder-button-up btn btn-monospaced btn-secondary"
+            type="button"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-caret-top"
+              role="presentation"
+            >
+              <use
+                xlink:href="/path/to/some/resource.svg#caret-top"
+              />
+            </svg>
+          </button>
+          <button
+            class="reorder-button reorder-button-down btn btn-monospaced btn-secondary"
+            type="button"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-caret-bottom"
+              role="presentation"
+            >
+              <use
+                xlink:href="/path/to/some/resource.svg#caret-bottom"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Rendering renders ClaySelectBox with multiple options selected 1`] = `
+<div>
+  <div
+    class="form-group"
+  >
+    <div
+      class="clay-reorder clay-reorder-footer-right"
+    >
+      <select
+        class="form-control form-control-inset"
+        multiple=""
+      >
+        <option
+          class="reorder-option"
+          value="1"
+        >
+          Option 1
+        </option>
+        <option
+          class="reorder-option"
+          value="2"
+        >
+          Option 2
+        </option>
+        <option
+          class="reorder-option"
+          value="3"
+        >
+          Option 3
+        </option>
+      </select>
+      <div
+        class="clay-reorder-underlay form-control"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/clay-form/src/index.tsx
+++ b/packages/clay-form/src/index.tsx
@@ -4,20 +4,24 @@
  */
 
 import ClayCheckbox from './Checkbox';
+import ClayDualListbox from './DualListbox';
 import ClayForm from './Form';
 import ClayInput from './Input';
 import ClayRadio from './Radio';
 import ClayRadioGroup from './RadioGroup';
 import ClaySelect from './Select';
+import ClaySelectBox from './SelectBox';
 import ClaySelectWithOption from './SelectWithOption';
 import ClayToggle from './Toggle';
 
 export {
 	ClayCheckbox,
 	ClayInput,
+	ClayDualListbox,
 	ClayRadio,
 	ClayRadioGroup,
 	ClaySelect,
+	ClaySelectBox,
 	ClaySelectWithOption,
 	ClayToggle,
 };

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -8,10 +8,12 @@ import React from 'react';
 
 import {
 	ClayCheckbox,
+	ClayDualListbox,
 	ClayInput,
 	ClayRadio,
 	ClayRadioGroup,
 	ClaySelect,
+	ClaySelectBox,
 	ClaySelectWithOption,
 	ClayToggle,
 } from '../src';
@@ -35,6 +37,94 @@ const ClayCheckboxWithState = () => {
 		/>
 	);
 };
+
+const moveBoxesOptions = [
+	[
+		{
+			label: 'Discord',
+			value: 'discord',
+		},
+		{
+			label: 'Evernote',
+			value: 'evernote',
+		},
+		{
+			label: 'Facebook',
+			value: 'facebook',
+		},
+		{
+			label: 'LinkedIn',
+			value: 'linkedin',
+		},
+	],
+	[
+		{
+			label: 'Reddit',
+			value: 'reddit',
+		},
+		{
+			label: 'Slack',
+			value: 'slack',
+		},
+		{
+			label: 'Twitter',
+			value: 'twitter',
+		},
+	],
+];
+
+storiesOf('Components|ClayDualListbox', module).add('default', () => {
+	const [items, setItems] = React.useState<
+		Array<
+			Array<{
+				label: string;
+				value: string;
+			}>
+		>
+	>(moveBoxesOptions);
+	const [leftSelected, setLeftSelected] = React.useState<Array<string>>([]);
+	const [rightSelected, setRightSelected] = React.useState<Array<string>>([]);
+
+	return (
+		<ClayDualListbox
+			items={items}
+			left={{
+				label: 'In Use',
+				onSelectChange: (leftSelected: Array<string>) =>
+					setLeftSelected(leftSelected),
+				selected: leftSelected,
+			}}
+			onItemsChange={setItems}
+			right={{
+				label: 'Available',
+				onSelectChange: (rightSelected: Array<string>) =>
+					setRightSelected(rightSelected),
+				selected: rightSelected,
+			}}
+			size={8}
+			spritemap={spritemap}
+		/>
+	);
+});
+
+storiesOf('Components|ClaySelectBox', module).add('default', () => {
+	const [items, setItems] = React.useState<Array<any>>(moveBoxesOptions[0]);
+	const [value, setValue] = React.useState<Array<string>>([]);
+
+	return (
+		<ClaySelectBox
+			items={items}
+			label="In Use"
+			multiple
+			onItemsChange={setItems}
+			onSelectChange={setValue}
+			showArrows
+			size={8}
+			spritemap={spritemap}
+			value={value}
+		/>
+	);
+});
 
 storiesOf('Components|ClayForm', module).add('Feedback', () => (
 	<div className="sheet">

--- a/yarn.lock
+++ b/yarn.lock
@@ -6471,7 +6471,7 @@ command-exists@^1.2.2, command-exists@^1.2.6:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
-commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.2.0, commander@^2.20.0, commander@^2.5.0, commander@^2.6.0, commander@^2.8.1, commander@^2.9.0, commander@~2.20.0:
+commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.2.0, commander@^2.20.0, commander@^2.5.0, commander@^2.6.0, commander@^2.8.1, commander@~2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -6613,7 +6613,7 @@ concat-with-sourcemaps@*:
   dependencies:
     source-map "^0.6.1"
 
-config-chain@^1.1.11, config-chain@~1.1.5:
+config-chain@^1.1.11:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
   integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
@@ -8542,17 +8542,6 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-editorconfig@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
-  integrity sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==
-  dependencies:
-    bluebird "^3.0.5"
-    commander "^2.9.0"
-    lru-cache "^3.2.0"
-    semver "^5.1.0"
-    sigmund "^1.0.1"
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -9255,7 +9244,7 @@ event-source-polyfill@^1.0.5:
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz#b34be2740a685a8dc65ae750065fc983538ffcfe"
   integrity sha512-PdStgZ3+G2o2gjqsBYbV4931ByVmwLwSrX7mFgawCL+9I1npo9dwAQTnWtNWXe5IY2P8+AbbPteeOueiEtRCUA==
 
-event-stream@3.3.4, event-stream@^3.1.0:
+event-stream@^3.1.0:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
@@ -13821,16 +13810,6 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
   integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
-js-beautify@1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.7.5.tgz#69d9651ef60dbb649f65527b53674950138a7919"
-  integrity sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==
-  dependencies:
-    config-chain "~1.1.5"
-    editorconfig "^0.13.2"
-    mkdirp "~0.5.0"
-    nopt "~3.0.1"
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -15186,13 +15165,6 @@ lru-cache@4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-cache@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
-  integrity sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=
-  dependencies:
-    pseudomap "^1.0.1"
-
 lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -15689,13 +15661,13 @@ metalsmith-permalinks@^0.4.0:
     slug-component "~1.1.0"
     substitute "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz"
 
-metalsmith-sass@^1.3.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/metalsmith-sass/-/metalsmith-sass-1.6.0.tgz#a5cfcf3ba05fea5fd900a5c6fce60b20aad4f2cd"
-  integrity sha512-6VZ3uHkdL8XFSSa8LUiDKB+jNU0MBvDswvyCZeeedOjtvPOUNWCIs18agJwCsCeouYrB+rxvR/RzpkXTclR9WQ==
+metalsmith-sass@^1.4.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/metalsmith-sass/-/metalsmith-sass-1.7.0.tgz#bcef7be679405a416570ab5d90a5deefe5f42053"
+  integrity sha512-zM1JhUcKug6IPunD89gQftOuFdyTu+SfoWCFCKEOMo2BuYfshU2yeje1OyWyGFo+zV+HsZVwsVQzoISrM+FX7g==
   dependencies:
     async "^2.6.0"
-    node-sass "^4.11.0"
+    node-sass "^4.13.0"
 
 metalsmith-templates@^0.7.0:
   version "0.7.0"
@@ -16439,6 +16411,29 @@ node-sass@^4.11.0, node-sass@^4.12.0, node-sass@^4.8.1:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
+node-sass@^4.13.0:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
 node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
@@ -16452,7 +16447,7 @@ noms@0.0.0:
     inherits "^2.0.1"
     readable-stream "~1.0.31"
 
-"nopt@2 || 3", nopt@^3.0.0, nopt@~3.0.1:
+"nopt@2 || 3", nopt@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
@@ -20658,7 +20653,7 @@ sift@^5.1.0:
   resolved "https://registry.yarnpkg.com/sift/-/sift-5.1.0.tgz#1bbf2dfb0eb71e56c4cc7fb567fbd1351b65015e"
   integrity sha1-G78t+w63HlbEzH+1Z/vRNRtlAV4=
 
-sigmund@^1.0.1, sigmund@~1.0.0:
+sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
   integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=


### PR DESCRIPTION
Here's the draft implementation of the Input Move Boxes component.
Note: 
The ordering and transferring works only for 1 selection at the moment, in order to see if my approach is valid before pursuing, and also to maybe get a piece of advice on how best to do it, since outside of some convoluted array manipulation I didn't get an idea of how to do it.

Tests are failing unrelated to my code, at least from what I can see locally, ClayAlert is the culprit.