### PR TITLE
docs(clayui.com): Documentation for the ClayPanelTitle component

### DIFF
--- a/clayui.com/content/docs/components/Panel.mdx
+++ b/clayui.com/content/docs/components/Panel.mdx
@@ -5,24 +5,35 @@ packageNpm: '@clayui/panel'
 sibling: 'docs/components/css-panel.html'
 ---
 
-import {Panel} from '../../../src/components/clay/Panel';
+import {Panel, PanelWithCustomTitle} from '../../../src/components/clay/Panel';
 
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
+-   [Basic Usage](#basic-usage)
+-   [Usage with a custom Title](#usage-with-a-custom-title)
 -   [API](#api)
     -   [ClayPanel](#claypanel)
     -   [ClayPanel.Body](#claypanel.body)
     -   [ClayPanel.Footer](#claypanel.footer)
     -   [ClayPanel.Group](#claypanel.group)
     -   [ClayPanel.Header](#claypanel.header)
+    -   [ClayPanel.Title](#claypanel.title)
 
 </div>
 </div>
 
 The Panel is a replacement for the old ClayCollapse in version 2.x, has the same effect but written in React using composition, try it. We recommend that you review the [use cases in the Storybook](https://storybook.clayui.com/?path=/story/claypanel--default).
 
+## Basic Usage
+
 <Panel />
+
+## Usage with a custom Title
+
+`ClayPanel.Title` allows you to add custom content to the title of the panel as seen in this example using `ClayLabels`.
+
+<PanelWithCustomTitle />
 
 ## API
 
@@ -47,6 +58,12 @@ The Panel is a replacement for the old ClayCollapse in version 2.x, has the same
 <div>[APITable "clay-panel/src/Group.tsx"]</div>
 
 ### ClayPanel.Header
+
+<code class="list-api-item-type">
+	Extends from {`React.HTMLAttributes<HTMLDivElement>`}
+</code>
+
+### ClayPanel.Title
 
 <code class="list-api-item-type">
 	Extends from {`React.HTMLAttributes<HTMLDivElement>`}

--- a/clayui.com/content/docs/components/css-panel.md
+++ b/clayui.com/content/docs/components/css-panel.md
@@ -10,6 +10,7 @@ description: 'Panel provides an expandable details-summary view.'
 -   [Collapsable](#collapsable)
 -   [Groups](#groups)
 -   [With Sheets](#with-sheets)
+-   [With a custom Title](#with-a-custom-title)
 
 </div>
 </div>
@@ -492,6 +493,103 @@ Sometimes you might want to place a panel inside of a card or a sheet, in that c
 				</div>
 			</div>
 		</div>
+	</div>
+</div>
+```
+
+## With a custom Title
+
+Sometimes you want to have some custom content that's not a string or a number in your title, that's where `ClayPanel.Title` comes in handy. It allows you to add custom content to the title of the panel as seen in this example using `ClayLabels`.
+
+<div class="sheet-example">
+	<div class="panel panel-secondary" role="tablist">
+		<button aria-controls="panelWithCustomTitle" aria-expanded="false" class="btn btn-unstyled panel-header panel-header-link collapse-icon collapse-icon-middle collapsed" data-target="#collapsePanelWithCustomTitle" data-toggle="collapse" role="tab">
+			<div>
+				<h3>Title</h3>
+				<span>If field </span>
+				<span class="label label-success">
+					<span class="label-item label-item-expand">Country</span>
+				</span>
+				<span class="label label-secondary">
+					<span class="label-item label-item-expand">Is Equal To</span>
+				</span>
+				<span>value </span>
+				<span class="label label-info">
+					<span class="label-item label-item-expand">Brazil</span>
+				</span>
+				<span>enable </span>
+				<span class="label label-success">
+					<span class="label-item label-item-expand">State</span>
+				</span>
+			</div>
+			<span class="collapse-icon-closed">
+				<svg class="lexicon-icon lexicon-icon-angle-right" role="presentation">
+					<use xlink:href="/images/icons/icons.svg#angle-right"></use>
+				</svg>
+			</span>
+			<span class="collapse-icon-open">
+				<svg class="lexicon-icon lexicon-icon-angle-down" role="presentation">
+					<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+				</svg>
+			</span>
+		</button>
+		<div class="panel-collapse collapse" id="collapsePanelWithCustomTitle" role="tabpanel">
+			<div class="panel-body">Body!</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="panel panel-secondary" role="tablist">
+	<button
+		aria-controls="panelWithCustomTitle"
+		aria-expanded="false"
+		class="btn btn-unstyled panel-header panel-header-link collapse-icon collapse-icon-middle collapsed"
+		data-target="#collapsePanelWithCustomTitle"
+		data-toggle="collapse"
+		role="tab"
+	>
+		<div>
+			<h3>Title</h3>
+			<span>If field </span>
+			<span class="label label-success">
+				<span class="label-item label-item-expand">Country</span>
+			</span>
+			<span class="label label-secondary">
+				<span class="label-item label-item-expand">Is Equal To</span>
+			</span>
+			<span>value </span>
+			<span class="label label-info">
+				<span class="label-item label-item-expand">Brazil</span>
+			</span>
+			<span>enable </span>
+			<span class="label label-success">
+				<span class="label-item label-item-expand">State</span>
+			</span>
+		</div>
+		<span class="collapse-icon-closed">
+			<svg
+				class="lexicon-icon lexicon-icon-angle-right"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#angle-right"></use>
+			</svg>
+		</span>
+		<span class="collapse-icon-open">
+			<svg
+				class="lexicon-icon lexicon-icon-angle-down"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+			</svg>
+		</span>
+	</button>
+	<div
+		class="panel-collapse collapse"
+		id="collapsePanelWithCustomTitle"
+		role="tabpanel"
+	>
+		<div class="panel-body">Body!</div>
 	</div>
 </div>
 ```

--- a/clayui.com/src/components/clay/Panel.js
+++ b/clayui.com/src/components/clay/Panel.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import ClayLabel from '@clayui/label';
 import ClayPanel from '@clayui/panel';
 import React, {useState} from 'react';
 
@@ -33,4 +34,45 @@ const Panel = () => {
 	return <Editor code={panelCode} imports={panelImportsCode} scope={scope} />;
 };
 
-export {Panel};
+const panelWithCustomTitleImports = `import ClayPanel from '@clayui/panel';
+import ClayLabel from '@clayui/label';
+import React from 'react';`;
+
+const panelWithCustomTitleCode = `const Component = () => (
+	<ClayPanel
+		collapsable
+		displayTitle={
+			<ClayPanel.Title>
+				<h3>{'Title'}</h3>
+				<span>{'If field '}</span>
+				<ClayLabel displayType="success">{'Country'}</ClayLabel>
+				<ClayLabel>{'Is Equal To'}</ClayLabel>
+				<span>{'value '}</span>
+				<ClayLabel displayType="info">{'Brazil'}</ClayLabel>
+				<span>{'enable '}</span>
+				<ClayLabel displayType="success">{'State'}</ClayLabel>
+			</ClayPanel.Title>
+		}
+		displayType="secondary"
+		showCollapseIcon={true}
+		spritemap={spritemap}
+	>
+		<ClayPanel.Body>{'Body!'}</ClayPanel.Body>
+	</ClayPanel>
+);
+
+render(<Component />)`;
+
+const PanelWithCustomTitle = () => {
+	const scope = {ClayLabel, ClayPanel, spritemap, useState};
+
+	return (
+		<Editor
+			code={panelWithCustomTitleCode}
+			imports={panelWithCustomTitleImports}
+			scope={scope}
+		/>
+	);
+};
+
+export {Panel, PanelWithCustomTitle};


### PR DESCRIPTION
Fixes #3135 

One caveat with this one, it won't work until `ClayPanelTitle` at #3133 isn't merged.
Also tried to rename `Panel.mdx`to `panel.mdx` again, not sure if it got picked up, VSCode shows both exist in the Search but not in the Explorer.

So I'm marking this as a Draft and then when #3133 gets merged whoever is present can switch it to a normal PR. 