### PR TITLE
feat(@clayui/modal): Adds a new `center` API to vertically center the modal

### DIFF
--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -27,6 +27,11 @@ interface IProps
 	extends React.HTMLAttributes<HTMLDivElement>,
 		Omit<IContext, 'onClose'> {
 	/**
+	 * Flag indicating to vertically center the modal.
+	 */
+	center?: boolean;
+
+	/**
 	 * The size of element modal.
 	 */
 	size?: Size;
@@ -50,6 +55,7 @@ const warningMessage = `You need to pass the 'observer' prop to ClayModal for ev
 `;
 
 const ClayModal: React.FunctionComponent<IProps> = ({
+	center,
 	children,
 	className,
 	observer,
@@ -98,6 +104,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 						className={classNames('modal-dialog', {
 							[`modal-${size}`]: size,
 							[`modal-${status}`]: status,
+							'modal-dialog-centered': center,
 						})}
 						tabIndex={-1}
 					>

--- a/packages/clay-modal/src/Provider.tsx
+++ b/packages/clay-modal/src/Provider.tsx
@@ -28,6 +28,11 @@ type TState = {
 	body: React.ReactElement | React.ReactText;
 
 	/**
+	 * Flag indicating to vertically center the modal.
+	 */
+	center?: boolean;
+
+	/**
 	 * Render the action buttons on the footer following the order of `ClayModal.Footer`:
 	 * - first
 	 * - middle
@@ -94,7 +99,7 @@ const ClayModalProvider: React.FunctionComponent<IProps> = ({
 	const {observer, onClose} = useModal({
 		onClose: () => dispatch({type: Action.Close}),
 	});
-	const {body, footer, header, size, status, url} = otherState;
+	const {body, center, footer, header, size, status, url} = otherState;
 	const [first, middle, last] = footer;
 	const state = {
 		...otherState,
@@ -105,6 +110,7 @@ const ClayModalProvider: React.FunctionComponent<IProps> = ({
 		<>
 			{visible && (
 				<ClayModal
+					center={center}
 					observer={observer}
 					size={size}
 					spritemap={spritemap}

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -304,6 +304,36 @@ exports[`ClayModal renders with Header 1`] = `
 </body>
 `;
 
+exports[`ClayModal renders with center 1`] = `
+<body
+  class="modal-open"
+>
+  <div>
+    <div
+      class="modal-backdrop fade show"
+    />
+    <div
+      class="fade modal d-block show"
+    >
+      <div
+        class=""
+        style="margin: auto; max-width: 600px;"
+      >
+        <div
+          class="modal-dialog modal-dialog-centered"
+          tabindex="-1"
+        >
+          <div
+            class="modal-content"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div />
+</body>
+`;
+
 exports[`ClayModal renders with size 1`] = `
 <body
   class="modal-open"

--- a/packages/clay-modal/src/__tests__/index.tsx
+++ b/packages/clay-modal/src/__tests__/index.tsx
@@ -157,6 +157,28 @@ describe('ClayModal', () => {
 		expect(document.body).toMatchSnapshot();
 	});
 
+	it('renders with center', () => {
+		const ModalWithState = () => {
+			const {observer} = useModal({onClose: () => {}});
+
+			return (
+				<ClayModal
+					center
+					observer={observer}
+					spritemap={spritemap}
+				/>
+			);
+		};
+
+		render(<ModalWithState />);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(document.body).toMatchSnapshot();
+	});
+
 	it('renders a body component with url', () => {
 		const ModalWithState = () => {
 			const {observer} = useModal({onClose: () => {}});

--- a/packages/clay-modal/src/__tests__/index.tsx
+++ b/packages/clay-modal/src/__tests__/index.tsx
@@ -162,11 +162,7 @@ describe('ClayModal', () => {
 			const {observer} = useModal({onClose: () => {}});
 
 			return (
-				<ClayModal
-					center
-					observer={observer}
-					spritemap={spritemap}
-				/>
+				<ClayModal center observer={observer} spritemap={spritemap} />
 			);
 		};
 

--- a/packages/clay-modal/stories/index.tsx
+++ b/packages/clay-modal/stories/index.tsx
@@ -71,6 +71,7 @@ storiesOf('Components|ClayModal', module)
 			<>
 				{visibleModal && (
 					<ClayModal
+						center={boolean('Vertically Center', false)}
 						observer={observer}
 						size={select('Size', size, 'lg') as Size}
 						spritemap={spritemap}


### PR DESCRIPTION
Fixes #3414

We apparently missed this use case when we were building this component or it was a recent change to Lexicon. 🤷‍♂️