### PR TITLE
fix(@clayui/css): Atlas Drilldown header button is off by 1px

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_drilldown.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_drilldown.scss
@@ -1,8 +1,15 @@
-$drilldown-item-header: () !default;
-$drilldown-item-header: map-deep-merge(
+$drilldown-dropdown-item-indicator-start: () !default;
+$drilldown-dropdown-item-indicator-start: map-merge(
 	(
-		font-weight: $font-weight-semi-bold,
-		text-transform: uppercase,
+		top: 0.5rem,
 	),
-	$drilldown-item-header
+	$drilldown-dropdown-item-indicator-start
+);
+
+$drilldown-dropdown-item-indicator-end: () !default;
+$drilldown-dropdown-item-indicator-end: map-merge(
+	(
+		top: 0.5rem,
+	),
+	$drilldown-dropdown-item-indicator-end
 );


### PR DESCRIPTION
fix(@clayui/css): Atlas Drilldown variables removes unused `$drilldown-item-header`

fixes #3576 