### PR TITLE
fix(clay-css): 2.x Forms small form elements should have 4px border-radius

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -15,6 +15,8 @@ $input-border-top-width: $input-border-width !default; // 1px
 
 $input-border-style: solid !default;
 
+$input-border-radius-sm: $border-radius !default;
+
 $input-padding-x: 1rem !default; // 16px
 $input-padding-y: 0.4375rem !default; // 7px
 


### PR DESCRIPTION
issue #3105