### PR TITLE
fix(clayui.com): Make Using Clay in JSPs page not draft so it shows up in the navigation

### DIFF
--- a/clayui.com/content/docs/get-started/using-clay-in-jsps.md
+++ b/clayui.com/content/docs/get-started/using-clay-in-jsps.md
@@ -1,6 +1,5 @@
 ---
 title: 'Using Clay in JSPs'
-draft: true
 order: 6
 ---
 


### PR DESCRIPTION
Fixes #3400 

Pretty basic, we left the `draft` status on this page to `true` in it's early stages and forgot to remove it once the page was ready.