### PR TITLE
feat(@clayui/css): Mixin `clay-modal-variant` should use `clay-css` mixin to generate properties

### DIFF
--- a/packages/clay-css/src/scss/mixins/_close.scss
+++ b/packages/clay-css/src/scss/mixins/_close.scss
@@ -9,26 +9,41 @@
 /// See Mixin `clay-css` for available keys to pass into the base selector
 /// hover: {Map | Null}, // See Mixin `clay-css` for available keys
 /// focus: {Map | Null}, // See Mixin `clay-css` for available keys
-/// disabled: {Map | Null}, // See Mixin `clay-css` for available keys
 /// active: {Map | Null}, // See Mixin `clay-css` for available keys
+/// active-class: {Map | Null}, // See Mixin `clay-css` for available keys, inherits:
+/// // background-color, border-color, color, font-weight, z-index from active
+/// disabled: {Map | Null}, // See Mixin `clay-css` for available keys
+/// disabled-active: {Map | Null}, // See Mixin `clay-css` for available keys
 /// btn-focus: {Map | Null}, // See Mixin `clay-css` for available keys
 /// lexicon-icon: {Map | Null}, // See Mixin `clay-css` for available keys
 /// c-inner: {Map | Null}, // Pass parameters to `clay-css` mixin
 /// -=-=-=-=-=- Deprecated -=-=-=-=-=-
 /// bg: {Color | String | Null}, // deprecated after 3.9.0
 /// hover-bg: {Color | String | Null}, // deprecated after 3.9.0
+/// hover-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
 /// hover-color: {Color | String | Null}, // deprecated after 3.9.0
 /// hover-opacity: {Number | String | Null}, // deprecated after 3.9.0
 /// hover-text-decoration: {String | Null}, // deprecated after 3.9.0
+/// hover-z-index: {Number | String | Null}, // deprecated after 3.9.0
 /// focus-bg: {Color | String | Null}, // deprecated after 3.9.0
+/// focus-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
+/// focus-border-radius: {Number | String | List | Null}, // deprecated after 3.9.0
 /// focus-box-shadow: {String | List | Null}, // deprecated after 3.9.0
 /// focus-color: {Color | String | Null}, // deprecated after 3.9.0
 /// focus-opacity: {Number | String | Null}, // deprecated after 3.9.0
 /// focus-outline: {Number | String | Null}, // deprecated after 3.9.0
+/// focus-z-index: {Number | String | Null}, // deprecated after 3.9.0
 /// focus-text-decoration: {String | Null}, // deprecated after 3.9.0
 /// active-bg: {Color | String | Null}, // deprecated after 3.9.0
 /// active-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
 /// active-color: {Color | String | Null}, // deprecated after 3.9.0
+/// active-font-weight: {Number | String | Null}, // deprecated after 3.9.0
+/// active-z-index: {Number | String | Null}, // deprecated after 3.9.0
+/// active-class-bg: {Color | String | Null}, // deprecated after 3.9.0 Default: active-bg
+/// active-class-border-color: {Color | String | List | Null}, // deprecated after 3.9.0 Default: active-border-color
+/// active-class-color: {Color | String | Null}, // deprecated after 3.9.0 Default: active-color
+/// active-class-font-weight: {Number | String | Null}, // deprecated after 3.9.0 Default: active-font-weight
+/// active-class-z-index: {Number | String | Null}, // deprecated after 3.9.0 Default: active-z-index
 /// disabled-bg: {Color | String | Null}, // deprecated after 3.9.0
 /// disabled-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
 /// disabled-box-shadow: {String | List | Null}, // deprecated after 3.9.0
@@ -37,6 +52,7 @@
 /// disabled-opacity: {Number | String | Null}, // deprecated after 3.9.0
 /// disabled-pointer-events: {String | Null}, // deprecated after 3.9.0
 /// disabled-text-decoration: {String | Null}, // deprecated after 3.9.0
+/// disabled-active-pointer-events: {String | Null}, // deprecated after 3.9.0
 /// btn-focus-box-shadow: {String | List | Null}, // deprecated after 3.9.0
 /// btn-focus-outline: {Number | String | Null}, // deprecated after 3.9.0
 /// lexicon-icon-margin-bottom: {Number | String | Null}, // deprecated after 3.9.0
@@ -61,9 +77,11 @@
 	$hover: map-merge(
 		(
 			background-color: map-get($map, hover-bg),
+			border-color: map-get($map, hover-border-color),
 			color: map-get($map, hover-color),
 			opacity: map-get($map, hover-opacity),
 			text-decoration: map-get($map, hover-text-decoration),
+			z-index: map-get($map, hover-z-index),
 		),
 		$hover
 	);
@@ -72,13 +90,57 @@
 	$focus: map-merge(
 		(
 			background-color: map-get($map, focus-bg),
+			border-color: map-get($map, focus-border-color),
+			border-radius: map-get($map, focus-border-radius),
 			box-shadow: map-get($map, focus-box-shadow),
 			color: map-get($map, focus-color),
 			opacity: map-get($map, focus-opacity),
 			outline: map-get($map, focus-outline),
 			text-decoration: map-get($map, focus-text-decoration),
+			z-index: map-get($map, focus-z-index),
 		),
 		$focus
+	);
+
+	$active: setter(map-get($map, active), ());
+	$active: map-merge(
+		(
+			background-color: map-get($map, active-bg),
+			border-color: map-get($map, active-border-color),
+			color: map-get($map, active-color),
+			font-weight: map-get($map, active-font-weight),
+			z-index: map-get($map, active-z-index),
+		),
+		$active
+	);
+
+	$active-class: setter(map-get($map, active-class), ());
+	$active-class: map-merge(
+		(
+			background-color:
+				setter(map-get($map, active-class-bg), map-get($map, active-bg)),
+			border-color:
+				setter(
+					map-get($map, active-class-border-color),
+					map-get($map, active-border-color)
+				),
+			color:
+				setter(
+					map-get($map, active-class-color),
+					map-get($map, active-color)
+				),
+			font-weight:
+				setter(
+					map-get($map, active-class-font-weight),
+					map-get($map, active-font-weight)
+				),
+			z-index:
+				setter(
+					map-get($map, active-class-z-index),
+					map-get($map, active-z-index)
+				),
+		),
+		$active-class
 	);
 
 	$disabled: setter(map-get($map, disabled), ());
@@ -96,14 +158,12 @@
 		$disabled
 	);
 
-	$active: setter(map-get($map, active), ());
-	$active: map-merge(
+	$disabled-active: setter(map-get($map, disabled-active), ());
+	$disabled-active: map-merge(
 		(
-			background-color: map-get($map, active-bg),
-			border-color: map-get($map, active-border-color),
-			color: map-get($map, active-color),
+			pointer-events: map-get($map, disabled-active-pointer-events),
 		),
-		$active
+		$disabled-active
 	);
 
 	$btn-focus: setter(map-get($map, btn-focus), ());
@@ -118,6 +178,7 @@
 	$lexicon-icon: setter(map-get($map, lexicon-icon), ());
 	$lexicon-icon: map-merge(
 		(
+			font-size: map-get($map, lexicon-icon-font-size),
 			margin-bottom: map-get($map, lexicon-icon-margin-bottom),
 			margin-left: map-get($map, lexicon-icon-margin-left),
 			margin-right: map-get($map, lexicon-icon-margin-right),
@@ -168,14 +229,22 @@
 			}
 		}
 
-		&:active,
-		&.active {
+		&:active {
 			@include clay-css($active);
+		}
+
+		.show > &,
+		&.active {
+			@include clay-css($active-class);
 		}
 
 		&:disabled,
 		&.disabled {
 			@include clay-css($disabled);
+
+			&:active {
+				@include clay-css($disabled-active);
+			}
 		}
 
 		@if ($enable-c-inner) {

--- a/packages/clay-css/src/scss/mixins/_modals.scss
+++ b/packages/clay-css/src/scss/mixins/_modals.scss
@@ -5,67 +5,90 @@
 /// A mixin to create a Modal color variant. This is used in `.modal-danger`, `.modal-info`, `.modal-success`, and `.modal-warning`.
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
-/// header-bg: {Color | String | Null},
-/// header-border-color: {Color | String | List | Null},
-/// header-color: {Color | String | Null},
-///	// header-close-color is deprecated in v2.0.0-rc.12 use header-close instead
-/// header-close-color: {Color | String},
-/// header-close: {Map | Null}, // Pass parameters to `clay-link` mixin
-/// body-bg: {Color | String | Null},
-/// body-color: {Color | String | Null},
-/// footer-bg: {Color | String | Null},
-/// footer-border-color: {Color | String | List | Null},
+/// enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// header: {Map | Null}, // See Mixin `clay-css` for available keys
+/// header-close: {Map | Null}, // See Mixin `clay-close` for available keys
+/// body: {Map | Null}, // See Mixin `clay-css` for available keys
+/// footer: {Map | Null}, // See Mixin `clay-css` for available keys
+/// -=-=-=-=-=- Deprecated -=-=-=-=-=-
+/// header-bg: {Color | String | Null}, // deprecated after 3.9.0
+/// header-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
+/// header-color: {Color | String | Null}, // deprecated after 3.9.0
+/// header-close-color: {Color | String}, // deprecated in v2.0.0-rc.12
+/// body-bg: {Color | String | Null}, // deprecated after 3.9.0
+/// body-color: {Color | String | Null}, // deprecated after 3.9.0
+/// footer-bg: {Color | String | Null}, // deprecated after 3.9.0
+/// footer-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
 
 @mixin clay-modal-variant($map) {
-	$header-bg: map-get($map, header-bg);
-	$header-border-color: map-get($map, header-border-color);
-	$header-color: map-get($map, header-color);
+	$enabled: setter(map-get($map, enabled), true);
 
-	// header-close-color is deprecated in v2.0.0-rc.12 use header-close instead
-
-	$header-close-color: setter(
-		map-get($map, header-close-color),
-		$header-color
+	$header: setter(map-get($map, header), ());
+	$header: map-merge(
+		(
+			background-color: map-get($map, header-bg),
+			border-color: map-get($map, header-border-color),
+			color: map-get($map, header-color),
+		),
+		$header
 	);
 
 	$header-close: setter(map-get($map, header-close), ());
+	$header-close: map-merge(
+		(
+			color: map-get($map, header-close-color),
+		),
+		$header-close
+	);
 
-	$body-bg: map-get($map, body-bg);
-	$body-color: map-get($map, body-color);
-	$footer-bg: map-get($map, footer-bg);
-	$footer-border-color: map-get($map, footer-border-color);
+	$body: setter(map-get($map, body), ());
+	$body: map-merge(
+		(
+			background-color: map-get($map, body-bg),
+			color: map-get($map, body-color),
+		),
+		$body
+	);
 
-	// Modal specific btn-monospaced is deprecated in v2.0.0-rc.12
+	$footer: setter(map-get($map, footer), ());
+	$footer: map-merge(
+		(
+			background-color: map-get($map, footer-bg),
+			border-color: map-get($map, footer-border-color),
+		),
+		$footer
+	);
 
-	.btn-monospaced {
-		color: $header-close-color;
-	}
+	@if ($enabled) {
+		@include clay-css($map);
 
-	.close {
-		@include clay-link($header-close);
-	}
+		// Modal specific btn-monospaced is deprecated in v2.0.0-rc.12
 
-	button.close {
-		&:focus {
-			box-shadow: map-get($header-close, btn-focus-box-shadow);
-			outline: map-get($header-close, btn-focus-outline);
+		.btn-monospaced {
+			color: map-get($header-close, color);
 		}
-	}
 
-	.modal-header {
-		background-color: $header-bg;
-		border-color: $header-border-color;
-		color: $header-color;
-	}
+		.close {
+			@include clay-close($header-close);
+		}
 
-	.modal-body {
-		background-color: $body-bg;
-		color: $body-color;
-	}
+		button.close {
+			&:focus {
+				box-shadow: map-get($header-close, btn-focus-box-shadow);
+				outline: map-get($header-close, btn-focus-outline);
+			}
+		}
 
-	.modal-footer {
-		background-color: $footer-bg;
-		border-color: $footer-border-color;
-		color: $footer-border-color;
+		.modal-header {
+			@include clay-css($header);
+		}
+
+		.modal-body {
+			@include clay-css($body);
+		}
+
+		.modal-footer {
+			@include clay-css($footer);
+		}
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_modals.scss
+++ b/packages/clay-css/src/scss/mixins/_modals.scss
@@ -25,38 +25,76 @@
 
 	$header: setter(map-get($map, header), ());
 	$header: map-merge(
+		$header,
 		(
-			background-color: map-get($map, header-bg),
-			border-color: map-get($map, header-border-color),
-			color: map-get($map, header-color),
-		),
-		$header
+			background-color:
+				setter(
+					map-get($map, header-bg),
+					map-get($header, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, header-border-color),
+					map-get($header, border-color)
+				),
+			color: setter(map-get($map, header-color), map-get($header, color)),
+		)
 	);
 
 	$header-close: setter(map-get($map, header-close), ());
 	$header-close: map-merge(
+		$header-close,
 		(
-			color: map-get($map, header-close-color),
-		),
-		$header-close
+			color:
+				setter(
+					map-get($map, header-close-color),
+					map-get($header-close, color)
+				),
+		)
+	);
+
+	$header-close-btn-focus: setter(map-get($header-close, btn-focus), ());
+	$header-close-btn-focus: map-merge(
+		$header-close-btn-focus,
+		(
+			box-shadow:
+				setter(
+					map-get($header-close, btn-focus-box-shadow),
+					map-get($header-close-btn-focus, box-shadow)
+				),
+			outline:
+				setter(
+					map-get($header-close, btn-focus-outline),
+					map-get($header-close-btn-focus, outline)
+				),
+		)
 	);
 
 	$body: setter(map-get($map, body), ());
 	$body: map-merge(
+		$body,
 		(
-			background-color: map-get($map, body-bg),
-			color: map-get($map, body-color),
-		),
-		$body
+			background-color:
+				setter(map-get($map, body-bg), map-get($body, background-color)),
+			color: setter(map-get($map, body-color), map-get($body, color)),
+		)
 	);
 
 	$footer: setter(map-get($map, footer), ());
 	$footer: map-merge(
+		$footer,
 		(
-			background-color: map-get($map, footer-bg),
-			border-color: map-get($map, footer-border-color),
-		),
-		$footer
+			background-color:
+				setter(
+					map-get($map, footer-bg),
+					map-get($footer, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, footer-border-color),
+					map-get($footer, border-color)
+				),
+		)
 	);
 
 	@if ($enabled) {
@@ -74,8 +112,8 @@
 
 		button.close {
 			&:focus {
-				box-shadow: map-get($header-close, btn-focus-box-shadow);
-				outline: map-get($header-close, btn-focus-outline);
+				box-shadow: map-get($header-close-btn-focus, box-shadow);
+				outline: map-get($header-close-btn-focus, outline);
 			}
 		}
 


### PR DESCRIPTION
feat(@clayui/css): Mixin `clay-close` should match `clay-link` to preserve compatibility.

feat(@clayui/css): Mixin `clay-modal-variant` should use `clay-close` to generate `.close` properties

feat(@clayui/css): Mixin `clay-modal-variant` add option to passin base selector styles

feat(@clayui/css): Mixin `clay-modal-variant` adds `enabled` to prevent styles from being output for a specific close variant. This is set to `true` by default.

fix(@clayui/css): Mixin `clay-modal-variant` deprecated keys should win to preserve backward compatibility

issue #3075