### PR TITLE
fix(@clayui/css): C Kbd each key in a keyboard shortcut should be wrapped in its own `kbd` element

### DIFF
--- a/clayui.com/content/docs/components/css-dropdown.md
+++ b/clayui.com/content/docs/components/css-dropdown.md
@@ -21,6 +21,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/dropdowns/'
         -   [Start](#start)
         -   [End](#end)
         -   [Start and End](#start-and-end)
+    -   [Keyboard Shortcuts](#keyboard-shortcuts)
     -   [Scrolling Content](#scrolling-content)
 -   [Actions](#actions)
     -   [Buttons](#buttons)
@@ -1142,6 +1143,191 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 	<li><a class="active dropdown-item" href="#1">Dinner Preference</a></li>
 	<li><a class="dropdown-item" href="#1">Submit Payment</a></li>
 	<li class="dropdown-caption">Dropdown Caption</li>
+</ul>
+```
+
+### Keyboard Shortcuts
+
+<div class="sheet-example">
+	<div class="clay-site-dropdown-menu-container">
+		<ul aria-labelledby="theDropdownToggleId" class="dropdown-menu show">
+			<li>
+				<a class="active autofit-row dropdown-item" href="#1" tabindex="-1">
+					<span class="autofit-col autofit-col-expand">
+						First Option
+					</span>
+					<span class="autofit-col">
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd>
+						</kbd>
+					</span>
+				</a>
+			</li>
+			<li>
+				<a class="autofit-row disabled dropdown-item" href="#1" tabindex="-1">
+					<span class="autofit-col autofit-col-expand">
+						Second Option
+					</span>
+					<span class="autofit-col">
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd
+							><kbd class="c-kbd">K</kbd>
+						</kbd>
+					</span>
+				</a>
+			</li>
+			<li class="dropdown-divider"></li>
+			<li>
+				<button class="autofit-row dropdown-item" type="button">
+					<span class="autofit-col autofit-col-expand">
+						Third Option is the Button Option ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+					</span>
+					<span class="autofit-col">
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd
+							><span class="c-kbd-separator">+</span
+							><kbd class="c-kbd">Shift</kbd
+							><span class="c-kbd-separator">+</span
+							><kbd class="c-kbd">Y</kbd>
+						</kbd>
+					</span>
+				</button>
+			</li>
+			<li>
+				<a class="autofit-row dropdown-item" href="#1">
+					<span class="autofit-col autofit-col-expand">
+						Fourth Option
+					</span>
+				</a>
+			</li>
+			<li class="dropdown-divider"></li>
+			<li>
+				<a class="autofit-row dropdown-item" href="#1">
+					<span class="autofit-col autofit-col-expand">
+						Fifth Option
+					</span>
+				</a>
+			</li>
+			<li class="dropdown-divider"></li>
+			<li>
+				<a class="autofit-row dropdown-item" href="#1">
+					<span class="autofit-col autofit-col-expand">
+						Sixth Option
+					</span>
+				</a>
+			</li>
+			<li>
+				<a class="autofit-row dropdown-item" href="#1">
+					<span class="autofit-col autofit-col-expand">
+						Seventh Option
+					</span>
+					<span class="autofit-col">
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd
+							><kbd class="c-kbd">P</kbd>
+						</kbd>
+					</span>
+				</a>
+			</li>
+			<li class="dropdown-divider"></li>
+			<li>
+				<a class="autofit-row dropdown-item" href="#1">
+					<span class="autofit-col autofit-col-expand">
+						Eighth Option
+					</span>
+				</a>
+			</li>
+		</ul>
+	</div>
+</div>
+
+```html
+<ul aria-labelledby="theDropdownToggleId" class="dropdown-menu show">
+	<li>
+		<a class="active autofit-row dropdown-item" href="#1" tabindex="-1">
+			<span class="autofit-col autofit-col-expand">
+				First Option
+			</span>
+			<span class="autofit-col">
+				<kbd class="c-kbd c-kbd-inline">
+					<kbd class="c-kbd">⌘</kbd>
+				</kbd>
+			</span>
+		</a>
+	</li>
+	<li>
+		<a class="autofit-row disabled dropdown-item" href="#1" tabindex="-1">
+			<span class="autofit-col autofit-col-expand">
+				Second Option
+			</span>
+			<span class="autofit-col">
+				<kbd class="c-kbd c-kbd-inline">
+					<kbd class="c-kbd">⌘</kbd><kbd class="c-kbd">K</kbd>
+				</kbd>
+			</span>
+		</a>
+	</li>
+	<li class="dropdown-divider"></li>
+	<li>
+		<button class="autofit-row dropdown-item" type="button">
+			<span class="autofit-col autofit-col-expand">
+				Third Option is the Button Option
+				ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+			</span>
+			<span class="autofit-col">
+				<kbd class="c-kbd c-kbd-inline">
+					<kbd class="c-kbd">⌘</kbd
+					><span class="c-kbd-separator">+</span
+					><kbd class="c-kbd">Shift</kbd
+					><span class="c-kbd-separator">+</span
+					><kbd class="c-kbd">Y</kbd>
+				</kbd>
+			</span>
+		</button>
+	</li>
+	<li>
+		<a class="autofit-row dropdown-item" href="#1">
+			<span class="autofit-col autofit-col-expand">
+				Fourth Option
+			</span>
+		</a>
+	</li>
+	<li class="dropdown-divider"></li>
+	<li>
+		<a class="autofit-row dropdown-item" href="#1">
+			<span class="autofit-col autofit-col-expand">
+				Fifth Option
+			</span>
+		</a>
+	</li>
+	<li class="dropdown-divider"></li>
+	<li>
+		<a class="autofit-row dropdown-item" href="#1">
+			<span class="autofit-col autofit-col-expand">
+				Sixth Option
+			</span>
+		</a>
+	</li>
+	<li>
+		<a class="autofit-row dropdown-item" href="#1">
+			<span class="autofit-col autofit-col-expand">
+				Seventh Option
+			</span>
+			<span class="autofit-col">
+				<kbd class="c-kbd c-kbd-inline">
+					<kbd class="c-kbd">⌘</kbd><kbd class="c-kbd">P</kbd>
+				</kbd>
+			</span>
+		</a>
+	</li>
+	<li class="dropdown-divider"></li>
+	<li>
+		<a class="autofit-row dropdown-item" href="#1">
+			<span class="autofit-col autofit-col-expand">
+				Eighth Option
+			</span>
+		</a>
+	</li>
 </ul>
 ```
 

--- a/clayui.com/content/docs/css/content/c-kbd.md
+++ b/clayui.com/content/docs/css/content/c-kbd.md
@@ -7,7 +7,7 @@ order: 4
 <div class="nav-toc">
 
 -   [Base](#base)
-    -   [Kbd](#c-kbd)
+    -   [Nested Kbd](#nested-c-kbd)
     -   [Monospaced](#c-kbd-monospaced)
     -   [Inline](#c-kbd-inline)
     -   [Group](#c-kbd-group)
@@ -37,24 +37,31 @@ order: 4
 A visual pattern used to allow users to learn how to access actions via keyboard.
 
 <div class="clay-site-alert alert alert-info">
-    Check the <a href="https://liferay.design/lexicon">Lexicon</a> <a href="https://liferay.design/lexicon/core-components/keys/">Keys Pattern</a> for a more in-depth look at the motivations and proper usage of this component.
+	Check the <a href="https://liferay.design/lexicon">Lexicon</a> <a href="https://liferay.design/lexicon/core-components/keys/">Keys Pattern</a> for a more in-depth look at the motivations and proper usage of this component.
 </div>
 
 ## Base
 
-The <code>c-kbd</code> component provides base size and spacing styles for the <code>kbd</code> HTML element.
+The `c-kbd` component provides base size and spacing styles for the `kbd` HTML element.
 
-### C Kbd
-
-1.5rem (24px) minimum width and 1.5rem (24px) tall <code>kbd</code> element with <code>padding-left</code>, <code>padding-right</code>, and <code>border-width: 1px</code>.
+1.5rem (24px) minimum width and 1.5rem (24px) tall `kbd` element with `padding-left`, `padding-right`, and `border-width: 1px`.
 
 <div class="sheet-example">
-    <kbd class="c-kbd">Esc</kbd>
-    <kbd class="c-kbd">Ctrl</kbd>
-    <kbd class="c-kbd">Shift</kbd>
-    <kbd class="c-kbd">Alt</kbd>
-    <kbd class="c-kbd">&#8984;+Shift+Y</kbd>
-    <kbd class="c-kbd">&#8984;P</kbd>
+	<kbd class="c-kbd">Esc</kbd>,
+	<kbd class="c-kbd">Ctrl</kbd>,
+	<kbd class="c-kbd">Shift</kbd>,
+	<kbd class="c-kbd">Alt</kbd>,
+	<kbd class="c-kbd">
+		<kbd class="c-kbd">&#8984;</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">Shift</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">P</kbd>
+	</kbd>,
+	<kbd class="c-kbd">
+		<kbd class="c-kbd">&#8984;</kbd
+		><kbd class="c-kbd">P</kbd>
+	</kbd>
 </div>
 
 ```html
@@ -62,62 +69,241 @@ The <code>c-kbd</code> component provides base size and spacing styles for the <
 <kbd class="c-kbd">Ctrl</kbd>
 <kbd class="c-kbd">Shift</kbd>
 <kbd class="c-kbd">Alt</kbd>
-<kbd class="c-kbd">&#8984;+Shift+Y</kbd>
-<kbd class="c-kbd">&#8984;P</kbd>
+
+<!-- This formatting forces browser to render no white space -->
+<kbd class="c-kbd">
+	<kbd class="c-kbd">&#8984;</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">Shift</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">P</kbd>
+</kbd>
+
+<kbd class="c-kbd">
+	<kbd class="c-kbd">&#8984;</kbd><kbd class="c-kbd">P</kbd>
+</kbd>
+```
+
+### Nested C Kbd
+
+Nest multiple `.c-kbd` elements inside a single `.c-kbd` element to describe a keyboard command comprising of multiple keys.
+
+<div class="sheet-example">
+	<kbd class="c-kbd">
+		<kbd class="c-kbd">&#8984;</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">Shift</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">Y</kbd>
+	</kbd>,
+	<kbd class="c-kbd">
+		<kbd class="c-kbd">&#8984;</kbd
+		><kbd class="c-kbd">P</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-inline">
+		<kbd class="c-kbd">&#8984;</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">Shift</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">Y</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-inline">
+		<kbd class="c-kbd">&#8984;</kbd
+		><kbd class="c-kbd">P</kbd>
+	</kbd>
+</div>
+
+```html
+<!-- This formatting forces browser to render no white space -->
+<kbd class="c-kbd">
+	<kbd class="c-kbd">&#8984;</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">Shift</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">Y</kbd>
+</kbd>
+
+<kbd class="c-kbd">
+	<kbd class="c-kbd">&#8984;</kbd><kbd class="c-kbd">P</kbd>
+</kbd>
+
+<kbd class="c-kbd c-kbd-inline">
+	<kbd class="c-kbd">&#8984;</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">Shift</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">Y</kbd>
+</kbd>
+
+<kbd class="c-kbd c-kbd-inline">
+	<kbd class="c-kbd">&#8984;</kbd><kbd class="c-kbd">P</kbd>
+</kbd>
+```
+
+<div class="sheet-example">
+	<kbd class="c-kbd">
+		<kbd class="c-kbd c-kbd-light">&#8984;</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-light">Shift</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-light">Y</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-light">
+		<kbd class="c-kbd">&#8984;</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">Shift</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">Y</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-dark">
+		<kbd class="c-kbd">&#8984;</kbd
+		><kbd class="c-kbd">P</kbd>
+	</kbd>
+</div>
+
+```html
+<kbd class="c-kbd">
+	<kbd class="c-kbd c-kbd-light">&#8984;</kbd>
+	<span class="c-kbd-separator">+</span>
+	<kbd class="c-kbd c-kbd-light">Shift</kbd>
+	<span class="c-kbd-separator">+</span>
+	<kbd class="c-kbd c-kbd-light">Y</kbd>
+</kbd>
+
+<!-- This formatting forces browser to render no white space -->
+<kbd class="c-kbd c-kbd-light">
+	<kbd class="c-kbd">&#8984;</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">Shift</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">Y</kbd>
+</kbd>
+
+<kbd class="c-kbd c-kbd-dark">
+	<kbd class="c-kbd">&#8984;</kbd><kbd class="c-kbd">P</kbd>
+</kbd>
 ```
 
 ### C Kbd Monospaced
 
-1.5rem (24px) minimum width and 1.5rem (24px) tall <code>kbd</code> element with no <code>padding</code> and <code>border-width: 1px</code>. This is generally used to display single characters.
+1.5rem (24px) minimum width and 1.5rem (24px) tall `kbd` element with no `padding` and `border-width: 1px`. This is generally used to display single characters.
 
 <div class="sheet-example">
-    <kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8984;">&#8984;</kbd>
-    <kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8592;">&#8592;</kbd>
-    <kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8593;">&#8593;</kbd>
-    <kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8594;">&#8594;</kbd>
-    <kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8595;">&#8595;</kbd>
-    <kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8679;">&#8679;</kbd>
-    <kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8997;">&#8997;</kbd>
-    <kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#11152;">&#11152;</kbd>
-    <kbd class="c-kbd c-kbd-monospaced" data-entity="&amp#8984;N">&#8984;N</kbd>
+	<kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8984;">&#8984;</kbd>,
+	<kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8592;">&#8592;</kbd>,
+	<kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8593;">&#8593;</kbd>,
+	<kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8594;">&#8594;</kbd>,
+	<kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8595;">&#8595;</kbd>,
+	<kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8679;">&#8679;</kbd>,
+	<kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#8997;">&#8997;</kbd>,
+	<kbd class="c-kbd c-kbd-monospaced" data-entity="&amp;#11152;">&#11152;</kbd>,
+	<kbd class="c-kbd c-kbd-monospaced" data-entity="&amp#8984;N">
+		<kbd class="c-kbd" data-entity="&amp#8984;">&#8984;</kbd
+		><kbd class="c-kbd" data-entity="N">N</kbd>
+	</kbd>
 </div>
 
 ```html
 <kbd class="c-kbd c-kbd-monospaced">&#8984;</kbd>
+
+<kbd class="c-kbd c-kbd-monospaced">&#8592;</kbd>
+
+<kbd class="c-kbd c-kbd-monospaced">&#8593;</kbd>
+
+<kbd class="c-kbd c-kbd-monospaced">&#8594;</kbd>
+
+<kbd class="c-kbd c-kbd-monospaced">&#8595;</kbd>
+
+<kbd class="c-kbd c-kbd-monospaced">&#8679;</kbd>
+
+<kbd class="c-kbd c-kbd-monospaced">&#8997;</kbd>
+
+<!-- This formatting forces browser to render no white space -->
+<kbd class="c-kbd c-kbd-monospaced">
+	<kbd class="c-kbd">&#8984;</kbd><kbd class="c-kbd">N</kbd>
+</kbd>
 ```
 
 ### C Kbd Inline
 
-No minimum width or height <code>kbd</code> element with <code>padding: 0</code> and <code>border-width: 0</code>. This is used to display keyboard shortcuts in small spaces such as <code>dropdown-item</code>.
+No minimum width or height `kbd` element with `padding: 0` and `border-width: 0`. This is used to display keyboard shortcuts in small spaces such as `dropdown-item`.
+
+The most robust markup to use is nested `kbd` elements:
+
+```html
+<kbd class="c-kbd c-kbd-inline">
+	<kbd class="c-kbd">key</kbd>
+</kbd>
+```
+
+but the markup:
+
+```html
+<kbd class="c-kbd c-kbd-inline">key</kbd>
+```
+
+works as well.
 
 <div class="sheet-example">
-    <kbd class="c-kbd c-kbd-inline">Esc</kbd>
-    <kbd class="c-kbd c-kbd-inline">Ctrl</kbd>
-    <kbd class="c-kbd c-kbd-inline">Shift</kbd>
-    <kbd class="c-kbd c-kbd-inline">Alt</kbd>
-    <kbd class="c-kbd c-kbd-inline">&#8984;+Shift+Y</kbd>
-    <kbd class="c-kbd c-kbd-inline">&#8984;P</kbd>
+	<kbd class="c-kbd c-kbd-inline">
+		<kbd class="c-kbd">Esc</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-inline">Ctrl</kbd>,
+	<kbd class="c-kbd c-kbd-inline">
+		<kbd class="c-kbd">Shift</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-inline">
+		<kbd class="c-kbd">Alt</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-inline">
+		<kbd class="c-kbd">&#8984;</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">Shift</kbd
+		><span class="c-kbd-separator">+</span
+		><kbd class="c-kbd">Y</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-inline">
+		<kbd class="c-kbd">&#8984;</kbd
+		><kbd class="c-kbd">P</kbd>
+	</kbd>
 </div>
 
 ```html
-<kbd class="c-kbd c-kbd-inline">&#8984;+Shift+Y</kbd>
+<kbd class="c-kbd c-kbd-inline">
+	<kbd class="c-kbd">Esc</kbd>
+</kbd>
+
+<kbd class="c-kbd c-kbd-inline">Ctrl</kbd>
+
+<!-- This formatting forces browser to render no white space -->
+<kbd class="c-kbd c-kbd-inline">
+	<kbd class="c-kbd">&#8984;</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">Shift</kbd><span class="c-kbd-separator">+</span
+	><kbd class="c-kbd">Y</kbd>
+</kbd>
+
+<kbd class="c-kbd c-kbd-inline">
+	<kbd class="c-kbd">&#8984;</kbd><kbd class="c-kbd">P</kbd>
+</kbd>
 ```
 
 ### C Kbd Group
 
-A container element for grouping text with several <code>kbd</code> elements together. This is also useful inside <code>autofit-col</code> if you don't want several <code>kbd</code> elements to break to a new line.
+A container element for grouping text with several `kbd` elements together. This is also useful inside `autofit-col` if you don't want several `kbd` elements to break to a new line.
 
 <div class="sheet-example">
-    <span class="c-kbd-group">
-        Press <kbd class="c-kbd">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced">N</kbd> to see an amazing effect.
-    </span>
+	<span class="c-kbd-group">
+		Press
+		<kbd class="c-kbd">
+			<kbd class="c-kbd">Esc</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd">N</kbd>
+		</kbd>
+		to see an amazing effect.
+	</span>
 </div>
 
 ```html
 <span class="c-kbd-group">
-	Press <kbd class="c-kbd">Esc</kbd>
-	+
-	<kbd class="c-kbd c-kbd-monospaced">N</kbd> to see an amazing effect.
+	Press
+	<kbd class="c-kbd">
+		<kbd class="c-kbd">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd">N</kbd>
+	</kbd>
+	to see an amazing effect.
 </span>
 ```
 
@@ -127,77 +313,163 @@ The color variants are modifier classes added to any of the base components list
 
 ### C Kbd Light
 
+A color modifier on `c-kbd` to style the `kbd` element with dark text, light background and border.
+
 <div class="sheet-example">
-    <kbd class="c-kbd c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+	<kbd class="c-kbd">
+		<kbd class="c-kbd c-kbd-light">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-light">
+		<kbd class="c-kbd">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd">N</kbd>
+	</kbd>
 </div>
 
 ```html
-<kbd class="c-kbd c-kbd-light">Esc</kbd>
-+
-<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+<kbd class="c-kbd">
+	<kbd class="c-kbd c-kbd-light">Esc</kbd>
+	<span class="c-kbd-separator">+</span>
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+</kbd>
+
+<kbd class="c-kbd c-kbd-light">
+	<kbd class="c-kbd">Esc</kbd>
+	<span class="c-kbd-separator">+</span>
+	<kbd class="c-kbd">N</kbd>
+</kbd>
 ```
 
 ### C Kbd Dark
 
+A color modifier on `c-kbd` to style the `kbd` element with light text, dark background and border.
+
 <div class="sheet-example">
-    <kbd class="c-kbd c-kbd-dark">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+	<kbd class="c-kbd">
+		<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+	</kbd>,
+	<kbd class="c-kbd c-kbd-dark">
+		<kbd class="c-kbd">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd">N</kbd>
+	</kbd>
 </div>
 
 ```html
-<kbd class="c-kbd c-kbd-dark">Esc</kbd>
-+
-<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+<kbd class="c-kbd">
+	<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+	<span class="c-kbd-separator">+</span>
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+</kbd>
+
+<kbd class="c-kbd c-kbd-dark">
+	<kbd class="c-kbd">Esc</kbd>
+	<span class="c-kbd-separator">+</span>
+	<kbd class="c-kbd">N</kbd>
+</kbd>
 ```
 
 ### C Kbd Group Light
 
-A color modifier on <code>c-kbd-group</code> that sets the text color to <code>\$secondary</code>. This can be used with <code>c-kbd-light</code> and <code>c-kbd-dark</code>.
+A color modifier on `c-kbd-group`, for use with light backgrounds, that sets the text color to `\$secondary`. This can be used with `c-kbd-light` and `c-kbd-dark`.
 
 <div class="sheet-example">
-    <div class="c-mb-2">
-        <span class="c-kbd-group c-kbd-group-light">Press <kbd class="c-kbd c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.</span>
-    </div>
-    <div>
-        <span class="c-kbd-group c-kbd-group-light">Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing effect.</span>
-    </div>
+	<div class="c-mb-2">
+		<span class="c-kbd-group c-kbd-group-light">
+			Press
+			<kbd class="c-kbd">
+				<kbd class="c-kbd c-kbd-light">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+			</kbd>
+			to see an amazing effect.
+		</span>
+	</div>
+	<span class="c-kbd-group c-kbd-group-light">
+		Press
+		<kbd class="c-kbd">
+			<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+		</kbd>
+		to see an amazing effect.
+	</span>
 </div>
 
 ```html
 <span class="c-kbd-group c-kbd-group-light">
-	Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing
-	effect.
+	Press
+	<kbd class="c-kbd">
+		<kbd class="c-kbd c-kbd-light">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+	</kbd>
+	to see an amazing effect.
 </span>
+
 <span class="c-kbd-group c-kbd-group-light">
-	Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> +
-	<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing
-	effect.
+	Press
+	<kbd class="c-kbd">
+		<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+	</kbd>
+	to see an amazing effect.
 </span>
 ```
 
 ### C Kbd Group Dark
 
-A color modifier on <code>c-kbd-group</code> that sets the text color to <code>\$white</code>. This can be used with <code>c-kbd-light</code> and <code>c-kbd-dark</code>.
+A color modifier on `c-kbd-group`, for use with dark backgrounds, that sets the text color to `\$white`. This can be used with `c-kbd-light` and `c-kbd-dark`.
 
 <div class="sheet-example">
-    <div class="c-mb-2" style="background-color:#1C1C24;padding: 10px;">
-        <span class="c-kbd-group c-kbd-group-dark">Press <kbd class="c-kbd c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.</span>
-    </div>
-    <div style="background-color:#1C1C24;padding: 10px;">
-        <span class="c-kbd-group c-kbd-group-dark">Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing effect.</span>
-    </div>
+	<div class="bg-dark c-mb-2 c-p-2">
+		<span class="c-kbd-group c-kbd-group-dark">
+			Press
+			<kbd class="c-kbd">
+				<kbd class="c-kbd c-kbd-light">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+			</kbd>
+			to see an amazing effect.
+		</span>
+	</div>
+	<div class="bg-dark c-mb-2 c-p-2">
+		<span class="c-kbd-group c-kbd-group-dark">
+			Press
+			<kbd class="c-kbd">
+				<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+			</kbd>
+			to see an amazing effect.
+		</span>
+	</div>
 </div>
 
 ```html
 <span class="c-kbd-group c-kbd-group-dark">
-	Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing
-	effect.
+	Press
+	<kbd class="c-kbd">
+		<kbd class="c-kbd c-kbd-light">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+	</kbd>
+	to see an amazing effect.
 </span>
+
 <span class="c-kbd-group c-kbd-group-dark">
-	Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> +
-	<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing
-	effect.
+	Press
+	<kbd class="c-kbd">
+		<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+	</kbd>
+	to see an amazing effect.
 </span>
 ```
 
@@ -207,53 +479,147 @@ Size variants are modifier classes added to the base component to change the fon
 
 ### C Kbd Sm
 
-<code>c-kbd-sm</code> and <code>c-kbd-group-sm</code> are size modifiers that sets <code>font-size: 0.75rem</code> (12px).
+`c-kbd-sm` and `c-kbd-group-sm` are size modifiers that sets `font-size: 0.75rem` (12px).
 
 <div class="sheet-example">
-    <div class="c-mb-2">
-        <kbd class="c-kbd c-kbd-sm c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-sm c-kbd-monospaced c-kbd-light">N</kbd>
-    </div>
-    <div>
-        <span class="c-kbd-group c-kbd-group-sm c-kbd-group-light">
-            Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-            <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.
-        </span>
-    </div>
+	<div class="c-mb-2">
+		<kbd class="c-kbd c-kbd-sm c-kbd-light">Esc</kbd>
+		<span class="c-kbd-separator c-kbd-sm">+</span>
+		<kbd class="c-kbd c-kbd-sm c-kbd-monospaced c-kbd-light">N</kbd>
+	</div>
+	<div class="c-mb-2">
+		<kbd class="c-kbd c-kbd-sm">
+			<kbd class="c-kbd c-kbd-light">Esc</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+		</kbd>
+	</div>
+	<div class="c-mb-2">
+		<span class="c-kbd-group c-kbd-group-sm c-kbd-group-light">
+			Press
+			<kbd class="c-kbd">
+				<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+			</kbd>
+			to see an amazing effect.
+		</span>
+	</div>
+	<div>
+		<span class="c-kbd-group c-kbd-group-sm c-kbd-group-light">
+			Press
+			<kbd class="c-kbd c-kbd-lg">
+				<kbd class="c-kbd c-kbd-light">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+			</kbd>
+			to see an amazing effect.
+		</span>
+	</div>
 </div>
 
 ```html
-<kbd class="c-kbd c-kbd-sm c-kbd-light">Esc</kbd> +
+<kbd class="c-kbd c-kbd-sm c-kbd-light">Esc</kbd>
+<span class="c-kbd-separator c-kbd-sm">+</span>
 <kbd class="c-kbd c-kbd-sm c-kbd-monospaced c-kbd-light">N</kbd>
+
+<kbd class="c-kbd c-kbd-sm">
+	<kbd class="c-kbd c-kbd-light">Esc</kbd>
+	<span class="c-kbd-separator">+</span>
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+</kbd>
+
 <span class="c-kbd-group c-kbd-group-sm c-kbd-group-light">
-	Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing
-	effect.
+	Press
+	<kbd class="c-kbd">
+		<kbd class="c-kbd c-kbd-light">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+	</kbd>
+	to see an amazing effect.
+</span>
+
+<span class="c-kbd-group c-kbd-group-sm c-kbd-group-light">
+	Press
+	<kbd class="c-kbd c-kbd-lg">
+		<kbd class="c-kbd c-kbd-light">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+	</kbd>
+	to see an amazing effect.
 </span>
 ```
 
 ### C Kbd Lg
 
-<code>c-kbd-lg</code> and <code>c-kbd-group-lg</code> are size modifiers that sets <code>font-size: 1rem</code> (16px).
+`c-kbd-lg` and `c-kbd-group-lg` are size modifiers that sets `font-size: 1rem` (16px).
 
 <div class="sheet-example">
-    <div class="c-mb-2">
-        <kbd class="c-kbd c-kbd-lg c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-lg c-kbd-monospaced c-kbd-light">N</kbd>
-    </div>
-    <div>
-        <span class="c-kbd-group c-kbd-group-lg c-kbd-group-light">
-            Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-            <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.
-        </span>
-    </div>
+	<div class="c-mb-2">
+		<kbd class="c-kbd c-kbd-lg c-kbd-light">Esc</kbd>
+		<span class="c-kbd-separator c-kbd-lg">+</span>
+		<kbd class="c-kbd c-kbd-lg c-kbd-monospaced c-kbd-light">N</kbd>
+	</div>
+	<div class="c-mb-2">
+		<kbd class="c-kbd c-kbd-lg">
+			<kbd class="c-kbd c-kbd-light">Esc</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+		</kbd>
+	</div>
+	<div class="c-mb-2">
+		<span class="c-kbd-group c-kbd-group-lg c-kbd-group-light">
+			Press
+			<kbd class="c-kbd">
+				<kbd class="c-kbd c-kbd-light">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+			</kbd>
+			to see an amazing effect.
+		</span>
+	</div>
+	<div>
+		<span class="c-kbd-group c-kbd-group-lg c-kbd-group-light">
+			Press
+			<kbd class="c-kbd c-kbd-sm">
+				<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+			</kbd>
+			to see an amazing effect.
+		</span>
+	</div>
 </div>
 
 ```html
-<kbd class="c-kbd c-kbd-lg c-kbd-light"> Esc</kbd> +
-<kbd class="c-kbd c-kbd-lg c-kbd-monospaced c-kbd-light">N </kbd>
+<kbd class="c-kbd c-kbd-lg c-kbd-light">Esc</kbd>
+<span class="c-kbd-separator c-kbd-lg">+</span>
+<kbd class="c-kbd c-kbd-lg c-kbd-monospaced c-kbd-light">N</kbd>
+
+<kbd class="c-kbd c-kbd-lg">
+	<kbd class="c-kbd c-kbd-light">Esc</kbd>
+	<span class="c-kbd-separator">+</span>
+	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+</kbd>
+
 <span class="c-kbd-group c-kbd-group-lg c-kbd-group-light">
-	Press <kbd class="c-kbd c-kbd-light">Esc</kbd> +
-	<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing
-	effect.
+	Press
+	<kbd class="c-kbd">
+		<kbd class="c-kbd c-kbd-light">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+	</kbd>
+	to see an amazing effect.
+</span>
+
+<span class="c-kbd-group c-kbd-group-lg c-kbd-group-light">
+	Press
+	<kbd class="c-kbd c-kbd-sm">
+		<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+	</kbd>
+	to see an amazing effect.
 </span>
 ```
 

--- a/packages/clay-css/src/content/dropdowns.html
+++ b/packages/clay-css/src/content/dropdowns.html
@@ -694,7 +694,9 @@ section: Components
 						First Option
 					</span>
 					<span class="autofit-col">
-						<kbd class="c-kbd c-kbd-inline">⌘</kbd>
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd>
+						</kbd>
 					</span>
 				</a>
 			</li>
@@ -704,7 +706,10 @@ section: Components
 						Second Option
 					</span>
 					<span class="autofit-col">
-						<kbd class="c-kbd c-kbd-inline">⌘K</kbd>
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd
+							><kbd class="c-kbd">K</kbd>
+						</kbd>
 					</span>
 				</a>
 			</li>
@@ -715,7 +720,13 @@ section: Components
 						Third Option
 					</span>
 					<span class="autofit-col">
-						<kbd class="c-kbd c-kbd-inline">⌘+Shift+Y</kbd>
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd
+							><span class="c-kbd-separator">+</span
+							><kbd class="c-kbd">Shift</kbd
+							><span class="c-kbd-separator">+</span
+							><kbd class="c-kbd">Y</kbd>
+						</kbd>
 					</span>
 				</a>
 			</li>
@@ -748,7 +759,10 @@ section: Components
 						Seventh Option
 					</span>
 					<span class="autofit-col">
-						<kbd class="c-kbd c-kbd-inline">⌘P</kbd>
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd
+							><kbd class="c-kbd">P</kbd>
+						</kbd>
 					</span>
 				</a>
 			</li>
@@ -772,7 +786,9 @@ section: Components
 						First Option
 					</span>
 					<span class="autofit-col">
-						<kbd class="c-kbd c-kbd-inline">⌘</kbd>
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd>
+						</kbd>
 					</span>
 				</button>
 			</li>
@@ -782,7 +798,10 @@ section: Components
 						Second Option
 					</span>
 					<span class="autofit-col">
-						<kbd class="c-kbd c-kbd-inline">⌘K</kbd>
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd
+							><kbd class="c-kbd">K</kbd>
+						</kbd>
 					</span>
 				</button>
 			</li>
@@ -793,7 +812,13 @@ section: Components
 						Third Option
 					</span>
 					<span class="autofit-col">
-						<kbd class="c-kbd c-kbd-inline">⌘+Shift+Y</kbd>
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd
+							><span class="c-kbd-separator">+</span
+							><kbd class="c-kbd">Shift</kbd
+							><span class="c-kbd-separator">+</span
+							><kbd class="c-kbd">Y</kbd>
+						</kbd>
 					</span>
 				</button>
 			</li>
@@ -826,7 +851,10 @@ section: Components
 						Seventh Option
 					</span>
 					<span class="autofit-col">
-						<kbd class="c-kbd c-kbd-inline">⌘P</kbd>
+						<kbd class="c-kbd c-kbd-inline">
+							<kbd class="c-kbd">⌘</kbd
+							><kbd class="c-kbd">P</kbd>
+						</kbd>
 					</span>
 				</button>
 			</li>

--- a/packages/clay-css/src/content/typography_kbd.html
+++ b/packages/clay-css/src/content/typography_kbd.html
@@ -15,8 +15,76 @@ section: Elements
 		<kbd class="c-kbd">Ctrl</kbd>
 		<kbd class="c-kbd">Shift</kbd>
 		<kbd class="c-kbd">Alt</kbd>
-		<kbd class="c-kbd">&#8984;+Shift+Y</kbd>
-		<kbd class="c-kbd">&#8984;P</kbd>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Nested C Kbd</h3>
+
+		<blockquote class="blockquote">
+			<p>Nest multiple <code>c-kbd</code> elements inside a single <code>c-kbd</code> element to describe a keyboard command comprising of multiple keys.</p>
+		</blockquote>
+
+		<kbd class="c-kbd">
+			<kbd class="c-kbd">&#8984;</kbd
+			><span class="c-kbd-separator">+</span
+			><kbd class="c-kbd">Shift</kbd
+			><span class="c-kbd-separator">+</span
+			><kbd class="c-kbd">Y</kbd>
+		</kbd>
+		<kbd class="c-kbd">
+			<kbd class="c-kbd">&#8984;</kbd
+			><kbd class="c-kbd">P</kbd>
+		</kbd>
+		<br />
+
+		<kbd class="c-kbd c-kbd-inline">
+			<kbd class="c-kbd">&#8984;</kbd
+			><span class="c-kbd-separator">+</span
+			><kbd class="c-kbd">Shift</kbd
+			><span class="c-kbd-separator">+</span
+			><kbd class="c-kbd">Y</kbd>
+		</kbd>
+		<kbd class="c-kbd c-kbd-inline">
+			<kbd class="c-kbd">&#8984;</kbd
+			><kbd class="c-kbd">P</kbd>
+		</kbd>
+		<br />
+
+		<kbd class="c-kbd">
+			<kbd class="c-kbd c-kbd-light">&#8984;</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd c-kbd-light">Shift</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd c-kbd-light">Y</kbd>
+		</kbd>
+		<kbd class="c-kbd c-kbd-light">
+			<kbd class="c-kbd">&#8984;</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd">Shift</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd">Y</kbd>
+		</kbd>
+		<kbd class="c-kbd c-kbd-dark">
+			<kbd class="c-kbd">&#8984;</kbd
+			><kbd class="c-kbd">P</kbd>
+		</kbd>
+		<br />
+
+		<kbd class="c-kbd c-kbd-dark c-kbd-sm">
+			<kbd class="c-kbd">&#8984;</kbd
+			><kbd class="c-kbd">P</kbd>
+		</kbd>
+		<br />
+
+		<kbd class="c-kbd c-kbd-light c-kbd-lg">
+			<kbd class="c-kbd">&#8984;</kbd
+			><span class="c-kbd-separator">+</span
+			><kbd class="c-kbd">Shift</kbd
+			><span class="c-kbd-separator">+</span
+			><kbd class="c-kbd">Y</kbd>
+		</kbd>
 	</div>
 </div>
 
@@ -46,14 +114,27 @@ section: Elements
 
 		<blockquote class="blockquote">
 			<p>No minimum width or height <code>kbd</code> element with <code>padding: 0</code> and <code>border-width: 0</code>. This is generally used to display keyboard shortcuts in small spaces such as <code>dropdown-item</code>.</p>
+			<p>The most robust markup to use is nested kbd elements (e.g., <code>```<kbd class="c-kbd c-kbd-inline"><kbd class="c-kbd">key</kbd></kbd>```</code>), but the markup <code>```<kbd class="c-kbd c-kbd-inline">key1</kbd>```</code> works as well.</p>
 		</blockquote>
 
 		<kbd class="c-kbd c-kbd-inline">Esc</kbd>
 		<kbd class="c-kbd c-kbd-inline">Ctrl</kbd>
 		<kbd class="c-kbd c-kbd-inline">Shift</kbd>
-		<kbd class="c-kbd c-kbd-inline">Alt</kbd>
-		<kbd class="c-kbd c-kbd-inline">&#8984;+Shift+Y</kbd>
-		<kbd class="c-kbd c-kbd-inline">&#8984;P</kbd>
+		<kbd class="c-kbd c-kbd-inline">
+			<kbd class="c-kbd">Alt</kbd>
+		</kbd>
+		<kbd class="c-kbd c-kbd-inline">
+			<kbd class="c-kbd">&#8984;</kbd
+			><span class="c-kbd-separator">+</span
+			><kbd class="c-kbd">Shift</kbd
+			><span class="c-kbd-separator">+</span
+			><kbd class="c-kbd">Y</kbd>
+		</kbd>
+		<kbd class="c-kbd c-kbd-inline">
+			<kbd class="c-kbd">&#8984;</kbd
+			><kbd class="c-kbd">P</kbd>
+		</kbd>
+		<kbd class="c-kbd c-kbd-inline">&#8984;</kbd><kbd class="c-kbd c-kbd-inline">O</kbd>
 	</div>
 </div>
 
@@ -66,7 +147,21 @@ section: Elements
 		</blockquote>
 
 		<span class="c-kbd-group">
-			Press <kbd class="c-kbd">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced">N</kbd> to see an amazing effect.
+			Press
+			<kbd class="c-kbd">Esc</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd c-kbd-monospaced">N</kbd>
+			to see an amazing effect.
+		</span>
+		<br/>
+		<span class="c-kbd-group">
+			Press
+			<kbd class="c-kbd c-kbd-light">
+				<kbd class="c-kbd">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd">N</kbd>
+			</kbd>
+			to see an amazing effect.
 		</span>
 	</div>
 </div>
@@ -75,7 +170,9 @@ section: Elements
 	<div class="col-md-12">
 		<h3>C Kbd Light</h3>
 
-		<kbd class="c-kbd c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+		<kbd class="c-kbd c-kbd-light">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
 	</div>
 </div>
 
@@ -83,7 +180,9 @@ section: Elements
 	<div class="col-md-12">
 		<h3>C Kbd Dark</h3>
 
-		<kbd class="c-kbd c-kbd-dark">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+		<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+		<span class="c-kbd-separator">+</span>
+		<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
 	</div>
 </div>
 
@@ -91,11 +190,27 @@ section: Elements
 	<div class="col-md-12">
 		<h3>C Kbd Group Light with C Kbd Light / Dark</h3>
 
+		<blockquote class="blockquote">
+			<p><code>c-kbd-group-light</code> changes the text color lighter and nested <code>c-kbd-light</code> and <code>c-kbd-dark</code> elements can be used interchangebly.</p>
+		</blockquote>
+
 		<div class="c-mb-2">
-			<span class="c-kbd-group c-kbd-group-light">Press <kbd class="c-kbd c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.</span>
+			<span class="c-kbd-group c-kbd-group-light">
+				Press
+				<kbd class="c-kbd c-kbd-light">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+				to see an amazing effect.
+			</span>
 		</div>
 		<div>
-			<span class="c-kbd-group c-kbd-group-light">Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing effect.</span>
+			<span class="c-kbd-group c-kbd-group-light">
+				Press
+				<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+				to see an amazing effect.
+			</span>
 		</div>
 	</div>
 </div>
@@ -104,11 +219,27 @@ section: Elements
 	<div class="col-md-12">
 		<h3>C Kbd Group Dark with C Kbd Light / Dark</h3>
 
+		<blockquote class="blockquote">
+			<p><code>c-kbd-group-dark</code> changes the text color darker and nested <code>c-kbd-light</code> and <code>c-kbd-dark</code> elements can be used interchangebly.</p>
+		</blockquote>
+
 		<div class="c-mb-2" style="background-color:#1C1C24;padding: 10px;">
-			<span class="c-kbd-group c-kbd-group-dark">Press <kbd class="c-kbd c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.</span>
+			<span class="c-kbd-group c-kbd-group-dark">
+				Press
+				<kbd class="c-kbd c-kbd-light">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+				to see an amazing effect.
+			</span>
 		</div>
 		<div style="background-color:#1C1C24;padding: 10px;">
-			<span class="c-kbd-group c-kbd-group-dark">Press <kbd class="c-kbd c-kbd-dark">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd> to see an amazing effect.</span>
+			<span class="c-kbd-group c-kbd-group-dark">
+				Press
+				<kbd class="c-kbd c-kbd-dark">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-dark">N</kbd>
+				to see an amazing effect.
+			</span>
 		</div>
 	</div>
 </div>
@@ -118,10 +249,18 @@ section: Elements
 		<h3>C Kbd Sm</h3>
 
 		<div class="c-mb-2">
-			<kbd class="c-kbd c-kbd-sm c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-sm c-kbd-monospaced c-kbd-light">N</kbd>
+			<kbd class="c-kbd c-kbd-sm c-kbd-light">Esc</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd c-kbd-sm c-kbd-monospaced c-kbd-light">N</kbd>
 		</div>
 		<div>
-			<span class="c-kbd-group c-kbd-group-sm c-kbd-group-light">Press <kbd class="c-kbd c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.</span>
+			<span class="c-kbd-group c-kbd-group-sm c-kbd-group-light">
+				Press
+				<kbd class="c-kbd c-kbd-light">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+				to see an amazing effect.
+			</span>
 		</div>
 
 	</div>
@@ -132,10 +271,18 @@ section: Elements
 		<h3>C Kbd Lg</h3>
 
 		<div class="c-mb-2">
-			<kbd class="c-kbd c-kbd-lg c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-lg c-kbd-monospaced c-kbd-light">N</kbd>
+			<kbd class="c-kbd c-kbd-lg c-kbd-light">Esc</kbd>
+			<span class="c-kbd-separator">+</span>
+			<kbd class="c-kbd c-kbd-lg c-kbd-monospaced c-kbd-light">N</kbd>
 		</div>
 		<div>
-			<span class="c-kbd-group c-kbd-group-lg c-kbd-group-light">Press <kbd class="c-kbd c-kbd-light">Esc</kbd> + <kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd> to see an amazing effect.</span>
+			<span class="c-kbd-group c-kbd-group-lg c-kbd-group-light">
+				Press
+				<kbd class="c-kbd c-kbd-light">Esc</kbd>
+				<span class="c-kbd-separator">+</span>
+				<kbd class="c-kbd c-kbd-monospaced c-kbd-light">N</kbd>
+				to see an amazing effect.
+			</span>
 		</div>
 
 	</div>

--- a/packages/clay-css/src/scss/components/_type.scss
+++ b/packages/clay-css/src/scss/components/_type.scss
@@ -199,44 +199,91 @@ strong {
 
 .c-kbd-group {
 	@include clay-css($c-kbd-group);
+
+	> .c-kbd {
+		font-size: inherit;
+	}
 }
 
 .c-kbd {
 	@include clay-css($c-kbd);
 }
 
+// Nested Kbd
+
+.c-kbd {
+	> .c-kbd {
+		@include clay-css($c-kbd-c-kbd);
+
+		&[class*='c-kbd-'] {
+			border-width: inherit;
+			height: inherit;
+			min-width: inherit;
+			padding: inherit;
+
+			&:first-child {
+				margin-left: math-sign(map-get($c-kbd, padding-left));
+			}
+
+			&:last-child {
+				margin-right: math-sign(map-get($c-kbd, padding-right));
+			}
+		}
+	}
+
+	> .c-kbd.c-kbd-monospaced {
+		@include clay-css($c-kbd-monospaced);
+	}
+
+	> .c-kbd-separator {
+		@include clay-css($c-kbd-c-kbd-separator);
+	}
+}
+
+// Kbd Monospaced
+
 .c-kbd-monospaced {
 	@include clay-css($c-kbd-monospaced);
 }
 
+// Kbd Inline
+
 .c-kbd-inline {
 	@include clay-css($c-kbd-inline);
+
+	.c-kbd-separator {
+		@include clay-css($c-kbd-inline-c-kbd-separator);
+	}
 }
 
-// Kbd Sizes
+// Kbd Sm
+
+%c-kbd-sm {
+	@include clay-css($c-kbd-sm);
+}
 
 .c-kbd-group-sm {
 	@include clay-css($c-kbd-group-sm);
+}
 
-	.c-kbd {
-		font-size: inherit;
-	}
+.c-kbd-sm,
+.c-kbd.c-kbd-sm {
+	@extend %c-kbd-sm !optional;
+}
+
+// Kbd Lg
+
+%c-kbd-lg {
+	@include clay-css($c-kbd-lg);
 }
 
 .c-kbd-group-lg {
 	@include clay-css($c-kbd-group-lg);
-
-	.c-kbd {
-		font-size: inherit;
-	}
 }
 
-.c-kbd.c-kbd-sm {
-	@include clay-css($c-kbd-sm);
-}
-
+.c-kbd-lg,
 .c-kbd.c-kbd-lg {
-	@include clay-css($c-kbd-lg);
+	@extend %c-kbd-lg !optional;
 }
 
 // Kbd Light

--- a/packages/clay-css/src/scss/variables/_type.scss
+++ b/packages/clay-css/src/scss/variables/_type.scss
@@ -7,6 +7,8 @@ $reference-mark-vertical-align: super !default;
 
 $mark-color: null !default;
 
+// C Kbd
+
 $c-kbd-group: () !default;
 $c-kbd-group: map-deep-merge(
 	(
@@ -32,11 +34,30 @@ $c-kbd: map-deep-merge(
 		height: 1.5rem,
 		line-height: 1.375rem,
 		min-width: 1.5rem,
-		padding: 0 0.3125rem,
+		padding-bottom: 0,
+		padding-left: 0.3125rem,
+		padding-right: 0.3125rem,
+		padding-top: 0,
 		text-align: center,
 		text-transform: capitalize,
 	),
 	$c-kbd
+);
+
+// .c-kbd > .c-kbd
+
+$c-kbd-c-kbd: () !default;
+$c-kbd-c-kbd: map-merge(
+	(
+		border-width: 0,
+		font-size: inherit,
+		font-weight: inherit,
+		height: auto,
+		line-height: inherit,
+		min-width: 0,
+		padding: 0,
+	),
+	$c-kbd-c-kbd
 );
 
 $c-kbd-monospaced: () !default;
@@ -58,6 +79,28 @@ $c-kbd-inline: map-deep-merge(
 		padding: 0,
 	),
 	$c-kbd-inline
+);
+
+// Kbd Separator
+
+// .c-kbd > .c-kbd-separator
+
+$c-kbd-c-kbd-separator: () !default;
+$c-kbd-c-kbd-separator: map-merge(
+	(
+		font-weight: $font-weight-normal,
+	),
+	$c-kbd-c-kbd-separator
+);
+
+// .c-kbd-inline > .c-kbd-separator
+
+$c-kbd-inline-c-kbd-separator: () !default;
+$c-kbd-inline-c-kbd-separator: map-merge(
+	(
+		font-weight: inherit,
+	),
+	$c-kbd-inline-c-kbd-separator
 );
 
 // Kbd Sizes


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd#Representing_keystrokes_within_an_input is the reason for this update.

fixes #3283
