### PR TITLE
docs(clayui.com): Sliders removes whitespace from `tooltip-inner` so …

### DIFF
--- a/clayui.com/content/docs/components/css-slider.md
+++ b/clayui.com/content/docs/components/css-slider.md
@@ -177,9 +177,7 @@ To create a custom slider is necessary to use JavaScript to manipulate the thumb
 					<div class="clay-range-thumb">
 						<div class="tooltip clay-tooltip-top" role="tooltip">
 							<div class="tooltip-arrow"></div>
-							<div class="tooltip-inner">
-								<div class="clay-range-value">34</div>
-							</div>
+							<div class="tooltip-inner"><div class="clay-range-value">34</div></div>
 						</div>
 					</div>
 				</div>
@@ -196,9 +194,7 @@ To create a custom slider is necessary to use JavaScript to manipulate the thumb
 					<div class="clay-range-thumb">
 						<div class="tooltip clay-tooltip-bottom" role="tooltip">
 							<div class="tooltip-arrow"></div>
-							<div class="tooltip-inner">
-								<div class="clay-range-value">55</div>
-							</div>
+							<div class="tooltip-inner"><div class="clay-range-value">55</div></div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
…they display properly

issue #3503