### PR TITLE
feat(@clayui/modal): Add iFrameProps to ModalBody

### DIFF
--- a/packages/clay-modal/src/Body.tsx
+++ b/packages/clay-modal/src/Body.tsx
@@ -8,6 +8,11 @@ import React from 'react';
 
 export interface IBodyProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
+	 * Props to add to the iframe element
+	 */
+	iFrameProps?: React.HTMLAttributes<HTMLIFrameElement>;
+
+	/**
 	 * Flag to indicate if body should be a fixed height with a scrollable overflow.
 	 */
 	scrollable?: boolean;
@@ -20,6 +25,7 @@ export interface IBodyProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const ClayModalBody: React.FunctionComponent<IBodyProps> = ({
 	children,
+	iFrameProps = {},
 	scrollable,
 	url,
 }: IBodyProps) => (
@@ -30,7 +36,7 @@ const ClayModalBody: React.FunctionComponent<IBodyProps> = ({
 		})}
 		tabIndex={scrollable ? 0 : undefined}
 	>
-		{url ? <iframe src={url} title={url} /> : children}
+		{url ? <iframe {...iFrameProps} src={url} title={url} /> : children}
 	</div>
 );
 

--- a/packages/clay-modal/stories/index.tsx
+++ b/packages/clay-modal/stories/index.tsx
@@ -80,6 +80,9 @@ storiesOf('Components|ClayModal', module)
 							{text('Title', 'Title')}
 						</ClayModal.Header>
 						<ClayModal.Body
+							iFrameProps={{
+								'aria-label': 'Hello World',
+							}}
 							scrollable={boolean('scrollable', false)}
 							url={text('Url', '')}
 						>


### PR DESCRIPTION
Hey @bryceosterhaus & @matuzalemsteles is this what we want from the [issue](https://github.com/liferay/clay/issues/3111)? I included a usage example to showcase how I think it will get used. I picked up the pattern from other places that we have on Clay, like ClayTabs etc.