### PR TITLE
fix(@clayui/time-picker): prevent scroll when using arrow keys to cycle numbers

### DIFF
--- a/packages/clay-time-picker/src/index.tsx
+++ b/packages/clay-time-picker/src/index.tsx
@@ -210,6 +210,8 @@ const ClayTimePicker: React.FunctionComponent<IProps> = ({
 				setValue(DEFAULT_VALUE);
 				break;
 			case KEY_ARROWUP:
+				event.preventDefault();
+
 				if (configName === TimeType.ampm) {
 					setValue((config as ConfigAmpm).pm);
 				} else {
@@ -221,6 +223,8 @@ const ClayTimePicker: React.FunctionComponent<IProps> = ({
 				}
 				break;
 			case KEY_ARROWDOWN:
+				event.preventDefault();
+
 				if (configName === TimeType.ampm) {
 					setValue((config as ConfigAmpm).am);
 				} else {


### PR DESCRIPTION
fixes #3011