### PR TITLE
feat(@clayui/css): Mixins `clay-text-typography` use `clay-css` mixin…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -318,72 +318,29 @@
 /// A mixin for styling a text element (e.g., h1, div, span). This is used in Clay CSS for `*-title`, `*-subtitle`, and `*-tertiary-title` elements.
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
-/// color: {Color | String | Null},
-/// display: {String | Null},
-/// font-family: {String | List | Null},
-/// font-size: {Number | String | Null},
-/// font-weight: {Number | String | Null},
-/// letter-spacing: {String | Null},
-/// line-height: {Number | String | Null},
-/// margin-bottom: {Number | String | Null},
-/// margin-left: {Number | String | Null},
-/// margin-right: {Number | String | Null},
-/// margin-top: {Number | String | Null},
-/// max-width: {Number | String | Null},
-/// padding-bottom: {Number | String | Null},
-/// padding-left: {Number | String | Null},
-/// padding-right: {Number | String | Null},
-/// padding-top: {Number | String | Null},
-/// text-transform: {String | Null},
-/// word-wrap: {String | Null},
-/// clay-link: {Map | Null}, // Pass parameters to `clay-link` mixin
+/// enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// See Mixin `clay-css` for available keys to pass into the base selector
+/// link: {Map | Null},  // See Mixin `clay-css` for available keys
+/// -=-=-=-=-=- Deprecated -=-=-=-=-=-
+/// clay-link: {Map | Null}, // deprecated after 3.9.0 maps to link
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
 
 @mixin clay-text-typography($map) {
-	$color: map-get($map, color);
-	$display: map-get($map, display);
-	$font-family: map-get($map, font-family);
-	$font-size: map-get($map, font-size);
-	$font-weight: map-get($map, font-weight);
-	$letter-spacing: map-get($map, letter-spacing);
-	$line-height: map-get($map, line-height);
-	$margin-bottom: map-get($map, margin-bottom);
-	$margin-left: map-get($map, margin-left);
-	$margin-right: map-get($map, margin-right);
-	$margin-top: map-get($map, margin-top);
-	$max-width: map-get($map, max-width);
-	$padding-bottom: map-get($map, padding-bottom);
-	$padding-left: map-get($map, padding-left);
-	$padding-right: map-get($map, padding-right);
-	$padding-top: map-get($map, padding-top);
-	$text-transform: map-get($map, text-transform);
-	$word-wrap: map-get($map, word-wrap);
+	$enabled: setter(map-get($map, enabled), true);
 
-	$clay-link: setter(map-get($map, clay-link), ());
+	@if ($enabled) {
+		$clay-link: setter(map-get($map, clay-link), ());
 
-	color: $color;
-	display: $display;
-	font-family: $font-family;
-	font-size: $font-size;
-	font-weight: $font-weight;
-	letter-spacing: $letter-spacing;
-	line-height: $line-height;
-	margin-bottom: $margin-bottom;
-	margin-left: $margin-left;
-	margin-right: $margin-right;
-	margin-top: $margin-top;
-	max-width: $max-width;
-	padding-bottom: $padding-bottom;
-	padding-left: $padding-left;
-	padding-right: $padding-right;
-	padding-top: $padding-top;
-	text-transform: $text-transform;
-	word-wrap: $word-wrap;
+		$link: setter(map-get($map, link), ());
+		$link: map-merge($clay-link, $link);
 
-	a {
-		@include clay-link($clay-link);
+		@include clay-css($map);
+
+		a {
+			@include clay-link($link);
+		}
 	}
 }
 


### PR DESCRIPTION
… to generate properties

feat(@clayui/css): Mixins `clay-text-typography` deprecate `clay-link` key and map `clay-link` to `link`

feat(@clayui/css): Mixins `clay-text-typography` adds `enabled` to prevent styles from being output for a specific close variant. This is set to `true` by default.

issue #3075