### PR TITLE
fix(@clayui/modal): Changes the body's tabIndex with scroll and focuses on the element only when pressing the Up/Down keyboard

### DIFF
--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -346,7 +346,7 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 
 				<Wrap>
 					{footerContent ? (
-						<div className="inline-scroller" tabIndex={0}>
+						<div className="inline-scroller">
 							<DropDownContent
 								items={items}
 								spritemap={spritemap}

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
@@ -205,7 +205,6 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with footer content 1
         <form>
           <div
             class="inline-scroller"
-            tabindex="0"
           >
             <ul
               class="list-unstyled"

--- a/packages/clay-modal/src/Body.tsx
+++ b/packages/clay-modal/src/Body.tsx
@@ -4,7 +4,7 @@
  */
 
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 
 export interface IBodyProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
@@ -28,16 +28,43 @@ const ClayModalBody: React.FunctionComponent<IBodyProps> = ({
 	iFrameProps = {},
 	scrollable,
 	url,
-}: IBodyProps) => (
-	<div
-		className={classNames('modal-body', {
-			'inline-scroller': scrollable,
-			'modal-body-iframe': url,
-		})}
-		tabIndex={scrollable ? 0 : undefined}
-	>
-		{url ? <iframe {...iFrameProps} src={url} title={url} /> : children}
-	</div>
-);
+}: IBodyProps) => {
+	const elementRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (
+				elementRef.current &&
+				(event.key === 'ArrowUp' || event.key === 'ArrowDown') &&
+				!elementRef.current.contains(document.activeElement)
+			) {
+				if (event.defaultPrevented) {
+					return;
+				}
+
+				elementRef.current.focus();
+			}
+		};
+
+		document.addEventListener('keydown', onKeyDown);
+
+		return () => {
+			document.removeEventListener('keydown', onKeyDown);
+		};
+	}, [elementRef]);
+
+	return (
+		<div
+			className={classNames('modal-body', {
+				'inline-scroller c-inner': scrollable,
+				'modal-body-iframe': url,
+			})}
+			ref={elementRef}
+			tabIndex={scrollable ? -1 : undefined}
+		>
+			{url ? <iframe {...iFrameProps} src={url} title={url} /> : children}
+		</div>
+	);
+};
 
 export default ClayModalBody;

--- a/packages/clay-modal/src/Body.tsx
+++ b/packages/clay-modal/src/Body.tsx
@@ -56,7 +56,7 @@ const ClayModalBody: React.FunctionComponent<IBodyProps> = ({
 	return (
 		<div
 			className={classNames('modal-body', {
-				'inline-scroller c-inner': scrollable,
+				'inline-scroller': scrollable,
 				'modal-body-iframe': url,
 			})}
 			ref={elementRef}

--- a/packages/clay-popover/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-popover/src/__tests__/__snapshots__/index.tsx.snap
@@ -9,7 +9,7 @@ exports[`ClayPopover renders 1`] = `
       class="arrow"
     />
     <div
-      class="inline-scroller c-inner"
+      class="inline-scroller"
       tabindex="-1"
     >
       <div
@@ -38,7 +38,7 @@ exports[`ClayPopover renders with \`show\` 1`] = `
       class="arrow"
     />
     <div
-      class="inline-scroller c-inner"
+      class="inline-scroller"
       tabindex="-1"
     >
       <div

--- a/packages/clay-popover/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-popover/src/__tests__/__snapshots__/index.tsx.snap
@@ -9,8 +9,8 @@ exports[`ClayPopover renders 1`] = `
       class="arrow"
     />
     <div
-      class="inline-scroller"
-      tabindex="0"
+      class="inline-scroller c-inner"
+      tabindex="-1"
     >
       <div
         class="popover-header"
@@ -38,8 +38,8 @@ exports[`ClayPopover renders with \`show\` 1`] = `
       class="arrow"
     />
     <div
-      class="inline-scroller"
-      tabindex="0"
+      class="inline-scroller c-inner"
+      tabindex="-1"
     >
       <div
         class="popover-header"

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -136,8 +136,10 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 				<div className="arrow" />
 
 				<div
-					className={classNames({'inline-scroller': !disableScroll})}
-					tabIndex={!disableScroll ? 0 : undefined}
+					className={classNames({
+						'inline-scroller c-inner': !disableScroll,
+					})}
+					tabIndex={!disableScroll ? -1 : undefined}
 				>
 					{header && <div className="popover-header">{header}</div>}
 

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -6,7 +6,7 @@
 import {ClayPortal} from '@clayui/shared';
 import classNames from 'classnames';
 import domAlign from 'dom-align';
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 export const ALIGN_POSITIONS = [
 	'top',
@@ -87,10 +87,11 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 		}: IProps,
 		ref
 	) => {
-		const [internalShow, internalSetShow] = React.useState(externalShow);
+		const [internalShow, internalSetShow] = useState(externalShow);
 
-		const triggerRef = React.useRef<HTMLElement | null>(null);
-		const popoverRef = React.useRef<HTMLElement | null>(null);
+		const triggerRef = useRef<HTMLElement | null>(null);
+		const popoverRef = useRef<HTMLElement | null>(null);
+		const popoverScrollerRef = useRef<HTMLDivElement | null>(null);
 
 		if (!ref) {
 			ref = popoverRef as React.Ref<HTMLDivElement>;
@@ -99,7 +100,7 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 		const show = externalShow ? externalShow : internalShow;
 		const setShow = onShowChange ? onShowChange : internalSetShow;
 
-		React.useEffect(() => {
+		useEffect(() => {
 			if (
 				trigger &&
 				ref &&
@@ -122,6 +123,12 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 			}
 		}, [show]);
 
+		useEffect(() => {
+			if (popoverScrollerRef.current && show) {
+				popoverScrollerRef.current.focus();
+			}
+		}, [popoverScrollerRef, show]);
+
 		let content = (
 			<div
 				className={classNames(
@@ -139,6 +146,7 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 					className={classNames({
 						'inline-scroller': !disableScroll,
 					})}
+					ref={popoverScrollerRef}
 					tabIndex={!disableScroll ? -1 : undefined}
 				>
 					{header && <div className="popover-header">{header}</div>}

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -137,7 +137,7 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 
 				<div
 					className={classNames({
-						'inline-scroller c-inner': !disableScroll,
+						'inline-scroller': !disableScroll,
 					})}
 					tabIndex={!disableScroll ? -1 : undefined}
 				>


### PR DESCRIPTION
Fixes #3581 

I took a different approach to Modal and maybe we can replicate for Popover, unfortunately, I still need `tabIndex` and I'm also using `c-inner` to remove the outline, as suggested by @pat270.

The case of Modal is that its content is not controllable, so there may be focusable elements or not, so it is still necessary to support that the container scroll is done via keyboard using Up/Down, so I using the strategy of when the keyboard of Up/Down is pressed to change the focus to the body, so it will be possible to scroll and remove it from the focus order and we have a behavior similar to the page scroll.

For Modal's case, this makes sense since when Modal is open it removes the scroll from the page but for Popover's case, we still need to deal with it better.