### PR TITLE
fix(@clayui/drop-down): fixes the side effect of recalculating domAlign with each rendering

### DIFF
--- a/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
@@ -38,7 +38,6 @@ exports[`ClayBreadcrumb calls callback when an item is clicked 1`] = `
       <button
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
-        style=""
         type="button"
       >
         <svg
@@ -117,7 +116,6 @@ exports[`ClayBreadcrumb renders 1`] = `
       <button
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
-        style=""
         type="button"
       >
         <svg
@@ -197,7 +195,6 @@ exports[`ClayBreadcrumb renders with properties passed by \`ellipsisProps\` 1`] 
       <button
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
-        style=""
         type="button"
       >
         <svg

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -8,7 +8,6 @@ exports[`BasicRendering renders by default 1`] = `
     >
       <div
         class="input-group"
-        style=""
       >
         <div
           class="input-group-item"
@@ -51,7 +50,6 @@ exports[`BasicRendering renders by default 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
-        style="left: -999px; top: -995px;"
       >
         <div
           class="date-picker-calendar"

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -177,7 +177,8 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 		React.useLayoutEffect(() => {
 			if (
 				alignElementRef.current &&
-				(ref as React.RefObject<HTMLDivElement>).current
+				(ref as React.RefObject<HTMLDivElement>).current &&
+				active
 			) {
 				let points = alignmentPosition;
 
@@ -200,7 +201,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 					}
 				);
 			}
-		});
+		}, [active]);
 
 		return (
 			<ClayPortal subPortalRef={subPortalRef}>

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
@@ -8,7 +8,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems 1`] = `
     >
       <button
         class="dropdown-toggle btn btn-primary"
-        style=""
         type="button"
       >
         Click Me
@@ -19,7 +18,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems 1`] = `
     <div>
       <div
         class="dropdown-menu"
-        style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
@@ -59,7 +57,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with caption 1`] = `
     >
       <button
         class="dropdown-toggle btn btn-primary"
-        style=""
         type="button"
       >
         Click Me
@@ -70,7 +67,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with caption 1`] = `
     <div>
       <div
         class="dropdown-menu"
-        style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
@@ -103,7 +99,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with checkbox 1`] = `
     >
       <button
         class="dropdown-toggle btn btn-primary"
-        style=""
         type="button"
       >
         Click Me
@@ -114,7 +109,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with checkbox 1`] = `
     <div>
       <div
         class="dropdown-menu"
-        style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
@@ -197,7 +191,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with footer content 1
     >
       <button
         class="dropdown-toggle btn btn-primary"
-        style=""
         type="button"
       >
         Click Me
@@ -208,7 +201,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with footer content 1
     <div>
       <div
         class="dropdown-menu"
-        style="left: -999px; top: -995px;"
       >
         <form>
           <div
@@ -253,7 +245,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with help text 1`] = 
     >
       <button
         class="dropdown-toggle btn btn-primary"
-        style=""
         type="button"
       >
         Click Me
@@ -264,7 +255,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with help text 1`] = 
     <div>
       <div
         class="dropdown-menu"
-        style="left: -999px; top: -995px;"
       >
         <div
           class="alert alert-fluid alert-info"
@@ -298,7 +288,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with radio group 1`] 
     >
       <button
         class="dropdown-toggle btn btn-primary"
-        style=""
         type="button"
       >
         Click Me
@@ -309,7 +298,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with radio group 1`] 
     <div>
       <div
         class="dropdown-menu"
-        style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
@@ -402,7 +390,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with search 1`] = `
     >
       <button
         class="dropdown-toggle btn btn-primary"
-        style=""
         type="button"
       >
         Click Me
@@ -413,7 +400,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with search 1`] = `
     <div>
       <div
         class="dropdown-menu"
-        style="left: -999px; top: -995px;"
       >
         <form
           class=""

--- a/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
@@ -31,7 +31,6 @@ exports[`ClayLocalizedInput renders 1`] = `
         >
           <button
             class="dropdown-toggle btn btn-monospaced btn-unstyled"
-            style=""
             title="Open Localizations"
             type="button"
           >
@@ -96,7 +95,6 @@ exports[`ClayLocalizedInput renders with prepend content and result formatter 1`
         >
           <button
             class="dropdown-toggle btn btn-monospaced btn-unstyled"
-            style=""
             title="Open Localizations"
             type="button"
           >

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -11,7 +11,6 @@ exports[`ClayPaginationBar renders 1`] = `
       <button
         class="dropdown-toggle btn btn-unstyled"
         data-testid="selectPaginationBar"
-        style=""
         type="button"
       >
         10 items
@@ -88,7 +87,6 @@ exports[`ClayPaginationBar renders 1`] = `
       >
         <button
           class="dropdown-toggle page-link btn btn-unstyled"
-          style=""
           type="button"
         >
           ...

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -39,7 +39,6 @@ exports[`ClayPagination renders 1`] = `
     >
       <button
         class="dropdown-toggle page-link btn btn-unstyled"
-        style=""
         type="button"
       >
         ...
@@ -100,7 +99,6 @@ exports[`ClayPagination renders 1`] = `
     >
       <button
         class="dropdown-toggle page-link btn btn-unstyled"
-        style=""
         type="button"
       >
         ...

--- a/packages/clay-upper-toolbar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-upper-toolbar/src/__tests__/__snapshots__/index.tsx.snap
@@ -123,7 +123,6 @@ exports[`ClayUpperToolbar renders 1`] = `
             >
               <button
                 class="dropdown-toggle btn btn-monospaced btn-sm btn-unstyled"
-                style=""
                 type="button"
               >
                 <svg


### PR DESCRIPTION
Hey @bryceosterhaus, I took this trying to identify some performance problems that were making the Forms editing very slow in App Builder, I think this is not the root cause but I realized that it was eating 20ms in every rendering that happened. I added this fix on my local machine to test it, inside the Portal to see how it would flow, apparently saving 20ms each rendering helped a lot to take away the impression of slowness when trying to edit a Text in App Builder as a result in Forms too. This is in the migration I'm doing to React.

Some images, this is before this fix: You can see that there are many long tasks, all of which are based on a React keypress event, in the end, there are 20ms of domAlign.
<img width="939" alt="Screen Shot 2020-06-15 at 19 17 29" src="https://user-images.githubusercontent.com/13750819/84711732-5ad51000-af3d-11ea-910a-4f1032a42a2b.png">

Another image after this fix: You can see that the duration of tasks is shorter and we don't have 20ms of domAlign anymore, this saved more budget for the application.
<img width="924" alt="Screen Shot 2020-06-15 at 19 14 34" src="https://user-images.githubusercontent.com/13750819/84711835-97087080-af3d-11ea-9b07-3ce29ea34191.png">

Bearing in mind that in tasks that are represented by gray in the images, there are other parts of the application that cause a slowness, it is not entirely the fault of domAligm here but we can help with the budget of time for these applications.

The strange thing is that we didn't discover this before 🤷‍♂️