### PR TITLE
feat(@clayui/label): Adds `truncated` option for ClayLabel component

### DIFF
--- a/packages/clay-label/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-label/src/__tests__/__snapshots__/index.tsx.snap
@@ -97,3 +97,15 @@ exports[`Rendering with a different displayType  1`] = `
   </span>
 </span>
 `;
+
+exports[`Rendering with truncated text 1`] = `
+<span
+  className="label label-secondary"
+>
+  <span
+    className="label-item label-item-expand text-truncate"
+  >
+    LaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLa
+  </span>
+</span>
+`;

--- a/packages/clay-label/src/__tests__/index.tsx
+++ b/packages/clay-label/src/__tests__/index.tsx
@@ -27,6 +27,18 @@ describe('Rendering', () => {
 		expect(testRenderer.toJSON()).toMatchSnapshot();
 	});
 
+	it('with truncated text', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayLabel truncated>
+				{
+					'LaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLaLa'
+				}
+			</ClayLabel>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
 	it('as a link ', () => {
 		const testRenderer = TestRenderer.create(
 			<ClayLabel href="#/foo/bar">{'Label w/ link'}</ClayLabel>

--- a/packages/clay-label/src/index.tsx
+++ b/packages/clay-label/src/index.tsx
@@ -38,6 +38,11 @@ interface IProps
 	 * Path to the location of the spritemap resource used for Icon.
 	 */
 	spritemap?: string;
+
+	/**
+	 * Flag to indicate if the label should be truncated.
+	 */
+	truncated?: boolean;
 }
 
 const ClayLabel = React.forwardRef<HTMLAnchorElement | HTMLSpanElement, IProps>(
@@ -50,6 +55,7 @@ const ClayLabel = React.forwardRef<HTMLAnchorElement | HTMLSpanElement, IProps>(
 			href,
 			large = false,
 			spritemap,
+			truncated,
 			...otherProps
 		}: IProps,
 		ref
@@ -66,7 +72,12 @@ const ClayLabel = React.forwardRef<HTMLAnchorElement | HTMLSpanElement, IProps>(
 				})}
 				ref={ref}
 			>
-				<TagName className="label-item label-item-expand" href={href}>
+				<TagName
+					className={classNames('label-item label-item-expand', {
+						'text-truncate': truncated,
+					})}
+					href={href}
+				>
 					{children}
 				</TagName>
 

--- a/packages/clay-label/stories/index.tsx
+++ b/packages/clay-label/stories/index.tsx
@@ -39,6 +39,7 @@ const ClayLabelWithState = () => {
 			href={text('Href', '')}
 			large={boolean('Large', false)}
 			spritemap={spritemap}
+			truncated={boolean('Truncated', false)}
 		>
 			{text('Label', 'Label')}
 		</ClayLabel>


### PR DESCRIPTION
Fixes #2977﻿
