### PR TITLE
feat(@clayui/form): Adds `leftMaxItems` and `rightMaxItems` properties for providing the user to limit the number of items that each select box can store

### DIFF
--- a/packages/clay-form/src/DualListBox.tsx
+++ b/packages/clay-form/src/DualListBox.tsx
@@ -61,19 +61,19 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	};
 
 	/**
+	 * Disables the button responsible for moving items from right to left box.
+	 */
+	disableRTL: boolean;
+
+	/**
+	 * Disables the button responsible for moving items from left to right box.
+	 */
+	disableLTR: boolean;
+
+	/**
 	 * Items spread across two arrays that will be displayed in the two Select Boxes.
 	 */
 	items: TItems;
-
-	/**
-	 * The maximum number of items for left Select Box.
-	 */
-	leftMaxItems?: number;
-
-	/**
-	 * The maximum number of items for left Select Box.
-	 */
-	rightMaxItems?: number;
 
 	/**
 	 * Handler that triggers when the content of the items prop are changed. Caused by either reordering or transfering of items.
@@ -107,10 +107,10 @@ const ClayDualListBox: React.FunctionComponent<IProps> = ({
 		transferRTL: 'Transfer Item Right to Left',
 	},
 	className,
+	disableLTR,
+	disableRTL,
 	items,
 	left = {},
-	leftMaxItems = Infinity,
-	rightMaxItems = Infinity,
 	onItemsChange,
 	right = {},
 	size,
@@ -161,10 +161,7 @@ const ClayDualListBox: React.FunctionComponent<IProps> = ({
 						aria-label={ariaLabels.transferLTR}
 						className="transfer-button-ltr"
 						data-testid="ltr"
-						disabled={
-							leftSelected.length === 0 ||
-							rightItems.length >= rightMaxItems
-						}
+						disabled={leftSelected.length === 0 || disableLTR}
 						displayType="secondary"
 						onClick={() => {
 							const [arrayLeft, arrayRight] = swapArrayItems(
@@ -183,10 +180,7 @@ const ClayDualListBox: React.FunctionComponent<IProps> = ({
 						aria-label={ariaLabels.transferRTL}
 						className="transfer-button-rtl"
 						data-testid="rtl"
-						disabled={
-							rightSelected.length === 0 ||
-							leftItems.length >= leftMaxItems
-						}
+						disabled={rightSelected.length === 0 || disableRTL}
 						displayType="secondary"
 						onClick={() => {
 							const [arrayRight, arrayLeft] = swapArrayItems(

--- a/packages/clay-form/src/DualListBox.tsx
+++ b/packages/clay-form/src/DualListBox.tsx
@@ -66,6 +66,16 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	items: TItems;
 
 	/**
+	 * The maximum number of items for left Select Box.
+	 */
+	leftMaxItems?: number;
+
+	/**
+	 * The maximum number of items for left Select Box.
+	 */
+	rightMaxItems?: number;
+
+	/**
 	 * Handler that triggers when the content of the items prop are changed. Caused by either reordering or transfering of items.
 	 */
 	onItemsChange: (val: TItems) => void;
@@ -99,6 +109,8 @@ const ClayDualListBox: React.FunctionComponent<IProps> = ({
 	className,
 	items,
 	left = {},
+	leftMaxItems = Infinity,
+	rightMaxItems = Infinity,
 	onItemsChange,
 	right = {},
 	size,
@@ -149,7 +161,10 @@ const ClayDualListBox: React.FunctionComponent<IProps> = ({
 						aria-label={ariaLabels.transferLTR}
 						className="transfer-button-ltr"
 						data-testid="ltr"
-						disabled={!leftSelected.length}
+						disabled={
+							leftSelected.length === 0 ||
+							rightItems.length >= rightMaxItems
+						}
 						displayType="secondary"
 						onClick={() => {
 							const [arrayLeft, arrayRight] = swapArrayItems(
@@ -168,7 +183,10 @@ const ClayDualListBox: React.FunctionComponent<IProps> = ({
 						aria-label={ariaLabels.transferRTL}
 						className="transfer-button-rtl"
 						data-testid="rtl"
-						disabled={!rightSelected.length}
+						disabled={
+							rightSelected.length === 0 ||
+							leftItems.length >= leftMaxItems
+						}
 						displayType="secondary"
 						onClick={() => {
 							const [arrayRight, arrayLeft] = swapArrayItems(

--- a/packages/clay-form/src/DualListBox.tsx
+++ b/packages/clay-form/src/DualListBox.tsx
@@ -63,12 +63,12 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Disables the button responsible for moving items from right to left box.
 	 */
-	disableRTL: boolean;
+	disableRTL?: boolean;
 
 	/**
 	 * Disables the button responsible for moving items from left to right box.
 	 */
-	disableLTR: boolean;
+	disableLTR?: boolean;
 
 	/**
 	 * Items spread across two arrays that will be displayed in the two Select Boxes.

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -78,8 +78,21 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 	const [leftSelected, setLeftSelected] = React.useState<Array<string>>([]);
 	const [rightSelected, setRightSelected] = React.useState<Array<string>>([]);
 
+	const [firstSelectBoxItems, secondSelectBoxItems] = items;
+
+	const leftMaxItems = number('leftMaxItems', 3);
+	const rightMaxItems = number('rightMaxItems', 5);
+
 	return (
 		<ClayDualListBox
+			disableLTR={
+				boolean('disableLTR', false) ||
+				secondSelectBoxItems.length >= rightMaxItems
+			}
+			disableRTL={
+				boolean('disableRTL', false) ||
+				firstSelectBoxItems.length >= leftMaxItems
+			}
 			items={items}
 			left={{
 				id: 'leftSelectBox',
@@ -87,7 +100,6 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 				onSelectChange: setLeftSelected,
 				selected: leftSelected,
 			}}
-			leftMaxItems={number('leftMaxItems', 3)}
 			onItemsChange={setItems}
 			right={{
 				id: 'rightSelectBox',
@@ -95,7 +107,6 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 				onSelectChange: setRightSelected,
 				selected: rightSelected,
 			}}
-			rightMaxItems={number('rightMaxItems', 5)}
 			size={8}
 			spritemap={spritemap}
 		/>

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -21,7 +21,7 @@ import ClayForm from '../src/Form';
 
 import '@clayui/css/lib/css/atlas.css';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
-import {boolean, select, text} from '@storybook/addon-knobs';
+import {boolean, number, select, text} from '@storybook/addon-knobs';
 
 const ClayCheckboxWithState = () => {
 	const [value, setValue] = React.useState<boolean>(false);
@@ -87,7 +87,7 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 				onSelectChange: setLeftSelected,
 				selected: leftSelected,
 			}}
-			leftMaxItems={3}
+			leftMaxItems={number('leftMaxItems', 3)}
 			onItemsChange={setItems}
 			right={{
 				id: 'rightSelectBox',
@@ -95,7 +95,7 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 				onSelectChange: setRightSelected,
 				selected: rightSelected,
 			}}
-			rightMaxItems={5}
+			rightMaxItems={number('rightMaxItems', 5)}
 			size={8}
 			spritemap={spritemap}
 		/>

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -87,6 +87,7 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 				onSelectChange: setLeftSelected,
 				selected: leftSelected,
 			}}
+			leftMaxItems={3}
 			onItemsChange={setItems}
 			right={{
 				id: 'rightSelectBox',
@@ -94,6 +95,7 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 				onSelectChange: setRightSelected,
 				selected: rightSelected,
 			}}
+			rightMaxItems={5}
 			size={8}
 			spritemap={spritemap}
 		/>


### PR DESCRIPTION
…s for providing the user to limit the number of items that each select box can store

### Test Case:

1. Open ClayDualListbox component on the deploy Preview of our storybook of this PR
2. On story, the limit for left list is 3 and for the right is 5
3. Use the knob for modifying the values and test


This PR is a part of https://issues.liferay.com/browse/LPS-116801 just for studying if We can have maxItems here :)