### PR TITLE
feat(@clayui/css): Absorb Bootstrap's _btn-group.scss into Clay CSS _btn-group.scss

### DIFF
--- a/packages/clay-css/src/scss/_bs4.scss
+++ b/packages/clay-css/src/scss/_bs4.scss
@@ -11,7 +11,6 @@
 // @import 'bootstrap/buttons';
 @import 'components/transitions';
 // @import 'bootstrap/dropdown';
-@import 'bootstrap/button-group';
 @import 'bootstrap/input-group';
 @import 'bootstrap/custom-forms';
 @import 'bootstrap/nav';

--- a/packages/clay-css/src/scss/components/_button-groups.scss
+++ b/packages/clay-css/src/scss/components/_button-groups.scss
@@ -1,6 +1,16 @@
 .btn-group,
 .btn-group-vertical {
+	display: inline-flex;
+	position: relative;
+	vertical-align: middle;
+
 	> .btn {
+		position: relative;
+
+		&:hover {
+			z-index: 1;
+		}
+
 		&:focus {
 			z-index: 3;
 		}
@@ -9,6 +19,23 @@
 		&.active {
 			z-index: 2;
 		}
+	}
+}
+
+.btn-group {
+	> .btn:not(:first-child),
+	> .btn-group:not(:first-child) {
+		margin-left: math-sign($btn-border-width);
+	}
+
+	> .btn:not(:last-child):not(.dropdown-toggle),
+	> .btn-group:not(:last-child) > .btn {
+		@include border-right-radius(0);
+	}
+
+	> .btn:not(:first-child),
+	> .btn-group:not(:first-child) > .btn {
+		@include border-left-radius(0);
 	}
 }
 
@@ -32,6 +59,10 @@
 }
 
 .btn-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+
 	.btn-group,
 	.input-group {
 		margin-bottom: $btn-toolbar-spacer-y;
@@ -41,30 +72,122 @@
 			margin-right: $btn-toolbar-spacer-x;
 		}
 	}
+
+	.input-group {
+		width: auto;
+	}
 }
 
+// Button Group Sizes
+
 .btn-group-lg {
+	> .btn,
 	.btn-group > .btn {
-		@extend .btn-lg !optional;
+		@extend %clay-btn-lg !optional;
 	}
 
 	.btn-monospaced {
-		padding: 0;
+		@extend %clay-btn-monospaced-lg !optional;
 	}
 }
 
 .btn-group-sm {
+	> .btn,
 	.btn-group > .btn {
-		@extend .btn-sm !optional;
+		@extend %clay-btn-sm !optional;
 	}
 
 	.btn-monospaced {
-		padding: 0;
+		@extend %clay-btn-monospaced-sm !optional;
 	}
 }
 
+// Dropdown Toggle Split
+// Makes .btn narrower
+
+.dropdown-toggle-split {
+	padding-left: $btn-padding-x * 0.75;
+	padding-right: $btn-padding-x * 0.75;
+
+	@if ($enable-caret) {
+		&::after,
+		.dropup::after,
+		.dropright::after {
+			margin-left: 0;
+		}
+
+		.dropleft::before {
+			margin-right: 0;
+		}
+	}
+}
+
+.btn-sm + .dropdown-toggle-split {
+	padding-right: $btn-padding-x-sm * 0.75;
+	padding-left: $btn-padding-x-sm * 0.75;
+}
+
+.btn-lg + .dropdown-toggle-split {
+	padding-right: $btn-padding-x-lg * 0.75;
+	padding-left: $btn-padding-x-lg * 0.75;
+}
+
+// Button Group Vertical
+
 .btn-group-vertical {
+	align-items: flex-start;
+	flex-direction: column;
+	justify-content: center;
+
+	> .btn,
+	> .btn-group {
+		width: 100%;
+	}
+
+	> .btn:not(:first-child),
+	> .btn-group:not(:first-child) {
+		margin-top: math-sign($btn-border-width);
+	}
+
+	> .btn:not(:last-child):not(.dropdown-toggle),
+	> .btn-group:not(:last-child) > .btn {
+		@include border-bottom-radius(0);
+	}
+
+	> .btn:not(:first-child),
+	> .btn-group:not(:first-child) > .btn {
+		@include border-top-radius(0);
+	}
+
 	> .btn-monospaced {
 		width: $btn-monospaced-size;
+	}
+}
+
+// Checkbox and radio options
+//
+// In order to support the browser's form validation feedback, powered by the
+// `required` attribute, we have to "hide" the inputs via `clip`. We cannot use
+// `display: none;` or `visibility: hidden;` as that also hides the popover.
+// Simply visually hiding the inputs via `opacity` would leave them clickable in
+// certain cases which is prevented by using `clip` and `pointer-events`.
+// This way, we ensure a DOM element is visible to position the popover from.
+//
+// See https://github.com/twbs/bootstrap/pull/12794 and
+// https://github.com/twbs/bootstrap/pull/14559 for more information.
+
+.btn-group-toggle {
+	> .btn,
+	> .btn-group > .btn {
+		// Override default `<label>` value
+
+		margin-bottom: 0;
+
+		input[type='radio'],
+		input[type='checkbox'] {
+			clip: rect(0, 0, 0, 0);
+			pointer-events: none;
+			position: absolute;
+		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -215,37 +215,45 @@ input[type='button'] {
 		width: $btn-monospaced-size-mobile;
 	}
 
-	&.btn-lg {
-		height: $btn-monospaced-size-lg;
-		padding-bottom: $btn-monospaced-padding-y-lg;
-		padding-left: $btn-monospaced-padding-x-lg;
-		padding-right: $btn-monospaced-padding-x-lg;
-		padding-top: $btn-monospaced-padding-y-lg;
-		width: $btn-monospaced-size-lg;
-
-		@include clay-scale-component {
-			height: $btn-monospaced-size-lg-mobile;
-			width: $btn-monospaced-size-lg-mobile;
-		}
-	}
-
-	&.btn-sm {
-		height: $btn-monospaced-size-sm;
-		padding-bottom: $btn-monospaced-padding-y-sm;
-		padding-left: $btn-monospaced-padding-x-sm;
-		padding-right: $btn-monospaced-padding-x-sm;
-		padding-top: $btn-monospaced-padding-y-sm;
-		width: $btn-monospaced-size-sm;
-
-		@include clay-scale-component {
-			height: $btn-monospaced-size-sm-mobile;
-			width: $btn-monospaced-size-sm-mobile;
-		}
-	}
-
 	&.btn .lexicon-icon {
 		margin-top: 0;
 	}
+}
+
+%clay-btn-monospaced-lg {
+	height: $btn-monospaced-size-lg;
+	padding-bottom: $btn-monospaced-padding-y-lg;
+	padding-left: $btn-monospaced-padding-x-lg;
+	padding-right: $btn-monospaced-padding-x-lg;
+	padding-top: $btn-monospaced-padding-y-lg;
+	width: $btn-monospaced-size-lg;
+
+	@include clay-scale-component {
+		height: $btn-monospaced-size-lg-mobile;
+		width: $btn-monospaced-size-lg-mobile;
+	}
+}
+
+.btn-monospaced.btn-lg {
+	@extend %clay-btn-monospaced-lg !optional;
+}
+
+%clay-btn-monospaced-sm {
+	height: $btn-monospaced-size-sm;
+	padding-bottom: $btn-monospaced-padding-y-sm;
+	padding-left: $btn-monospaced-padding-x-sm;
+	padding-right: $btn-monospaced-padding-x-sm;
+	padding-top: $btn-monospaced-padding-y-sm;
+	width: $btn-monospaced-size-sm;
+
+	@include clay-scale-component {
+		height: $btn-monospaced-size-sm-mobile;
+		width: $btn-monospaced-size-sm-mobile;
+	}
+}
+
+.btn-monospaced.btn-sm {
+	@extend %clay-btn-monospaced-sm !optional;
 }
 
 // Button C Inner


### PR DESCRIPTION
feat(@clayui/css): Button adds placeholders `%clay-btn-monospaced-lg`, `%clay-btn-monospaced-sm` so we can extend with Sass `@extend` without unnecessary selectors

issue #3149