### PR TITLE
fix(clayui.com): White text in gatsyby-highlight html

### DIFF
--- a/clayui.com/src/styles/_prismjs.scss
+++ b/clayui.com/src/styles/_prismjs.scss
@@ -35,7 +35,7 @@ $insertedBack: #f0fff4;
 .gatsby-highlight pre.prism-code {
 	height: auto !important;
 	margin: 1rem;
-	color: $white;
+	color: $prismWhite;
 	font-size: 13px;
 	line-height: 20px;
 	white-space: pre-wrap;


### PR DESCRIPTION
<img width="669" alt="html-example" src="https://user-images.githubusercontent.com/788266/75595161-1c741d80-5a40-11ea-8fa3-56286159bb32.png">
