### PR TITLE
fix(@clayui/card): When pressing `enter` or `space`, triggers a click event on CardWithNavigation

### DIFF
--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -32,7 +32,6 @@
 		"@clayui/label": "^3.3.1",
 		"@clayui/layout": "^3.1.0",
 		"@clayui/link": "^3.2.0",
-		"@clayui/shared": "^3.1.2",
 		"@clayui/sticker": "^3.1.1",
 		"classnames": "^2.2.6"
 	},

--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -32,6 +32,7 @@
 		"@clayui/label": "^3.3.1",
 		"@clayui/layout": "^3.1.0",
 		"@clayui/link": "^3.2.0",
+		"@clayui/shared": "^3.1.2",
 		"@clayui/sticker": "^3.1.1",
 		"classnames": "^2.2.6"
 	},

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {noop} from '@clayui/shared';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClaySticker from '@clayui/sticker';
@@ -66,6 +67,7 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 	horizontalSymbol = '',
 	href,
 	onClick,
+	onKeyDown = noop,
 	spritemap,
 	title,
 }: IProps) => {
@@ -86,6 +88,8 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 						onClick(event);
 					}
 				}
+
+				onKeyDown(event);
 			}}
 			tabIndex={0}
 		>

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {noop} from '@clayui/shared';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
+import {noop} from '@clayui/shared';
 import ClaySticker from '@clayui/sticker';
 import React from 'react';
 

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -5,7 +5,6 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import {noop} from '@clayui/shared';
 import ClaySticker from '@clayui/sticker';
 import React from 'react';
 
@@ -59,6 +58,8 @@ const KEYCODES = {
 	ENTER: 13,
 	SPACE: 32,
 };
+
+const noop = () => {};
 
 export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 	children,

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -36,7 +36,12 @@ interface IProps {
 	/**
 	 * Callback for when card is clicked on
 	 */
-	onClick?: () => void;
+	onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
+
+	/**
+	 * Callback for when a keyboard key pressed on a card
+	 */
+	onKeyDown?: (event: React.KeyboardEvent) => void;
 
 	/**
 	 * Path to spritemap for icon symbol.
@@ -49,13 +54,18 @@ interface IProps {
 	title?: React.ReactText;
 }
 
+const KEYCODES = {
+	ENTER: 13,
+	SPACE: 32,
+};
+
 export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 	children,
 	description,
 	horizontal = false,
 	horizontalSymbol = '',
 	href,
-	onClick,
+	onClick: onClickCallback,
 	spritemap,
 	title,
 }: IProps) => {
@@ -64,7 +74,19 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 			horizontal={horizontal}
 			href={href}
 			interactive
-			onClick={onClick}
+			onClick={onClickCallback}
+			onKeyDown={(event: React.KeyboardEvent) => {
+				if (
+					(event && event.keyCode === KEYCODES.ENTER) ||
+					(event && event.keyCode === KEYCODES.SPACE)
+				) {
+					event.preventDefault();
+
+					if (onClickCallback) {
+						onClickCallback(event);
+					}
+				}
+			}}
 			tabIndex={0}
 		>
 			{!horizontal && (

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -65,7 +65,7 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 	horizontal = false,
 	horizontalSymbol = '',
 	href,
-	onClick: onClickCallback,
+	onClick,
 	spritemap,
 	title,
 }: IProps) => {
@@ -74,7 +74,7 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 			horizontal={horizontal}
 			href={href}
 			interactive
-			onClick={onClickCallback}
+			onClick={onClick}
 			onKeyDown={(event: React.KeyboardEvent) => {
 				if (
 					(event && event.keyCode === KEYCODES.ENTER) ||
@@ -82,8 +82,8 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 				) {
 					event.preventDefault();
 
-					if (onClickCallback) {
-						onClickCallback(event);
+					if (onClick) {
+						onClick(event);
 					}
 				}
 			}}


### PR DESCRIPTION
## Test Case

> Open Storybook on CardWithNavigation story: https://storybook.clayui.com/?path=/story/components-claycard--cardwithnavigation, try to focus the onClick card and then press SPACE or ENTER key.

The original behaviour is when a button is focused, this element be triggered by SPACE or a ENTER key but when using a div with a role="button" this isn't possible.

## Description

I needed to hack the onKeyDown event for detecting a SPACE or ENTER keydown event passing the event of keydown for these keys to onClick callback.

## Questions/Issues:

Is there a way for avoiding using a div with a role="button" attribute? /cc @pat270

See https://twitter.com/scottohara/status/1183020913509502978

Closes #3365