### PR TITLE
fix(clayui.com): Fix missing Icon Markup/CSS page

### DIFF
--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -108,7 +108,7 @@ export default (props) => {
 													)}
 												</div>
 												<div className="col-12">
-													{tab && tab.html ? (
+													{tab ? (
 														<ul
 															className="border-bottom nav nav-clay nav-underline"
 															role="tablist"


### PR DESCRIPTION
Hey @bryceosterhaus this brings back the Icon's missing page, as noted in #3215.

I've manually checked some pages to see if this doesn't break anything, and I haven't noticed any problems. The problem was in the `tab && tab.html` check not returning true in the case of Icon because it's the only page that has an `.mdx` file for the Markup/CSS page because it needs to have a search functionality.