### PR TITLE
feat(clayui.com): Document using Clay in JSPs

### DIFF
--- a/clayui.com/content/docs/get-started/using-clay-in-jsps.md
+++ b/clayui.com/content/docs/get-started/using-clay-in-jsps.md
@@ -17,7 +17,7 @@ Clay in combination with DXP provides a set of tags for creating Clay components
 
 ## Setting up your module
 
-To use the Clay taglib in your apps, add the following to your module:
+To use Clay components in your JSP apps, add the following to your module:
 
 ### Gradle
 
@@ -37,7 +37,7 @@ Add the following snippet into either the JSP file you're using the component in
 
 ## Using Clay taglib in your JSPs
 
-The syntax for using Clay taglibs follows the following principle:
+The syntax for using Clay taglibs follows this principle:
 
 ```jsx
 <clay:componentName backendProperty="<%= Value %>" property="Property Value" />
@@ -54,12 +54,15 @@ This is how it's supposed to look like with a ClayButton:
 Clay taglibs provide the following UI components for your apps:
 
 -   [Alert](/docs/components/alert.html)
+-   [Badge](/docs/components/badge.html)
 -   [Button](/docs/components/button.html)
 -   [Card](/docs/components/card.html)
 -   [Checkbox](/docs/components/checkbox.html)
--   [Layout Elements](/docs/components/layout.html)
 -   [Dropdown](/docs/components/drop-down.html)
 -   [Form Elements](/docs/components/form.html)
+-   [Icon](/docs/components/icon.html)
+-   [Label](/docs/components/label.html)
+-   [Layout Elements](/docs/components/layout.html)
 -   [Link](/docs/components/link.html)
 -   [Management Toolbar](/docs/components/management-toolbar.html)
 -   [Multi Select](/docs/components/multi-select.html)
@@ -67,4 +70,5 @@ Clay taglibs provide the following UI components for your apps:
 -   [Progress Bar](/docs/components/progress-bar.html)
 -   [Radio](/docs/components/radio.html)
 -   [Select](/docs/components/select.html)
+-   [Sticker](/docs/components/sticker.html)
 -   [Table](/docs/components/table.html)

--- a/clayui.com/content/docs/get-started/using-clay-in-jsps.md
+++ b/clayui.com/content/docs/get-started/using-clay-in-jsps.md
@@ -1,41 +1,25 @@
 ---
 title: 'Using Clay in JSPs'
+draft: true
 order: 6
 ---
 
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Setting up your module](#setting-up-your-module)
--   [Using Clay taglib in your JSPs](#using-clay-taglib-in-your-jsps)
--   [Clay components available in JSPs](#clay-components-available-in-jsps)
+-   [Using taglibs](#using-taglibs)
+-   [Clay taglibs available](#clay-taglibs-available)
 
 </div>
 </div>
 
-Clay in combination with DXP provides a set of tags for creating Clay components in your JSP files.
-
-## Setting up your module
-
-To use Clay components in your JSP apps, add the following to your module:
-
-### Gradle
-
-Add the following snippet into your module's `build.gradle` file:
-
-```jsx
-compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
-```
-
-### JSP
+## Using taglibs
 
 Add the following snippet into either the JSP file you're using the component in, or in the module's `init.jsp` file:
 
 ```jsx
 <%@ taglib prefix="clay" uri="http://liferay.com/tld/clay" %>
 ```
-
-## Using Clay taglib in your JSPs
 
 The syntax for using Clay taglibs follows this principle:
 
@@ -49,7 +33,7 @@ This is how it's supposed to look like with a ClayButton:
 <clay:button label="<%= Button Label %>" style="primary" />
 ```
 
-## Clay components available in JSPs
+## Clay taglibs available
 
 Clay taglibs provide the following UI components for your apps:
 

--- a/clayui.com/content/docs/get-started/using-clay-in-jsps.md
+++ b/clayui.com/content/docs/get-started/using-clay-in-jsps.md
@@ -1,0 +1,70 @@
+---
+title: 'Using Clay in JSPs'
+order: 6
+---
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Setting up your module](#setting-up-your-module)
+-   [Using Clay taglib in your JSPs](#using-clay-taglib-in-your-jsps)
+-   [Clay components available in JSPs](#clay-components-available-in-jsps)
+
+</div>
+</div>
+
+Clay in combination with DXP provides a set of tags for creating Clay components in your JSP files.
+
+## Setting up your module
+
+To use the Clay taglib in your apps, add the following to your module:
+
+### Gradle
+
+Add the following snippet into your module's `build.gradle` file:
+
+```jsx
+compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+```
+
+### JSP
+
+Add the following snippet into either the JSP file you're using the component in, or in the module's `init.jsp` file:
+
+```jsx
+<%@ taglib prefix="clay" uri="http://liferay.com/tld/clay" %>
+```
+
+## Using Clay taglib in your JSPs
+
+The syntax for using Clay taglibs follows the following principle:
+
+```jsx
+<clay:componentName backendProperty="<%= Value %>" property="Property Value" />
+```
+
+This is how it's supposed to look like with a ClayButton:
+
+```jsx
+<clay:button label="<%= Button Label %>" style="primary" />
+```
+
+## Clay components available in JSPs
+
+Clay taglibs provide the following UI components for your apps:
+
+-   [Alert](/docs/components/alert.html)
+-   [Button](/docs/components/button.html)
+-   [Card](/docs/components/card.html)
+-   [Checkbox](/docs/components/checkbox.html)
+-   [Layout Elements](/docs/components/layout.html)
+-   [Dropdown](/docs/components/drop-down.html)
+-   [Form Elements](/docs/components/form.html)
+-   [Link](/docs/components/link.html)
+-   [Management Toolbar](/docs/components/management-toolbar.html)
+-   [Multi Select](/docs/components/multi-select.html)
+-   [Navigation Bar](/docs/components/navigation-bar.html)
+-   [Progress Bar](/docs/components/progress-bar.html)
+-   [Radio](/docs/components/radio.html)
+-   [Select](/docs/components/select.html)
+-   [Table](/docs/components/table.html)


### PR DESCRIPTION
Hey @bryceosterhaus this PR addresses #3286, and it aims to fill some initial documentation requirements for our users that want to use Clay in JSPs.

### Some notes
-  I took inspiration from [Liferay Help Center](https://help.liferay.com/hc/en-us/articles/360017888252-Using-the-Clay-Taglib-in-Your-portlets) when it comes to text
-  I referenced [liferay-clay.tld](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld) to get the list of components that exist as tags
    -  Badge, Icon, Label & Sticker are for some reason marked as deprecated, making me think that Clay doesn't support them 😕 
    -  Stripe & Sheet are mentioned but we don't have them on clayui.com 🤷 