### PR TITLE
fix(@clayui/date-picker): Adds FocusScope for an appropriated tab navigation on DatePicker's calendar

### DIFF
--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -26,6 +26,7 @@
 		"@clayui/drop-down": "^3.4.4",
 		"@clayui/form": "^3.8.0",
 		"@clayui/icon": "^3.0.5",
+		"@clayui/shared": "^3.1.2",
 		"@clayui/time-picker": "^3.1.4",
 		"classnames": "^2.2.6",
 		"date-fns": "^2.14.0"

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -345,6 +345,29 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		 */
 		const handleCalendarButtonClicked = () => setExpanded(!expanded);
 
+		/**
+		 * Handle with the focus when it's outside of the component
+		 * In this case, forces the state of expanded to be false
+		 */
+		const handleFocus = (event: FocusEvent) => {
+			if (
+				dropdownContainerRef.current &&
+				!dropdownContainerRef.current.contains(event.target as Node) &&
+				triggerElementRef.current &&
+				!triggerElementRef.current.contains(event.target as Node)
+			) {
+				setExpanded(false);
+			}
+		};
+
+		React.useEffect(() => {
+			document.addEventListener('focus', handleFocus, true);
+
+			return () => {
+				document.removeEventListener('focus', handleFocus, true);
+			};
+		}, [handleFocus]);
+
 		return (
 			<FocusScope arrowKeysLeftRight>
 				<div className="date-picker">

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -7,6 +7,7 @@ import Button from '@clayui/button';
 import DropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
+import {FocusScope} from '@clayui/shared';
 import React from 'react';
 
 import DateNavigation from './DateNavigation';
@@ -345,105 +346,110 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		const handleCalendarButtonClicked = () => setExpanded(!expanded);
 
 		return (
-			<div className="date-picker">
-				<ClayInput.Group id={id} ref={triggerElementRef}>
-					<ClayInput.GroupItem>
-						<InputDate
-							{...otherProps}
-							ariaLabel={ariaLabels.input}
-							currentTime={currentTime}
-							dateFormat={dateFormat}
-							disabled={disabled}
-							inputName={inputName}
-							onChange={inputChange}
-							placeholder={placeholder}
-							ref={ref}
-							time={time}
-							useNative={useNative}
-							value={value}
-						/>
-						{!useNative && (
-							<ClayInput.GroupInsetItem after>
-								<Button
-									className="date-picker-dropdown-toggle"
-									data-testid="date-button"
-									disabled={disabled}
-									displayType="unstyled"
-									onClick={handleCalendarButtonClicked}
-								>
-									<Icon
-										spritemap={spritemap}
-										symbol="calendar"
-									/>
-								</Button>
-							</ClayInput.GroupInsetItem>
-						)}
-					</ClayInput.GroupItem>
-				</ClayInput.Group>
-
-				{!useNative && (
-					<DropDown.Menu
-						active={expanded}
-						alignElementRef={triggerElementRef}
-						className="date-picker-dropdown-menu"
-						data-testid="dropdown"
-						onSetActive={setExpanded}
-						ref={dropdownContainerRef}
-					>
-						<div className="date-picker-calendar">
-							<DateNavigation
-								ariaLabels={ariaLabels}
-								currentMonth={currentMonth}
+			<FocusScope arrowKeysLeftRight>
+				<div className="date-picker">
+					<ClayInput.Group id={id} ref={triggerElementRef}>
+						<ClayInput.GroupItem>
+							<InputDate
+								{...otherProps}
+								ariaLabel={ariaLabels.input}
+								currentTime={currentTime}
+								dateFormat={dateFormat}
 								disabled={disabled}
-								months={months}
-								onDotClicked={handleDotClicked}
-								onMonthChange={changeMonth}
-								spritemap={spritemap}
-								years={years}
+								inputName={inputName}
+								onChange={inputChange}
+								placeholder={placeholder}
+								ref={ref}
+								time={time}
+								useNative={useNative}
+								value={value}
 							/>
-							<div className="date-picker-calendar-body">
-								<WeekdayHeader
-									firstDayOfWeek={firstDayOfWeek}
-									weekdaysShort={weekdaysShort}
-								>
-									{({key, weekday}) => (
-										<Weekday key={key} weekday={weekday} />
-									)}
-								</WeekdayHeader>
-								<DaysTable weeks={weeks}>
-									{({day, key}) => (
-										<DayNumber
-											day={day}
-											daySelected={daySelected}
-											disabled={disabled}
-											key={key}
-											onClick={handleDayClicked}
-										/>
-									)}
-								</DaysTable>
-							</div>
-							{(footerElement || time) && (
-								<div className="date-picker-calendar-footer">
-									{time && (
-										<TimePicker
-											currentTime={currentTime}
-											disabled={disabled}
-											onTimeChange={handleTimeChange}
+							{!useNative && (
+								<ClayInput.GroupInsetItem after>
+									<Button
+										className="date-picker-dropdown-toggle"
+										data-testid="date-button"
+										disabled={disabled}
+										displayType="unstyled"
+										onClick={handleCalendarButtonClicked}
+									>
+										<Icon
 											spritemap={spritemap}
-											timezone={timezone}
+											symbol="calendar"
 										/>
-									)}
-									{!time &&
-										footerElement &&
-										React.Children.only(
-											footerElement({spritemap})
-										)}
-								</div>
+									</Button>
+								</ClayInput.GroupInsetItem>
 							)}
-						</div>
-					</DropDown.Menu>
-				)}
-			</div>
+						</ClayInput.GroupItem>
+					</ClayInput.Group>
+
+					{!useNative && (
+						<DropDown.Menu
+							active={expanded}
+							alignElementRef={triggerElementRef}
+							className="date-picker-dropdown-menu"
+							data-testid="dropdown"
+							onSetActive={setExpanded}
+							ref={dropdownContainerRef}
+						>
+							<div className="date-picker-calendar">
+								<DateNavigation
+									ariaLabels={ariaLabels}
+									currentMonth={currentMonth}
+									disabled={disabled}
+									months={months}
+									onDotClicked={handleDotClicked}
+									onMonthChange={changeMonth}
+									spritemap={spritemap}
+									years={years}
+								/>
+								<div className="date-picker-calendar-body">
+									<WeekdayHeader
+										firstDayOfWeek={firstDayOfWeek}
+										weekdaysShort={weekdaysShort}
+									>
+										{({key, weekday}) => (
+											<Weekday
+												key={key}
+												weekday={weekday}
+											/>
+										)}
+									</WeekdayHeader>
+									<DaysTable weeks={weeks}>
+										{({day, key}) => (
+											<DayNumber
+												day={day}
+												daySelected={daySelected}
+												disabled={disabled}
+												key={key}
+												onClick={handleDayClicked}
+											/>
+										)}
+									</DaysTable>
+								</div>
+								{(footerElement || time) && (
+									<div className="date-picker-calendar-footer">
+										{time && (
+											<TimePicker
+												currentTime={currentTime}
+												disabled={disabled}
+												onTimeChange={handleTimeChange}
+												spritemap={spritemap}
+												timezone={timezone}
+											/>
+										)}
+										{!time &&
+											footerElement &&
+											React.Children.only(
+												footerElement({spritemap})
+											)}
+									</div>
+								)}
+							</div>
+						</DropDown.Menu>
+					)}
+				</div>
+			</FocusScope>
 		);
 	}
 );

--- a/packages/demos/stories/FormPage.tsx
+++ b/packages/demos/stories/FormPage.tsx
@@ -97,6 +97,11 @@ export default () => {
 										</ClayForm.Group>
 
 										<ClayForm.Group>
+											<label>{'Date'}</label>
+											<ClayDatePickerWithState />
+										</ClayForm.Group>
+
+										<ClayForm.Group>
 											<label>{'State'}</label>
 											<select
 												className="form-control"
@@ -114,11 +119,6 @@ export default () => {
 												<option>{'Mad'}</option>
 												<option>{'Sad'}</option>
 											</select>
-										</ClayForm.Group>
-
-										<ClayForm.Group>
-											<label>{'Date'}</label>
-											<ClayDatePickerWithState />
 										</ClayForm.Group>
 									</ClayPanel.Body>
 								</ClayPanel>

--- a/packages/demos/stories/FormPage.tsx
+++ b/packages/demos/stories/FormPage.tsx
@@ -5,12 +5,26 @@
 
 import ClayButton from '@clayui/button';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import ClayDatePicker from '@clayui/date-picker';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayMultiSelect from '@clayui/multi-select';
 import {ClayVerticalNav} from '@clayui/nav';
 import ClayPanel from '@clayui/panel';
 import React from 'react';
+
+const ClayDatePickerWithState = (props: {[key: string]: any}) => {
+	const [value, setValue] = React.useState<string | Date>('');
+
+	return (
+		<ClayDatePicker
+			{...props}
+			onValueChange={setValue}
+			spritemap={spritemap}
+			value={value as string}
+		/>
+	);
+};
 
 export default () => {
 	const [formValues, setFormValues] = React.useState<any>({});
@@ -100,6 +114,11 @@ export default () => {
 												<option>{'Mad'}</option>
 												<option>{'Sad'}</option>
 											</select>
+										</ClayForm.Group>
+
+										<ClayForm.Group>
+											<label>{'Date'}</label>
+											<ClayDatePickerWithState />
 										</ClayForm.Group>
 									</ClayPanel.Body>
 								</ClayPanel>


### PR DESCRIPTION
### Test Case:

> Add a ClayDatePicker to the Storybook Form Page Demo

Note that when opening the Date Picker calendar using SPACE, we were unable to focus any elements within the DatePicker using TABS.

---

To solve this problem, I used FocusScope and fixed the Focus problem when opening the Date Picker Calendar.

### Questions/Issues:

When going through the entire focus, the Focus scope does not close the component and focuses on the next component in the DOM tree (which is still right 🤔)

When closing the Date Picker Calendar by pressing the ESC key, the next element to focus according to the focus scope is the closest element to the document.body (where the ClayDropDown.Menu element portal was opened) making the focus stay on the submit.

### Commits:

- docs(@clayui/date-picker): Adds a DatePicker on FormPage story
- fix(@clayui/date-picker): Adds FocusScope for navigating int o DatePicker calendar component using TABS


Closes #3368