### PR TITLE
fix(@clayui/css): override specific styles for rtl support

### DIFF
--- a/clayui.com/content/docs/css/content/c-kbd.md
+++ b/clayui.com/content/docs/css/content/c-kbd.md
@@ -7,29 +7,29 @@ order: 4
 <div class="nav-toc">
 
 -   [Base](#base)
-    -    [Kbd](#c-kbd)
-    -    [Monospaced](#c-kbd-monospaced)
-    -    [Inline](#c-kbd-inline)
-    -    [Group](#c-kbd-group)
+    -   [Kbd](#c-kbd)
+    -   [Monospaced](#c-kbd-monospaced)
+    -   [Inline](#c-kbd-inline)
+    -   [Group](#c-kbd-group)
 -   [Color Variants](#color-variants)
-    -    [Light](#c-kbd-light)
-    -    [Dark](#c-kbd-dark)
-    -    [Group Light](#c-kbd-group-light)
-    -    [Group Dark](#c-kbd-group-dark)
+    -   [Light](#c-kbd-light)
+    -   [Dark](#c-kbd-dark)
+    -   [Group Light](#c-kbd-group-light)
+    -   [Group Dark](#c-kbd-group-dark)
 -   [Size Variants](#size-variants)
     -   [Small](#c-kbd-sm)
     -   [Large](#c-kbd-lg)
 -   [Unicode Character List](#unicode-character-list)
-    -    [Standard](#standard-0-255-(utf-8)-character-set)
-    -    [General Punctuation](#general-punctuation-(u+2000-to-u+206f))
-    -    [Superscripts and Subscripts](#superscripts-and-subscripts-(u+2070-to-u+209f))
-    -    [Currency Symbols](#currency-symbols-(u+20a0-to-u+20cf))
-    -    [Letterlike Symbols](#letterlike-symbols-(u+2100-to-u+214f))
-    -    [Greek Characters](#greek-characters-(u+0391-to-u+03c9))
-    -    [Number Forms](#number-forms-(u+2150-to-u+218f))
-    -    [Supplemental Arrows - A](#supplemental-arrows---a-(u+27f0-to-u+27ff))
-    -    [Supplemental Arrows - B](#supplemental-arrows---b-(u+2900-to-u+297f))
-    -    [Mathematical Operators](#mathematical-operators-(u+2200-to-u+22ff))
+    -   [Standard](<#standard-0-255-(utf-8)-character-set>)
+    -   [General Punctuation](<#general-punctuation-(u+2000-to-u+206f)>)
+    -   [Superscripts and Subscripts](<#superscripts-and-subscripts-(u+2070-to-u+209f)>)
+    -   [Currency Symbols](<#currency-symbols-(u+20a0-to-u+20cf)>)
+    -   [Letterlike Symbols](<#letterlike-symbols-(u+2100-to-u+214f)>)
+    -   [Greek Characters](<#greek-characters-(u+0391-to-u+03c9)>)
+    -   [Number Forms](<#number-forms-(u+2150-to-u+218f)>)
+    -   [Supplemental Arrows - A](<#supplemental-arrows---a-(u+27f0-to-u+27ff)>)
+    -   [Supplemental Arrows - B](<#supplemental-arrows---b-(u+2900-to-u+297f)>)
+    -   [Mathematical Operators](<#mathematical-operators-(u+2200-to-u+22ff)>)
 
 </div>
 </div>
@@ -115,9 +115,9 @@ A container element for grouping text with several <code>kbd</code> elements tog
 
 ```html
 <span class="c-kbd-group">
-    Press <kbd class="c-kbd">Esc</kbd>
-    +
-    <kbd class="c-kbd c-kbd-monospaced">N</kbd> to see an amazing effect.
+	Press <kbd class="c-kbd">Esc</kbd>
+	+
+	<kbd class="c-kbd c-kbd-monospaced">N</kbd> to see an amazing effect.
 </span>
 ```
 
@@ -151,7 +151,7 @@ The color variants are modifier classes added to any of the base components list
 
 ### C Kbd Group Light
 
-A color modifier on <code>c-kbd-group</code> that sets the text color to <code>$secondary</code>. This can be used with <code>c-kbd-light</code> and <code>c-kbd-dark</code>.
+A color modifier on <code>c-kbd-group</code> that sets the text color to <code>\$secondary</code>. This can be used with <code>c-kbd-light</code> and <code>c-kbd-dark</code>.
 
 <div class="sheet-example">
     <div class="c-mb-2">
@@ -164,18 +164,20 @@ A color modifier on <code>c-kbd-group</code> that sets the text color to <code>$
 
 ```html
 <span class="c-kbd-group c-kbd-group-light">
-    Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-    <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.
+	Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing
+	effect.
 </span>
 <span class="c-kbd-group c-kbd-group-light">
-    Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> +
-    <kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing effect.
+	Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> +
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing
+	effect.
 </span>
 ```
 
 ### C Kbd Group Dark
 
-A color modifier on <code>c-kbd-group</code> that sets the text color to <code>$white</code>. This can be used with <code>c-kbd-light</code> and <code>c-kbd-dark</code>.
+A color modifier on <code>c-kbd-group</code> that sets the text color to <code>\$white</code>. This can be used with <code>c-kbd-light</code> and <code>c-kbd-dark</code>.
 
 <div class="sheet-example">
     <div class="c-mb-2" style="background-color:#1C1C24;padding: 10px;">
@@ -188,12 +190,14 @@ A color modifier on <code>c-kbd-group</code> that sets the text color to <code>$
 
 ```html
 <span class="c-kbd-group c-kbd-group-dark">
-    Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-    <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.
+	Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing
+	effect.
 </span>
 <span class="c-kbd-group c-kbd-group-dark">
-    Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> +
-    <kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing effect.
+	Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> +
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing
+	effect.
 </span>
 ```
 
@@ -218,10 +222,12 @@ Size variants are modifier classes added to the base component to change the fon
 </div>
 
 ```html
-<kbd class="c-kbd c-kbd-sm c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-sm c-kbd-monospaced c-kbd-light">N</kbd>
+<kbd class="c-kbd c-kbd-sm c-kbd-light">Esc</kbd> +
+<kbd class="c-kbd c-kbd-sm c-kbd-monospaced c-kbd-light">N</kbd>
 <span class="c-kbd-group c-kbd-group-sm c-kbd-group-light">
-    Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-    <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.
+	Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing
+	effect.
 </span>
 ```
 
@@ -242,12 +248,12 @@ Size variants are modifier classes added to the base component to change the fon
 </div>
 
 ```html
-<kbd class="c-kbd c-kbd-lg c-kbd-light">
-    Esc</kbd> + <kbd class="c-kbd c-kbd-lg c-kbd-monospaced c-kbd-light">N
-</kbd>
+<kbd class="c-kbd c-kbd-lg c-kbd-light"> Esc</kbd> +
+<kbd class="c-kbd c-kbd-lg c-kbd-monospaced c-kbd-light">N </kbd>
 <span class="c-kbd-group c-kbd-group-lg c-kbd-group-light">
-    Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-    <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.
+	Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing
+	effect.
 </span>
 ```
 
@@ -258,13 +264,13 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0033;">&#0033;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0034;">&#0034;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0035;">&#0035;</kbd>
-<kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0036;">&#0036;</kbd>
+<kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0036;">\$</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0037;">&#0037;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0038;">&#0038;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0039;">&#0039;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0040;">&#0040;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0041;">&#0041;</kbd>
-<kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0042;">&#0042;</kbd>
+<kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0042;">\*</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0043;">&#0043;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0044;">&#0044;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0045;">&#0045;</kbd>
@@ -317,7 +323,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0092;">&#0092;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0093;">&#0093;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0094;">&#0094;</kbd>
-<kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0095;">&#0095;</kbd>
+<kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0095;">\_</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0096;">&#0096;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0097;">&#0097;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0098;">&#0098;</kbd>

--- a/clayui.com/content/docs/css/utilities/c-focus-inset.md
+++ b/clayui.com/content/docs/css/utilities/c-focus-inset.md
@@ -72,5 +72,11 @@ A bailout utility to set the focus border inside the element, just add the class
 </div>
 
 ```html
-<input class="c-focus-inset form-control" id="basicInputTypeText" name="basicInputTypeText" placeholder="Placeholder" type="text" />
+<input
+	class="c-focus-inset form-control"
+	id="basicInputTypeText"
+	name="basicInputTypeText"
+	placeholder="Placeholder"
+	type="text"
+/>
 ```

--- a/clayui.com/content/docs/css/utilities/c-inner.md
+++ b/clayui.com/content/docs/css/utilities/c-inner.md
@@ -125,7 +125,7 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 
 ```html
 <button class="btn btn-primary" type="button">
-    <span class="c-inner" tabindex="-1">Primary</span>
+	<span class="c-inner" tabindex="-1">Primary</span>
 </button>
 ```
 
@@ -182,7 +182,7 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 
 ```html
 <a href="/">
-    <span class="c-inner" tabindex="-1">Regular Anchor Tag</span>
+	<span class="c-inner" tabindex="-1">Regular Anchor Tag</span>
 </a>
 ```
 
@@ -239,18 +239,26 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 
 ```html
 <button aria-label="Close" class="close" type="button">
-    <span class="c-inner" tabindex="-1">
-        <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-            <use xlink:href="/images/icons/icons.svg#times" />
-        </svg>
-    </span>
+	<span class="c-inner" tabindex="-1">
+		<svg
+			class="lexicon-icon lexicon-icon-times"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#times" />
+		</svg>
+	</span>
 </button>
 <a aria-label="Close" class="close" href="javascript:;" role="button">
-    <span class="c-inner" tabindex="-1">
-        <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-            <use xlink:href="/images/icons/icons.svg#times" />
-        </svg>
-    </span>
+	<span class="c-inner" tabindex="-1">
+		<svg
+			class="lexicon-icon lexicon-icon-times"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#times" />
+		</svg>
+	</span>
 </a>
 ```
 
@@ -303,9 +311,9 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 
 ```html
 <a class="badge badge-primary" href="javascript:;">
-    <span class="c-inner" tabindex="-1">
-        <span class="badge-item badge-item-expand">Primary</span>
-    </span>
+	<span class="c-inner" tabindex="-1">
+		<span class="badge-item badge-item-expand">Primary</span>
+	</span>
 </a>
 ```
 
@@ -480,9 +488,9 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 
 ```html
 <a class="label label-primary" href="javascript:;">
-    <span class="c-inner" tabindex="-1">
-        <span class="label-item label-item-expand">Primary</span>
-    </span>
+	<span class="c-inner" tabindex="-1">
+		<span class="label-item label-item-expand">Primary</span>
+	</span>
 </a>
 ```
 
@@ -611,21 +619,58 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 
 ```html
 <div class="dropdown">
-    <button aria-expanded="false" aria-haspopup="true" class="link-outline link-outline-primary dropdown-toggle" data-toggle="dropdown" id="dropdownSites1" type="button">
-        <span class="c-inner" tabindex="-1">
-            Dropdown
-            <svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-                <use xlink:href="/images/icons/icons.svg#caret-bottom" />
-            </svg>
-        </span>
-    </button>
-    <ul aria-labelledby="dropdownSites1" class="dropdown-menu">
-        <li><a class="dropdown-item" href="javascript:;"><span class="c-inner" tabindex="-1">Download</span></a></li>
-        <li><a class="dropdown-item" href="javascript:;"><span class="c-inner" tabindex="-1">Edit</span></a></li>
-        <li><a class="dropdown-item" href="javascript:;"><span class="c-inner" tabindex="-1">Move</span></a></li>
-        <li><a class="dropdown-item" href="javascript:;"><span class="c-inner" tabindex="-1">Checkout</span></a></li>
-        <li><a class="dropdown-item" href="javascript:;"><span class="c-inner" tabindex="-1">Permissions</span></a></li>
-        <li><a class="dropdown-item" href="javascript:;"><span class="c-inner" tabindex="-1">Move to Recycle Bin</span></a></li>
-    </ul>
+	<button
+		aria-expanded="false"
+		aria-haspopup="true"
+		class="link-outline link-outline-primary dropdown-toggle"
+		data-toggle="dropdown"
+		id="dropdownSites1"
+		type="button"
+	>
+		<span class="c-inner" tabindex="-1">
+			Dropdown
+			<svg
+				class="lexicon-icon lexicon-icon-caret-bottom"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+			</svg>
+		</span>
+	</button>
+	<ul aria-labelledby="dropdownSites1" class="dropdown-menu">
+		<li>
+			<a class="dropdown-item" href="javascript:;"
+				><span class="c-inner" tabindex="-1">Download</span></a
+			>
+		</li>
+		<li>
+			<a class="dropdown-item" href="javascript:;"
+				><span class="c-inner" tabindex="-1">Edit</span></a
+			>
+		</li>
+		<li>
+			<a class="dropdown-item" href="javascript:;"
+				><span class="c-inner" tabindex="-1">Move</span></a
+			>
+		</li>
+		<li>
+			<a class="dropdown-item" href="javascript:;"
+				><span class="c-inner" tabindex="-1">Checkout</span></a
+			>
+		</li>
+		<li>
+			<a class="dropdown-item" href="javascript:;"
+				><span class="c-inner" tabindex="-1">Permissions</span></a
+			>
+		</li>
+		<li>
+			<a class="dropdown-item" href="javascript:;"
+				><span class="c-inner" tabindex="-1"
+					>Move to Recycle Bin</span
+				></a
+			>
+		</li>
+	</ul>
 </div>
 ```

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -93,6 +93,11 @@
 	}
 }
 
+html[dir="rtl"] .dropdown-menu {
+	left: auto;
+	right: 0;
+}
+
 .dropdown-menu {
 	border-style: $dropdown-border-style;
 	font-size: $dropdown-font-size;


### PR DESCRIPTION
Fixes #2971

So it turns out this issue was because `left: 0;` on `.dropdown-menu` was getting flipped to `right: 0;` when using rtl in portal. This is an issue because dom-align is setting the `left` property and that is ignored if the `right` property exists.
rlt specification says
> If direction of the containing block is rtl, right wins and left is ignored.


It also looks like we encountered this in portal before and we added this file, https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_dropdown.scss#L5. However that style was specifically scoped within `#clay_dropdown_portal` which is no longer used.

So ultimately the question here is, should we add this to `@clayui/css`(like ive done here), or do we just update liferay-portal.

I am inclined to change it here in clay since we are also the same ones giving them the dropdown component and dom-align dependency.