### PR TITLE
chore: add verbose flag to debug github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   curl \
+                      -v
                       -X POST \
                       $URL \
                       -H "Content-Type: application/json" \


### PR DESCRIPTION
We are getting an error in our curl call stating "Resource not accessible by integration", so I am adding this flag to help debug the action since this worked fine on my local fork.