### PR TITLE
fix(@clayui/css): Atlas Alerts change `.alert .close` font-size to 12px

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_alerts.scss
@@ -15,6 +15,7 @@ $alert-close-opacity: 1 !default;
 $alert-close: () !default;
 $alert-close: map-deep-merge(
 	(
+		font-size: 0.75rem,
 		opacity: $alert-close-opacity,
 		disabled: (
 			color: inherit,


### PR DESCRIPTION
fixes #3557 

@drakonux We decided to change the `font-size` in Clay CSS because we would have to change the icon name in too many places.