### PR TITLE
fix(@clayui/modal): removes the duplication of modal- {size} and the size of the forced width to the default value

### DIFF
--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -68,9 +68,6 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 
 	React.useEffect(() => observer.dispatch(ObserverType.Open), []);
 
-	// Defines a default Modal size when size is not set.
-	const maxWidth = size ? {} : {maxWidth: '600px'};
-
 	const [show, content] =
 		observer && observer.mutation ? observer.mutation : [false, false];
 
@@ -88,11 +85,11 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 				})}
 			>
 				<div
-					className={classNames({
-						[`modal-${size}`]: size,
-					})}
 					ref={modalBodyElementRef}
-					style={{margin: 'auto', ...maxWidth}}
+					style={{
+						display: 'table',
+						margin: 'auto',
+					}}
 				>
 					<div
 						className={classNames('modal-dialog', {

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -5,7 +5,7 @@
 
 import {ClayPortal} from '@clayui/shared';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import warning from 'warning';
 
 import Body from './Body';
@@ -58,7 +58,10 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 	status,
 	...otherProps
 }: IProps) => {
-	const modalBodyElementRef = React.useRef<HTMLDivElement | null>(null);
+	const [maxWidth, setMaxWidth] = useState<number | string>('initial');
+
+	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
+	const modalDialogElementRef = useRef<HTMLDivElement | null>(null);
 
 	warning(observer !== undefined, warningMessage);
 
@@ -66,10 +69,16 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 		observer.dispatch(ObserverType.Close)
 	);
 
-	React.useEffect(() => observer.dispatch(ObserverType.Open), []);
+	useEffect(() => observer.dispatch(ObserverType.Open), []);
 
 	const [show, content] =
 		observer && observer.mutation ? observer.mutation : [false, false];
+
+	useEffect(() => {
+		if (modalDialogElementRef.current && content) {
+			setMaxWidth(modalDialogElementRef.current.clientWidth);
+		}
+	}, [modalDialogElementRef, content]);
 
 	return (
 		<ClayPortal subPortalRef={modalBodyElementRef}>
@@ -87,8 +96,8 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 				<div
 					ref={modalBodyElementRef}
 					style={{
-						display: 'table',
 						margin: 'auto',
+						maxWidth,
 					}}
 				>
 					<div
@@ -96,6 +105,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 							[`modal-${size}`]: size,
 							[`modal-${status}`]: status,
 						})}
+						ref={modalDialogElementRef}
 						tabIndex={-1}
 					>
 						<div className="modal-content">

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -28,8 +28,7 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
       class="fade modal d-block show"
     >
       <div
-        class="modal-lg"
-        style="margin: auto;"
+        style="display: table; margin: auto;"
       >
         <div
           class="modal-dialog modal-lg"

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -28,7 +28,7 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
       class="fade modal d-block show"
     >
       <div
-        style="display: table; margin: auto;"
+        style="margin: auto; max-width: 0;"
       >
         <div
           class="modal-dialog modal-lg"

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -12,7 +12,7 @@ exports[`ClayModal renders 1`] = `
       class="fade modal d-block show"
     >
       <div
-        style="display: table; margin: auto;"
+        style="margin: auto; max-width: 0;"
       >
         <div
           class="modal-dialog"
@@ -92,7 +92,7 @@ exports[`ClayModal renders Header w/ low-level API 1`] = `
       class="fade modal d-block show"
     >
       <div
-        style="display: table; margin: auto;"
+        style="margin: auto; max-width: 0;"
       >
         <div
           class="modal-dialog"
@@ -156,7 +156,7 @@ exports[`ClayModal renders a body component with url 1`] = `
       class="fade modal d-block show"
     >
       <div
-        style="display: table; margin: auto;"
+        style="margin: auto; max-width: 0;"
       >
         <div
           class="modal-dialog"
@@ -194,7 +194,7 @@ exports[`ClayModal renders a footer component with buttons 1`] = `
       class="fade modal d-block show"
     >
       <div
-        style="display: table; margin: auto;"
+        style="margin: auto; max-width: 0;"
       >
         <div
           class="modal-dialog"
@@ -258,7 +258,7 @@ exports[`ClayModal renders with Header 1`] = `
       class="fade modal d-block show"
     >
       <div
-        style="display: table; margin: auto;"
+        style="margin: auto; max-width: 0;"
       >
         <div
           class="modal-dialog"
@@ -311,7 +311,7 @@ exports[`ClayModal renders with size 1`] = `
       class="fade modal d-block show"
     >
       <div
-        style="display: table; margin: auto;"
+        style="margin: auto; max-width: 0;"
       >
         <div
           class="modal-dialog modal-lg"
@@ -340,7 +340,7 @@ exports[`ClayModal renders with status 1`] = `
       class="fade modal d-block show"
     >
       <div
-        style="display: table; margin: auto;"
+        style="margin: auto; max-width: 0;"
       >
         <div
           class="modal-dialog modal-success"

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -12,8 +12,7 @@ exports[`ClayModal renders 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        style="display: table; margin: auto;"
       >
         <div
           class="modal-dialog"
@@ -93,8 +92,7 @@ exports[`ClayModal renders Header w/ low-level API 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        style="display: table; margin: auto;"
       >
         <div
           class="modal-dialog"
@@ -158,8 +156,7 @@ exports[`ClayModal renders a body component with url 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        style="display: table; margin: auto;"
       >
         <div
           class="modal-dialog"
@@ -197,8 +194,7 @@ exports[`ClayModal renders a footer component with buttons 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        style="display: table; margin: auto;"
       >
         <div
           class="modal-dialog"
@@ -262,8 +258,7 @@ exports[`ClayModal renders with Header 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        style="display: table; margin: auto;"
       >
         <div
           class="modal-dialog"
@@ -316,8 +311,7 @@ exports[`ClayModal renders with size 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class="modal-lg"
-        style="margin: auto;"
+        style="display: table; margin: auto;"
       >
         <div
           class="modal-dialog modal-lg"
@@ -346,8 +340,7 @@ exports[`ClayModal renders with status 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        style="display: table; margin: auto;"
       >
         <div
           class="modal-dialog modal-success"


### PR DESCRIPTION
Fixes #3107

With `display: table;` we can make the content fit children and we don’t need to force the size of the element, we could achieve the same with `width: max-content` but it doesn’t support IE 11 😞