### PR TITLE
docs(clayui.com): Use c-inner for better focus experience

### DIFF
--- a/clayui.com/content/docs/get-started/how-to-read-this-documentation.md
+++ b/clayui.com/content/docs/get-started/how-to-read-this-documentation.md
@@ -1,5 +1,5 @@
 ---
-title: 'How to read this documentation'
+title: 'How to Read This Documentation'
 description: 'The status of each package is shown in the corresponding documentation'
 order: 3
 ---

--- a/clayui.com/content/docs/get-started/how-to-use-clay.md
+++ b/clayui.com/content/docs/get-started/how-to-use-clay.md
@@ -1,5 +1,5 @@
 ---
-title: 'How to use clay'
+title: 'How to Use Clay'
 description: 'Practical guidelines to start using Clay, a quick guide on how to install components and css to get started.'
 order: 2
 ---

--- a/clayui.com/content/docs/migration/migrate-the-clay-components-from-v2-to-v3.md
+++ b/clayui.com/content/docs/migration/migrate-the-clay-components-from-v2-to-v3.md
@@ -1,5 +1,5 @@
 ---
-title: 'Migrate the Clay components from v2 to v3'
+title: 'Migrate the Clay Components From v2 to v3'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/src/components/LayoutNav/LayoutNav.js
+++ b/clayui.com/src/components/LayoutNav/LayoutNav.js
@@ -21,12 +21,16 @@ export default () => (
 							className="nav-link"
 							to="/docs/get-started/what-is-clay.html"
 						>
-							{'Docs'}
+							<span className="c-inner" tabIndex="-1">
+								{'Docs'}
+							</span>
 						</Link>
 					</li>
 					<li className="nav-item">
 						<Link className="nav-link" to="/blog">
-							{'Blog'}
+							<span className="c-inner" tabIndex="-1">
+								{'Blog'}
+							</span>
 						</Link>
 					</li>
 					<li className="nav-item">
@@ -36,7 +40,9 @@ export default () => (
 							rel="noopener noreferrer"
 							target="_blank"
 						>
-							{'Storybook'}
+							<span className="c-inner" tabIndex="-1">
+								{'Storybook'}
+							</span>
 						</a>
 					</li>
 					<li className="nav-item">
@@ -46,7 +52,9 @@ export default () => (
 							rel="noopener noreferrer"
 							target="_blank"
 						>
-							{'Codesandbox'}
+							<span className="c-inner" tabIndex="-1">
+								{'Codesandbox'}
+							</span>
 						</a>
 					</li>
 					<li className="nav-item">
@@ -56,11 +64,13 @@ export default () => (
 							rel="noopener noreferrer"
 							target="_blank"
 						>
-							<img
-								alt="Github"
-								className="github-logo"
-								src="/images/home/github-logo.svg"
-							/>
+							<span className="c-inner" tabIndex="-1">
+								<img
+									alt="Github"
+									className="github-logo"
+									src="/images/home/github-logo.svg"
+								/>
+							</span>
 						</a>
 					</li>
 				</ul>

--- a/clayui.com/src/components/Sidebar/Navigation.js
+++ b/clayui.com/src/components/Sidebar/Navigation.js
@@ -127,18 +127,20 @@ const Anchor = ({location, onclick, onnavigation, page}) => {
 
 	return (
 		<TagName className="nav-link" {...props}>
-			<span>{page.title}</span>
-			{page.items && (
-				<svg
-					className="collapse-toggle"
-					focusable="false"
-					name="keyboardArrowRight"
-					role="presentation"
-				>
-					<path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z" />
-					<path d="M0 0h24v24H0V0z" fill="none" />
-				</svg>
-			)}
+			<span className="c-inner" tabIndex="-1">
+				{page.title}
+				{page.items && (
+					<svg
+						className="collapse-toggle"
+						focusable="false"
+						name="keyboardArrowRight"
+						role="presentation"
+					>
+						<path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z" />
+						<path d="M0 0h24v24H0V0z" fill="none" />
+					</svg>
+				)}
+			</span>
 		</TagName>
 	);
 };

--- a/clayui.com/src/components/Sidebar/Sidebar.js
+++ b/clayui.com/src/components/Sidebar/Sidebar.js
@@ -54,13 +54,15 @@ export default props => (
 						className="d-inline-block p-2 sidebar-logo text-decoration-none text-reset"
 						to="/"
 					>
-						<img
-							alt="Clay"
-							className="align-middle sidebar-logo-image"
-							src="/images/clay_logo_w.png"
-						/>
-						<span className="align-middle font-weight-700 h3 ml-2 sidebar-logo-title">
-							{'Clay'}
+						<span className="c-inner" tabIndex="-1">
+							<img
+								alt="Clay"
+								className="align-middle sidebar-logo-image"
+								src="/images/clay_logo_w.png"
+							/>
+							<span className="align-middle font-weight-700 h3 ml-2 sidebar-logo-title">
+								{'Clay'}
+							</span>
 						</span>
 					</Link>
 
@@ -75,18 +77,20 @@ export default props => (
 							onClick={onClick}
 							type="button"
 						>
-							<svg
-								aria-hidden="true"
-								className="lexicon-icon lexicon-icon-bars"
-							>
-								<use xlinkHref="/images/icons/icons.svg#bars" />
-							</svg>
-							<svg
-								aria-hidden="true"
-								className="lexicon-icon lexicon-icon-times"
-							>
-								<use xlinkHref="/images/icons/icons.svg#times" />
-							</svg>
+							<span className="c-inner" tabIndex="-1">
+								<svg
+									aria-hidden="true"
+									className="lexicon-icon lexicon-icon-bars"
+								>
+									<use xlinkHref="/images/icons/icons.svg#bars" />
+								</svg>
+								<svg
+									aria-hidden="true"
+									className="lexicon-icon lexicon-icon-times"
+								>
+									<use xlinkHref="/images/icons/icons.svg#times" />
+								</svg>
+							</span>
 						</button>
 					</div>
 				</div>

--- a/clayui.com/src/styles/_code.scss
+++ b/clayui.com/src/styles/_code.scss
@@ -25,11 +25,16 @@
 	padding: 0;
 	position: absolute;
 	top: 5px;
+	transition: $btn-transition;
 	width: 32px;
 	z-index: 9;
 
 	&:hover {
 		background: rgba(255, 255, 255, 0.8);
+	}
+
+	&:focus {
+		box-shadow: $component-focus-box-shadow;
 	}
 
 	.lexicon-icon {

--- a/clayui.com/src/styles/_guide.scss
+++ b/clayui.com/src/styles/_guide.scss
@@ -104,8 +104,6 @@
 	}
 
 	.clay-site-label {
-		display: flex;
-
 		a:hover {
 			text-decoration: none;
 		}
@@ -183,8 +181,6 @@
 		padding: 15px 15px 15px 0;
 
 		a {
-			@include focus-a11y;
-
 			color: #30313f;
 			word-break: break-word;
 		}

--- a/clayui.com/src/styles/_navbar.scss
+++ b/clayui.com/src/styles/_navbar.scss
@@ -38,6 +38,11 @@
 
 	.navbar-nav .nav-link {
 		font-weight: 600;
+
+		.c-inner {
+			margin-left: -0.5rem;
+			margin-right: -0.5rem;
+		}
 	}
 
 	.github-logo {

--- a/clayui.com/src/styles/site/_sidebar-site.scss
+++ b/clayui.com/src/styles/site/_sidebar-site.scss
@@ -11,6 +11,10 @@
 			.sidebar-logo-image {
 				max-height: 32px;
 			}
+
+			.c-inner {
+				margin: -0.5rem;
+			}
 		}
 
 		@media (min-width: $grid-float-breakpoint) {
@@ -19,6 +23,12 @@
 
 		@media (max-width: $grid-float-breakpoint - 1) {
 			display: none;
+		}
+	}
+
+	.sidebar-toggler {
+		.c-inner {
+			margin: -0.3125rem -0.5625rem;
 		}
 	}
 
@@ -37,25 +47,25 @@
 
 		> .nav-link {
 			font-weight: 600;
-			padding-right: 32px;
+			padding-right: 2rem;
+
+			> .c-inner {
+				margin-right: -2rem;
+			}
 		}
 	}
 
 	.nav-link {
-		align-items: center;
 		border-radius: 6px;
 		color: $brand-secondary;
-		display: flex;
-		line-height: $base-size / 1.375;
+		line-height: 1;
 		margin-bottom: 2px;
-		padding: 0.45rem 1rem;
-		min-height: 35px;
 
 		&:hover {
 			background-color: $brand-dark-lighter;
 		}
 
-		> .collapse-toggle {
+		.collapse-toggle {
 			display: inline-block;
 			height: 24px;
 			margin-top: -12px;

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -125,9 +125,14 @@ export default props => {
 																	id="advancedTabs"
 																	role="tab"
 																>
-																	{
-																		'React Component'
-																	}
+																	<span
+																		className="c-inner"
+																		tabIndex="-1"
+																	>
+																		{
+																			'React Component'
+																		}
+																	</span>
 																</a>
 															</li>
 															<li className="nav-item">
@@ -139,9 +144,14 @@ export default props => {
 																	id="simpleTab"
 																	role="tab"
 																>
-																	{
-																		'CSS / Markup'
-																	}
+																	<span
+																		className="c-inner"
+																		tabIndex="-1"
+																	>
+																		{
+																			'CSS / Markup'
+																		}
+																	</span>
 																</a>
 															</li>
 														</ul>
@@ -175,37 +185,41 @@ export default props => {
 																{fields && (
 																	<>
 																		{fields.packageStatus && (
-																			<Link to="/docs/get-started/how-to-read-this-documentation.html">
+																			<Link
+																				className={`label label-lg label-${
+																					mapStatus[
+																						fields.packageStatus.toLowerCase()
+																					]
+																				}`}
+																				to="/docs/get-started/how-to-read-this-documentation.html"
+																			>
 																				<span
-																					className={`label label-lg label-${
-																						mapStatus[
-																							fields.packageStatus.toLowerCase()
-																						]
-																					}`}
+																					className="c-inner"
+																					tabIndex="-1"
 																				>
-																					<span className="label-item label-item-expand">
-																						{
-																							fields.packageStatus
-																						}
-																					</span>
+																					{
+																						fields.packageStatus
+																					}
 																				</span>
 																			</Link>
 																		)}
 
 																		{fields.packageVersion && (
 																			<a
+																				className="label label-lg label-secondary"
 																				href={`https://www.npmjs.com/package/${
 																					frontmatter.packageNpm
 																				}`}
 																				rel="noopener noreferrer"
 																				target="_blank"
 																			>
-																				<span className="label label-lg label-secondary">
-																					<span className="label-item label-item-expand">
-																						{
-																							fields.packageVersion
-																						}
-																					</span>
+																				<span
+																					className="c-inner"
+																					tabIndex="-1"
+																				>
+																					{
+																						fields.packageVersion
+																					}
 																				</span>
 																			</a>
 																		)}
@@ -215,6 +229,7 @@ export default props => {
 																{frontmatter.packageNpm && (
 																	<>
 																		<a
+																			className="label label-lg label-secondary"
 																			href={`https://github.com/liferay/clay/blob/master/packages/${frontmatter.packageNpm.replace(
 																				'@clayui/',
 																				'clay-'
@@ -222,16 +237,18 @@ export default props => {
 																			rel="noopener noreferrer"
 																			target="_blank"
 																		>
-																			<span className="label label-lg label-secondary">
-																				<span className="label-item label-item-expand">
-																					{
-																						'CHANGELOG'
-																					}
-																				</span>
+																			<span
+																				className="c-inner"
+																				tabIndex="-1"
+																			>
+																				{
+																					'CHANGELOG'
+																				}
 																			</span>
 																		</a>
 
 																		<a
+																			className="align-middle d-inline-block link-primary"
 																			href={`https://storybook.clayui.com/?path=/story/components-${frontmatter.packageNpm
 																				.replace(
 																					'@clayui/',
@@ -244,10 +261,16 @@ export default props => {
 																			rel="noopener noreferrer"
 																			target="_blank"
 																		>
-																			<img
-																				alt="storybook demos"
-																				src="/images/storybook_badge.svg"
-																			/>
+																			<span
+																				className="c-inner d-block"
+																				tabIndex="-1"
+																			>
+																				<img
+																					alt="storybook demos"
+																					className="d-block"
+																					src="/images/storybook_badge.svg"
+																				/>
+																			</span>
 																		</a>
 																	</>
 																)}
@@ -259,6 +282,8 @@ export default props => {
 																{markdownJsx ? (
 																	<MDXProvider
 																		components={{
+																			a:
+																				Typography.A,
 																			h1:
 																				Typography.H1,
 																			h2:
@@ -326,6 +351,8 @@ export default props => {
 																<CodeClipboard>
 																	<MDXProvider
 																		components={{
+																			a:
+																				Typography.A,
 																			h1:
 																				Typography.H1,
 																			h2:
@@ -391,15 +418,20 @@ export default props => {
 															rel="noopener noreferrer"
 															target="_blank"
 														>
-															<svg
-																className="lexicon-icon"
-																height="24"
-																name="github"
-																viewBox="12 12 24 24"
-																width="24"
+															<span
+																className="c-inner"
+																tabIndex="-1"
 															>
-																<path d="M24.06 12C17.426 12 12 17.395 12 23.988c0 5.275 3.497 9.83 8.2 11.389.603.12.845-.24.845-.6V32.74c-3.377.72-4.1-1.558-4.1-1.558-.483-1.439-1.327-1.799-1.327-1.799-1.085-.719.12-.719.12-.719 1.206.12 1.81 1.199 1.81 1.199 1.085 1.918 2.894 1.319 3.497 1.079.12-.72.361-1.319.723-1.558-2.532-.36-5.427-1.439-5.427-5.994 0-1.32.483-2.398 1.206-3.237-.12-.36-.482-1.559.12-3.237 0 0 .966-.36 3.257 1.199 1.085-.12 2.17-.36 3.135-.36.965 0 2.05.12 3.015.36 2.291-1.559 3.256-1.199 3.256-1.199.603 1.678.241 2.877.12 3.117a4.854 4.854 0 0 1 1.207 3.237c0 4.555-2.774 5.634-5.548 5.874.483.36.844 1.079.844 2.277v3.237c0 .36.242.72.845.6 4.823-1.559 8.2-6.114 8.2-11.389C36.118 17.395 30.692 12 24.059 12z" />
-															</svg>
+																<svg
+																	className="lexicon-icon"
+																	height="24"
+																	name="github"
+																	viewBox="12 12 24 24"
+																	width="24"
+																>
+																	<path d="M24.06 12C17.426 12 12 17.395 12 23.988c0 5.275 3.497 9.83 8.2 11.389.603.12.845-.24.845-.6V32.74c-3.377.72-4.1-1.558-4.1-1.558-.483-1.439-1.327-1.799-1.327-1.799-1.085-.719.12-.719.12-.719 1.206.12 1.81 1.199 1.81 1.199 1.085 1.918 2.894 1.319 3.497 1.079.12-.72.361-1.319.723-1.558-2.532-.36-5.427-1.439-5.427-5.994 0-1.32.483-2.398 1.206-3.237-.12-.36-.482-1.559.12-3.237 0 0 .966-.36 3.257 1.199 1.085-.12 2.17-.36 3.135-.36.965 0 2.05.12 3.015.36 2.291-1.559 3.256-1.199 3.256-1.199.603 1.678.241 2.877.12 3.117a4.854 4.854 0 0 1 1.207 3.237c0 4.555-2.774 5.634-5.548 5.874.483.36.844 1.079.844 2.277v3.237c0 .36.242.72.845.6 4.823-1.559 8.2-6.114 8.2-11.389C36.118 17.395 30.692 12 24.059 12z" />
+																</svg>
+															</span>
 														</a>
 													</li>
 												</ul>


### PR DESCRIPTION
Renamed all docs with `nav-toc` from `.md` to `.mdx`. The code changes to doc files are from running `yarn  format:all`.

fixes #3042

going to revisit `nav-toc` later, just used browser default focus styles for now.