### PR TITLE
fix(clay-css): copy LICENSES to lib before publish

### DIFF
--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -23,8 +23,9 @@
 	"scripts": {
 		"build": "yarn compile",
 		"compile": "gulp compile",
+		"link": "npm link",
 		"prepublish": "yarn compile && ncp ../../LICENSES ./lib",
-		"link": "npm link"
+		"version": "gulp version"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -23,7 +23,7 @@
 	"scripts": {
 		"build": "yarn compile",
 		"compile": "gulp compile",
-		"prepublish": "yarn compile",
+		"prepublish": "yarn compile && ncp ../../LICENSES ./lib",
 		"link": "npm link"
 	},
 	"repository": {


### PR DESCRIPTION
@pat270 is this what you were thinking for copying the licenses? It'll copy it straight to the lib folder before release

I also added the `gulp version` command. This should run after `lerna version` but before we commit.