### PR TITLE
feat(@clayui/css): Absorb Bootstrap's _jumbotron.scss into Clay CSS

### DIFF
--- a/packages/clay-css/src/scss/_bs4.scss
+++ b/packages/clay-css/src/scss/_bs4.scss
@@ -30,7 +30,7 @@
 @import 'bootstrap/breadcrumb';
 @import 'bootstrap/pagination';
 @import 'bootstrap/badge';
-@import 'bootstrap/jumbotron';
+@import 'components/_jumbotron';
 @import 'bootstrap/alert';
 @import 'bootstrap/progress';
 @import 'bootstrap/media';

--- a/packages/clay-css/src/scss/components/_jumbotron.scss
+++ b/packages/clay-css/src/scss/components/_jumbotron.scss
@@ -1,0 +1,20 @@
+.jumbotron {
+	background-color: $jumbotron-bg;
+
+	@include border-radius($border-radius-lg);
+
+	color: $jumbotron-color;
+	margin-bottom: $jumbotron-padding;
+	padding: $jumbotron-padding ($jumbotron-padding / 2);
+
+	@include media-breakpoint-up(sm) {
+		padding: ($jumbotron-padding * 2) $jumbotron-padding;
+	}
+}
+
+.jumbotron-fluid {
+	@include border-radius(0);
+
+	padding-left: 0;
+	padding-right: 0;
+}


### PR DESCRIPTION
issue #3149