### PR TITLE
chore(@clayui/css): Use Reuse Spec Snippets for licensing code snippets from Normalize.css, Suitcss, and HTML5 Boilerplate

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/clay-css/gulpfile.js
+++ b/packages/clay-css/gulpfile.js
@@ -205,13 +205,13 @@ gulp.task('version', function() {
 		path.join(scssDir, '_license-text.scss'),
 	];
 
-	function changeVersion(filePath) {
+	function changeVersion(filePath, regex = /\*\sClay\s(.*)\n/g, value = `* Clay ${VERSION}\n`) {
 		fs.readFile(filePath, 'utf8', function(err, data) {
 			if (err) {
 				return console.log(err);
 			}
 
-			var result = data.replace(/\*\sClay\s(.*)\n/g, `* Clay ${VERSION}\n`);
+			var result = data.replace(regex, value);
 
 			fs.writeFile(filePath, result, 'utf8', function(err) {
 				if (err) return console.log(err);
@@ -226,6 +226,23 @@ gulp.task('version', function() {
 			changeVersion(filePath);
 		}
 	});
+
+	var libIconsSvg = path.join('.', 'lib', 'images', 'icons', 'icons.svg');
+
+	var regex = /<\?xml version=\"1.0\" encoding=\"UTF-8\"\?([\s\S]+-->|>)/g;
+	var license = `<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* Clay ${VERSION}
+*
+* SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+* SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributor
+*
+* SPDX-License-Identifier: BSD-3-Clause
+-->`;
+
+	changeVersion(libIconsSvg, regex, license);
+
+
 });
 
 gulp.task('serve', ['serve:start', 'watch']);

--- a/packages/clay-css/gulpfile.js
+++ b/packages/clay-css/gulpfile.js
@@ -202,10 +202,7 @@ gulp.task('version', function() {
 	var scssDir = path.join('.', 'src', 'scss');
 
 	var clayFiles = [
-		path.join(scssDir, 'atlas-variables.scss'),
-		path.join(scssDir, 'atlas.scss'),
-		path.join(scssDir, 'base-variables.scss'),
-		path.join(scssDir, 'base.scss'),
+		path.join(scssDir, '_license-text.scss'),
 	];
 
 	function changeVersion(filePath) {

--- a/packages/clay-css/gulpfile.js
+++ b/packages/clay-css/gulpfile.js
@@ -199,7 +199,6 @@ gulp.task('version', function() {
 		fs.readFileSync(path.join('.', 'package.json'))
 	).version;
 
-	var svgsDir = path.join('.', 'src', 'images', 'icons');
 	var scssDir = path.join('.', 'src', 'scss');
 
 	var clayFiles = [
@@ -229,12 +228,6 @@ gulp.task('version', function() {
 		if (clayFiles.includes(filePath)) {
 			changeVersion(filePath);
 		}
-	});
-
-	fs.readdirSync(svgsDir).forEach(function(file) {
-		var filePath = path.join(svgsDir, file);
-
-		changeVersion(filePath);
 	});
 });
 

--- a/packages/clay-css/src/images/icons/add-cell.svg
+++ b/packages/clay-css/src/images/icons/add-cell.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/add-column.svg
+++ b/packages/clay-css/src/images/icons/add-column.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/add-role.svg
+++ b/packages/clay-css/src/images/icons/add-role.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/add-row.svg
+++ b/packages/clay-css/src/images/icons/add-row.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/adjust.svg
+++ b/packages/clay-css/src/images/icons/adjust.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/align-center.svg
+++ b/packages/clay-css/src/images/icons/align-center.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/align-justify.svg
+++ b/packages/clay-css/src/images/icons/align-justify.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/align-left.svg
+++ b/packages/clay-css/src/images/icons/align-left.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/align-right.svg
+++ b/packages/clay-css/src/images/icons/align-right.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/analytics.svg
+++ b/packages/clay-css/src/images/icons/analytics.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/angle-down-small.svg
+++ b/packages/clay-css/src/images/icons/angle-down-small.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/angle-down.svg
+++ b/packages/clay-css/src/images/icons/angle-down.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/angle-left-small.svg
+++ b/packages/clay-css/src/images/icons/angle-left-small.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/angle-left.svg
+++ b/packages/clay-css/src/images/icons/angle-left.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/angle-right-small.svg
+++ b/packages/clay-css/src/images/icons/angle-right-small.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/angle-right.svg
+++ b/packages/clay-css/src/images/icons/angle-right.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/angle-up-small.svg
+++ b/packages/clay-css/src/images/icons/angle-up-small.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/angle-up.svg
+++ b/packages/clay-css/src/images/icons/angle-up.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/announcement.svg
+++ b/packages/clay-css/src/images/icons/announcement.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/anonymize.svg
+++ b/packages/clay-css/src/images/icons/anonymize.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/api-lock.svg
+++ b/packages/clay-css/src/images/icons/api-lock.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/api-web.svg
+++ b/packages/clay-css/src/images/icons/api-web.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/archive.svg
+++ b/packages/clay-css/src/images/icons/archive.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/arrow-end.svg
+++ b/packages/clay-css/src/images/icons/arrow-end.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/arrow-join.svg
+++ b/packages/clay-css/src/images/icons/arrow-join.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/arrow-split.svg
+++ b/packages/clay-css/src/images/icons/arrow-split.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/arrow-start.svg
+++ b/packages/clay-css/src/images/icons/arrow-start.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/arrow-up-full.svg
+++ b/packages/clay-css/src/images/icons/arrow-up-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/arrow-xor.svg
+++ b/packages/clay-css/src/images/icons/arrow-xor.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/asterisk.svg
+++ b/packages/clay-css/src/images/icons/asterisk.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/audio.svg
+++ b/packages/clay-css/src/images/icons/audio.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/autosize.svg
+++ b/packages/clay-css/src/images/icons/autosize.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/bars.svg
+++ b/packages/clay-css/src/images/icons/bars.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/bell-full.svg
+++ b/packages/clay-css/src/images/icons/bell-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/bell-off.svg
+++ b/packages/clay-css/src/images/icons/bell-off.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/bell-on.svg
+++ b/packages/clay-css/src/images/icons/bell-on.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/blogs.svg
+++ b/packages/clay-css/src/images/icons/blogs.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/bold.svg
+++ b/packages/clay-css/src/images/icons/bold.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/bolt.svg
+++ b/packages/clay-css/src/images/icons/bolt.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/bookmarks.svg
+++ b/packages/clay-css/src/images/icons/bookmarks.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/books.svg
+++ b/packages/clay-css/src/images/icons/books.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/box-container.svg
+++ b/packages/clay-css/src/images/icons/box-container.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/breadcrumb.svg
+++ b/packages/clay-css/src/images/icons/breadcrumb.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/briefcase.svg
+++ b/packages/clay-css/src/images/icons/briefcase.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/button.svg
+++ b/packages/clay-css/src/images/icons/button.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/calendar.svg
+++ b/packages/clay-css/src/images/icons/calendar.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/camera.svg
+++ b/packages/clay-css/src/images/icons/camera.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/cards-full.svg
+++ b/packages/clay-css/src/images/icons/cards-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/cards.svg
+++ b/packages/clay-css/src/images/icons/cards.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/cards2.svg
+++ b/packages/clay-css/src/images/icons/cards2.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-bottom-l.svg
+++ b/packages/clay-css/src/images/icons/caret-bottom-l.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-bottom.svg
+++ b/packages/clay-css/src/images/icons/caret-bottom.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-double-l.svg
+++ b/packages/clay-css/src/images/icons/caret-double-l.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-double.svg
+++ b/packages/clay-css/src/images/icons/caret-double.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-left-l.svg
+++ b/packages/clay-css/src/images/icons/caret-left-l.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-left.svg
+++ b/packages/clay-css/src/images/icons/caret-left.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-right-l.svg
+++ b/packages/clay-css/src/images/icons/caret-right-l.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-right.svg
+++ b/packages/clay-css/src/images/icons/caret-right.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-top-l.svg
+++ b/packages/clay-css/src/images/icons/caret-top-l.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/caret-top.svg
+++ b/packages/clay-css/src/images/icons/caret-top.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/catalog.svg
+++ b/packages/clay-css/src/images/icons/catalog.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/categories.svg
+++ b/packages/clay-css/src/images/icons/categories.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/chain-broken.svg
+++ b/packages/clay-css/src/images/icons/chain-broken.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/change-list-disabled.svg
+++ b/packages/clay-css/src/images/icons/change-list-disabled.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/change-list.svg
+++ b/packages/clay-css/src/images/icons/change-list.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/change.svg
+++ b/packages/clay-css/src/images/icons/change.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/check-circle-full.svg
+++ b/packages/clay-css/src/images/icons/check-circle-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/check-circle.svg
+++ b/packages/clay-css/src/images/icons/check-circle.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/check-square.svg
+++ b/packages/clay-css/src/images/icons/check-square.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/check.svg
+++ b/packages/clay-css/src/images/icons/check.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/chip.svg
+++ b/packages/clay-css/src/images/icons/chip.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/circle.svg
+++ b/packages/clay-css/src/images/icons/circle.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/cloud.svg
+++ b/packages/clay-css/src/images/icons/cloud.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/code.svg
+++ b/packages/clay-css/src/images/icons/code.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/cog.svg
+++ b/packages/clay-css/src/images/icons/cog.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/color-picker.svg
+++ b/packages/clay-css/src/images/icons/color-picker.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/columns.svg
+++ b/packages/clay-css/src/images/icons/columns.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/comments.svg
+++ b/packages/clay-css/src/images/icons/comments.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/community.svg
+++ b/packages/clay-css/src/images/icons/community.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/compress.svg
+++ b/packages/clay-css/src/images/icons/compress.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/container.svg
+++ b/packages/clay-css/src/images/icons/container.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/control-panel.svg
+++ b/packages/clay-css/src/images/icons/control-panel.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/credit-card.svg
+++ b/packages/clay-css/src/images/icons/credit-card.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/custom-field.svg
+++ b/packages/clay-css/src/images/icons/custom-field.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/custom-size.svg
+++ b/packages/clay-css/src/images/icons/custom-size.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/cut.svg
+++ b/packages/clay-css/src/images/icons/cut.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/date.svg
+++ b/packages/clay-css/src/images/icons/date.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/decimal.svg
+++ b/packages/clay-css/src/images/icons/decimal.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/desktop.svg
+++ b/packages/clay-css/src/images/icons/desktop.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/device-check.svg
+++ b/packages/clay-css/src/images/icons/device-check.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/devices.svg
+++ b/packages/clay-css/src/images/icons/devices.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/diagram.svg
+++ b/packages/clay-css/src/images/icons/diagram.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/diamond.svg
+++ b/packages/clay-css/src/images/icons/diamond.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/diary.svg
+++ b/packages/clay-css/src/images/icons/diary.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/disk.svg
+++ b/packages/clay-css/src/images/icons/disk.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/display-content.svg
+++ b/packages/clay-css/src/images/icons/display-content.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/display.svg
+++ b/packages/clay-css/src/images/icons/display.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-code.svg
+++ b/packages/clay-css/src/images/icons/document-code.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-compressed.svg
+++ b/packages/clay-css/src/images/icons/document-compressed.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-default.svg
+++ b/packages/clay-css/src/images/icons/document-default.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-image.svg
+++ b/packages/clay-css/src/images/icons/document-image.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-multimedia.svg
+++ b/packages/clay-css/src/images/icons/document-multimedia.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-pdf.svg
+++ b/packages/clay-css/src/images/icons/document-pdf.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-pending.svg
+++ b/packages/clay-css/src/images/icons/document-pending.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-presentation.svg
+++ b/packages/clay-css/src/images/icons/document-presentation.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-table.svg
+++ b/packages/clay-css/src/images/icons/document-table.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-text.svg
+++ b/packages/clay-css/src/images/icons/document-text.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document-vector.svg
+++ b/packages/clay-css/src/images/icons/document-vector.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/document.svg
+++ b/packages/clay-css/src/images/icons/document.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/documents-and-media.svg
+++ b/packages/clay-css/src/images/icons/documents-and-media.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/download.svg
+++ b/packages/clay-css/src/images/icons/download.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/drag.svg
+++ b/packages/clay-css/src/images/icons/drag.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/drop.svg
+++ b/packages/clay-css/src/images/icons/drop.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/dynamic-data-list.svg
+++ b/packages/clay-css/src/images/icons/dynamic-data-list.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/dynamic-data-mapping.svg
+++ b/packages/clay-css/src/images/icons/dynamic-data-mapping.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/edit-layout.svg
+++ b/packages/clay-css/src/images/icons/edit-layout.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/effects.svg
+++ b/packages/clay-css/src/images/icons/effects.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/ellipsis-h.svg
+++ b/packages/clay-css/src/images/icons/ellipsis-h.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/ellipsis-v.svg
+++ b/packages/clay-css/src/images/icons/ellipsis-v.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/embed.svg
+++ b/packages/clay-css/src/images/icons/embed.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/emoji.svg
+++ b/packages/clay-css/src/images/icons/emoji.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/envelope-closed.svg
+++ b/packages/clay-css/src/images/icons/envelope-closed.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/envelope-open.svg
+++ b/packages/clay-css/src/images/icons/envelope-open.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/environment-connected.svg
+++ b/packages/clay-css/src/images/icons/environment-connected.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/environment-disconnected.svg
+++ b/packages/clay-css/src/images/icons/environment-disconnected.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/environment.svg
+++ b/packages/clay-css/src/images/icons/environment.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/exclamation-circle.svg
+++ b/packages/clay-css/src/images/icons/exclamation-circle.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/exclamation-full.svg
+++ b/packages/clay-css/src/images/icons/exclamation-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/expand.svg
+++ b/packages/clay-css/src/images/icons/expand.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/file-script.svg
+++ b/packages/clay-css/src/images/icons/file-script.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/file-template.svg
+++ b/packages/clay-css/src/images/icons/file-template.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/file-xsl.svg
+++ b/packages/clay-css/src/images/icons/file-xsl.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/filter.svg
+++ b/packages/clay-css/src/images/icons/filter.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flag-empty.svg
+++ b/packages/clay-css/src/images/icons/flag-empty.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flag-full.svg
+++ b/packages/clay-css/src/images/icons/flag-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-ar-SA.svg
+++ b/packages/clay-css/src/images/icons/flags-ar-SA.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-bg-BG.svg
+++ b/packages/clay-css/src/images/icons/flags-bg-BG.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-ca-AD.svg
+++ b/packages/clay-css/src/images/icons/flags-ca-AD.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-ca-ES.svg
+++ b/packages/clay-css/src/images/icons/flags-ca-ES.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-cs-CZ.svg
+++ b/packages/clay-css/src/images/icons/flags-cs-CZ.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-da-DK.svg
+++ b/packages/clay-css/src/images/icons/flags-da-DK.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-de-DE.svg
+++ b/packages/clay-css/src/images/icons/flags-de-DE.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-el-GR.svg
+++ b/packages/clay-css/src/images/icons/flags-el-GR.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-en-AU.svg
+++ b/packages/clay-css/src/images/icons/flags-en-AU.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-en-GB.svg
+++ b/packages/clay-css/src/images/icons/flags-en-GB.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-en-US.svg
+++ b/packages/clay-css/src/images/icons/flags-en-US.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-es-ES.svg
+++ b/packages/clay-css/src/images/icons/flags-es-ES.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-et-EE.svg
+++ b/packages/clay-css/src/images/icons/flags-et-EE.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-eu-ES.svg
+++ b/packages/clay-css/src/images/icons/flags-eu-ES.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-fa-IR.svg
+++ b/packages/clay-css/src/images/icons/flags-fa-IR.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-fi-FI.svg
+++ b/packages/clay-css/src/images/icons/flags-fi-FI.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-fr-CA.svg
+++ b/packages/clay-css/src/images/icons/flags-fr-CA.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-fr-FR.svg
+++ b/packages/clay-css/src/images/icons/flags-fr-FR.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-gl-ES.svg
+++ b/packages/clay-css/src/images/icons/flags-gl-ES.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-hi-IN.svg
+++ b/packages/clay-css/src/images/icons/flags-hi-IN.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-hr-HR.svg
+++ b/packages/clay-css/src/images/icons/flags-hr-HR.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-hu-HU.svg
+++ b/packages/clay-css/src/images/icons/flags-hu-HU.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-in-ID.svg
+++ b/packages/clay-css/src/images/icons/flags-in-ID.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-it-IT.svg
+++ b/packages/clay-css/src/images/icons/flags-it-IT.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-iw-IL.svg
+++ b/packages/clay-css/src/images/icons/flags-iw-IL.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-ja-JP.svg
+++ b/packages/clay-css/src/images/icons/flags-ja-JP.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-kk-KZ.svg
+++ b/packages/clay-css/src/images/icons/flags-kk-KZ.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-ko-KR.svg
+++ b/packages/clay-css/src/images/icons/flags-ko-KR.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-lo-LA.svg
+++ b/packages/clay-css/src/images/icons/flags-lo-LA.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-lt-LT.svg
+++ b/packages/clay-css/src/images/icons/flags-lt-LT.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-ms-MY.svg
+++ b/packages/clay-css/src/images/icons/flags-ms-MY.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-nb-NO.svg
+++ b/packages/clay-css/src/images/icons/flags-nb-NO.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-nl-BE.svg
+++ b/packages/clay-css/src/images/icons/flags-nl-BE.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-nl-NL.svg
+++ b/packages/clay-css/src/images/icons/flags-nl-NL.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-pl-PL.svg
+++ b/packages/clay-css/src/images/icons/flags-pl-PL.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-pt-BR.svg
+++ b/packages/clay-css/src/images/icons/flags-pt-BR.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-pt-PT.svg
+++ b/packages/clay-css/src/images/icons/flags-pt-PT.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-ro-RO.svg
+++ b/packages/clay-css/src/images/icons/flags-ro-RO.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-ru-RU.svg
+++ b/packages/clay-css/src/images/icons/flags-ru-RU.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-sk-SK.svg
+++ b/packages/clay-css/src/images/icons/flags-sk-SK.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-sl-SI.svg
+++ b/packages/clay-css/src/images/icons/flags-sl-SI.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-sr-RS-latin.svg
+++ b/packages/clay-css/src/images/icons/flags-sr-RS-latin.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-sr-RS.svg
+++ b/packages/clay-css/src/images/icons/flags-sr-RS.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-sv-SE.svg
+++ b/packages/clay-css/src/images/icons/flags-sv-SE.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-ta-IN.svg
+++ b/packages/clay-css/src/images/icons/flags-ta-IN.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-th-TH.svg
+++ b/packages/clay-css/src/images/icons/flags-th-TH.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-tr-TR.svg
+++ b/packages/clay-css/src/images/icons/flags-tr-TR.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-uk-UA.svg
+++ b/packages/clay-css/src/images/icons/flags-uk-UA.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-vi-VN.svg
+++ b/packages/clay-css/src/images/icons/flags-vi-VN.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-zh-CN.svg
+++ b/packages/clay-css/src/images/icons/flags-zh-CN.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/flags-zh-TW.svg
+++ b/packages/clay-css/src/images/icons/flags-zh-TW.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/folder.svg
+++ b/packages/clay-css/src/images/icons/folder.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/format.svg
+++ b/packages/clay-css/src/images/icons/format.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/forms.svg
+++ b/packages/clay-css/src/images/icons/forms.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/full-size.svg
+++ b/packages/clay-css/src/images/icons/full-size.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/geolocation.svg
+++ b/packages/clay-css/src/images/icons/geolocation.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/globe.svg
+++ b/packages/clay-css/src/images/icons/globe.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/google.svg
+++ b/packages/clay-css/src/images/icons/google.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/grid.svg
+++ b/packages/clay-css/src/images/icons/grid.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/h1.svg
+++ b/packages/clay-css/src/images/icons/h1.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/h2.svg
+++ b/packages/clay-css/src/images/icons/h2.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/hashtag.svg
+++ b/packages/clay-css/src/images/icons/hashtag.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/hdd.svg
+++ b/packages/clay-css/src/images/icons/hdd.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/heart-full.svg
+++ b/packages/clay-css/src/images/icons/heart-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/heart.svg
+++ b/packages/clay-css/src/images/icons/heart.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/hidden.svg
+++ b/packages/clay-css/src/images/icons/hidden.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/home.svg
+++ b/packages/clay-css/src/images/icons/home.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/horizontal-scroll.svg
+++ b/packages/clay-css/src/images/icons/horizontal-scroll.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/hr.svg
+++ b/packages/clay-css/src/images/icons/hr.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/import-export.svg
+++ b/packages/clay-css/src/images/icons/import-export.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/import-list.svg
+++ b/packages/clay-css/src/images/icons/import-list.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/import.svg
+++ b/packages/clay-css/src/images/icons/import.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/indent-less.svg
+++ b/packages/clay-css/src/images/icons/indent-less.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/indent-more.svg
+++ b/packages/clay-css/src/images/icons/indent-more.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/info-book.svg
+++ b/packages/clay-css/src/images/icons/info-book.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/info-circle-open.svg
+++ b/packages/clay-css/src/images/icons/info-circle-open.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/info-circle.svg
+++ b/packages/clay-css/src/images/icons/info-circle.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/info-panel-closed.svg
+++ b/packages/clay-css/src/images/icons/info-panel-closed.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/info-panel-open.svg
+++ b/packages/clay-css/src/images/icons/info-panel-open.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/information-live.svg
+++ b/packages/clay-css/src/images/icons/information-live.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/integer.svg
+++ b/packages/clay-css/src/images/icons/integer.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/italic.svg
+++ b/packages/clay-css/src/images/icons/italic.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/liferay-ac.svg
+++ b/packages/clay-css/src/images/icons/liferay-ac.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/link.svg
+++ b/packages/clay-css/src/images/icons/link.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/list-ol-rtl.svg
+++ b/packages/clay-css/src/images/icons/list-ol-rtl.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/list-ol.svg
+++ b/packages/clay-css/src/images/icons/list-ol.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/list-ul-rtl.svg
+++ b/packages/clay-css/src/images/icons/list-ul-rtl.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/list-ul.svg
+++ b/packages/clay-css/src/images/icons/list-ul.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/list.svg
+++ b/packages/clay-css/src/images/icons/list.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/live.svg
+++ b/packages/clay-css/src/images/icons/live.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/lock-dots.svg
+++ b/packages/clay-css/src/images/icons/lock-dots.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/lock.svg
+++ b/packages/clay-css/src/images/icons/lock.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/logout.svg
+++ b/packages/clay-css/src/images/icons/logout.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/magic.svg
+++ b/packages/clay-css/src/images/icons/magic.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/mark-as-answer.svg
+++ b/packages/clay-css/src/images/icons/mark-as-answer.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/mark-as-question.svg
+++ b/packages/clay-css/src/images/icons/mark-as-question.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/megaphone-full.svg
+++ b/packages/clay-css/src/images/icons/megaphone-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/merge.svg
+++ b/packages/clay-css/src/images/icons/merge.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/message-boards.svg
+++ b/packages/clay-css/src/images/icons/message-boards.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/message.svg
+++ b/packages/clay-css/src/images/icons/message.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/minus-circle.svg
+++ b/packages/clay-css/src/images/icons/minus-circle.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/mobile-device-rules.svg
+++ b/packages/clay-css/src/images/icons/mobile-device-rules.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/mobile-landscape.svg
+++ b/packages/clay-css/src/images/icons/mobile-landscape.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/mobile-portrait.svg
+++ b/packages/clay-css/src/images/icons/mobile-portrait.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/moon.svg
+++ b/packages/clay-css/src/images/icons/moon.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/move-folder.svg
+++ b/packages/clay-css/src/images/icons/move-folder.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/move.svg
+++ b/packages/clay-css/src/images/icons/move.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/myspace.svg
+++ b/packages/clay-css/src/images/icons/myspace.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/number.svg
+++ b/packages/clay-css/src/images/icons/number.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/oauth.svg
+++ b/packages/clay-css/src/images/icons/oauth.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/open-id.svg
+++ b/packages/clay-css/src/images/icons/open-id.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/order-arrow-down.svg
+++ b/packages/clay-css/src/images/icons/order-arrow-down.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/order-arrow-left.svg
+++ b/packages/clay-css/src/images/icons/order-arrow-left.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/order-arrow-right.svg
+++ b/packages/clay-css/src/images/icons/order-arrow-right.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/order-arrow-up.svg
+++ b/packages/clay-css/src/images/icons/order-arrow-up.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/order-arrow.svg
+++ b/packages/clay-css/src/images/icons/order-arrow.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/organizations.svg
+++ b/packages/clay-css/src/images/icons/organizations.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/page-template.svg
+++ b/packages/clay-css/src/images/icons/page-template.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/page.svg
+++ b/packages/clay-css/src/images/icons/page.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/pages-tree.svg
+++ b/packages/clay-css/src/images/icons/pages-tree.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/paperclip.svg
+++ b/packages/clay-css/src/images/icons/paperclip.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/paragraph.svg
+++ b/packages/clay-css/src/images/icons/paragraph.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/password-policies.svg
+++ b/packages/clay-css/src/images/icons/password-policies.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/pause.svg
+++ b/packages/clay-css/src/images/icons/pause.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/pencil.svg
+++ b/packages/clay-css/src/images/icons/pencil.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/phone.svg
+++ b/packages/clay-css/src/images/icons/phone.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/picture.svg
+++ b/packages/clay-css/src/images/icons/picture.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/pin-full.svg
+++ b/packages/clay-css/src/images/icons/pin-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/pin.svg
+++ b/packages/clay-css/src/images/icons/pin.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/play.svg
+++ b/packages/clay-css/src/images/icons/play.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/plug.svg
+++ b/packages/clay-css/src/images/icons/plug.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/plus-squares.svg
+++ b/packages/clay-css/src/images/icons/plus-squares.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/plus.svg
+++ b/packages/clay-css/src/images/icons/plus.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/polls.svg
+++ b/packages/clay-css/src/images/icons/polls.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/print.svg
+++ b/packages/clay-css/src/images/icons/print.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/product-menu-closed.svg
+++ b/packages/clay-css/src/images/icons/product-menu-closed.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/product-menu-open.svg
+++ b/packages/clay-css/src/images/icons/product-menu-open.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/product-menu.svg
+++ b/packages/clay-css/src/images/icons/product-menu.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/propagation.svg
+++ b/packages/clay-css/src/images/icons/propagation.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/question-circle-full.svg
+++ b/packages/clay-css/src/images/icons/question-circle-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/question-circle.svg
+++ b/packages/clay-css/src/images/icons/question-circle.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/quote-left.svg
+++ b/packages/clay-css/src/images/icons/quote-left.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/quote-right.svg
+++ b/packages/clay-css/src/images/icons/quote-right.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/radio-button.svg
+++ b/packages/clay-css/src/images/icons/radio-button.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/redo.svg
+++ b/packages/clay-css/src/images/icons/redo.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/reload.svg
+++ b/packages/clay-css/src/images/icons/reload.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/remove-role.svg
+++ b/packages/clay-css/src/images/icons/remove-role.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/remove-style.svg
+++ b/packages/clay-css/src/images/icons/remove-style.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/reply.svg
+++ b/packages/clay-css/src/images/icons/reply.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/repository.svg
+++ b/packages/clay-css/src/images/icons/repository.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/reset.svg
+++ b/packages/clay-css/src/images/icons/reset.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/restore.svg
+++ b/packages/clay-css/src/images/icons/restore.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/rss-full.svg
+++ b/packages/clay-css/src/images/icons/rss-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/rss.svg
+++ b/packages/clay-css/src/images/icons/rss.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/rules.svg
+++ b/packages/clay-css/src/images/icons/rules.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/search-plus.svg
+++ b/packages/clay-css/src/images/icons/search-plus.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/search.svg
+++ b/packages/clay-css/src/images/icons/search.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/select-from-list.svg
+++ b/packages/clay-css/src/images/icons/select-from-list.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/select.svg
+++ b/packages/clay-css/src/images/icons/select.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/separator.svg
+++ b/packages/clay-css/src/images/icons/separator.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/share-alt.svg
+++ b/packages/clay-css/src/images/icons/share-alt.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/share.svg
+++ b/packages/clay-css/src/images/icons/share.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/sheets.svg
+++ b/packages/clay-css/src/images/icons/sheets.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/shopping-cart.svg
+++ b/packages/clay-css/src/images/icons/shopping-cart.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/shortcut.svg
+++ b/packages/clay-css/src/images/icons/shortcut.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/sign-in.svg
+++ b/packages/clay-css/src/images/icons/sign-in.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/simple-circle.svg
+++ b/packages/clay-css/src/images/icons/simple-circle.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/simulation-menu-closed.svg
+++ b/packages/clay-css/src/images/icons/simulation-menu-closed.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/simulation-menu-open.svg
+++ b/packages/clay-css/src/images/icons/simulation-menu-open.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/simulation-menu.svg
+++ b/packages/clay-css/src/images/icons/simulation-menu.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/site-template.svg
+++ b/packages/clay-css/src/images/icons/site-template.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/sites.svg
+++ b/packages/clay-css/src/images/icons/sites.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/slideshow.svg
+++ b/packages/clay-css/src/images/icons/slideshow.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/social-facebook.svg
+++ b/packages/clay-css/src/images/icons/social-facebook.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/social-instagram.svg
+++ b/packages/clay-css/src/images/icons/social-instagram.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/social-linkedin.svg
+++ b/packages/clay-css/src/images/icons/social-linkedin.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/social-twitter.svg
+++ b/packages/clay-css/src/images/icons/social-twitter.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/social-vimeo.svg
+++ b/packages/clay-css/src/images/icons/social-vimeo.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/spacer.svg
+++ b/packages/clay-css/src/images/icons/spacer.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/special-character.svg
+++ b/packages/clay-css/src/images/icons/special-character.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/square-hole.svg
+++ b/packages/clay-css/src/images/icons/square-hole.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/square.svg
+++ b/packages/clay-css/src/images/icons/square.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/staging.svg
+++ b/packages/clay-css/src/images/icons/staging.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/star-half.svg
+++ b/packages/clay-css/src/images/icons/star-half.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/star-o.svg
+++ b/packages/clay-css/src/images/icons/star-o.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/star.svg
+++ b/packages/clay-css/src/images/icons/star.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/sticky.svg
+++ b/packages/clay-css/src/images/icons/sticky.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/strikethrough.svg
+++ b/packages/clay-css/src/images/icons/strikethrough.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/subscript.svg
+++ b/packages/clay-css/src/images/icons/subscript.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/suitcase.svg
+++ b/packages/clay-css/src/images/icons/suitcase.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/sun.svg
+++ b/packages/clay-css/src/images/icons/sun.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/superscript.svg
+++ b/packages/clay-css/src/images/icons/superscript.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/table.svg
+++ b/packages/clay-css/src/images/icons/table.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/table2.svg
+++ b/packages/clay-css/src/images/icons/table2.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/tablet-landscape.svg
+++ b/packages/clay-css/src/images/icons/tablet-landscape.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/tablet-portrait.svg
+++ b/packages/clay-css/src/images/icons/tablet-portrait.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/tabs.svg
+++ b/packages/clay-css/src/images/icons/tabs.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/tag.svg
+++ b/packages/clay-css/src/images/icons/tag.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/tap-ahead.svg
+++ b/packages/clay-css/src/images/icons/tap-ahead.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/test.svg
+++ b/packages/clay-css/src/images/icons/test.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/text-color.svg
+++ b/packages/clay-css/src/images/icons/text-color.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/text-editor.svg
+++ b/packages/clay-css/src/images/icons/text-editor.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/text-l.svg
+++ b/packages/clay-css/src/images/icons/text-l.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/text.svg
+++ b/packages/clay-css/src/images/icons/text.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/textbox.svg
+++ b/packages/clay-css/src/images/icons/textbox.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/third-party.svg
+++ b/packages/clay-css/src/images/icons/third-party.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/thumbs-down-full.svg
+++ b/packages/clay-css/src/images/icons/thumbs-down-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/thumbs-down.svg
+++ b/packages/clay-css/src/images/icons/thumbs-down.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/thumbs-up-arrow.svg
+++ b/packages/clay-css/src/images/icons/thumbs-up-arrow.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/thumbs-up-full.svg
+++ b/packages/clay-css/src/images/icons/thumbs-up-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/thumbs-up.svg
+++ b/packages/clay-css/src/images/icons/thumbs-up.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/time.svg
+++ b/packages/clay-css/src/images/icons/time.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/times-circle-full.svg
+++ b/packages/clay-css/src/images/icons/times-circle-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/times-circle.svg
+++ b/packages/clay-css/src/images/icons/times-circle.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/times-small.svg
+++ b/packages/clay-css/src/images/icons/times-small.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/times.svg
+++ b/packages/clay-css/src/images/icons/times.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/transform.svg
+++ b/packages/clay-css/src/images/icons/transform.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/trash.svg
+++ b/packages/clay-css/src/images/icons/trash.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/truck.svg
+++ b/packages/clay-css/src/images/icons/truck.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/twitter.svg
+++ b/packages/clay-css/src/images/icons/twitter.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/underline.svg
+++ b/packages/clay-css/src/images/icons/underline.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/undo.svg
+++ b/packages/clay-css/src/images/icons/undo.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/unlock.svg
+++ b/packages/clay-css/src/images/icons/unlock.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/unpin.svg
+++ b/packages/clay-css/src/images/icons/unpin.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/upload-multiple.svg
+++ b/packages/clay-css/src/images/icons/upload-multiple.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/upload.svg
+++ b/packages/clay-css/src/images/icons/upload.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/urgent.svg
+++ b/packages/clay-css/src/images/icons/urgent.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/user-plus.svg
+++ b/packages/clay-css/src/images/icons/user-plus.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/user.svg
+++ b/packages/clay-css/src/images/icons/user.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/users.svg
+++ b/packages/clay-css/src/images/icons/users.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/vertical-scroll.svg
+++ b/packages/clay-css/src/images/icons/vertical-scroll.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/video.svg
+++ b/packages/clay-css/src/images/icons/video.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/view.svg
+++ b/packages/clay-css/src/images/icons/view.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/vocabulary.svg
+++ b/packages/clay-css/src/images/icons/vocabulary.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/warning-full.svg
+++ b/packages/clay-css/src/images/icons/warning-full.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/warning.svg
+++ b/packages/clay-css/src/images/icons/warning.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/web-content.svg
+++ b/packages/clay-css/src/images/icons/web-content.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/wiki-page.svg
+++ b/packages/clay-css/src/images/icons/wiki-page.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/wiki.svg
+++ b/packages/clay-css/src/images/icons/wiki.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/images/icons/workflow.svg
+++ b/packages/clay-css/src/images/icons/workflow.svg
@@ -1,6 +1,4 @@
 <!--
-* Clay 3.12.0
-*
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
 *

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,0 +1,17 @@
+/**
+* Clay 3.12.0
+*
+* SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+* SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
+*
+* SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/**
+* Bootstrap v4.4.1
+*
+* SPDX-FileCopyrightText: © 2019 Twitter, Inc. <https://twitter.com>
+* SPDX-FileCopyrightText: © 2019 The Bootstrap Authors <https://getbootstrap.com/>
+*
+* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
+*/

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
-* Clay 3.12.0
+* Clay 3.13.0
 *
 * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>

--- a/packages/clay-css/src/scss/atlas-variables.scss
+++ b/packages/clay-css/src/scss/atlas-variables.scss
@@ -1,20 +1,4 @@
-/**
-* Clay 3.12.0
-*
-* SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
-* SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
-*
-* SPDX-License-Identifier: BSD-3-Clause
-*/
-
-/**
-* Bootstrap v4.4.1
-*
-* SPDX-FileCopyrightText: © 2019 Twitter, Inc. <https://twitter.com>
-* SPDX-FileCopyrightText: © 2019 The Bootstrap Authors <https://getbootstrap.com/>
-*
-* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
-*/
+@import '_license-text';
 
 @import 'bootstrap/_functions';
 @import 'functions/_global-functions';

--- a/packages/clay-css/src/scss/atlas.scss
+++ b/packages/clay-css/src/scss/atlas.scss
@@ -1,20 +1,4 @@
-/**
-* Clay 3.12.0
-*
-* SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
-* SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
-*
-* SPDX-License-Identifier: BSD-3-Clause
-*/
-
-/**
-* Bootstrap v4.4.1
-*
-* SPDX-FileCopyrightText: © 2019 Twitter, Inc. <https://twitter.com>
-* SPDX-FileCopyrightText: © 2019 The Bootstrap Authors <https://getbootstrap.com/>
-*
-* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
-*/
+@import '_license-text';
 
 @import 'bootstrap/_functions';
 @import 'functions/_global-functions';

--- a/packages/clay-css/src/scss/base-variables.scss
+++ b/packages/clay-css/src/scss/base-variables.scss
@@ -1,20 +1,4 @@
-/**
-* Clay 3.12.0
-*
-* SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
-* SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
-*
-* SPDX-License-Identifier: BSD-3-Clause
-*/
-
-/**
-* Bootstrap v4.4.1
-*
-* SPDX-FileCopyrightText: © 2019 Twitter, Inc. <https://twitter.com>
-* SPDX-FileCopyrightText: © 2019 The Bootstrap Authors <https://getbootstrap.com/>
-*
-* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
-*/
+@import '_license-text';
 
 @import 'bootstrap/_functions';
 @import 'functions/_global-functions';

--- a/packages/clay-css/src/scss/base.scss
+++ b/packages/clay-css/src/scss/base.scss
@@ -1,20 +1,4 @@
-/**
-* Clay 3.12.0
-*
-* SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
-* SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
-*
-* SPDX-License-Identifier: BSD-3-Clause
-*/
-
-/**
-* Bootstrap v4.4.1
-*
-* SPDX-FileCopyrightText: © 2019 Twitter, Inc. <https://twitter.com>
-* SPDX-FileCopyrightText: © 2019 The Bootstrap Authors <https://getbootstrap.com/>
-*
-* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
-*/
+@import '_license-text';
 
 @import 'bootstrap/_functions';
 @import 'functions/_global-functions';

--- a/packages/clay-css/src/scss/components/_print.scss
+++ b/packages/clay-css/src/scss/components/_print.scss
@@ -1,10 +1,7 @@
-// Source: https://github.com/h5bp/main.css/blob/master/src/_print.css
-
-// ==========================================================================
-// Print styles.
-// Inlined to avoid the additional HTTP request:
-// https://www.phpied.com/delay-loading-your-print-css/
-// ==========================================================================
+/* REUSE-Snippet-Begin
+* SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: © 2018 HTML5 Boilerplate <https://github.com/h5bp/main.css>
+*/
 
 @if $enable-print-styles {
 	@media print {
@@ -122,3 +119,5 @@
 		// Bootstrap specific changes end
 	}
 }
+
+/* REUSE-Snippet-End */

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -1,9 +1,7 @@
-// Reboot
-//
-// Normalization of HTML elements, manually forked from Normalize.css to remove
-// styles targeting irrelevant browsers while applying new styles.
-//
-// Normalize is licensed MIT. https://github.com/necolas/normalize.css
+/* REUSE-Snippet-Begin
+* SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: © 2016 Nicolas Gallagher and Jonathan Neal <https://github.com/necolas/normalize.css>
+*/
 
 *,
 *::before,
@@ -383,3 +381,5 @@ template {
 
 	display: none;
 }
+
+/* REUSE-Snippet-End */

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -188,8 +188,10 @@
 	}
 }
 
-// Embed
-// Credit: Nicolas Gallagher and SUIT CSS.
+/* REUSE-Snippet-Begin
+* SPDX-License-Identifier: MIT
+* SPDX-Copyright: © 2012 Nicolas Gallagher <https://github.com/suitcss/components-flex-embed>
+*/
 
 .embed-responsive {
 	display: block;
@@ -231,6 +233,8 @@
 		}
 	}
 }
+
+/* REUSE-Snippet-End */
 
 // Flex
 

--- a/packages/clay-css/tasks/lib/svgstore.js
+++ b/packages/clay-css/tasks/lib/svgstore.js
@@ -24,7 +24,6 @@ module.exports = function(gulp, plugins, _, config) {
 			.pipe(plugins.rename(exports.rename))
 			.pipe(plugins.svgmin(exports.svgmin))
 			.pipe(plugins.svgstore())
-			.pipe(plugins.header(license.TPL_SVG_C_LICENSE, license.metadata))
 			.pipe(gulp.dest(dest));
 };
 


### PR DESCRIPTION
- moves license text to its own file so we don't overwrite commit history every time we release a new version
- removes Clay version from individual svg source files for same reason

fixes #3437

@bryceosterhaus @wincent