### PR TITLE
feat(@clayui/toolbar): Add Toolbar component

### DIFF
--- a/packages/clay-toolbar/.yarnrc
+++ b/packages/clay-toolbar/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/toolbar@"
+version-git-message "chore: prepare @clayui/toolbar@%s"

--- a/packages/clay-toolbar/README.md
+++ b/packages/clay-toolbar/README.md
@@ -1,0 +1,17 @@
+# clay-toolbar
+
+A toolbar is a set of actions related to a specific context that are grouped into a horizontal bar.
+
+## Setup
+
+1. Install `yarn`
+
+2. Install local dependencies:
+
+```
+yarn
+```
+
+## Contribute
+
+We'd love to get contributions from you! Please, check our [Contributing Guidelines](https://github.com/liferay/clay/blob/master/CONTRIBUTING.md) to see how you can help us improve.

--- a/packages/clay-toolbar/package.json
+++ b/packages/clay-toolbar/package.json
@@ -26,6 +26,7 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/icon": "^3.0.5",
 		"@clayui/label": "^3.3.0",
 		"@clayui/link": "^3.1.1",
 		"classnames": "^2.2.6"

--- a/packages/clay-toolbar/package.json
+++ b/packages/clay-toolbar/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "@clayui/toolbar",
+	"version": "3.0.0",
+	"description": "ClayToolbar component",
+	"license": "BSD-3-Clause",
+	"repository": "https://github.com/liferay/clay",
+	"engines": {
+		"node": ">=0.12.0",
+		"npm": ">=3.0.0"
+	},
+	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
+	"scripts": {
+		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
+		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
+		"prepublishOnly": "yarn build && yarn build:types",
+		"test": "jest --config ../../jest.config.js"
+	},
+	"keywords": [
+		"clay",
+		"react"
+	],
+	"dependencies": {
+		"@clayui/label": "^3.3.0",
+		"@clayui/link": "^3.1.1",
+		"classnames": "^2.2.6"
+	},
+	"peerDependencies": {
+		"@clayui/css": "3.x",
+		"react": "^16.8.1",
+		"react-dom": "^16.8.1"
+	},
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
+}

--- a/packages/clay-toolbar/src/Action.tsx
+++ b/packages/clay-toolbar/src/Action.tsx
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import React from 'react';
+
+export interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+	/**
+	 * Flag that determines if the Action will have a `disabled` class, disabling interactions.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Path to clay icon spritemap
+	 */
+	spritemap: string;
+	symbol: string;
+}
+
+const Action: React.FunctionComponent<IProps> = ({
+	className,
+	disabled,
+	spritemap,
+	symbol,
+	...otherProps
+}: IProps) => (
+	<a
+		className={classNames(className, 'component-action', {disabled})}
+		role="button"
+		{...otherProps}
+	>
+		<ClayIcon spritemap={spritemap} symbol={symbol} />
+	</a>
+);
+
+Action.displayName = 'ClayToolbarAction';
+
+export default Action;

--- a/packages/clay-toolbar/src/Action.tsx
+++ b/packages/clay-toolbar/src/Action.tsx
@@ -17,6 +17,10 @@ export interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	 * Path to clay icon spritemap
 	 */
 	spritemap: string;
+
+	/**
+	 * Symbol of the icon used inside the Action. You can find available symbols here: https://clayui.com/docs/components/icon.html
+	 */
 	symbol: string;
 }
 

--- a/packages/clay-toolbar/src/Item.tsx
+++ b/packages/clay-toolbar/src/Item.tsx
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+export interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
+	/**
+	 * Flag to indicate if Item should auto expand to fill the remaining width.
+	 */
+	expand?: boolean;
+}
+
+const Item: React.FunctionComponent<IItemProps> = ({
+	children,
+	className,
+	expand,
+	...otherProps
+}: IItemProps) => {
+	return (
+		<li
+			className={classNames(className, 'tbar-item', {
+				'tbar-item-expand': expand,
+			})}
+			{...otherProps}
+		>
+			<div className="tbar-section">{children}</div>
+		</li>
+	);
+};
+
+Item.displayName = 'ClayToolbarItem';
+
+export default Item;

--- a/packages/clay-toolbar/src/Item.tsx
+++ b/packages/clay-toolbar/src/Item.tsx
@@ -6,19 +6,19 @@
 import classNames from 'classnames';
 import React from 'react';
 
-export interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
+export interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Flag to indicate if Item should auto expand to fill the remaining width.
 	 */
 	expand?: boolean;
 }
 
-const Item: React.FunctionComponent<IItemProps> = ({
+const Item: React.FunctionComponent<IProps> = ({
 	children,
 	className,
 	expand,
 	...otherProps
-}: IItemProps) => {
+}: IProps) => {
 	return (
 		<li
 			className={classNames(className, 'tbar-item', {
@@ -26,7 +26,7 @@ const Item: React.FunctionComponent<IItemProps> = ({
 			})}
 			{...otherProps}
 		>
-			<div className="tbar-section">{children}</div>
+			{children}
 		</li>
 	);
 };

--- a/packages/clay-toolbar/src/Label.tsx
+++ b/packages/clay-toolbar/src/Label.tsx
@@ -7,10 +7,25 @@ import ClayLabel from '@clayui/label';
 import classNames from 'classnames';
 import React from 'react';
 
-const Label: React.FunctionComponent<React.ComponentProps<
-	typeof ClayLabel
->> = ({children, className, ...otherProps}) => (
-	<ClayLabel className={classNames(className, 'tbar-label')} {...otherProps}>
+export interface IProps extends React.ComponentProps<typeof ClayLabel> {
+	/**
+	 * FLag that determines if the Link will have a `component-label` class, allowing CSS overrides.
+	 */
+	componentLabel?: boolean;
+}
+
+const Label: React.FunctionComponent<IProps> = ({
+	children,
+	className,
+	componentLabel,
+	...otherProps
+}) => (
+	<ClayLabel
+		className={classNames(className, 'tbar-label', {
+			'component-label': componentLabel,
+		})}
+		{...otherProps}
+	>
 		{children}
 	</ClayLabel>
 );

--- a/packages/clay-toolbar/src/Label.tsx
+++ b/packages/clay-toolbar/src/Label.tsx
@@ -7,23 +7,11 @@ import ClayLabel from '@clayui/label';
 import classNames from 'classnames';
 import React from 'react';
 
-export interface IProps extends React.ComponentProps<typeof ClayLabel> {
-	/**
-	 * FLag that determines if the Link will have a `component-label` class, allowing CSS overrides.
-	 */
-	componentLabel?: boolean;
-}
-
-const Label: React.FunctionComponent<IProps> = ({
-	children,
-	className,
-	componentLabel,
-	...otherProps
-}) => (
+const Label: React.FunctionComponent<React.ComponentProps<
+	typeof ClayLabel
+>> = ({children, className, ...otherProps}) => (
 	<ClayLabel
-		className={classNames(className, 'tbar-label', {
-			'component-label': componentLabel,
-		})}
+		className={classNames(className, 'component-label tbar-label')}
 		{...otherProps}
 	>
 		{children}

--- a/packages/clay-toolbar/src/Label.tsx
+++ b/packages/clay-toolbar/src/Label.tsx
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayLabel from '@clayui/label';
+import classNames from 'classnames';
+import React from 'react';
+
+const Label: React.FunctionComponent<React.ComponentProps<
+	typeof ClayLabel
+>> = ({children, className, ...otherProps}) => (
+	<ClayLabel className={classNames(className, 'tbar-label')} {...otherProps}>
+		{children}
+	</ClayLabel>
+);
+
+Label.displayName = 'ClayToolbarLabel';
+
+export default Label;

--- a/packages/clay-toolbar/src/Link.tsx
+++ b/packages/clay-toolbar/src/Link.tsx
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayLink from '@clayui/link';
+import classNames from 'classnames';
+import React from 'react';
+
+const Link: React.FunctionComponent<React.ComponentProps<typeof ClayLink>> = ({
+	children,
+	className,
+	...otherProps
+}) => {
+	return (
+		<ClayLink
+			className={classNames(className, 'component-link tbar-link')}
+			{...otherProps}
+		>
+			{children}
+		</ClayLink>
+	);
+};
+
+Link.displayName = 'ClayToolbarLink';
+
+export default Link;

--- a/packages/clay-toolbar/src/Link.tsx
+++ b/packages/clay-toolbar/src/Link.tsx
@@ -9,11 +9,6 @@ import React from 'react';
 
 export interface IProps extends React.ComponentProps<typeof ClayLink> {
 	/**
-	 * FLag that determines if the Link will have a `component-link` class, allowing CSS overrides.
-	 */
-	componentLink?: boolean;
-
-	/**
 	 * Flag that determines if the Link will have a `disabled` class, disabling interactions.
 	 */
 	disabled?: boolean;
@@ -22,13 +17,11 @@ export interface IProps extends React.ComponentProps<typeof ClayLink> {
 const Link: React.FunctionComponent<IProps> = ({
 	children,
 	className,
-	componentLink,
 	disabled,
 	...otherProps
 }: IProps) => (
 	<ClayLink
-		className={classNames(className, 'tbar-link', {
-			'component-link': componentLink,
+		className={classNames(className, 'component-link tbar-link', {
 			disabled,
 		})}
 		{...otherProps}

--- a/packages/clay-toolbar/src/Link.tsx
+++ b/packages/clay-toolbar/src/Link.tsx
@@ -7,20 +7,35 @@ import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
 
-const Link: React.FunctionComponent<React.ComponentProps<typeof ClayLink>> = ({
+export interface IProps extends React.ComponentProps<typeof ClayLink> {
+	/**
+	 * FLag that determines if the Link will have a `component-link` class, allowing CSS overrides.
+	 */
+	componentLink?: boolean;
+
+	/**
+	 * Flag that determines if the Link will have a `disabled` class, disabling interactions.
+	 */
+	disabled?: boolean;
+}
+
+const Link: React.FunctionComponent<IProps> = ({
 	children,
 	className,
+	componentLink,
+	disabled,
 	...otherProps
-}) => {
-	return (
-		<ClayLink
-			className={classNames(className, 'component-link tbar-link')}
-			{...otherProps}
-		>
-			{children}
-		</ClayLink>
-	);
-};
+}: IProps) => (
+	<ClayLink
+		className={classNames(className, 'tbar-link', {
+			'component-link': componentLink,
+			disabled,
+		})}
+		{...otherProps}
+	>
+		{children}
+	</ClayLink>
+);
 
 Link.displayName = 'ClayToolbarLink';
 

--- a/packages/clay-toolbar/src/Nav.tsx
+++ b/packages/clay-toolbar/src/Nav.tsx
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+export interface IProps extends React.HTMLAttributes<HTMLUListElement> {
+	/**
+	 * Specifies whether the `tbar-nav-wrap` class should be added to the Toolbar.Nav
+	 */
+	wrap?: boolean;
+}
+
+const Nav: React.FunctionComponent<IProps> = ({
+	children,
+	className,
+	wrap,
+	...otherProps
+}: IProps) => (
+	<ul
+		className={classNames(className, 'tbar-nav', {
+			'tbar-nav-wrap': wrap,
+		})}
+		{...otherProps}
+	>
+		{children}
+	</ul>
+);
+
+Nav.displayName = 'ClayToolbarNav';
+
+export default Nav;

--- a/packages/clay-toolbar/src/Section.tsx
+++ b/packages/clay-toolbar/src/Section.tsx
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+const Section: React.FunctionComponent<React.HTMLAttributes<
+	HTMLDivElement
+>> = ({children, className, ...otherProps}) => (
+	<div className={classNames(className, 'tbar-section')} {...otherProps}>
+		{children}
+	</div>
+);
+
+Section.displayName = 'ClayToolbarSection';
+
+export default Section;

--- a/packages/clay-toolbar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-toolbar/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClayToolbar renders 1`] = `
+<div>
+  <nav
+    class="tbar"
+  />
+</div>
+`;

--- a/packages/clay-toolbar/src/__tests__/index.tsx
+++ b/packages/clay-toolbar/src/__tests__/index.tsx
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayToolbar from '..';
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+describe('ClayToolbar', () => {
+	afterEach(cleanup);
+
+	it('renders', () => {
+		const {container} = render(<ClayToolbar />);
+
+		expect(container).toMatchSnapshot();
+	});
+});

--- a/packages/clay-toolbar/src/index.tsx
+++ b/packages/clay-toolbar/src/index.tsx
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+import Item from './Item';
+import Label from './Label';
+import Link from './Link';
+import Nav from './Nav';
+import Section from './Section';
+
+interface IProps extends React.HTMLAttributes<HTMLElement> {
+	/**
+	 * Specifies whether the Toolbar will have a `component-tbar` class.
+	 */
+	component?: boolean;
+	/**
+	 * Adds a helper class that turns the Toolbar inline at a specified breakpoint.
+	 */
+	inlineBreakpoint?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+	/**
+	 * Defines if the toolbar should have the `subnav-tbar` class.
+	 */
+	subnav?:
+		| boolean
+		| {
+				disabled?: boolean;
+				displayType?: 'light' | 'primary';
+		  };
+}
+
+const ClayToolbar: React.FunctionComponent<IProps> & {
+	Item: typeof Item;
+	Label: typeof Label;
+	Link: typeof Link;
+	Nav: typeof Nav;
+	Section: typeof Section;
+} = ({
+	children,
+	className,
+	component,
+	inlineBreakpoint,
+	subnav,
+	...otherProps
+}: IProps) => {
+	const classes = classNames(
+		className,
+		'tbar',
+		{
+			'component-tbar': component,
+			'subnav-tbar': !!subnav,
+			'subnav-tbar-disabled': !!(
+				subnav &&
+				typeof subnav !== 'boolean' &&
+				subnav.disabled
+			),
+			[`tbar-inline-${inlineBreakpoint}-down`]: inlineBreakpoint,
+		},
+		subnav &&
+			typeof subnav !== 'boolean' &&
+			subnav.displayType &&
+			`subnav-tbar-${subnav.displayType}`
+	);
+
+	return (
+		<nav {...otherProps} className={classes}>
+			{children}
+		</nav>
+	);
+};
+
+ClayToolbar.Item = Item;
+ClayToolbar.Label = Label;
+ClayToolbar.Link = Link;
+ClayToolbar.Nav = Nav;
+ClayToolbar.Section = Section;
+
+export default ClayToolbar;

--- a/packages/clay-toolbar/src/index.tsx
+++ b/packages/clay-toolbar/src/index.tsx
@@ -6,6 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import Action from './Action';
 import Item from './Item';
 import Label from './Label';
 import Link from './Link';
@@ -33,6 +34,7 @@ interface IProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 const ClayToolbar: React.FunctionComponent<IProps> & {
+	Action: typeof Action;
 	Item: typeof Item;
 	Label: typeof Label;
 	Link: typeof Link;
@@ -72,6 +74,7 @@ const ClayToolbar: React.FunctionComponent<IProps> & {
 	);
 };
 
+ClayToolbar.Action = Action;
 ClayToolbar.Item = Item;
 ClayToolbar.Label = Label;
 ClayToolbar.Link = Link;

--- a/packages/clay-toolbar/stories/index.tsx
+++ b/packages/clay-toolbar/stories/index.tsx
@@ -4,87 +4,216 @@
  */
 
 import '@clayui/css/lib/css/atlas.css';
+import ClayButton from '@clayui/button';
+const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import ClayLayout from '@clayui/layout';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 
 import ClayToolbar from '../src';
 
 storiesOf('Components|ClayToolbar', module)
-	.add('default', () => (
+	.add('Default', () => (
 		<ClayToolbar>
 			<ClayToolbar.Nav>
-				<ClayToolbar.Item expand>{'Item #1'}</ClayToolbar.Item>
-				<ClayToolbar.Item expand>{'Item #2'}</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Label>{'Label #1'}</ClayToolbar.Label>
+				<ClayToolbar.Item>
+					<ClayToolbar.Action
+						disabled
+						href="#"
+						spritemap={spritemap}
+						symbol="angle-left"
+					/>
 				</ClayToolbar.Item>
+
 				<ClayToolbar.Item expand>
-					<ClayToolbar.Link>{'Link #1'}</ClayToolbar.Link>
+					<ClayToolbar.Section>
+						<span className="text-truncate-inline">
+							<span className="text-truncate">
+								{
+									'Item 1 of 3,138,732,873,467,182,321,341,231,234,342,559,827,334,424'
+								}
+							</span>
+						</span>
+					</ClayToolbar.Section>
 				</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Section>{'Section #1'}</ClayToolbar.Section>
-					<ClayToolbar.Section>{'Section #2'}</ClayToolbar.Section>
-				</ClayToolbar.Item>
-			</ClayToolbar.Nav>
-		</ClayToolbar>
-	))
-	.add('subnav', () => (
-		<ClayToolbar subnav={{disabled: true, displayType: 'primary'}}>
-			<ClayToolbar.Nav>
-				<ClayToolbar.Item expand>{'Item #1'}</ClayToolbar.Item>
-				<ClayToolbar.Item expand>{'Item #2'}</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Label>{'Label #1'}</ClayToolbar.Label>
-				</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Link displayType="primary" href="#">
-						{'Link #1'}
+
+				<ClayToolbar.Item>
+					<ClayToolbar.Link href="#">
+						{'Component Link'}
 					</ClayToolbar.Link>
 				</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Section>{'Section #1'}</ClayToolbar.Section>
-					<ClayToolbar.Section>{'Section #2'}</ClayToolbar.Section>
+
+				<ClayToolbar.Item>
+					<ClayToolbar.Action
+						disabled
+						href="#"
+						spritemap={spritemap}
+						symbol="angle-right"
+					/>
+				</ClayToolbar.Item>
+
+				<ClayToolbar.Item>
+					<ClayToolbar.Action
+						disabled
+						href="#"
+						spritemap={spritemap}
+						symbol="times"
+					/>
 				</ClayToolbar.Item>
 			</ClayToolbar.Nav>
 		</ClayToolbar>
 	))
-	.add('component toolbar', () => (
+	.add('Component Toolbar', () => (
 		<ClayToolbar component>
-			<ClayToolbar.Nav>
-				<ClayToolbar.Item expand>{'Item #1'}</ClayToolbar.Item>
-				<ClayToolbar.Item expand>{'Item #2'}</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Label>{'Label #1'}</ClayToolbar.Label>
-				</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Link displayType="primary" href="#">
-						{'Link #1'}
-					</ClayToolbar.Link>
-				</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Section>{'Section #1'}</ClayToolbar.Section>
-					<ClayToolbar.Section>{'Section #2'}</ClayToolbar.Section>
-				</ClayToolbar.Item>
-			</ClayToolbar.Nav>
+			<ClayLayout.ContainerFluid>
+				<ClayToolbar.Nav>
+					<ClayToolbar.Item>
+						<ClayToolbar.Action
+							disabled
+							href="#"
+							spritemap={spritemap}
+							symbol="angle-left"
+						/>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item expand>
+						{
+							'Item 1 of 3,138,732,873,467,182,321,341,231,234,342,559,827,334,424'
+						}
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayToolbar.Action
+							disabled
+							href="#"
+							spritemap={spritemap}
+							symbol="angle-right"
+						/>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayToolbar.Action
+							disabled
+							href="#"
+							spritemap={spritemap}
+							symbol="times"
+						/>
+					</ClayToolbar.Item>
+				</ClayToolbar.Nav>
+			</ClayLayout.ContainerFluid>
 		</ClayToolbar>
 	))
-	.add('inlineBreakpoint', () => (
-		<ClayToolbar inlineBreakpoint="xl">
-			<ClayToolbar.Nav>
-				<ClayToolbar.Item expand>{'Item #1'}</ClayToolbar.Item>
-				<ClayToolbar.Item expand>{'Item #2'}</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Label>{'Label #1'}</ClayToolbar.Label>
-				</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Link displayType="primary" href="#">
-						{'Link #1'}
-					</ClayToolbar.Link>
-				</ClayToolbar.Item>
-				<ClayToolbar.Item expand>
-					<ClayToolbar.Section>{'Section #1'}</ClayToolbar.Section>
-					<ClayToolbar.Section>{'Section #2'}</ClayToolbar.Section>
-				</ClayToolbar.Item>
-			</ClayToolbar.Nav>
+	.add('Subnav', () => (
+		<ClayToolbar subnav>
+			<ClayLayout.ContainerFluid>
+				<ClayToolbar.Nav>
+					<ClayToolbar.Item expand>
+						<ClayToolbar.Section>
+							<span className="text-truncate-inline">
+								<span className="text-truncate">
+									{'25,392 results for '}
+
+									<strong>
+										{
+											'ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual'
+										}
+									</strong>
+								</span>
+							</span>
+						</ClayToolbar.Section>
+					</ClayToolbar.Item>
+					<ClayToolbar.Item>
+						<ClayToolbar.Link componentLink href="#">
+							{'Clear'}
+						</ClayToolbar.Link>
+					</ClayToolbar.Item>
+					<ClayToolbar.Item>
+						<ClayButton
+							className="component-link tbar-link"
+							displayType="unstyled"
+						>
+							{'Clear'}
+						</ClayButton>
+					</ClayToolbar.Item>
+				</ClayToolbar.Nav>
+			</ClayLayout.ContainerFluid>
+		</ClayToolbar>
+	))
+	.add('Subnav Primary Disabled', () => (
+		<ClayToolbar
+			inlineBreakpoint="md"
+			subnav={{disabled: true, displayType: 'primary'}}
+		>
+			<ClayLayout.ContainerFluid>
+				<ClayToolbar.Nav wrap>
+					<ClayToolbar.Item>
+						<ClayToolbar.Section>
+							<span className="component-text">
+								{'25,392 results for '}
+
+								<strong>
+									{
+										'"ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"'
+									}
+								</strong>
+							</span>
+						</ClayToolbar.Section>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayToolbar.Section>
+							<ClayToolbar.Label
+								closeButtonProps={{disabled: true}}
+								componentLabel
+								dismissible
+								displayType="unstyled"
+								spritemap={spritemap}
+							>
+								{'Category: Productivity'}
+							</ClayToolbar.Label>
+						</ClayToolbar.Section>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayToolbar.Section>
+							<ClayToolbar.Label
+								closeButtonProps={{disabled: true}}
+								componentLabel
+								dismissible
+								displayType="unstyled"
+								spritemap={spritemap}
+							>
+								{'Status: Approved'}
+							</ClayToolbar.Label>
+						</ClayToolbar.Section>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item expand>
+						<ClayToolbar.Section>
+							<ClayToolbar.Label
+								closeButtonProps={{disabled: true}}
+								componentLabel
+								dismissible
+								displayType="unstyled"
+								spritemap={spritemap}
+							>
+								{'Type: png'}
+							</ClayToolbar.Label>
+						</ClayToolbar.Section>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayToolbar.Section>
+							<ClayButton
+								className="component-link tbar-link"
+								disabled
+								displayType="unstyled"
+							>
+								{'Clear All'}
+							</ClayButton>
+						</ClayToolbar.Section>
+					</ClayToolbar.Item>
+				</ClayToolbar.Nav>
+			</ClayLayout.ContainerFluid>
 		</ClayToolbar>
 	));

--- a/packages/clay-toolbar/stories/index.tsx
+++ b/packages/clay-toolbar/stories/index.tsx
@@ -123,9 +123,7 @@ storiesOf('Components|ClayToolbar', module)
 						</ClayToolbar.Section>
 					</ClayToolbar.Item>
 					<ClayToolbar.Item>
-						<ClayToolbar.Link componentLink href="#">
-							{'Clear'}
-						</ClayToolbar.Link>
+						<ClayToolbar.Link href="#">{'Clear'}</ClayToolbar.Link>
 					</ClayToolbar.Item>
 					<ClayToolbar.Item>
 						<ClayButton
@@ -164,7 +162,6 @@ storiesOf('Components|ClayToolbar', module)
 						<ClayToolbar.Section>
 							<ClayToolbar.Label
 								closeButtonProps={{disabled: true}}
-								componentLabel
 								dismissible
 								displayType="unstyled"
 								spritemap={spritemap}
@@ -178,7 +175,6 @@ storiesOf('Components|ClayToolbar', module)
 						<ClayToolbar.Section>
 							<ClayToolbar.Label
 								closeButtonProps={{disabled: true}}
-								componentLabel
 								dismissible
 								displayType="unstyled"
 								spritemap={spritemap}
@@ -192,7 +188,6 @@ storiesOf('Components|ClayToolbar', module)
 						<ClayToolbar.Section>
 							<ClayToolbar.Label
 								closeButtonProps={{disabled: true}}
-								componentLabel
 								dismissible
 								displayType="unstyled"
 								spritemap={spritemap}

--- a/packages/clay-toolbar/stories/index.tsx
+++ b/packages/clay-toolbar/stories/index.tsx
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import '@clayui/css/lib/css/atlas.css';
+import {storiesOf} from '@storybook/react';
+import React from 'react';
+
+import ClayToolbar from '../src';
+
+storiesOf('Components|ClayToolbar', module)
+	.add('default', () => (
+		<ClayToolbar>
+			<ClayToolbar.Nav>
+				<ClayToolbar.Item expand>{'Item #1'}</ClayToolbar.Item>
+				<ClayToolbar.Item expand>{'Item #2'}</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Label>{'Label #1'}</ClayToolbar.Label>
+				</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Link>{'Link #1'}</ClayToolbar.Link>
+				</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Section>{'Section #1'}</ClayToolbar.Section>
+					<ClayToolbar.Section>{'Section #2'}</ClayToolbar.Section>
+				</ClayToolbar.Item>
+			</ClayToolbar.Nav>
+		</ClayToolbar>
+	))
+	.add('subnav', () => (
+		<ClayToolbar subnav={{disabled: true, displayType: 'primary'}}>
+			<ClayToolbar.Nav>
+				<ClayToolbar.Item expand>{'Item #1'}</ClayToolbar.Item>
+				<ClayToolbar.Item expand>{'Item #2'}</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Label>{'Label #1'}</ClayToolbar.Label>
+				</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Link displayType="primary" href="#">
+						{'Link #1'}
+					</ClayToolbar.Link>
+				</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Section>{'Section #1'}</ClayToolbar.Section>
+					<ClayToolbar.Section>{'Section #2'}</ClayToolbar.Section>
+				</ClayToolbar.Item>
+			</ClayToolbar.Nav>
+		</ClayToolbar>
+	))
+	.add('component toolbar', () => (
+		<ClayToolbar component>
+			<ClayToolbar.Nav>
+				<ClayToolbar.Item expand>{'Item #1'}</ClayToolbar.Item>
+				<ClayToolbar.Item expand>{'Item #2'}</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Label>{'Label #1'}</ClayToolbar.Label>
+				</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Link displayType="primary" href="#">
+						{'Link #1'}
+					</ClayToolbar.Link>
+				</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Section>{'Section #1'}</ClayToolbar.Section>
+					<ClayToolbar.Section>{'Section #2'}</ClayToolbar.Section>
+				</ClayToolbar.Item>
+			</ClayToolbar.Nav>
+		</ClayToolbar>
+	))
+	.add('inlineBreakpoint', () => (
+		<ClayToolbar inlineBreakpoint="xl">
+			<ClayToolbar.Nav>
+				<ClayToolbar.Item expand>{'Item #1'}</ClayToolbar.Item>
+				<ClayToolbar.Item expand>{'Item #2'}</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Label>{'Label #1'}</ClayToolbar.Label>
+				</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Link displayType="primary" href="#">
+						{'Link #1'}
+					</ClayToolbar.Link>
+				</ClayToolbar.Item>
+				<ClayToolbar.Item expand>
+					<ClayToolbar.Section>{'Section #1'}</ClayToolbar.Section>
+					<ClayToolbar.Section>{'Section #2'}</ClayToolbar.Section>
+				</ClayToolbar.Item>
+			</ClayToolbar.Nav>
+		</ClayToolbar>
+	));

--- a/packages/clay-toolbar/tsconfig.declarations.json
+++ b/packages/clay-toolbar/tsconfig.declarations.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"declarationDir": "./lib"
+	},
+	"extends": "../../tsconfig.declarations.json",
+	"include": ["src"]
+}

--- a/packages/clay-toolbar/tsconfig.json
+++ b/packages/clay-toolbar/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}


### PR DESCRIPTION
Hey @bryceosterhaus here's my initial draft of how I imagine the Toolbar component should be structured.

### What I've done:
- Removed mentions of Upper Toolbar as a package
- Essentially renamed upper-toolbar.tsx to toolbar.tsx
  - I actually made a new file, and then in the existing upper-toolbar.tsx I just return Toolbar
  - This doesn't do anything different than the regular Toolbar but it serves as a placeholder for me to get my point across
- Added a new `default` story for Toolbar, which is just an empty `nav` right now
- Separated `Item` and `Input` into their own files and added them to the `ClayToolbar` namespace.

### Questions
1. Did I have to remove mentions of Upper Toolbar anywhere else? Both clayui.com and storybook build successfully with the current state of the PR
2. What are the differences between `Toolbar` and `Upper Toolbar`? Some classes, if so, which ones?
  2.1. Is Upper Toolbar a very specific combination of `Toolbar.Item`'s and `Toolbar.Input`'s? If so, which combination, the docs are vague.
3. Am I on the right track? The Lexicon docs aren't prescriptive on the same level as for other components, but that's probably on purpose.
4. Is the `info-bar` mentioned by @jbalsas [here](https://github.com/liferay/clay/pull/3248#issuecomment-631588453) basically a variation of this `Toolbar` I'm working on but with the `info-bar` class? It's hard to know for sure with the fact that the jsp file you linked is just some HTML
5. Should Management Toolbar also go under this component as a high level component?

It's all kinda muddy in information, @pat270 can you, as an extension of this [comment](https://github.com/liferay/clay/pull/3248#issuecomment-631586212) you made, give me some clarification as to when we use which classes in relation to Toolbar vs Management Toolbar vs Upper Toolbar vs Info Bar. Maybe you can make it a table or something that's easy for my tiny brain to understand.