### PR TITLE
fix(@clayui/list): add dev warning to ensure child elements

### DIFF
--- a/packages/clay-list/README.mdx
+++ b/packages/clay-list/README.mdx
@@ -12,6 +12,7 @@ import {List, ListQuickActionsMenu} from '$packages/clay-list/docs/index';
 <div class="nav-toc">
 
 -   [QuickActionMenu](#quickactionmenu)
+-   [ClayList children](#claylist-children)
 -   [API](#api)
     -   [ClayList](#claylist)
     -   [ClayList.Header](#claylist.header)
@@ -37,6 +38,10 @@ Use `QuickActionMenu` composition inside `Item` for defining a QuickActionMenu.
 Wrap `QuickActionMenu.Item` inside `QuickActionMenu` for defining an `Item` of QuickActionMenu. See the following example:
 
 <ListQuickActionsMenu />
+
+## ClayList children
+
+To ensure your html structure is accessible, make sure any children passed to `ClayList` are `li` elements. Both `ClayList.Item` and `ClayListHeader` are `li` elements.
 
 ## API
 

--- a/packages/clay-list/package.json
+++ b/packages/clay-list/package.json
@@ -33,7 +33,8 @@
 		"@clayui/layout": "^3.0.1",
 		"@clayui/link": "^3.1.1",
 		"@clayui/sticker": "^3.1.1",
-		"classnames": "^2.2.6"
+		"classnames": "^2.2.6",
+		"warning": "^4.0.3"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-list/src/Header.tsx
+++ b/packages/clay-list/src/Header.tsx
@@ -19,4 +19,6 @@ const ClayListHeader: React.FunctionComponent<React.HTMLAttributes<
 	);
 };
 
+ClayListHeader.displayName = 'ClayListHeader';
+
 export default ClayListHeader;

--- a/packages/clay-list/src/Item.tsx
+++ b/packages/clay-list/src/Item.tsx
@@ -78,4 +78,6 @@ const ClayListItem = React.forwardRef<HTMLLIElement, IProps>(
 	}
 );
 
+ClayListItem.displayName = 'ClayListItem';
+
 export default ClayListItem;

--- a/packages/clay-list/src/List.tsx
+++ b/packages/clay-list/src/List.tsx
@@ -6,6 +6,7 @@
 import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
 import React from 'react';
+import warning from 'warning';
 
 import Header from './Header';
 import Item from './Item';
@@ -13,13 +14,19 @@ import ItemText from './ItemText';
 import ItemTitle from './ItemTitle';
 import QuickActionMenu from './QuickActionMenu';
 
+type TLIAttributes = React.ReactElement<React.HTMLAttributes<HTMLLIElement>>;
+
 interface IProps extends React.HTMLAttributes<HTMLUListElement> {
-	/**
+	children?: TLIAttributes | Array<TLIAttributes>;
+
+	/*
 	 * Flag to indicate if action items should be shown on hover.
 	 * Defaults to `true`
 	 */
 	showQuickActionsOnHover?: boolean;
 }
+
+const CLAY_REGEX = /Clay(?!ListItem|ListHeader).+/;
 
 const ClayList: React.FunctionComponent<IProps> & {
 	Header: typeof Header;
@@ -41,10 +48,30 @@ const ClayList: React.FunctionComponent<IProps> & {
 				'show-quick-actions-on-hover': showQuickActionsOnHover,
 			})}
 		>
-			{children}
+			{process.env.NODE_ENV !== 'development' && children}
+
+			{process.env.NODE_ENV === 'development' &&
+				children &&
+				React.Children.map(children, (child) => {
+					warning(
+						!(
+							child &&
+							// @ts-ignore
+							child.type.displayName &&
+							// @ts-ignore
+							child.type.displayName.match(CLAY_REGEX)
+						),
+						// @ts-ignore
+						`Direct descendant of ClayList must be either ClayList.Item or ClayList.Header. You used ${child.type.displayName}.`
+					);
+
+					return child;
+				})}
 		</ul>
 	);
 };
+
+ClayList.displayName = 'ClayList';
 
 ClayList.Header = Header;
 ClayList.Item = Item;


### PR DESCRIPTION
fixes #3295

I wasn't able to find a great way to force child elements to render an `li` element. I read a handful of places that people recommended setting the type to ReactElement with specific props, and then I also added a warning for if the child is not a Item or Header.

I'm open to other ideas here as well.