### PR TITLE
feat(@clayui/color-picker): add prop for disabling palette for custom colors

### DIFF
--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -96,6 +96,11 @@ interface IProps {
 	onColorsChange: (val: Array<string>) => void;
 
 	/**
+	 * Flag for showing and disabling the palette of colors
+	 */
+	showPalette?: boolean;
+
+	/**
 	 * Path to the location of the spritemap resource.
 	 */
 	spritemap?: string;
@@ -109,11 +114,12 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 	label,
 	onChange,
 	onColorsChange,
+	showPalette,
 	spritemap,
 }) => {
 	const inputRef = React.useRef(null);
 	const [activeSplotchIndex, setActiveSplotchIndex] = React.useState(0);
-	const [editorActive, setEditorActive] = React.useState(false);
+	const [editorActive, setEditorActive] = React.useState(!showPalette);
 
 	const color = tinycolor(colors[activeSplotchIndex]);
 
@@ -157,42 +163,46 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 				<div className="clay-color-header">
 					<span className="component-title">{label}</span>
 
-					<button
-						className={`${
-							editorActive ? 'close' : ''
-						} component-action`}
-						onClick={() => setEditorActive(!editorActive)}
-						type="button"
-					>
-						<Icon
-							spritemap={spritemap}
-							symbol={editorActive ? 'times' : 'drop'}
-						/>
-					</button>
+					{showPalette && (
+						<button
+							className={`${
+								editorActive ? 'close' : ''
+							} component-action`}
+							onClick={() => setEditorActive(!editorActive)}
+							type="button"
+						>
+							<Icon
+								spritemap={spritemap}
+								symbol={editorActive ? 'times' : 'drop'}
+							/>
+						</button>
+					)}
 				</div>
 			)}
 
-			<div className="clay-color-swatch">
-				{colors.map((hex, i) => (
-					<div className="clay-color-swatch-item" key={i}>
-						<Splotch
-							active={i === activeSplotchIndex}
-							onClick={() => {
-								if (hex === 'FFFFFF') {
-									setEditorActive(true);
-								}
+			{showPalette && (
+				<div className="clay-color-swatch">
+					{colors.map((hex, i) => (
+						<div className="clay-color-swatch-item" key={i}>
+							<Splotch
+								active={i === activeSplotchIndex}
+								onClick={() => {
+									if (hex === 'FFFFFF') {
+										setEditorActive(true);
+									}
 
-								setActiveSplotchIndex(i);
+									setActiveSplotchIndex(i);
 
-								setHue(tinycolor(hex).toHsv().h);
+									setHue(tinycolor(hex).toHsv().h);
 
-								onChange(hex);
-							}}
-							value={hex}
-						/>
-					</div>
-				))}
-			</div>
+									onChange(hex);
+								}}
+								value={hex}
+							/>
+						</div>
+					))}
+				</div>
+			)}
 
 			{editorActive && (
 				<>

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -430,6 +430,381 @@ exports[`Rendering default 1`] = `
 </body>
 `;
 
+exports[`Rendering disabled palette 1`] = `
+<body>
+  <div>
+    <div
+      class="clay-color-picker"
+    >
+      <input
+        name="colorPicker1"
+        style="display: none;"
+        type="text"
+        value="FFF"
+      />
+      <label>
+        Default
+      </label>
+      <div
+        class="input-group clay-color"
+      >
+        <div
+          class="input-group-item input-group-item-shrink input-group-prepend"
+        >
+          <div
+            class="input-group-text"
+          >
+            <button
+              aria-label="Select a color"
+              class="btn clay-color-btn dropdown-toggle clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
+              title="FFF"
+              type="button"
+            />
+          </div>
+        </div>
+        <div
+          class="input-group-item input-group-append"
+        >
+          <input
+            aria-label="Color selection is FFF"
+            class="form-control input-group-inset input-group-inset-before"
+            type="text"
+            value="FFF"
+          />
+          <label
+            class="input-group-inset-item input-group-inset-item-before"
+          >
+            #
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div>
+      <div
+        class="dropdown-menu clay-color-dropdown-menu"
+      >
+        <div
+          class="clay-color-header"
+        >
+          <span
+            class="component-title"
+          >
+            Default Colors
+          </span>
+        </div>
+        <div
+          class="clay-color-swatch"
+        >
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(0, 0, 0);"
+              title="000000"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(95, 95, 95);"
+              title="5F5F5F"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(154, 154, 154);"
+              title="9A9A9A"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(203, 203, 203);"
+              title="CBCBCB"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(225, 225, 225);"
+              title="E1E1E1"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
+              title="FFFFFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 13, 13);"
+              title="FF0D0D"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 138, 28);"
+              title="FF8A1C"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(43, 166, 118);"
+              title="2BA676"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(0, 110, 248);"
+              title="006EF8"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(127, 38, 255);"
+              title="7F26FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 33, 160);"
+              title="FF21A0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 95, 95);"
+              title="FF5F5F"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 180, 110);"
+              title="FFB46E"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(80, 210, 160);"
+              title="50D2A0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(75, 155, 255);"
+              title="4B9BFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(175, 120, 255);"
+              title="AF78FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 115, 195);"
+              title="FF73C3"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 177, 177);"
+              title="FFB1B1"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 222, 192);"
+              title="FFDEC0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(145, 227, 195);"
+              title="91E3C3"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(157, 200, 255);"
+              title="9DC8FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(223, 202, 255);"
+              title="DFCAFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 197, 230);"
+              title="FFC5E6"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 217, 217);"
+              title="FFD9D9"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 243, 232);"
+              title="FFF3E8"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(177, 235, 213);"
+              title="B1EBD5"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(197, 223, 255);"
+              title="C5DFFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(248, 242, 255);"
+              title="F8F2FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 237, 247);"
+              title="FFEDF7"
+              type="button"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`Rendering disabled state 1`] = `
 <body>
   <div>

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -72,6 +72,22 @@ describe('Rendering', () => {
 
 		expect(document.body).toMatchSnapshot();
 	});
+
+	it('disabled palette', () => {
+		render(
+			<ClayColorPicker
+				label="Default Colors"
+				name="colorPicker1"
+				onValueChange={() => {}}
+				showPalette={false}
+				spritemap="/test/path"
+				title="Default"
+				value="FFF"
+			/>
+		);
+
+		expect(document.body).toMatchSnapshot();
+	});
 });
 
 describe('Interactions', () => {

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -99,6 +99,12 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	showHex?: boolean;
 
 	/**
+	 * Flag for showing and disabling the palette of colors.
+	 * This defaults to true
+	 */
+	showPalette?: boolean;
+
+	/**
 	 * Flag to indicate if `input-group-sm` class should
 	 * be applied to `ClayInput.Group`
 	 */
@@ -135,6 +141,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	onColorsChange,
 	onValueChange = () => {},
 	showHex = true,
+	showPalette = true,
 	small,
 	spritemap,
 	title,
@@ -233,6 +240,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 									onValueChange(value);
 								}}
 								onColorsChange={onColorsChange}
+								showPalette={showPalette}
 								spritemap={spritemap}
 							/>
 						)}

--- a/packages/clay-color-picker/stories/index.tsx
+++ b/packages/clay-color-picker/stories/index.tsx
@@ -63,6 +63,16 @@ storiesOf('Components|ClayColorPicker', module)
 			title={text('Title', 'Default')}
 		/>
 	))
+	.add('custom w/o palette', () => (
+		<ClayColorPickerWithCustomColors
+			disabled={boolean('Disabled', false)}
+			label={text('Label', '')}
+			name="colorPicker2"
+			showHex={boolean('Show Hex', true)}
+			showPalette={false}
+			title={text('Title', 'Default')}
+		/>
+	))
 	.add('native', () => (
 		<ClayColorPickerWithState
 			disabled={boolean('Disabled', false)}


### PR DESCRIPTION
Hey @victorg1991, is this what you would expect for https://github.com/liferay/clay/issues/3527? Check out the storybook demo https://5f2322ebba586a00071c8a01--next-storybook-clayui.netlify.app/?path=/story/components-claycolorpicker--custom-w-o-palette