### PR TITLE
feat(clayui.com): Update content of some components

### DIFF
--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -48,8 +48,6 @@ export default (props) => {
 		stable: 'success',
 	};
 
-	const showDescTop = !frontmatter.packageNpm && frontmatter.description;
-
 	useEffect(() => {
 		document
 			.querySelectorAll('.clay-site-custom-checkbox-indeterminate')
@@ -99,7 +97,7 @@ export default (props) => {
 															{`yarn add ${frontmatter.packageNpm}`}
 														</p>
 													)}
-													{showDescTop && (
+													{frontmatter.description && (
 														<p className="docs-subtitle">
 															{
 																frontmatter.description
@@ -351,13 +349,6 @@ export default (props) => {
 														id="simpleTabs"
 														role="tabpanel"
 													>
-														{frontmatter.description && (
-															<p className="docs-description">
-																{
-																	frontmatter.description
-																}
-															</p>
-														)}
 														{tab && tab.html && (
 															<div
 																dangerouslySetInnerHTML={{

--- a/packages/clay-badge/README.mdx
+++ b/packages/clay-badge/README.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Badges'
+title: 'Badge'
 description: 'Badges help highlight important information, such as notifications or new and unread messages.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/badges/'
 packageNpm: '@clayui/badge'
@@ -16,19 +16,13 @@ import {Badge} from '$packages/clay-badge/docs/index';
 </div>
 </div>
 
-## Colors
-
-Badges can be used with the following colors:
+Badges are not used for non-numeric values. If you have a non-numeric value, use labels instead. Badges work for exact numbers up to 999.
+For numbers greater than 999, use K to indicate Thousands (5K for 5.231) and M to indicate Millions (2M for 2.100.523).
 
 <Badge />
 
 We recommend that you review the use cases in the <a href="https://storybook-clayui.netlify.com/?path=/story/claybadge--default">Storybook</a>.
 
-<div class="clay-site-alert alert alert-warning">
-	Badges are not used for non-numeric values. If you have a non-numeric value,
-	use labels instead.
-</div>
-
-### API
+## API
 
 <div>[APITable "clay-badge/src/index.tsx"]</div>

--- a/packages/clay-breadcrumb/README.mdx
+++ b/packages/clay-breadcrumb/README.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'Breadcrumbs'
+title: 'Breadcrumb'
 description: 'Breadcrumb is a secondary navigation pattern that identifies the page position inside a hierarchy.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/breadcrumb/'
 packageNpm: '@clayui/breadcrumb'
 sibling: 'docs/components/css-breadcrumbs.html'
 ---
 
-import {Breadcrumbs} from '$packages/clay-breadcrumb/docs/index';
+import {Breadcrumb} from '$packages/clay-breadcrumb/docs/index';
 
 <div class="nav-toc-absolute">
 <div class="nav-toc">
@@ -16,10 +16,10 @@ import {Breadcrumbs} from '$packages/clay-breadcrumb/docs/index';
 </div>
 </div>
 
-<Breadcrumbs />
+Breadcrumbs are a navigation aid for your site, use them when you need to provide a quick way to jump back to previously viewed pages or sections.
+
+<Breadcrumb />
 
 ## API
 
-### ClayBreadcrumb
-
-<div>[APITable "clay-navigation/src/Breadcrumb.tsx"]</div>
+<div>[APITable "clay-breadcrumb/src/index.tsx"]</div>

--- a/packages/clay-breadcrumb/docs/index.js
+++ b/packages/clay-breadcrumb/docs/index.js
@@ -44,11 +44,11 @@ const BreadcrumbCode = `const Component = () => {
 
 render(<Component />);`;
 
-const Breadcrumbs = () => {
+const Breadcrumb = () => {
 	const scope = {ClayBreadcrumb};
 	const code = BreadcrumbCode;
 
 	return <Editor code={code} imports={breadcrumbImportsCode} scope={scope} />;
 };
 
-export {Breadcrumbs};
+export {Breadcrumb};

--- a/packages/clay-form/DUAL_LIST_BOX.mdx
+++ b/packages/clay-form/DUAL_LIST_BOX.mdx
@@ -16,11 +16,14 @@ import {DualListBox} from '$packages/clay-form/docs/duallistbox';
 </div>
 </div>
 
-`ClayDualListBox` is exported from the `@clayui/form` package, consisting of some low-level utilities that provides the ability to create a Select with multiple options selectable.
+ClayDualListBox consists of low-level utilities that provides the ability to create a Select with multiple options selectable.
+Users are allowed to multi-select different items from a list and sometimes, options in use can be re-order.
+It's a high level component using `ClaySelectBox` under the hood.
 
 > Note: The actual select functionality will not work here due to a pending issue at [FormidableLabs/react-live#196](https://github.com/FormidableLabs/react-live/issues/196). To see it in action, check out the [storybook demo](https://storybook.clayui.com/?path=/story/components-clayduallistbox--default).
 
 <DualListBox />
+
 ## API
 
 <div>[APITable "clay-form/src/DualListBox.tsx"]</div>

--- a/packages/clay-loading-indicator/README.mdx
+++ b/packages/clay-loading-indicator/README.mdx
@@ -15,7 +15,8 @@ import {
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Sizes](#sizes)
+-   [Light](#light)
+-   [Small](#small)
 -   [API](#api)
 
 </div>
@@ -23,11 +24,13 @@ import {
 
 <LoadingIndicator />
 
+## Light
+
 Use [`light`](#api-light) property for setting the loading indicator to be more accessible in some cases.
 
 <LoadingIndicatorLight />
 
-### Sizes
+## Small
 
 By default, the loading indicator is sized 16px but if you want a smaller version, you can try using the [`small`](#api-small) property.
 

--- a/packages/clay-localized-input/README.mdx
+++ b/packages/clay-localized-input/README.mdx
@@ -14,19 +14,19 @@ import {
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Usages](#usages)
-    -   [Basic Usage](#basic-usage)
-    -   [Localizable URL](#localizable-url)
+-   [Localized URL](#localized-url)
 -   [API](#api)
 
 </div>
 </div>
 
-## Basic usage
+Use it when you want to enable the users to define values like post titles, headings in multiple languages not having to rely on automatic translations.
 
 <LocalizableInput />
 
-## Localizable URL
+## Localized URL
+
+You might want to allow your users to localize URLs, in that case here's an example of how to compose Localized Input to get the desired result. The main parts are the `prependContent` and `resultFormatter` props.
 
 <LocalizableInputWithURL />
 

--- a/packages/clay-multi-step-nav/README.mdx
+++ b/packages/clay-multi-step-nav/README.mdx
@@ -14,18 +14,21 @@ import {
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [ClayMultiStepNav](#claymultistepnav)
--   [ClayMultiStepNavWithBasicItems](#claymultistepnavwithbasicitems)
+-   [Collapsable Steps](#collapsable-steps)
 -   [API](#api)
 
 </div>
 </div>
 
-### ClayMultiStepNav
+It's used when a major or big task has to be divided into smaller task, with the aim of letting the user breath in the process and providing them with a sense of progression.
+
+Each step can have two different states: `active` or `complete` defined by props as you can see below.
 
 <MultiStepNav />
 
-### ClayMultiStepNavWithBasicItems
+## Collapsable Steps
+
+Using `ClayMultiStepNavWithBasicItems` in combination with `maxStepsShown` prop you can collapse the steps that don't fit into a dropdown to ensure good user experience.
 
 <MultiStepNavWithBasicItems />
 
@@ -37,7 +40,9 @@ import {
 
 ### MultiStepNav.Divider
 
-<div>[APITable "clay-multi-step-nav/src/Divider.tsx"]</div>
+<code class="list-api-item-type">
+	Extends from {`React.HTMLAttributes<HTMLDivElement>`}
+</code>
 
 ### MultiStepNav.Item
 
@@ -49,7 +54,9 @@ import {
 
 ### MultiStepNav.Title
 
-<div>[APITable "clay-multi-step-nav/src/Title.tsx"]</div>
+<code class="list-api-item-type">
+	Extends from {`React.HTMLAttributes<HTMLDivElement>`}
+</code>
 
 ### MultiStepNavWithBasicItems
 


### PR DESCRIPTION
Addresses some components listed in #3210 

@bryceosterhaus I decided to send this halfway through to make it easier to review and iterate over. I'll be working on the other half of the components listed in the issue next.

### Here's what I've done:
- Add content where it was missing
- Rename `badges` to `badge`
- Rename `text-input-localizable` to `localized-input`
- Update headings to start at h1 (amount of `#` in Markdown)
- Update some navigations where it was needed

### Components included
- Badges
- Breadcrumbs
- Dual List Box
- Loading Indicator
- Localized Input
- Multi Step Nav

### Something I noticed
Localized Input is missing prop to render textarea, this example was included in the Markup/CSS page but we had no support for that. So I removed the example with the idea of eventually adding it back when we add a prop to the component.