### PR TITLE
fix(@clayui/list): When running on IE11, use `target.ownerDocument.activeElement` instead of `event.relatedTarget` on onBlur callbacks

### DIFF
--- a/packages/clay-list/src/Item.tsx
+++ b/packages/clay-list/src/Item.tsx
@@ -6,8 +6,6 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const isIE11 = typeof window !== 'undefined' && 'msCrypto' in window;
-
 interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Flag to indicate if the `list-group-item-action` class should be applied.
@@ -70,10 +68,9 @@ const ClayListItem = React.forwardRef<HTMLLIElement, IProps>(
 				}) => {
 					// IE11 doesn't support event.relatedTarget, but you can use
 					// document.activeElement.
-					const relatedTarget =
-						isIE11 && !relatedTargetElement
-							? target.ownerDocument.activeElement
-							: relatedTargetElement;
+					const relatedTarget = !relatedTargetElement
+						? target.ownerDocument.activeElement
+						: relatedTargetElement;
 
 					if (
 						relatedTarget &&

--- a/packages/clay-list/src/Item.tsx
+++ b/packages/clay-list/src/Item.tsx
@@ -6,6 +6,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+const isIE11 = typeof window !== 'undefined' && 'msCrypto' in window;
+
 interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Flag to indicate if the `list-group-item-action` class should be applied.
@@ -61,7 +63,18 @@ const ClayListItem = React.forwardRef<HTMLLIElement, IProps>(
 					'list-group-item-disabled': disabled,
 					'list-group-item-flex': flex,
 				})}
-				onBlur={({currentTarget, relatedTarget}) => {
+				onBlur={({
+					currentTarget,
+					relatedTarget: relatedTargetElement,
+					target,
+				}) => {
+					// IE11 doesn't support event.relatedTarget, but you can use
+					// document.activeElement.
+					const relatedTarget =
+						isIE11 && !relatedTargetElement
+							? target.ownerDocument.activeElement
+							: relatedTargetElement;
+
 					if (
 						relatedTarget &&
 						!currentTarget.contains(relatedTarget as Node)


### PR DESCRIPTION
See: https://github.com/facebook/react/issues/3751

Closes #3531