### PR TITLE
chore(@clayui/css): Copy Licenses from root to clay-css/LICENSES

### DIFF
--- a/packages/clay-css/.gitignore
+++ b/packages/clay-css/.gitignore
@@ -1,4 +1,5 @@
 build
+LICENSES
 node_modules
 temp
 !tasks/lib

--- a/packages/clay-css/gulpfile.js
+++ b/packages/clay-css/gulpfile.js
@@ -196,7 +196,7 @@ gulp.task(
 );
 
 gulp.task('copy:licenses', function() {
-	var newLicenseDir = path.join('.', 'LICENSES');
+	var newLicenseDir = 'LICENSES';
 	var originalLicenseDir = path.join('..', '..', 'LICENSES');
 
 	return gulp.src([

--- a/packages/clay-css/gulpfile.js
+++ b/packages/clay-css/gulpfile.js
@@ -52,6 +52,7 @@ gulp.task(
 			'compile:css',
 			'compile:clean-scss',
 			'compile:svg',
+			'copy:licenses',
 			function(err) {
 				cb(err);
 			}
@@ -193,6 +194,19 @@ gulp.task(
 		});
 	}
 );
+
+gulp.task('copy:licenses', function() {
+	var newLicenseDir = path.join('.', 'LICENSES');
+	var originalLicenseDir = path.join('..', '..', 'LICENSES');
+
+	return gulp.src([
+		path.join(originalLicenseDir, 'BSD-3-Clause.txt'),
+		path.join(originalLicenseDir, 'LicenseRef-MIT-Bootstrap.txt'),
+		path.join(originalLicenseDir, 'MIT.txt')
+	]).pipe(
+		gulp.dest(newLicenseDir)
+	);
+});
 
 gulp.task('version', function() {
 	var VERSION = JSON.parse(

--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -23,8 +23,9 @@
 	"scripts": {
 		"build": "yarn compile",
 		"compile": "gulp compile",
+		"link": "npm link",
 		"prepublish": "yarn compile && ncp ../../LICENSES ./lib",
-		"link": "npm link"
+		"version": "gulp version"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -24,7 +24,7 @@
 		"build": "yarn compile",
 		"compile": "gulp compile",
 		"link": "npm link",
-		"prepublish": "yarn compile && ncp ../../LICENSES ./lib",
+		"prepublish": "yarn compile",
 		"version": "gulp version"
 	},
 	"repository": {

--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -23,7 +23,7 @@
 	"scripts": {
 		"build": "yarn compile",
 		"compile": "gulp compile",
-		"prepublish": "yarn compile",
+		"prepublish": "yarn compile && ncp ../../LICENSES ./lib",
 		"link": "npm link"
 	},
 	"repository": {


### PR DESCRIPTION
issue #3282 

Hey @bryceosterhaus, I ended up adding a gulp task (`gulp copy:licenses`) that runs when `gulp compile` is run. It copies the licenses used by Clay CSS into `clay-css/LICENSES`. We should include this directory when we publish. I can add a commit to do that, I just don't know where.

I had a hard time trying to figure out `ncp dir1 dir2 --filter=""`.  My conclusion is that it's bugged. 