### PR TITLE
fix(@clayui/date-picker): When selecting a date using space key, removes properly the `:active` state of the element

### DIFF
--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -29,18 +29,20 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	onKeyDown = noop,
 	onKeyUp = noop,
 }) => {
+	const {date, outside} = day;
+
 	const classNames = classnames(
 		'date-picker-date date-picker-calendar-item',
 		{
-			active: day.date.toDateString() === daySelected.toDateString(),
-			disabled: day.outside || disabled,
+			active: date.toDateString() === daySelected.toDateString(),
+			disabled: outside || disabled,
 		}
 	);
 
 	return (
 		<button
 			aria-label={formatDate(
-				setDate(day.date, {
+				setDate(date, {
 					hours: 12,
 					milliseconds: 0,
 					minutes: 0,
@@ -49,8 +51,8 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 				'yyyy MM dd'
 			)}
 			className={classNames}
-			disabled={day.outside}
-			onClick={() => onClick(day.date)}
+			disabled={outside}
+			onClick={() => onClick(date)}
 			onKeyDown={(event) => {
 				// When tabbing and selecting a DayNumber using
 				// SPACE key the active state it's not being removed.
@@ -63,14 +65,14 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 			}}
 			onKeyUp={(event) => {
 				if (event.keyCode === KEY_CODE_SPACE) {
-					onClick(day.date);
+					onClick(date);
 				}
 
 				onKeyUp(event);
 			}}
 			type="button"
 		>
-			{day.date.getDate()}
+			{date.getDate()}
 		</button>
 	);
 };

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -13,13 +13,21 @@ interface IProps {
 	daySelected: Date;
 	disabled?: boolean;
 	onClick: (date: Date) => void;
+	onKeyUp?: (event: React.KeyboardEvent) => void;
+	onKeyDown?: (event: React.KeyboardEvent) => void;
 }
+
+const noop = () => {};
+
+const KEY_CODE_SPACE = 32;
 
 const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	day,
 	daySelected,
 	disabled,
-	onClick,
+	onClick = noop,
+	onKeyDown = noop,
+	onKeyUp = noop,
 }) => {
 	const classNames = classnames(
 		'date-picker-date date-picker-calendar-item',
@@ -43,6 +51,23 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 			className={classNames}
 			disabled={day.outside}
 			onClick={() => onClick(day.date)}
+			onKeyDown={(event) => {
+				// When tabbing and selecting a DayNumber using
+				// SPACE key the active state it's not being removed.
+				// See https://github.com/liferay/clay/issues/3374 for more details.
+				if (event.keyCode === KEY_CODE_SPACE) {
+					event.preventDefault();
+				}
+
+				onKeyDown(event);
+			}}
+			onKeyUp={(event) => {
+				if (event.keyCode === KEY_CODE_SPACE) {
+					onClick(day.date);
+				}
+
+				onKeyUp(event);
+			}}
 			type="button"
 		>
 			{day.date.getDate()}

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -15,10 +15,6 @@ interface IProps {
 	onClick: (date: Date) => void;
 }
 
-const KEYS = {
-	SPACE: ('Spacebar' || ' '),
-};
-
 const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	day,
 	daySelected,
@@ -53,12 +49,12 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 				// When tabbing and selecting a DayNumber using
 				// SPACE key the active state it's not being removed.
 				// See https://github.com/liferay/clay/issues/3374 for more details.
-				if (event.key === KEYS.SPACE) {
+				if (event.key === 'Spacebar' || event.key === ' ') {
 					event.preventDefault();
 				}
 			}}
 			onKeyUp={(event) => {
-				if (event.key === KEYS.SPACE) {
+				if (event.key === 'Spacebar' || event.key === ' ') {
 					onClick(date);
 				}
 			}}

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -13,11 +13,7 @@ interface IProps {
 	daySelected: Date;
 	disabled?: boolean;
 	onClick: (date: Date) => void;
-	onKeyUp?: (event: React.KeyboardEvent) => void;
-	onKeyDown?: (event: React.KeyboardEvent) => void;
 }
-
-const noop = () => {};
 
 const KEYS = {
 	SPACE: ' ',
@@ -27,9 +23,7 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	day,
 	daySelected,
 	disabled,
-	onClick = noop,
-	onKeyDown = noop,
-	onKeyUp = noop,
+	onClick,
 }) => {
 	const {date, outside} = day;
 
@@ -62,15 +56,11 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 				if (event.key === KEYS.SPACE) {
 					event.preventDefault();
 				}
-
-				onKeyDown(event);
 			}}
 			onKeyUp={(event) => {
 				if (event.key === KEYS.SPACE) {
 					onClick(date);
 				}
-
-				onKeyUp(event);
 			}}
 			type="button"
 		>

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -16,7 +16,7 @@ interface IProps {
 }
 
 const KEYS = {
-	SPACE: ' ',
+	SPACE: 'Spacebar',
 };
 
 const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -19,7 +19,9 @@ interface IProps {
 
 const noop = () => {};
 
-const KEY_CODE_SPACE = 32;
+const KEYS = {
+	SPACE: ' ',
+};
 
 const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	day,
@@ -57,14 +59,14 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 				// When tabbing and selecting a DayNumber using
 				// SPACE key the active state it's not being removed.
 				// See https://github.com/liferay/clay/issues/3374 for more details.
-				if (event.keyCode === KEY_CODE_SPACE) {
+				if (event.key === KEYS.SPACE) {
 					event.preventDefault();
 				}
 
 				onKeyDown(event);
 			}}
 			onKeyUp={(event) => {
-				if (event.keyCode === KEY_CODE_SPACE) {
+				if (event.key === KEYS.SPACE) {
 					onClick(date);
 				}
 

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -16,7 +16,7 @@ interface IProps {
 }
 
 const KEYS = {
-	SPACE: 'Spacebar',
+	SPACE: ('Spacebar' || ' '),
 };
 
 const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({


### PR DESCRIPTION
## Test Case

1. Open our Date Picker component on storybook: https://storybook.clayui.com/?path=/story/components-claydatepicker--default
2. Navigate thru days using tabs and select a day using SPACE key
3. Navigate faster thru days and try to select multiple days using SPACE key
4. You will able to select multiple days when using SPACE key

----

For solving this problem, the keyDown event when the space key is pressed was prevented and when keyUp, the click callback was called.



## Commits

- chore(@clayui/date-picker): Prefer destructuring
- fix(@clayui/date-picker): When selecting a date using space key, removes properly the `:active` state of the element. This issue can't be reproduced on IE/FF but it can be reproduced on Chrome/Safari. Apparently this is a WebKit issue

Closes #3374