### PR TITLE
fix(clayui.com): Fix links that pointed to APITable but didn't work

### DIFF
--- a/clayui.com/plugins/gatsby-remark-api-table/index.js
+++ b/clayui.com/plugins/gatsby-remark-api-table/index.js
@@ -8,7 +8,7 @@ const path = require('path');
 const reactDocs = require('react-docgen');
 const visit = require('unist-util-visit');
 
-const generateTr = (item, key) => `<tr>
+const generateTr = (item, key) => `<tr id="api-${key}">
 	<td>
 		<div class="table-title">
 			${key}

--- a/packages/clay-button/README.mdx
+++ b/packages/clay-button/README.mdx
@@ -26,11 +26,11 @@ import {
 
 ## Display Types
 
-You can determine how your button can be displayed using [`displayType`](#api-displayType) property:
+You can determine how your button can be displayed using the [`displayType`](#api-displayType) property:
 
-Use [`unstyled`](#api-unstyled) to reset all the stylings from Bootstrap 4.
+Set `displayType` to `unstyled` to reset all the stylings from Bootstrap 4.
 
-If you want use the button as a link use [`link`](#api-link).
+If you want use the button as a link set `displayType` to `link`.
 
 <ButtonDisplayTypes />
 
@@ -38,7 +38,7 @@ If you want use the button as a link use [`link`](#api-link).
 
 You can use the variant `ClayButton.Group` for creating button groups:
 
-Use [`spaced`](#api-spaced) property to create spacing between buttons.
+Use the [`spaced`](#api-spaced) property to create spacing between buttons.
 
 <ButtonGroup />
 

--- a/packages/clay-date-picker/README.mdx
+++ b/packages/clay-date-picker/README.mdx
@@ -41,7 +41,7 @@ The component is treated as controlled, use the [`onValueChange`](#api-onValueCh
 <div class="clay-site-alert alert alert-warning">
 	<strong class="lead">Warning</strong>
 	You can set a range of years using the API <code class="language-text">
-		years
+		<a href="#api-years">years</a>
 	</code>, which can be displayed in the Date Picker, if the user enters a year
 	that is not within the range will be treated as an invalid date.
 </div>
@@ -50,18 +50,18 @@ The component is treated as controlled, use the [`onValueChange`](#api-onValueCh
 
 ## Time
 
-The ClayTimePicker by default is already implemented in the Date Picker, you can enable it using the [`time`](#api-time) API. To provide a context for the timezone user, use the `timezone` API for this.
+The ClayTimePicker by default is already implemented in the Date Picker, you can enable it using the [`time`](#api-time) API. To provide a context for the timezone user, use the [`timezone`](#api-timezone) API for this.
 
 <DatePickerWithTime />
 
 ## Internationalization
 
-To set internationalization of the component, you need to configure the props according to the language. Date Picker offers low level APIs to configure [`firstDayOfWeek`](#api-firstDayOfWeek), [`weekdaysShort`](#api-weekdaysShort), [`months`](#api-months), [`timeFormat`](#api-timeFormat), [`timezone`](#api-timezone) and [`dateFormat`](#api-dateFormat), you can follow the example below to set up a Date Picker for Russian.
+To set internationalization of the component, you need to configure the props according to the language. Date Picker offers low level APIs to configure [`firstDayOfWeek`](#api-firstDayOfWeek), [`weekdaysShort`](#api-weekdaysShort), [`months`](#api-months), [`timezone`](#api-timezone) and [`dateFormat`](#api-dateFormat), you can follow the example below to set up a Date Picker for Russian.
 
 <DatePickerLocale />
 
 -   [`firstDayOfWeek`](#api-firstDayOfWeek) by default the value by default the value is 0 (Sunday) and its values ​​are the days of the week, 1 (Monday), 2 (Tuesday), 3 (Wednesday), 4 (Thursday), 5 (Friday), 6 (Saturday).
--   [`dateFormat`](#api-dateFormat) and [`timeFormat`](#api-timeFormat) is defined according to the **formatting rules of [Moment.js](https://momentjs.com/docs/#/parsing/string-format/)**.
+-   [`dateFormat`](#api-dateFormat) and `timeFormat` is defined according to the **formatting rules of [Moment.js](https://momentjs.com/docs/#/parsing/string-format/)**.
 -   [`months`](#api-months) is an `Array<string>` with available months **starting January to December**.
 -   [`weekdaysShort`](#api-weekdaysShort) is an `Array<string>` with the **names of the days of the week in short form**, starting from **Sunday to Saturday**.
 


### PR DESCRIPTION
Fixes #3228 

Hey @bryceosterhaus can you please review this.

I've done the following as part of this PR:

- Add `id="api-${key}"` to the `tr` that's being constructed by the `gatsby-remark-api-table` plugin
- Add all the DatePicker subcomponents to the APITable of DatePicker because some of them were being referenced so I assumed that was the right course
    - Note: most of these are missing descriptions/JSDoc
- Reword a couple sentences in Button and Date Picker to match these, now fixed, links to API props