### PR TITLE
chore: fix gh action error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
     pull_request:
         branches-ignore:
             - '**'
-        branches: [master]
 
 jobs:
     build_and_comment:


### PR DESCRIPTION
Gh errors with `you may only define one of branches and branches-ignore for a single event`. Removing branches for now