### PR TITLE
feat(clay-css): Adds Dual Listbox component (input move box replacement)

### DIFF
--- a/packages/clay-css/src/content/form_elements.html
+++ b/packages/clay-css/src/content/form_elements.html
@@ -195,6 +195,36 @@ section: Components
 		</select>
 	</div>
 	<div class="form-group">
+		<label>A Div Styled Like a Select Element</label>
+		<div class="form-control form-control-select">This is all show</div>
+	</div>
+	<div class="form-group">
+		<label for="selectElementWithSize5">Select Element with Size 5</label>
+		<select class="form-control" id="selectElementWithSize5" size="5">
+			<option>Sample 1</option>
+			<option>Sample 2</option>
+			<option>Sample 3</option>
+			<option>Sample 4</option>
+			<option>Sample 5</option>
+			<option>Sample 6</option>
+			<option>Sample 7</option>
+			<option>Sample 8</option>
+		</select>
+	</div>
+	<div class="form-group">
+		<label for="selectElementWithSize10">Select Element with Size 10</label>
+		<select class="form-control" id="selectElementWithSize10" size="10">
+			<option>Sample 1</option>
+			<option>Sample 2</option>
+			<option>Sample 3</option>
+			<option>Sample 4</option>
+			<option>Sample 5</option>
+			<option>Sample 6</option>
+			<option>Sample 7</option>
+			<option>Sample 8</option>
+		</select>
+	</div>
+	<div class="form-group">
 		<label for="multipleSelectOptionsSelectElement">Select Element with Multiple Select Options</label>
 		<select class="form-control" id="multipleSelectOptionsSelectElement" multiple>
 			<option>Sample 1</option>

--- a/packages/clay-css/src/content/form_elements_clay_reorder.html
+++ b/packages/clay-css/src/content/form_elements_clay_reorder.html
@@ -1,0 +1,146 @@
+---
+title: Form Elements (Clay Reorder)
+section: Components
+---
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Clay Reorder</h3>
+
+		<div class="alert alert-warning">
+			<code>```<div class="clay-reorder-underlay form-control"></div>```</code> must be declared right after (adjacent sibling of) <code>form-control-inset</code>.
+		</div>
+
+		<div class="alert alert-warning">This requires external javascript to reorder <code>option</code> elements.</div>
+
+		<blockquote class="blockquote">
+			<p>A <code>select[multiple]</code> component that lets you reorganize <code>option</code> elements.</p>
+		</blockquote>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label for="clayReorderNoActionsDemo1">Clay Reorder No Footer</label>
+				<div class="clay-reorder">
+					<select class="form-control form-control-inset" id="clayReorderNoActionsDemo1" multiple>
+						<option value="1">1</option>
+						<option value="2">2</option>
+						<option value="3">3</option>
+						<option value="4">4</option>
+						<option value="5">5</option>
+					</select>
+					<div class="clay-reorder-underlay form-control"></div>
+				</div>
+			</div>
+
+			<div class="form-group">
+				<label for="clayReorderWithActionsDemo1">Clay Reorder with Footer</label>
+				<div class="clay-reorder">
+					<select class="form-control form-control-inset" id="clayReorderWithActionsDemo1" multiple>
+						<option>1</option>
+						<option>2</option>
+						<option>3</option>
+						<option>4</option>
+						<option>5</option>
+					</select>
+					<div class="clay-reorder-underlay form-control"></div>
+					<div class="clay-reorder-footer">
+						<div class="btn-group" role="group">
+							<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+								<span class="inline-item">
+									<svg class="lexicon-icon lexicon-icon-caret-top" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-top" />
+									</svg>
+								</span>
+							</button>
+							<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+								<span class="inline-item">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
+							</button>
+							<button class="btn btn-secondary btn-sm" disabled type="button">Disabled</button>
+							<button class="active btn btn-secondary btn-sm" type="button">Active</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Clay Reorder Utilities</h3>
+
+		<blockquote class="blockquote">
+			<p>Add the class <code>clay-reorder-footer-end</code> or <code>clay-reorder-footer-center</code> on <code>clay-reorder</code> to align footer content to the right or center, respectively.</p>
+		</blockquote>
+
+<div class="sheet">
+	<div class="form-group">
+		<label for="_asyupi06i">Clay Reorder with Footer End</label>
+		<div class="clay-reorder clay-reorder-footer-end">
+			<select class="form-control form-control-inset" id="_asyupi06i" multiple>
+				<option>1</option>
+				<option>2</option>
+				<option>3</option>
+				<option>4</option>
+				<option>5</option>
+			</select>
+			<div class="clay-reorder-underlay form-control"></div>
+			<div class="clay-reorder-footer">
+				<div class="btn-group" role="group">
+					<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+						<span class="inline-item">
+							<svg class="lexicon-icon lexicon-icon-caret-top" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-top" />
+							</svg>
+						</span>
+					</button>
+					<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+						<span class="inline-item">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="form-group">
+		<label for="_k7bny0crp">Clay Reorder with Footer Center</label>
+		<div class="clay-reorder clay-reorder-footer-center">
+			<select class="form-control form-control-inset" id="_k7bny0crp" multiple>
+				<option>1</option>
+				<option>2</option>
+				<option>3</option>
+				<option>4</option>
+				<option>5</option>
+			</select>
+			<div class="clay-reorder-underlay form-control"></div>
+			<div class="clay-reorder-footer">
+				<div class="btn-group" role="group">
+					<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+						<span class="inline-item">
+							<svg class="lexicon-icon lexicon-icon-caret-top" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-top" />
+							</svg>
+						</span>
+					</button>
+					<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+						<span class="inline-item">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+	</div>
+</div>

--- a/packages/clay-css/src/content/form_elements_dual_listbox.html
+++ b/packages/clay-css/src/content/form_elements_dual_listbox.html
@@ -1,0 +1,180 @@
+---
+title: Form Elements (Dual Listbox)
+section: Components
+---
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Clay Dual Listbox</h3>
+
+		<blockquote class="blockquote">
+			<p>The <code>size</code> attribute on each <code>.clay-reorder select[multiple]</code> should be the maximum number of <code>option</code>s that the inputs can contain. This ensures that <code>clay-dual-listbox</code> will not grow and shrink when items are moved from one input to another.</p>
+
+			<p>If shifting content isn't an issue, the <code>size</code> attribute can be updated to match as <code>option</code>s get moved around.</p>
+		</blockquote>
+
+<div class="sheet">
+	<div class="form-group">
+		<div class="clay-dual-listbox">
+			<div class="clay-dual-listbox-item clay-dual-listbox-item-expand">
+				<label for="_9d5cxj5xm">
+					<span class="text-truncate-inline">
+						<span class="text-truncate">In Use</span>
+					</span>
+				</label>
+				<div class="clay-reorder clay-reorder-footer-end">
+					<select class="form-control form-control-inset" id="_9d5cxj5xm" multiple size="7">
+						<option value="twitter">Twitter</option>
+						<option value="linkedin">Linkedin</option>
+						<option value="facebook">Facebook</option>
+					</select>
+					<div class="clay-reorder-underlay form-control"></div>
+					<div class="clay-reorder-footer">
+						<div class="btn-group" role="group">
+							<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+								<span class="inline-item">
+									<svg class="lexicon-icon lexicon-icon-caret-top" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-top" />
+									</svg>
+								</span>
+							</button>
+							<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+								<span class="inline-item">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="clay-dual-listbox-item clay-dual-listbox-actions">
+				<div class="btn-group-vertical">
+					<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+						<span class="inline-item">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+					</button>
+					<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+						<span class="inline-item">
+							<svg class="lexicon-icon lexicon-icon-caret-left" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-left" />
+							</svg>
+						</span>
+					</button>
+				</div>
+			</div>
+
+			<div class="clay-dual-listbox-item clay-dual-listbox-item-expand">
+				<label for="_957gwvjvl">
+					<span class="text-truncate-inline">
+						<span class="text-truncate">Available</span>
+					</span>
+				</label>
+				<div class="clay-reorder">
+					<select class="form-control form-control-inset" id="_957gwvjvl" multiple size="7">
+						<option value="addthis">AddThis</option>
+						<option value="delicious">Delicious</option>
+						<option value="digg">Digg</option>
+						<option value="evernote">Evernote</option>
+					</select>
+					<div class="clay-reorder-underlay form-control"></div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Clay Dual Listbox</h3>
+
+		<blockquote class="blockquote">
+			<p>Add the class <code>clay-reorder-footer-invisible</code> to <code>clay-reorder</code> to hide the contents of the footer. It uses <code>visibility: hidden;</code> to ensure the boxes do not shift.</p>
+		</blockquote>
+
+<div class="sheet">
+	<div class="form-group">
+		<div class="clay-dual-listbox">
+			<div class="clay-dual-listbox-item clay-dual-listbox-item-expand">
+				<label for="_hlzxq63gx">
+					<span class="text-truncate-inline">
+						<span class="text-truncate">In Use</span>
+					</span>
+				</label>
+				<div class="clay-reorder clay-reorder-footer-end clay-reorder-footer-invisible">
+					<select class="form-control form-control-inset" id="_hlzxq63gx" multiple size="7">
+						<option value="twitter">Twitter</option>
+					</select>
+					<div class="clay-reorder-underlay form-control"></div>
+					<div class="clay-reorder-footer">
+						<div class="btn-group" role="group">
+							<button class="btn btn-monospaced btn-secondary btn-sm" disabled type="button">
+								<span class="inline-item">
+									<svg class="lexicon-icon lexicon-icon-caret-top" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-top" />
+									</svg>
+								</span>
+							</button>
+							<button class="btn btn-monospaced btn-secondary btn-sm" disabled type="button">
+								<span class="inline-item">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="clay-dual-listbox-item clay-dual-listbox-actions">
+				<div class="btn-group-vertical">
+					<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+						<span class="inline-item">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+					</button>
+					<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+						<span class="inline-item">
+							<svg class="lexicon-icon lexicon-icon-caret-left" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-left" />
+							</svg>
+						</span>
+					</button>
+				</div>
+			</div>
+
+			<div class="clay-dual-listbox-item clay-dual-listbox-item-expand">
+				<label for="_ngi3gwyo7">
+					<span class="text-truncate-inline">
+						<span class="text-truncate">Available</span>
+					</span>
+				</label>
+				<div class="clay-reorder">
+					<select class="form-control form-control-inset" id="_ngi3gwyo7" multiple size="7">
+						<option value="addthis">AddThis</option>
+						<option value="delicious">Delicious</option>
+						<option value="digg">Digg</option>
+						<option value="evernote">Evernote</option>
+						<option value="linkedin">Linkedin</option>
+						<option value="facebook">Facebook</option>
+					</select>
+					<div class="clay-reorder-underlay form-control"></div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+	</div>
+</div>

--- a/packages/clay-css/src/content/form_validation.html
+++ b/packages/clay-css/src/content/form_validation.html
@@ -325,6 +325,20 @@ section: Components
 		<div class="sheet">
 			<div class="has-success">
 				<div class="form-group">
+					<label for="sizeSelectElementSuccess">
+						Select Element with Size 3 and Success
+						<svg class="lexicon-icon lexicon-icon-asterisk reference-mark" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+						</svg>
+					</label>
+					<select class="form-control" id="sizeSelectElementSuccess" size="3">
+						<option>Sample 1</option>
+						<option>Sample 2</option>
+						<option>Sample 3</option>
+						<option>Sample 4</option>
+					</select>
+				</div>
+				<div class="form-group">
 					<label for="multipleSelectElementSuccess">
 						Multiple Select Element with Success
 						<svg class="lexicon-icon lexicon-icon-asterisk reference-mark" focusable="false" role="presentation">
@@ -341,6 +355,20 @@ section: Components
 			</div>
 			<div class="has-warning">
 				<div class="form-group">
+					<label for="sizeSelectElementWarning">
+						Select Element with Size 3 and Warning
+						<svg class="lexicon-icon lexicon-icon-asterisk reference-mark" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+						</svg>
+					</label>
+					<select class="form-control" id="sizeSelectElementWarning" size="3">
+						<option>Sample 1</option>
+						<option>Sample 2</option>
+						<option>Sample 3</option>
+						<option>Sample 4</option>
+					</select>
+				</div>
+				<div class="form-group">
 					<label for="multipleSelectElementWarning">
 						Multiple Select Element with Warning
 						<svg class="lexicon-icon lexicon-icon-asterisk reference-mark" focusable="false" role="presentation">
@@ -356,6 +384,20 @@ section: Components
 				</div>
 			</div>
 			<div class="has-error">
+				<div class="form-group">
+					<label for="sizeSelectElementError">
+						Select Element with Size 3 and Error
+						<svg class="lexicon-icon lexicon-icon-asterisk reference-mark" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#asterisk" />
+						</svg>
+					</label>
+					<select class="form-control" id="sizeSelectElementError" size="3">
+						<option>Sample 1</option>
+						<option>Sample 2</option>
+						<option>Sample 3</option>
+						<option>Sample 4</option>
+					</select>
+				</div>
 				<div class="form-group">
 					<label for="multipleSelectElementError">
 						Multiple Select Element with Error

--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -21,6 +21,7 @@
 @import "components/_links";
 
 @import "components/_range";
+@import "components/_reorder";
 
 @import "components/_clay-color";
 @import "components/_custom-forms";

--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -28,6 +28,7 @@
 @import "components/_time";
 
 @import "components/_date-picker";
+@import "components/_dual-listbox";
 @import "components/_form-validation";
 @import "components/_icons";
 @import "components/_input-groups";

--- a/packages/clay-css/src/scss/_variables.scss
+++ b/packages/clay-css/src/scss/_variables.scss
@@ -23,6 +23,7 @@
 @import "variables/_time";
 
 @import "variables/_date-picker";
+@import "variables/_dual-listbox";
 @import "variables/_list-group";
 @import "variables/_loaders";
 @import "variables/_modals";

--- a/packages/clay-css/src/scss/_variables.scss
+++ b/packages/clay-css/src/scss/_variables.scss
@@ -16,6 +16,7 @@
 @import "variables/_links";
 
 @import "variables/_range";
+@import "variables/_reorder";
 
 @import "variables/_clay-color";
 @import "variables/_custom-forms";

--- a/packages/clay-css/src/scss/atlas/_variables.scss
+++ b/packages/clay-css/src/scss/atlas/_variables.scss
@@ -15,6 +15,7 @@
 @import "variables/_links";
 
 @import "variables/_range";
+@import "variables/_reorder";
 
 @import "variables/_clay-color";
 @import "variables/_custom-forms";

--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -151,6 +151,13 @@ $input-select-icon-focus: clay-icon(caret-double-l, $input-select-icon-focus-col
 $input-select-icon-disabled-color: $gray-500 !default;
 $input-select-icon-disabled: clay-icon(caret-double-l, $input-select-icon-disabled-color) !default;
 
+$input-select-size: () !default;
+$input-select-size: map-deep-merge((
+	option: (
+		padding: 0.25rem 0.5rem,
+	),
+), $input-select-size);
+
 // Form Feedback
 
 $form-feedback-font-weight: $font-weight-semi-bold !default;

--- a/packages/clay-css/src/scss/atlas/variables/_reorder.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_reorder.scss
@@ -1,0 +1,4 @@
+$clay-reorder-underlay-focus: () !default;
+$clay-reorder-underlay-focus: map-deep-merge((
+	box-shadow: null,
+), $clay-reorder-underlay-focus);

--- a/packages/clay-css/src/scss/components/_dual-listbox.scss
+++ b/packages/clay-css/src/scss/components/_dual-listbox.scss
@@ -1,0 +1,31 @@
+.clay-dual-listbox {
+	@include clay-css($clay-dual-listbox);
+
+	.clay-reorder {
+		@include clay-css($clay-dual-listbox-clay-reorder);
+	}
+
+	label {
+		@include clay-css($clay-dual-listbox-label);
+	}
+}
+
+.clay-dual-listbox-item {
+	@include clay-css($clay-dual-listbox-item);
+
+	@include media-breakpoint-up(sm) {
+		@include clay-css($clay-dual-listbox-item-sm-up);
+	}
+
+	&:last-child {
+		@include clay-css($clay-dual-listbox-item-last-child);
+	}
+}
+
+.clay-dual-listbox-item-expand {
+	@include clay-css($clay-dual-listbox-item-expand);
+}
+
+.clay-dual-listbox-actions {
+	@include clay-css($clay-dual-listbox-actions);
+}

--- a/packages/clay-css/src/scss/components/_form-validation.scss
+++ b/packages/clay-css/src/scss/components/_form-validation.scss
@@ -102,6 +102,14 @@
 
 	select.form-control {
 		background-image: $input-danger-select-icon;
+
+		&[size] {
+			@include clay-select-variant($input-danger-select-size);
+		}
+
+		&[multiple] {
+			@include clay-select-variant($input-danger-select-multiple);
+		}
 	}
 
 	.input-group-item {
@@ -166,6 +174,14 @@
 
 	select.form-control {
 		background-image: $input-warning-select-icon;
+
+		&[size] {
+			@include clay-select-variant($input-warning-select-size);
+		}
+
+		&[multiple] {
+			@include clay-select-variant($input-warning-select-multiple);
+		}
 	}
 
 	.input-group-item {
@@ -230,6 +246,14 @@
 
 	select.form-control {
 		background-image: $input-success-select-icon;
+
+		&[size] {
+			@include clay-select-variant($input-success-select-size);
+		}
+
+		&[multiple] {
+			@include clay-select-variant($input-success-select-multiple);
+		}
 	}
 
 	.input-group-item {

--- a/packages/clay-css/src/scss/components/_form-validation.scss
+++ b/packages/clay-css/src/scss/components/_form-validation.scss
@@ -100,7 +100,7 @@
 		color: $form-feedback-invalid-color;
 	}
 
-	select.form-control:not([multiple]):not([size]) {
+	select.form-control {
 		background-image: $input-danger-select-icon;
 	}
 
@@ -164,7 +164,7 @@
 		color: $form-feedback-warning-color;
 	}
 
-	select.form-control:not([multiple]):not([size]) {
+	select.form-control {
 		background-image: $input-warning-select-icon;
 	}
 
@@ -228,7 +228,7 @@
 		color: $form-feedback-valid-color;
 	}
 
-	select.form-control:not([multiple]):not([size]) {
+	select.form-control {
 		background-image: $input-success-select-icon;
 	}
 

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -252,47 +252,20 @@ div {
 
 // Select
 
-.form-control[multiple],
-.form-control[size] {
-	height: auto;
-}
-
 select.form-control {
-	cursor: $input-select-cursor;
-
-	option {
-		cursor: $input-select-cursor;
-	}
+	@include clay-select-variant($input-select);
 }
 
-// Will need to be revisted if action is taken on https://github.com/twbs/bootstrap/issues/23058
-select.form-control,
 .form-control-select {
-	-moz-appearance: none;
-	-webkit-appearance: none;
+	@include clay-css($form-control-select);
+}
 
-	&::-ms-expand {
-		display: none;
-	}
+select.form-control[size] {
+	@include clay-select-variant($input-select-size);
+}
 
-	background-color: $input-select-bg;
-	background-image: $input-select-icon;
-	background-position: $input-select-bg-position;
-	background-repeat: no-repeat;
-	background-size: $input-select-bg-size;
-	padding-bottom: $input-select-padding-bottom;
-	padding-left: $input-select-padding-left;
-	padding-right: $input-select-padding-right;
-	padding-top: $input-select-padding-top;
-
-	&:focus {
-		background-color: $input-select-focus-bg;
-		background-image: $input-select-icon-focus;
-	}
-
-	&:disabled {
-		background-image: $input-select-icon-disabled;
-	}
+select.form-control[multiple] {
+	@include clay-select-variant($input-select-multiple);
 }
 
 // Textarea

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -266,7 +266,7 @@ select.form-control {
 }
 
 // Will need to be revisted if action is taken on https://github.com/twbs/bootstrap/issues/23058
-select.form-control:not([multiple]):not([size]),
+select.form-control,
 .form-control-select {
 	-moz-appearance: none;
 	-webkit-appearance: none;
@@ -428,12 +428,11 @@ fieldset[disabled] label {
 }
 
 %clay-select-form-control-lg {
-	&:not([size]):not([multiple]) {
-		height: $input-height-lg;
 
-		@include clay-scale-component {
-			height: $input-height-lg-mobile;
-		}
+	height: $input-height-lg;
+
+	@include clay-scale-component {
+		height: $input-height-lg-mobile;
 	}
 }
 
@@ -473,12 +472,10 @@ textarea.form-control-lg,
 }
 
 %clay-select-form-control-sm {
-	&:not([size]):not([multiple]) {
-		height: $input-height-sm;
+	height: $input-height-sm;
 
-		@include clay-scale-component {
-			height: $input-height-sm-mobile;
-		}
+	@include clay-scale-component {
+		height: $input-height-sm-mobile;
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_reorder.scss
+++ b/packages/clay-css/src/scss/components/_reorder.scss
@@ -1,0 +1,45 @@
+.clay-reorder {
+	@include clay-css($clay-reorder);
+
+	.form-control-inset {
+		@include clay-form-control-variant($clay-reorder-input-inset);
+
+		&:focus,
+		&.focus {
+			+ .clay-reorder-underlay {
+				@include clay-css($clay-reorder-underlay-focus);
+			}
+		}
+
+		+ .clay-reorder-underlay {
+			@include clay-css($clay-reorder-underlay);
+		}
+	}
+}
+
+.clay-reorder-footer {
+	@include clay-css($clay-reorder-footer);
+}
+
+.clay-reorder-footer-invisible {
+	&.clay-reorder-footer,
+	.clay-reorder-footer {
+		* {
+			@include clay-css($clay-reorder-footer-invisible);
+		}
+	}
+}
+
+.clay-reorder-footer-center {
+	&.clay-reorder-footer,
+	.clay-reorder-footer {
+		@include clay-css($clay-reorder-footer-center);
+	}
+}
+
+.clay-reorder-footer-end {
+	&.clay-reorder-footer,
+	.clay-reorder-footer {
+		@include clay-css($clay-reorder-footer-end);
+	}
+}

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -13,53 +13,28 @@
 /// A mixin to create Form Control variants. You can base your variant off Bootstrap's `.form-control` class or create your own base class (e.g., `<input class="form-control my-custom-form-control" type="text" />` or `<input class="my-custom-form-control" type="text" />`).
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
+/// See Mixin `clay-css` for available keys to pass into the base selector
 /// enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
-/// align-items: {String | Null},
-/// bg: {Color | String | Null},
-/// bg-clip: {String | Null},
-/// bg-image: {String | List | Null},
-/// bg-position: {String | List | Null},
-/// bg-repeat: {String | List | Null},
-/// bg-size: {Number | String | List | Null},
-/// border-color: {Color | String | List | Null},
-/// border-radius: {Number | String | List | Null},
-/// border-style: {String | List | Null},
-/// border-width: {Number | String | List | Null},
-/// box-shadow: {String | List | Null},
-/// color: {Color | String | Null},
-/// cursor: {String | Null},
-/// display: {String | Null},
-/// flex-wrap: {String | Null},
-/// font-size: {Number | String | Null},
-/// font-weight: {Number | String | Null},
-/// height: {Number | String | Null},
-/// justify-content: {String | Null},
-/// line-height: {Number | String | Null},
-/// max-width: {Number | String | Null},
-/// min-height: {Number | String | Null},
-/// min-width: {Number | String | Null},
-/// outline: {Number | String | Null},
-/// padding-bottom: {Number | String | Null},
-/// padding-left: {Number | String | Null},
-/// padding-right: {Number | String | Null},
-/// padding-top: {Number | String | Null},
-/// text-align: {String | Null},
-/// text-transform: {String | Null},
-/// transition: {String | List | Null},
-/// width: {Number | String | Null},
-/// placeholder-color: {Color | String | Null},
-/// placeholder-opacity: {Number | String | Null},
-/// hover-bg: {Color | String | Null},
-/// hover-border-color: {Color | String | List | Null},
-/// hover-box-shadow: {String | List | Null},
-/// hover-color: {Color | String | Null},
-/// hover-placeholder-color: {Color | String | Null},
-/// focus-bg: {Color | String | Null},
-/// focus-bg-image: {String | List | Null},
-/// focus-border-color: {Color | String | List | Null},
-/// focus-box-shadow: {String | List | Null},
-/// focus-color: {Color | String | Null},
-/// focus-placeholder-color: {Color | String | Null},
+/// placeholder-color: {Color | String | Null}, // deprecated after 3.7.0
+/// placeholder-opacity: {Number | String | Null}, // deprecated after 3.7.0
+/// placeholder: {Map | Null}, // See Mixin `clay-css` for available keys
+/// selection-bg: {Color | String | Null}, // deprecated after 3.7.0
+/// selection-color: {Color | String | Null}, // deprecated after 3.7.0
+/// selection: {Map | Null}, // See Mixin `clay-css` for available keys
+/// hover-bg: {Color | String | Null}, // deprecated after 3.7.0
+/// hover-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
+/// hover-box-shadow: {String | List | Null}, // deprecated after 3.7.0
+/// hover-color: {Color | String | Null}, // deprecated after 3.7.0
+/// hover-placeholder-color: {Color | String | Null}, // deprecated after 3.7.0
+/// hover: {Map | Null}, // See Mixin `clay-css` for available keys
+/// focus-bg: {Color | String | Null}, // deprecated after 3.7.0
+/// focus-bg-image: {String | List | Null}, // deprecated after 3.7.0
+/// focus-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
+/// focus-box-shadow: {String | List | Null}, // deprecated after 3.7.0
+/// focus-color: {Color | String | Null}, // deprecated after 3.7.0
+/// focus: {Map | Null}, // See Mixin `clay-css` for available keys
+/// focus-placeholder-color: {Color | String | Null}, // deprecated after 3.7.0
+/// focus-placeholder: {Map | Null}, // See Mixin `clay-css` for available keys
 /// readonly-bg: {Color | String | Null}, // deprecated after v2.18.0
 /// readonly-bg-image: {String | List | Null}, // deprecated after v2.18.0
 /// readonly-border-color: {Color | String | List | Null}, // deprecated after v2.18.0
@@ -68,14 +43,16 @@
 /// readonly-cursor: {String | Null}, // deprecated after v2.18.0
 /// readonly-opacity: {Number | String | Null}, // deprecated after v2.18.0
 /// readonly-placeholder-color: {Color | String | Null}, // deprecated after v2.18.0
-/// disabled-bg: {Color | String | Null},
-/// disabled-bg-image: {String | List | Null},
-/// disabled-border-color: {Color | String | List | Null},
-/// disabled-box-shadow: {String | List | Null},
-/// disabled-color: {Color | String | Null},
-/// disabled-cursor: {String | Null},
-/// disabled-opacity: {Number | String | Null},
-/// disabled-placeholder-color: {Color | String | Null},
+/// disabled-bg: {Color | String | Null}, // deprecated after 3.7.0
+/// disabled-bg-image: {String | List | Null}, // deprecated after 3.7.0
+/// disabled-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
+/// disabled-box-shadow: {String | List | Null}, // deprecated after 3.7.0
+/// disabled-color: {Color | String | Null}, // deprecated after 3.7.0
+/// disabled-cursor: {String | Null}, // deprecated after 3.7.0
+/// disabled-opacity: {Number | String | Null}, // deprecated after 3.7.0
+/// disabled: {Map | Null}, // See Mixin `clay-css` for available keys
+/// disabled-placeholder-color: {Color | String | Null}, // deprecated after 3.7.0
+/// disabled-placeholder: {Map | Null}, // See Mixin `clay-css` for available keys
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
@@ -83,56 +60,38 @@
 @mixin clay-form-control-variant($map) {
 	$enabled: setter(map-get($map, enabled), true);
 
-	$align-items: map-get($map, align-items);
-	$bg: map-get($map, bg);
-	$bg-clip: map-get($map, bg-clip);
-	$bg-image: map-get($map, bg-image);
-	$bg-position: map-get($map, bg-position);
-	$bg-repeat: map-get($map, bg-repeat);
-	$bg-size: map-get($map, bg-size);
-	$border-color: map-get($map, border-color);
-	$border-radius: map-get($map, border-radius);
-	$border-style: map-get($map, border-style);
-	$border-width: map-get($map, border-width);
-	$box-shadow: map-get($map, box-shadow);
-	$color: map-get($map, color);
-	$cursor: map-get($map, cursor);
-	$display: map-get($map, display);
-	$flex-wrap: map-get($map, flex-wrap);
-	$font-size: map-get($map, font-size);
-	$font-weight: map-get($map, font-weight);
-	$height: map-get($map, height);
-	$justify-content: map-get($map, justify-content);
-	$line-height: map-get($map, line-height);
-	$max-width: map-get($map, max-width);
-	$min-height: map-get($map, min-height);
-	$min-width: map-get($map, min-width);
-	$outline: map-get($map, outline);
-	$padding-bottom: map-get($map, padding-bottom);
-	$padding-left: map-get($map, padding-left);
-	$padding-right: map-get($map, padding-right);
-	$padding-top: map-get($map, padding-top);
-	$text-align: map-get($map, text-align);
-	$text-transform: map-get($map, text-transform);
-	$transition: map-get($map, transition);
-	$width: map-get($map, width);
-	$placeholder-color: map-get($map, placeholder-color);
-	$placeholder-opacity: map-get($map, placeholder-opacity);
-	$selection-bg: map-get($map, selection-bg);
-	$selection-color: map-get($map, selection-color);
+	$placeholder: map-deep-merge((
+		color: map-get($map, placeholder-color),
+		opacity: map-get($map, placeholder-opacity),
+	), map-get($map, placeholder));
 
-	$hover-bg: map-get($map, hover-bg);
-	$hover-border-color: map-get($map, hover-border-color);
-	$hover-box-shadow: map-get($map, hover-box-shadow);
-	$hover-color: map-get($map, hover-color);
-	$hover-placeholder-color: map-get($map, hover-placeholder-color);
+	$selection: map-deep-merge((
+		background-color: map-get($map, selection-bg),
+		color: map-get($map, selection-color),
+	), map-get($map, selection));
 
-	$focus-bg: map-get($map, focus-bg);
-	$focus-bg-image: map-get($map, focus-bg-image);
-	$focus-border-color: map-get($map, focus-border-color);
-	$focus-box-shadow: map-get($map, focus-box-shadow);
-	$focus-color: map-get($map, focus-color);
-	$focus-placeholder-color: map-get($map, focus-placeholder-color);
+	$hover: map-deep-merge((
+		background-color: map-get($map, hover-bg),
+		border-color: map-get($map, hover-border-color),
+		box-shadow: map-get($map, hover-box-shadow),
+		color: map-get($map, hover-color),
+	), map-get($map, hover));
+
+	$hover-placeholder: map-deep-merge((
+		color: map-get($map, hover-placeholder-color),
+	), map-get($map, hover-placeholder));
+
+	$focus: map-deep-merge((
+		background-color: map-get($map, focus-bg),
+		background-image: map-get($map, focus-bg-image),
+		border-color: map-get($map, focus-border-color),
+		box-shadow: map-get($map, focus-box-shadow),
+		color: map-get($map, focus-color),
+	), map-get($map, focus));
+
+	$focus-placeholder: map-deep-merge((
+		color: map-get($map, focus-placeholder-color),
+	), map-get($map, focus-placeholder));
 
 	// deprecated after v2.18.0 [readonly] can have hover focus styles, declare a separate selector and use `clay-form-control-variant` mixin (e.g., `.form-control[readonly] { @include clay-form-control-variant($the-readonly-map); }`).
 
@@ -145,86 +104,46 @@
 	$readonly-opacity: map-get($map, readonly-opacity);
 	$readonly-placeholder-color: map-get($map, readonly-placeholder-color);
 
-	$disabled-bg: map-get($map, disabled-bg);
-	$disabled-bg-image: map-get($map, disabled-bg-image);
-	$disabled-border-color: map-get($map, disabled-border-color);
-	$disabled-box-shadow: map-get($map, disabled-box-shadow);
-	$disabled-color: map-get($map, disabled-color);
-	$disabled-cursor: map-get($map, disabled-cursor);
-	$disabled-opacity: map-get($map, disabled-opacity);
-	$disabled-placeholder-color: map-get($map, disabled-placeholder-color);
+	$disabled: map-deep-merge((
+		background-color: map-get($map, disabled-bg),
+		background-image: map-get($map, disabled-bg-image),
+		border-color: map-get($map, disabled-border-color),
+		box-shadow: map-get($map, disabled-box-shadow),
+		color: map-get($map, disabled-color),
+		cursor: map-get($map, disabled-cursor),
+		opacity: map-get($map, disabled-opacity),
+	), map-get($map, disabled));
+
+	$disabled-placeholder: map-deep-merge((
+		color: map-get($map, disabled-placeholder-color),
+	), map-get($map, disabled-placeholder));
 
 	@if ($enabled) {
-		align-items: $align-items;
-		background-color: $bg;
-		background-clip: $bg-clip;
-		background-image: $bg-image;
-		background-position: $bg-position;
-		background-repeat: $bg-repeat;
-		background-size: $bg-size;
-		border-color: $border-color;
-		border-radius: $border-radius;
-		border-style: $border-style;
-		border-width: $border-width;
-		box-shadow: $box-shadow;
-		color: $color;
-		cursor: $cursor;
-		display: $display;
-		flex-wrap: $flex-wrap;
-		font-size: $font-size;
-		font-weight: $font-weight;
-		height: $height;
-		justify-content: $justify-content;
-		line-height: $line-height;
-		max-width: $max-width;
-		min-height: $min-height;
-		min-width: $min-width;
-		outline: $outline;
-		padding-bottom: $padding-bottom;
-		padding-left: $padding-left;
-		padding-right: $padding-right;
-		padding-top: $padding-top;
-		text-align: $text-align;
-		text-transform: $text-transform;
-		transition: $transition;
-		width: $width;
+		@include clay-css($map);
 
 		&::placeholder {
-			color: $placeholder-color;
-			opacity: $placeholder-opacity;
+			@include clay-css($placeholder);
 		}
 
-		&::-moz-selection {
-			background-color: $selection-bg;
-			color: $selection-color;
-		}
-
+		&::-moz-selection,
 		&::selection {
-			background-color: $selection-bg;
-			color: $selection-color;
+			@include clay-css($selection);
 		}
 
 		&:hover {
-			background-color: $hover-bg;
-			border-color: $hover-border-color;
-			box-shadow: $hover-box-shadow;
-			color: $hover-color;
+			@include clay-css($hover);
 
 			&::placeholder {
-				color: $hover-placeholder-color;
+				@include clay-css($hover-placeholder);
 			}
 		}
 
 		&:focus,
 		&.focus {
-			background-color: $focus-bg;
-			background-image: $focus-bg-image;
-			border-color: $focus-border-color;
-			box-shadow: $focus-box-shadow;
-			color: $focus-color;
+			@include clay-css($focus);
 
 			&::placeholder {
-				color: $focus-placeholder-color;
+				@include clay-css($focus-placeholder);
 			}
 		}
 
@@ -246,16 +165,10 @@
 
 		&:disabled,
 		&.disabled {
-			background-color: $disabled-bg;
-			background-image: $disabled-bg-image;
-			border-color: $disabled-border-color;
-			box-shadow: $disabled-box-shadow;
-			color: $disabled-color;
-			cursor: $disabled-cursor;
-			opacity: $disabled-opacity;
+			@include clay-css($disabled);
 
 			&::placeholder {
-				color: $disabled-placeholder-color;
+				@include clay-css($disabled-placeholder);
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -272,7 +272,21 @@
 	$disabled-cursor: map-get($map, disabled-cursor);
 	$disabled-opacity: map-get($map, disabled-opacity);
 
+	-moz-appearance: $appearance;
+	-webkit-appearance: $appearance;
+
+	@if ($appearance) {
+		&::-ms-expand {
+			display: none;
+		}
+	}
+
 	background-clip: $bg-clip;
+	background-color: $bg;
+	background-image: $bg-image;
+	background-position: $bg-position;
+	background-repeat: $bg-repeat;
+	background-size: $bg-size;
 	border-color: $border-color;
 	border-radius: $border-radius;
 	border-style: $border-style;
@@ -283,55 +297,27 @@
 	display: $display;
 	font-size: $font-size;
 	font-weight: $font-weight;
+	height: $height;
 	line-height: $line-height;
 	min-width: $min-width;
 	outline: $outline;
+	padding-bottom: $padding-bottom;
+	padding-left: $padding-left;
+	padding-right: $padding-right;
+	padding-top: $padding-top;
 	transition: $transition;
 	width: $width;
 
-	&:not([multiple]):not([size]) {
-		-moz-appearance: $appearance;
-		-webkit-appearance: $appearance;
-
-		@if ($appearance) {
-			&::-ms-expand {
-				display: none;
-			}
-		}
-
-		background-color: $bg;
-		background-image: $bg-image;
-		background-position: $bg-position;
-		background-repeat: $bg-repeat;
-		background-size: $bg-size;
-		height: $height;
-		padding-bottom: $padding-bottom;
-		padding-left: $padding-left;
-		padding-right: $padding-right;
-		padding-top: $padding-top;
-
-		&:hover {
-			background-color: $hover-bg;
-		}
-
-		&:focus {
-			background-color: $focus-bg;
-			background-image: $focus-bg-image;
-		}
-
-		&:disabled {
-			background-color: $disabled-bg;
-			background-image: $disabled-bg-image;
-		}
-	}
-
 	&:hover {
+		background-color: $hover-bg;
 		border-color: $hover-border-color;
 		box-shadow: $hover-box-shadow;
 		color: $hover-color;
 	}
 
 	&:focus {
+		background-color: $focus-bg;
+		background-image: $focus-bg-image;
 		border-color: $focus-border-color;
 		box-shadow: $focus-box-shadow;
 		color: $focus-color;
@@ -349,6 +335,8 @@
 	}
 
 	&:disabled {
+		background-color: $disabled-bg;
+		background-image: $disabled-bg-image;
 		border-color: $disabled-border-color;
 		box-shadow: $disabled-box-shadow;
 		color: $disabled-color;

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -177,150 +177,71 @@
 /// A mixin to create Select Form Control variants. You can base your variant off Bootstrap's `select.form-control` selector or create your own base class (e.g., `<select class="form-control my-custom-form-control"></select>` or `<select class="my-custom-form-control"></select>`).
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
-/// appearance: {String | Null},
-/// bg: {Color | String | Null},
-/// bg-clip: {String | Null},
-/// bg-image: {String | List | Null},
-/// bg-position: {String | List | Null},
-/// bg-repeat: {String | List | Null},
-/// bg-size: {Number | String | List | Null},
-/// border-color: {Color | String | List | Null},
-/// border-radius: {Number | String | List | Null},
-/// border-style: {String | List | Null},
-/// border-width: {Number | String | List | Null},
-/// box-shadow: {String | List | Null},
-/// color: {Color | String | Null},
-/// cursor: {String | Null},
-/// display: {String | Null},
-/// font-size: {Number | String | Null},
-/// font-weight: {Number | String | Null},
-/// height: {Number | String | Null},
-/// line-height: {Number | String | Null},
-/// min-width: {Number | String | Null},
-/// outline: {Number | String | Null},
-/// padding-bottom: {Number | String | Null},
-/// padding-left: {Number | String | Null},
-/// padding-right: {Number | String | Null},
-/// padding-top: {Number | String | Null},
-/// transition: {String | List | Null},
-/// width: {Number | String | Null},
-/// hover-bg: {Color | String | Null},
-/// hover-border-color: {Color | String | List | Null},
-/// hover-box-shadow: {String | List | Null},
-/// hover-color: {Color | String | Null},
-/// focus-bg: {Color | String | Null},
-/// focus-bg-image: {String | List | Null},
-/// focus-border-color: {Color | String | List | Null},
-/// focus-box-shadow: {String | List | Null},
-/// focus-color: {Color | String | Null},
-/// disabled-bg: {Color | String | Null},
-/// disabled-bg-image: {String | List | Null},
-/// disabled-border-color: {Color | String | List | Null},
-/// disabled-box-shadow: {String | List | Null},
-/// disabled-color: {Color | String | Null},
-/// disabled-cursor: {String | Null},
-/// disabled-opacity: {Number | String | Null},
+/// See Mixin `clay-css` for available keys to pass into the base selector
+/// hover-bg: {Color | String | Null}, // deprecated after 3.7.0
+/// hover-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
+/// hover-box-shadow: {String | List | Null}, // deprecated after 3.7.0
+/// hover-color: {Color | String | Null}, // deprecated after 3.7.0
+/// hover: {Map | Null}, // See Mixin `clay-css` for available keys
+/// focus-bg: {Color | String | Null}, // deprecated after 3.7.0
+/// focus-bg-image: {String | List | Null}, // deprecated after 3.7.0
+/// focus-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
+/// focus-box-shadow: {String | List | Null}, // deprecated after 3.7.0
+/// focus-color: {Color | String | Null}, // deprecated after 3.7.0
+/// focus: {Map | Null}, // See Mixin `clay-css` for available keys
+/// disabled-bg: {Color | String | Null}, // deprecated after 3.7.0
+/// disabled-bg-image: {String | List | Null}, // deprecated after 3.7.0
+/// disabled-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
+/// disabled-box-shadow: {String | List | Null}, // deprecated after 3.7.0
+/// disabled-color: {Color | String | Null}, // deprecated after 3.7.0
+/// disabled-cursor: {String | Null}, // deprecated after 3.7.0
+/// disabled-opacity: {Number | String | Null}, // deprecated after 3.7.0
+/// disabled: {Map | Null}, // See Mixin `clay-css` for available keys
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
 
 @mixin clay-select-variant($map) {
-	$appearance: map-get($map, appearance);
-	$bg: map-get($map, bg);
-	$bg-clip: map-get($map, bg-clip);
-	$bg-image: map-get($map, bg-image);
-	$bg-position: map-get($map, bg-position);
-	$bg-repeat: map-get($map, bg-repeat);
-	$bg-size: map-get($map, bg-size);
-	$border-color: map-get($map, border-color);
-	$border-radius: map-get($map, border-radius);
-	$border-style: map-get($map, border-style);
-	$border-width: map-get($map, border-width);
-	$box-shadow: map-get($map, box-shadow);
-	$color: map-get($map, color);
-	$cursor: map-get($map, cursor);
-	$display: map-get($map, display);
-	$font-size: map-get($map, font-size);
-	$font-weight: map-get($map, font-weight);
-	$height: map-get($map, height);
-	$line-height: map-get($map, line-height);
-	$min-width: map-get($map, min-width);
-	$outline: map-get($map, outline);
-	$padding-bottom: map-get($map, padding-bottom);
-	$padding-left: map-get($map, padding-left);
-	$padding-right: map-get($map, padding-right);
-	$padding-top: map-get($map, padding-top);
-	$transition: map-get($map, transition);
-	$width: map-get($map, width);
+	$hover: map-deep-merge((
+		background-color: map-get($map, hover-bg),
+		border-color: map-get($map, hover-border-color),
+		box-shadow: map-get($map, hover-box-shadow),
+		color: map-get($map, hover-color),
+	), map-get($map, hover));
 
-	$hover-bg: map-get($map, hover-bg);
-	$hover-border-color: map-get($map, hover-border-color);
-	$hover-box-shadow: map-get($map, hover-box-shadow);
-	$hover-color: map-get($map, hover-color);
+	$focus: map-deep-merge((
+		background-color: map-get($map, focus-bg),
+		background-image: map-get($map, focus-bg-image),
+		border-color: map-get($map, focus-border-color),
+		box-shadow: map-get($map, focus-box-shadow),
+		color: map-get($map, focus-color),
+	), map-get($map, focus));
 
-	$focus-bg: map-get($map, focus-bg);
-	$focus-bg-image: map-get($map, focus-bg-image);
-	$focus-border-color: map-get($map, focus-border-color);
-	$focus-box-shadow: map-get($map, focus-box-shadow);
-	$focus-color: map-get($map, focus-color);
+	$disabled: map-deep-merge((
+		background-color: map-get($map, disabled-bg),
+		background-image: map-get($map, disabled-bg-image),
+		border-color: map-get($map, disabled-border-color),
+		box-shadow: map-get($map, disabled-box-shadow),
+		color: map-get($map, disabled-color),
+		cursor: map-get($map, disabled-cursor),
+		opacity: map-get($map, disabled-opacity),
+	), map-get($map, disabled));
 
-	$disabled-bg: map-get($map, disabled-bg);
-	$disabled-bg-image: map-get($map, disabled-bg-image);
-	$disabled-border-color: map-get($map, disabled-border-color);
-	$disabled-box-shadow: map-get($map, disabled-box-shadow);
-	$disabled-color: map-get($map, disabled-color);
-	$disabled-cursor: map-get($map, disabled-cursor);
-	$disabled-opacity: map-get($map, disabled-opacity);
+	$disabled-option: map-deep-merge((
+		color: map-get($map, disabled-color),
+	), map-get($map, disabled-option));
 
-	-moz-appearance: $appearance;
-	-webkit-appearance: $appearance;
+	$option: map-deep-merge((), map-get($map, option));
 
-	@if ($appearance) {
-		&::-ms-expand {
-			display: none;
-		}
-	}
-
-	background-clip: $bg-clip;
-	background-color: $bg;
-	background-image: $bg-image;
-	background-position: $bg-position;
-	background-repeat: $bg-repeat;
-	background-size: $bg-size;
-	border-color: $border-color;
-	border-radius: $border-radius;
-	border-style: $border-style;
-	border-width: $border-width;
-	box-shadow: $box-shadow;
-	color: $color;
-	cursor: $cursor;
-	display: $display;
-	font-size: $font-size;
-	font-weight: $font-weight;
-	height: $height;
-	line-height: $line-height;
-	min-width: $min-width;
-	outline: $outline;
-	padding-bottom: $padding-bottom;
-	padding-left: $padding-left;
-	padding-right: $padding-right;
-	padding-top: $padding-top;
-	transition: $transition;
-	width: $width;
+	@include clay-css($map);
 
 	&:hover {
-		background-color: $hover-bg;
-		border-color: $hover-border-color;
-		box-shadow: $hover-box-shadow;
-		color: $hover-color;
+		@include clay-css($hover);
 	}
 
-	&:focus {
-		background-color: $focus-bg;
-		background-image: $focus-bg-image;
-		border-color: $focus-border-color;
-		box-shadow: $focus-box-shadow;
-		color: $focus-color;
+	&:focus,
+	&.focus {
+		@include clay-css($focus);
 
 		&::-ms-value {
 			// Suppress the nested default white text on blue background highlight given to
@@ -329,29 +250,22 @@
 			// match the appearance of the native widget.
 			// See https://github.com/twbs/bootstrap/issues/19398.
 
-			background-color: $bg;
-			color: $color;
+			background-color: map-get($focus, background-color);
+			color: map-get($focus, color);
 		}
 	}
 
-	&:disabled {
-		background-color: $disabled-bg;
-		background-image: $disabled-bg-image;
-		border-color: $disabled-border-color;
-		box-shadow: $disabled-box-shadow;
-		color: $disabled-color;
-		cursor: $disabled-cursor;
-		opacity: $disabled-opacity;
+	&:disabled,
+	&.disabled {
+		@include clay-css($disabled);
 
 		> option {
-			@media (-webkit-min-device-pixel-ratio: 0) { // Webkit only
-				color: $disabled-color;
-			}
+			@include clay-css($disabled-option);
 		}
 	}
 
 	option {
-		cursor: $input-select-cursor;
+		@include clay-css($option);
 	}
 }
 

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -204,6 +204,7 @@
 		resize: map-get($map, resize);
 		right: map-get($map, right);
 		scroll-behavior: map-get($map, scroll-behavior);
+		scrollbar-width: map-get($map, scrollbar-width);
 		table-layout: map-get($map, table-layout);
 		text-align: map-get($map, text-align);
 		text-decoration: map-get($map, text-decoration);

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -25,18 +25,28 @@
 		animation-name: map-get($map, animation-name);
 		animation-play-state: map-get($map, animation-play-state);
 		animation-timing-function: map-get($map, animation-timing-function);
+
+		-moz-appearance: map-get($map, appearance);
+		-webkit-appearance: map-get($map, appearance);
+
+		&::-ms-expand {
+			display: map-get($map, appearance);
+		}
+
+		appearance: map-get($map, appearance);
+
 		backface-visibility: map-get($map, backface-visibility);
 		background: map-get($map, background);
 
 		background-attachment: map-get($map, background-attachment);
 		background-blend-mode: map-get($map, background-blend-mode);
 		background-clip: map-get($map, background-clip);
-		background-color: map-get($map, background-color);
-		background-image: map-get($map, background-image);
+		background-color: setter(map-get($map, bg), map-get($map, background-color));
+		background-image: setter(map-get($map, bg-image), map-get($map, background-image));
 		background-origin: map-get($map, background-origin);
-		background-position: map-get($map, background-position);
-		background-repeat: map-get($map, background-repeat);
-		background-size: map-get($map, background-size);
+		background-position: setter(map-get($map, bg-position), map-get($map, background-position));
+		background-repeat: setter(map-get($map, bg-repeat), map-get($map, background-repeat));
+		background-size: setter(map-get($map, bg-size), map-get($map, background-size));
 		border: map-get($map, border);
 
 		border-bottom: map-get($map, border-bottom);

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -38,12 +38,12 @@
 		backface-visibility: map-get($map, backface-visibility);
 		background: map-get($map, background);
 
-		background-attachment: map-get($map, background-attachment);
-		background-blend-mode: map-get($map, background-blend-mode);
-		background-clip: map-get($map, background-clip);
+		background-attachment: setter(map-get($map, bg-attachment), map-get($map, background-attachment));
+		background-blend-mode: setter(map-get($map, bg-blend-mode), map-get($map, background-blend-mode));
+		background-clip: setter(map-get($map, bg-clip), map-get($map, background-clip));
 		background-color: setter(map-get($map, bg), map-get($map, background-color));
 		background-image: setter(map-get($map, bg-image), map-get($map, background-image));
-		background-origin: map-get($map, background-origin);
+		background-origin: setter(map-get($map, bg-origin), map-get($map, background-origin));
 		background-position: setter(map-get($map, bg-position), map-get($map, background-position));
 		background-repeat: setter(map-get($map, bg-repeat), map-get($map, background-repeat));
 		background-size: setter(map-get($map, bg-size), map-get($map, background-size));

--- a/packages/clay-css/src/scss/variables/_dual-listbox.scss
+++ b/packages/clay-css/src/scss/variables/_dual-listbox.scss
@@ -1,0 +1,47 @@
+$clay-dual-listbox: () !default;
+$clay-dual-listbox: map-deep-merge((
+	display: flex,
+	flex-direction: row,
+), $clay-dual-listbox);
+
+$clay-dual-listbox-label: () !default;
+$clay-dual-listbox-label: map-deep-merge((
+	margin-bottom: 1rem,
+), $clay-dual-listbox-label);
+
+$clay-dual-listbox-clay-reorder: () !default;
+$clay-dual-listbox-clay-reorder: map-deep-merge((
+	display: flex,
+	flex-direction: column,
+	flex-grow: 1,
+), $clay-dual-listbox-clay-reorder);
+
+$clay-dual-listbox-item: () !default;
+$clay-dual-listbox-item: map-deep-merge((
+	display: flex,
+	flex-direction: column,
+	margin-right: 0.25rem,
+), $clay-dual-listbox-item);
+
+$clay-dual-listbox-item-sm-up: () !default;
+$clay-dual-listbox-item-sm-up: map-deep-merge((
+	margin-right: 1.5rem,
+), $clay-dual-listbox-item-sm-up);
+
+$clay-dual-listbox-item-last-child: () !default;
+$clay-dual-listbox-item-last-child: map-deep-merge((
+	margin-right: 0,
+), $clay-dual-listbox-item-last-child);
+
+$clay-dual-listbox-item-expand: () !default;
+$clay-dual-listbox-item-expand: map-deep-merge((
+	flex-grow: 1,
+	width: 3rem,
+	word-wrap: break-word,
+), $clay-dual-listbox-item-expand);
+
+$clay-dual-listbox-actions: () !default;
+$clay-dual-listbox-actions: map-deep-merge((
+	align-self: center,
+	margin-top: calc(21px + 1rem),
+), $clay-dual-listbox-actions);

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -348,6 +348,8 @@ $input-select-size: map-deep-merge((
 	background-image: none,
 	padding-left: 0.5rem,
 	padding-right: 0.5rem,
+	// Future proof: if https://github.com/w3c/csswg-drafts/issues/1958 ever gets added
+	scrollbar-width: thin,
 	focus: (
 		background-image: none,
 	),

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -222,6 +222,14 @@ $input-danger-label-color: null !default;
 $input-danger-select-icon-color: $input-danger-border-color !default;
 $input-danger-select-icon: clay-str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='#{$input-danger-select-icon-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
+$input-danger-select-size: () !default;
+$input-danger-select-size: map-deep-merge((
+	background-image: none,
+), $input-danger-select-size);
+
+$input-danger-select-multiple: () !default;
+$input-danger-select-multiple: map-deep-merge($input-danger-select-size, $input-danger-select-multiple);
+
 $input-success-bg: null !default;
 $input-success-focus-bg: null !default;
 $input-success-border-color: $form-feedback-valid-color !default;
@@ -238,6 +246,14 @@ $input-success-label-color: null !default;
 $input-success-select-icon-color: $input-success-border-color !default;
 $input-success-select-icon: clay-str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='#{$input-success-select-icon-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
+$input-success-select-size: () !default;
+$input-success-select-size: map-deep-merge((
+	background-image: none,
+), $input-success-select-size);
+
+$input-success-select-multiple: () !default;
+$input-success-select-multiple: map-deep-merge($input-success-select-size, $input-success-select-multiple);
+
 $input-warning-bg: null !default;
 $input-warning-focus-bg: null !default;
 $input-warning-border-color: $form-feedback-warning-color !default;
@@ -253,6 +269,14 @@ $input-warning-checkbox-label-color: $form-feedback-warning-color !default;
 $input-warning-label-color: null !default;
 $input-warning-select-icon-color: $input-warning-border-color !default;
 $input-warning-select-icon: clay-str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='#{$input-warning-select-icon-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E"), "#", "%23") !default;
+
+$input-warning-select-size: () !default;
+$input-warning-select-size: map-deep-merge((
+	background-image: none,
+), $input-warning-select-size);
+
+$input-warning-select-multiple: () !default;
+$input-warning-select-multiple: map-deep-merge($input-warning-select-size, $input-warning-select-multiple);
 
 // Select Element
 
@@ -275,6 +299,68 @@ $input-select-icon-focus: null !default;
 
 $input-select-icon-disabled-color: null !default;
 $input-select-icon-disabled: null !default;
+
+$input-select: () !default;
+$input-select: map-deep-merge((
+	appearance: none,
+	background-color: $input-select-bg,
+	background-image: $input-select-icon,
+	background-position: $input-select-bg-position,
+	background-repeat: no-repeat,
+	background-size: $input-select-bg-size,
+	cursor: $input-select-cursor,
+	padding-bottom: $input-select-padding-bottom,
+	padding-left: $input-select-padding-left,
+	padding-right: $input-select-padding-right,
+	padding-top: $input-select-padding-top,
+	focus: (
+		background-color: $input-select-focus-bg,
+		background-image: $input-select-icon-focus,
+	),
+	disabled: (
+		background-image: $input-select-icon-disabled,
+	),
+	disabled-option: (
+		cursor: $disabled-cursor,
+	),
+	option: (
+		cursor: $input-select-cursor,
+	),
+), $input-select);
+
+// Form Control Select for Divs Styled Like Select
+
+$form-control-select: () !default;
+$form-control-select: map-deep-merge((
+	map-deep-merge(
+		$input-select,
+		(
+			appearance: null,
+			cursor: null,
+		)
+	)
+), $form-control-select);
+
+// Select Size
+
+$input-select-size: () !default;
+$input-select-size: map-deep-merge((
+	background-image: none,
+	overflow: auto,
+	padding-left: 0.5rem,
+	padding-right: 0.5rem,
+	focus: (
+		background-image: none,
+	),
+	option: (
+		padding: 0.25rem,
+	),
+), $input-select-size);
+
+// Select Multiple
+
+$input-select-multiple: () !default;
+$input-select-multiple: map-deep-merge($input-select-size, $input-select-multiple);
 
 // Form Feedback
 

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -292,7 +292,7 @@ $input-select-padding-right: $custom-select-indicator-padding + $input-btn-paddi
 $input-select-padding-top: null !default;
 
 $input-select-icon-color: $input-color !default;
-$input-select-icon: $custom-select-indicator !default;
+$input-select-icon: clay-str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='#{$input-select-icon-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 $input-select-icon-focus-color: null !default;
 $input-select-icon-focus: null !default;
@@ -346,7 +346,6 @@ $form-control-select: map-deep-merge((
 $input-select-size: () !default;
 $input-select-size: map-deep-merge((
 	background-image: none,
-	overflow: auto,
 	padding-left: 0.5rem,
 	padding-right: 0.5rem,
 	focus: (

--- a/packages/clay-css/src/scss/variables/_reorder.scss
+++ b/packages/clay-css/src/scss/variables/_reorder.scss
@@ -1,0 +1,56 @@
+$clay-reorder: () !default;
+$clay-reorder: map-deep-merge((
+	padding: 2px,
+	position: relative,
+	z-index: 0,
+), $clay-reorder);
+
+$clay-reorder-input-inset: () !default;
+$clay-reorder-input-inset: map-deep-merge((
+	margin-bottom: 0,
+	margin-top: 0,
+	overflow: auto,
+	padding-bottom: $input-padding-y,
+	padding-top: $input-padding-y,
+	focus: (
+		background-color: transparent,
+		box-shadow: none,
+	),
+), $clay-reorder-input-inset);
+
+$clay-reorder-underlay: () !default;
+$clay-reorder-underlay: map-deep-merge((
+	bottom: 0,
+	left: 0,
+	position: absolute,
+	right: 0,
+	top: 0,
+	z-index: -1,
+), $clay-reorder-underlay);
+
+$clay-reorder-underlay-focus: () !default;
+$clay-reorder-underlay-focus: map-deep-merge((
+	background-color: $input-focus-bg,
+	border-color: $input-focus-border-color,
+	box-shadow: $input-focus-box-shadow,
+), $clay-reorder-underlay-focus);
+
+$clay-reorder-footer: () !default;
+$clay-reorder-footer: map-deep-merge((
+	padding: 0.5rem,
+), $clay-reorder-footer);
+
+$clay-reorder-footer-invisible: () !default;
+$clay-reorder-footer-invisible: map-deep-merge((
+	visibility: hidden,
+), $clay-reorder-footer-invisible);
+
+$clay-reorder-footer-center: () !default;
+$clay-reorder-footer-center: map-deep-merge((
+	text-align: center,
+), $clay-reorder-footer-center);
+
+$clay-reorder-footer-end: () !default;
+$clay-reorder-footer-end: map-deep-merge((
+	text-align: right,
+), $clay-reorder-footer-end);


### PR DESCRIPTION
There are some issues with `select[size]` and `select[multiple]` in Firefox and Safari. They render the scrollbar track even if there is no overflowing content. I couldn't work around this with native inputs in those browsers so there is a potential "bug" that could pop up. On the other hand they look nice on Chrome, IE11, and Edge.

@kresimir-coko you can find the markup for the component on my test site under Form Elements (Dual Listbox). @jonmak08 mentioned he put in a lot of work with keyboard shortcuts in the old Input Move Boxes component. ~I tried look for the ticket, but can't find it.~ Here it is https://issues.liferay.com/browse/LPS-77051. We should find out what shortcuts we need.

<img width="633" alt="clay-dual-listbox" src="https://user-images.githubusercontent.com/788266/76027108-ed005d80-5ee4-11ea-9cd1-e0170be8901a.png">