### PR TITLE
fix(@clayui/color-picker): fix native usage across browsers

### DIFF
--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -7,9 +7,9 @@ exports[`Interactions opens custom color picker drop down when clicked 1`] = `
   >
     <input
       name="colorPicker2"
-      style="display: none;"
+      style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
       type="text"
-      value="008000"
+      value="#008000"
     />
     <label>
       Custom Colors
@@ -63,9 +63,9 @@ exports[`Rendering default 1`] = `
     >
       <input
         name="colorPicker1"
-        style="display: none;"
+        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
         type="text"
-        value="FFF"
+        value="#FFF"
       />
       <label>
         Default
@@ -438,9 +438,9 @@ exports[`Rendering disabled palette 1`] = `
     >
       <input
         name="colorPicker1"
-        style="display: none;"
+        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
         type="text"
-        value="FFF"
+        value="#FFF"
       />
       <label>
         Default
@@ -813,9 +813,9 @@ exports[`Rendering disabled state 1`] = `
     >
       <input
         name="colorPicker1"
-        style="display: none;"
+        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
         type="text"
-        value="FFF"
+        value="#FFF"
       />
       <label>
         Default
@@ -1182,6 +1182,381 @@ exports[`Rendering disabled state 1`] = `
 </body>
 `;
 
+exports[`Rendering renders with a hash for the value 1`] = `
+<body>
+  <div>
+    <div
+      class="clay-color-picker"
+    >
+      <input
+        name="colorPicker1"
+        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
+        type="text"
+        value="#FFF"
+      />
+      <label>
+        Default
+      </label>
+      <div
+        class="input-group clay-color"
+      >
+        <div
+          class="input-group-item input-group-item-shrink input-group-prepend"
+        >
+          <div
+            class="input-group-text"
+          >
+            <button
+              aria-label="Select a color"
+              class="btn clay-color-btn dropdown-toggle clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
+              title="FFF"
+              type="button"
+            />
+          </div>
+        </div>
+        <div
+          class="input-group-item input-group-append"
+        >
+          <input
+            aria-label="Color selection is FFF"
+            class="form-control input-group-inset input-group-inset-before"
+            type="text"
+            value="FFF"
+          />
+          <label
+            class="input-group-inset-item input-group-inset-item-before"
+          >
+            #
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div>
+      <div
+        class="dropdown-menu clay-color-dropdown-menu"
+      >
+        <div
+          class="clay-color-header"
+        >
+          <span
+            class="component-title"
+          >
+            Default Colors
+          </span>
+        </div>
+        <div
+          class="clay-color-swatch"
+        >
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(0, 0, 0);"
+              title="000000"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(95, 95, 95);"
+              title="5F5F5F"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(154, 154, 154);"
+              title="9A9A9A"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(203, 203, 203);"
+              title="CBCBCB"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(225, 225, 225);"
+              title="E1E1E1"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
+              title="FFFFFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 13, 13);"
+              title="FF0D0D"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 138, 28);"
+              title="FF8A1C"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(43, 166, 118);"
+              title="2BA676"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(0, 110, 248);"
+              title="006EF8"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(127, 38, 255);"
+              title="7F26FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 33, 160);"
+              title="FF21A0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 95, 95);"
+              title="FF5F5F"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 180, 110);"
+              title="FFB46E"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(80, 210, 160);"
+              title="50D2A0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(75, 155, 255);"
+              title="4B9BFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(175, 120, 255);"
+              title="AF78FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 115, 195);"
+              title="FF73C3"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 177, 177);"
+              title="FFB1B1"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 222, 192);"
+              title="FFDEC0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(145, 227, 195);"
+              title="91E3C3"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(157, 200, 255);"
+              title="9DC8FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(223, 202, 255);"
+              title="DFCAFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 197, 230);"
+              title="FFC5E6"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 217, 217);"
+              title="FFD9D9"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 243, 232);"
+              title="FFF3E8"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(177, 235, 213);"
+              title="B1EBD5"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(197, 223, 255);"
+              title="C5DFFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(248, 242, 255);"
+              title="F8F2FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 237, 247);"
+              title="FFEDF7"
+              type="button"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`Rendering small color-picker 1`] = `
 <body>
   <div>
@@ -1190,9 +1565,9 @@ exports[`Rendering small color-picker 1`] = `
     >
       <input
         name="colorPicker1"
-        style="display: none;"
+        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
         type="text"
-        value="FFF"
+        value="#FFF"
       />
       <label>
         Small

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -41,6 +41,21 @@ describe('Rendering', () => {
 		expect(document.body).toMatchSnapshot();
 	});
 
+	it('renders with a hash for the value', () => {
+		render(
+			<ClayColorPicker
+				label="Default Colors"
+				name="colorPicker1"
+				onValueChange={() => {}}
+				spritemap="/test/path"
+				title="Default"
+				value="#FFF"
+			/>
+		);
+
+		expect(document.body).toMatchSnapshot();
+	});
+
 	it('small color-picker', () => {
 		render(
 			<ClayColorPicker

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -149,6 +149,14 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	value = 'FFFFFF',
 	...otherProps
 }: IProps) => {
+	if (value.indexOf('#') === 0) {
+		value = value.slice(1);
+	}
+
+	if (useNative && window.navigator.userAgent.indexOf('MSIE') !== -1) {
+		useNative = false;
+	}
+
 	const triggerElementRef = React.useRef<HTMLDivElement>(null);
 	const dropdownContainerRef = React.useRef<HTMLDivElement>(null);
 	const inputRef = React.useRef<HTMLInputElement>(null);
@@ -174,9 +182,15 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 							useNative ? onValueChange(e.target.value) : null
 						}
 						ref={valueInputRef}
-						style={{display: 'none'}}
+						style={{
+							height: 0,
+							margin: 0,
+							padding: 0,
+							visibility: 'hidden',
+							width: 0,
+						}}
 						type={useNative ? 'color' : 'text'}
-						value={value}
+						value={`#${hexInputValue}`}
 					/>
 				)}
 

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -153,7 +153,18 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 		value = value.slice(1);
 	}
 
-	if (useNative && window.navigator.userAgent.indexOf('MSIE') !== -1) {
+	const inputColorTypeSupport = React.useMemo(() => {
+		if (typeof document !== 'undefined') {
+			var input = document.createElement('input');
+			input.setAttribute('type', 'color');
+
+			return input.value !== '';
+		}
+
+		return true;
+	}, []);
+
+	if (!inputColorTypeSupport) {
 		useNative = false;
 	}
 


### PR DESCRIPTION
fixes #3524

This addresses several issues with native mode
1. Native shoudl now work across browsers
3. If browser is IE11, we use don't use type="color" since it is not supported

One change was for type="color", we were using hex values without the hash, however this wrong since the html specification says the value must include a hash.