### PR TITLE
fix: update packages to appropriate dependencies

### DIFF
--- a/packages/clay-breadcrumb/package.json
+++ b/packages/clay-breadcrumb/package.json
@@ -30,7 +30,7 @@
 		"@clayui/drop-down": "^3.4.6",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/link": "^3.2.0",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6",
 		"warning": "^4.0.3"
 	},

--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -32,7 +32,7 @@
 		"@clayui/label": "^3.3.1",
 		"@clayui/layout": "^3.1.1",
 		"@clayui/link": "^3.2.0",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"@clayui/sticker": "^3.1.1",
 		"classnames": "^2.2.6"
 	},

--- a/packages/clay-color-picker/package.json
+++ b/packages/clay-color-picker/package.json
@@ -29,7 +29,7 @@
 		"@clayui/drop-down": "^3.4.6",
 		"@clayui/form": "^3.9.0",
 		"@clayui/icon": "^3.0.5",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"tinycolor2": "^1.4.1"
 	},
 	"peerDependencies": {

--- a/packages/clay-data-provider/package.json
+++ b/packages/clay-data-provider/package.json
@@ -26,7 +26,7 @@
 		"react"
 	],
 	"dependencies": {
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"fast-json-stable-stringify": "^2.0.0",
 		"warning": "^4.0.3"
 	},

--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -26,7 +26,7 @@
 		"@clayui/drop-down": "^3.4.6",
 		"@clayui/form": "^3.9.0",
 		"@clayui/icon": "^3.0.5",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"@clayui/time-picker": "^3.1.6",
 		"classnames": "^2.2.6",
 		"date-fns": "^2.14.0"

--- a/packages/clay-drop-down/package.json
+++ b/packages/clay-drop-down/package.json
@@ -30,7 +30,7 @@
 		"@clayui/form": "^3.9.0",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/link": "^3.2.0",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6",
 		"dom-align": "^1.10.2",
 		"warning": "^4.0.3"

--- a/packages/clay-form/package.json
+++ b/packages/clay-form/package.json
@@ -28,7 +28,7 @@
 	"dependencies": {
 		"@clayui/button": "^3.3.1",
 		"@clayui/icon": "^3.0.5",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-multi-select/package.json
+++ b/packages/clay-multi-select/package.json
@@ -31,7 +31,7 @@
 		"@clayui/form": "^3.9.0",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/label": "^3.3.1",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-nav/package.json
+++ b/packages/clay-nav/package.json
@@ -27,7 +27,7 @@
 	],
 	"dependencies": {
 		"@clayui/icon": "^3.0.5",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6",
 		"warning": "^4.0.3"
 	},

--- a/packages/clay-navigation-bar/package.json
+++ b/packages/clay-navigation-bar/package.json
@@ -29,7 +29,7 @@
 		"@clayui/button": "^3.3.1",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/layout": "^3.1.1",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6",
 		"warning": "^4.0.3"
 	},

--- a/packages/clay-pagination-bar/package.json
+++ b/packages/clay-pagination-bar/package.json
@@ -30,7 +30,7 @@
 		"@clayui/drop-down": "^3.4.6",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/pagination": "^3.2.3",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-pagination/package.json
+++ b/packages/clay-pagination/package.json
@@ -30,7 +30,7 @@
 		"@clayui/drop-down": "^3.4.6",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/link": "^3.2.0",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-panel/package.json
+++ b/packages/clay-panel/package.json
@@ -27,7 +27,7 @@
 	],
 	"dependencies": {
 		"@clayui/icon": "^3.0.5",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-popover/package.json
+++ b/packages/clay-popover/package.json
@@ -26,7 +26,7 @@
 		"react"
 	],
 	"dependencies": {
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6",
 		"dom-align": "^1.10.2"
 	},

--- a/packages/clay-tabs/package.json
+++ b/packages/clay-tabs/package.json
@@ -26,7 +26,7 @@
 		"react"
 	],
 	"dependencies": {
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-time-picker/package.json
+++ b/packages/clay-time-picker/package.json
@@ -25,7 +25,7 @@
 		"@clayui/button": "^3.3.1",
 		"@clayui/form": "^3.9.0",
 		"@clayui/icon": "^3.0.5",
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-tooltip/package.json
+++ b/packages/clay-tooltip/package.json
@@ -26,7 +26,7 @@
 		"react"
 	],
 	"dependencies": {
-		"@clayui/shared": "^3.1.3",
+		"@clayui/shared": "^3.2.0",
 		"classnames": "^2.2.6",
 		"dom-align": "^1.10.2",
 		"warning": "^4.0.3"


### PR DESCRIPTION
Current upstream is failing "Verify Dependencies" since we updated and publish shared and modal independently without updating packages that were dependent on them