### PR TITLE
feat(@clayui/css): Move components `type`, `icons`, `aspect-ratio`, a…

### DIFF
--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -2,14 +2,18 @@
 	@import url($font-import-url);
 }
 
+@import 'components/_type';
+
+@import 'components/_icons';
+
+@import 'components/_aspect-ratio';
+@import 'components/_buttons';
 @import 'components/_grid';
 
 @import 'components/_alerts';
-@import 'components/_aspect-ratio';
 @import 'components/_badges';
 @import 'components/_breadcrumbs';
 @import 'components/_button-groups';
-@import 'components/_buttons';
 @import 'components/_empty-state';
 @import 'components/_labels';
 @import 'components/_stickers';
@@ -31,7 +35,6 @@
 @import 'components/_date-picker';
 @import 'components/_dual-listbox';
 @import 'components/_form-validation';
-@import 'components/_icons';
 @import 'components/_input-groups';
 @import 'components/_list-group';
 @import 'components/_modals';
@@ -60,7 +63,6 @@
 @import 'components/_timelines';
 @import 'components/_toggle-switch';
 @import 'components/_tooltip';
-@import 'components/_type';
 
 @import 'components/_utilities';
 


### PR DESCRIPTION
…nd `buttons` earlier in the import chain so they are easier to overwrite

fixes #3191