### PR TITLE
fix(@clayui/date-picker): remove moment.js

### DIFF
--- a/packages/clay-date-picker/README.mdx
+++ b/packages/clay-date-picker/README.mdx
@@ -61,7 +61,7 @@ To set internationalization of the component, you need to configure the props ac
 <DatePickerLocale />
 
 -   [`firstDayOfWeek`](#api-firstDayOfWeek) by default the value by default the value is 0 (Sunday) and its values ​​are the days of the week, 1 (Monday), 2 (Tuesday), 3 (Wednesday), 4 (Thursday), 5 (Friday), 6 (Saturday).
--   [`dateFormat`](#api-dateFormat) and `timeFormat` is defined according to the **formatting rules of [Moment.js](https://momentjs.com/docs/#/parsing/string-format/)**.
+-   [`dateFormat`](#api-dateFormat) and `timeFormat` is defined according to the **formatting rules of [date-fns](https://date-fns.org/v2.14.0/docs/format)** which is an implementation of the [unicode technical standards](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table).
 -   [`months`](#api-months) is an `Array<string>` with available months **starting January to December**.
 -   [`weekdaysShort`](#api-weekdaysShort) is an `Array<string>` with the **names of the days of the week in short form**, starting from **Sunday to Saturday**.
 
@@ -85,6 +85,10 @@ To customize the Date Picker content footer you can use the [`footerElement`](#a
 ## Programatically Expand Dropdown
 
 If you want to expand or close the picker from outside of the component, use the props `expand` and `onExpandChange`.
+
+## Note about Moment.js
+
+In version 3.4.0, we made the decision to switch to use [date-fns](https://date-fns.org/v2.14.0) instead of Moment.js due to dependency size. Making this changed help reduce the size of @clayui/date-picker by almost 50 KB.
 
 ## API
 

--- a/packages/clay-date-picker/docs/index.js
+++ b/packages/clay-date-picker/docs/index.js
@@ -50,7 +50,7 @@ const DatePickerLocale = () => {
 
 	return (
 		<ClayDatePicker
-			dateFormat="DD.MM.YYYY"
+			dateFormat="dd.MM.yyyy"
 			firstDayOfWeek={1}
 			months={[
 				'Январь',

--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -28,7 +28,7 @@
 		"@clayui/icon": "^3.0.5",
 		"@clayui/time-picker": "^3.1.3",
 		"classnames": "^2.2.6",
-		"moment": "^2.22.2"
+		"date-fns": "^2.14.0"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -5,10 +5,9 @@
 
 import Button from '@clayui/button';
 import Icon from '@clayui/icon';
-import moment from 'moment';
 import React from 'react';
 
-import * as Helpers from './Helpers';
+import {addMonths, range} from './Helpers';
 import Select, {ISelectOption} from './Select';
 import {IAriaLabels, IYears} from './types';
 
@@ -40,7 +39,7 @@ const ClayDatePickerDateNavigation: React.FunctionComponent<IProps> = ({
 }) => {
 	const memoizedYears: Array<ISelectOption> = React.useMemo(
 		() =>
-			Helpers.range(years).map((elem) => {
+			range(years).map((elem) => {
 				return {
 					label: elem,
 					value: elem,
@@ -69,7 +68,7 @@ const ClayDatePickerDateNavigation: React.FunctionComponent<IProps> = ({
 	 * years in the range
 	 */
 	function handleChangeMonth(month: number) {
-		const date = moment(currentMonth).clone().add(month, 'M').toDate();
+		const date = addMonths(currentMonth, month);
 		const year = date.getFullYear();
 
 		if (memoizedYears.find((elem) => elem.value === year)) {

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -4,10 +4,9 @@
  */
 
 import classnames from 'classnames';
-import moment from 'moment';
 import React from 'react';
 
-import {IDay} from './Helpers';
+import {IDay, formatDate, setDate} from './Helpers';
 
 interface IProps {
 	day: IDay;
@@ -25,27 +24,25 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	const classNames = classnames(
 		'date-picker-date date-picker-calendar-item',
 		{
-			active:
-				moment(day.date).format('YYYY-MM-DD') ===
-				moment(daySelected).format('YYYY-MM-DD'),
+			active: day.date.toDateString() === daySelected.toDateString(),
 			disabled: day.outside || disabled,
 		}
 	);
 
-	const handleClick = () => onClick(day.date);
-
 	return (
 		<button
-			aria-label={moment(day.date)
-				.clone()
-				.set('hour', 12)
-				.set('minute', 0)
-				.set('second', 0)
-				.set('millisecond', 0)
-				.format('YYYY MM DD')}
+			aria-label={formatDate(
+				setDate(day.date, {
+					hours: 12,
+					milliseconds: 0,
+					minutes: 0,
+					seconds: 0,
+				}),
+				'yyyy MM dd'
+			)}
 			className={classNames}
 			disabled={day.outside}
-			onClick={handleClick}
+			onClick={() => onClick(day.date)}
 			type="button"
 		>
 			{day.date.getDate()}

--- a/packages/clay-date-picker/src/Helpers.ts
+++ b/packages/clay-date-picker/src/Helpers.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import moment from 'moment';
+import {default as formatDate} from 'date-fns/format';
+import {default as parseDate} from 'date-fns/parse';
+
+export {formatDate, parseDate};
 
 export interface IDay {
 	date: Date;
@@ -17,8 +20,8 @@ export type Month = Array<WeekDays>;
 /**
  * Clone a date object.
  */
-export function clone(d: Date) {
-	return new Date(d.getTime());
+export function clone(date: number | Date) {
+	return new Date(date instanceof Date ? date.getTime() : date);
 }
 
 export function getDaysInMonth(d: Date) {
@@ -103,17 +106,36 @@ export function range({end, start}: {end: number; start: number}) {
 	);
 }
 
-/**
- * Helper function for getting certain props from `moment`.
- * This allows users to not have to import and use `moment` themselves.
- */
-export function getLocaleProps(locale: string) {
-	const localeData = moment.localeData(locale);
+export function addMonths(date: number | Date, months: number) {
+	date = clone(date);
 
-	return {
-		dateFormat: localeData.longDateFormat('L'),
-		firstDayOfWeek: localeData.firstDayOfWeek(),
-		months: localeData.months(),
-		weekdaysShort: localeData.weekdaysShort(),
-	};
+	date.setMonth(date.getMonth() + months);
+
+	return date;
+}
+
+export function setDate(
+	date: Date,
+	obj: {
+		date?: number | string;
+		seconds?: number | string;
+		milliseconds?: number | string;
+		hours?: number | string;
+		minutes?: number | string;
+		year?: number | string;
+	}
+) {
+	date = clone(date);
+
+	return Object.keys(obj).reduce((acc, key) => {
+		const method = `set${key.charAt(0).toUpperCase() + key.slice(1)}`;
+		// @ts-ignore
+		acc[method](obj[key]);
+
+		return acc;
+	}, date);
+}
+
+export function isValid(date: Date) {
+	return date instanceof Date && !isNaN(date.getTime());
 }

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -3,25 +3,24 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import moment from 'moment';
 import React from 'react';
 
-import * as Helpers from './Helpers';
+import {Month, formatDate, getWeekArray, setDate} from './Helpers';
 import {FirstDayOfWeek} from './types';
 
 /**
  * Generates the table of days of the month.
  */
 const useWeeks = (currentMonth: Date, firstDayOfWeek: FirstDayOfWeek) => {
-	const [weeks, set] = React.useState<Helpers.Month>(() =>
-		Helpers.getWeekArray(currentMonth, firstDayOfWeek)
+	const [weeks, set] = React.useState<Month>(() =>
+		getWeekArray(currentMonth, firstDayOfWeek)
 	);
 
 	function setWeeks(value: Date) {
-		set(Helpers.getWeekArray(value, firstDayOfWeek));
+		set(getWeekArray(value, firstDayOfWeek));
 	}
 
-	return [weeks, setWeeks] as [Helpers.Month, (value: Date) => void];
+	return [weeks, setWeeks] as [Month, (value: Date) => void];
 };
 
 /**
@@ -29,19 +28,21 @@ const useWeeks = (currentMonth: Date, firstDayOfWeek: FirstDayOfWeek) => {
  */
 const useCurrentTime = (format: string) => {
 	const [currentTime, set] = React.useState<string>(() =>
-		moment().set('h', 0).set('m', 0).format(format)
+		formatDate(setDate(new Date(), {hours: 0, minutes: 0}), format)
 	);
 
 	function setCurrentTime(
 		hours: number | string,
 		minutes: number | string
 	): void {
+		const date = setDate(new Date(), {hours, minutes});
+
 		if (typeof hours !== 'string') {
-			hours = moment().set('h', hours).format('H');
+			hours = formatDate(date, 'H');
 		}
 
 		if (typeof minutes !== 'string') {
-			minutes = moment().set('m', minutes).format('m');
+			minutes = formatDate(date, 'm');
 		}
 
 		set(`${hours}:${minutes}`);

--- a/packages/clay-date-picker/src/InputDate.tsx
+++ b/packages/clay-date-picker/src/InputDate.tsx
@@ -4,8 +4,9 @@
  */
 
 import {ClayInput} from '@clayui/form';
-import moment from 'moment';
 import React from 'react';
+
+import {formatDate, isValid} from './Helpers';
 
 interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	ariaLabel?: string;
@@ -15,7 +16,6 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	inputName?: string;
 	placeholder?: string;
 	time: boolean;
-	timeFormat: string;
 	useNative: boolean;
 	value: string;
 }
@@ -28,7 +28,6 @@ const ClayDatePickerInputDate = React.forwardRef<HTMLInputElement, IProps>(
 			dateFormat,
 			inputName = 'datePicker',
 			time = false,
-			timeFormat,
 			useNative = false,
 			value = '',
 			...otherProps
@@ -36,10 +35,8 @@ const ClayDatePickerInputDate = React.forwardRef<HTMLInputElement, IProps>(
 		ref
 	) => {
 		const isValidValue = (value: string | Date): string => {
-			const format = time ? `${dateFormat} ${timeFormat}` : dateFormat;
-
-			if (moment(value, format).isValid() && value instanceof Date) {
-				const date = moment(value).clone().format(dateFormat);
+			if (value instanceof Date && isValid(value)) {
+				const date = formatDate(value, dateFormat);
 
 				return time ? `${date} ${currentTime}` : date;
 			}

--- a/packages/clay-date-picker/stories/index.tsx
+++ b/packages/clay-date-picker/stories/index.tsx
@@ -9,7 +9,7 @@ import {boolean} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 
-import ClayDatePicker, {FirstDayOfWeek, getLocaleProps} from '../src';
+import ClayDatePicker, {FirstDayOfWeek} from '../src';
 
 const ClayDatePickerWithState = (props: {[key: string]: any}) => {
 	const [value, setValue] = React.useState<string | Date>('');
@@ -67,7 +67,7 @@ storiesOf('Components|ClayDatePicker', module)
 	))
 	.add('w/ locale', () => (
 		<ClayDatePickerWithState
-			dateFormat="DD.MM.YYYY"
+			dateFormat="dd.MM.yyyy"
 			firstDayOfWeek={FirstDayOfWeek.Monday}
 			months={[
 				'Январь',
@@ -83,22 +83,11 @@ storiesOf('Components|ClayDatePicker', module)
 				'Ноябрь',
 				'Декабрь',
 			]}
-			placeholder="DD.MM.YYYY HH:mm"
+			placeholder="YYYY-MM-DD HH:mm"
 			spritemap={spritemap}
 			time
 			timezone="GMT+03:00"
 			weekdaysShort={['Вс', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб']}
-			years={{
-				end: 2024,
-				start: 1997,
-			}}
-		/>
-	))
-	.add('w/ getLocaleProps', () => (
-		<ClayDatePickerWithState
-			{...getLocaleProps('ru')}
-			placeholder="DD.MM.YYYY"
-			spritemap={spritemap}
 			years={{
 				end: 2024,
 				start: 1997,

--- a/packages/demos/stories/Recharts.tsx
+++ b/packages/demos/stories/Recharts.tsx
@@ -7,7 +7,7 @@ import '@clayui/css/lib/css/atlas.css';
 import {ClayRadio, ClayRadioGroup} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import {storiesOf} from '@storybook/react';
-import moment from 'moment';
+import {getYear, parse as parseDate} from 'date-fns';
 import * as React from 'react';
 import {
 	Area,
@@ -332,7 +332,11 @@ storiesOf('Demos|Recharts', module)
 		>
 			<Tooltip />
 			<YAxis label={{angle: -90, value: 'Y-Axis'}} tick={false} />
-			<XAxis tickFormatter={(val) => moment(val).year()} />
+			<XAxis
+				tickFormatter={(val) =>
+					getYear(parseDate(val, 'dd/LL/yyyy', new Date()))
+				}
+			/>
 
 			<Line dataKey="val" stroke={COLORS[0]} />
 		</LineChart>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7701,6 +7701,11 @@ dataloader@^1.4.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
+date-fns@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
+  integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -16148,7 +16153,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@^2.21.0, moment@^2.22.2, moment@^2.5.1:
+moment@^2.21.0, moment@^2.5.1:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
I went with a POC in removing moment by replacing it with ~luxon~ date-fns. We still have a dependency, but its about 50kb smaller than when we used moment.

One caveat is that the "format" strings are different, so that would be a breaking change, although we could create some sort of map.

Additionally, I want to see if it'd be possible to just use native APIs, so I will continue on that and see what it requires.

Curious to hear any thoughts on this

~**1st commit is using luxon**~

~**2nd commit is using date-fns**~