### PR TITLE
fix(@clayui/css): Adds leading whitespace for License texts

### DIFF
--- a/packages/clay-css/gulpfile.js
+++ b/packages/clay-css/gulpfile.js
@@ -205,7 +205,7 @@ gulp.task('version', function() {
 		path.join(scssDir, '_license-text.scss'),
 	];
 
-	function changeVersion(filePath, regex = /\*\sClay\s(.*)\n/g, value = `* Clay ${VERSION}\n`) {
+	function changeVersion(filePath, regex = /\*\s+Clay\s(.+)\n/g, value = `* Clay ${VERSION}\n`) {
 		fs.readFile(filePath, 'utf8', function(err, data) {
 			if (err) {
 				return console.log(err);
@@ -229,7 +229,7 @@ gulp.task('version', function() {
 
 	var libIconsSvg = path.join('.', 'lib', 'images', 'icons', 'icons.svg');
 
-	var regex = /<\?xml version=\"1.0\" encoding=\"UTF-8\"\?([\s\S]+-->|>)/g;
+	var regex = /<\?xml version="1.0" encoding="UTF-8"\?(.+-->|>)/gs;
 	var license = `<?xml version="1.0" encoding="UTF-8"?>
 <!--
 * Clay ${VERSION}

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,17 +1,17 @@
 /**
-* Clay 3.13.0
-*
-* SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
-* SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
-*
-* SPDX-License-Identifier: BSD-3-Clause
-*/
+ * Clay 3.13.0
+ *
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 /**
-* Bootstrap v4.4.1
-*
-* SPDX-FileCopyrightText: © 2019 Twitter, Inc. <https://twitter.com>
-* SPDX-FileCopyrightText: © 2019 The Bootstrap Authors <https://getbootstrap.com/>
-*
-* SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
-*/
+ * Bootstrap v4.4.1
+ *
+ * SPDX-FileCopyrightText: © 2019 Twitter, Inc. <https://twitter.com>
+ * SPDX-FileCopyrightText: © 2019 The Bootstrap Authors <https://getbootstrap.com/>
+ *
+ * SPDX-License-Identifier: LicenseRef-MIT-Bootstrap
+ */

--- a/packages/clay-css/src/scss/components/_print.scss
+++ b/packages/clay-css/src/scss/components/_print.scss
@@ -1,7 +1,7 @@
 /* REUSE-Snippet-Begin
-* SPDX-License-Identifier: MIT
-* SPDX-FileCopyrightText: © 2018 HTML5 Boilerplate <https://github.com/h5bp/main.css>
-*/
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: © 2018 HTML5 Boilerplate <https://github.com/h5bp/main.css>
+ */
 
 @if $enable-print-styles {
 	@media print {

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -1,7 +1,7 @@
 /* REUSE-Snippet-Begin
-* SPDX-License-Identifier: MIT
-* SPDX-FileCopyrightText: © 2016 Nicolas Gallagher and Jonathan Neal <https://github.com/necolas/normalize.css>
-*/
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: © 2016 Nicolas Gallagher and Jonathan Neal <https://github.com/necolas/normalize.css>
+ */
 
 *,
 *::before,

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -189,9 +189,9 @@
 }
 
 /* REUSE-Snippet-Begin
-* SPDX-License-Identifier: MIT
-* SPDX-Copyright: © 2012 Nicolas Gallagher <https://github.com/suitcss/components-flex-embed>
-*/
+ * SPDX-License-Identifier: MIT
+ * SPDX-Copyright: © 2012 Nicolas Gallagher <https://github.com/suitcss/components-flex-embed>
+ */
 
 .embed-responsive {
 	display: block;


### PR DESCRIPTION
fix(@clayui/css): `gulp version` use the s flag to make `.` match everything including newlines instead of `[\s\S]`, remove excess escaping of double quote, and use more robust `+` instead of `*`

issue #3437 

@wincent