### PR TITLE
feat(@clayui/toolbar): Add Upper Toolbar high-level component

### DIFF
--- a/clayui.com/gatsby/onCreateNode.js
+++ b/clayui.com/gatsby/onCreateNode.js
@@ -60,7 +60,7 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 				pkgVersion.includes(subs)
 			);
 
-			pkgStatus = isBeta ? 'Beta' : 'Stable';
+			pkgStatus = pkgStatus ? pkgStatus : isBeta ? 'Beta' : 'Stable';
 		}
 
 		if (!slug) {

--- a/packages/clay-css/src/scss/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/variables/_tbar.scss
@@ -1,4 +1,4 @@
-$tbar-item-padding-x: 0.25rem !default;
+$tbar-item-padding-x: 0.5rem !default;
 $tbar-item-padding-y: null !default;
 
 // Tbar Stacked

--- a/packages/clay-toolbar/package.json
+++ b/packages/clay-toolbar/package.json
@@ -26,6 +26,7 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/form": "^3.10.0",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/label": "^3.3.1",
 		"@clayui/link": "^3.2.0",

--- a/packages/clay-toolbar/package.json
+++ b/packages/clay-toolbar/package.json
@@ -26,7 +26,7 @@
 		"react"
 	],
 	"dependencies": {
-		"@clayui/form": "^3.10.0",
+		"@clayui/form": "^3.10.1",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/label": "^3.3.1",
 		"@clayui/link": "^3.2.0",

--- a/packages/clay-toolbar/src/Input.tsx
+++ b/packages/clay-toolbar/src/Input.tsx
@@ -7,9 +7,7 @@ import {ClayInput} from '@clayui/form';
 import classNames from 'classnames';
 import React from 'react';
 
-export interface IProps
-	extends React.InputHTMLAttributes<HTMLInputElement>,
-		React.ComponentProps<typeof ClayInput> {}
+export interface IProps extends React.ComponentProps<typeof ClayInput> {}
 
 const Input: React.FunctionComponent<IProps> = ({className, ...otherProps}) => (
 	<ClayInput.Group>

--- a/packages/clay-toolbar/src/Input.tsx
+++ b/packages/clay-toolbar/src/Input.tsx
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ClayInput} from '@clayui/form';
+import classNames from 'classnames';
+import React from 'react';
+
+export interface IProps
+	extends React.InputHTMLAttributes<HTMLInputElement>,
+		React.ComponentProps<typeof ClayInput> {}
+
+const Input: React.FunctionComponent<IProps> = ({className, ...otherProps}) => (
+	<ClayInput.Group>
+		<ClayInput.GroupItem>
+			<ClayInput
+				className={classNames(className, 'form-control')}
+				type="text"
+				{...otherProps}
+			/>
+		</ClayInput.GroupItem>
+	</ClayInput.Group>
+);
+
+Input.displayName = 'ClayToolbarInput';
+
+export default Input;

--- a/packages/clay-toolbar/src/index.tsx
+++ b/packages/clay-toolbar/src/index.tsx
@@ -60,7 +60,7 @@ const ClayToolbar: React.FunctionComponent<IProps> & {
 		{
 			'component-tbar': !subnav,
 			'subnav-tbar': !!subnav,
-			'tbar-light': !!light,
+			'tbar-light': light,
 		},
 		subnav && {
 			'subnav-tbar-disabled': subnav.disabled,

--- a/packages/clay-toolbar/src/index.tsx
+++ b/packages/clay-toolbar/src/index.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 import Action from './Action';
+import Input from './Input';
 import Item from './Item';
 import Label from './Label';
 import Link from './Link';
@@ -18,6 +19,11 @@ interface IProps extends React.HTMLAttributes<HTMLElement> {
 	 * Adds a helper class that turns the Toolbar inline at a specified breakpoint.
 	 */
 	inlineBreakpoint?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+	/**
+	 * Determines if the tbar-light class should be added to the Toolbar, making it's background white.
+	 */
+	light?: boolean;
 
 	/**
 	 * Defines if the toolbar should have the `subnav-tbar` class.
@@ -33,6 +39,7 @@ interface IProps extends React.HTMLAttributes<HTMLElement> {
 const ClayToolbar: React.FunctionComponent<IProps> & {
 	Action: typeof Action;
 	Item: typeof Item;
+	Input: typeof Input;
 	Label: typeof Label;
 	Link: typeof Link;
 	Nav: typeof Nav;
@@ -41,6 +48,7 @@ const ClayToolbar: React.FunctionComponent<IProps> & {
 	children,
 	className,
 	inlineBreakpoint,
+	light,
 	subnav,
 	...otherProps
 }: IProps) => {
@@ -52,6 +60,7 @@ const ClayToolbar: React.FunctionComponent<IProps> & {
 		{
 			'component-tbar': !subnav,
 			'subnav-tbar': !!subnav,
+			'tbar-light': !!light,
 		},
 		subnav && {
 			'subnav-tbar-disabled': subnav.disabled,
@@ -69,6 +78,7 @@ const ClayToolbar: React.FunctionComponent<IProps> & {
 
 ClayToolbar.Action = Action;
 ClayToolbar.Item = Item;
+ClayToolbar.Input = Input;
 ClayToolbar.Label = Label;
 ClayToolbar.Link = Link;
 ClayToolbar.Nav = Nav;

--- a/packages/clay-toolbar/stories/index.tsx
+++ b/packages/clay-toolbar/stories/index.tsx
@@ -4,8 +4,9 @@
  */
 
 import '@clayui/css/lib/css/atlas.css';
-import ClayButton from '@clayui/button';
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
@@ -207,6 +208,71 @@ storiesOf('Components|ClayToolbar', module)
 								{'Clear All'}
 							</ClayButton>
 						</ClayToolbar.Section>
+					</ClayToolbar.Item>
+				</ClayToolbar.Nav>
+			</ClayLayout.ContainerFluid>
+		</ClayToolbar>
+	))
+	.add('Upper Toolbar', () => (
+		<ClayToolbar light>
+			<ClayLayout.ContainerFluid>
+				<ClayToolbar.Nav>
+					<ClayToolbar.Item expand>
+						<span className="text-left">
+							{'Workshop_idea_generation.pdf'}
+						</span>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayToolbar.Input
+							placeholder="Search..."
+							sizing="sm"
+						/>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayButton.Group>
+							<ClayButtonWithIcon
+								displayType="secondary"
+								small
+								spritemap={spritemap}
+								symbol="angle-left"
+							/>
+							<ClayButtonWithIcon
+								displayType="secondary"
+								small
+								spritemap={spritemap}
+								symbol="angle-right"
+							/>
+						</ClayButton.Group>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayButton displayType="secondary" small>
+							{'Share'}
+						</ClayButton>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayButton small>
+							<span className="inline-item inline-item-before">
+								<ClayIcon
+									spritemap={spritemap}
+									symbol="download"
+								/>
+							</span>
+
+							{'Download'}
+						</ClayButton>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayButtonWithIcon
+							displayType="unstyled"
+							small
+							spritemap={spritemap}
+							symbol="ellipsis-v"
+						/>
 					</ClayToolbar.Item>
 				</ClayToolbar.Nav>
 			</ClayLayout.ContainerFluid>

--- a/packages/clay-upper-toolbar/README.mdx
+++ b/packages/clay-upper-toolbar/README.mdx
@@ -3,6 +3,7 @@ title: 'Upper Toolbar'
 description: 'Upper toolbar is a guidance pattern to allow designers create their own toolbars for edition with preview pages.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/toolbar-upper/'
 packageNpm: '@clayui/upper-toolbar'
+packageStatus: 'Deprecated'
 ---
 
 import {UpperToolbarExample} from '$packages/clay-upper-toolbar/docs/index';

--- a/packages/clay-upper-toolbar/stories/index.tsx
+++ b/packages/clay-upper-toolbar/stories/index.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 
 import ClayUpperToolbar from '../src';
 
-storiesOf('Components|ClayUpperToolbar', module).add('default', () => (
+storiesOf('Deprecated|ClayUpperToolbar', module).add('default', () => (
 	<ClayUpperToolbar>
 		<ClayUpperToolbar.Item className="text-left" expand>
 			<label className="component-title">{'Foo Bar'}</label>


### PR DESCRIPTION
Hey @bryceosterhaus I started looking at #3336 and investigating, I'm looking for some inspiration as to how I should approach it. 

This PR has only one very simple commit right now, an example of how I imagined this should be done. Basically adding a UpperToolbar high-level component inside the Toolbar package.

Outside of that, I'm unsure how to deprecate the UpperToolbar on our side (Clay), is there some configuration that needs to be changed, or added to signal that it's deprecated? 

Here's what I assume needs to be done, before we replace usages in DXP:

- [ ] Mark `@clayui/upper-toolbar` as deprecated
- [ ] Add Upper Toolbar variant to `@clayui/toolbar`, including implementation, story, and documentation
- [ ] Remove Upper Toolbar page from clayui.com, and remove `draft` from Toolbar page

Let me know if I'm missing something and if you have some quick advice regarding some more obscure things that need to be done (like some special configuration that maybe needs to be added) 