### PR TITLE
fix(@clayui/css): Reboot makes `use[href]` inherit parent styles

### DIFF
--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -163,6 +163,17 @@ sup {
 	outline: 0;
 }
 
+use[href] {
+	color: inherit;
+	cursor: inherit;
+	text-decoration: none;
+
+	&:hover {
+		color: inherit;
+		text-decoration: none;
+	}
+}
+
 // Code
 
 pre,


### PR DESCRIPTION
Rebase