### PR TITLE
chore: disable action due to it not working properly when PR is from a fork

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: Comment Build Stats
 
 on:
     pull_request:
+        branches-ignore:
+            - '**'
         branches: [master]
 
 jobs:


### PR DESCRIPTION
Long story short, this action works only if the PR is from the same repo. If its fork, the token doesnt have access for writing comments.

See https://github.com/actions/labeler/issues/12#issuecomment-525762657 for more indepth discussion