### PR TITLE
fix(@clayui/color-picker): Tapping on HSB Map or Hue Range on a mobile device should update colors and be draggable

### DIFF
--- a/packages/clay-color-picker/src/GradientSelector.tsx
+++ b/packages/clay-color-picker/src/GradientSelector.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import tinycolor from 'tinycolor2';
 
-import {useMousePosition} from './hooks';
+import {usePointerPosition} from './hooks';
 import {colorToXY, xToSaturation, yToVisibility} from './util';
 
 interface IProps {
@@ -37,16 +37,16 @@ const ClayColorPickerGradientSelector: React.FunctionComponent<IProps> = ({
 	const containerRef = React.useRef<HTMLDivElement>(null);
 	const selectorActive = React.useRef<boolean>(false);
 
-	const {onMouseMove, setXY, x, y} = useMousePosition(containerRef);
+	const {onPointerMove, setXY, x, y} = usePointerPosition(containerRef);
 
 	const removeListeners = () => {
 		selectorActive.current = false;
 
-		window.removeEventListener('mousemove', onMouseMove);
-		window.removeEventListener('mouseup', removeListeners);
+		window.removeEventListener('pointermove', onPointerMove);
+		window.removeEventListener('pointerup', removeListeners);
 	};
 
-	React.useEffect(() => {
+	React.useLayoutEffect(() => {
 		const {current} = containerRef;
 
 		if (current && selectorActive.current) {
@@ -65,12 +65,18 @@ const ClayColorPickerGradientSelector: React.FunctionComponent<IProps> = ({
 	return (
 		<div
 			className="clay-color-map clay-color-map-hsb"
-			onMouseDown={(event) => {
-				selectorActive.current = true;
-				onMouseMove(event);
+			onPointerDown={(event) => {
+				event.preventDefault();
 
-				window.addEventListener('mousemove', onMouseMove);
-				window.addEventListener('mouseup', removeListeners);
+				selectorActive.current = true;
+				onPointerMove(event);
+
+				(containerRef.current!.querySelector(
+					'.clay-color-map-pointer'
+				) as HTMLElement)!.focus();
+
+				window.addEventListener('pointermove', onPointerMove);
+				window.addEventListener('pointerup', removeListeners);
 			}}
 			ref={containerRef}
 			style={{
@@ -78,13 +84,14 @@ const ClayColorPickerGradientSelector: React.FunctionComponent<IProps> = ({
 				backgroundImage: `linear-gradient(to top, #000, rgba(0, 0, 0, 0)), linear-gradient(to right, #FFF, rgba(255, 255, 255, 0))`,
 			}}
 		>
-			<span
+			<button
 				className="clay-color-map-pointer clay-color-pointer"
 				style={{
 					background: color.toHexString(),
 					left: x - 7,
 					top: y - 7,
 				}}
+				type="button"
 			/>
 		</div>
 	);

--- a/packages/clay-color-picker/src/Hue.tsx
+++ b/packages/clay-color-picker/src/Hue.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 
-import {useMousePosition} from './hooks';
+import {usePointerPosition} from './hooks';
 import {hueToX, xToHue} from './util';
 
 interface IProps {
@@ -30,13 +30,13 @@ const ClayColorPickerHue: React.FunctionComponent<IProps> = ({
 	const containerRef = React.useRef<HTMLDivElement>(null);
 	const selectorActive = React.useRef<boolean>(false);
 
-	const {onMouseMove, setXY, x, y} = useMousePosition(containerRef);
+	const {onPointerMove, setXY, x, y} = usePointerPosition(containerRef);
 
 	const removeListeners = () => {
 		selectorActive.current = false;
 
-		window.removeEventListener('mousemove', onMouseMove);
-		window.removeEventListener('mouseup', removeListeners);
+		window.removeEventListener('pointermove', onPointerMove);
+		window.removeEventListener('pointerup', removeListeners);
 	};
 
 	React.useLayoutEffect(() => {
@@ -56,12 +56,18 @@ const ClayColorPickerHue: React.FunctionComponent<IProps> = ({
 	return (
 		<div
 			className="clay-color-range clay-color-range-hue"
-			onMouseDown={(event) => {
-				selectorActive.current = true;
-				onMouseMove(event);
+			onPointerDown={(event) => {
+				event.preventDefault();
 
-				window.addEventListener('mousemove', onMouseMove);
-				window.addEventListener('mouseup', removeListeners);
+				selectorActive.current = true;
+				onPointerMove(event);
+
+				(containerRef.current!.querySelector(
+					'.clay-color-range-pointer'
+				) as HTMLElement)!.focus();
+
+				window.addEventListener('pointermove', onPointerMove);
+				window.addEventListener('pointerup', removeListeners);
 			}}
 			ref={containerRef}
 		>

--- a/packages/clay-color-picker/src/hooks.ts
+++ b/packages/clay-color-picker/src/hooks.ts
@@ -8,10 +8,10 @@ import React from 'react';
 /**
  * Utility hook for calculating the mouse position
  */
-export function useMousePosition(containerRef: React.RefObject<any>) {
+export function usePointerPosition(containerRef: React.RefObject<any>) {
 	const [xy, setXY] = React.useState({x: 0, y: 0});
 
-	const onMouseMove = (event: React.MouseEvent | MouseEvent) => {
+	const onPointerMove = (event: React.PointerEvent | PointerEvent) => {
 		if (containerRef.current) {
 			const rect = containerRef.current.getBoundingClientRect();
 			const x = event.pageX;
@@ -32,7 +32,7 @@ export function useMousePosition(containerRef: React.RefObject<any>) {
 		}
 	};
 
-	return {...xy, onMouseMove, setXY};
+	return {...xy, onPointerMove, setXY};
 }
 
 /**

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -185,6 +185,7 @@
 		'text-shadow',
 		'text-transform',
 		'top',
+		'touch-action',
 		'transform',
 		'transform-origin',
 		'transform-style',

--- a/packages/clay-css/src/scss/variables/_clay-color.scss
+++ b/packages/clay-css/src/scss/variables/_clay-color.scss
@@ -233,6 +233,8 @@ $clay-color-map: map-deep-merge(
 		margin-bottom: 1rem,
 		margin-right: 1rem,
 		position: relative,
+		touch-action: none,
+		user-select: none,
 		width: 144px,
 	),
 	$clay-color-map
@@ -293,6 +295,8 @@ $clay-color-range: map-deep-merge(
 		margin-bottom: 1.25rem,
 		margin-top: 0.25rem,
 		position: relative,
+		touch-action: none,
+		user-select: none,
 	),
 	$clay-color-range
 );


### PR DESCRIPTION
I changed the mouse event to pointer event. This is supported by IE11, Safari, Chrome, Firefox, iOS Safari 13+ and Chrome for Android (https://caniuse.com/#feat=pointer). I can't figure out how to mimic pointer events using testing-library. I think this feature is missing from js-dom from the research I did.

issue #3540