### PR TITLE
fix(@clayui/localized-input): Add missing spritemap value for Localized Input story

### DIFF
--- a/packages/clay-localized-input/stories/index.tsx
+++ b/packages/clay-localized-input/stories/index.tsx
@@ -10,6 +10,7 @@
  */
 
 import '@clayui/css/lib/css/atlas.css';
+const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 
@@ -51,6 +52,7 @@ storiesOf('Components|ClayLocalizedInput', module).add('default', () => {
 				onSelectedLocaleChange={setSelectedLocale}
 				onTranslationsChange={setTranslations}
 				selectedLocale={selectedLocale}
+				spritemap={spritemap}
 				translations={translations}
 			/>
 			<br />
@@ -64,6 +66,7 @@ storiesOf('Components|ClayLocalizedInput', module).add('default', () => {
 				prependContent={prepend}
 				resultFormatter={val => `https://liferay.com${prepend}${val}`}
 				selectedLocale={selectedLocale}
+				spritemap={spritemap}
 				translations={translations}
 			/>
 		</div>


### PR DESCRIPTION
Fixes [3115](https://github.com/liferay/clay/issues/3115)