### PR TITLE
feat: Icon for Collections in DXP

### DIFF
--- a/packages/clay-css/src/images/icons/closed-book.svg
+++ b/packages/clay-css/src/images/icons/closed-book.svg
@@ -1,0 +1,10 @@
+<!--
+* SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+* SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
+*
+* SPDX-License-Identifier: BSD-3-Clause
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+	<rect class="lexicon-icon-outline lx-closed-book-cover" fill="none" x="160" y="64" width="224" height="224"/>
+	<path class="lexicon-icon-outline lx-closed-book-case" d="M416,0H160c-53,0-96,46.3-96,96v320c0,0,0,64,80.2,63.7c0.1,0,4.7,0.3,15.8,0.3v-32h-16 c-64.1-0.1-63.9-96.1,0.2-96H416c17.7-0.1,32-15.4,32-32V32C448,15.4,433.7,0,416,0z M384,288H160V64h224V288z M192,512l48-32l48,32 v-96h112c23.1-1.6,19.4-31.7,0-32H143.8c-20.1,0.3-22.2,31,0,32H192V512z M432,480c0,0-52,0-112,0v-32l112,0.1 C452.9,449.3,453.6,478.7,432,480z"/>
+</svg>

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -475,6 +475,8 @@
 
 	'circle': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><circle class="lexicon-icon-outline" cx="256" cy="256" r="256" fill="#{$color}"/></svg>',
 
+	'closed-book': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="lexicon-icon-outline lx-closed-book-cover" fill="#{$color}" d="M160 64h224v224H160z"/><path class="lexicon-icon-outline lx-closed-book-case" d="M416 0H160c-53 0-96 46.3-96 96v320s0 64 80.2 63.7c.1 0 4.7.3 15.8.3v-32h-16c-64.1-.1-63.9-96.1.2-96H416c17.7-.1 32-15.4 32-32V32c0-16.6-14.3-32-32-32zm-32 288H160V64h224v224zM192 512l48-32 48 32v-96h112c23.1-1.6 19.4-31.7 0-32H143.8c-20.1.3-22.2 31 0 32H192v96zm240-32H320v-32l112 .1c20.9 1.2 21.6 30.6 0 31.9z" fill="#{$color}"/></svg>',
+
 	'cloud': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="lexicon-icon-outline" d="M413.3 197.4C385.4 45.7 184.4 12 113.6 152.9c-150 21-157.6 283.7 13.9 295.6h278.2c143.1-7.8 137.8-239 7.6-251.1zm-32.7 186.9H140.2c-99.6 0-116.1-177.4 16.6-177.4 30.4-121.8 201.4-103 201.4 33.4 118.6.9 111.2 141.1 22.4 144z" fill="#{$color}"/></svg>',
 
 	'code': '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="lexicon-icon-outline" d="M183.23 185.38c31.09-31.09-16.11-78.3-47.21-47.21l-94.41 94.41c-13.56 13.56-12.04 35.17 0 47.21l94.41 94.41c30.03 30.03 78.71-15.7 47.21-47.21l-70.72-70.58 70.72-71.03zm145.54 141.24c-31.09 31.09 16.11 78.3 47.21 47.21l94.41-94.41c13.56-13.56 12.04-35.17 0-47.21l-94.41-94.41c-30.03-30.03-78.71 15.7-47.21 47.21l70.72 70.58-70.72 71.03z" fill="#{$color}"/></svg>',


### PR DESCRIPTION
Due to [LEXI-962](https://issues.liferay.com/browse/LEXI-962) we've decided to add a new icon to represent a Collection in DXP. 

![Closed-book](https://user-images.githubusercontent.com/21216422/88296896-8ea31280-ccff-11ea-9cb4-ba35af3bab6a.png)

This is a complex concept because 1 or more collections can be part of an asset library. Thus we have decided to design the icon thinking the relationship with the asset library icon (_books_). In addition, we also added a little bookmark in anticipation of the icon for adding/saving elements to a Collection. 

@pat270 I named it _closed-book_ what do you think? I would have liked to name it book-closed but checking the other book icon (_info-book_) it's wiser to follow that naming order, isn't?
