### PR TITLE
fix(@clayui/modal): simplifies subportal grouping implementation and removes the extra container

### DIFF
--- a/packages/clay-modal/src/Hook.ts
+++ b/packages/clay-modal/src/Hook.ts
@@ -27,12 +27,13 @@ const FOCUSABLE_ELEMENTS = [
  * modal by pressing the ESC key and control the focus within the Modal.
  */
 const useUserInteractions = (
-	elementRef: React.MutableRefObject<any>,
+	modalElementRef: React.MutableRefObject<any>,
+	modalBodyElementRef: React.MutableRefObject<any>,
 	onClick: () => void
 ) => {
 	const getFocusableNodes = () => {
-		if (elementRef.current) {
-			const nodes = elementRef.current.querySelectorAll(
+		if (modalBodyElementRef.current) {
+			const nodes = modalBodyElementRef.current.querySelectorAll(
 				FOCUSABLE_ELEMENTS
 			);
 
@@ -45,11 +46,11 @@ const useUserInteractions = (
 	const handleKeydown = (event: KeyboardEvent) => {
 		if (event.keyCode === KEY_CODE_TAB) {
 			if (
-				elementRef.current &&
+				modalElementRef.current &&
 				event.target !== null &&
-				!elementRef.current.contains(event.target)
+				!modalElementRef.current.contains(event.target)
 			) {
-				elementRef.current.focus();
+				modalBodyElementRef.current.focus();
 			} else {
 				const focusableNodes = getFocusableNodes();
 				const focusedItemIndex = focusableNodes.indexOf(
@@ -83,12 +84,7 @@ const useUserInteractions = (
 			return;
 		}
 
-		if (
-			elementRef.current &&
-			event.target !== null &&
-			!elementRef.current.contains(event.target as HTMLDivElement) &&
-			document.contains(event.target as HTMLElement)
-		) {
+		if (event.target === modalElementRef.current) {
 			onClick();
 		}
 	};

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -5,7 +5,7 @@
 
 import {ClayPortal} from '@clayui/shared';
 import classNames from 'classnames';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef} from 'react';
 import warning from 'warning';
 
 import Body from './Body';

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -5,7 +5,7 @@
 
 import {ClayPortal} from '@clayui/shared';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import warning from 'warning';
 
 import Body from './Body';
@@ -64,24 +64,22 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 	status,
 	...otherProps
 }: IProps) => {
-	const modalBodyElementRef = React.useRef<HTMLDivElement | null>(null);
+	const modalElementRef = useRef<HTMLDivElement | null>(null);
+	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
 
 	warning(observer !== undefined, warningMessage);
 
-	useUserInteractions(modalBodyElementRef, () =>
+	useUserInteractions(modalElementRef, modalBodyElementRef, () =>
 		observer.dispatch(ObserverType.Close)
 	);
 
-	React.useEffect(() => observer.dispatch(ObserverType.Open), []);
-
-	// Defines a default Modal size when size is not set.
-	const maxWidth = size ? {} : {maxWidth: '600px'};
+	useEffect(() => observer.dispatch(ObserverType.Open), []);
 
 	const [show, content] =
 		observer && observer.mutation ? observer.mutation : [false, false];
 
 	return (
-		<ClayPortal subPortalRef={modalBodyElementRef}>
+		<ClayPortal subPortalRef={modalElementRef}>
 			<div
 				className={classNames('modal-backdrop fade', {
 					show,
@@ -92,34 +90,28 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 				className={classNames('fade modal d-block', className, {
 					show,
 				})}
+				ref={modalElementRef}
 			>
 				<div
-					className={classNames({
+					className={classNames('modal-dialog', {
 						[`modal-${size}`]: size,
+						[`modal-${status}`]: status,
+						'modal-dialog-centered': center,
 					})}
 					ref={modalBodyElementRef}
-					style={{margin: 'auto', ...maxWidth}}
+					tabIndex={-1}
 				>
-					<div
-						className={classNames('modal-dialog', {
-							[`modal-${size}`]: size,
-							[`modal-${status}`]: status,
-							'modal-dialog-centered': center,
-						})}
-						tabIndex={-1}
-					>
-						<div className="modal-content">
-							<Context.Provider
-								value={{
-									onClose: () =>
-										observer.dispatch(ObserverType.Close),
-									spritemap,
-									status,
-								}}
-							>
-								{content && children}
-							</Context.Provider>
-						</div>
+					<div className="modal-content">
+						<Context.Provider
+							value={{
+								onClose: () =>
+									observer.dispatch(ObserverType.Close),
+								spritemap,
+								status,
+							}}
+						>
+							{content && children}
+						</Context.Provider>
 					</div>
 				</div>
 			</div>

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -92,7 +92,7 @@ describe('Modal -> IncrementalInteractions', () => {
 		expect(backdropEl).toBeDefined();
 		expect(modalEl).toBeDefined();
 
-		fireEvent.click(backdropEl!, {});
+		fireEvent.click(modalEl!);
 
 		expect(document.body.classList).not.toContain('modal-open');
 		expect(document.querySelector(backdropElSelector)).toBeNull();
@@ -127,9 +127,9 @@ describe('Modal -> IncrementalInteractions', () => {
 		const backdropElSelector = '.modal-backdrop.fade.show';
 		const modalElSelector = '.fade.modal.d-block.show';
 
-		const backdropEl = document.querySelector(backdropElSelector);
+		const modalEl = document.querySelector(modalElSelector);
 
-		fireEvent.click(backdropEl!, {});
+		fireEvent.click(modalEl!, {});
 
 		expect(document.body.classList).toContain('modal-open');
 		expect(document.querySelector(backdropElSelector)).toBeDefined();

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ModalProvider -> IncrementalInteractions renders a modal closed when dispatching Close by provider 1`] = `
 <body
-  class=""
+  class="modal-open"
 >
   <div>
     <button
@@ -28,65 +28,60 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
       class="fade modal d-block show"
     >
       <div
-        class="modal-lg"
-        style="margin: auto;"
+        class="modal-dialog modal-lg"
+        tabindex="-1"
       >
         <div
-          class="modal-dialog modal-lg"
-          tabindex="-1"
+          class="modal-content"
         >
           <div
-            class="modal-content"
+            class="modal-header"
           >
             <div
-              class="modal-header"
+              class="modal-title"
             >
-              <div
-                class="modal-title"
+              Title
+            </div>
+            <button
+              aria-label="close"
+              class="close btn btn-unstyled"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times"
+                role="presentation"
               >
-                Title
-              </div>
+                <use
+                  xlink:href="icons.svg#times"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="modal-body"
+          >
+            <h1>
+              Hello world!
+            </h1>
+          </div>
+          <div
+            class="modal-footer"
+          >
+            <div
+              class="modal-item-first"
+            />
+            <div
+              class="modal-item"
+            />
+            <div
+              class="modal-item-last"
+            >
               <button
-                aria-label="close"
-                class="close btn btn-unstyled"
+                class="btn btn-primary"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-times"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#times"
-                  />
-                </svg>
+                Primary
               </button>
-            </div>
-            <div
-              class="modal-body"
-            >
-              <h1>
-                Hello world!
-              </h1>
-            </div>
-            <div
-              class="modal-footer"
-            >
-              <div
-                class="modal-item-first"
-              />
-              <div
-                class="modal-item"
-              />
-              <div
-                class="modal-item-last"
-              >
-                <button
-                  class="btn btn-primary"
-                  type="button"
-                >
-                  Primary
-                </button>
-              </div>
             </div>
           </div>
         </div>

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -12,65 +12,60 @@ exports[`ClayModal renders 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        class="modal-dialog"
+        tabindex="-1"
       >
         <div
-          class="modal-dialog"
-          tabindex="-1"
+          class="modal-content"
         >
           <div
-            class="modal-content"
+            class="modal-header"
           >
             <div
-              class="modal-header"
+              class="modal-title"
             >
-              <div
-                class="modal-title"
+              Foo
+            </div>
+            <button
+              aria-label="close"
+              class="close btn btn-unstyled"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times"
+                role="presentation"
               >
-                Foo
-              </div>
+                <use
+                  xlink:href="icons.svg#times"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="modal-body"
+          >
+            <h1>
+              Hello world!
+            </h1>
+          </div>
+          <div
+            class="modal-footer"
+          >
+            <div
+              class="modal-item-first"
+            />
+            <div
+              class="modal-item"
+            />
+            <div
+              class="modal-item-last"
+            >
               <button
-                aria-label="close"
-                class="close btn btn-unstyled"
+                class="btn btn-primary"
                 type="button"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-times"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#times"
-                  />
-                </svg>
+                Primary
               </button>
-            </div>
-            <div
-              class="modal-body"
-            >
-              <h1>
-                Hello world!
-              </h1>
-            </div>
-            <div
-              class="modal-footer"
-            >
-              <div
-                class="modal-item-first"
-              />
-              <div
-                class="modal-item"
-              />
-              <div
-                class="modal-item-last"
-              >
-                <button
-                  class="btn btn-primary"
-                  type="button"
-                >
-                  Primary
-                </button>
-              </div>
             </div>
           </div>
         </div>
@@ -93,46 +88,41 @@ exports[`ClayModal renders Header w/ low-level API 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        class="modal-dialog"
+        tabindex="-1"
       >
         <div
-          class="modal-dialog"
-          tabindex="-1"
+          class="modal-content"
         >
           <div
-            class="modal-content"
+            class="modal-header"
           >
             <div
-              class="modal-header"
+              class="modal-item-group"
             >
               <div
-                class="modal-item-group"
+                class="modal-item"
               >
                 <div
-                  class="modal-item"
+                  class="modal-title-section"
                 >
                   <div
-                    class="modal-title-section"
+                    class="modal-title"
                   >
-                    <div
-                      class="modal-title"
-                    >
-                      Modal Title
-                    </div>
+                    Modal Title
                   </div>
                 </div>
+              </div>
+              <div
+                class="modal-item modal-item-shrink"
+              >
                 <div
-                  class="modal-item modal-item-shrink"
+                  class="modal-subtitle-section"
                 >
                   <div
-                    class="modal-subtitle-section"
+                    class="modal-subtitle"
                   >
-                    <div
-                      class="modal-subtitle"
-                    >
-                      Modal Subtitle
-                    </div>
+                    Modal Subtitle
                   </div>
                 </div>
               </div>
@@ -158,24 +148,19 @@ exports[`ClayModal renders a body component with url 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        class="modal-dialog"
+        tabindex="-1"
       >
         <div
-          class="modal-dialog"
-          tabindex="-1"
+          class="modal-content"
         >
           <div
-            class="modal-content"
+            class="modal-body modal-body-iframe"
           >
-            <div
-              class="modal-body modal-body-iframe"
-            >
-              <iframe
-                src="http://localhost"
-                title="http://localhost"
-              />
-            </div>
+            <iframe
+              src="http://localhost"
+              title="http://localhost"
+            />
           </div>
         </div>
       </div>
@@ -197,49 +182,44 @@ exports[`ClayModal renders a footer component with buttons 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        class="modal-dialog"
+        tabindex="-1"
       >
         <div
-          class="modal-dialog"
-          tabindex="-1"
+          class="modal-content"
         >
           <div
-            class="modal-content"
+            class="modal-footer"
           >
             <div
-              class="modal-footer"
+              class="modal-item-first"
             >
-              <div
-                class="modal-item-first"
+              <button
+                class="btn btn-primary"
+                type="button"
               >
-                <button
-                  class="btn btn-primary"
-                  type="button"
-                >
-                  Bar
-                </button>
-              </div>
-              <div
-                class="modal-item"
+                Bar
+              </button>
+            </div>
+            <div
+              class="modal-item"
+            >
+              <button
+                class="btn btn-primary"
+                type="button"
               >
-                <button
-                  class="btn btn-primary"
-                  type="button"
-                >
-                  Baz
-                </button>
-              </div>
-              <div
-                class="modal-item-last"
+                Baz
+              </button>
+            </div>
+            <div
+              class="modal-item-last"
+            >
+              <button
+                class="btn btn-primary"
+                type="button"
               >
-                <button
-                  class="btn btn-primary"
-                  type="button"
-                >
-                  Foo
-                </button>
-              </div>
+                Foo
+              </button>
             </div>
           </div>
         </div>
@@ -262,39 +242,34 @@ exports[`ClayModal renders with Header 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        class="modal-dialog"
+        tabindex="-1"
       >
         <div
-          class="modal-dialog"
-          tabindex="-1"
+          class="modal-content"
         >
           <div
-            class="modal-content"
+            class="modal-header"
           >
             <div
-              class="modal-header"
+              class="modal-title"
             >
-              <div
-                class="modal-title"
-              >
-                Foo
-              </div>
-              <button
-                aria-label="close"
-                class="close btn btn-unstyled"
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-times"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="icons.svg#times"
-                  />
-                </svg>
-              </button>
+              Foo
             </div>
+            <button
+              aria-label="close"
+              class="close btn btn-unstyled"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times"
+                role="presentation"
+              >
+                <use
+                  xlink:href="icons.svg#times"
+                />
+              </svg>
+            </button>
           </div>
         </div>
       </div>
@@ -316,17 +291,12 @@ exports[`ClayModal renders with center 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        class="modal-dialog modal-dialog-centered"
+        tabindex="-1"
       >
         <div
-          class="modal-dialog modal-dialog-centered"
-          tabindex="-1"
-        >
-          <div
-            class="modal-content"
-          />
-        </div>
+          class="modal-content"
+        />
       </div>
     </div>
   </div>
@@ -346,17 +316,12 @@ exports[`ClayModal renders with size 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class="modal-lg"
-        style="margin: auto;"
+        class="modal-dialog modal-lg"
+        tabindex="-1"
       >
         <div
-          class="modal-dialog modal-lg"
-          tabindex="-1"
-        >
-          <div
-            class="modal-content"
-          />
-        </div>
+          class="modal-content"
+        />
       </div>
     </div>
   </div>
@@ -376,17 +341,12 @@ exports[`ClayModal renders with status 1`] = `
       class="fade modal d-block show"
     >
       <div
-        class=""
-        style="margin: auto; max-width: 600px;"
+        class="modal-dialog modal-success"
+        tabindex="-1"
       >
         <div
-          class="modal-dialog modal-success"
-          tabindex="-1"
-        >
-          <div
-            class="modal-content"
-          />
-        </div>
+          class="modal-content"
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #3107

This removes the extra container that we were adding before. I did some tests with a DropDown being rendered and other bugs that we got related to that and it works well. The strange thing is that I have the feeling that I’ve done this before and I don't remember the reason why I didn't do it 🤷‍♂️.

Thanks @pat270 for helping me with this!