### PR TITLE
feat(clay-css): Atlas change `$indigo` to #7785FF. You can revert bac…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -72,7 +72,7 @@ $gray-900: #272833 !default;
 $black: #000 !default;
 
 $blue: if($enable-lexicon-flat-colors, #4B9FFF, #0B5FFF) !default;
-$indigo: if($enable-lexicon-flat-colors, #6610F2, #6610F2) !default;
+$indigo: if($enable-lexicon-flat-colors, #7785FF, #6610F2) !default;
 $purple: if($enable-lexicon-flat-colors, #AF78FF, #6F42C1) !default;
 $pink: if($enable-lexicon-flat-colors, #FF73C3, #E83E8C) !default;
 $red: if($enable-lexicon-flat-colors, #FF5F5F, #DA1414) !default;


### PR DESCRIPTION
…k to old colors with `$enable-lexicon-flat-colors: false;`.

fixes #2960