### PR TITLE
fix(@clayui/shared): only preventDefault if next/previous node exists in the focusManager

### DIFF
--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -52,15 +52,17 @@ export const FocusScope: React.FunctionComponent<IProps> = ({
 			(arrowKeysLeftRight && keyCode === ARROW_RIGHT_KEY_CODE) ||
 			(keyCode === TAB_KEY_CODE && !shiftKey)
 		) {
-			event.preventDefault();
-			focusManager.focusNext();
+			if (focusManager.focusNext()) {
+				event.preventDefault();
+			}
 		} else if (
 			(arrowKeysUpDown && keyCode === ARROW_UP_KEY_CODE) ||
 			(arrowKeysLeftRight && keyCode === ARROW_LEFT_KEY_CODE) ||
 			(keyCode === TAB_KEY_CODE && shiftKey)
 		) {
-			event.preventDefault();
-			focusManager.focusPrevious();
+			if (focusManager.focusPrevious()) {
+				event.preventDefault();
+			}
 		}
 	};
 


### PR DESCRIPTION
fixes #3332

I ran this through a handful of manual tests and seems to fix the problem while also maintaining previous functionality.

@matuzalemsteles, can you think of any edge cases this would break?