### PR TITLE
feat(@clayui/data-provider): Adds the new fetcher API and deprecated the link behavior in accepting async function

### DIFF
--- a/packages/clay-data-provider/BREAKING.md
+++ b/packages/clay-data-provider/BREAKING.md
@@ -1,1 +1,3 @@
 # List of Breaking Changes for 4.x
+
+-   Remove the behavior of the prop `link` that accepts an asynchronous function with the return of a promise.

--- a/packages/clay-data-provider/README.mdx
+++ b/packages/clay-data-provider/README.mdx
@@ -110,7 +110,7 @@ The cache is guided by a policy, use the `fetchPolicy` prop to enable and config
 ### Data Fetching
 
 ```javascript
-const {resource} = useResource({fetcher, link});
+const {resource} = useResource({fetch, link});
 ```
 
 This is an API that replaces the `link` behavior of receiving an async function, this did not allow us to validate the cache correctly because we do not have the URL view. This API is more friendly and has a unique responsibility, you may be able to pass an async function that accepts the `link` and `options`, and return the data. `useResource` will use its async function instead of the `fetch` default.
@@ -120,10 +120,8 @@ This is an API that replaces the `link` behavior of receiving an async function,
 ```javascript
 import fetch from 'unfetch';
 
-const fetcher = (url, options) => fetch(url, options);
-
 const App = () => {
-	const {resource} = useResource({fetcher, link: 'https://clay.dev'});
+	const {resource} = useResource({fetch, link: 'https://clay.dev'});
 	// ...
 };
 ```

--- a/packages/clay-data-provider/README.mdx
+++ b/packages/clay-data-provider/README.mdx
@@ -26,6 +26,8 @@ import {
     -   [Network Status](#network-status)
     -   [Variables change](#variables-change)
     -   [Caching data](#caching-data)
+    -   [Data Fetching](#data-fetching)
+        -   [Fetch](#fetch)
 -   [Advanced](#advanced)
     -   [Avoiding thundering herd problem](#avoiding-thundering-herd-problem)
     -   [Caching data at root level](#caching-data-at-root-level)
@@ -104,6 +106,27 @@ The cache is guided by a policy, use the `fetchPolicy` prop to enable and config
 		storageMaxSize
 	</code> API. <b>Each new query is equivalent to 1 size</b>.
 </div>
+
+### Data Fetching
+
+```javascript
+const {resource} = useResource({fetcher, link});
+```
+
+This is an API that replaces the `link` behavior of receiving an async function, this did not allow us to validate the cache correctly because we do not have the URL view. This API is more friendly and has a unique responsibility, you may be able to pass an async function that accepts the `link` and `options`, and return the data. `useResource` will use its async function instead of the `fetch` default.
+
+#### Fetch
+
+```javascript
+import fetch from 'unfetch';
+
+const fetcher = (url, options) => fetch(url, options);
+
+const App = () => {
+	const {resource} = useResource({fetcher, link: 'https://clay.dev'});
+	// ...
+};
+```
 
 ## Advanced
 

--- a/packages/clay-data-provider/src/__tests__/index.tsx
+++ b/packages/clay-data-provider/src/__tests__/index.tsx
@@ -102,6 +102,22 @@ describe('ClayDataProvider', () => {
 		expect(fetchMock.mock.calls[0][0]).toEqual('https://clay.data');
 	});
 
+	it('call clay.data with a custom fetcher', async () => {
+		const fetcher = jest
+			.fn()
+			.mockImplementation(() => Promise.resolve({data: 'Foo'}));
+
+		render(
+			<DataProvider fetcher={fetcher} link="https://clay.data">
+				{() => <div />}
+			</DataProvider>
+		);
+
+		await wait(() => expect(fetcher).toHaveBeenCalled());
+
+		expect(fetcher).toHaveBeenCalledWith('https://clay.data/', undefined);
+	});
+
 	it('calls clay.data and return data from cache', async () => {
 		const data = {title: 'Foo'};
 		const cache = setupCache('https://clay.data:null', data);

--- a/packages/clay-data-provider/src/__tests__/index.tsx
+++ b/packages/clay-data-provider/src/__tests__/index.tsx
@@ -102,20 +102,20 @@ describe('ClayDataProvider', () => {
 		expect(fetchMock.mock.calls[0][0]).toEqual('https://clay.data');
 	});
 
-	it('call clay.data with a custom fetcher', async () => {
-		const fetcher = jest
+	it('call clay.data with a custom fetch', async () => {
+		const fetch = jest
 			.fn()
 			.mockImplementation(() => Promise.resolve({data: 'Foo'}));
 
 		render(
-			<DataProvider fetcher={fetcher} link="https://clay.data">
+			<DataProvider fetch={fetch} link="https://clay.data">
 				{() => <div />}
 			</DataProvider>
 		);
 
-		await wait(() => expect(fetcher).toHaveBeenCalled());
+		await wait(() => expect(fetch).toHaveBeenCalled());
 
-		expect(fetcher).toHaveBeenCalledWith('https://clay.data/', undefined);
+		expect(fetch).toHaveBeenCalledWith('https://clay.data/', undefined);
 	});
 
 	it('calls clay.data and return data from cache', async () => {

--- a/packages/clay-data-provider/src/types.ts
+++ b/packages/clay-data-provider/src/types.ts
@@ -88,10 +88,7 @@ export interface IDataProvider {
 	 * A Promise returning function to fetch your data, this replaces the
 	 * use of `fetch` by default.
 	 */
-	fetch?: (
-		link: string,
-		init?: RequestInit | undefined
-	) => Promise<Response>;
+	fetch?: (link: string, init?: RequestInit | undefined) => Promise<Response>;
 
 	/**
 	 * This API is used in conjunction with variables API, if it is always

--- a/packages/clay-data-provider/src/types.ts
+++ b/packages/clay-data-provider/src/types.ts
@@ -85,21 +85,21 @@ export interface IFetchRetry {
 
 export interface IDataProvider {
 	/**
+	 * A Promise returning function to fetch your data, this replaces the
+	 * use of `fetch` by default.
+	 */
+	fetch?: (
+		link: string,
+		init?: RequestInit | undefined
+	) => Promise<Response>;
+
+	/**
 	 * This API is used in conjunction with variables API, if it is always
 	 * changing its value set a debounce time to make a new request.
 	 *
 	 * Set a value in ms.
 	 */
 	fetchDelay?: number;
-
-	/**
-	 * A Promise returning function to fetch your data, this replaces the
-	 * use of `fetch` by default.
-	 */
-	fetcher?: (
-		link: string,
-		init?: RequestInit | undefined
-	) => Promise<Response>;
 
 	/**
 	 * Options passed to request configuration.

--- a/packages/clay-data-provider/src/types.ts
+++ b/packages/clay-data-provider/src/types.ts
@@ -93,6 +93,15 @@ export interface IDataProvider {
 	fetchDelay?: number;
 
 	/**
+	 * A Promise returning function to fetch your data, this replaces the
+	 * use of `fetch` by default.
+	 */
+	fetcher?: (
+		link: string,
+		init?: RequestInit | undefined
+	) => Promise<Response>;
+
+	/**
 	 * Options passed to request configuration.
 	 */
 	fetchOptions?: RequestInit;
@@ -139,6 +148,9 @@ export interface IDataProvider {
 	 * a Promise. We do not recommend that you use a function to do so,
 	 * you will lose some benefits of the data provider,
 	 * always try to avoid.
+	 *
+	 * The behavior of the `link` accepting a function has been deprecated
+	 * in favor of the `fetcher` API.
 	 */
 	link: TLink;
 

--- a/packages/clay-data-provider/src/useResource.ts
+++ b/packages/clay-data-provider/src/useResource.ts
@@ -23,6 +23,7 @@ interface IResource extends IDataProvider {
 
 const useResource = ({
 	fetchDelay = 300,
+	fetcher,
 	fetchOptions,
 	fetchPolicy = FetchPolicy.NoCache,
 	fetchTimeout = 6000,
@@ -155,7 +156,7 @@ const useResource = ({
 
 		warning(
 			uri.searchParams.toString() === '',
-			'DataProvider: We recommend that instead of passing parameters over the link, use the variables API. \n More details: https://next.clayui.com/docs/components/data-provider.html'
+			'DataProvider: We recommend that instead of passing parameters over the link, use the variables API. \n More details: https://clayui.com/docs/components/data-provider.html'
 		);
 
 		if (!variables) {
@@ -170,6 +171,11 @@ const useResource = ({
 	const doFetch = (retryAttempts = 0) => {
 		let promise: Promise<any>;
 
+		warning(
+			typeof link === 'string',
+			'DataProvider: The behavior of the `link` accepting a function has been deprecated in favor of the `fetcher` API. \n More details: https://clayui.com/docs/components/data-provider.html#data-fetching'
+		);
+
 		switch (typeof link) {
 			case 'function':
 				promise = link(
@@ -182,12 +188,20 @@ const useResource = ({
 					).searchParams.toString()
 				);
 				break;
-			case 'string':
-				promise = fetch(
-					getUrlFormat(link, variables),
-					fetchOptions
-				).then((res) => res.json());
+			case 'string': {
+				const fn = fetcher ?? fetch;
+
+				promise = fn(getUrlFormat(link, variables), fetchOptions).then(
+					(res) => {
+						if (fetcher) {
+							return res;
+						}
+
+						return res.json();
+					}
+				);
 				break;
+			}
 			default:
 				return null;
 		}

--- a/packages/clay-data-provider/src/useResource.ts
+++ b/packages/clay-data-provider/src/useResource.ts
@@ -192,12 +192,12 @@ const useResource = ({
 				const fn = fetcher ?? fetch;
 
 				promise = fn(getUrlFormat(link, variables), fetchOptions).then(
-					(res) => {
-						if (fetcher) {
-							return res;
+					(res: Response) => {
+						if (res.ok && res.body && !res.body.locked) {
+							return res.json();
 						}
 
-						return res.json();
+						return res;
 					}
 				);
 				break;

--- a/packages/clay-data-provider/src/useResource.ts
+++ b/packages/clay-data-provider/src/useResource.ts
@@ -22,8 +22,8 @@ interface IResource extends IDataProvider {
 }
 
 const useResource = ({
+	fetch: fetcher,
 	fetchDelay = 300,
-	fetcher,
 	fetchOptions,
 	fetchPolicy = FetchPolicy.NoCache,
 	fetchTimeout = 6000,

--- a/packages/clay-data-provider/stories/index.tsx
+++ b/packages/clay-data-provider/stories/index.tsx
@@ -242,4 +242,30 @@ storiesOf('Components|ClayDataProvider', module)
 				</div>
 			</div>
 		);
+	})
+	.add('custom fetcher', () => {
+		const customFetcher = (
+			url: string,
+			options?: RequestInit | undefined
+		) =>
+			fetch(url, {...options, headers: {'x-clay': 'Clay'}}).then((res) =>
+				res.json()
+			);
+
+		useResource({
+			fetcher: customFetcher,
+			link: 'https://rickandmortyapi.com/api/character/',
+			variables: {limit: 10},
+		});
+
+		return (
+			<div className="pb-4 sheet">
+				<h3>{'Custom Fetcher'}</h3>
+				<div className="row">
+					<div className="col-md-5">
+						<p>{'Open your console to see the network tab.'}</p>
+					</div>
+				</div>
+			</div>
+		);
 	});

--- a/packages/clay-data-provider/stories/index.tsx
+++ b/packages/clay-data-provider/stories/index.tsx
@@ -253,7 +253,7 @@ storiesOf('Components|ClayDataProvider', module)
 			);
 
 		useResource({
-			fetcher: customFetcher,
+			fetch: customFetcher,
 			link: 'https://rickandmortyapi.com/api/character/',
 			variables: {limit: 10},
 		});


### PR DESCRIPTION
This PR introduces two changes and at the same time improvements for cache validation for custom fetch cases, this is explained better in the documentation.

- Deprecates the behavior of the `link` API to accept an async function (Throws a warning if used)
- Adds the new API `fetcher`

The `fetcher` API facilitates the custom fetch use cases and improves the cache validation when used, mainly for the Portal use cases that we need to use the `fetch` from ` frontend-js-web`.

```javascript
import {fetch} from 'frontend-js-web';

useResource({
    fetcher: fetch,
    link: 'https://clay.data/',
}); 
```