### PR TITLE
feat(@clayui/data-provider): dedupe concurrent requests

### DIFF
--- a/packages/clay-data-provider/stories/index.tsx
+++ b/packages/clay-data-provider/stories/index.tsx
@@ -24,7 +24,7 @@ const ClayDataProviderWithVariablesAndStorage = () => {
 		<div className="col-md-4">
 			<ClayDataProvider
 				fetchPolicy={FetchPolicy.CacheFirst}
-				link="https://rickandmortyapi.com/api/character"
+				link="https://rickandmortyapi.com/api/character/"
 				notifyOnNetworkStatusChange
 				storage={store}
 				variables={{name: value}}
@@ -217,7 +217,7 @@ storiesOf('Components|ClayDataProvider', module)
 		const [poll, setPoll] = React.useState(false);
 
 		useResource({
-			link: 'https://rickandmortyapi.com/api/character',
+			link: 'https://rickandmortyapi.com/api/character/',
 			pollInterval: poll ? 1000 : 0,
 			variables: {limit: 10},
 		});
@@ -238,6 +238,57 @@ storiesOf('Components|ClayDataProvider', module)
 						>
 							{'Toggle Poll'}
 						</button>
+					</div>
+				</div>
+			</div>
+		);
+	})
+	.add('with dedupe concurrent requests', () => {
+		const List = () => {
+			const {resource} = useResource({
+				fetchPolicy: FetchPolicy.CacheFirst,
+				link: 'https://rickandmortyapi.com/api/character/1,2,3',
+			});
+
+			if (!resource) {
+				return null;
+			}
+
+			return resource.map((item: any) => (
+				<li
+					className="list-group-item list-group-item-flex"
+					key={item.id}
+				>
+					<div className="autofit-col autofit-col-expand">
+						<p className="list-group-title text-truncate">
+							{'Name'}
+						</p>
+						<p className="list-group-subtitle text-truncate">
+							{item.name}
+						</p>
+					</div>
+				</li>
+			));
+		};
+
+		return (
+			<div className="pb-4 sheet">
+				<h3>{`Concurrent requests`}</h3>
+				<div className="row">
+					<div className="col-md-5">
+						<p>
+							{
+								'This screen has the duplicate component that makes the request for the same endpoint but only one request is made. Open your console to see the network tab.'
+							}
+						</p>
+					</div>
+				</div>
+				<div className="row">
+					<div className="col-md-5">
+						<List />
+					</div>
+					<div className="col-md-5">
+						<List />
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This dedup of concurrent requests to the same address, this is for cases when the same component is displayed twice on the screen, a strategy that the application does to mitigate this is to move to above of component with useResource state, but now it is not more necessary because we have normalized everything, it makes the experience more comfortable for the developer.

I think this is part of other details that I want to implement in the data provider to encourage good standards in dealing with the flow of data in the applications, using suspense, fetching early... I will work more on this after I am finished with the migration DDM-field-type... probably 😁! 