### PR TITLE
set dom-align prop for rtl languages

### DIFF
--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -191,6 +191,8 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>((
 						adjustY: autoBestAlign,
 					},
 					points,
+					// @ts-ignore
+					useCssTransform: !!window.TransitionEvent,
 				}
 			);
 		}


### PR DESCRIPTION
So I still am not entirely sure why dom-align breaks when portal is set to right-to-left. I did discover that if we use the css transform flag on dom-align that is works fine. However, I don't feel great about just throwing this boolean on there and being okay with. Has anyone seen anything similar in portal? See the gif below for example. The top button is using Clay's drop-down without css transform, and the below example is using dom-align with that flag enabled.

Other options I also thought of were

1. Allowing users to pass args to domAlign from the component props.
2. Adding a very specific hack for portal where we only add this flag if dir="rtl" id enabled.

Any other thoughts on this? Really scratching my head as to what portal is adding or doing that ends up breaking dom-align.


![Kapture 2020-03-16 at 16 25 29](https://user-images.githubusercontent.com/6843530/76807801-cecb1500-67a2-11ea-8390-9103ba36d52e.gif)

