### PR TITLE
feat(@clayui/button): Add label prop to ClayButtonWithIcon

### DIFF
--- a/packages/clay-button/README.mdx
+++ b/packages/clay-button/README.mdx
@@ -9,6 +9,7 @@ sibling: 'docs/components/css-buttons.html'
 import {
 	ButtonDisplayTypes,
 	ButtonGroup,
+	ButtonWithIcon,
 } from '$packages/clay-button/docs/index';
 
 <div class="nav-toc-absolute">
@@ -16,6 +17,7 @@ import {
 
 -   [Display Types](#display-types)
 -   [Group](#group)
+-   [With Icon](#with-icon)
 -   [API](#api)
     -   [ClayButton](#claybutton)
     -   [ClayButton.Group](#claybutton.group)
@@ -41,6 +43,14 @@ You can use the variant `ClayButton.Group` for creating button groups:
 Use the [`spaced`](#api-spaced) property to create spacing between buttons.
 
 <ButtonGroup />
+
+## With Icon
+
+If you want an icon inside of your button, either in combination with a label or without, use `ClayButtonWithIcon`.
+
+`ClayButtonWithIcon` extends `ClayButton`'s props, e.g. `block`, `displayType`, `small`, etc.
+
+<ButtonWithIcon />
 
 ## API
 

--- a/packages/clay-button/docs/index.js
+++ b/packages/clay-button/docs/index.js
@@ -4,7 +4,7 @@
  */
 
 import Editor from '$clayui.com/src/components/Editor';
-import ClayButton from '@clayui/button';
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import React from 'react';
 
 const buttonDisplayTypesImportsCode = `import ClayButton from '@clayui/button';
@@ -70,4 +70,24 @@ const ButtonGroup = () => {
 	);
 };
 
-export {ButtonDisplayTypes, ButtonGroup};
+const buttonWithIconImportsCode = `import {ClayButtonWithIcon} from '@clayui/button';`;
+
+const ButtonWithIconCode = `const Component = () => {
+	return (
+		<ClayButtonWithIcon displayType="secondary" label="Settings" symbol="cog" spritemap={spritemap} />
+	);
+}
+
+render(<Component />);
+`;
+
+const ButtonWithIcon = () => {
+	const scope = {ClayButtonWithIcon};
+	const code = ButtonWithIconCode;
+
+	return (
+		<Editor code={code} imports={buttonWithIconImportsCode} scope={scope} />
+	);
+};
+
+export {ButtonDisplayTypes, ButtonGroup, ButtonWithIcon};

--- a/packages/clay-button/src/ButtonWithIcon.tsx
+++ b/packages/clay-button/src/ButtonWithIcon.tsx
@@ -10,6 +10,16 @@ import ClayButton from './Button';
 
 interface IProps extends React.ComponentProps<typeof ClayButton> {
 	/**
+	 * Label to be displayed within the button, alongside the icon.
+	 */
+	label?: string;
+
+	/**
+	 * Position of the icon inside the button.
+	 */
+	iconPosition?: 'after' | 'before';
+
+	/**
 	 * Path to the location of the spritemap resource.
 	 */
 	spritemap?: string;
@@ -21,9 +31,36 @@ interface IProps extends React.ComponentProps<typeof ClayButton> {
 }
 
 const ClayButtonWithIcon = React.forwardRef<HTMLButtonElement, IProps>(
-	({spritemap, symbol, ...otherProps}: IProps, ref) => (
-		<ClayButton {...otherProps} monospaced ref={ref}>
-			<ClayIcon spritemap={spritemap} symbol={symbol} />
+	(
+		{
+			iconPosition = 'before',
+			label,
+			spritemap,
+			symbol,
+			...otherProps
+		}: IProps,
+		ref
+	) => (
+		<ClayButton {...otherProps} monospaced={!label} ref={ref}>
+			{label ? (
+				<>
+					{iconPosition === 'before' && (
+						<span className="inline-item inline-item-before">
+							<ClayIcon spritemap={spritemap} symbol={symbol} />
+						</span>
+					)}
+
+					{label}
+
+					{iconPosition === 'after' && (
+						<span className="inline-item inline-item-after">
+							<ClayIcon spritemap={spritemap} symbol={symbol} />
+						</span>
+					)}
+				</>
+			) : (
+				<ClayIcon spritemap={spritemap} symbol={symbol} />
+			)}
 		</ClayButton>
 	)
 );

--- a/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
@@ -23,6 +23,27 @@ exports[`ClayButton renders ButtonWithIcon 1`] = `
 </button>
 `;
 
+exports[`ClayButton renders ButtonWithIcon with label 1`] = `
+<button
+  className="btn btn-primary"
+  type="button"
+>
+  <span
+    className="inline-item inline-item-before"
+  >
+    <svg
+      className="lexicon-icon lexicon-icon-trash"
+      role="presentation"
+    >
+      <use
+        xlinkHref="/some/path#trash"
+      />
+    </svg>
+  </span>
+  Delete
+</button>
+`;
+
 exports[`ClayButton renders a ButtonGroup with spaced 1`] = `
 <div
   className="btn-group"

--- a/packages/clay-button/src/__tests__/index.tsx
+++ b/packages/clay-button/src/__tests__/index.tsx
@@ -98,4 +98,16 @@ describe('ClayButton', () => {
 
 		expect(testRenderer.toJSON()).toMatchSnapshot();
 	});
+
+	it('renders ButtonWithIcon with label', () => {
+		const testRenderer = TestRenderer.create(
+			<ClayButtonWithIcon
+				label="Delete"
+				spritemap="/some/path"
+				symbol="trash"
+			/>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
 });

--- a/packages/clay-button/stories/index.tsx
+++ b/packages/clay-button/stories/index.tsx
@@ -55,6 +55,7 @@ storiesOf('Components|ClayButton', module)
 			<ClayButtonWithIcon
 				aria-label="Cog"
 				displayType="secondary"
+				label="Settings"
 				spritemap={spritemap}
 				symbol="cog"
 			/>


### PR DESCRIPTION
Fixes #3407 

While adding the `label` prop I came to the conclusion that we could also allow the users to change the positioning of the Icon, which is why I added an `iconPosition` prop that wraps the icon in a `span.inline-item`.

I also updated the related story, added a new test, and added to the documentation.