### PR TITLE
fix(@clayui/css): Table `.table` should have 1px borders

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_tables.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tables.scss
@@ -98,11 +98,12 @@ $table-link: map-deep-merge(
 
 // Table List
 
+$table-list-border-color: $gray-300 !default;
+$table-list-color: $body-color !default;
+
 $table-list-accent-bg: $gray-100 !default;
 $table-list-hover-bg: $table-hover-bg !default;
 $table-list-active-bg: $table-list-hover-bg !default;
-$table-list-border-color: $gray-300 !default;
-$table-list-color: $body-color !default;
 
 $table-list-disabled-color: $gray-500 !default;
 

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -259,7 +259,7 @@ button,
 [type='button'],
 [type='reset'],
 [type='submit'] {
-	@include clay-css($c-button);
+	@include clay-css($c-button-base);
 }
 
 // Remove inner border from Firefox, but don't restore the outline like Normalize.

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -1,10 +1,9 @@
 table {
-	border-collapse: separate;
+	@include clay-css($c-table-base);
 }
 
 th {
-	height: 20px;
-	text-align: left;
+	@include clay-css($c-th-base);
 }
 
 .table-head-title {
@@ -32,7 +31,7 @@ th {
 	thead {
 		td,
 		th {
-			// Webkit rendering issue with responsive-tables
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 
 			background-color: $table-head-bg;
 			border-bottom: $table-head-border-bottom-width solid
@@ -47,6 +46,7 @@ th {
 	}
 
 	th {
+		background-clip: padding-box;
 		border-top: $table-border-width solid $table-border-color;
 		color: $table-head-color;
 		font-size: $table-head-font-size;
@@ -58,6 +58,7 @@ th {
 	}
 
 	td {
+		background-clip: padding-box;
 		border-bottom-width: $table-data-border-bottom-width;
 		border-left-width: $table-data-border-left-width;
 		border-right-width: $table-data-border-right-width;
@@ -86,7 +87,7 @@ th {
 	tfoot {
 		td,
 		th {
-			// Webkit rendering issue with responsive-tables
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 
 			background-color: $table-bg;
 		}
@@ -202,6 +203,7 @@ th {
 .table-hover {
 	tbody tr {
 		&:hover {
+			&,
 			td,
 			th {
 				color: $table-hover-color;
@@ -248,6 +250,7 @@ th {
 }
 
 .table-hover .table-disabled:hover {
+	&,
 	> td,
 	> th {
 		background-color: $table-disabled-bg;
@@ -366,8 +369,8 @@ th {
 // Table List Skin
 
 .table-list {
-	@include border-radius($table-list-border-radius);
-
+	border-collapse: separate;
+	border-radius: clay-enable-rounded($table-list-border-radius);
 	color: $table-list-color;
 	font-size: $table-list-font-size;
 	margin-bottom: $table-list-margin-bottom;
@@ -381,17 +384,17 @@ th {
 				th:first-child,
 				td:first-child,
 				.table-cell-start {
-					@if $enable-rounded {
-						border-top-left-radius: $table-list-border-radius;
-					}
+					border-top-left-radius: clay-enable-rounded(
+						$table-list-border-radius
+					);
 				}
 
 				th:last-child,
 				td:last-child,
 				.table-cell-end {
-					@if $enable-rounded {
-						border-top-right-radius: $table-list-border-radius;
-					}
+					border-top-right-radius: clay-enable-rounded(
+						$table-list-border-radius
+					);
 				}
 			}
 		}
@@ -401,17 +404,17 @@ th {
 				th:first-child,
 				td:first-child,
 				.table-cell-start {
-					@if $enable-rounded {
-						border-bottom-left-radius: $table-list-border-radius;
-					}
+					border-bottom-left-radius: clay-enable-rounded(
+						$table-list-border-radius
+					);
 				}
 
 				th:last-child,
 				td:last-child,
 				.table-cell-end {
-					@if $enable-rounded {
-						border-bottom-right-radius: $table-list-border-radius;
-					}
+					border-bottom-right-radius: clay-enable-rounded(
+						$table-list-border-radius
+					);
 				}
 			}
 		}
@@ -419,29 +422,29 @@ th {
 
 	.table-row-start {
 		.table-cell-start {
-			@if $enable-rounded {
-				border-top-left-radius: $table-list-border-radius;
-			}
+			border-top-left-radius: clay-enable-rounded(
+				$table-list-border-radius
+			);
 		}
 
 		.table-cell-end {
-			@if $enable-rounded {
-				border-top-right-radius: $table-list-border-radius;
-			}
+			border-top-right-radius: clay-enable-rounded(
+				$table-list-border-radius
+			);
 		}
 	}
 
 	.table-row-end {
 		.table-cell-start {
-			@if $enable-rounded {
-				border-bottom-left-radius: $table-list-border-radius;
-			}
+			border-bottom-left-radius: clay-enable-rounded(
+				$table-list-border-radius
+			);
 		}
 
 		.table-cell-end {
-			@if $enable-rounded {
-				border-bottom-right-radius: $table-list-border-radius;
-			}
+			border-bottom-right-radius: clay-enable-rounded(
+				$table-list-border-radius
+			);
 		}
 	}
 
@@ -503,7 +506,7 @@ th {
 	thead {
 		td,
 		th {
-			// Webkit rendering issue with responsive-tables
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 
 			background-color: $table-list-head-bg;
 			border-width: 0;
@@ -522,7 +525,7 @@ th {
 	tfoot {
 		td,
 		th {
-			// Webkit rendering issue with responsive-tables
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 
 			background-color: $table-list-bg;
 			border-width: 0;
@@ -572,6 +575,7 @@ th {
 .table-list.table-hover {
 	tbody tr {
 		&:hover {
+			&,
 			td,
 			th {
 				background-color: $table-list-hover-bg;
@@ -585,8 +589,7 @@ th {
 .table-list.table-hover {
 	.table-active {
 		&:hover {
-			background-color: $table-list-active-bg;
-
+			&,
 			> th,
 			> td {
 				background-color: $table-list-active-bg;
@@ -606,6 +609,7 @@ th {
 // Table List Disabled
 
 .table-list .table-disabled {
+	background-color: $table-list-disabled-bg;
 	color: $table-list-disabled-color;
 
 	> td,
@@ -626,6 +630,7 @@ th {
 }
 
 .table-list.table-hover .table-disabled:hover {
+	&,
 	> td,
 	> th {
 		background-color: $table-list-disabled-bg;
@@ -634,6 +639,7 @@ th {
 
 .table-list.table-striped {
 	tbody .table-disabled:nth-of-type(#{$table-striped-order}) {
+		&,
 		td,
 		th {
 			background-color: $table-list-disabled-bg;

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -116,11 +116,11 @@ $body-moz-osx-font-smoothing: $moz-osx-font-smoothing !default;
 $body-webkit-font-smoothing: $webkit-font-smoothing !default;
 $body-text-align: inherit !default;
 
-$c-button: () !default;
-$c-button: map-merge(
+$c-button-base: () !default;
+$c-button-base: map-merge(
 	(
 		cursor: $link-cursor,
 		-webkit-appearance: button,
 	),
-	$c-button
+	$c-button-base
 );

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -1,3 +1,26 @@
+// <table> element
+
+$c-table-base: () !default;
+$c-table-base: map-merge(
+	(
+		border-collapse: collapse,
+	),
+	$c-table-base
+);
+
+// <th> element
+
+$c-th-base: () !default;
+$c-th-base: map-merge(
+	(
+		height: 20px,
+		text-align: left,
+	),
+	$c-th-base
+);
+
+// Table Responsive
+
 $table-responsive-margin-bottom: 1.5rem !default;
 
 // Table
@@ -125,7 +148,18 @@ $table-img-max-height: 100px !default;
 // Table List
 
 $table-list-bg: $white !default;
+$table-list-border-color: $table-border-color !default;
+$table-list-border-x-width: 0.0625rem !default;
+$table-list-border-y-width: 0.0625rem !default;
+
+$table-list-border-width: $table-list-border-y-width $table-list-border-x-width !default;
+
+$table-list-border-radius: $border-radius !default;
 $table-list-color: null !default;
+$table-list-font-size: null !default;
+$table-list-margin-bottom: $table-list-border-y-width !default;
+$table-list-margin-top: null !default;
+
 $table-list-accent-bg: #f2f2f2 !default;
 $table-list-hover-bg: #ececec !default;
 $table-list-active-bg: #dadada !default;
@@ -134,18 +168,6 @@ $table-list-disabled-bg: $white !default;
 $table-list-disabled-color: #acacac !default;
 $table-list-disabled-cursor: $disabled-cursor !default;
 $table-list-disabled-pointer-events: none !default;
-
-$table-list-border-color: $table-border-color !default;
-
-$table-list-border-x-width: 0.0625rem !default; // 1px
-$table-list-border-y-width: 0.0625rem !default; // 1px
-
-$table-list-border-width: $table-list-border-y-width $table-list-border-x-width !default;
-
-$table-list-border-radius: $border-radius !default;
-$table-list-font-size: null !default;
-$table-list-margin-bottom: $table-list-border-y-width !default;
-$table-list-margin-top: null !default;
 
 $table-list-head-bg: null !default;
 $table-list-head-font-size: null !default;


### PR DESCRIPTION
fix(@clayui/css): Table `.table` should have 1px borders

feat(@clayui/css): Table adds Sass maps `$c-table-base` and `$c-th-base` for styling base `table` and `th` elements

fix(@clayui/css): `variables/_globals.scss` and `components/_reboot.scss` rename `$c-button` Sass map, added in #3575, to `$c-button-base`. This namespace references a base element, in this case, `<button>`. This is to free up the variable namespace `$c-button` to refer to `.button` if we ever need it in the future.

fix(@clayui/css): Table use function `clay-enable-rounded` to support `$enable-rounded` variable instead of Bootstraps `border-radius` mixin / inlining `if` check
    
chore(@clayui/css): Table reorganize `$table-list-*` variables so properties for `.table-list` are grouped together

fixes #3592