### PR TITLE
fix(@clayui/css): Reboot removes focus outline on negative `tabindex` elements. Chrome adds outline on focus to any element with a `tabindex` attribute.

### DIFF
--- a/clayui.com/content/docs/components/css-links.md
+++ b/clayui.com/content/docs/components/css-links.md
@@ -90,7 +90,7 @@ Use these patterns for actions in components.
 			<use href="/images/icons/icons.svg#times" />
 		</svg>
 	</a>
-	<a class="component-action disabled" href="#disabled" role="button" tabindex="-1">
+	<a class="component-action disabled" href="#1" role="button" tabindex="-1">
 		<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 			<use href="/images/icons/icons.svg#times" />
 		</svg>
@@ -107,12 +107,7 @@ Use these patterns for actions in components.
 		<use href="/images/icons/icons.svg#times" />
 	</svg>
 </a>
-<a
-	class="component-action disabled"
-	href="#disabled"
-	role="button"
-	tabindex="-1"
->
+<a class="component-action disabled" href="#1" role="button" tabindex="-1">
 	<svg
 		class="lexicon-icon lexicon-icon-times"
 		focusable="false"

--- a/clayui.com/content/docs/components/css-sidebar.md
+++ b/clayui.com/content/docs/components/css-sidebar.md
@@ -50,7 +50,7 @@ Just add `sidebar-light` class on the same element that you are using `sidebar`.
             <div class="container-fluid">
                 <ul class="tbar-nav">
                     <li class="tbar-item">
-                        <a class="component-action disabled" href="#disabled" role="button" tabindex="-1">
+                        <a class="component-action disabled" href="#1" role="button" tabindex="-1">
                             <svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
                                 <use href="/images/icons/icons.svg#angle-left"></use>
                             </svg>
@@ -264,7 +264,7 @@ Just add `sidebar-light` class on the same element that you are using `sidebar`.
 				<li class="tbar-item">
 					<a
 						class="component-action disabled"
-						href="#disabled"
+						href="#1"
 						role="button"
 						tabindex="-1"
 					>

--- a/clayui.com/src/html.js
+++ b/clayui.com/src/html.js
@@ -38,6 +38,7 @@ export default (props) => {
 					id="___gatsby"
 				/>
 				{props.postBodyComponents}
+				<script src="/js/docs-site.js" />
 				<script src="/js/code-collapse.js" />
 				<script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" />
 			</body>

--- a/clayui.com/static/js/docs-site.js
+++ b/clayui.com/static/js/docs-site.js
@@ -1,0 +1,29 @@
+if (!Element.prototype.closest) {
+	Element.prototype.closest = function(selector) {
+		var node = this;
+
+		while (node.nodeType === 1) {
+			if (node.matches(selector)) {
+				return node;
+			}
+
+			node = node.parentNode;
+		}
+
+		return null;
+	}
+}
+
+(function() {
+	document.addEventListener('click', function(event) {
+		var t = event.target;
+
+		var a = t.tagName === 'a' ? t : t.closest('a');
+
+		if (a) {
+			if (a.getAttribute('href') === '#1') {
+				event.preventDefault();
+			}
+		}
+	});
+})();

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -159,6 +159,10 @@ sup {
 	}
 }
 
+[tabindex^='-'] {
+	outline: 0;
+}
+
 // Code
 
 pre,


### PR DESCRIPTION
fixes #3436