### PR TITLE
feat(@clayui/css): Mixin `clay-panel-variant` should use `clay-css` mixin to generate properties

### DIFF
--- a/packages/clay-css/src/scss/mixins/_panels.scss
+++ b/packages/clay-css/src/scss/mixins/_panels.scss
@@ -5,200 +5,230 @@
 /// A mixin to create Panel variants. You can base your variant off `.panel` or create your own base class (e.g., `<div class="panel my-custom-panel-variant"></div>` or `<div class="my-custom-panel"></div>`).
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
-/// bg: {Color | String | Null},
-/// border-color: {Color | String | List | Null},
-/// border-style: {String | List | Null},
-/// border-width: {Number | String | List | Null},
-/// box-shadow: {String | List | Null},
-/// color: {Color | String | Null},
-/// font-size: {Number | String | Null},
-/// header-bg: {Color | String | Null},
-/// header-border-color: {Color | String | List | Null},
-/// header-border-style: {String | List | Null},
-/// header-border-width: {Number | String | List | Null},
-/// header-color: {Color | String | Null},
-/// header-margin-bottom: {Number | String | Null},
-/// header-margin-left: {Number | String | Null},
-/// header-margin-right: {Number | String | Null},
-/// header-margin-top: {Number | String | Null},
-/// header-padding-bottom: {Number | String | Null},
-/// header-padding-left: {Number | String | Null},
-/// header-padding-right: {Number | String | Null},
-/// header-padding-top: {Number | String | Null},
-/// header-transition: {String | List | Null},
-/// header-collapsed-border-color: {Color | String | List | Null},
-/// header-link: {Map | Null}, // Pass parameters to `clay-link` mixin
-/// title-font-size: {Number | String | Null},
-/// title-font-weight: {Number | String | Null},
-/// title-text-transform: {String | List | Null},
-/// collapse-icon-bottom: {Number | String | Null},
-/// collapse-icon-font-size: {Number | String | Null},
-/// collapse-icon-left: {Number | String | Null},
-/// collapse-icon-right: {Number | String | Null},
-/// collapse-icon-top: {Number | String | Null},
-/// body-margin-bottom: {Number | String | Null},
-/// body-margin-left: {Number | String | Null},
-/// body-margin-right: {Number | String | Null},
-/// body-margin-top: {Number | String | Null},
-/// body-padding-bottom: {Number | String | Null},
-/// body-padding-left: {Number | String | Null},
-/// body-padding-right: {Number | String | Null},
-/// body-padding-top: {Number | String | Null},
-/// footer-bg: {Color | String | Null},
-/// footer-border-color: {Color | String | List | Null},
-/// footer-color: {Color | String | Null},
+/// enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// See Mixin `clay-css` for available keys to pass into the base selector
+/// header: {Map | Null}, // See Mixin `clay-css` for available keys
+/// header-collapsed: {Map | Null}, // See Mixin `clay-css` for available keys
+/// header-c-inner: {Map | Null}, // See Mixin `clay-css` for available keys
+/// header-link: {Map | Null}, // See Mixin `clay-link` for available keys
+/// title: {Map | Null}, // See Mixin `clay-css` for available keys
+/// collapse-icon: {Map | Null}, // See Mixin `clay-css` for available keys
+/// body: {Map | Null}, // See Mixin `clay-css` for available keys
+/// footer: {Map | Null}, // See Mixin `clay-css` for available keys
+/// -=-=-=-=-=- Deprecated -=-=-=-=-=-
+/// bg: {Color | String | Null}, // deprecated after 3.9.0
+/// header-bg: {Color | String | Null}, // deprecated after 3.9.0
+/// header-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
+/// header-border-style: {String | List | Null}, // deprecated after 3.9.0
+/// header-border-width: {Number | String | List | Null}, // deprecated after 3.9.0
+/// header-color: {Color | String | Null}, // deprecated after 3.9.0
+/// header-margin-bottom: {Number | String | Null}, // deprecated after 3.9.0
+/// header-margin-left: {Number | String | Null}, // deprecated after 3.9.0
+/// header-margin-right: {Number | String | Null}, // deprecated after 3.9.0
+/// header-margin-top: {Number | String | Null}, // deprecated after 3.9.0
+/// header-padding-bottom: {Number | String | Null}, // deprecated after 3.9.0
+/// header-padding-left: {Number | String | Null}, // deprecated after 3.9.0
+/// header-padding-right: {Number | String | Null}, // deprecated after 3.9.0
+/// header-padding-top: {Number | String | Null}, // deprecated after 3.9.0
+/// header-transition: {String | List | Null}, // deprecated after 3.9.0
+/// header-collapsed-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
+/// title-font-size: {Number | String | Null}, // deprecated after 3.9.0
+/// title-font-weight: {Number | String | Null}, // deprecated after 3.9.0
+/// title-text-transform: {String | List | Null}, // deprecated after 3.9.0
+/// collapse-icon-bottom: {Number | String | Null}, // deprecated after 3.9.0
+/// collapse-icon-font-size: {Number | String | Null}, // deprecated after 3.9.0
+/// collapse-icon-left: {Number | String | Null}, // deprecated after 3.9.0
+/// collapse-icon-right: {Number | String | Null}, // deprecated after 3.9.0
+/// collapse-icon-top: {Number | String | Null}, // deprecated after 3.9.0
+/// body-margin-bottom: {Number | String | Null}, // deprecated after 3.9.0
+/// body-margin-left: {Number | String | Null}, // deprecated after 3.9.0
+/// body-margin-right: {Number | String | Null}, // deprecated after 3.9.0
+/// body-margin-top: {Number | String | Null}, // deprecated after 3.9.0
+/// body-padding-bottom: {Number | String | Null}, // deprecated after 3.9.0
+/// body-padding-left: {Number | String | Null}, // deprecated after 3.9.0
+/// body-padding-right: {Number | String | Null}, // deprecated after 3.9.0
+/// body-padding-top: {Number | String | Null}, // deprecated after 3.9.0
+/// footer-bg: {Color | String | Null}, // deprecated after 3.9.0
+/// footer-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
+/// footer-color: {Color | String | Null}, // deprecated after 3.9.0
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
 
 @mixin clay-panel-variant($map) {
-	$bg: map-get($map, bg);
-	$border-color: map-get($map, border-color);
-	$border-style: map-get($map, border-style);
-	$border-width: map-get($map, border-width);
-	$box-shadow: map-get($map, box-shadow);
-	$color: map-get($map, color);
-	$font-size: map-get($map, font-size);
+	$enabled: setter(map-get($map, enabled), true);
 
-	$header-bg: map-get($map, header-bg);
-	$header-border-color: map-get($map, header-border-color);
-	$header-border-style: map-get($map, header-border-style);
-	$header-border-width: map-get($map, header-border-width);
-	$header-color: map-get($map, header-color);
-	$header-margin-bottom: map-get($map, header-margin-bottom);
-	$header-margin-left: map-get($map, header-margin-left);
-	$header-margin-right: map-get($map, header-margin-right);
-	$header-margin-top: map-get($map, header-margin-top);
-	$header-padding-bottom: map-get($map, header-padding-bottom);
-	$header-padding-left: map-get($map, header-padding-left);
-	$header-padding-right: map-get($map, header-padding-right);
-	$header-padding-top: map-get($map, header-padding-top);
-	$header-transition: map-get($map, header-transition);
+	$base: map-merge(
+		(
+			background-color: map-get($map, bg),
+		),
+		$map
+	);
 
-	$header-collapsed-border-color: map-get(
-		$map,
-		header-collapsed-border-color
+	$header: setter(map-get($map, header), ());
+	$header: map-merge(
+		(
+			background-color: map-get($map, header-bg),
+			border-color: map-get($map, header-border-color),
+			border-style: map-get($map, header-border-style),
+			border-width: map-get($map, header-border-width),
+			color: map-get($map, header-color),
+			margin-bottom: map-get($map, header-margin-bottom),
+			margin-left: map-get($map, header-margin-left),
+			margin-right: map-get($map, header-margin-right),
+			margin-top: map-get($map, header-margin-top),
+			padding-bottom: map-get($map, header-padding-bottom),
+			padding-left: map-get($map, header-padding-left),
+			padding-right: map-get($map, header-padding-right),
+			padding-top: map-get($map, header-padding-top),
+			transition: map-get($map, header-transition),
+		),
+		$header
+	);
+
+	$header-collapsed: setter(map-get($map, header-collapsed), ());
+	$header-collapsed: map-merge(
+		(
+			border-color: map-get($map, header-collapsed-border-color),
+		),
+		$header-collapsed
+	);
+
+	$header-c-inner: setter(map-get($map, header-c-inner), ());
+	$header-c-inner: map-merge(
+		(
+			margin-bottom:
+				setter(
+					map-get($header-c-inner, margin-bottom),
+					math-sign(map-get($header, padding-bottom))
+				),
+			margin-left:
+				setter(
+					map-get($header-c-inner, margin-left),
+					math-sign(map-get($header, padding-left))
+				),
+			margin-right:
+				setter(
+					map-get($header-c-inner, margin-right),
+					math-sign(map-get($header, padding-right))
+				),
+			margin-top:
+				setter(
+					map-get($header-c-inner, margin-top),
+					math-sign(map-get($header, padding-top))
+				),
+		),
+		$header-c-inner
 	);
 
 	$header-link: setter(map-get($map, header-link), ());
 
-	$title-font-size: map-get($map, title-font-size);
-	$title-font-weight: map-get($map, title-font-weight);
-	$title-text-transform: map-get($map, title-text-transform);
+	$title: setter(map-get($map, title), ());
+	$title: map-merge(
+		(
+			font-size: map-get($map, title-font-size),
+			font-weight: map-get($map, title-font-weight),
+			text-transform: map-get($map, title-text-transform),
+		),
+		$title
+	);
 
-	$collapse-icon-bottom: map-get($map, collapse-icon-bottom);
-	$collapse-icon-font-size: map-get($map, collapse-icon-font-size);
-	$collapse-icon-left: map-get($map, collapse-icon-left);
-	$collapse-icon-right: map-get($map, collapse-icon-right);
-	$collapse-icon-top: map-get($map, collapse-icon-top);
+	$collapse-icon: setter(map-get($map, collapse-icon), ());
+	$collapse-icon: map-merge(
+		(
+			bottom: map-get($map, collapse-icon-bottom),
+			font-size: map-get($map, collapse-icon-font-size),
+			left: map-get($map, collapse-icon-left),
+			right: map-get($map, collapse-icon-right),
+			top: map-get($map, collapse-icon-top),
+		),
+		$collapse-icon
+	);
 
-	$body-margin-bottom: map-get($map, body-margin-bottom);
-	$body-margin-left: map-get($map, body-margin-left);
-	$body-margin-right: map-get($map, body-margin-right);
-	$body-margin-top: map-get($map, body-margin-top);
-	$body-padding-bottom: map-get($map, body-padding-bottom);
-	$body-padding-left: map-get($map, body-padding-left);
-	$body-padding-right: map-get($map, body-padding-right);
-	$body-padding-top: map-get($map, body-padding-top);
+	$body: setter(map-get($map, body), ());
+	$body: map-merge(
+		(
+			margin-bottom: map-get($map, body-margin-bottom),
+			margin-left: map-get($map, body-margin-left),
+			margin-right: map-get($map, body-margin-right),
+			margin-top: map-get($map, body-margin-top),
+			padding-bottom: map-get($map, body-padding-bottom),
+			padding-left: map-get($map, body-padding-left),
+			padding-right: map-get($map, body-padding-right),
+			padding-top: map-get($map, body-padding-top),
+		),
+		$body
+	);
 
-	$footer-bg: map-get($map, footer-bg);
-	$footer-border-color: map-get($map, footer-border-color);
-	$footer-color: map-get($map, footer-color);
+	$footer: setter(map-get($map, footer), ());
+	$footer: map-merge(
+		(
+			background-color: map-get($map, footer-bg),
+			border-color: map-get($map, footer-border-color),
+			color: map-get($map, footer-color),
+		),
+		$footer
+	);
 
-	background-color: $bg;
-	border-color: $border-color;
-	border-style: $border-style;
-	border-width: $border-width;
-	box-shadow: $box-shadow;
-	color: $color;
-	font-size: $font-size;
+	@if ($enabled) {
+		@include clay-css($base);
 
-	.panel-header {
-		background-color: $header-bg;
-		border-color: $header-border-color;
-		border-style: $header-border-style;
-		border-width: $header-border-width;
-		color: $header-color;
-		margin-bottom: $header-margin-bottom;
-		margin-left: $header-margin-left;
-		margin-right: $header-margin-right;
-		margin-top: $header-margin-top;
-		padding-bottom: $header-padding-bottom;
-		padding-left: $header-padding-left;
-		padding-right: $header-padding-right;
-		padding-top: $header-padding-top;
-		transition: $header-transition;
+		.panel-header {
+			@include clay-css($header);
 
-		@if ($enable-c-inner) {
-			.c-inner {
-				margin-bottom: #{math-sign($header-padding-bottom)};
-				margin-left: #{math-sign($header-padding-left)};
-				margin-right: #{math-sign($header-padding-right)};
-				margin-top: #{math-sign($header-padding-top)};
+			@if ($enable-c-inner) {
+				.c-inner {
+					@include clay-css($header-c-inner);
+				}
 			}
-		}
 
-		&.collapsed {
-			border-color: $header-collapsed-border-color;
-		}
-
-		&.panel-header-link {
-			@include clay-link($header-link);
-		}
-
-		&:not(.collapse-icon-middle) {
-			.collapse-icon-closed,
-			.collapse-icon-open {
-				bottom: $collapse-icon-bottom;
-				font-size: $collapse-icon-font-size;
-				left: $collapse-icon-left;
-				right: $collapse-icon-right;
-				top: $collapse-icon-top;
+			&.collapsed {
+				@include clay-css($header-collapsed);
 			}
-		}
 
-		.panel-group & {
-			+ .panel-collapse > .panel-body {
-				border-color: $border-color;
+			&.panel-header-link {
+				@include clay-link($header-link);
 			}
-		}
-	}
 
-	.panel-title {
-		font-size: $title-font-size;
-		font-weight: $title-font-weight;
-		text-transform: $title-text-transform;
-	}
+			&:not(.collapse-icon-middle) {
+				.collapse-icon-closed,
+				.collapse-icon-open {
+					@include clay-css($collapse-icon);
+				}
+			}
 
-	.panel-body {
-		margin-bottom: $body-margin-bottom;
-		margin-left: $body-margin-left;
-		margin-right: $body-margin-right;
-		margin-top: $body-margin-top;
-		padding-bottom: $body-padding-bottom;
-		padding-left: $body-padding-left;
-		padding-right: $body-padding-right;
-		padding-top: $body-padding-top;
-	}
-
-	.panel-footer {
-		background-color: $footer-bg;
-		border-color: $footer-border-color;
-		color: $footer-color;
-	}
-
-	// For Focus Box Shadow
-
-	@at-root {
-		.panel-group.panel-group-flush & {
-			.panel-header-link {
-				&,
-				&.collapsed {
-					border-radius: map-get($header-link, border-radius);
+			.panel-group & {
+				+ .panel-collapse > .panel-body {
+					border-color: map-get($base, border-color);
 				}
 			}
 		}
-	}
 
-	@content;
+		.panel-title {
+			@include clay-css($title);
+		}
+
+		.panel-body {
+			@include clay-css($body);
+		}
+
+		.panel-footer {
+			@include clay-css($footer);
+		}
+
+		// For Focus Box Shadow
+
+		@at-root {
+			.panel-group.panel-group-flush & {
+				.panel-header-link {
+					&,
+					&.collapsed {
+						border-radius: map-get($header-link, border-radius);
+					}
+				}
+			}
+		}
+
+		@content;
+	}
 }

--- a/packages/clay-css/src/scss/mixins/_panels.scss
+++ b/packages/clay-css/src/scss/mixins/_panels.scss
@@ -59,64 +59,105 @@
 	$enabled: setter(map-get($map, enabled), true);
 
 	$base: map-merge(
+		$map,
 		(
-			background-color: map-get($map, bg),
-		),
-		$map
+			background-color:
+				setter(map-get($map, bg), map-get($map, background-color)),
+		)
 	);
 
 	$header: setter(map-get($map, header), ());
 	$header: map-merge(
+		$header,
 		(
-			background-color: map-get($map, header-bg),
-			border-color: map-get($map, header-border-color),
-			border-style: map-get($map, header-border-style),
-			border-width: map-get($map, header-border-width),
-			color: map-get($map, header-color),
-			margin-bottom: map-get($map, header-margin-bottom),
-			margin-left: map-get($map, header-margin-left),
-			margin-right: map-get($map, header-margin-right),
-			margin-top: map-get($map, header-margin-top),
-			padding-bottom: map-get($map, header-padding-bottom),
-			padding-left: map-get($map, header-padding-left),
-			padding-right: map-get($map, header-padding-right),
-			padding-top: map-get($map, header-padding-top),
-			transition: map-get($map, header-transition),
-		),
-		$header
+			background-color:
+				setter(
+					map-get($map, header-bg),
+					map-get($header, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, header-border-color),
+					map-get($header, border-color)
+				),
+			border-style:
+				setter(
+					map-get($map, header-border-style),
+					map-get($header, border-style)
+				),
+			border-width:
+				setter(
+					map-get($map, header-border-width),
+					map-get($header, border-width)
+				),
+			color: setter(map-get($map, header-color), map-get($header, color)),
+			margin-bottom:
+				setter(
+					map-get($map, header-margin-bottom),
+					map-get($header, margin-bottom)
+				),
+			margin-left:
+				setter(
+					map-get($map, header-margin-left),
+					map-get($header, margin-left)
+				),
+			margin-right:
+				setter(
+					map-get($map, header-margin-right),
+					map-get($header, margin-right)
+				),
+			margin-top:
+				setter(
+					map-get($map, header-margin-top),
+					map-get($header, margin-top)
+				),
+			padding-bottom:
+				setter(
+					map-get($map, header-padding-bottom),
+					map-get($header, padding-bottom)
+				),
+			padding-left:
+				setter(
+					map-get($map, header-padding-left),
+					map-get($header, padding-left)
+				),
+			padding-right:
+				setter(
+					map-get($map, header-padding-right),
+					map-get($header, padding-right)
+				),
+			padding-top:
+				setter(
+					map-get($map, header-padding-top),
+					map-get($header, padding-top)
+				),
+			transition:
+				setter(
+					map-get($map, header-transition),
+					map-get($header, transition)
+				),
+		)
 	);
 
 	$header-collapsed: setter(map-get($map, header-collapsed), ());
 	$header-collapsed: map-merge(
+		$header-collapsed,
 		(
-			border-color: map-get($map, header-collapsed-border-color),
-		),
-		$header-collapsed
+			border-color:
+				setter(
+					map-get($map, header-collapsed-border-color),
+					map-get($header-collapsed, border-color)
+				),
+		)
 	);
 
 	$header-c-inner: setter(map-get($map, header-c-inner), ());
 	$header-c-inner: map-merge(
 		(
-			margin-bottom:
-				setter(
-					map-get($header-c-inner, margin-bottom),
-					math-sign(map-get($header, padding-bottom))
-				),
-			margin-left:
-				setter(
-					map-get($header-c-inner, margin-left),
-					math-sign(map-get($header, padding-left))
-				),
-			margin-right:
-				setter(
-					map-get($header-c-inner, margin-right),
-					math-sign(map-get($header, padding-right))
-				),
-			margin-top:
-				setter(
-					map-get($header-c-inner, margin-top),
-					math-sign(map-get($header, padding-top))
-				),
+			margin-bottom: math-sign(map-get($header, padding-bottom)),
+			margin-left: math-sign(map-get($header, padding-left)),
+			margin-right: math-sign(map-get($header, padding-right)),
+			margin-top: math-sign(map-get($header, padding-top)),
 		),
 		$header-c-inner
 	);
@@ -125,49 +166,121 @@
 
 	$title: setter(map-get($map, title), ());
 	$title: map-merge(
+		$title,
 		(
-			font-size: map-get($map, title-font-size),
-			font-weight: map-get($map, title-font-weight),
-			text-transform: map-get($map, title-text-transform),
-		),
-		$title
+			font-size:
+				setter(
+					map-get($map, title-font-size),
+					map-get($title, font-size)
+				),
+			font-weight:
+				setter(
+					map-get($map, title-font-weight),
+					map-get($title, font-weight)
+				),
+			text-transform:
+				setter(
+					map-get($map, title-text-transform),
+					map-get($title, text-transform)
+				),
+		)
 	);
 
 	$collapse-icon: setter(map-get($map, collapse-icon), ());
 	$collapse-icon: map-merge(
+		$collapse-icon,
 		(
-			bottom: map-get($map, collapse-icon-bottom),
-			font-size: map-get($map, collapse-icon-font-size),
-			left: map-get($map, collapse-icon-left),
-			right: map-get($map, collapse-icon-right),
-			top: map-get($map, collapse-icon-top),
-		),
-		$collapse-icon
+			bottom:
+				setter(
+					map-get($map, collapse-icon-bottom),
+					map-get($collapse-icon, bottom)
+				),
+			font-size:
+				setter(
+					map-get($map, collapse-icon-font-size),
+					map-get($collapse-icon, font-size)
+				),
+			left:
+				setter(
+					map-get($map, collapse-icon-left),
+					map-get($collapse-icon, left)
+				),
+			right:
+				setter(
+					map-get($map, collapse-icon-right),
+					map-get($collapse-icon, right)
+				),
+			top:
+				setter(
+					map-get($map, collapse-icon-top),
+					map-get($collapse-icon, top)
+				),
+		)
 	);
 
 	$body: setter(map-get($map, body), ());
 	$body: map-merge(
+		$body,
 		(
-			margin-bottom: map-get($map, body-margin-bottom),
-			margin-left: map-get($map, body-margin-left),
-			margin-right: map-get($map, body-margin-right),
-			margin-top: map-get($map, body-margin-top),
-			padding-bottom: map-get($map, body-padding-bottom),
-			padding-left: map-get($map, body-padding-left),
-			padding-right: map-get($map, body-padding-right),
-			padding-top: map-get($map, body-padding-top),
-		),
-		$body
+			margin-bottom:
+				setter(
+					map-get($map, body-margin-bottom),
+					map-get($body, margin-bottom)
+				),
+			margin-left:
+				setter(
+					map-get($map, body-margin-left),
+					map-get($body, margin-left)
+				),
+			margin-right:
+				setter(
+					map-get($map, body-margin-right),
+					map-get($body, margin-right)
+				),
+			margin-top:
+				setter(
+					map-get($map, body-margin-top),
+					map-get($body, margin-top)
+				),
+			padding-bottom:
+				setter(
+					map-get($map, body-padding-bottom),
+					map-get($body, padding-bottom)
+				),
+			padding-left:
+				setter(
+					map-get($map, body-padding-left),
+					map-get($body, padding-left)
+				),
+			padding-right:
+				setter(
+					map-get($map, body-padding-right),
+					map-get($body, padding-right)
+				),
+			padding-top:
+				setter(
+					map-get($map, body-padding-top),
+					map-get($body, padding-top)
+				),
+		)
 	);
 
 	$footer: setter(map-get($map, footer), ());
 	$footer: map-merge(
+		$footer,
 		(
-			background-color: map-get($map, footer-bg),
-			border-color: map-get($map, footer-border-color),
-			color: map-get($map, footer-color),
-		),
-		$footer
+			background-color:
+				setter(
+					map-get($map, footer-bg),
+					map-get($footer, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, footer-border-color),
+					map-get($footer, border-color)
+				),
+			color: setter(map-get($map, footer-color), map-get($footer, color)),
+		)
 	);
 
 	@if ($enabled) {


### PR DESCRIPTION
feat(@clayui/css): Mixin `clay-panel-variant` adds options `header`, `header-collapsed`, `header-c-inner`, `title`, `collapse-icon`, `body`, `footer`

feat(@clayui/css): Mixin `clay-panel-variant` adds `enabled` to prevent styles from being output for a specific close variant. This is set to `true` by default.

fix(@clayui/css): Mixin `clay-panel-variant` deprecated keys should win to preserve backward compatibility

issue #3075