### PR TITLE
fix(@clayui/color-picker): splotch should get focus if menu is closed via 'esc'

### DIFF
--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -233,6 +233,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 						active={active}
 						alignElementRef={triggerElementRef}
 						className="clay-color-dropdown-menu"
+						focusRefOnEsc={splotchRef}
 						onSetActive={setActive}
 						ref={dropdownContainerRef}
 					>

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -133,6 +133,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	hasRightSymbols?: boolean;
 
 	/**
+	 * Element ref to call focus() on after menu is closed via Escape key
+	 */
+	focusRefOnEsc?: React.RefObject<HTMLElement>;
+
+	/**
 	 * Function for setting the offset of the menu from the trigger.
 	 */
 	offsetFn?: (points: TPointOptions) => [number, number];
@@ -154,6 +159,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 			className,
 			hasLeftSymbols,
 			hasRightSymbols,
+			focusRefOnEsc,
 			offsetFn = (points) =>
 				OFFSET_MAP[points.join('') as keyof typeof OFFSET_MAP] as [
 					number,
@@ -171,7 +177,8 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 
 		useDropdownCloseInteractions(
 			[alignElementRef, subPortalRef],
-			onSetActive
+			onSetActive,
+			focusRefOnEsc
 		);
 
 		React.useLayoutEffect(() => {

--- a/packages/clay-drop-down/src/hooks.ts
+++ b/packages/clay-drop-down/src/hooks.ts
@@ -13,7 +13,8 @@ export function useDropdownCloseInteractions(
 	nodeRefs:
 		| React.RefObject<HTMLElement>
 		| Array<React.RefObject<HTMLElement>>,
-	setActive: (val: boolean) => void
+	setActive: (val: boolean) => void,
+	focusRefOnEsc?: React.RefObject<HTMLElement>
 ) {
 	React.useEffect(() => {
 		const handleClick = (event: MouseEvent) => {
@@ -32,8 +33,15 @@ export function useDropdownCloseInteractions(
 			}
 		};
 
-		const handleEsc = (event: KeyboardEvent) =>
-			event.key === Keys.Esc && setActive(false);
+		const handleEsc = (event: KeyboardEvent) => {
+			if (event.key === Keys.Esc) {
+				if (focusRefOnEsc && focusRefOnEsc.current) {
+					focusRefOnEsc.current.focus();
+				}
+
+				return setActive(false);
+			}
+		};
 
 		window.addEventListener('mousedown', handleClick);
 		window.addEventListener('keydown', handleEsc);


### PR DESCRIPTION
fixes #3539

> We should normalize where the focus is placed when closing a color picker menu via keyboard. I think it should always return to the dropdown toggle splotch when the menu closes with esc or enter.