### PR TITLE
feat(@clayui/label): Add contentBefore prop to ClayLabel

### DIFF
--- a/packages/clay-label/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-label/src/__tests__/__snapshots__/index.tsx.snap
@@ -25,7 +25,7 @@ exports[`Rendering default 1`] = `
 </span>
 `;
 
-exports[`Rendering renders as a link and closable  1`] = `
+exports[`Rendering renders as a link and closable 1`] = `
 <span
   className="label label-dismissible label-secondary"
 >
@@ -82,6 +82,23 @@ exports[`Rendering renders as closable 1`] = `
         />
       </svg>
     </button>
+  </span>
+</span>
+`;
+
+exports[`Rendering renders with an icon before content 1`] = `
+<span
+  className="label label-secondary"
+>
+  <span
+    className="label-item label-item-before"
+  >
+    Content before
+  </span>
+  <span
+    className="label-item label-item-expand"
+  >
+    Label
   </span>
 </span>
 `;

--- a/packages/clay-label/src/__tests__/index.tsx
+++ b/packages/clay-label/src/__tests__/index.tsx
@@ -50,7 +50,7 @@ describe('Rendering', () => {
 		expect(testRenderer.toJSON()).toMatchSnapshot();
 	});
 
-	it('renders as a link and closable ', () => {
+	it('renders as a link and closable', () => {
 		const testRenderer = TestRenderer.create(
 			<ClayLabel
 				closeButtonProps={{
@@ -61,6 +61,14 @@ describe('Rendering', () => {
 			>
 				{'Label Closable'}
 			</ClayLabel>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
+	it('renders with contentBefore prop', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayLabel contentBefore="Content before">{'Label'}</ClayLabel>
 		);
 
 		expect(testRenderer.toJSON()).toMatchSnapshot();

--- a/packages/clay-label/src/index.tsx
+++ b/packages/clay-label/src/index.tsx
@@ -8,6 +8,25 @@ import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
 
+const ClayLabelItemBefore: React.FunctionComponent<
+	React.HTMLAttributes<HTMLDivElement>
+> = ({children}) => (
+	<>
+		<div className="label-item label-item-before">
+			{React.Children.map(children, (child, i) =>
+				React.cloneElement(
+					<span className="label-item label-item-before">
+						{child}
+					</span>,
+					{
+						key: i,
+					}
+				)
+			)}
+		</div>
+	</>
+);
+
 type DisplayType =
 	| 'secondary'
 	| 'info'
@@ -24,6 +43,11 @@ interface IProps
 	closeButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement> & {
 		ref?: (instance: HTMLButtonElement | null) => void;
 	};
+
+	/**
+	 * Any content that you would like to have render inside the label before the children content
+	 */
+	contentBefore?: React.ReactFragment | typeof ClayLabelItemBefore;
 
 	/**
 	 * Determines the style of the label.
@@ -54,6 +78,7 @@ const ClayLabel = React.forwardRef<HTMLAnchorElement | HTMLSpanElement, IProps>(
 			children,
 			className,
 			closeButtonProps,
+			contentBefore,
 			displayType = 'secondary',
 			href,
 			innerElementProps = {},
@@ -75,6 +100,10 @@ const ClayLabel = React.forwardRef<HTMLAnchorElement | HTMLSpanElement, IProps>(
 				})}
 				ref={ref}
 			>
+				{contentBefore && (
+					<ClayLabelItemBefore>{contentBefore}</ClayLabelItemBefore>
+				)}
+
 				<TagName
 					{...innerElementProps}
 					className={classNames(

--- a/packages/clay-label/stories/index.tsx
+++ b/packages/clay-label/stories/index.tsx
@@ -5,6 +5,7 @@
 
 import '@clayui/css/lib/css/atlas.css';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import ClayIcon from '@clayui/icon';
 import {boolean, select, text} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
@@ -56,4 +57,40 @@ storiesOf('Components|ClayLabel', module)
 				{'this is a very long bit of text, can you see the end of it?'}
 			</ClayLabelWithState>
 		</div>
+	))
+	.add('w/ content before', () => (
+		<ClayLabel
+			contentBefore={
+				<ClayIcon spritemap={spritemap} symbol={'repository'} />
+			}
+			displayType={'secondary'}
+			spritemap={spritemap}
+		>
+			{text('Label', 'Label')}
+		</ClayLabel>
+	))
+	.add('w/ content before', () => (
+		<ClayLabel
+			contentBefore={
+				<ClayIcon spritemap={spritemap} symbol="repository" />
+			}
+			displayType={'secondary'}
+			spritemap={spritemap}
+		>
+			{text('Label', 'Label')}
+		</ClayLabel>
+	))
+	.add('w/ multiple contents before', () => (
+		<ClayLabel
+			contentBefore={
+				<>
+					<ClayIcon spritemap={spritemap} symbol="repository" />
+					<ClayIcon spritemap={spritemap} symbol="repository" />
+				</>
+			}
+			displayType={'secondary'}
+			spritemap={spritemap}
+		>
+			{text('Label', 'Label')}
+		</ClayLabel>
 	));


### PR DESCRIPTION
Hey @pat270 I think this one's for you. It's a simple change as requested [here](https://github.com/liferay/clay/issues/2939).

Not specific to the task I'm wondering, when we take on these CSS tasks how do we know what CSS rules to apply, mixins to use, etc.? Do you have a list of rules/classes to use when you want to achieve some things, like is there a class for `display: inline-flex` for example?