### PR TITLE
chore: Replace `keyCode` usages with `key` for KeyboardEvents

### DIFF
--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -32,7 +32,7 @@
 		"@clayui/label": "^3.3.1",
 		"@clayui/layout": "^3.1.1",
 		"@clayui/link": "^3.2.0",
-		"@clayui/shared": "^3.1.2",
+		"@clayui/shared": "^3.1.3",
 		"@clayui/sticker": "^3.1.1",
 		"classnames": "^2.2.6"
 	},

--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -32,6 +32,7 @@
 		"@clayui/label": "^3.3.1",
 		"@clayui/layout": "^3.1.1",
 		"@clayui/link": "^3.2.0",
+		"@clayui/shared": "^3.1.2",
 		"@clayui/sticker": "^3.1.1",
 		"classnames": "^2.2.6"
 	},

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -54,11 +54,6 @@ interface IProps {
 	title?: React.ReactText;
 }
 
-const KEYCODES = {
-	ENTER: 13,
-	SPACE: 32,
-};
-
 const noop = () => {};
 
 export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
@@ -80,8 +75,8 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 			onClick={onClick}
 			onKeyDown={(event: React.KeyboardEvent) => {
 				if (
-					(event && event.keyCode === KEYCODES.ENTER) ||
-					(event && event.keyCode === KEYCODES.SPACE)
+					(event && event.key === 'Enter') ||
+					(event && event.key === ' ')
 				) {
 					event.preventDefault();
 

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -5,6 +5,7 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
+import {Keys} from '@clayui/shared';
 import ClaySticker from '@clayui/sticker';
 import React from 'react';
 
@@ -75,8 +76,8 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 			onClick={onClick}
 			onKeyDown={(event: React.KeyboardEvent) => {
 				if (
-					(event && event.key === 'Enter') ||
-					(event && event.key === ' ')
+					(event && event.key === Keys.Enter) ||
+					(event && event.key === Keys.Spacebar)
 				) {
 					event.preventDefault();
 

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {Keys} from '@clayui/shared';
 import classnames from 'classnames';
 import React from 'react';
 
@@ -49,12 +50,12 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 				// When tabbing and selecting a DayNumber using
 				// SPACE key the active state it's not being removed.
 				// See https://github.com/liferay/clay/issues/3374 for more details.
-				if (event.key === ' ') {
+				if (event.key === Keys.Spacebar) {
 					event.preventDefault();
 				}
 			}}
 			onKeyUp={(event) => {
-				if (event.key === ' ') {
+				if (event.key === Keys.Spacebar) {
 					onClick(date);
 				}
 			}}

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -49,12 +49,12 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 				// When tabbing and selecting a DayNumber using
 				// SPACE key the active state it's not being removed.
 				// See https://github.com/liferay/clay/issues/3374 for more details.
-				if (event.key === 'Spacebar' || event.key === ' ') {
+				if (event.key === ' ') {
 					event.preventDefault();
 				}
 			}}
 			onKeyUp={(event) => {
-				if (event.key === 'Spacebar' || event.key === ' ') {
+				if (event.key === ' ') {
 					onClick(date);
 				}
 			}}

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {FocusScope} from '@clayui/shared';
+import {FocusScope, Keys} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -96,7 +96,7 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 	const menuElementRef = React.useRef<HTMLDivElement>(null);
 
 	const handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {
-		if (event.key === 'Escape') {
+		if (event.key === Keys.Esc) {
 			onActiveChange(!active);
 		}
 	};

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -67,8 +67,6 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement | HTMLLIElement> {
 	};
 }
 
-const KEY_CODE_ESC = 27;
-
 const ClayDropDown: React.FunctionComponent<IProps> & {
 	Action: typeof Action;
 	Caption: typeof Caption;
@@ -98,7 +96,7 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 	const menuElementRef = React.useRef<HTMLDivElement>(null);
 
 	const handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {
-		if (event.keyCode === KEY_CODE_ESC) {
+		if (event.key === 'Escape') {
 			onActiveChange(!active);
 		}
 	};

--- a/packages/clay-drop-down/src/hooks.ts
+++ b/packages/clay-drop-down/src/hooks.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {Keys} from '@clayui/shared';
 import React from 'react';
 
 /**
@@ -32,7 +33,7 @@ export function useDropdownCloseInteractions(
 		};
 
 		const handleEsc = (event: KeyboardEvent) =>
-			event.key === 'Escape' && setActive(false);
+			event.key === Keys.Esc && setActive(false);
 
 		window.addEventListener('mousedown', handleClick);
 		window.addEventListener('keydown', handleEsc);

--- a/packages/clay-drop-down/src/hooks.ts
+++ b/packages/clay-drop-down/src/hooks.ts
@@ -5,8 +5,6 @@
 
 import React from 'react';
 
-const ESC_KEY_CODE = 27;
-
 /**
  * Hook for closing dropdown when user hits ESC key or clicks outside the menu.
  */
@@ -34,7 +32,7 @@ export function useDropdownCloseInteractions(
 		};
 
 		const handleEsc = (event: KeyboardEvent) =>
-			event.keyCode === ESC_KEY_CODE && setActive(false);
+			event.key === 'Escape' && setActive(false);
 
 		window.addEventListener('mousedown', handleClick);
 		window.addEventListener('keydown', handleEsc);

--- a/packages/clay-form/package.json
+++ b/packages/clay-form/package.json
@@ -28,7 +28,7 @@
 	"dependencies": {
 		"@clayui/button": "^3.3.1",
 		"@clayui/icon": "^3.0.5",
-		"@clayui/shared": "^3.1.2",
+		"@clayui/shared": "^3.1.3",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-form/package.json
+++ b/packages/clay-form/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@clayui/button": "^3.3.1",
 		"@clayui/icon": "^3.0.5",
+		"@clayui/shared": "^3.1.2",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-form/src/SelectBox.tsx
+++ b/packages/clay-form/src/SelectBox.tsx
@@ -12,9 +12,6 @@ export type TItem = {
 	value: string;
 };
 
-const KEY_ARROWDOWN = 40;
-const KEY_ARROWUP = 38;
-
 function arrayMove(
 	arrayToMove: Array<TItem>,
 	oldIndex: number,
@@ -184,9 +181,9 @@ const ClaySelectBox: React.FunctionComponent<IProps> = ({
 					onKeyDown={(event) =>
 						selectedIndexes.forEach((index) => {
 							if (
-								(event.keyCode === KEY_ARROWDOWN &&
+								(event.key === 'ArrowDown' &&
 									index === items.length - 1) ||
-								(event.keyCode === KEY_ARROWUP && index === 0)
+								(event.key === 'ArrowUp' && index === 0)
 							) {
 								event.preventDefault();
 							}

--- a/packages/clay-form/src/SelectBox.tsx
+++ b/packages/clay-form/src/SelectBox.tsx
@@ -4,6 +4,7 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import {Keys} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -181,9 +182,9 @@ const ClaySelectBox: React.FunctionComponent<IProps> = ({
 					onKeyDown={(event) =>
 						selectedIndexes.forEach((index) => {
 							if (
-								(event.key === 'ArrowDown' &&
+								(event.key === Keys.Down &&
 									index === items.length - 1) ||
-								(event.key === 'ArrowUp' && index === 0)
+								(event.key === Keys.Up && index === 0)
 							) {
 								event.preventDefault();
 							}

--- a/packages/clay-modal/src/Hook.ts
+++ b/packages/clay-modal/src/Hook.ts
@@ -5,8 +5,6 @@
 
 import React from 'react';
 
-const KEY_CODE_ESC = 27;
-const KEY_CODE_TAB = 9;
 const FOCUSABLE_ELEMENTS = [
 	'a[href]',
 	'[contenteditable]',
@@ -44,7 +42,7 @@ const useUserInteractions = (
 	};
 
 	const handleKeydown = (event: KeyboardEvent) => {
-		if (event.keyCode === KEY_CODE_TAB) {
+		if (event.key === 'Tab') {
 			if (
 				modalElementRef.current &&
 				event.target !== null &&
@@ -74,7 +72,7 @@ const useUserInteractions = (
 	};
 
 	const handleKeyup = (event: KeyboardEvent) => {
-		if (event.keyCode === KEY_CODE_ESC) {
+		if (event.key === 'Escape') {
 			onClick();
 		}
 	};

--- a/packages/clay-modal/src/Hook.ts
+++ b/packages/clay-modal/src/Hook.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {Keys} from '@clayui/shared';
 import React from 'react';
 
 const FOCUSABLE_ELEMENTS = [
@@ -42,7 +43,7 @@ const useUserInteractions = (
 	};
 
 	const handleKeydown = (event: KeyboardEvent) => {
-		if (event.key === 'Tab') {
+		if (event.key === Keys.Tab) {
 			if (
 				modalElementRef.current &&
 				event.target !== null &&
@@ -72,7 +73,7 @@ const useUserInteractions = (
 	};
 
 	const handleKeyup = (event: KeyboardEvent) => {
-		if (event.key === 'Escape') {
+		if (event.key === Keys.Esc) {
 			onClick();
 		}
 	};

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -152,7 +152,7 @@ describe('Modal -> IncrementalInteractions', () => {
 		expect(backdropEl).toBeDefined();
 		expect(modalEl).toBeDefined();
 
-		fireEvent.keyUp(container, {keyCode: 27});
+		fireEvent.keyUp(container, {key: 'Escape'});
 
 		expect(document.body.classList).not.toContain('modal-open');
 		expect(document.querySelector(backdropElSelector)).toBeNull();

--- a/packages/clay-multi-select/src/__tests__/index.tsx
+++ b/packages/clay-multi-select/src/__tests__/index.tsx
@@ -142,7 +142,7 @@ describe('Interactions', () => {
 		});
 
 		fireEvent.keyDown(input as HTMLInputElement, {
-			keyCode: 188,
+			key: 'Comma',
 		});
 
 		expect(container.querySelectorAll('.label').length).toEqual(1);
@@ -151,7 +151,7 @@ describe('Interactions', () => {
 			target: {value: 'bar'},
 		});
 
-		fireEvent.keyDown(input as HTMLInputElement, {keyCode: 188});
+		fireEvent.keyDown(input as HTMLInputElement, {key: 'Comma'});
 
 		expect(container.querySelectorAll('.label').length).toEqual(2);
 	});
@@ -196,14 +196,14 @@ describe('Interactions', () => {
 
 		fireEvent.keyDown(
 			container.querySelector('input[type=text]') as HTMLInputElement,
-			{keyCode: 8}
+			{key: 'Backspace'}
 		);
 
 		expect(document.activeElement!.tagName).toEqual('BUTTON');
 		expect(document.activeElement!.classList).toContain('close');
 
 		fireEvent.keyDown(document.activeElement as HTMLSpanElement, {
-			keyCode: 8,
+			key: 'Backspace',
 		});
 
 		expect(onItemsChangeFn).toHaveBeenCalled();

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -12,11 +12,7 @@ import {FocusScope, noop, sub} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
-const BACKSPACE_KEY = 8;
-const COMMA_KEY = 188;
-const ENTER_KEY = 13;
-
-const DELIMITER_KEYS = [ENTER_KEY, COMMA_KEY];
+const DELIMITER_KEYS = ['Enter', 'Comma'];
 
 type Item = {
 	[propName: string]: any;
@@ -227,19 +223,19 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 		) => {
 			onKeyDown(event);
 
-			const {keyCode} = event;
+			const {key} = event;
 
-			if (keyCode === BACKSPACE_KEY && !inputValue) {
+			if (key === 'Backspace' && !inputValue) {
 				event.preventDefault();
 			}
 
-			if (inputValue && DELIMITER_KEYS.includes(keyCode)) {
+			if (inputValue && DELIMITER_KEYS.includes(key)) {
 				event.preventDefault();
 
 				setNewValue(getNewItem(inputValue));
 			} else if (
 				!inputValue &&
-				keyCode === BACKSPACE_KEY &&
+				key === 'Backspace' &&
 				inputRef.current &&
 				lastItemRef.current
 			) {
@@ -308,8 +304,8 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 												}
 											},
 										}}
-										onKeyDown={({keyCode}) => {
-											if (keyCode !== BACKSPACE_KEY) {
+										onKeyDown={({key}) => {
+											if (key !== 'Backspace') {
 												return;
 											}
 											if (inputRef.current) {

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -8,7 +8,7 @@ import ClayDropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
-import {FocusScope, noop, sub} from '@clayui/shared';
+import {FocusScope, Keys, noop, sub} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -225,7 +225,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 
 			const {key} = event;
 
-			if (key === 'Backspace' && !inputValue) {
+			if (key === Keys.Backspace && !inputValue) {
 				event.preventDefault();
 			}
 
@@ -235,7 +235,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 				setNewValue(getNewItem(inputValue));
 			} else if (
 				!inputValue &&
-				key === 'Backspace' &&
+				key === Keys.Backspace &&
 				inputRef.current &&
 				lastItemRef.current
 			) {
@@ -305,7 +305,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 											},
 										}}
 										onKeyDown={({key}) => {
-											if (key !== 'Backspace') {
+											if (key !== Keys.Backspace) {
 												return;
 											}
 											if (inputRef.current) {

--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -25,12 +25,6 @@ interface IProps {
 	};
 }
 
-const ARROW_DOWN_KEY_CODE = 40;
-const ARROW_UP_KEY_CODE = 38;
-const ARROW_RIGHT_KEY_CODE = 39;
-const ARROW_LEFT_KEY_CODE = 37;
-const TAB_KEY_CODE = 9;
-
 /**
  * FocusScope is a component only for controlling focus and listening
  * for children's key down events, since the component handles the `onKeyDown`
@@ -45,20 +39,20 @@ export const FocusScope: React.FunctionComponent<IProps> = ({
 	const focusManager = useFocusManagement(elRef);
 
 	const onKeyDown = (event: React.KeyboardEvent<any>) => {
-		const {keyCode, shiftKey} = event;
+		const {key, shiftKey} = event;
 
 		if (
-			(arrowKeysUpDown && keyCode === ARROW_DOWN_KEY_CODE) ||
-			(arrowKeysLeftRight && keyCode === ARROW_RIGHT_KEY_CODE) ||
-			(keyCode === TAB_KEY_CODE && !shiftKey)
+			(arrowKeysUpDown && key === 'ArrowDown') ||
+			(arrowKeysLeftRight && key === 'ArrowRight') ||
+			(key === 'Tab' && !shiftKey)
 		) {
 			if (focusManager.focusNext()) {
 				event.preventDefault();
 			}
 		} else if (
-			(arrowKeysUpDown && keyCode === ARROW_UP_KEY_CODE) ||
-			(arrowKeysLeftRight && keyCode === ARROW_LEFT_KEY_CODE) ||
-			(keyCode === TAB_KEY_CODE && shiftKey)
+			(arrowKeysUpDown && key === 'ArrowUp') ||
+			(arrowKeysLeftRight && key === 'ArrowLeft') ||
+			(key === 'Tab' && shiftKey)
 		) {
 			if (focusManager.focusPrevious()) {
 				event.preventDefault();

--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 
+import {Keys} from './Keys';
 import {useFocusManagement} from './useFocusManagement';
 
 interface IProps {
@@ -42,17 +43,17 @@ export const FocusScope: React.FunctionComponent<IProps> = ({
 		const {key, shiftKey} = event;
 
 		if (
-			(arrowKeysUpDown && key === 'ArrowDown') ||
-			(arrowKeysLeftRight && key === 'ArrowRight') ||
-			(key === 'Tab' && !shiftKey)
+			(arrowKeysUpDown && key === Keys.Down) ||
+			(arrowKeysLeftRight && key === Keys.Right) ||
+			(key === Keys.Tab && !shiftKey)
 		) {
 			if (focusManager.focusNext()) {
 				event.preventDefault();
 			}
 		} else if (
-			(arrowKeysUpDown && key === 'ArrowUp') ||
-			(arrowKeysLeftRight && key === 'ArrowLeft') ||
-			(key === 'Tab' && shiftKey)
+			(arrowKeysUpDown && key === Keys.Up) ||
+			(arrowKeysLeftRight && key === Keys.Left) ||
+			(key === Keys.Tab && shiftKey)
 		) {
 			if (focusManager.focusPrevious()) {
 				event.preventDefault();

--- a/packages/clay-shared/src/Keys.ts
+++ b/packages/clay-shared/src/Keys.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Key names for comparison with `Event.prototype.key`.
+ *
+ * Note that because React normalizes key names in its synthetic
+ * event system, we don't have to worry about browser-specific
+ * edge cases (such as "Spacebar" instead of " " in IE):
+ *
+ * See:
+ *
+ * - https://github.com/facebook/react/blob/b87aabdfe1/packages/react-dom/src/events/getEventKey.js#L12-L29
+ * - https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
+ */
+export const Keys = {
+	Backspace: 'Backspace',
+	Del: 'Delete',
+	Down: 'ArrowDown',
+	Enter: 'Enter',
+	Esc: 'Escape',
+	Left: 'ArrowLeft',
+	Right: 'ArrowRight',
+	Spacebar: ' ',
+	Tab: 'Tab',
+	Up: 'ArrowUp',
+};

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -7,6 +7,7 @@ export const noop = () => {};
 export {ClayPortal} from './Portal';
 export {FocusScope} from './FocusScope';
 export {getEllipsisItems} from './getEllipsisItems';
+export {Keys} from './Keys';
 export {LinkOrButton} from './LinkOrButton';
 export {sub} from './sub';
 export {useDebounce} from './useDebounce';

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -5,8 +5,6 @@
 
 import React from 'react';
 
-const TAB_KEY_CODE = 9;
-
 // https://github.com/facebook/react/blob/master/packages/shared/ReactWorkTags.js#L39
 const HostComponent = 5;
 
@@ -123,7 +121,7 @@ export function useFocusManagement(scope: React.RefObject<null | HTMLElement>) {
 			return;
 		}
 
-		if (event.keyCode === TAB_KEY_CODE && event.shiftKey) {
+		if (event.key === 'Tab' && event.shiftKey) {
 			const elements = getFocusableElementsInScope(getFiber(scope));
 
 			if (elements.length === 0) {

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -5,6 +5,8 @@
 
 import React from 'react';
 
+import {Keys} from './Keys';
+
 // https://github.com/facebook/react/blob/master/packages/shared/ReactWorkTags.js#L39
 const HostComponent = 5;
 
@@ -121,7 +123,7 @@ export function useFocusManagement(scope: React.RefObject<null | HTMLElement>) {
 			return;
 		}
 
-		if (event.key === 'Tab' && event.shiftKey) {
+		if (event.key === Keys.Tab && event.shiftKey) {
 			const elements = getFocusableElementsInScope(getFiber(scope));
 
 			if (elements.length === 0) {

--- a/packages/clay-time-picker/src/__tests__/index.tsx
+++ b/packages/clay-time-picker/src/__tests__/index.tsx
@@ -7,11 +7,6 @@ import ClayTimePicker from '..';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
-const KEY_BACKSPACE = 8;
-const KEY_ARROWRIGHT = 39;
-const KEY_ARROWLEFT = 37;
-const KEY_ARROWUP = 38;
-const KEY_ARROWDOWN = 40;
 const spritemap = 'icons.svg';
 
 const TimePickerWithState = (props: any) => {
@@ -83,7 +78,7 @@ describe('IncrementalInteractions', () => {
 		const minutesEl = getByTestId('minutes');
 
 		hoursEl.focus();
-		fireEvent.keyDown(hoursEl, {keyCode: KEY_ARROWRIGHT});
+		fireEvent.keyDown(hoursEl, {key: 'ArrowRight'});
 
 		expect(document.activeElement).toBe(minutesEl);
 	});
@@ -97,7 +92,7 @@ describe('IncrementalInteractions', () => {
 		const minutesEl = getByTestId('minutes');
 
 		minutesEl.focus();
-		fireEvent.keyDown(minutesEl, {keyCode: KEY_ARROWLEFT});
+		fireEvent.keyDown(minutesEl, {key: 'ArrowLeft'});
 
 		expect(document.activeElement).toBe(hoursEl);
 	});
@@ -229,7 +224,7 @@ describe('IncrementalInteractions', () => {
 			fireEvent.focus(hoursEl, {});
 			fireEvent.keyDown(hoursEl, {key: '1'});
 			fireEvent.keyDown(minutesEl, {key: '1'});
-			fireEvent.keyDown(ampmEl, {keyCode: KEY_ARROWUP});
+			fireEvent.keyDown(ampmEl, {key: 'ArrowUp'});
 
 			expect(hoursEl.value).toBe('1');
 			expect(minutesEl.value).toBe('1');
@@ -354,7 +349,7 @@ describe('IncrementalInteractions', () => {
 
 			expect(hoursEl.value).toBe('1');
 
-			fireEvent.keyDown(hoursEl, {keyCode: KEY_BACKSPACE});
+			fireEvent.keyDown(hoursEl, {key: 'Backspace'});
 
 			expect(hoursEl.value).toBe('--');
 		});
@@ -367,7 +362,7 @@ describe('IncrementalInteractions', () => {
 
 			expect(minutesEl.value).toBe('1');
 
-			fireEvent.keyDown(minutesEl, {keyCode: KEY_BACKSPACE});
+			fireEvent.keyDown(minutesEl, {key: 'Backspace'});
 
 			expect(minutesEl.value).toBe('--');
 		});
@@ -382,7 +377,7 @@ describe('IncrementalInteractions', () => {
 
 			expect(ampmEl.value).toBe('AM');
 
-			fireEvent.keyDown(ampmEl, {keyCode: KEY_BACKSPACE});
+			fireEvent.keyDown(ampmEl, {key: 'Backspace'});
 
 			expect(ampmEl.value).toBe('--');
 		});
@@ -391,7 +386,7 @@ describe('IncrementalInteractions', () => {
 			const {getByTestId} = render(<TimePickerWithState />);
 			const hoursEl = getByTestId('hours') as HTMLInputElement;
 
-			fireEvent.keyDown(hoursEl, {keyCode: KEY_ARROWUP});
+			fireEvent.keyDown(hoursEl, {key: 'ArrowUp'});
 
 			expect(hoursEl.value).toBe('0');
 		});
@@ -400,7 +395,7 @@ describe('IncrementalInteractions', () => {
 			const {getByTestId} = render(<TimePickerWithState />);
 			const minutesEl = getByTestId('minutes') as HTMLInputElement;
 
-			fireEvent.keyDown(minutesEl, {keyCode: KEY_ARROWUP});
+			fireEvent.keyDown(minutesEl, {key: 'ArrowUp'});
 
 			expect(minutesEl.value).toBe('0');
 		});
@@ -409,7 +404,7 @@ describe('IncrementalInteractions', () => {
 			const {getByTestId} = render(<TimePickerWithState />);
 			const hoursEl = getByTestId('hours') as HTMLInputElement;
 
-			fireEvent.keyDown(hoursEl, {keyCode: KEY_ARROWDOWN});
+			fireEvent.keyDown(hoursEl, {key: 'ArrowDown'});
 
 			expect(hoursEl.value).toBe('23');
 		});
@@ -418,7 +413,7 @@ describe('IncrementalInteractions', () => {
 			const {getByTestId} = render(<TimePickerWithState />);
 			const minutesEl = getByTestId('minutes') as HTMLInputElement;
 
-			fireEvent.keyDown(minutesEl, {keyCode: KEY_ARROWDOWN});
+			fireEvent.keyDown(minutesEl, {key: 'ArrowDown'});
 
 			expect(minutesEl.value).toBe('59');
 		});
@@ -427,7 +422,7 @@ describe('IncrementalInteractions', () => {
 			const {getByTestId} = render(<TimePickerWithState use12Hours />);
 			const ampmEl = getByTestId('ampm') as HTMLInputElement;
 
-			fireEvent.keyDown(ampmEl, {keyCode: KEY_ARROWUP});
+			fireEvent.keyDown(ampmEl, {key: 'ArrowUp'});
 
 			expect(ampmEl.value).toBe('PM');
 		});
@@ -438,7 +433,7 @@ describe('IncrementalInteractions', () => {
 			const ampmEl = getByTestId('ampm') as HTMLInputElement;
 
 			fireEvent.mouseEnter(formControlEl, {});
-			fireEvent.keyDown(ampmEl, {keyCode: KEY_ARROWDOWN});
+			fireEvent.keyDown(ampmEl, {key: 'ArrowDown'});
 
 			expect(ampmEl.value).toBe('AM');
 		});
@@ -476,8 +471,8 @@ describe('IncrementalInteractions', () => {
 			expect(hoursEl.value).toBe('0');
 			expect(minutesEl.value).toBe('0');
 
-			fireEvent.keyDown(hoursEl, {keyCode: KEY_ARROWDOWN});
-			fireEvent.keyDown(minutesEl, {keyCode: KEY_ARROWDOWN});
+			fireEvent.keyDown(hoursEl, {key: 'ArrowDown'});
+			fireEvent.keyDown(minutesEl, {key: 'ArrowDown'});
 
 			expect(hoursEl.value).toBe('23');
 			expect(minutesEl.value).toBe('59');
@@ -494,8 +489,8 @@ describe('IncrementalInteractions', () => {
 			expect(hoursEl.value).toBe('23');
 			expect(minutesEl.value).toBe('59');
 
-			fireEvent.keyDown(hoursEl, {keyCode: KEY_ARROWUP});
-			fireEvent.keyDown(minutesEl, {keyCode: KEY_ARROWUP});
+			fireEvent.keyDown(hoursEl, {key: 'ArrowUp'});
+			fireEvent.keyDown(minutesEl, {key: 'ArrowUp'});
 
 			expect(hoursEl.value).toBe('0');
 			expect(minutesEl.value).toBe('0');

--- a/packages/clay-time-picker/src/index.tsx
+++ b/packages/clay-time-picker/src/index.tsx
@@ -104,9 +104,6 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	use12Hours?: boolean;
 }
 
-const KEY_BACKSPACE = 8;
-const KEY_ARROWUP = 38;
-const KEY_ARROWDOWN = 40;
 const DEFAULT_VALUE = '--';
 const DEFAULT_CONFIG = {
 	use12Hours: {
@@ -209,11 +206,11 @@ const ClayTimePicker: React.FunctionComponent<IProps> = ({
 						  ),
 			});
 
-		switch (event.keyCode) {
-			case KEY_BACKSPACE:
+		switch (event.key) {
+			case 'Backspace':
 				setValue(DEFAULT_VALUE);
 				break;
-			case KEY_ARROWUP:
+			case 'ArrowUp':
 				event.preventDefault();
 
 				if (configName === TimeType.ampm) {
@@ -226,7 +223,7 @@ const ClayTimePicker: React.FunctionComponent<IProps> = ({
 					);
 				}
 				break;
-			case KEY_ARROWDOWN:
+			case 'ArrowDown':
 				event.preventDefault();
 
 				if (configName === TimeType.ampm) {


### PR DESCRIPTION
Some keys can be different depending the browser which is being running the application but React normalize it when creating the synthetic event on: https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/getEventKey.js#L12-L29

### How I tested It:
Regarding
> but React normalize it when creating the synthetic event

From https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values: 
>[1] Older browsers may return "Spacebar" instead of " " for the Space Bar key. Firefox did so until version 37, as did Internet Explorer 9, 10, and 11.

Spacebar: 

https://github.com/liferay/clay/pull/3513/files#diff-18ecf9fd4dc1fbbb2a2bff5e734cc990L52

1. Open our Storybook on IE11
2. Open ClayCardWithNavigation story
3. Try navigating via tabs and select the first card with Spacebar key
4. You'll see an alert opening

Closes https://github.com/liferay/clay/issues/3430