### PR TITLE
feat(@clayui/css): Absorb Bootstrap 4 _reboot.scss

### DIFF
--- a/packages/clay-css/src/content/test_reboot.html
+++ b/packages/clay-css/src/content/test_reboot.html
@@ -1,0 +1,201 @@
+---
+title: 1) Reboot
+section: Visual Tests
+---
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Article, Aside, Figcaption, Figure, Footer, Header, Hgroup, Main, Nav, Section</h3>
+
+		<blockquote class="blockquote">
+			<p>IE11: "new" HTML5 structural elements should be `display: block`</p>
+		</blockquote>
+
+		<article class="bg-primary">Article</article>
+		<aside class="bg-info">Aside</aside>
+		<figcaption class="bg-primary">Figcaption</figcaption>
+		<figure class="bg-info">Figure</figure>
+		<footer class="bg-primary">Footer</footer>
+		<header class="bg-info">Header</header>
+		<hgroup class="bg-primary">Hgroup</hgroup>
+		<main class="bg-info">Main</main>
+		<nav class="bg-primary">Nav</nav>
+		<section class="bg-info">Section</section>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Hr</h3>
+
+		<blockquote class="blockquote">
+			<p>IE and Edge should show `overflow`</p>
+		</blockquote>
+
+		<hr />
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Abbr[title]</h3>
+
+		<abbr>abbr no title</abbr>
+		<abbr title="The Abbr Title">abbr with title</abbr>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Address</h3>
+
+		<address>
+			Liferay, Inc.<br />
+			1400 Montefino Avenue<br />
+			Diamond Bar, CA 91765<br />
+			USA
+		</address>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>B, Strong</h3>
+
+		<b>Bold</b>
+		<strong>Strong</strong>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Small</h3>
+
+		<small>Small</small>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Sub, Sup</h3>
+
+		<div>This is <sub>subscript</sub> text. The quick brown fox jumped over the lazy dog. The quick brown fox jumped over the lazy dog. This is <sup>superscript</sup> text. The quick brown fox jumped over the lazy dog. The quick brown fox jumped over the lazy dog. The quick brown fox jumped over the lazy dog. The quick brown fox jumped over the lazy dog. The quick brown fox jumped over the lazy dog.</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Anchor</h3>
+
+		<div><a href="#1">This is a link</a></div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Pre, Code, Kbd, Samp</h3>
+
+		<pre>// Comment ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+
+pre,
+code,
+kbd,
+samp {
+	font-family: $font-family-monospace;
+}</pre>
+		<p>
+			<code>font-family: $font-family-monospace;</code>
+		</p>
+		<p><kbd>Kbd</kbd></p>
+		<p>
+			Sample output from a computer program:<br />
+			<samp>
+				[12:20:05] Finished 'build' after 7.42 s<br />
+				[12:21:02] Starting 'build'...<br />
+				[12:21:02] Starting 'build:svg'...<br />
+				[12:21:03] Finished 'build:svg' after 1.05 s<br />
+				[12:21:03] Starting 'build:svg:scss-icons'...
+			</samp>
+		</p>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Figure</h3>
+
+		<figure>Figure</figure>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Img</h3>
+
+		<div>Image Inside Link</div>
+		<a href="#1"><img alt="thumbnail" src="{{rootPath}}/content/site-images/thumbnail_coffee.jpg"></a>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>table</h3>
+
+		<table>
+			<caption>The table caption</caption>
+			<thead>
+				<th>Heading 1</th>
+				<th>Heading 2</th>
+			</thead>
+			<tbody>
+				<td>Column 1 Content</td>
+				<td>Column 2 Content</td>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Button</h3>
+
+		<button type="button">Button</button><br />
+		<input type="button" value="Input Type Button" /><br />
+		<input type="reset" value="Input Type Reset" /><br />
+		<input type="submit" value="Input Type Submit" />
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Form Elements</h3>
+
+		<input hidden type="text" />
+		<input type="text" value="Input Type Text" /><br />
+		<select>
+			<option>The quick brown fox jumped over the lazy dog. The quick brown fox jumped over the lazy dog.</option>
+			<option>Sample 2</option>
+			<option>Sample 3</option>
+			<option>Sample 4</option>
+		</select><br />
+		<textarea></textarea><br />
+		<input type="file" />
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Checkbox, Radio</h3>
+
+		<input class="form-check-input" type="checkbox" value="" /><br />
+		<input class="form-check-input" type="radio" value="">
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Template</h3>
+
+		<template>This is an HTML Template.</template>
+	</div>
+</div>

--- a/packages/clay-css/src/scss/_bs4.scss
+++ b/packages/clay-css/src/scss/_bs4.scss
@@ -1,10 +1,7 @@
 // This file imports Bootstrap 4 for base.scss and atlas.scss.
 
-@import 'bootstrap/functions';
-@import 'bootstrap/variables';
-@import 'bootstrap/mixins';
 @import 'components/_root';
-@import 'bootstrap/reboot';
+@import 'components/_reboot';
 // @import 'bootstrap/type';
 @import 'bootstrap/images';
 @import 'bootstrap/code';

--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -8,6 +8,7 @@
 
 @import 'components/_aspect-ratio';
 @import 'components/_buttons';
+
 @import 'components/_grid';
 
 @import 'components/_alerts';

--- a/packages/clay-css/src/scss/atlas-variables.scss
+++ b/packages/clay-css/src/scss/atlas-variables.scss
@@ -16,6 +16,7 @@
 * SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
 */
 
+@import 'bootstrap/_functions';
 @import 'functions/_global-functions';
 
 // INSERT CUSTOM BASE VARS
@@ -24,11 +25,12 @@
 
 @import 'variables/_bs4-variable-overwrites';
 
-@import 'bootstrap/_functions';
 @import 'bootstrap/_variables';
-@import 'bootstrap/_mixins';
 
 @import '_variables';
+
+@import 'bootstrap/_mixins';
+
 @import '_mixins';
 
 // INSERT CUSTOM VARS

--- a/packages/clay-css/src/scss/atlas.scss
+++ b/packages/clay-css/src/scss/atlas.scss
@@ -16,6 +16,7 @@
 * SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
 */
 
+@import 'bootstrap/_functions';
 @import 'functions/_global-functions';
 
 // INSERT CUSTOM VARS
@@ -24,11 +25,15 @@
 
 @import 'variables/_bs4-variable-overwrites';
 
-@import '_bs4';
+@import 'bootstrap/_variables';
 
 @import '_variables';
 
+@import 'bootstrap/mixins';
+
 @import '_mixins';
+
+@import '_bs4';
 
 @import '_components';
 

--- a/packages/clay-css/src/scss/base-variables.scss
+++ b/packages/clay-css/src/scss/base-variables.scss
@@ -16,17 +16,19 @@
 * SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
 */
 
+@import 'bootstrap/_functions';
 @import 'functions/_global-functions';
 
 // INSERT CUSTOM BASE VARS
 
 @import 'variables/_bs4-variable-overwrites';
 
-@import 'bootstrap/_functions';
 @import 'bootstrap/_variables';
-@import 'bootstrap/_mixins';
 
 @import '_variables';
+
+@import 'bootstrap/_mixins';
+
 @import '_mixins';
 
 // INSERT CUSTOM VARS

--- a/packages/clay-css/src/scss/base.scss
+++ b/packages/clay-css/src/scss/base.scss
@@ -16,17 +16,22 @@
 * SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
 */
 
+@import 'bootstrap/_functions';
 @import 'functions/_global-functions';
 
 // INSERT CUSTOM VARS
 
 @import 'variables/_bs4-variable-overwrites';
 
-@import '_bs4';
+@import 'bootstrap/_variables';
 
 @import '_variables';
 
+@import 'bootstrap/_mixins';
+
 @import '_mixins';
+
+@import '_bs4';
 
 @import '_components';
 

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -290,6 +290,7 @@ textarea.form-control,
 textarea.form-control-plaintext,
 .form-control.form-control-textarea {
 	height: $input-textarea-height;
+	resize: vertical;
 }
 
 // File

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -1,0 +1,540 @@
+// Reboot
+//
+// Normalization of HTML elements, manually forked from Normalize.css to remove
+// styles targeting irrelevant browsers while applying new styles.
+//
+// Normalize is licensed MIT. https://github.com/necolas/normalize.css
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+html {
+	// Change the default font family in all browsers
+
+	font-family: sans-serif;
+
+	// Correct the line height in all browsers
+
+	line-height: 1.15;
+
+	// Prevent adjustments of font size after orientation changes in IE on Windows Phone and in iOS
+
+	-webkit-text-size-adjust: 100%;
+
+	// Change the default tap highlight to be completely transparent in iOS
+
+	-webkit-tap-highlight-color: rgba($black, 0);
+}
+
+// Shim for "new" HTML5 structural elements to display correctly (IE10, older browsers)
+
+article,
+aside,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section {
+	display: block;
+}
+
+body {
+	// As a best practice, apply a default `background-color`
+
+	background-color: $body-bg;
+	color: $body-color;
+	font-family: $font-family-base;
+
+	@include font-size($font-size-base);
+
+	font-weight: $font-weight-base;
+	line-height: $line-height-base;
+
+	// Remove the margin in all browsers
+
+	margin: 0;
+
+	// Set an explicit initial text-align value so that we can later use the `inherit` value on things like `<th>` elements
+
+	text-align: left;
+}
+
+// Future-proof rule: in browsers that support :focus-visible, suppress the focus outline
+// on elements that programmatically receive focus but wouldn't normally show a visible
+// focus outline. In general, this would mean that the outline is only applied if the
+// interaction that led to the element receiving programmatic focus was a keyboard interaction,
+// or the browser has somehow determined that the user is primarily a keyboard user and/or
+// wants focus outlines to always be presented.
+//
+// See https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
+// and https://developer.paciellogroup.com/blog/2018/03/focus-visible-and-backwards-compatibility/
+
+[tabindex='-1']:focus:not(:focus-visible) {
+	outline: 0 !important;
+}
+
+hr {
+	// Add the correct box sizing in Firefox
+
+	box-sizing: content-box;
+	height: 0;
+
+	// Show the overflow in Edge and IE
+
+	overflow: visible; // 2
+}
+
+// Remove top margins from headings
+//
+// By default, `<h1>`-`<h6>` all receive top and bottom margins. We nuke the top
+// margin for easier control within type scales as it avoids margin collapsing.
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	margin-top: 0;
+	margin-bottom: $headings-margin-bottom;
+}
+
+// Reset margins on paragraphs
+//
+// Similarly, the top margin on `<p>`s get reset. However, we also reset the
+// bottom margin to use `rem` units instead of `em`.
+
+p {
+	margin-top: 0;
+	margin-bottom: $paragraph-margin-bottom;
+}
+
+// Duplicate behavior to the data-* attribute for our tooltip plugin
+
+abbr[title],
+abbr[data-original-title] {
+	// Remove the bottom border in Firefox 39-
+
+	border-bottom: 0;
+	cursor: help;
+
+	// Prevent the text-decoration to be skipped
+
+	text-decoration-skip-ink: none; // 5
+
+	// Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari
+
+	text-decoration: underline dotted;
+	text-decoration: underline;
+}
+
+address {
+	font-style: normal;
+	line-height: inherit;
+	margin-bottom: 1rem;
+}
+
+ol,
+ul,
+dl {
+	margin-bottom: 1rem;
+	margin-top: 0;
+}
+
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+	margin-bottom: 0;
+}
+
+dt {
+	font-weight: $dt-font-weight;
+}
+
+dd {
+	margin-bottom: 0.5rem;
+
+	// Undo browser default
+
+	margin-left: 0;
+}
+
+blockquote {
+	margin: 0 0 1rem;
+}
+
+b,
+strong {
+	// Add the correct font weight in Chrome, Edge, and Safari
+
+	font-weight: $font-weight-bolder;
+}
+
+small {
+	// Add the correct font size in all browsers
+
+	@include font-size(80%);
+}
+
+// Prevent `sub` and `sup` elements from affecting the line height in
+// all browsers.
+
+sub,
+sup {
+	@include font-size(75%);
+
+	line-height: 0;
+	position: relative;
+	vertical-align: baseline;
+}
+
+sub {
+	bottom: -0.25em;
+}
+
+sup {
+	top: -0.5em;
+}
+
+a {
+	// Remove the gray background on active links in IE 10
+
+	background-color: transparent;
+	color: $link-color;
+	text-decoration: $link-decoration;
+
+	@include hover() {
+		color: $link-hover-color;
+		text-decoration: $link-hover-decoration;
+	}
+}
+
+// And undo these styles for placeholder links/named anchors (without href).
+// It would be more straightforward to just use a[href] in previous block, but that
+// causes specificity issues in many other styles that are too complex to fix.
+// See https://github.com/twbs/bootstrap/issues/19402
+
+a:not([href]) {
+	color: inherit;
+	text-decoration: none;
+
+	@include hover() {
+		color: inherit;
+		text-decoration: none;
+	}
+}
+
+// Code
+
+pre,
+code,
+kbd,
+samp {
+	font-family: $font-family-monospace;
+
+	// Correct the odd `em` font sizing in all browsers
+
+	@include font-size(1em);
+}
+
+pre {
+	// Reset browser default of `1em` to use `rem`s
+
+	margin-bottom: 1rem;
+
+	// Remove browser default top margin
+
+	margin-top: 0;
+
+	// Don't allow content to break outside
+
+	overflow: auto;
+}
+
+// Figures
+
+figure {
+	margin: 0 0 1rem;
+}
+
+// Images and content
+
+img {
+	// Remove the border on images inside links in IE 10-
+
+	border-style: none;
+	vertical-align: middle;
+}
+
+svg {
+	// Workaround for the SVG overflow bug in IE10/11 is still required.
+	// See https://github.com/twbs/bootstrap/issues/26878
+
+	overflow: hidden;
+	vertical-align: middle;
+}
+
+// Tables
+
+table {
+	// Prevent double borders
+
+	border-collapse: collapse;
+}
+
+caption {
+	caption-side: bottom;
+	color: $table-caption-color;
+	padding-bottom: $table-cell-padding;
+	padding-top: $table-cell-padding;
+	text-align: left;
+}
+
+th {
+	// Matches default `<td>` alignment by inheriting from the `<body>`, or the
+	// closest parent with a set `text-align`.
+
+	text-align: inherit;
+}
+
+// Forms
+
+label {
+	// Allow labels to use `margin` for spacing. This is the reason we have `.form-control-label` and `.form-control-label-text pattern`.
+
+	display: inline-block;
+	margin-bottom: $label-margin-bottom;
+}
+
+// Remove the default `border-radius` that macOS Chrome adds.
+//
+// Details at https://github.com/twbs/bootstrap/issues/24093
+
+button {
+	border-radius: 0;
+}
+
+// Work around a Firefox/IE bug where the transparent `button` background
+// results in a loss of the default `button` focus styles.
+//
+// Credit: https://github.com/suitcss/base/
+
+button:focus {
+	outline: 1px dotted;
+	outline: 5px auto -webkit-focus-ring-color;
+}
+
+input,
+button,
+select,
+optgroup,
+textarea {
+	@include font-size(inherit);
+
+	font-family: inherit;
+	line-height: inherit;
+
+	// Remove the margin in Firefox and Safari
+
+	margin: 0;
+}
+
+button,
+input {
+	// Show the overflow in Edge
+
+	overflow: visible;
+}
+
+button,
+select {
+	// Remove the inheritance of text transform in Firefox
+
+	text-transform: none;
+}
+
+// Remove the inheritance of word-wrap in Safari.
+//
+// Details at https://github.com/twbs/bootstrap/issues/24990
+
+select {
+	word-wrap: normal;
+}
+
+// [type="button"] { -webkit-appearance: button; } prevent WebKit bug where `-webkit-appearance` destroys native `audio` and `video` controls in Android 4
+
+button,
+[type="button"], // 1
+[type="reset"],
+[type="submit"] {
+	// Correct the inability to style clickable types in iOS and Safari
+
+	-webkit-appearance: button;
+}
+
+// Opinionated: add "hand" cursor to non-disabled button elements.
+
+@if $enable-pointer-cursor-for-buttons {
+	button,
+	[type='button'],
+	[type='reset'],
+	[type='submit'] {
+		&:not(:disabled) {
+			cursor: pointer;
+		}
+	}
+}
+
+// Remove inner border and padding from Firefox, but don't restore the outline like Normalize.
+
+button::-moz-focus-inner,
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner {
+	padding: 0;
+	border-style: none;
+}
+
+input[type='radio'],
+input[type='checkbox'] {
+	// Add the correct box sizing in IE 10-
+
+	box-sizing: border-box;
+
+	// Remove the padding in IE 10-
+
+	padding: 0;
+}
+
+input[type='date'],
+input[type='time'],
+input[type='datetime-local'],
+input[type='month'] {
+	// Remove the default appearance of temporal inputs to avoid a Mobile Safari
+	// bug where setting a custom line-height prevents text from being vertically
+	// centered within the input.
+	// See https://bugs.webkit.org/show_bug.cgi?id=139848
+	// and https://github.com/twbs/bootstrap/issues/11266
+
+	-webkit-appearance: listbox;
+}
+
+textarea {
+	// Remove the default vertical scrollbar in IE
+
+	overflow: auto;
+
+	// Textareas should really only resize vertically so they don't break their (horizontal) containers.
+
+	resize: vertical;
+}
+
+fieldset {
+	border: 0;
+	margin: 0;
+
+	// Browsers set a default `min-width: min-content;` on fieldsets,
+	// unlike e.g. `<div>`s, which have `min-width: 0;` by default.
+	// So we reset that to ensure fieldsets behave more like a standard block element.
+	// See https://github.com/twbs/bootstrap/issues/12359
+	// and https://html.spec.whatwg.org/multipage/#the-fieldset-and-legend-elements
+
+	min-width: 0;
+
+	// Reset the default outline behavior of fieldsets so they don't affect page layout.
+
+	padding: 0;
+}
+
+legend {
+	// Correct the color inheritance from `fieldset` elements in IE
+
+	color: inherit;
+	display: block;
+
+	@include font-size(1.5rem);
+
+	line-height: inherit;
+	margin-bottom: 0.5rem;
+
+	// Correct the text wrapping in Edge and IE
+
+	max-width: 100%;
+	padding: 0;
+
+	// Correct the text wrapping in Edge and IE
+
+	white-space: normal;
+	width: 100%;
+}
+
+progress {
+	// Add the correct vertical alignment in Chrome, Firefox, and Opera
+
+	vertical-align: baseline;
+}
+
+// Correct the cursor style of increment and decrement buttons in Chrome
+
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+	height: auto;
+}
+
+[type='search'] {
+	// This overrides the extra rounded corners on search inputs in iOS so that our
+	// `.form-control` class can properly style them. Note that this cannot simply
+	// be added to `.form-control` as it's not specific enough. For details, see
+	// https://github.com/twbs/bootstrap/issues/11586
+	// Correct the outline style in Safari
+
+	outline-offset: -2px;
+	-webkit-appearance: none;
+}
+
+// Remove the inner padding in Chrome and Safari on macOS.
+
+[type='search']::-webkit-search-decoration {
+	-webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+	// Correct the inability to style clickable types in iOS and Safari
+
+	-webkit-appearance: button;
+
+	// Change font properties to `inherit` in Safari
+
+	font: inherit;
+}
+
+output {
+	display: inline-block;
+}
+
+summary {
+	// Add the correct display in all browsers
+
+	display: list-item;
+	cursor: pointer;
+}
+
+template {
+	// Add the correct display in IE
+
+	display: none;
+}
+
+// Always hide an element with the `hidden` HTML attribute (from PureCSS).
+// Needed for proper display in IE 10-.
+
+[hidden] {
+	display: none !important;
+}

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -12,14 +12,6 @@
 }
 
 html {
-	// Change the default font family in all browsers
-
-	font-family: sans-serif;
-
-	// Correct the line height in all browsers
-
-	line-height: 1.15;
-
 	// Prevent adjustments of font size after orientation changes in IE on Windows Phone and in iOS
 
 	-webkit-text-size-adjust: 100%;
@@ -50,33 +42,13 @@ body {
 	background-color: $body-bg;
 	color: $body-color;
 	font-family: $font-family-base;
-
-	@include font-size($font-size-base);
-
+	font-size: $font-size-base;
 	font-weight: $font-weight-base;
 	line-height: $line-height-base;
 
 	// Remove the margin in all browsers
 
 	margin: 0;
-
-	// Set an explicit initial text-align value so that we can later use the `inherit` value on things like `<th>` elements
-
-	text-align: left;
-}
-
-// Future-proof rule: in browsers that support :focus-visible, suppress the focus outline
-// on elements that programmatically receive focus but wouldn't normally show a visible
-// focus outline. In general, this would mean that the outline is only applied if the
-// interaction that led to the element receiving programmatic focus was a keyboard interaction,
-// or the browser has somehow determined that the user is primarily a keyboard user and/or
-// wants focus outlines to always be presented.
-//
-// See https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
-// and https://developer.paciellogroup.com/blog/2018/03/focus-visible-and-backwards-compatibility/
-
-[tabindex='-1']:focus:not(:focus-visible) {
-	outline: 0 !important;
 }
 
 hr {
@@ -87,7 +59,7 @@ hr {
 
 	// Show the overflow in Edge and IE
 
-	overflow: visible; // 2
+	overflow: visible;
 }
 
 // Remove top margins from headings
@@ -101,8 +73,8 @@ h3,
 h4,
 h5,
 h6 {
-	margin-top: 0;
 	margin-bottom: $headings-margin-bottom;
+	margin-top: 0;
 }
 
 // Reset margins on paragraphs
@@ -111,11 +83,9 @@ h6 {
 // bottom margin to use `rem` units instead of `em`.
 
 p {
-	margin-top: 0;
 	margin-bottom: $paragraph-margin-bottom;
+	margin-top: 0;
 }
-
-// Duplicate behavior to the data-* attribute for our tooltip plugin
 
 abbr[title],
 abbr[data-original-title] {
@@ -126,7 +96,7 @@ abbr[data-original-title] {
 
 	// Prevent the text-decoration to be skipped
 
-	text-decoration-skip-ink: none; // 5
+	text-decoration-skip-ink: none;
 
 	// Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari
 
@@ -180,7 +150,7 @@ strong {
 small {
 	// Add the correct font size in all browsers
 
-	@include font-size(80%);
+	font-size: 80%;
 }
 
 // Prevent `sub` and `sup` elements from affecting the line height in
@@ -188,8 +158,7 @@ small {
 
 sub,
 sup {
-	@include font-size(75%);
-
+	font-size: 75%;
 	line-height: 0;
 	position: relative;
 	vertical-align: baseline;
@@ -203,31 +172,16 @@ sup {
 	top: -0.5em;
 }
 
-a {
+[href] {
 	// Remove the gray background on active links in IE 10
 
 	background-color: transparent;
 	color: $link-color;
 	text-decoration: $link-decoration;
 
-	@include hover() {
+	&:hover {
 		color: $link-hover-color;
 		text-decoration: $link-hover-decoration;
-	}
-}
-
-// And undo these styles for placeholder links/named anchors (without href).
-// It would be more straightforward to just use a[href] in previous block, but that
-// causes specificity issues in many other styles that are too complex to fix.
-// See https://github.com/twbs/bootstrap/issues/19402
-
-a:not([href]) {
-	color: inherit;
-	text-decoration: none;
-
-	@include hover() {
-		color: inherit;
-		text-decoration: none;
 	}
 }
 
@@ -241,7 +195,7 @@ samp {
 
 	// Correct the odd `em` font sizing in all browsers
 
-	@include font-size(1em);
+	font-size: 1em;
 }
 
 pre {
@@ -297,13 +251,6 @@ caption {
 	text-align: left;
 }
 
-th {
-	// Matches default `<td>` alignment by inheriting from the `<body>`, or the
-	// closest parent with a set `text-align`.
-
-	text-align: inherit;
-}
-
 // Forms
 
 label {
@@ -314,7 +261,6 @@ label {
 }
 
 // Remove the default `border-radius` that macOS Chrome adds.
-//
 // Details at https://github.com/twbs/bootstrap/issues/24093
 
 button {
@@ -323,7 +269,6 @@ button {
 
 // Work around a Firefox/IE bug where the transparent `button` background
 // results in a loss of the default `button` focus styles.
-//
 // Credit: https://github.com/suitcss/base/
 
 button:focus {
@@ -336,9 +281,8 @@ button,
 select,
 optgroup,
 textarea {
-	@include font-size(inherit);
-
 	font-family: inherit;
+	font-size: inherit;
 	line-height: inherit;
 
 	// Remove the margin in Firefox and Safari
@@ -361,35 +305,21 @@ select {
 }
 
 // Remove the inheritance of word-wrap in Safari.
-//
 // Details at https://github.com/twbs/bootstrap/issues/24990
 
 select {
 	word-wrap: normal;
 }
 
-// [type="button"] { -webkit-appearance: button; } prevent WebKit bug where `-webkit-appearance` destroys native `audio` and `video` controls in Android 4
+// `[type="button"] { -webkit-appearance: button; }` prevent WebKit bug where `-webkit-appearance` destroys native `audio` and `video` controls in Android 4
 
 button,
-[type="button"], // 1
+[type="button"],
 [type="reset"],
 [type="submit"] {
 	// Correct the inability to style clickable types in iOS and Safari
 
 	-webkit-appearance: button;
-}
-
-// Opinionated: add "hand" cursor to non-disabled button elements.
-
-@if $enable-pointer-cursor-for-buttons {
-	button,
-	[type='button'],
-	[type='reset'],
-	[type='submit'] {
-		&:not(:disabled) {
-			cursor: pointer;
-		}
-	}
 }
 
 // Remove inner border and padding from Firefox, but don't restore the outline like Normalize.
@@ -458,9 +388,7 @@ legend {
 
 	color: inherit;
 	display: block;
-
-	@include font-size(1.5rem);
-
+	font-size: 1.5rem;
 	line-height: inherit;
 	margin-bottom: 0.5rem;
 

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -21,18 +21,9 @@ html {
 	-webkit-tap-highlight-color: rgba($black, 0);
 }
 
-// Shim for "new" HTML5 structural elements to display correctly (IE10, older browsers)
+// Shim for "new" HTML5 structural elements to display correctly (IE11)
 
-article,
-aside,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-nav,
-section {
+main {
 	display: block;
 }
 
@@ -59,17 +50,6 @@ body {
 	}
 }
 
-hr {
-	// Add the correct box sizing in Firefox
-
-	box-sizing: content-box;
-	height: 0;
-
-	// Show the overflow in Edge and IE
-
-	overflow: visible;
-}
-
 // Remove top margins from headings
 //
 // By default, `<h1>`-`<h6>` all receive top and bottom margins. We nuke the top
@@ -86,7 +66,6 @@ h6 {
 }
 
 // Reset margins on paragraphs
-//
 // Similarly, the top margin on `<p>`s get reset. However, we also reset the
 // bottom margin to use `rem` units instead of `em`.
 
@@ -97,24 +76,20 @@ p {
 
 abbr[title],
 abbr[data-original-title] {
-	// Remove the bottom border in Firefox 39-
-
-	border-bottom: 0;
 	cursor: help;
 
-	// Prevent the text-decoration to be skipped
+	// Add `text-decoration: underline` in IE and Safari, `underline dotted` not supported.
+
+	text-decoration: underline;
+	text-decoration: underline dotted;
+
+	// Prevent underline from disappearing on letters like `g`, `j`, `y`.
 
 	text-decoration-skip-ink: none;
-
-	// Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari
-
-	text-decoration: underline dotted;
-	text-decoration: underline;
 }
 
 address {
 	font-style: normal;
-	line-height: inherit;
 	margin-bottom: 1rem;
 }
 
@@ -155,19 +130,14 @@ strong {
 	font-weight: $font-weight-bolder;
 }
 
-small {
-	// Add the correct font size in all browsers
-
-	font-size: 80%;
-}
-
-// Prevent `sub` and `sup` elements from affecting the line height in
-// all browsers.
-
 sub,
 sup {
-	font-size: 75%;
+	// Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+
 	line-height: 0;
+
+	// Opinionated: Fixes alignment within multi-line text displayed oddly in all browsers
+
 	position: relative;
 	vertical-align: baseline;
 }
@@ -181,9 +151,6 @@ sup {
 }
 
 [href] {
-	// Remove the gray background on active links in IE 10
-
-	background-color: transparent;
 	color: $link-color;
 	cursor: $link-cursor;
 	text-decoration: $link-decoration;
@@ -201,10 +168,6 @@ code,
 kbd,
 samp {
 	font-family: $font-family-monospace;
-
-	// Correct the odd `em` font sizing in all browsers
-
-	font-size: 1em;
 }
 
 pre {
@@ -230,9 +193,6 @@ figure {
 // Images and content
 
 img {
-	// Remove the border on images inside links in IE 10-
-
-	border-style: none;
 	vertical-align: middle;
 }
 
@@ -245,12 +205,6 @@ svg {
 }
 
 // Tables
-
-table {
-	// Prevent double borders
-
-	border-collapse: collapse;
-}
 
 caption {
 	caption-side: bottom;
@@ -269,22 +223,6 @@ label {
 	margin-bottom: $label-margin-bottom;
 }
 
-// Remove the default `border-radius` that macOS Chrome adds.
-// Details at https://github.com/twbs/bootstrap/issues/24093
-
-button {
-	border-radius: 0;
-}
-
-// Work around a Firefox/IE bug where the transparent `button` background
-// results in a loss of the default `button` focus styles.
-// Credit: https://github.com/suitcss/base/
-
-button:focus {
-	outline: 1px dotted;
-	outline: 5px auto -webkit-focus-ring-color;
-}
-
 input,
 button,
 select,
@@ -294,7 +232,7 @@ textarea {
 	font-size: inherit;
 	line-height: inherit;
 
-	// Remove the margin in Firefox and Safari
+	// Remove the margin in Safari
 
 	margin: 0;
 }
@@ -304,13 +242,6 @@ input {
 	// Show the overflow in Edge
 
 	overflow: visible;
-}
-
-button,
-select {
-	// Remove the inheritance of text transform in Firefox
-
-	text-transform: none;
 }
 
 // Remove the inheritance of word-wrap in Safari.
@@ -331,25 +262,13 @@ button,
 	-webkit-appearance: button;
 }
 
-// Remove inner border and padding from Firefox, but don't restore the outline like Normalize.
+// Remove inner border from Firefox, but don't restore the outline like Normalize.
 
 button::-moz-focus-inner,
 [type='button']::-moz-focus-inner,
 [type='reset']::-moz-focus-inner,
 [type='submit']::-moz-focus-inner {
-	padding: 0;
 	border-style: none;
-}
-
-input[type='radio'],
-input[type='checkbox'] {
-	// Add the correct box sizing in IE 10-
-
-	box-sizing: border-box;
-
-	// Remove the padding in IE 10-
-
-	padding: 0;
 }
 
 input[type='date'],
@@ -369,10 +288,6 @@ textarea {
 	// Remove the default vertical scrollbar in IE
 
 	overflow: auto;
-
-	// Textareas should really only resize vertically so they don't break their (horizontal) containers.
-
-	resize: vertical;
 }
 
 fieldset {
@@ -467,11 +382,4 @@ template {
 	// Add the correct display in IE
 
 	display: none;
-}
-
-// Always hide an element with the `hidden` HTML attribute (from PureCSS).
-// Needed for proper display in IE 10-.
-
-[hidden] {
-	display: none !important;
 }

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -323,9 +323,9 @@ select {
 // `[type="button"] { -webkit-appearance: button; }` prevent WebKit bug where `-webkit-appearance` destroys native `audio` and `video` controls in Android 4
 
 button,
-[type="button"],
-[type="reset"],
-[type="submit"] {
+[type='button'],
+[type='reset'],
+[type='submit'] {
 	// Correct the inability to style clickable types in iOS and Safari
 
 	-webkit-appearance: button;

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -44,11 +44,19 @@ body {
 	font-family: $font-family-base;
 	font-size: $font-size-base;
 	font-weight: $font-weight-base;
+	-moz-osx-font-smoothing: $body-moz-osx-font-smoothing;
+	-webkit-font-smoothing: $body-webkit-font-smoothing;
 	line-height: $line-height-base;
 
 	// Remove the margin in all browsers
 
 	margin: 0;
+	-ms-overflow-style: scrollbar;
+	text-align: $body-text-align;
+
+	@include clay-scale-component {
+		font-size: $font-size-base-mobile;
+	}
 }
 
 hr {
@@ -177,6 +185,7 @@ sup {
 
 	background-color: transparent;
 	color: $link-color;
+	cursor: $link-cursor;
 	text-decoration: $link-decoration;
 
 	&:hover {

--- a/packages/clay-css/src/scss/components/_type.scss
+++ b/packages/clay-css/src/scss/components/_type.scss
@@ -1,20 +1,3 @@
-body {
-	-moz-osx-font-smoothing: $body-moz-osx-font-smoothing;
-	-ms-overflow-style: scrollbar;
-	-webkit-font-smoothing: $body-webkit-font-smoothing;
-	text-align: $body-text-align;
-
-	@include clay-scale-component {
-		font-size: $font-size-base-mobile;
-	}
-}
-
-a {
-	@if ($link-cursor != pointer) {
-		cursor: $link-cursor;
-	}
-}
-
 // Headings
 
 h1,


### PR DESCRIPTION
issue #3149

List of changes to Bootstrap's Reboot:
- We don't need to set `font-family`, `line-height` on the `html` element already set on `body`
- Don't set `text-align: left` on `body` due to RTL issues. See #1743
- Remove `:focus-visible` future-proof rule (very experimental https://caniuse.com/#search=focus-visible)
- Remove uses of Bootstrap's `font-size` and `hover` mixin, we don't support it in Clay CSS
- Remove Bootstrap's `text-align` reset on `th`. See #2219
- Remove Bootstrap's "hand" cursor to non-disabled button elements. We don't support `$enable-pointer-cursor-for-buttons`. We can change the cursor to whatever we want in Clay CSS.
- Use selector `[href]` for styling anchor links instead of `a` so we don't need to overwrite placeholder anchor styles with `a:not([href])`. Styling `<a tabindex="0">a link</a>` should be done with a class like `link-primary`.
- Combine `body` and `a` styles from Type