### PR TITLE
feat(clayui.com): Add tabular display for different code examples depending on language

### DIFF
--- a/clayui.com/src/components/Editor/index.js
+++ b/clayui.com/src/components/Editor/index.js
@@ -38,6 +38,7 @@ const Editor = ({
 }) => {
 	let reactSnippet = {
 		code: '',
+		format: true,
 		name: 'React',
 	};
 
@@ -45,14 +46,14 @@ const Editor = ({
 		const codeToFormat = [...code];
 
 		codeToFormat.forEach((snippet) => {
-			if (snippet.name !== 'JSP') {
+			if (snippet.format) {
 				snippet.code = formatCode(snippet.code);
 			}
 		});
 
 		code = codeToFormat;
 
-		reactSnippet = code.find((snippet) => snippet.name === 'React');
+		reactSnippet = code[0];
 	} else {
 		code = formatCode(code);
 

--- a/clayui.com/src/components/Editor/index.js
+++ b/clayui.com/src/components/Editor/index.js
@@ -15,6 +15,8 @@ import theme from '../../utils/react-live-theme';
 
 const spritemap = '/images/icons/icons.svg';
 
+const REACT_SNIPPET_INDEX = 0;
+
 function formatCode(code) {
 	try {
 		return prettier.format(code, {
@@ -36,9 +38,11 @@ const Editor = ({
 	preview = true,
 	scope = {},
 }) => {
-	let reactSnippet = {
+	let defaultSnippet = {
 		code: '',
+		disabled: false,
 		format: true,
+		imports,
 		name: 'React',
 	};
 
@@ -53,19 +57,20 @@ const Editor = ({
 
 		code = codeToFormat;
 
-		reactSnippet = code[0];
+		defaultSnippet = code[REACT_SNIPPET_INDEX];
 	} else {
 		code = formatCode(code);
 
-		reactSnippet.code = code;
+		defaultSnippet.code = code;
 	}
 
 	const [collapseCode, setCollapseCode] = useState(false);
 	const [activeTabKeyValue, setActiveTabKeyValue] = React.useState(0);
+	const [values, setValues] = React.useState(code);
 
 	return (
 		<LiveProvider
-			code={reactSnippet.code}
+			code={defaultSnippet.code}
 			disabled={disabled}
 			noInline
 			scope={{spritemap, useContext, useState, ...scope}}
@@ -132,27 +137,37 @@ const Editor = ({
 									activeIndex={activeTabKeyValue}
 									fade
 								>
-									{code.map((snippet) => (
-										<ClayTabs.TabPane
-											aria-labelledby={`tab-${snippet.name}`}
-											key={snippet.name}
-										>
-											{snippet === reactSnippet &&
-												imports && (
+									{code.map((snippet, index) => {
+										return (
+											<ClayTabs.TabPane
+												aria-labelledby={`tab-${snippet.name}`}
+												key={snippet.name}
+											>
+												{snippet.imports && (
 													<LiveEditor
 														disabled
-														value={imports}
+														value={snippet.imports}
 													/>
 												)}
 
-											<LiveEditor
-												disabled={
-													snippet !== reactSnippet
-												}
-												value={snippet.code}
-											/>
-										</ClayTabs.TabPane>
-									))}
+												<LiveEditor
+													disabled={snippet.disabled}
+													onValueChange={(value) => {
+														const newValues = [
+															...values,
+														];
+
+														newValues[
+															index
+														].code = value;
+
+														setValues(newValues);
+													}}
+													value={values[index].code}
+												/>
+											</ClayTabs.TabPane>
+										);
+									})}
 								</ClayTabs.Content>
 							)}
 						</>

--- a/packages/clay-alert/docs/index.js
+++ b/packages/clay-alert/docs/index.js
@@ -27,11 +27,30 @@ render(<Component />);`;
 const alertImportsCode = `import React from 'react';
 import ClayAlert from '@clayui/alert';`;
 
+const AlertJSPCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
+
+<clay:alert
+	message='<%= LanguageUtil.get(resourceBundle, "csv-warning-message") %>'
+	style="warning"
+	title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
+/>`;
+
 export const Alert = () => {
 	const scope = {ClayAlert};
-	const code = AlertCode;
+	const codeSnippets = [
+		{
+			code: AlertCode,
+			name: 'React',
+		},
+		{
+			code: AlertJSPCode,
+			name: 'JSP',
+		},
+	];
 
-	return <Editor code={code} imports={alertImportsCode} scope={scope} />;
+	return (
+		<Editor code={codeSnippets} imports={alertImportsCode} scope={scope} />
+	);
 };
 
 const AlertWithButtonCode = `const Component = () => {

--- a/packages/clay-alert/docs/index.js
+++ b/packages/clay-alert/docs/index.js
@@ -27,30 +27,11 @@ render(<Component />);`;
 const alertImportsCode = `import React from 'react';
 import ClayAlert from '@clayui/alert';`;
 
-const AlertJSPCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
-
-<clay:alert
-	message='<%= LanguageUtil.get(resourceBundle, "csv-warning-message") %>'
-	style="warning"
-	title='<%= LanguageUtil.get(resourceBundle, "warning") %>'
-/>`;
-
 export const Alert = () => {
 	const scope = {ClayAlert};
-	const codeSnippets = [
-		{
-			code: AlertCode,
-			name: 'React',
-		},
-		{
-			code: AlertJSPCode,
-			name: 'JSP',
-		},
-	];
+	const code = AlertCode;
 
-	return (
-		<Editor code={codeSnippets} imports={alertImportsCode} scope={scope} />
-	);
+	return <Editor code={code} imports={alertImportsCode} scope={scope} />;
 };
 
 const AlertWithButtonCode = `const Component = () => {

--- a/packages/clay-tabs/docs/index.js
+++ b/packages/clay-tabs/docs/index.js
@@ -19,7 +19,7 @@ const tabsCode = `const Component = () => {
         <>
             <ClayTabs modern>
                 <ClayTabs.Item
-                    active={activeTabKeyValue == 0}
+                    active={activeTabKeyValue === 0}
                     innerProps={{
                         'aria-controls': 'tabpanel-1',
                     }}
@@ -28,7 +28,7 @@ const tabsCode = `const Component = () => {
                     {'Tab 1'}
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue == 1}
+                    active={activeTabKeyValue === 1}
                     innerProps={{
                         'aria-controls': 'tabpanel-2',
                     }}
@@ -37,7 +37,7 @@ const tabsCode = `const Component = () => {
                     {'Tab 2'}
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue == 2}
+                    active={activeTabKeyValue === 2}
                     innerProps={{
                         'aria-controls': 'tabpanel-3',
                     }}
@@ -118,7 +118,7 @@ const tabsDropdownCode = `const Component = () => {
         <ClayIconSpriteContext.Provider value={spritemap}>
             <ClayTabs modern>
                 <ClayTabs.Item
-                    active={activeTabKeyValue == 0}
+                    active={activeTabKeyValue === 0}
                     innerProps={{
                         'aria-controls': 'tabpanel-1',
                     }}
@@ -127,7 +127,7 @@ const tabsDropdownCode = `const Component = () => {
                     {'Tab 1'}
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue == 1}
+                    active={activeTabKeyValue === 1}
                     innerProps={{
                         'aria-controls': 'tabpanel-2',
                     }}
@@ -136,7 +136,7 @@ const tabsDropdownCode = `const Component = () => {
                     {'Tab 2'}
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue == 2}
+                    active={activeTabKeyValue === 2}
                     innerProps={{
                         'aria-controls': 'tabpanel-3',
                     }}
@@ -145,7 +145,7 @@ const tabsDropdownCode = `const Component = () => {
                     {'Tab 3'}
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue == 3}
+                    active={activeTabKeyValue === 3}
                     innerProps={{
                         'aria-controls': 'tabpanel-4',
                     }}


### PR DESCRIPTION
Here's my initial implementation for tabs in code examples. The goal is to offer both React and JSP code examples in a single view, by switching tabs.

### For those that just want the visual example
![JSP tab example](https://user-images.githubusercontent.com/24564752/82881942-a6009200-9f40-11ea-9e77-0d6d0b48e568.gif)

### The approach
I utilized `ClayTabs` inside of ClayAlert's docs file, meaning that if we decided to take this approach we would have to change a lot of files in order to get the tabbing functionality to all our component docs. The alternative might be wrapping it at a lower level, perhaps in [templates/docs.js](https://github.com/liferay/clay/blob/master/clayui.com/src/templates/docs.js#L296)

### The alternative
In case you haven't noticed, this implementation swaps both the display(`.sheet-example`) and the code, we might want to just change the code but leave the display same for both React and JSP implementation