### PR TITLE
feat(@clayui/css): Mixin `clay-autofit-row` should use `clay-css` mix…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_utilities.scss
+++ b/packages/clay-css/src/scss/mixins/_utilities.scss
@@ -25,45 +25,35 @@
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
 /// enabled: {Bool},  // Set to false to prevent mixin styles from being output. Default: true
-/// margin: {Number | String | List | Null},
-/// margin-bottom: {Number | String | Null},
-/// margin-left: {Number | String | Null},
-/// margin-right: {Number | String | Null},
-/// margin-top: {Number | String | Null},
-/// autofit-col-padding: {Number | String | List | Null},
-/// autofit-col-padding-bottom: {Number | String | Null},
-/// autofit-col-padding-left: {Number | String | Null},
-/// autofit-col-padding-right: {Number | String | Null},
-/// autofit-col-padding-top: {Number | String | Null},
+/// See Mixin `clay-css` for available keys to pass into the base selector
+/// autofit-col: {Map | Null}, // See Mixin `clay-css` for available keys
+/// -=-=-=-=-=- Deprecated -=-=-=-=-=-
+/// autofit-col-padding: {Number | String | List | Null}, // deprecated after 3.9.0
+/// autofit-col-padding-bottom: {Number | String | Null}, // deprecated after 3.9.0
+/// autofit-col-padding-left: {Number | String | Null}, // deprecated after 3.9.0
+/// autofit-col-padding-right: {Number | String | Null}, // deprecated after 3.9.0
+/// autofit-col-padding-top: {Number | String | Null}, // deprecated after 3.9.0
 
 @mixin clay-autofit-row($map) {
 	$enabled: setter(map-get($map, enabled), true);
 
-	$margin: map-get($map, margin);
-	$margin-bottom: map-get($map, margin-bottom);
-	$margin-left: map-get($map, margin-left);
-	$margin-right: map-get($map, margin-right);
-	$margin-top: map-get($map, margin-top);
-
-	$autofit-col-padding: map-get($map, autofit-col-padding);
-	$autofit-col-padding-bottom: map-get($map, autofit-col-padding-bottom);
-	$autofit-col-padding-left: map-get($map, autofit-col-padding-left);
-	$autofit-col-padding-right: map-get($map, autofit-col-padding-right);
-	$autofit-col-padding-top: map-get($map, autofit-col-padding-top);
+	$autofit-col: setter(map-get($map, autofit-col), ());
+	$autofit-col: map-merge(
+		(
+			padding: map-get($map, autofit-col-padding),
+			padding-bottom: map-get($map, autofit-col-padding-bottom),
+			padding-left: map-get($map, autofit-col-padding-left),
+			padding-right: map-get($map, autofit-col-padding-right),
+			padding-top: map-get($map, autofit-col-padding-top),
+		),
+		$autofit-col
+	);
 
 	@if ($enabled) {
-		margin: $margin;
-		margin-bottom: $margin-bottom;
-		margin-left: $margin-left;
-		margin-right: $margin-right;
-		margin-top: $margin-top;
+		@include clay-css($map);
 
 		> .autofit-col {
-			padding: $autofit-col-padding;
-			padding-bottom: $autofit-col-padding-bottom;
-			padding-left: $autofit-col-padding-left;
-			padding-right: $autofit-col-padding-right;
-			padding-top: $autofit-col-padding-top;
+			@include clay-css($autofit-col);
 		}
 	}
 }


### PR DESCRIPTION
…in to generate properties

fixes #3075