### PR TITLE
feat(clayui.com): Add JSP code example to Icon

### DIFF
--- a/packages/clay-icon/docs/index.js
+++ b/packages/clay-icon/docs/index.js
@@ -7,8 +7,7 @@ import Editor from '$clayui.com/src/components/Editor';
 import ClayIcon, {ClayIconSpriteContext} from '@clayui/icon';
 import React from 'react';
 
-const iconImportsCode = `import ClayIcon from '@clayui/icon';
-`;
+const iconImportsCode = `import ClayIcon from '@clayui/icon';`;
 
 const IconCode = `const Component = () => {
 	return (
@@ -18,11 +17,28 @@ const IconCode = `const Component = () => {
 
 render(<Component />)`;
 
+const iconJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
+
+const IconJSPCode = `<clay:icon symbol="heart" />`;
+
 export const Icon = () => {
 	const scope = {ClayIcon};
-	const code = IconCode;
 
-	return <Editor code={code} imports={iconImportsCode} scope={scope} />;
+	const codeSnippets = [
+		{
+			imports: iconImportsCode,
+			name: 'React',
+			value: IconCode,
+		},
+		{
+			disabled: true,
+			imports: iconJSPImportsCode,
+			name: 'JSP',
+			value: IconJSPCode,
+		},
+	];
+
+	return <Editor code={codeSnippets} scope={scope} />;
 };
 
 const iconWithContextImportsCode = `import ClayIcon, {ClayIconSpriteContext} from '@clayui/icon';


### PR DESCRIPTION
Fixes #3447.

Apart from the title, I removed an empty line from React code import because it was creating a double empty line, making the spacing between imports and code bigger than it's supposed to be.

![image](https://user-images.githubusercontent.com/24564752/86460165-2c6e7780-bd28-11ea-9b5f-614ffb0ae467.png)
