### PR TITLE
feat(clayui.com): Add documentation for examples in form of list of links to their stories

### DIFF
--- a/clayui.com/content/docs/examples.mdx
+++ b/clayui.com/content/docs/examples.mdx
@@ -5,7 +5,6 @@ order: 5
 
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
-import ClayList from '@clayui/list';
 
 ## What is Storybook and how do we use it?
 
@@ -27,62 +26,48 @@ Here are our demos we have in Storybook that utilize Clay components showcasing 
 <ClayLayout.Container>
 	<ClayLayout.Row justify="start">
 		<ClayLayout.Col md={4} size={4}>
-			<ClayList flex>
-				<ClayLink
-					href="https://storybook.clayui.com/?path=/story/demos-templates--list-page"
-					target="_blank"
-				>
-					<ClayList.Item>
-						<ClayList.ItemTitle>List Page</ClayList.ItemTitle>
-					</ClayList.Item>
-				</ClayLink>
-				<ClayLink
-					href="https://storybook.clayui.com/?path=/story/demos-templates--files-page"
-					target="_blank"
-				>
-					<ClayList.Item>
-						<ClayList.ItemTitle>Files Page</ClayList.ItemTitle>
-					</ClayList.Item>
-				</ClayLink>
-				<ClayLink
-					href="https://storybook.clayui.com/?path=/story/demos-templates--form-page"
-					target="_blank"
-				>
-					<ClayList.Item>
-						<ClayList.ItemTitle>Form Page</ClayList.ItemTitle>
-					</ClayList.Item>
-				</ClayLink>
-				<ClayLink
-					href="https://storybook.clayui.com/?path=/story/demos-templates--table-rows-drag-drop"
-					target="_blank"
-				>
-					<ClayList.Item>
-						<ClayList.ItemTitle>
-							Table Rows Drag & Drop
-						</ClayList.ItemTitle>
-					</ClayList.Item>
-				</ClayLink>
-				<ClayLink
-					href="https://storybook.clayui.com/?path=/story/demos-templates--table-columns-drag-drop"
-					target="_blank"
-				>
-					<ClayList.Item>
-						<ClayList.ItemTitle>
-							Table Columns Drag & Drop
-						</ClayList.ItemTitle>
-					</ClayList.Item>
-				</ClayLink>
-				<ClayLink
-					href="https://storybook.clayui.com/?path=/story/demos-templates--drag-drop"
-					target="_blank"
-				>
-					<ClayList.Item>
-						<ClayList.ItemTitle>
-							List Drag & Drop
-						</ClayList.ItemTitle>
-					</ClayList.Item>
-				</ClayLink>
-			</ClayList>
+			<ClayLink
+				className="d-block"
+				href="https://storybook.clayui.com/?path=/story/demos-templates--list-page"
+				target="_blank"
+			>
+				List Page
+			</ClayLink>
+			<ClayLink
+				className="d-block"
+				href="https://storybook.clayui.com/?path=/story/demos-templates--files-page"
+				target="_blank"
+			>
+				Files Page
+			</ClayLink>
+			<ClayLink
+				className="d-block"
+				href="https://storybook.clayui.com/?path=/story/demos-templates--form-page"
+				target="_blank"
+			>
+				Form Page
+			</ClayLink>
+			<ClayLink
+				className="d-block"
+				href="https://storybook.clayui.com/?path=/story/demos-templates--table-rows-drag-drop"
+				target="_blank"
+			>
+				Table Rows Drag & Drop
+			</ClayLink>
+			<ClayLink
+				className="d-block"
+				href="https://storybook.clayui.com/?path=/story/demos-templates--table-columns-drag-drop"
+				target="_blank"
+			>
+				Table Columns Drag & drop
+			</ClayLink>
+			<ClayLink
+				className="d-block"
+				href="https://storybook.clayui.com/?path=/story/demos-templates--drag-drop"
+				target="_blank"
+			>
+				List Drag & Drop
+			</ClayLink>
 		</ClayLayout.Col>
 	</ClayLayout.Row>
 </ClayLayout.Container>

--- a/clayui.com/content/docs/examples.mdx
+++ b/clayui.com/content/docs/examples.mdx
@@ -1,0 +1,88 @@
+---
+title: 'Examples'
+order: 5
+---
+
+import ClayLayout from '@clayui/layout';
+import ClayLink from '@clayui/link';
+import ClayList from '@clayui/list';
+
+## What is Storybook and how do we use it?
+
+Storybook is a user interface development environment and playground for UI components.
+We use it to create components independently and showcase components interactively in an isolated development environment.
+A Storybook is a collection of stories. Each story represents a single visual state of a component.
+
+## How you can leverage Storybook to make using Clay easier
+
+Whenever you have doubts about how a component is implemented or used, checking out its stories
+is a great way of getting valuable information about how we envisioned that component be used.
+
+You can use Storybook for inspiration, as well as guidelines, for your use case as well as getting insight into the composition of a component.
+
+## Examples/Demos
+
+Here are our demos we have in Storybook that utilize Clay components showcasing some common use cases.
+
+<ClayLayout.Container>
+	<ClayLayout.Row justify="start">
+		<ClayLayout.Col md={4} size={4}>
+			<ClayList flex>
+				<ClayLink
+					href="https://storybook.clayui.com/?path=/story/demos-templates--list-page"
+					target="_blank"
+				>
+					<ClayList.Item>
+						<ClayList.ItemTitle>List Page</ClayList.ItemTitle>
+					</ClayList.Item>
+				</ClayLink>
+				<ClayLink
+					href="https://storybook.clayui.com/?path=/story/demos-templates--files-page"
+					target="_blank"
+				>
+					<ClayList.Item>
+						<ClayList.ItemTitle>Files Page</ClayList.ItemTitle>
+					</ClayList.Item>
+				</ClayLink>
+				<ClayLink
+					href="https://storybook.clayui.com/?path=/story/demos-templates--form-page"
+					target="_blank"
+				>
+					<ClayList.Item>
+						<ClayList.ItemTitle>Form Page</ClayList.ItemTitle>
+					</ClayList.Item>
+				</ClayLink>
+				<ClayLink
+					href="https://storybook.clayui.com/?path=/story/demos-templates--table-rows-drag-drop"
+					target="_blank"
+				>
+					<ClayList.Item>
+						<ClayList.ItemTitle>
+							Table Rows Drag & Drop
+						</ClayList.ItemTitle>
+					</ClayList.Item>
+				</ClayLink>
+				<ClayLink
+					href="https://storybook.clayui.com/?path=/story/demos-templates--table-columns-drag-drop"
+					target="_blank"
+				>
+					<ClayList.Item>
+						<ClayList.ItemTitle>
+							Table Columns Drag & Drop
+						</ClayList.ItemTitle>
+					</ClayList.Item>
+				</ClayLink>
+				<ClayLink
+					href="https://storybook.clayui.com/?path=/story/demos-templates--drag-drop"
+					target="_blank"
+				>
+					<ClayList.Item>
+						<ClayList.ItemTitle>
+							List Drag & Drop
+						</ClayList.ItemTitle>
+					</ClayList.Item>
+				</ClayLink>
+			</ClayList>
+		</ClayLayout.Col>
+	</ClayLayout.Row>
+</ClayLayout.Container>

--- a/clayui.com/content/docs/storybook.md
+++ b/clayui.com/content/docs/storybook.md
@@ -1,5 +1,0 @@
----
-title: 'Storybook Demos'
-order: 5
-redirect: 'https://storybook.clayui.com/'
----

--- a/clayui.com/src/pages/index.js
+++ b/clayui.com/src/pages/index.js
@@ -93,6 +93,14 @@ export default () => {
 											<li className="nav-item">
 												<Link
 													className="nav-link-intro"
+													to="/docs/examples.html"
+												>
+													{'Examples'}
+												</Link>
+											</li>
+											<li className="nav-item">
+												<Link
+													className="nav-link-intro"
 													to="/blog"
 												>
 													{'Blog'}


### PR DESCRIPTION
Hey @matuzalemsteles @jbalsas here's a draft for the Examples page.

### Here's what I've done:

- I included a couple screenshots I took manually, and the rest are placeholder images.
- I added some copy that we can expand on/alter or whatever, describing Storybook and how we use it
- The examples I added are just the Demos we have, not all components, as I don't think we want all components as that would duplicate all the examples we have in component-specific docs

### My thoughts going forward

- We might need some illustrations instead of screenshots to showcase the examples, as they are visually quite complex for the low resolution, at least the ones I decided to showcase
- If we do want to have a component frontpage like in [Carbon Design](https://www.carbondesignsystem.com/components/overview/) we can utilize the Component homepage for that I made recently