### PR TITLE
feat(@clayui/demos): Drag and drop demo for table columns and rows

### DIFF
--- a/packages/demos/stories/TableColumnsDragDrop.tsx
+++ b/packages/demos/stories/TableColumnsDragDrop.tsx
@@ -1,0 +1,321 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayTable from '@clayui/table';
+import classNames from 'classnames';
+import React from 'react';
+import {
+	DropTargetMonitor,
+	XYCoord,
+	useDrag,
+	useDragLayer,
+	useDrop,
+} from 'react-dnd';
+
+const TABLE_COLUMN_DND_TYPE = 'tableColumn';
+
+const initialTableColumns = [
+	{
+		data: ['Red, white & blue', 'Tricolore', 'Stars & stripes'],
+		id: 'flag',
+		title: 'Flag',
+	},
+	{
+		data: ['Europe', 'Europe', 'North America'],
+		id: 'region',
+		title: 'Region',
+	},
+	{
+		data: ['Croatia', 'Italy', 'USA'],
+		id: 'country',
+		title: 'Country',
+	},
+	{
+		data: [
+			'Lorem ipsum dolor, sit amet consectetur adipisicing elit.',
+			'Lorem ipsum dolor, sit amet consectetur adipisicing elit.',
+			'Lorem ipsum dolor, sit amet consectetur adipisicing elit.',
+		],
+		id: 'description',
+		title: 'Description',
+	},
+];
+
+export type TColumn = {
+	data: Array<string>;
+	id: string;
+	title: string;
+};
+
+export interface ICustomDragLayerProps {
+	/**
+	 * List of columns in which the Drag Layer will find the one currently being dragged
+	 */
+	columns: Array<TColumn>;
+
+	/**
+	 * Width of the Drag Layer as specified by the width of the heading cell
+	 */
+	width: number;
+}
+
+const CustomDragLayer: React.FunctionComponent<ICustomDragLayerProps> = ({
+	columns,
+	width,
+}) => {
+	const {currentOffset, initialOffset, isDragging, item} = useDragLayer(
+		monitor => ({
+			currentOffset: monitor.getSourceClientOffset(),
+			initialOffset: monitor.getInitialSourceClientOffset(),
+			isDragging: monitor.isDragging(),
+			item: monitor.getItem(),
+		})
+	);
+
+	if (!isDragging) {
+		return null;
+	}
+
+	const columnBeingDragged = columns.find(
+		(column: TColumn) => column.id === item.id
+	);
+
+	return (
+		<ColumnDragPreview
+			column={columnBeingDragged!}
+			currentOffset={currentOffset}
+			initialOffset={initialOffset}
+			width={width}
+		/>
+	);
+};
+
+export interface IColumnDragPreviewProps {
+	/**
+	 * Column to be used as a Drag Preview
+	 */
+	column: TColumn;
+
+	/**
+	 * Current offset of the Drag Preview from the initial position of the heading cell
+	 */
+	currentOffset: XYCoord | null;
+
+	/**
+	 * Initial offset of the Drag Preview
+	 */
+	initialOffset: XYCoord | null;
+
+	/**
+	 * Width of the Drag Layer as specified by the width of the heading cell
+	 */
+	width: number;
+}
+
+const ColumnDragPreview: React.FunctionComponent<IColumnDragPreviewProps> = ({
+	column,
+	currentOffset,
+	initialOffset,
+	width,
+}) => {
+	const dragLayerStyles: React.CSSProperties = {
+		height: '100%',
+		left: 0,
+		pointerEvents: 'none',
+		position: 'fixed',
+		top: 0,
+		width,
+		zIndex: 1060,
+	};
+
+	const dragItemStyles: React.CSSProperties = {
+		display: !initialOffset || !currentOffset ? 'none' : '',
+		transform:
+			initialOffset && currentOffset
+				? `translate(${currentOffset.x}px, ${currentOffset.y}px)`
+				: '',
+	};
+
+	return (
+		<div style={dragLayerStyles}>
+			<div style={dragItemStyles}>
+				<ClayTable>
+					<ClayTable.Head>
+						<ClayTable.Row>
+							<ClayTable.Cell headingCell headingTitle>
+								{column.title}
+							</ClayTable.Cell>
+						</ClayTable.Row>
+					</ClayTable.Head>
+
+					<ClayTable.Body>
+						{column.data.map((cell: string, index: number) => (
+							<ClayTable.Row
+								key={`${column.id}_${cell}_${index}`}
+							>
+								<ClayTable.Cell>{cell}</ClayTable.Cell>
+							</ClayTable.Row>
+						))}
+					</ClayTable.Body>
+				</ClayTable>
+			</div>
+		</div>
+	);
+};
+
+interface IDraggableTableHeadingProps {
+	/**
+	 * Unique identifier of the table heading
+	 */
+	id: string;
+
+	/**
+	 * Index of the table heading item in order to keep track of it's positioning within the array
+	 */
+	index: number;
+
+	/**
+	 * Function that handles the moving of List Items
+	 */
+	onMove: (dragIndex: number, hoverIndex: number) => void;
+
+	/**
+	 * Title of the column, text to be displayed within the heading
+	 */
+	title: string;
+}
+
+interface IDragItem {
+	/**
+	 * List Item unique identifier
+	 */
+	id: string;
+
+	/**
+	 * Index of the List Item in order to keep track of it's positioning within the array
+	 */
+	index: number;
+
+	/**
+	 * Type of data that is allowed to be dragged
+	 */
+	type: string;
+}
+
+const DraggableTableHeaderCell: React.FunctionComponent<
+	IDraggableTableHeadingProps
+> = ({id, index, onMove, title}) => {
+	const ref = React.useRef<HTMLTableHeaderCellElement>(null);
+
+	const [{canDrop}, drop] = useDrop({
+		accept: TABLE_COLUMN_DND_TYPE,
+		collect: (monitor: DropTargetMonitor) => ({
+			canDrop: monitor.canDrop(),
+		}),
+		hover(dragItem: IDragItem) {
+			const dragIndex = dragItem.index;
+
+			const hoverIndex = index;
+
+			if (!ref.current || dragIndex === hoverIndex) {
+				return;
+			}
+
+			onMove(dragIndex, hoverIndex);
+
+			dragItem.index = hoverIndex;
+		},
+	});
+
+	const [{itemBeingDragged}, drag] = useDrag({
+		collect: (monitor: any) => ({
+			itemBeingDragged: monitor.getItem() || {id: 0},
+		}),
+		item: {id, index, type: TABLE_COLUMN_DND_TYPE},
+	});
+
+	drag(drop(ref));
+
+	return (
+		<ClayTable.Cell
+			className={classNames('c-drag', {
+				'c-dragging': itemBeingDragged.id === id,
+				'c-droppable': canDrop,
+			})}
+			headingCell
+			headingTitle
+			ref={ref}
+		>
+			{title}
+		</ClayTable.Cell>
+	);
+};
+
+const ClayTableWithDraggableColumns: React.FunctionComponent = () => {
+	const [tableColumns, setTableColumns] = React.useState(initialTableColumns);
+	const [dragPreviewWidth, setDragPreviewWidth] = React.useState(0);
+
+	const onMove = React.useCallback(
+		(dragIndex: number, hoverIndex: number) => {
+			const columns = [...tableColumns];
+
+			columns.splice(dragIndex, 1);
+
+			columns.splice(hoverIndex, 0, tableColumns[dragIndex]);
+
+			setTableColumns(columns);
+		},
+		[tableColumns]
+	);
+
+	const tableRows = new Array(tableColumns[0].data.length)
+		.fill(null)
+		.map((_item, index: number) =>
+			tableColumns.map((column: TColumn) => column.data[index])
+		);
+
+	return (
+		<>
+			<ClayTable className="table-drag">
+				<ClayTable.Head>
+					<ClayTable.Row>
+						{tableColumns.map((column: TColumn, index: number) => (
+							<DraggableTableHeaderCell
+								id={column.id}
+								index={index}
+								key={column.id}
+								onMove={onMove}
+								title={column.title}
+							/>
+						))}
+					</ClayTable.Row>
+				</ClayTable.Head>
+
+				<ClayTable.Body>
+					{tableRows.map((row, index) => (
+						<ClayTable.Row key={`${row[index]}_${index}`}>
+							{row.map(cell => (
+								<ClayTable.Cell
+									key={`${cell}_${Math.random().toString()}`}
+									ref={node =>
+										node &&
+										setDragPreviewWidth(node.offsetWidth)
+									}
+									truncate
+								>
+									{cell}
+								</ClayTable.Cell>
+							))}
+						</ClayTable.Row>
+					))}
+				</ClayTable.Body>
+			</ClayTable>
+
+			<CustomDragLayer columns={tableColumns} width={dragPreviewWidth} />
+		</>
+	);
+};
+
+export default ClayTableWithDraggableColumns;

--- a/packages/demos/stories/TableRowsDragDrop.tsx
+++ b/packages/demos/stories/TableRowsDragDrop.tsx
@@ -1,0 +1,201 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayTable from '@clayui/table';
+import {XYCoord} from 'dnd-core';
+import React from 'react';
+import {DropTargetMonitor, useDrag, useDrop} from 'react-dnd';
+
+const TABLE_ROW_DND_TYPE = 'tableRow';
+
+const initialTableRows = [
+	{
+		country: 'Croatia',
+		description:
+			'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nobis corrupti exercitationem esse unde a eveniet commodi voluptatem minus ipsum laborum enim quis atque sed nemo quia porro, aut quasi. Maiores.',
+		id: 'hr',
+		region: 'Europe',
+		title: 'Red, white & blue',
+	},
+	{
+		country: 'Italy',
+		description:
+			'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nobis corrupti exercitationem esse unde a eveniet commodi voluptatem minus ipsum laborum enim quis atque sed nemo quia porro, aut quasi. Maiores.',
+		id: 'it',
+		region: 'Europe',
+		title: 'Tricolore',
+	},
+	{
+		country: 'USA',
+		description:
+			'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Nobis corrupti exercitationem esse unde a eveniet commodi voluptatem minus ipsum laborum enim quis atque sed nemo quia porro, aut quasi. Maiores.',
+		id: 'usa',
+		region: 'North America',
+		title: 'Stars & stripes',
+	},
+];
+
+export type TRow = {
+	country: string;
+	description: string;
+	id: string;
+	region: string;
+	title: string;
+};
+
+interface IDraggableTableRowProps {
+	/**
+	 * Content of the row
+	 */
+	content: TRow;
+
+	/**
+	 * Index of the List Item in order to keep track of it's positioning within the array
+	 */
+	index: number;
+
+	/**
+	 * Function that handles the moving of List Items
+	 */
+	onMove: (dragIndex: number, hoverIndex: number) => void;
+}
+
+interface IDragItem {
+	/**
+	 * List Item unique identifier
+	 */
+	id: string;
+
+	/**
+	 * Index of the List Item in order to keep track of it's positioning within the array
+	 */
+	index: number;
+
+	/**
+	 * Type of data that is allowed to be dragged
+	 */
+	type: string;
+}
+
+const DraggableTableRow: React.FunctionComponent<IDraggableTableRowProps> = ({
+	content,
+	index,
+	onMove,
+}) => {
+	const ref = React.useRef<HTMLTableRowElement>(null);
+
+	const [, drop] = useDrop({
+		accept: TABLE_ROW_DND_TYPE,
+		hover(item: IDragItem, monitor: DropTargetMonitor) {
+			const dragIndex = item.index;
+
+			const hoverIndex = index;
+
+			if (!ref.current || dragIndex === hoverIndex) {
+				return;
+			}
+
+			const hoverBoundingRect = ref.current!.getBoundingClientRect();
+
+			const verticalMiddle =
+				(hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+
+			const mousePosition = monitor.getClientOffset();
+
+			const pixelsToTop =
+				(mousePosition as XYCoord).y - hoverBoundingRect.top;
+
+			const draggingUpwards =
+				dragIndex > hoverIndex && pixelsToTop > verticalMiddle * 1.5;
+
+			const draggingDownwards =
+				dragIndex < hoverIndex && pixelsToTop < verticalMiddle / 2;
+
+			if (draggingDownwards || draggingUpwards) {
+				return;
+			}
+
+			onMove(dragIndex, hoverIndex);
+
+			item.index = hoverIndex;
+		},
+	});
+
+	const [{isDragging, itemBeingDragged}, drag] = useDrag({
+		collect: (monitor: any) => ({
+			isDragging: monitor.isDragging(),
+			itemBeingDragged: monitor.getItem() || {id: 0},
+		}),
+		item: {id: content.id, index, type: TABLE_ROW_DND_TYPE},
+	});
+
+	const isItemBeingDragged = itemBeingDragged.id === content.id;
+
+	drag(drop(ref));
+
+	const style = {
+		cursor: isItemBeingDragged ? 'grabbing' : 'grab',
+		opacity: isDragging ? 0 : 1,
+	};
+
+	return (
+		<ClayTable.Row ref={ref} style={style}>
+			<ClayTable.Cell headingTitle>{content.title}</ClayTable.Cell>
+			<ClayTable.Cell>{content.region}</ClayTable.Cell>
+			<ClayTable.Cell>{content.country}</ClayTable.Cell>
+			<ClayTable.Cell truncate>{content.description}</ClayTable.Cell>
+		</ClayTable.Row>
+	);
+};
+
+const ClayTableWithDraggableRows: React.FunctionComponent = () => {
+	const [tableRows, setTableRows] = React.useState(initialTableRows);
+
+	const onMove = React.useCallback(
+		(dragIndex: number, hoverIndex: number) => {
+			const rows = [...tableRows];
+
+			rows.splice(dragIndex, 1);
+
+			rows.splice(hoverIndex, 0, tableRows[dragIndex]);
+
+			setTableRows(rows);
+		},
+		[tableRows]
+	);
+
+	return (
+		<ClayTable>
+			<ClayTable.Head>
+				<ClayTable.Row>
+					<ClayTable.Cell expanded headingCell headingTitle>
+						{'Teams'}
+					</ClayTable.Cell>
+					<ClayTable.Cell headingCell headingTitle>
+						{'Region'}
+					</ClayTable.Cell>
+					<ClayTable.Cell headingCell headingTitle>
+						{'Country'}
+					</ClayTable.Cell>
+					<ClayTable.Cell headingCell headingTitle>
+						{'Description'}
+					</ClayTable.Cell>
+				</ClayTable.Row>
+			</ClayTable.Head>
+			<ClayTable.Body>
+				{tableRows.map((tableRow: TRow, index: number) => (
+					<DraggableTableRow
+						content={tableRow}
+						index={index}
+						key={tableRow.id}
+						onMove={onMove}
+					/>
+				))}
+			</ClayTable.Body>
+		</ClayTable>
+	);
+};
+
+export default ClayTableWithDraggableRows;

--- a/packages/demos/stories/index.tsx
+++ b/packages/demos/stories/index.tsx
@@ -13,6 +13,8 @@ import DragDrop from './DragDrop';
 import FilesPage from './FilesPage';
 import FormPage from './FormPage';
 import ListPage from './ListPage';
+import ClayTableWithDraggableColumns from './TableColumnsDragDrop';
+import ClayTableWithDraggableRows from './TableRowsDragDrop';
 
 import './Recharts';
 
@@ -20,6 +22,16 @@ storiesOf('Demos|Templates', module)
 	.add('List Page', () => <ListPage />)
 	.add('Files Page', () => <FilesPage />)
 	.add('Form Page', () => <FormPage />)
+	.add('Table Rows Drag & Drop', () => (
+		<DndProvider backend={Backend}>
+			<ClayTableWithDraggableRows />
+		</DndProvider>
+	))
+	.add('Table Columns Drag & Drop', () => (
+		<DndProvider backend={Backend}>
+			<ClayTableWithDraggableColumns />
+		</DndProvider>
+	))
 	.add('Drag & Drop', () => (
 		<DndProvider backend={Backend}>
 			<DragDrop />


### PR DESCRIPTION
Hey @bryceosterhaus I've drafted a PR with 2 commits:

- Demos Commit is the one that I've tackled first thinking that's the requirement of the task, but then I figured out that your sentence "Feel free to get creative with it and make a "real" table that has drag and drop." might mean to give users of ClayTable an option to support DnD via a `draggable` prop. So in demos is an example of having a DnD Table but, at least IMO that doesn't really help our users as much as it could, it just gives them an example of how to use it.
- The @clayui/table commit is my proposition of how the API could look without investing too much time into making a working example as I'm unsure what're the exact requirements of the task.

Let me know which of the commits to pursue and polish. In case you wanna have a discussion about this hit me up on Slack when you see this.