### PR TITLE
fix(clay-css): 2.x `_global-functions` should be accessible to Portal's `…

### DIFF
--- a/packages/clay-css/src/scss/atlas-variables.scss
+++ b/packages/clay-css/src/scss/atlas-variables.scss
@@ -1,6 +1,6 @@
-// INSERT CUSTOM BASE VARS
-
 @import "functions/_global-functions";
+
+// INSERT CUSTOM BASE VARS
 
 @import "atlas/_variables";
 

--- a/packages/clay-css/src/scss/atlas.scss
+++ b/packages/clay-css/src/scss/atlas.scss
@@ -1,6 +1,6 @@
-// INSERT CUSTOM VARS
-
 @import "functions/_global-functions";
+
+// INSERT CUSTOM VARS
 
 @import "atlas/_variables";
 

--- a/packages/clay-css/src/scss/base-variables.scss
+++ b/packages/clay-css/src/scss/base-variables.scss
@@ -1,6 +1,6 @@
-// INSERT CUSTOM BASE VARS
-
 @import "functions/_global-functions";
+
+// INSERT CUSTOM BASE VARS
 
 @import "variables/_bs4-variable-overwrites";
 

--- a/packages/clay-css/src/scss/base.scss
+++ b/packages/clay-css/src/scss/base.scss
@@ -1,6 +1,6 @@
-// INSERT CUSTOM VARS
-
 @import "functions/_global-functions";
+
+// INSERT CUSTOM VARS
 
 @import "variables/_bs4-variable-overwrites";
 


### PR DESCRIPTION
…_clay_variables.scss` without having to import it manually

fixes #3193