### PR TITLE
fix(@clayui/css): Atlas Alerts adjust spacing to match Lexicon specs

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_alerts.scss
@@ -2,8 +2,8 @@
 /// @group alerts
 ////
 
-$alert-padding-x: 1rem !default; // 16px
-$alert-padding-y: 1.09375rem !default; // 17.5px
+$alert-padding-x: 1rem !default;
+$alert-padding-y: 1.03125rem !default;
 
 // For top only border use: 2px 0 0 0
 $alert-border-width: 0.0625rem !default;
@@ -53,9 +53,38 @@ $alert-subtitle: map-deep-merge(
 	$alert-subtitle
 );
 
+$alert-footer: () !default;
+$alert-footer: map-deep-merge(
+	(
+		margin-top: 1rem,
+	),
+	$alert-footer
+);
+
+// Alert Fluid
+
+$alert-fluid-container: () !default;
+$alert-fluid-container: map-merge(
+	(
+		padding-bottom: 1.0625rem,
+		padding-top: 1.0625rem,
+	),
+	$alert-fluid-container
+);
+
 // Alert Notification
 
 $alert-notifications-box-shadow: 0 0.5rem 2rem -0.25rem rgba(0, 0, 0, 0.3) !default;
+
+$alert-notification: () !default;
+$alert-notification: map-merge(
+	(
+		box-shadow: $alert-notifications-box-shadow,
+		padding-bottom: 1rem,
+		padding-top: 1rem,
+	),
+	$alert-notification
+);
 
 // Alert Autofit Row
 

--- a/packages/clay-css/src/scss/components/_alerts.scss
+++ b/packages/clay-css/src/scss/components/_alerts.scss
@@ -16,6 +16,10 @@
 		@include clay-button-variant($alert-btn);
 	}
 
+	.btn-group {
+		@include clay-container($alert-btn-group);
+	}
+
 	.btn-group-item {
 		@include clay-container($alert-btn-group-item);
 	}
@@ -80,28 +84,18 @@
 // Alert Fluid
 
 .alert-fluid {
-	@include border-radius(0);
-
-	border-width: $alert-fluid-border-width;
-	margin-bottom: $alert-fluid-margin-bottom;
-	padding: 0;
+	@include clay-css($alert-fluid);
 
 	&.alert-dismissible {
 		.container,
 		.container-fluid {
-			padding-bottom: $alert-dismissible-padding-bottom;
-			padding-left: $alert-dismissible-padding-left;
-			padding-right: calc(
-				#{$alert-dismissible-padding-right} + #{$grid-gutter-width / 2}
-			);
-			padding-top: $alert-dismissible-padding-top;
-			position: relative;
+			@include clay-css($alert-fluid-dismissible-container);
 		}
 	}
 
 	.container,
 	.container-fluid {
-		padding: $alert-padding-y $alert-padding-x;
+		@include clay-css($alert-fluid-container);
 	}
 
 	.close {
@@ -118,18 +112,20 @@
 
 .alert-notifications {
 	.alert {
-		@include box-shadow($alert-notifications-box-shadow);
+		@include clay-css($alert-notification);
 
-		width: $alert-notifications-max-width;
-
-		@include clay-scale-component {
-			max-width: none;
-			width: 100%;
+		@include media-breakpoint-down(sm) {
+			@include clay-css($alert-notification-sm-down);
 		}
 
 		&:last-child {
 			margin-bottom: 0;
 		}
+	}
+
+	.alert-fluid {
+		padding-bottom: 0;
+		padding-top: 0;
 	}
 }
 

--- a/packages/clay-css/src/scss/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/variables/_alerts.scss
@@ -18,6 +18,15 @@ $alert-btn: map-deep-merge(
 	$alert-btn
 );
 
+$alert-btn-group: () !default;
+$alert-btn-group: map-deep-merge(
+	(
+		margin-bottom: -0.125rem,
+		margin-top: -0.125rem,
+	),
+	$alert-btn-group
+);
+
 $alert-btn-group-item: () !default;
 $alert-btn-group-item: map-deep-merge(
 	(
@@ -141,6 +150,43 @@ $alert-fluid-border-width: $alert-fluid-border-top-width
 	$alert-fluid-border-left-width !default;
 $alert-fluid-margin-bottom: 0 !default;
 
+$alert-fluid: () !default;
+$alert-fluid: map-merge(
+	(
+		border-radius: 0,
+		border-width: $alert-fluid-border-width,
+		margin-bottom: $alert-fluid-margin-bottom,
+		padding: 0,
+	),
+	$alert-fluid
+);
+
+$alert-fluid-container: () !default;
+$alert-fluid-container: map-merge(
+	(
+		padding-bottom: $alert-padding-y,
+		padding-left: $alert-padding-x,
+		padding-right: $alert-padding-x,
+		padding-top: $alert-padding-y,
+	),
+	$alert-fluid-container
+);
+
+$alert-fluid-dismissible-container: () !default;
+$alert-fluid-dismissible-container: map-merge(
+	(
+		padding-bottom: $alert-dismissible-padding-bottom,
+		padding-left: $alert-dismissible-padding-left,
+		padding-right:
+			calc(
+				#{$alert-dismissible-padding-right} + #{$grid-gutter-width / 2}
+			),
+		padding-top: $alert-dismissible-padding-top,
+		position: relative,
+	),
+	$alert-fluid-dismissible-container
+);
+
 // Alert Notification
 
 $alert-notifications-absolute-bottom: null !default;
@@ -165,6 +211,26 @@ $alert-notifications-fixed-top-mobile: null !default; // 68px
 
 $alert-notifications-box-shadow: null !default;
 $alert-notifications-max-width: 22.5rem !default; // 360px
+
+$alert-notification: () !default;
+$alert-notification: map-merge(
+	(
+		box-shadow: $alert-notifications-box-shadow,
+		margin-bottom: $alert-margin-bottom,
+		max-width: $alert-notifications-max-width,
+	),
+	$alert-notification
+);
+
+$alert-notification-sm-down: () !default;
+$alert-notification-sm-down: map-merge(
+	(
+		enabled: $enable-scaling-components,
+		max-width: none,
+		width: 100%,
+	),
+	$alert-notification-sm-down
+);
 
 // Alert Autofit Row
 


### PR DESCRIPTION
feat(@clayui/css): Alerts adds Sass maps `$alert-btn-group`, `$alert-fluid`, `$alert-fluid-container`, `$alert-fluid-dismissible-container`, `$alert-notification`, `$alert-notification-sm-down`

feat(@clayui/css): Alerts use `clay-css` mixin to output styles

fixes #3558

@drakonux regarding
> there is a good reason to have distances not multiple of 8px (maybe the Lexicon team did a visual change agreed with you or similar)

Distances multiples of (4px or 8px) along with sizes multiple of (4px or 8px) doesn't always work out because CSS Box Model is margin + border + padding + content. Regular one line alerts (56px height in Lexicon) with border 1px, padding 16px, and content 21px is 55px (1px + 1px + 16px + 16px + 21px). We can hack around the Box Model by using `box-shadow` to make borders but it makes it harder than needed to make borders + shadow.

From the CSS side of things, the 8px rule is a loose guideline. I will try to follow it, but won't if the component height matters more than spacing. The rule I'm following if there is a conflict in final height/width vs spacing; if width/height matter more, I disregard the 8px rule for spacing. If spacing matters more, I disregard the 8px rule for final width/height.
