### PR TITLE
fix(@clayui/color-picker): Splotch should use classes provided by Clay CSS to style borders on light colors and active colors

### DIFF
--- a/clayui.com/content/docs/components/css-color-picker.md
+++ b/clayui.com/content/docs/components/css-color-picker.md
@@ -129,7 +129,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 					</div>
 					<div class="clay-color-swatch">
 						<div class="clay-color-swatch-item">
-							<button class="btn clay-color-btn focus" title="#B2EDFF" style="background-color:#B2EDFF;"></button>
+							<button class="active btn clay-color-btn" title="#B2EDFF" style="background-color:#B2EDFF;" tabindex="-1"></button>
 						</div>
 						<div class="clay-color-swatch-item">
 							<button class="btn clay-color-btn" title="#45EDC5" style="background-color:#45EDC5;"></button>
@@ -224,9 +224,10 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 				<div class="clay-color-swatch">
 					<div class="clay-color-swatch-item">
 						<button
-							class="btn clay-color-btn focus"
+							class="active btn clay-color-btn"
 							title="#B2EDFF"
 							style="background-color:#B2EDFF;"
+							tabindex="-1"
 						></button>
 					</div>
 					<div class="clay-color-swatch-item">
@@ -413,7 +414,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 			</div>
 			<div class="clay-color-swatch">
 				<div class="clay-color-swatch-item">
-					<button class="btn clay-color-btn focus" title="#B2EDFF" style="background-color:#B2EDFF;"></button>
+					<button class="active btn clay-color-btn" title="#B2EDFF" style="background-color:#B2EDFF;" tabindex="-1"></button>
 				</div>
 				<div class="clay-color-swatch-item">
 					<button class="btn clay-color-btn" title="#45EDC5" style="background-color:#45EDC5;"></button>
@@ -479,9 +480,10 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 	<div class="clay-color-swatch">
 		<div class="clay-color-swatch-item">
 			<button
-				class="btn clay-color-btn focus"
+				class="active btn clay-color-btn"
 				title="#B2EDFF"
 				style="background-color:#B2EDFF;"
+				tabindex="-1"
 			></button>
 		</div>
 		<div class="clay-color-swatch-item">
@@ -508,7 +510,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 			</div>
 			<div class="clay-color-swatch">
 				<div class="clay-color-swatch-item">
-					<button class="btn clay-color-btn focus" title="#B2EDFF" style="background-color:#B2EDFF;"></button>
+					<button class="active btn clay-color-btn" title="#B2EDFF" style="background-color:#B2EDFF;" tabindex="-1"></button>
 				</div>
 				<div class="clay-color-swatch-item">
 					<button class="btn clay-color-btn" title="#45EDC5" style="background-color:#45EDC5;"></button>
@@ -620,9 +622,10 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 	<div class="clay-color-swatch">
 		<div class="clay-color-swatch-item">
 			<button
-				class="btn clay-color-btn focus"
+				class="active btn clay-color-btn"
 				title="#B2EDFF"
 				style="background-color:#B2EDFF;"
+				tabindex="-1"
 			></button>
 		</div>
 		<div class="clay-color-swatch-item">

--- a/packages/clay-color-picker/package.json
+++ b/packages/clay-color-picker/package.json
@@ -30,6 +30,7 @@
 		"@clayui/form": "^3.9.0",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/shared": "^3.1.3",
+		"classnames": "^2.2.6",
 		"tinycolor2": "^1.4.1"
 	},
 	"peerDependencies": {

--- a/packages/clay-color-picker/src/Splotch.tsx
+++ b/packages/clay-color-picker/src/Splotch.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import classNames from 'classnames';
 import React from 'react';
 import tinycolor from 'tinycolor2';
 
@@ -33,13 +34,12 @@ const ClayColorPickerSplotch = React.forwardRef<HTMLButtonElement, IProps>(
 		return (
 			<button
 				{...otherProps}
-				className={`btn clay-color-btn ${className ? className : ''}`}
+				className={classNames('btn clay-color-btn', className, {
+					active,
+					'clay-color-btn-bordered': requireBorder,
+				})}
 				ref={ref}
 				style={{
-					...(active ? {outline: 'auto 3px #55ADFF'} : {}),
-					...(requireBorder
-						? {border: '1px solid #E7E7ED'}
-						: {borderWidth: 0}),
 					background: `#${value}`,
 					height: size,
 					width: size,

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -27,7 +27,7 @@ exports[`Interactions opens custom color picker drop down when clicked 1`] = `
           <button
             aria-label="Select a color"
             class="btn clay-color-btn dropdown-toggle"
-            style="border-width: 0px; background: rgb(0, 128, 0);"
+            style="background: rgb(0, 128, 0);"
             title="008000"
             type="button"
           />
@@ -81,8 +81,8 @@ exports[`Rendering default 1`] = `
           >
             <button
               aria-label="Select a color"
-              class="btn clay-color-btn dropdown-toggle"
-              style="border: 1px solid #e7e7ed; background: rgb(255, 255, 255);"
+              class="btn clay-color-btn dropdown-toggle clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
               title="FFF"
               type="button"
             />
@@ -127,8 +127,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(0, 0, 0);"
+              class="btn clay-color-btn"
+              style="background: rgb(0, 0, 0);"
               title="000000"
               type="button"
             />
@@ -137,8 +137,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(95, 95, 95);"
+              class="btn clay-color-btn"
+              style="background: rgb(95, 95, 95);"
               title="5F5F5F"
               type="button"
             />
@@ -147,8 +147,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(154, 154, 154);"
+              class="btn clay-color-btn"
+              style="background: rgb(154, 154, 154);"
               title="9A9A9A"
               type="button"
             />
@@ -157,8 +157,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(203, 203, 203);"
+              class="btn clay-color-btn"
+              style="background: rgb(203, 203, 203);"
               title="CBCBCB"
               type="button"
             />
@@ -167,8 +167,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(225, 225, 225);"
+              class="btn clay-color-btn"
+              style="background: rgb(225, 225, 225);"
               title="E1E1E1"
               type="button"
             />
@@ -177,8 +177,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border: 1px solid #e7e7ed; background: rgb(255, 255, 255);"
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
               title="FFFFFF"
               type="button"
             />
@@ -187,8 +187,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 13, 13);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 13, 13);"
               title="FF0D0D"
               type="button"
             />
@@ -197,8 +197,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 138, 28);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 138, 28);"
               title="FF8A1C"
               type="button"
             />
@@ -207,8 +207,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(43, 166, 118);"
+              class="btn clay-color-btn"
+              style="background: rgb(43, 166, 118);"
               title="2BA676"
               type="button"
             />
@@ -217,8 +217,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(0, 110, 248);"
+              class="btn clay-color-btn"
+              style="background: rgb(0, 110, 248);"
               title="006EF8"
               type="button"
             />
@@ -227,8 +227,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(127, 38, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(127, 38, 255);"
               title="7F26FF"
               type="button"
             />
@@ -237,8 +237,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 33, 160);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 33, 160);"
               title="FF21A0"
               type="button"
             />
@@ -247,8 +247,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 95, 95);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 95, 95);"
               title="FF5F5F"
               type="button"
             />
@@ -257,8 +257,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 180, 110);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 180, 110);"
               title="FFB46E"
               type="button"
             />
@@ -267,8 +267,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(80, 210, 160);"
+              class="btn clay-color-btn"
+              style="background: rgb(80, 210, 160);"
               title="50D2A0"
               type="button"
             />
@@ -277,8 +277,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(75, 155, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(75, 155, 255);"
               title="4B9BFF"
               type="button"
             />
@@ -287,8 +287,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(175, 120, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(175, 120, 255);"
               title="AF78FF"
               type="button"
             />
@@ -297,8 +297,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 115, 195);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 115, 195);"
               title="FF73C3"
               type="button"
             />
@@ -307,8 +307,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 177, 177);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 177, 177);"
               title="FFB1B1"
               type="button"
             />
@@ -317,8 +317,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 222, 192);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 222, 192);"
               title="FFDEC0"
               type="button"
             />
@@ -327,8 +327,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(145, 227, 195);"
+              class="btn clay-color-btn"
+              style="background: rgb(145, 227, 195);"
               title="91E3C3"
               type="button"
             />
@@ -337,8 +337,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(157, 200, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(157, 200, 255);"
               title="9DC8FF"
               type="button"
             />
@@ -347,8 +347,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(223, 202, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(223, 202, 255);"
               title="DFCAFF"
               type="button"
             />
@@ -357,8 +357,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 197, 230);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 197, 230);"
               title="FFC5E6"
               type="button"
             />
@@ -367,8 +367,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 217, 217);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 217, 217);"
               title="FFD9D9"
               type="button"
             />
@@ -377,8 +377,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border: 1px solid #e7e7ed; background: rgb(255, 243, 232);"
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 243, 232);"
               title="FFF3E8"
               type="button"
             />
@@ -387,8 +387,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(177, 235, 213);"
+              class="btn clay-color-btn"
+              style="background: rgb(177, 235, 213);"
               title="B1EBD5"
               type="button"
             />
@@ -397,8 +397,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(197, 223, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(197, 223, 255);"
               title="C5DFFF"
               type="button"
             />
@@ -407,8 +407,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border: 1px solid #e7e7ed; background: rgb(248, 242, 255);"
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(248, 242, 255);"
               title="F8F2FF"
               type="button"
             />
@@ -417,8 +417,8 @@ exports[`Rendering default 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 237, 247);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 237, 247);"
               title="FFEDF7"
               type="button"
             />
@@ -456,9 +456,9 @@ exports[`Rendering disabled state 1`] = `
           >
             <button
               aria-label="Select a color"
-              class="btn clay-color-btn dropdown-toggle"
+              class="btn clay-color-btn dropdown-toggle clay-color-btn-bordered"
               disabled=""
-              style="border: 1px solid #e7e7ed; background: rgb(255, 255, 255);"
+              style="background: rgb(255, 255, 255);"
               title="FFF"
               type="button"
             />
@@ -504,8 +504,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(0, 0, 0);"
+              class="btn clay-color-btn"
+              style="background: rgb(0, 0, 0);"
               title="000000"
               type="button"
             />
@@ -514,8 +514,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(95, 95, 95);"
+              class="btn clay-color-btn"
+              style="background: rgb(95, 95, 95);"
               title="5F5F5F"
               type="button"
             />
@@ -524,8 +524,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(154, 154, 154);"
+              class="btn clay-color-btn"
+              style="background: rgb(154, 154, 154);"
               title="9A9A9A"
               type="button"
             />
@@ -534,8 +534,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(203, 203, 203);"
+              class="btn clay-color-btn"
+              style="background: rgb(203, 203, 203);"
               title="CBCBCB"
               type="button"
             />
@@ -544,8 +544,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(225, 225, 225);"
+              class="btn clay-color-btn"
+              style="background: rgb(225, 225, 225);"
               title="E1E1E1"
               type="button"
             />
@@ -554,8 +554,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border: 1px solid #e7e7ed; background: rgb(255, 255, 255);"
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
               title="FFFFFF"
               type="button"
             />
@@ -564,8 +564,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 13, 13);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 13, 13);"
               title="FF0D0D"
               type="button"
             />
@@ -574,8 +574,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 138, 28);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 138, 28);"
               title="FF8A1C"
               type="button"
             />
@@ -584,8 +584,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(43, 166, 118);"
+              class="btn clay-color-btn"
+              style="background: rgb(43, 166, 118);"
               title="2BA676"
               type="button"
             />
@@ -594,8 +594,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(0, 110, 248);"
+              class="btn clay-color-btn"
+              style="background: rgb(0, 110, 248);"
               title="006EF8"
               type="button"
             />
@@ -604,8 +604,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(127, 38, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(127, 38, 255);"
               title="7F26FF"
               type="button"
             />
@@ -614,8 +614,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 33, 160);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 33, 160);"
               title="FF21A0"
               type="button"
             />
@@ -624,8 +624,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 95, 95);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 95, 95);"
               title="FF5F5F"
               type="button"
             />
@@ -634,8 +634,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 180, 110);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 180, 110);"
               title="FFB46E"
               type="button"
             />
@@ -644,8 +644,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(80, 210, 160);"
+              class="btn clay-color-btn"
+              style="background: rgb(80, 210, 160);"
               title="50D2A0"
               type="button"
             />
@@ -654,8 +654,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(75, 155, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(75, 155, 255);"
               title="4B9BFF"
               type="button"
             />
@@ -664,8 +664,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(175, 120, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(175, 120, 255);"
               title="AF78FF"
               type="button"
             />
@@ -674,8 +674,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 115, 195);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 115, 195);"
               title="FF73C3"
               type="button"
             />
@@ -684,8 +684,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 177, 177);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 177, 177);"
               title="FFB1B1"
               type="button"
             />
@@ -694,8 +694,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 222, 192);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 222, 192);"
               title="FFDEC0"
               type="button"
             />
@@ -704,8 +704,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(145, 227, 195);"
+              class="btn clay-color-btn"
+              style="background: rgb(145, 227, 195);"
               title="91E3C3"
               type="button"
             />
@@ -714,8 +714,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(157, 200, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(157, 200, 255);"
               title="9DC8FF"
               type="button"
             />
@@ -724,8 +724,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(223, 202, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(223, 202, 255);"
               title="DFCAFF"
               type="button"
             />
@@ -734,8 +734,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 197, 230);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 197, 230);"
               title="FFC5E6"
               type="button"
             />
@@ -744,8 +744,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 217, 217);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 217, 217);"
               title="FFD9D9"
               type="button"
             />
@@ -754,8 +754,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border: 1px solid #e7e7ed; background: rgb(255, 243, 232);"
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 243, 232);"
               title="FFF3E8"
               type="button"
             />
@@ -764,8 +764,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(177, 235, 213);"
+              class="btn clay-color-btn"
+              style="background: rgb(177, 235, 213);"
               title="B1EBD5"
               type="button"
             />
@@ -774,8 +774,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(197, 223, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(197, 223, 255);"
               title="C5DFFF"
               type="button"
             />
@@ -784,8 +784,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border: 1px solid #e7e7ed; background: rgb(248, 242, 255);"
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(248, 242, 255);"
               title="F8F2FF"
               type="button"
             />
@@ -794,8 +794,8 @@ exports[`Rendering disabled state 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 237, 247);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 237, 247);"
               title="FFEDF7"
               type="button"
             />
@@ -833,8 +833,8 @@ exports[`Rendering small color-picker 1`] = `
           >
             <button
               aria-label="Select a color"
-              class="btn clay-color-btn dropdown-toggle"
-              style="border: 1px solid #e7e7ed; background: rgb(255, 255, 255);"
+              class="btn clay-color-btn dropdown-toggle clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
               title="FFF"
               type="button"
             />
@@ -879,8 +879,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(0, 0, 0);"
+              class="btn clay-color-btn"
+              style="background: rgb(0, 0, 0);"
               title="000000"
               type="button"
             />
@@ -889,8 +889,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(95, 95, 95);"
+              class="btn clay-color-btn"
+              style="background: rgb(95, 95, 95);"
               title="5F5F5F"
               type="button"
             />
@@ -899,8 +899,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(154, 154, 154);"
+              class="btn clay-color-btn"
+              style="background: rgb(154, 154, 154);"
               title="9A9A9A"
               type="button"
             />
@@ -909,8 +909,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(203, 203, 203);"
+              class="btn clay-color-btn"
+              style="background: rgb(203, 203, 203);"
               title="CBCBCB"
               type="button"
             />
@@ -919,8 +919,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(225, 225, 225);"
+              class="btn clay-color-btn"
+              style="background: rgb(225, 225, 225);"
               title="E1E1E1"
               type="button"
             />
@@ -929,8 +929,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border: 1px solid #e7e7ed; background: rgb(255, 255, 255);"
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
               title="FFFFFF"
               type="button"
             />
@@ -939,8 +939,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 13, 13);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 13, 13);"
               title="FF0D0D"
               type="button"
             />
@@ -949,8 +949,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 138, 28);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 138, 28);"
               title="FF8A1C"
               type="button"
             />
@@ -959,8 +959,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(43, 166, 118);"
+              class="btn clay-color-btn"
+              style="background: rgb(43, 166, 118);"
               title="2BA676"
               type="button"
             />
@@ -969,8 +969,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(0, 110, 248);"
+              class="btn clay-color-btn"
+              style="background: rgb(0, 110, 248);"
               title="006EF8"
               type="button"
             />
@@ -979,8 +979,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(127, 38, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(127, 38, 255);"
               title="7F26FF"
               type="button"
             />
@@ -989,8 +989,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 33, 160);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 33, 160);"
               title="FF21A0"
               type="button"
             />
@@ -999,8 +999,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 95, 95);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 95, 95);"
               title="FF5F5F"
               type="button"
             />
@@ -1009,8 +1009,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 180, 110);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 180, 110);"
               title="FFB46E"
               type="button"
             />
@@ -1019,8 +1019,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(80, 210, 160);"
+              class="btn clay-color-btn"
+              style="background: rgb(80, 210, 160);"
               title="50D2A0"
               type="button"
             />
@@ -1029,8 +1029,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(75, 155, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(75, 155, 255);"
               title="4B9BFF"
               type="button"
             />
@@ -1039,8 +1039,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(175, 120, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(175, 120, 255);"
               title="AF78FF"
               type="button"
             />
@@ -1049,8 +1049,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 115, 195);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 115, 195);"
               title="FF73C3"
               type="button"
             />
@@ -1059,8 +1059,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 177, 177);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 177, 177);"
               title="FFB1B1"
               type="button"
             />
@@ -1069,8 +1069,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 222, 192);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 222, 192);"
               title="FFDEC0"
               type="button"
             />
@@ -1079,8 +1079,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(145, 227, 195);"
+              class="btn clay-color-btn"
+              style="background: rgb(145, 227, 195);"
               title="91E3C3"
               type="button"
             />
@@ -1089,8 +1089,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(157, 200, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(157, 200, 255);"
               title="9DC8FF"
               type="button"
             />
@@ -1099,8 +1099,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(223, 202, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(223, 202, 255);"
               title="DFCAFF"
               type="button"
             />
@@ -1109,8 +1109,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 197, 230);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 197, 230);"
               title="FFC5E6"
               type="button"
             />
@@ -1119,8 +1119,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 217, 217);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 217, 217);"
               title="FFD9D9"
               type="button"
             />
@@ -1129,8 +1129,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border: 1px solid #e7e7ed; background: rgb(255, 243, 232);"
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 243, 232);"
               title="FFF3E8"
               type="button"
             />
@@ -1139,8 +1139,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(177, 235, 213);"
+              class="btn clay-color-btn"
+              style="background: rgb(177, 235, 213);"
               title="B1EBD5"
               type="button"
             />
@@ -1149,8 +1149,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(197, 223, 255);"
+              class="btn clay-color-btn"
+              style="background: rgb(197, 223, 255);"
               title="C5DFFF"
               type="button"
             />
@@ -1159,8 +1159,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border: 1px solid #e7e7ed; background: rgb(248, 242, 255);"
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(248, 242, 255);"
               title="F8F2FF"
               type="button"
             />
@@ -1169,8 +1169,8 @@ exports[`Rendering small color-picker 1`] = `
             class="clay-color-swatch-item"
           >
             <button
-              class="btn clay-color-btn "
-              style="border-width: 0px; background: rgb(255, 237, 247);"
+              class="btn clay-color-btn"
+              style="background: rgb(255, 237, 247);"
               title="FFEDF7"
               type="button"
             />

--- a/packages/clay-css/src/scss/variables/_clay-color.scss
+++ b/packages/clay-css/src/scss/variables/_clay-color.scss
@@ -137,6 +137,9 @@ $clay-color-btn: map-deep-merge(
 		padding-right: 0,
 		padding-top: 0,
 		width: 1.5rem,
+		active: (
+			box-shadow: $component-focus-box-shadow,
+		),
 	),
 	$clay-color-btn
 );


### PR DESCRIPTION
~fix(@clayui/color-picker: Splotch adds `tabindex="-1"` when a splotch is active~

~One thing I noticed when tabbing through the dropdown menu is an element with `tabindex="-1"` doesn't take it out of the tab order. I was wondering if we had something that is managing the focus outside the browser.~

Edit: Not fixing these in this pr.

fixes #3525