### PR TITLE
fix(@clayui/css): Update Bootstrap 4 License to use SPDX naming scheme

### DIFF
--- a/packages/clay-css/LICENSES/LicenseRef-MIT-Bootstrap.txt
+++ b/packages/clay-css/LICENSES/LicenseRef-MIT-Bootstrap.txt
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2011-2019 Twitter, Inc.
+Copyright (c) 2011-2019 The Bootstrap Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/clay-css/src/scss/_bs4.scss
+++ b/packages/clay-css/src/scss/_bs4.scss
@@ -1,12 +1,5 @@
 // This file imports Bootstrap 4 for base.scss and atlas.scss.
 
-/*!
- * Bootstrap v4.4.1 (https://getbootstrap.com/)
- * Copyright 2011-2019 The Bootstrap Authors
- * Copyright 2011-2019 Twitter, Inc.
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
- */
-
 @import 'bootstrap/functions';
 @import 'bootstrap/variables';
 @import 'bootstrap/mixins';

--- a/packages/clay-css/src/scss/atlas-variables.scss
+++ b/packages/clay-css/src/scss/atlas-variables.scss
@@ -1,3 +1,9 @@
+/**
+* SPDX-FileCopyrightText: © 2019 Twitter, Inc.
+
+* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
+*/
+
 @import 'functions/_global-functions';
 
 // INSERT CUSTOM BASE VARS

--- a/packages/clay-css/src/scss/atlas.scss
+++ b/packages/clay-css/src/scss/atlas.scss
@@ -1,3 +1,9 @@
+/**
+* SPDX-FileCopyrightText: © 2019 Twitter, Inc.
+
+* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
+*/
+
 @import 'functions/_global-functions';
 
 // INSERT CUSTOM VARS

--- a/packages/clay-css/src/scss/base-variables.scss
+++ b/packages/clay-css/src/scss/base-variables.scss
@@ -1,3 +1,9 @@
+/**
+* SPDX-FileCopyrightText: © 2019 Twitter, Inc.
+
+* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
+*/
+
 @import 'functions/_global-functions';
 
 // INSERT CUSTOM BASE VARS

--- a/packages/clay-css/src/scss/base.scss
+++ b/packages/clay-css/src/scss/base.scss
@@ -1,3 +1,9 @@
+/**
+* SPDX-FileCopyrightText: © 2019 Twitter, Inc.
+
+* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
+*/
+
 @import 'functions/_global-functions';
 
 // INSERT CUSTOM VARS


### PR DESCRIPTION
fixes #3282

Questions:
1) Does the `LicenseRef-MIT-Bootstrap.txt` file need to be present in Liferay Portal?

2) Should `LicenseRef-MIT-Bootstrap.txt` be placed under `clay/LICENSES` or `clay/packages/clay-css/LICENSES`? Bootstrap 4.4.1 is only included in Clay CSS.

3) License text for Clay CSS:
```
/**
* Clay 3.11.0
*
* Copyright 2020, Liferay, Inc.
* All rights reserved.
* MIT license
*/
```
The [LICENSE.txt](https://unpkg.com/browse/@clayui/css@3.9.0/LICENSE.txt) is BSD-3-Clause but the text in our CSS file is MIT?

/cc @jbalsas @wincent @bryceosterhaus @silverhook