### PR TITLE
fix(clay-css): Forms `.form-control-sm` and `.form-control-lg` should…

### DIFF
--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -419,12 +419,7 @@ fieldset[disabled] label {
 }
 
 .form-control-lg {
-	font-size: $input-font-size-lg;
-	height: $input-height-lg;
-
-	@include clay-scale-component {
-		height: $input-height-lg-mobile;
-	}
+	@extend %clay-form-control-lg;
 }
 
 %clay-select-form-control-lg {
@@ -464,12 +459,7 @@ textarea.form-control-lg,
 }
 
 .form-control-sm {
-	font-size: $input-font-size-sm;
-	height: $input-height-sm;
-
-	@include clay-scale-component {
-		height: $input-height-sm-mobile;
-	}
+	@extend %clay-form-control-sm;
 }
 
 %clay-select-form-control-sm {


### PR DESCRIPTION
… have correct left and right padding

issue: #3110