### PR TITLE
feat(@clayui/layout): Adds missing xl property on Col component

### DIFF
--- a/packages/clay-drop-down/src/drilldown/Menu.tsx
+++ b/packages/clay-drop-down/src/drilldown/Menu.tsx
@@ -17,7 +17,7 @@ export interface IItem extends React.ComponentProps<typeof LinkOrButton> {
 	symbol?: string;
 }
 
-interface IProps {
+export interface IProps {
 	active?: boolean;
 	direction?: 'prev' | 'next';
 	header?: string;

--- a/packages/clay-layout/src/Col.tsx
+++ b/packages/clay-layout/src/Col.tsx
@@ -43,6 +43,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * The number of columns to span on extra-small devices
 	 */
 	xs?: TColSize;
+
+	/**
+	 * The number of columns to span on extra-large devices
+	 */
+	xl?: TColSize;
 }
 
 const ClayCol = React.forwardRef<HTMLElement, IProps>(
@@ -55,6 +60,7 @@ const ClayCol = React.forwardRef<HTMLElement, IProps>(
 			md,
 			size,
 			sm,
+			xl,
 			xs,
 			...otherProps
 		}: IProps,
@@ -76,6 +82,8 @@ const ClayCol = React.forwardRef<HTMLElement, IProps>(
 					'col-sm': sm === true,
 					[`col-sm-${sm}`]: sm && typeof sm !== 'boolean',
 					[`col-${xs}`]: xs && typeof xs !== 'boolean',
+					'col-xl': xl === true,
+					[`col-xl-${xl}`]: xl && typeof xl !== 'boolean',
 				})}
 				ref={ref}
 			>


### PR DESCRIPTION
It also fixes this error that is being thrown when running `yarn build`:

```
$ cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json
src/drilldown/index.tsx(21,1): error TS4082: Default export of the module has or is using private name 'IProps'.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Closes https://github.com/liferay/clay/issues/3561