### PR TITLE
fix(clayui.com): Fix Button JSP code example

### DIFF
--- a/packages/clay-button/docs/index.js
+++ b/packages/clay-button/docs/index.js
@@ -7,8 +7,7 @@ import Editor from '$clayui.com/src/components/Editor';
 import ClayButton from '@clayui/button';
 import React from 'react';
 
-const buttonDisplayTypesImportsCode = `import ClayButton from '@clayui/button';
-`;
+const buttonDisplayTypesImportsCode = `import ClayButton from '@clayui/button';`;
 
 const ButtonDisplayTypesCode = `const Component = () => {
 	return (
@@ -31,9 +30,9 @@ const ButtonDisplayTypesCode = `const Component = () => {
 
 render(<Component />);`;
 
-const ButtonJSPCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>
+const buttonJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
 
-<clay:button
+const ButtonJSPCode = `<clay:button
 	displayType="primary"
 	label="Button Primary"
 />
@@ -55,28 +54,25 @@ const ButtonJSPCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay
 
 const ButtonDisplayTypes = () => {
 	const scope = {ClayButton};
+
 	const codeSnippets = [
 		{
+			imports: buttonDisplayTypesImportsCode,
 			name: 'React',
 			value: ButtonDisplayTypesCode,
 		},
 		{
+			disabled: true,
+			imports: buttonJSPImportsCode,
 			name: 'JSP',
 			value: ButtonJSPCode,
 		},
 	];
 
-	return (
-		<Editor
-			code={codeSnippets}
-			imports={buttonDisplayTypesImportsCode}
-			scope={scope}
-		/>
-	);
+	return <Editor code={codeSnippets} scope={scope} />;
 };
 
-const buttonGroupImportsCode = `import ClayButton from '@clayui/button';
-`;
+const buttonGroupImportsCode = `import ClayButton from '@clayui/button';`;
 
 const ButtonGroupCode = `const Component = () => {
 	return (


### PR DESCRIPTION
Addendum to #3444 

Initial implementation had a couple small issues that I caught when adding the Icon JSP code example, this fixes them:
- The JSP example textarea had to be disabled
- React imports weren't being showed because the Editor API expects the imports to be defined inside the code object
- Excess empty lines that were at the end of code strings