### PR TITLE
fix(@clayui/css): Reboot go back to Bootstrap 4's styling `a` tag directly but omit styling placeholder anchors

### DIFF
--- a/packages/clay-css/src/content/test_reboot.html
+++ b/packages/clay-css/src/content/test_reboot.html
@@ -26,6 +26,16 @@ section: Visual Tests
 
 <div class="clay-site-row-spacer row">
 	<div class="col-md-12">
+		<h3>Anchor</h3>
+
+		<div><a href="#1">Link with href</a></div>
+		<div><a>Placeholder Link</a></div>
+		<div><a class="btn btn-primary" role="button" tabindex="0">Placeholder Link as Button Primary</a></div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
 		<h3>Hr</h3>
 
 		<blockquote class="blockquote">

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -148,7 +148,7 @@ sup {
 	top: -0.5em;
 }
 
-[href] {
+a {
 	color: $link-color;
 	cursor: $link-cursor;
 	text-decoration: $link-decoration;
@@ -161,17 +161,6 @@ sup {
 
 [tabindex^='-'] {
 	outline: 0;
-}
-
-use[href] {
-	color: inherit;
-	cursor: inherit;
-	text-decoration: none;
-
-	&:hover {
-		color: inherit;
-		text-decoration: none;
-	}
 }
 
 // Code

--- a/packages/clay-css/src/scss/components/_type.scss
+++ b/packages/clay-css/src/scss/components/_type.scss
@@ -107,8 +107,9 @@ h6,
 // Horizontal rules
 
 hr {
-	border-top: $hr-border-width solid $hr-border-color;
-	border: 0;
+	border-color: $hr-border-color;
+	border-style: solid;
+	border-width: $hr-border-width 0 0 0;
 	margin-bottom: $hr-margin-y;
 	margin-top: $hr-margin-y;
 }


### PR DESCRIPTION
Placeholders are styled the same as links now which makes it easier to use markup like `<a class="btn btn-primary" role="button" tabindex="0">` without having to add styles.

`hr` was not showing a horizontal line due to sorting properties by alphabetical order

fixes #3568 and https://issues.liferay.com/browse/LPS-118088 