### PR TITLE
fix(@clayui/alert): Make the default autoClose interval 10 seconds instead of 8

### DIFF
--- a/packages/clay-alert/src/index.tsx
+++ b/packages/clay-alert/src/index.tsx
@@ -14,7 +14,7 @@ import ToastContainer from './ToastContainer';
 const useAutoClose = (autoClose?: boolean | number, onClose = () => {}) => {
 	const startedTime = React.useRef<number>(0);
 	const timer = React.useRef<number | undefined>(undefined);
-	const timeToClose = React.useRef(autoClose === true ? 8000 : autoClose);
+	const timeToClose = React.useRef(autoClose === true ? 10000 : autoClose);
 
 	let pauseTimer = () => {};
 	let startTimer = () => {};
@@ -61,7 +61,7 @@ export interface IClayAlertProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Flag to indicate alert should automatically call `onClose`. It also
 	 * accepts a duration(in ms) which indicates how long to wait. If `true`
-	 * is passed in, the timeout will be 8000ms.
+	 * is passed in, the timeout will be 10000ms.
 	 */
 	autoClose?: boolean | number;
 


### PR DESCRIPTION
As per @wincent's report: #3281 I'm making the default `autoClose` interval 10 seconds instead of 8. Pretty self-explanatory, I've checked the docs, stories and tests for mention of the interval but found nothing, so this should all be self-contained within this one file.