### PR TITLE
fix(@clayui/multi-select): key should be ',' instead of 'Comma'

### DIFF
--- a/packages/clay-multi-select/src/__tests__/index.tsx
+++ b/packages/clay-multi-select/src/__tests__/index.tsx
@@ -142,7 +142,7 @@ describe('Interactions', () => {
 		});
 
 		fireEvent.keyDown(input as HTMLInputElement, {
-			key: 'Comma',
+			key: ',',
 		});
 
 		expect(container.querySelectorAll('.label').length).toEqual(1);
@@ -151,7 +151,7 @@ describe('Interactions', () => {
 			target: {value: 'bar'},
 		});
 
-		fireEvent.keyDown(input as HTMLInputElement, {key: 'Comma'});
+		fireEvent.keyDown(input as HTMLInputElement, {key: ','});
 
 		expect(container.querySelectorAll('.label').length).toEqual(2);
 	});

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -12,7 +12,7 @@ import {FocusScope, Keys, noop, sub} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
-const DELIMITER_KEYS = ['Enter', 'Comma'];
+const DELIMITER_KEYS = ['Enter', ','];
 
 type Item = {
 	[propName: string]: any;


### PR DESCRIPTION
Fix for https://issues.liferay.com/browse/LPS-118116