### PR TITLE
feat(@clayui/layout): Make ContentRow and ContentCol forwardRef

### DIFF
--- a/packages/clay-layout/src/Content.tsx
+++ b/packages/clay-layout/src/Content.tsx
@@ -45,17 +45,20 @@ interface IContentRowProps extends React.HTMLAttributes<HTMLDivElement> {
 	verticalAlign?: 'center' | 'end';
 }
 
-const ContentRow: React.FunctionComponent<IContentRowProps> = ({
-	children,
-	className,
-	containerElement: ContainerElement = 'div',
-	float,
-	noGutters,
-	padded,
-	verticalAlign,
-	...otherProps
-}: IContentRowProps) => {
-	return (
+const ContentRow = React.forwardRef<HTMLElement, IContentRowProps>(
+	(
+		{
+			children,
+			className,
+			containerElement: ContainerElement = 'div',
+			float,
+			noGutters,
+			padded,
+			verticalAlign,
+			...otherProps
+		}: IContentRowProps,
+		ref
+	) => (
 		<ContainerElement
 			{...otherProps}
 			className={classNames(className, 'autofit-row', {
@@ -67,11 +70,12 @@ const ContentRow: React.FunctionComponent<IContentRowProps> = ({
 					typeof noGutters === 'string',
 				[`autofit-row-${verticalAlign}`]: verticalAlign,
 			})}
+			ref={ref}
 		>
 			{children}
 		</ContainerElement>
-	);
-};
+	)
+);
 
 ContentRow.displayName = 'ClayContentRow';
 
@@ -103,16 +107,19 @@ interface IContentColProps extends React.HTMLAttributes<HTMLDivElement> {
 	gutters?: boolean;
 }
 
-const ContentCol: React.FunctionComponent<IContentColProps> = ({
-	children,
-	className,
-	containerElement: ContainerElement = 'div',
-	expand,
-	float,
-	gutters,
-	...otherProps
-}: IContentColProps) => {
-	return (
+const ContentCol = React.forwardRef<HTMLElement, IContentColProps>(
+	(
+		{
+			children,
+			className,
+			containerElement: ContainerElement = 'div',
+			expand,
+			float,
+			gutters,
+			...otherProps
+		}: IContentColProps,
+		ref
+	) => (
 		<ContainerElement
 			{...otherProps}
 			className={classNames(className, 'autofit-col', {
@@ -120,11 +127,12 @@ const ContentCol: React.FunctionComponent<IContentColProps> = ({
 				'autofit-col-gutters': gutters,
 				[`autofit-col-float-${float}`]: float,
 			})}
+			ref={ref}
 		>
 			{children}
 		</ContainerElement>
-	);
-};
+	)
+);
 
 ContentCol.displayName = 'ClayContentCol';
 

--- a/packages/demos/stories/LayoutContentDragDrop.tsx
+++ b/packages/demos/stories/LayoutContentDragDrop.tsx
@@ -1,0 +1,182 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayLayout from '@clayui/layout';
+import {XYCoord} from 'dnd-core';
+import React, {useCallback, useRef, useState} from 'react';
+import {DropTargetMonitor, useDrag, useDrop} from 'react-dnd';
+
+interface IProps {
+	/**
+	 * Content Row unique identifier
+	 */
+	id: any;
+
+	/**
+	 * Index of the Content Row in order to keep track of it's positioning within the array
+	 */
+	index: number;
+
+	/**
+	 * Function that handles the moving of Content Rows
+	 */
+	onMove: (dragIndex: number, hoverIndex: number) => void;
+}
+
+interface IDragItem {
+	/**
+	 * Content Row unique identifier
+	 */
+	id: string;
+
+	/**
+	 * Index of the Content Row in order to keep track of it's positioning within the array
+	 */
+	index: number;
+
+	/**
+	 * Type of data that is allowed to be dragged
+	 */
+	type: string;
+}
+
+const DraggableLayoutRow: React.FunctionComponent<IProps> = ({
+	id,
+	index,
+	onMove,
+}) => {
+	const ref = useRef<HTMLLIElement>(null);
+
+	const [, drop] = useDrop({
+		accept: 'listItem',
+		hover(item: IDragItem, monitor: DropTargetMonitor) {
+			const dragIndex = item.index;
+
+			const hoverIndex = index;
+
+			if (!ref.current || dragIndex === hoverIndex) {
+				return;
+			}
+
+			const hoverBoundingRect = ref.current!.getBoundingClientRect();
+
+			const verticalMiddle =
+				(hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+
+			const mousePosition = monitor.getClientOffset();
+
+			const pixelsToTop =
+				(mousePosition as XYCoord).y - hoverBoundingRect.top;
+
+			const draggingUpwards =
+				dragIndex > hoverIndex && pixelsToTop > verticalMiddle * 1.5;
+
+			const draggingDownwards =
+				dragIndex < hoverIndex && pixelsToTop < verticalMiddle / 2;
+
+			if (draggingDownwards || draggingUpwards) {
+				return;
+			}
+
+			onMove(dragIndex, hoverIndex);
+
+			item.index = hoverIndex;
+		},
+	});
+
+	const [{isDragging, itemBeingDragged}, drag] = useDrag({
+		collect: (monitor: any) => ({
+			isDragging: monitor.isDragging(),
+			itemBeingDragged: monitor.getItem() || {id: 0},
+		}),
+		item: {id, index, type: 'listItem'},
+	});
+
+	const isItemBeingDragged = itemBeingDragged.id === id;
+
+	drag(drop(ref));
+
+	const style = {
+		backgroundColor: isItemBeingDragged ? '#EFEFEF' : '#FFFFFF',
+		border: isItemBeingDragged ? '2px solid #555555' : '',
+		cursor: 'grab',
+		opacity: isDragging ? 0 : 1,
+	};
+
+	return (
+		<ClayLayout.ContentRow
+			className="border mb-1 p-2 rounded shadow-sm"
+			id={`listItem${id}`}
+			ref={ref}
+			style={style}
+		>
+			{`Item ${id}`}
+		</ClayLayout.ContentRow>
+	);
+};
+
+const DraggableColumn: React.FunctionComponent = () => {
+	const [listItems, setListItems] = useState([
+		{
+			id: 1,
+			text: 'Write a cool JS library',
+		},
+		{
+			id: 2,
+			text: 'Make it generic enough',
+		},
+		{
+			id: 3,
+			text: 'Write README',
+		},
+		{
+			id: 4,
+			text: 'Create some examples',
+		},
+		{
+			id: 5,
+			text:
+				'Spam in Twitter and IRC to promote it (note that this element is taller than the others)',
+		},
+		{
+			id: 6,
+			text: '???',
+		},
+		{
+			id: 7,
+			text: 'PROFIT',
+		},
+	]);
+
+	const onMove = useCallback(
+		(dragIndex: number, hoverIndex: number) => {
+			const tempList = [...listItems];
+
+			tempList.splice(dragIndex, 1);
+
+			tempList.splice(hoverIndex, 0, listItems[dragIndex]);
+
+			setListItems(tempList);
+		},
+		[listItems]
+	);
+
+	return (
+		<ClayLayout.ContainerFluid className="mt-3" size="sm">
+			<ClayLayout.ContentCol gutters>
+				{listItems.map((listItem, index) => (
+					<DraggableLayoutRow
+						id={listItem.id}
+						index={index}
+						key={listItem.id}
+						onMove={onMove}
+					/>
+				))}
+			</ClayLayout.ContentCol>
+		</ClayLayout.ContainerFluid>
+	);
+};
+
+export default DraggableColumn;

--- a/packages/demos/stories/index.tsx
+++ b/packages/demos/stories/index.tsx
@@ -12,6 +12,7 @@ import Backend from 'react-dnd-html5-backend';
 import DragDrop from './DragDrop';
 import FilesPage from './FilesPage';
 import FormPage from './FormPage';
+import LayoutDragDrop from './LayoutContentDragDrop';
 import ListPage from './ListPage';
 import ClayTableWithDraggableColumns from './TableColumnsDragDrop';
 import ClayTableWithDraggableRows from './TableRowsDragDrop';
@@ -35,5 +36,10 @@ storiesOf('Demos|Templates', module)
 	.add('Drag & Drop', () => (
 		<DndProvider backend={Backend}>
 			<DragDrop />
+		</DndProvider>
+	))
+	.add('Layout.Content Drag & Drop', () => (
+		<DndProvider backend={Backend}>
+			<LayoutDragDrop />
 		</DndProvider>
 	));


### PR DESCRIPTION
Fixes #3327 

Hey @bryceosterhaus here's my attempt at making ContentRow and ContentCol be `forwardRefs` instead of `FunctionComponents`. This is my first time using `forwardRef` so if I missed something let me know. Also feel free to take this and run away with it so we can merge it faster because an LPS linked in the issue depends on it.

I've also added a quick story to make sure it works and to provide people with the example of it working.