### PR TITLE
 fix(clay-css): 2.x input[type="range"].form-control shadow in Chrome 81 …

### DIFF
--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -129,6 +129,20 @@ label {
 	&[type="range"] {
 		background-color: transparent;
 		border-color: transparent;
+		padding: 0;
+
+		&:focus {
+			box-shadow: none;
+
+			&::-webkit-slider-thumb {
+				box-shadow: $input-focus-box-shadow;
+			}
+		}
+
+		&::-webkit-slider-thumb {
+			border-radius: 100px;
+			transition: $input-transition;
+		}
 	}
 
 	&:not([type="range"]) {


### PR DESCRIPTION
…caused by https://github.com/liferay/clay/issues/1179 and Chrome update

issue #3249

@bryceosterhaus this should also be released today if cutting a new version of 2.x