### PR TITLE
chore: lower size limit boundary and remove bundle step

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -37,5 +37,4 @@ jobs:
                   yarn genBuildSize:compare
             - name: Generate Total Size
               run: |
-                  yarn run bundle
                   yarn run sizeLimit

--- a/package.json
+++ b/package.json
@@ -3,14 +3,17 @@
 	"repository": "https://github.com/liferay/clay",
 	"size-limit": [
 		{
-			"path": "lib/all.js",
-			"limit": "150 kb"
+			"path": "all.js",
+			"limit": "140 kb",
+			"ignore": [
+				"react",
+				"react-dom"
+			]
 		}
 	],
 	"scripts": {
 		"build:csb": "lerna run --no-bail --ignore \"clayui.com\" build && lerna run --no-bail --ignore \"clayui.com\" build:types",
 		"build": "lerna run build && lerna run build:types",
-		"bundle": "NODE_ENV=production parcel build all.js --target browser --detailed-report --no-cache --no-source-maps --out-dir lib",
 		"checkDeps": "lerna run --ignore \"clayui.com\" build && node scripts/check-deps/check-dependencies.js",
 		"ci": "yarn lint && yarn format:check && yarn test && yarn checkDeps",
 		"coverage": "jest --coverage",


### PR DESCRIPTION
I realized that there was no need to add a bundle step since size-limit can already test that with a vanilla webpack bundle. I think using size-limit alone will give a more realistic idea of sizes.


I also realized you can run `yarn sizeLimit --why` to see a graph of all our dependencies.