### PR TITLE
fix(@clayui/css): Forms `input[type="range"].form-control` shadow in …

### DIFF
--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -135,12 +135,15 @@ label {
 
 		&:focus {
 			box-shadow: none;
+
+			&::-webkit-slider-thumb {
+				box-shadow: $input-focus-box-shadow;
+			}
 		}
 
 		&::-webkit-slider-thumb {
-			// Chrome hack for https://github.com/liferay/clay/issues/1179
-
-			outline: $primary-l2 auto 5px;
+			border-radius: 100px;
+			transition: $input-transition;
 		}
 	}
 


### PR DESCRIPTION
…Chrome 81 caused by https://github.com/liferay/clay/issues/1179 and Chrome update

fixes #3249

@bryceosterhaus this should get released today. Thanks!