### PR TITLE
fix(@clayui/css): Reboot makes `use[href]` inherit parent styles

### DIFF
--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -159,6 +159,17 @@ sup {
 	}
 }
 
+use[href] {
+	color: inherit;
+	cursor: inherit;
+	text-decoration: none;
+
+	&:hover {
+		color: inherit;
+		text-decoration: none;
+	}
+}
+
 // Code
 
 pre,


### PR DESCRIPTION
fixes #3495