### PR TITLE
fix(clay-css): 2.x Table `.table` should have 1px borders

### DIFF
--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -1,7 +1,3 @@
-table {
-	border-collapse: separate;
-}
-
 th {
 	height: 20px;
 	text-align: left;
@@ -22,14 +18,13 @@ th {
 }
 
 .table {
-	border-spacing: 0;
 	font-size: $table-font-size;
 	margin-bottom: $table-margin-bottom;
 
 	thead {
 		td,
 		th {
-			// Webkit rendering issue with responsive-tables
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 			background-color: $table-head-bg;
 			border-bottom-width: $table-head-border-bottom-width;
 			border-top-width: $table-head-border-top-width;
@@ -41,6 +36,7 @@ th {
 	}
 
 	th {
+		background-clip: padding-box;
 		color: $table-head-color;
 		font-size: $table-head-font-size;
 		font-weight: $table-head-font-weight;
@@ -49,6 +45,7 @@ th {
 	}
 
 	td {
+		background-clip: padding-box;
 		border-bottom-width: $table-data-border-bottom-width;
 		border-left-width: $table-data-border-left-width;
 		border-right-width: $table-data-border-right-width;
@@ -76,7 +73,7 @@ th {
 	tfoot {
 		td,
 		th {
-			// Webkit rendering issue with responsive-tables
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 			background-color: $table-bg;
 		}
 	}
@@ -148,6 +145,7 @@ th {
 
 .table-striped {
 	tbody tr:nth-of-type(#{$table-striped-order}) {
+		&,
 		td,
 		th {
 			background-color: $table-accent-bg;
@@ -160,6 +158,7 @@ th {
 .table-hover {
 	tbody tr {
 		&:hover {
+			&,
 			td,
 			th {
 				background-color: $table-hover-bg;
@@ -171,6 +170,7 @@ th {
 // Table Active
 
 .table .table-active {
+	&,
 	> td,
 	> th {
 		background-color: $table-active-bg;
@@ -180,6 +180,7 @@ th {
 // Table Disabled
 
 .table-disabled {
+	background-color: $table-disabled-bg;
 	color: $table-disabled-color;
 
 	> td,
@@ -200,6 +201,7 @@ th {
 }
 
 .table-hover .table-disabled:hover {
+	&,
 	> td,
 	> th {
 		background-color: $table-disabled-bg;
@@ -208,6 +210,7 @@ th {
 
 .table-striped {
 	tbody .table-disabled:nth-of-type(#{$table-striped-order}) {
+		&,
 		td,
 		th {
 			background-color: $table-disabled-bg;
@@ -240,6 +243,9 @@ th {
 // Table List Skin
 
 .table-list {
+	border-collapse: separate;
+	border-spacing: 0;
+
 	@include border-radius($table-list-border-radius);
 
 	color: $table-list-color;
@@ -371,7 +377,7 @@ th {
 	thead {
 		td,
 		th {
-			// Webkit rendering issue with responsive-tables
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 			background-color: $table-list-head-bg;
 			border-width: 0;
 			font-size: $table-list-head-font-size;
@@ -389,7 +395,7 @@ th {
 	tfoot {
 		td,
 		th {
-			// Webkit rendering issue with responsive-tables
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 			background-color: $table-list-bg;
 			border-width: 0;
 			vertical-align: middle;
@@ -424,6 +430,7 @@ th {
 
 .table-list.table-striped {
 	tbody tr:nth-of-type(#{$table-striped-order}) {
+		&,
 		td,
 		th {
 			background-color: $table-list-accent-bg;
@@ -436,6 +443,7 @@ th {
 .table-list.table-hover {
 	tbody tr {
 		&:hover {
+			&,
 			td,
 			th {
 				background-color: $table-list-hover-bg;
@@ -470,6 +478,7 @@ th {
 // Table List Disabled
 
 .table-list .table-disabled {
+	background-color: $table-list-disabled-bg;
 	color: $table-list-disabled-color;
 
 	> td,
@@ -490,6 +499,7 @@ th {
 }
 
 .table-list.table-hover .table-disabled:hover {
+	&,
 	> td,
 	> th {
 		background-color: $table-list-disabled-bg;
@@ -498,6 +508,7 @@ th {
 
 .table-list.table-striped {
 	tbody .table-disabled:nth-of-type(#{$table-striped-order}) {
+		&,
 		td,
 		th {
 			background-color: $table-list-disabled-bg;
@@ -573,6 +584,8 @@ th {
 }
 
 .table .table-divider {
+	background-color: $table-divider-bg;
+
 	td,
 	th {
 		background-color: $table-divider-bg;


### PR DESCRIPTION
issue #3592