### PR TITLE
fix(clay-css): 2.x Date Picker icons should flip when dir="rtl"

### DIFF
--- a/packages/clay-css/src/scss/_mixins.scss
+++ b/packages/clay-css/src/scss/_mixins.scss
@@ -1,5 +1,7 @@
 @import "mixins/_vendor-prefixes";
 
+@import "mixins/_globals";
+
 @import "mixins/_aspect-ratio";
 @import "mixins/_background";
 @import "mixins/_badges";

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -192,6 +192,7 @@
 /// padding-top-mobile: {Number | String | Null},
 /// width-mobile: {Number | String | Null},
 /// loading-animation: {String | Null}, // The placeholder name 'loading-animation' or 'loading-animation-light'
+/// rtl: {Map | Null}, // Pass parameters to `clay-css` mixin
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
@@ -280,6 +281,8 @@
 
 	$loading-animation: setter(map-get($map, loading-animation), $clay-unset-placeholder);
 
+	$rtl: setter(map-get($map, rtl), ());
+
 	align-items: $align-items;
 	background-color: $bg;
 	border-color: $border-color;
@@ -318,6 +321,10 @@
 	word-wrap: $word-wrap;
 
 	@at-root {
+		[dir="rtl"] & {
+			@include clay-css($rtl);
+		}
+
 		a#{&},
 		button#{&} {
 			cursor: $cursor;

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -1,0 +1,239 @@
+////
+/// @group globals
+////
+
+/// A mixin that outputs a CSS property based on the `key: value` pair passed to
+/// the mixin. Outputs nothing if no `key: value` pairs are passed. Prevent a
+/// Clay CSS Sass map from outputting properties with
+/// `$the-variable: (enabled: false);`
+/// @param {Map} $map - A map of `key: value` pairs.
+
+@mixin clay-css($map) {
+	$properties: (
+		'-moz-osx-font-smoothing',
+		'-ms-overflow-style',
+		'-webkit-font-smoothing',
+		'-webkit-tap-highlight-color',
+		'-webkit-text-size-adjust',
+		'align-content',
+		'align-items',
+		'align-self',
+		'animation',
+		'animation-delay',
+		'animation-direction',
+		'animation-duration',
+		'animation-fill-mode',
+		'animation-iteration-count',
+		'animation-name',
+		'animation-play-state',
+		'animation-timing-function',
+		'backface-visibility',
+		'background',
+		'background-attachment',
+		'background-blend-mode',
+		'background-clip',
+		'background-color',
+		'background-image',
+		'background-origin',
+		'background-position',
+		'background-repeat',
+		'background-size',
+		'border',
+		'border-bottom',
+		'border-bottom-color',
+		'border-bottom-left-radius',
+		'border-bottom-right-radius',
+		'border-bottom-style',
+		'border-bottom-width',
+		'border-collapse',
+		'border-color',
+		'border-image',
+		'border-image-outset',
+		'border-image-repeat',
+		'border-image-slice',
+		'border-image-source',
+		'border-image-width',
+		'border-left',
+		'border-left-color',
+		'border-left-style',
+		'border-left-width',
+		'border-radius',
+		'border-right',
+		'border-right-color',
+		'border-right-style',
+		'border-right-width',
+		'border-spacing',
+		'border-style',
+		'border-top',
+		'border-top-color',
+		'border-top-left-radius',
+		'border-top-right-radius',
+		'border-top-style',
+		'border-top-width',
+		'border-width',
+		'bottom',
+		'box-shadow',
+		'box-sizing',
+		'caption-side',
+		'clear',
+		'clip',
+		'color',
+		'column-count',
+		'column-fill',
+		'column-gap',
+		'column-rule',
+		'column-rule-color',
+		'column-rule-style',
+		'column-rule-width',
+		'column-span',
+		'column-width',
+		'columns',
+		'content',
+		'counter-increment',
+		'counter-reset',
+		'cursor',
+		'direction',
+		'display',
+		'empty-cells',
+		'filter',
+		'flex',
+		'flex-basis',
+		'flex-direction',
+		'flex-flow',
+		'flex-grow',
+		'flex-shrink',
+		'flex-wrap',
+		'float',
+		'font',
+		'font-family',
+		'font-kerning',
+		'font-size',
+		'font-stretch',
+		'font-style',
+		'font-variant',
+		'font-weight',
+		'grid',
+		'grid-area',
+		'grid-auto-columns',
+		'grid-auto-flow',
+		'grid-auto-rows',
+		'grid-column',
+		'grid-column-end',
+		'grid-column-gap',
+		'grid-column-start',
+		'grid-gap',
+		'grid-row',
+		'grid-row-end',
+		'grid-row-gap',
+		'grid-row-start',
+		'grid-template',
+		'grid-template-areas',
+		'grid-template-columns',
+		'grid-template-rows',
+		'height',
+		'justify-content',
+		'left',
+		'letter-spacing',
+		'line-height',
+		'list-style',
+		'list-style-image',
+		'list-style-position',
+		'list-style-type',
+		'margin',
+		'margin-bottom',
+		'margin-left',
+		'margin-right',
+		'margin-top',
+		'max-height',
+		'max-width',
+		'min-height',
+		'min-width',
+		'object-fit',
+		'object-position',
+		'opacity',
+		'order',
+		'outline',
+		'outline-color',
+		'outline-offset',
+		'outline-style',
+		'outline-width',
+		'overflow',
+		'overflow-x',
+		'overflow-y',
+		'padding',
+		'padding-bottom',
+		'padding-left',
+		'padding-right',
+		'padding-top',
+		'page-break-after',
+		'page-break-before',
+		'page-break-inside',
+		'perspective',
+		'perspective-origin',
+		'pointer-events',
+		'position',
+		'resize',
+		'right',
+		'scroll-behavior',
+		'scrollbar-width',
+		'table-layout',
+		'text-align',
+		'text-decoration',
+		'text-indent',
+		'text-justify',
+		'text-overflow',
+		'text-shadow',
+		'text-transform',
+		'top',
+		'transform',
+		'transform-origin',
+		'transform-style',
+		'transition',
+		'transition-delay',
+		'transition-duration',
+		'transition-property',
+		'transition-timing-function',
+		'vertical-align',
+		'visibility',
+		'white-space',
+		'width',
+		'word-break',
+		'word-spacing',
+		'writing-mode',
+		'z-index',
+	);
+
+	$enabled: setter(map-get($map, enabled), true);
+
+	@if ($enabled) {
+		@each $key, $value in $map {
+			@if ($key == 'appearance') {
+				-moz-appearance: map-get($map, appearance);
+				-webkit-appearance: map-get($map, appearance);
+
+				&::-ms-expand {
+					display: map-get($map, appearance);
+				}
+
+				appearance: map-get($map, appearance);
+			}
+			@else if ($key == 'word-wrap') {
+				overflow-wrap: map-get($map, word-wrap);
+				word-wrap: map-get($map, word-wrap);
+			}
+			@else if ($key == 'overflow-wrap') {
+				overflow-wrap: map-get($map, overflow-wrap);
+				word-wrap: map-get($map, overflow-wrap);
+			}
+			@else if ($key == 'user-select') {
+				-ms-user-select: map-get($map, user-select);
+				-moz-user-select: map-get($map, user-select);
+				-webkit-user-select: map-get($map, user-select);
+				user-select: map-get($map, user-select);
+			}
+			@else if (index($properties, $key)) {
+				#{$key}: #{$value};
+			}
+		}
+	}
+}

--- a/packages/clay-css/src/scss/variables/_date-picker.scss
+++ b/packages/clay-css/src/scss/variables/_date-picker.scss
@@ -36,6 +36,9 @@ $date-picker-nav-btn-monospaced: () !default;
 $date-picker-nav-btn-monospaced: map-deep-merge((
 	margin-bottom: 0,
 	margin-top: 0,
+	rtl: (
+		transform: rotate(180deg),
+	),
 ), $date-picker-nav-btn-monospaced);
 
 $date-picker-nav-select: () !default;


### PR DESCRIPTION
issue #3029