### PR TITLE
feat(clayui.com): Add a custom 404 page

### DIFF
--- a/clayui.com/src/pages/404.js
+++ b/clayui.com/src/pages/404.js
@@ -15,8 +15,8 @@ const spritemap = '/images/icons/icons.svg';
 const PageNotFound = () => {
 	return (
 		<div className="clay-404-page-container d-flex flex-column min-vh-100">
-			<header className="d-flex">
-				<div className="container-fluid-max-xl d-flex mb-0 ml-auto mr-auto mt-0 w-100">
+			<header className="bg-white d-flex">
+				<div className="container-fluid container-fluid-max-xl d-flex px-0">
 					<Link className="d-none d-sm-flex mx-3" to="/">
 						<img
 							alt="Clay"
@@ -29,61 +29,56 @@ const PageNotFound = () => {
 				</div>
 			</header>
 
-			<div className="align-items-center container-fluid-max-lg d-flex justify-content-center m-auto main-content row">
-				<h1 className="col-12 display-3">
-					{"These aren't the components you're looking for."}
+			<div className="container-fluid container-fluid-max-lg d-flex flex-column flex-grow-1 justify-content-center main-content">
+				<h1 className="display-3">
+					{"This isn't the page you're looking for."}
 				</h1>
 
-				<div className="col-12 container-fluid">
-					<p className="my-2 py-2">
-						{
-							"Hey there, we couldn't find the page that you were looking for."
-						}
-						<br />
-						{"Maybe it's one of these:"}
-					</p>
+				<p className="mb-0 py-3">
+					{
+						"Hey there, we couldn't find the page that you were looking for."
+					}
+					<br />
+					{"Maybe it's one of these:"}
+				</p>
 
-					<nav className="list-inline mt-3">
-						<Link
-							className="align-middle list-inline-item mb-3 mr-3 px-3 py-2 rounded shadow text-decoration-none"
-							to="/"
-						>
-							<ClayIcon spritemap={spritemap} symbol="home" />
+				<nav className="list-inline mt-2">
+					<Link
+						className="align-middle list-inline-item mb-3 mr-3 px-3 py-2 rounded shadow text-decoration-none"
+						to="/"
+					>
+						<ClayIcon spritemap={spritemap} symbol="home" />
 
-							<span className="pl-2">{'Home'}</span>
-						</Link>
+						<span className="pl-2">{'Home'}</span>
+					</Link>
 
-						<Link
-							className="align-middle list-inline-item mb-3 mr-3 px-3 py-2 rounded shadow text-decoration-none"
-							to="/docs/get-started/index.html"
-						>
-							<ClayIcon spritemap={spritemap} symbol="bolt" />
+					<Link
+						className="align-middle list-inline-item mb-3 mr-3 px-3 py-2 rounded shadow text-decoration-none"
+						to="/docs/get-started/index.html"
+					>
+						<ClayIcon spritemap={spritemap} symbol="bolt" />
 
-							<span className="pl-2">{'Get Started'}</span>
-						</Link>
+						<span className="pl-2">{'Get Started'}</span>
+					</Link>
 
-						<Link
-							className="align-middle list-inline-item mb-3 mr-3 px-3 py-2 rounded shadow text-decoration-none"
-							to="/docs/components/index.html"
-						>
-							<ClayIcon
-								spritemap={spritemap}
-								symbol="plus-squares"
-							/>
+					<Link
+						className="align-middle list-inline-item mb-3 mr-3 px-3 py-2 rounded shadow text-decoration-none"
+						to="/docs/components/index.html"
+					>
+						<ClayIcon spritemap={spritemap} symbol="plus-squares" />
 
-							<span className="pl-2">{'Components'}</span>
-						</Link>
+						<span className="pl-2">{'Components'}</span>
+					</Link>
 
-						<a
-							className="align-items-center align-middle d-inline-flex list-inline-item mb-3 px-3 py-2 rounded shadow text-decoration-none"
-							href="https://github.com/liferay/clay"
-						>
-							<div className="githubImage" />
+					<a
+						className="align-items-center align-middle d-inline-flex list-inline-item mb-3 px-3 py-2 rounded shadow text-decoration-none"
+						href="https://github.com/liferay/clay"
+					>
+						<div className="githubImage" />
 
-							<span className="pl-2">{'Clay on GitHub'}</span>
-						</a>
-					</nav>
-				</div>
+						<span className="pl-2">{'Clay on GitHub'}</span>
+					</a>
+				</nav>
 			</div>
 		</div>
 	);

--- a/clayui.com/src/pages/404.js
+++ b/clayui.com/src/pages/404.js
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayIcon from '@clayui/icon';
+import {Link} from 'gatsby';
+import React from 'react';
+
+import clayLogo from '../../static/images/home/clay_logo.svg';
+import LayoutNav from '../components/LayoutNav';
+
+const spritemap = '/images/icons/icons.svg';
+
+const PageNotFound = () => {
+	return (
+		<div className="clay-404-page-container d-flex flex-column min-vh-100">
+			<header className="d-flex">
+				<div className="container-fluid-max-xl d-flex mb-0 ml-auto mr-auto mt-0 w-100">
+					<Link className="d-none d-sm-flex mx-3" to="/">
+						<img
+							alt="Clay"
+							className="align-items-center d-flex justify-content-center"
+							src={clayLogo}
+						/>
+					</Link>
+
+					<LayoutNav />
+				</div>
+			</header>
+
+			<div className="align-items-center container-fluid-max-lg d-flex justify-content-center m-auto main-content row">
+				<h1 className="col-12 display-3">
+					{"These aren't the components you're looking for."}
+				</h1>
+
+				<div className="col-12 container-fluid">
+					<p className="my-2 py-2">
+						{
+							"Hey there, we couldn't find the page that you were looking for."
+						}
+						<br />
+						{"Maybe it's one of these:"}
+					</p>
+
+					<nav className="list-inline mt-3">
+						<Link
+							className="align-middle list-inline-item mb-3 mr-3 px-3 py-2 rounded shadow text-decoration-none"
+							to="/"
+						>
+							<ClayIcon spritemap={spritemap} symbol="home" />
+
+							<span className="pl-2">{'Home'}</span>
+						</Link>
+
+						<Link
+							className="align-middle list-inline-item mb-3 mr-3 px-3 py-2 rounded shadow text-decoration-none"
+							to="/docs/get-started/index.html"
+						>
+							<ClayIcon spritemap={spritemap} symbol="bolt" />
+
+							<span className="pl-2">{'Get Started'}</span>
+						</Link>
+
+						<Link
+							className="align-middle list-inline-item mb-3 mr-3 px-3 py-2 rounded shadow text-decoration-none"
+							to="/docs/components/index.html"
+						>
+							<ClayIcon
+								spritemap={spritemap}
+								symbol="plus-squares"
+							/>
+
+							<span className="pl-2">{'Components'}</span>
+						</Link>
+
+						<a
+							className="align-items-center align-middle d-inline-flex list-inline-item mb-3 px-3 py-2 rounded shadow text-decoration-none"
+							href="https://github.com/liferay/clay"
+						>
+							<div className="githubImage" />
+
+							<span className="pl-2">{'Clay on GitHub'}</span>
+						</a>
+					</nav>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default PageNotFound;

--- a/clayui.com/src/styles/_404-page.scss
+++ b/clayui.com/src/styles/_404-page.scss
@@ -1,0 +1,66 @@
+.clay-404-page-container {
+	background-image: url('../../static/images/home/bg_white.svg');
+
+	header {
+		background-color: #fff;
+
+		img {
+			width: 32px;
+		}
+	}
+
+	.navbar {
+		width: 100%;
+	}
+
+	.list-inline {
+		a {
+			background-color: $brand-primary;
+			color: #fff;
+			transition: all 0.3s ease-in-out;
+
+			.githubImage {
+				width: 16px;
+				height: 16px;
+				background-size: cover;
+				background-image: url('../../static/images/home/GitHub-Mark-64px.svg');
+			}
+
+			&:hover {
+				background-color: $brand-dark;
+				color: $brand-light;
+				box-shadow: 0 0 0 !important;
+
+				svg {
+					color: $brand-light;
+				}
+			}
+		}
+	}
+
+	.main-content {
+		transform: translateY(-66px);
+
+		@media (max-width: $screen-md) {
+			flex-direction: column;
+			margin: auto 48px !important;
+		}
+
+		@media (max-width: $screen-sm) {
+			margin: auto 24px !important;
+			transform: translateY(0);
+		}
+
+		h1 {
+			color: $brand-primary;
+
+			@media (max-width: $screen-md) {
+				font-size: 4em;
+			}
+
+			@media (max-width: $screen-sm) {
+				font-size: 2.5em;
+			}
+		}
+	}
+}

--- a/clayui.com/src/styles/_404-page.scss
+++ b/clayui.com/src/styles/_404-page.scss
@@ -2,8 +2,6 @@
 	background-image: url('../../static/images/home/bg_white.svg');
 
 	header {
-		background-color: #fff;
-
 		img {
 			width: 32px;
 		}
@@ -29,36 +27,28 @@
 			&:hover {
 				background-color: $brand-dark;
 				color: $brand-light;
-				box-shadow: 0 0 0 !important;
-
-				svg {
-					color: $brand-light;
-				}
+				box-shadow: none !important;
 			}
 		}
 	}
 
 	.main-content {
-		transform: translateY(-66px);
-
-		@media (max-width: $screen-md) {
-			flex-direction: column;
-			margin: auto 48px !important;
+		@media (min-width: $screen-lg + 1) {
+			transform: translateY(-66px);
 		}
 
 		@media (max-width: $screen-sm) {
-			margin: auto 24px !important;
-			transform: translateY(0);
+			padding: 0 24px;
 		}
 
-		h1 {
+		.display-3 {
 			color: $brand-primary;
 
 			@media (max-width: $screen-md) {
 				font-size: 4em;
 			}
 
-			@media (max-width: $screen-sm) {
+			@media (max-width: $screen-xs) {
 				font-size: 2.5em;
 			}
 		}

--- a/clayui.com/src/styles/main.scss
+++ b/clayui.com/src/styles/main.scss
@@ -14,6 +14,7 @@
 @import 'navbar';
 @import 'prismjs';
 @import 'sidebar';
+@import '404-page';
 
 @import 'site/site';
 @import 'site/content-site';


### PR DESCRIPTION
This is my proposal for an initial implementation of a custom 404 page for clayui.com.
It's pretty basic but I think it gets the job done. I wasn't sure if using a different font is something we are "allowed" to use, and also I wasn't sure where to get some illustrations, so that's why it looks barebones.

@pat270 can you check the layout and the styles I used, and point out any mistakes in that regard?

@esanzp do you know who we could ask for some illustrations (some pre-existing ones) to maybe spice up this page?