### PR TITLE
fix(@clayui/css): Cards change `.card-page-item-asset` `min-width: 19…

### DIFF
--- a/packages/clay-css/src/scss/variables/_cards.scss
+++ b/packages/clay-css/src/scss/variables/_cards.scss
@@ -327,7 +327,7 @@ $card-page-item-asset: map-deep-merge(
 	(
 		base: (
 			breakpoint: 0,
-			min-width: 200px,
+			min-width: 193px,
 			padding-left: $grid-gutter-width / 2,
 			padding-right: $grid-gutter-width / 2,
 		),


### PR DESCRIPTION
…3px` so 4 cards can fit in `sheet-lg` at maximum size

fixes #3479