### PR TITLE
docs(@clayui/sticker): fix bad example

### DIFF
--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -18,7 +18,7 @@ exports[`ClayCard renders a ClayCard as a directory 1`] = `
             class="flex-col"
           >
             <span
-              class="sticker sticker-rounded sticker-secondary"
+              class="sticker sticker-secondary"
             >
               <span
                 class="sticker-overlay inline-item"
@@ -84,7 +84,7 @@ exports[`ClayCard renders a ClayCard as a file card 1`] = `
         </svg>
       </div>
       <span
-        class="sticker sticker-rounded sticker-danger sticker-bottom-left"
+        class="sticker sticker-danger sticker-bottom-left"
       >
         <span
           class="sticker-overlay"
@@ -189,7 +189,7 @@ exports[`ClayCard renders a ClayCard as a selectable file card 1`] = `
               </svg>
             </div>
             <span
-              class="sticker sticker-rounded sticker-danger sticker-bottom-left"
+              class="sticker sticker-danger sticker-bottom-left"
             >
               <span
                 class="sticker-overlay"
@@ -291,7 +291,7 @@ exports[`ClayCard renders a ClayCard as a selectable folder 1`] = `
                 class="autofit-col"
               >
                 <span
-                  class="sticker sticker-rounded sticker-secondary"
+                  class="sticker sticker-secondary"
                 >
                   <span
                     class="sticker-overlay inline-item"
@@ -645,7 +645,7 @@ exports[`ClayCard renders a ClayCard as template navigation card as horizontal c
           class="autofit-col"
         >
           <span
-            class="sticker sticker-rounded sticker-light"
+            class="sticker sticker-light"
           >
             <span
               class="sticker-overlay inline-item"
@@ -966,7 +966,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
             </svg>
           </div>
           <span
-            class="sticker sticker-rounded sticker-danger sticker-bottom-left"
+            class="sticker sticker-danger sticker-bottom-left"
           >
             <span
               class="sticker-overlay"
@@ -1056,7 +1056,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
             </svg>
           </div>
           <span
-            class="sticker sticker-rounded sticker-danger sticker-bottom-left"
+            class="sticker sticker-danger sticker-bottom-left"
           >
             <span
               class="sticker-overlay"
@@ -1349,7 +1349,7 @@ exports[`ClayCardWithHorizontal renders as disabled 1`] = `
                 class="autofit-col"
               >
                 <span
-                  class="sticker sticker-rounded"
+                  class="sticker"
                 >
                   <span
                     class="sticker-overlay inline-item"
@@ -1411,7 +1411,7 @@ exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
             class="autofit-col"
           >
             <span
-              class="sticker sticker-rounded"
+              class="sticker"
             >
               <span
                 class="sticker-overlay inline-item"
@@ -1482,7 +1482,7 @@ exports[`ClayCardWithHorizontal renders as selectable 1`] = `
                 class="autofit-col"
               >
                 <span
-                  class="sticker sticker-rounded"
+                  class="sticker"
                 >
                   <span
                     class="sticker-overlay inline-item"
@@ -1562,7 +1562,7 @@ exports[`ClayCardWithInfo renders as disabled 1`] = `
               </svg>
             </div>
             <span
-              class="sticker sticker-rounded sticker-primary sticker-bottom-left"
+              class="sticker sticker-primary sticker-bottom-left"
             >
               <span
                 class="sticker-overlay"
@@ -1644,7 +1644,7 @@ exports[`ClayCardWithInfo renders as not selectable 1`] = `
         </svg>
       </div>
       <span
-        class="sticker sticker-rounded sticker-primary sticker-bottom-left"
+        class="sticker sticker-primary sticker-bottom-left"
       >
         <span
           class="sticker-overlay"
@@ -1753,7 +1753,7 @@ exports[`ClayCardWithInfo renders as selectable 1`] = `
               </svg>
             </div>
             <span
-              class="sticker sticker-rounded sticker-primary sticker-bottom-left"
+              class="sticker sticker-primary sticker-bottom-left"
             >
               <span
                 class="sticker-overlay"

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -366,7 +366,7 @@ exports[`ClayCard renders a ClayCard as a selectable image card 1`] = `
               />
             </div>
             <span
-              class="sticker sticker-rounded sticker-danger sticker-bottom-left"
+              class="sticker sticker-danger sticker-bottom-left"
             >
               <span
                 class="sticker-overlay"
@@ -502,7 +502,7 @@ exports[`ClayCard renders a ClayCard as image card 1`] = `
         src="https://via.placeholder.com/256"
       />
       <span
-        class="sticker sticker-rounded sticker-danger sticker-bottom-left"
+        class="sticker sticker-danger sticker-bottom-left"
       >
         <span
           class="sticker-overlay"

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -99,11 +99,7 @@ describe('ClayCard', () => {
 						className="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid"
 						src="https://via.placeholder.com/256"
 					/>
-					<ClaySticker
-						displayType="danger"
-						position="bottom-left"
-						shape="rounded"
-					>
+					<ClaySticker displayType="danger" position="bottom-left">
 						<ClayIcon
 							spritemap="/path/to/some/resource.svg"
 							symbol="document-image"
@@ -149,7 +145,6 @@ describe('ClayCard', () => {
 						<ClaySticker
 							displayType="danger"
 							position="bottom-left"
-							shape="rounded"
 						>
 							<ClayIcon
 								spritemap="/path/to/some/resource.svg"

--- a/packages/clay-card/stories/index.tsx
+++ b/packages/clay-card/stories/index.tsx
@@ -372,7 +372,6 @@ storiesOf('Components|ClayCard', module)
 						<ClaySticker
 							displayType="danger"
 							position="bottom-left"
-							shape="rounded"
 						>
 							<ClayIcon
 								spritemap={spritemap}
@@ -409,7 +408,6 @@ storiesOf('Components|ClayCard', module)
 						<ClaySticker
 							displayType="danger"
 							position="bottom-left"
-							shape="rounded"
 						>
 							<ClayIcon
 								spritemap={spritemap}

--- a/packages/clay-list/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-list/src/__tests__/__snapshots__/index.tsx.snap
@@ -152,7 +152,7 @@ exports[`ClayListWithItems renders with headers 1`] = `
           class="autofit-col"
         >
           <span
-            class="sticker sticker-rounded sticker-secondary"
+            class="sticker sticker-secondary"
           >
             <span
               class="sticker-overlay"
@@ -198,7 +198,7 @@ exports[`ClayListWithItems renders with headers 1`] = `
           class="autofit-col"
         >
           <span
-            class="sticker sticker-rounded sticker-secondary"
+            class="sticker sticker-secondary"
           >
             <span
               class="sticker-overlay"

--- a/packages/clay-sticker/docs/index.js
+++ b/packages/clay-sticker/docs/index.js
@@ -127,10 +127,14 @@ const stickerUserIconImportsCode = `import ClaySticker from '@clayui/sticker';
 const StickerUserIconCode = `const Component = () => {
 	return (
 		<>
-			<ClaySticker className="sticker-user-icon" size="xl">
-				<img className="sticker-img" src="/images/long_user_image.png" />
+			<ClaySticker userIcon size="xl">
+				<ClaySticker.Image
+					alt="placeholder"
+					src="/images/long_user_image.png"
+				/>
 			</ClaySticker>
-			<ClaySticker className="sticker-user-icon" size="xl">
+
+			<ClaySticker userIcon size="xl">
 				{'BS'}
 			</ClaySticker>
 		</>

--- a/packages/clay-sticker/docs/index.js
+++ b/packages/clay-sticker/docs/index.js
@@ -128,9 +128,7 @@ const StickerUserIconCode = `const Component = () => {
 	return (
 		<>
 			<ClaySticker className="sticker-user-icon" size="xl">
-				<div className="sticker-overlay">
-					<img className="sticker-img" src="/images/long_user_image.png" />
-				</div>
+				<img className="sticker-img" src="/images/long_user_image.png" />
 			</ClaySticker>
 			<ClaySticker className="sticker-user-icon" size="xl">
 				{'BS'}

--- a/packages/clay-sticker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-sticker/src/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ClaySticker renders 1`] = `
 <span
-  className="sticker sticker-rounded"
+  className="sticker"
 >
   <span
     className="sticker-overlay"
@@ -14,7 +14,7 @@ exports[`ClaySticker renders 1`] = `
 
 exports[`ClaySticker renders with a display type 1`] = `
 <span
-  className="sticker sticker-rounded sticker-danger"
+  className="sticker sticker-danger"
 >
   <span
     className="sticker-overlay"
@@ -26,7 +26,7 @@ exports[`ClaySticker renders with a display type 1`] = `
 
 exports[`ClaySticker renders with a outside 1`] = `
 <span
-  className="sticker sticker-rounded sticker-top-left sticker-outside"
+  className="sticker sticker-top-left sticker-outside"
 >
   <span
     className="sticker-overlay"
@@ -38,7 +38,7 @@ exports[`ClaySticker renders with a outside 1`] = `
 
 exports[`ClaySticker renders with a position 1`] = `
 <span
-  className="sticker sticker-rounded sticker-bottom-left"
+  className="sticker sticker-bottom-left"
 >
   <span
     className="sticker-overlay"
@@ -62,12 +62,69 @@ exports[`ClaySticker renders with a shape circle 1`] = `
 
 exports[`ClaySticker renders with a size 1`] = `
 <span
-  className="sticker sticker-rounded sticker-xl"
+  className="sticker sticker-xl"
 >
   <span
     className="sticker-overlay"
   >
     B
+  </span>
+</span>
+`;
+
+exports[`ClaySticker renders with a user icon 1`] = `
+<span
+  className="sticker sticker-user-icon"
+>
+  <span
+    className="sticker-overlay"
+  >
+    <img
+      alt="placeholder"
+      className="sticker-img"
+      src="#"
+    />
+  </span>
+</span>
+`;
+
+exports[`ClaySticker renders with an image 1`] = `
+<span
+  className="sticker"
+>
+  <span
+    className="sticker-overlay"
+  >
+    <img
+      alt="placeholder"
+      className="sticker-img"
+      src="#"
+    />
+  </span>
+</span>
+`;
+
+exports[`ClaySticker renders with an overlay 1`] = `
+<span
+  className="sticker"
+>
+  <span
+    className="sticker-overlay"
+  >
+    <span
+      className="sticker-overlay"
+    >
+      <img
+        alt=""
+        className="sticker-img"
+        src="#"
+      />
+    </span>
+    <span
+      className="sticker-overlay"
+    >
+      BC
+    </span>
   </span>
 </span>
 `;

--- a/packages/clay-sticker/src/__tests__/index.tsx
+++ b/packages/clay-sticker/src/__tests__/index.tsx
@@ -57,4 +57,37 @@ describe('ClaySticker', () => {
 
 		expect(testRenderer.toJSON()).toMatchSnapshot();
 	});
+
+	it('renders with an overlay', () => {
+		const testRenderer = TestRenderer.create(
+			<ClaySticker>
+				<ClaySticker.Overlay>
+					<ClaySticker.Image alt="" src="#" />
+				</ClaySticker.Overlay>
+				<ClaySticker.Overlay>{'BC'}</ClaySticker.Overlay>
+			</ClaySticker>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
+	it('renders with an image', () => {
+		const testRenderer = TestRenderer.create(
+			<ClaySticker>
+				<ClaySticker.Image alt="placeholder" src="#" />
+			</ClaySticker>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
+	it('renders with a user icon', () => {
+		const testRenderer = TestRenderer.create(
+			<ClaySticker shape="user-icon">
+				<ClaySticker.Image alt="placeholder" src="#" />
+			</ClaySticker>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
 });

--- a/packages/clay-sticker/src/index.tsx
+++ b/packages/clay-sticker/src/index.tsx
@@ -17,7 +17,7 @@ export type DisplayType =
 	| 'unstyled'
 	| 'warning';
 
-type Shape = 'circle' | 'rounded';
+type Shape = 'circle' | 'user-icon';
 
 type Position = 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
 
@@ -56,6 +56,30 @@ interface IProps extends React.HTMLAttributes<HTMLSpanElement> {
 	size?: Size;
 }
 
+const Overlay: React.FunctionComponent<
+	React.HTMLAttributes<HTMLSpanElement> & {
+		/**
+		 * Flag to indicate if `inline-item` class should be applied
+		 */
+		inline?: boolean;
+	}
+> = ({children, className, inline, ...otherProps}) => (
+	<span
+		className={classNames(className, 'sticker-overlay', {
+			'inline-item': inline,
+		})}
+		{...otherProps}
+	>
+		{children}
+	</span>
+);
+
+const Image: React.FunctionComponent<React.ImgHTMLAttributes<
+	HTMLImageElement
+>> = ({className, ...otherProps}) => (
+	<img className={classNames(className, 'sticker-img')} {...otherProps} />
+);
+
 const ClaySticker: React.FunctionComponent<IProps> = ({
 	children,
 	className,
@@ -63,7 +87,7 @@ const ClaySticker: React.FunctionComponent<IProps> = ({
 	inline,
 	outside = false,
 	position,
-	shape = 'rounded',
+	shape,
 	size,
 	...otherProps
 }: IProps) => (
@@ -77,14 +101,8 @@ const ClaySticker: React.FunctionComponent<IProps> = ({
 			[`sticker-${size}`]: size,
 		})}
 	>
-		<span
-			className={classNames('sticker-overlay', {
-				'inline-item': inline,
-			})}
-		>
-			{children}
-		</span>
+		<Overlay inline={inline}>{children}</Overlay>
 	</span>
 );
 
-export default ClaySticker;
+export default Object.assign(ClaySticker, {Image, Overlay});

--- a/packages/clay-sticker/stories/index.tsx
+++ b/packages/clay-sticker/stories/index.tsx
@@ -79,19 +79,48 @@ storiesOf('Components|ClaySticker', module)
 	.add('image', () => (
 		<div>
 			<ClaySticker size="sm">
-				<img alt="placeholder" src="https://via.placeholder.com/50" />
+				<ClaySticker.Image
+					alt="placeholder"
+					src="https://via.placeholder.com/50"
+				/>
 			</ClaySticker>
 
 			<ClaySticker>
-				<img alt="placeholder" src="https://via.placeholder.com/50" />
+				<ClaySticker.Image
+					alt="placeholder"
+					src="https://via.placeholder.com/50"
+				/>
 			</ClaySticker>
 
 			<ClaySticker size="lg">
-				<img alt="placeholder" src="https://via.placeholder.com/50" />
+				<ClaySticker.Image
+					alt="placeholder"
+					src="https://via.placeholder.com/50"
+				/>
 			</ClaySticker>
 
 			<ClaySticker size="xl">
-				<img alt="placeholder" src="https://via.placeholder.com/50" />
+				<ClaySticker.Image
+					alt="placeholder"
+					src="https://via.placeholder.com/50"
+				/>
+			</ClaySticker>
+		</div>
+	))
+	.add('user image', () => (
+		<div>
+			<ClaySticker shape="user-icon" size="sm">
+				<ClaySticker.Image
+					alt="placeholder"
+					src="https://via.placeholder.com/50"
+				/>
+			</ClaySticker>
+
+			<ClaySticker shape="user-icon">
+				<ClaySticker.Image
+					alt="placeholder"
+					src="https://via.placeholder.com/50"
+				/>
 			</ClaySticker>
 		</div>
 	))
@@ -145,14 +174,13 @@ storiesOf('Components|ClaySticker', module)
 	.add('overlay', () => (
 		<>
 			<ClaySticker displayType="dark" size="xl">
-				<div className="sticker-overlay">
-					<img
+				<ClaySticker.Overlay>
+					<ClaySticker.Image
 						alt=""
-						className="sticker-img"
 						src="https://via.placeholder.com/200"
 					/>
-				</div>
-				<div className="sticker-overlay">{'BC'}</div>
+				</ClaySticker.Overlay>
+				<ClaySticker.Overlay>{'BC'}</ClaySticker.Overlay>
 			</ClaySticker>
 		</>
 	));


### PR DESCRIPTION
fixes #3541

I also added a new API to allow for imgs directly instead of custom classes and child elements.