### PR TITLE
feat(@clayui/link): add ability to style link like a button

### DIFF
--- a/packages/clay-link/src/index.tsx
+++ b/packages/clay-link/src/index.tsx
@@ -66,10 +66,10 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 
 			classes = {
 				btn: !!button,
-				'btn-block': button?.block,
-				'btn-monospaced': button?.monospaced,
+				'btn-block': button.block,
+				'btn-monospaced': button.monospaced,
 				'btn-outline-borderless': borderless,
-				'btn-sm': button?.small,
+				'btn-sm': button.small,
 				[`btn-${displayType}`]: displayType && !outline && !borderless,
 				[`btn-outline-${displayType}`]:
 					displayType && (outline || borderless),

--- a/packages/clay-link/src/index.tsx
+++ b/packages/clay-link/src/index.tsx
@@ -15,9 +15,20 @@ interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	borderless?: boolean;
 
 	/**
+	 * Config for button props
+	 */
+	button?:
+		| boolean
+		| {
+				block?: boolean;
+				monospaced?: boolean;
+				small?: boolean;
+		  };
+
+	/**
 	 * Determines how the link is displayed.
 	 */
-	displayType?: 'primary' | 'secondary';
+	displayType?: 'primary' | 'secondary' | 'unstyled';
 
 	/**
 	 * Flag to indicate if link should be monospaced.
@@ -34,6 +45,7 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 	(
 		{
 			borderless,
+			button,
 			children,
 			className,
 			displayType,
@@ -47,19 +59,38 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 	) => {
 		const TagOrComponent = React.useContext(ClayLinkContext);
 
+		let classes;
+
+		if (button) {
+			button = button === true ? {} : button;
+
+			classes = {
+				btn: !!button,
+				'btn-block': button?.block,
+				'btn-monospaced': button?.monospaced,
+				'btn-outline-borderless': borderless,
+				'btn-sm': button?.small,
+				[`btn-${displayType}`]: displayType && !outline && !borderless,
+				[`btn-outline-${displayType}`]:
+					displayType && (outline || borderless),
+			};
+		} else {
+			classes = {
+				'link-monospaced': monospaced,
+				'link-outline': outline,
+				'link-outline-borderless': borderless,
+				[`link-${displayType}`]: displayType && !outline,
+				[`link-outline-${displayType}`]: displayType && outline,
+			};
+		}
+
 		if (target && !rel) {
 			rel = 'noreferrer noopener';
 		}
 
 		return (
 			<TagOrComponent
-				className={classNames(className, {
-					'link-monospaced': monospaced,
-					'link-outline': outline,
-					'link-outline-borderless': borderless,
-					[`link-${displayType}`]: displayType && !outline,
-					[`link-outline-${displayType}`]: displayType && outline,
-				})}
+				className={classNames(className, classes)}
 				ref={ref}
 				rel={rel}
 				target={target}

--- a/packages/clay-link/stories/index.tsx
+++ b/packages/clay-link/stories/index.tsx
@@ -54,6 +54,27 @@ storiesOf('Components|ClayLink', module)
 			<div id="1" />
 		</>
 	))
+	.add('displayed as button', () => (
+		<>
+			<ClayLink button displayType="primary" href="#1">
+				{'Primary'}
+			</ClayLink>
+			<ClayLink button displayType="secondary" href="#1">
+				{'Secondary'}
+			</ClayLink>
+			<ClayLink
+				borderless
+				button
+				displayType="secondary"
+				href="#1"
+				outline
+			>
+				{'Borderless Secondary'}
+			</ClayLink>
+
+			<div id="1" />
+		</>
+	))
 	.add('monospaced', () => (
 		<>
 			<ClayLink

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"noEmit": true,
 		"strict": true,
 		"jsx": "react",
-		"target": "esnext",
+		"target": "es2015",
 		"module": "esnext",
 		"moduleResolution": "node",
 		"removeComments": true,


### PR DESCRIPTION
fixes #3301

Here is a POC of adding ClayLink to Button so that we can render both links as buttons and buttons as links.

Any concerns with this?