### PR TITLE
feat(clayui.com): Make code collapsed by default and add localStorage to keep user's preference

### DIFF
--- a/clayui.com/src/components/Editor/index.js
+++ b/clayui.com/src/components/Editor/index.js
@@ -59,8 +59,22 @@ const Editor = ({
 	}
 
 	function useStickyState(defaultValue, key) {
+		const inBrowser = typeof window !== 'undefined';
+
+		const localStorage = {
+			getItem(key) {
+				return inBrowser ? window.localStorage.getItem(key) : null;
+			},
+
+			setItem(key, value) {
+				if (inBrowser) {
+					window.localStorage.setItem(key, value);
+				}
+			},
+		};
+
 		const [value, setValue] = React.useState(() => {
-			const stickyValue = window.localStorage.getItem(key);
+			const stickyValue = localStorage.getItem(key);
 
 			return stickyValue !== null
 				? JSON.parse(stickyValue)
@@ -68,7 +82,7 @@ const Editor = ({
 		});
 
 		React.useEffect(() => {
-			window.localStorage.setItem(key, JSON.stringify(value));
+			localStorage.setItem(key, JSON.stringify(value));
 		}, [key, value]);
 
 		return [value, setValue];

--- a/clayui.com/src/components/Editor/index.js
+++ b/clayui.com/src/components/Editor/index.js
@@ -59,24 +59,9 @@ const Editor = ({
 		];
 	}
 
-	const inBrowser = typeof window !== 'undefined';
-
-	const localStorage = {
-		getItem(key) {
-			return inBrowser ? window.localStorage.getItem(key) : null;
-		},
-
-		setItem(key, value) {
-			if (inBrowser) {
-				window.localStorage.setItem(key, value);
-			}
-		},
-	};
-
 	const [collapseCode, setCollapseCode] = useStickyState(
 		true,
-		'collapse-code',
-		localStorage
+		'collapse-code'
 	);
 	const [activeIndex, setActiveIndex] = React.useState(0);
 	const [snippets, setSnippets] = React.useState(code);

--- a/clayui.com/src/components/Editor/index.js
+++ b/clayui.com/src/components/Editor/index.js
@@ -58,7 +58,26 @@ const Editor = ({
 		];
 	}
 
-	const [collapseCode, setCollapseCode] = useState(false);
+	function useStickyState(defaultValue, key) {
+		const [value, setValue] = React.useState(() => {
+			const stickyValue = window.localStorage.getItem(key);
+
+			return stickyValue !== null
+				? JSON.parse(stickyValue)
+				: defaultValue;
+		});
+
+		React.useEffect(() => {
+			window.localStorage.setItem(key, JSON.stringify(value));
+		}, [key, value]);
+
+		return [value, setValue];
+	}
+
+	const [collapseCode, setCollapseCode] = useStickyState(
+		true,
+		'collapse-code'
+	);
 	const [activeIndex, setActiveIndex] = React.useState(0);
 	const [snippets, setSnippets] = React.useState(code);
 

--- a/clayui.com/src/components/Hooks/useStickyState.js
+++ b/clayui.com/src/components/Hooks/useStickyState.js
@@ -9,33 +9,41 @@ const inBrowser = typeof window !== 'undefined';
 
 const localStorage = {
 	getItem(key) {
-		return inBrowser ? window.localStorage.getItem(key) : null;
+		try {
+			return inBrowser ? window.localStorage.getItem(key) : null;
+		} catch {
+			return null;
+		}
 	},
 
 	setItem(key, value) {
 		if (inBrowser) {
-			window.localStorage.setItem(key, value);
+			try {
+				window.localStorage.setItem(key, value);
+			} catch {
+				return;
+			}
 		}
 	},
 };
 
 function useStickyState(defaultValue, key) {
 	const [value, setValue] = React.useState(() => {
-		let stickyValue;
-
 		try {
-			stickyValue = localStorage.getItem(key);
-		} catch (error) {
-			stickyValue = null;
-		}
+			const stickyValue = localStorage.getItem(key);
 
-		return stickyValue !== null ? JSON.parse(stickyValue) : defaultValue;
+			return stickyValue === null
+				? defaultValue
+				: JSON.parse(stickyValue);
+		} catch {
+			return defaultValue;
+		}
 	});
 
 	React.useEffect(() => {
 		try {
 			localStorage.setItem(key, JSON.stringify(value));
-		} catch (error) {
+		} catch {
 			return;
 		}
 	}, [key, value]);

--- a/clayui.com/src/components/Hooks/useStickyState.js
+++ b/clayui.com/src/components/Hooks/useStickyState.js
@@ -21,13 +21,23 @@ const localStorage = {
 
 function useStickyState(defaultValue, key) {
 	const [value, setValue] = React.useState(() => {
-		const stickyValue = localStorage.getItem(key);
+		let stickyValue;
+
+		try {
+			stickyValue = localStorage.getItem(key);
+		} catch (error) {
+			stickyValue = null;
+		}
 
 		return stickyValue !== null ? JSON.parse(stickyValue) : defaultValue;
 	});
 
 	React.useEffect(() => {
-		localStorage.setItem(key, JSON.stringify(value));
+		try {
+			localStorage.setItem(key, JSON.stringify(value));
+		} catch (error) {
+			return;
+		}
 	}, [key, value]);
 
 	return [value, setValue];

--- a/clayui.com/src/components/Hooks/useStickyState.js
+++ b/clayui.com/src/components/Hooks/useStickyState.js
@@ -5,7 +5,21 @@
 
 import React from 'react';
 
-function useStickyState(defaultValue, key, localStorage) {
+const inBrowser = typeof window !== 'undefined';
+
+const localStorage = {
+	getItem(key) {
+		return inBrowser ? window.localStorage.getItem(key) : null;
+	},
+
+	setItem(key, value) {
+		if (inBrowser) {
+			window.localStorage.setItem(key, value);
+		}
+	},
+};
+
+function useStickyState(defaultValue, key) {
 	const [value, setValue] = React.useState(() => {
 		const stickyValue = localStorage.getItem(key);
 

--- a/clayui.com/src/components/Hooks/useStickyState.js
+++ b/clayui.com/src/components/Hooks/useStickyState.js
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+function useStickyState(defaultValue, key, localStorage) {
+	const [value, setValue] = React.useState(() => {
+		const stickyValue = localStorage.getItem(key);
+
+		return stickyValue !== null ? JSON.parse(stickyValue) : defaultValue;
+	});
+
+	React.useEffect(() => {
+		localStorage.setItem(key, JSON.stringify(value));
+	}, [key, value]);
+
+	return [value, setValue];
+}
+
+export default useStickyState;


### PR DESCRIPTION
Fixes #3502 

It's been a while since I've worked with `localStorage` so I looked around the internet and I found [this neat article](https://joshwcomeau.com/react/persisting-react-state-in-localstorage/) that helped me understand exactly what's happening here.

I went pretty much line by line from the article's example seeing as I couldn't find a better way of approaching this implementation.

The idea being that when a user reveals at least one of the code examples and refreshes the page with at least one of the examples being revealed, it will be saved as a preference for the user until they collapse all examples on the page they're currently viewing.

I've tried simplifying this:
```
return stickyValue !== null
	? JSON.parse(stickyValue)
	: defaultValue;
```
but whenever I remove `JSON.parse` the text `true` or `false` gets passed instead of it's real value, even tried double bangs `!!stickyValue` but that had the same result, I think because even a string `false` is still truthy since it's not empty.

Also, removing the sanity check: `stickyValue !== null` provided to be bad, I assume because of rehydration, but not exactly sure, maybe someone can let me know why.

I kept the `useStickyState` as a function to provide better clarity in the future and for some future usage, I didn't export it into a separate file as I wasn't sure if that was our workflow when making custom hooks inside of the `clayui.com/components` workspace, I noticed we do have `Hooks/useResource.js` but I first wanted to get some feedback if this is the approach we want to use.