### PR TITLE
fix(clayui.com): Random fixes

### DIFF
--- a/clayui.com/content/docs/components/css-forms-hierarchy.md
+++ b/clayui.com/content/docs/components/css-forms-hierarchy.md
@@ -180,7 +180,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 		</div>
 		<div class="sheet-section">
 			<div class="form-group">
-				<label for="basicInputTypeText">
+				<label for="_yepzzftzb">
 					Screen Name
 					<span class="reference-mark">
 						<svg class="lexicon-icon lexicon-icon-asterisk" focusable="false" role="presentation">
@@ -188,15 +188,15 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 						</svg>
 					</span>
 				</label>
-				<input class="form-control" id="basicInputTypeText" placeholder="Placeholder" type="text">
+				<input class="form-control" id="_yepzzftzb" placeholder="Placeholder" type="text">
 			</div>
 			<div class="form-group">
 				<label for="basicInputTypeEmail">Email</label>
 				<input class="form-control" id="basicInputTypeEmail" type="email">
 			</div>
 			<div class="form-group">
-				<label for="basicInputTypeText">Name</label>
-				<input class="form-control" id="basicInputTypeText" placeholder="Name" type="text">
+				<label for="_3yzci7nce">Name</label>
+				<input class="form-control" id="_3yzci7nce" placeholder="Name" type="text">
 			</div>
 		</div>
 		<div class="sheet-footer sheet-footer-btn-block-sm-down">
@@ -223,7 +223,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 	</div>
 	<div class="sheet-section">
 		<div class="form-group">
-			<label for="basicInputTypeText">
+			<label for="_0rmtn466h">
 				Screen Name
 				<span class="reference-mark">
 					<svg
@@ -237,20 +237,20 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 			</label>
 			<input
 				class="form-control"
-				id="basicInputTypeText"
+				id="_0rmtn466h"
 				placeholder="Placeholder"
 				type="text"
 			/>
 		</div>
 		<div class="form-group">
-			<label for="basicInputTypeEmail">Email</label>
-			<input class="form-control" id="basicInputTypeEmail" type="email" />
+			<label for="_9hslbpuas">Email</label>
+			<input class="form-control" id="_9hslbpuas" type="email" />
 		</div>
 		<div class="form-group">
-			<label for="basicInputTypeText">Name</label>
+			<label for="_javf9wj9l">Name</label>
 			<input
 				class="form-control"
-				id="basicInputTypeText"
+				id="_javf9wj9l"
 				placeholder="Name"
 				type="text"
 			/>
@@ -282,7 +282,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 		<div class="sheet-section">
 			<div class="form-group-autofit">
 				<div class="form-group-item">
-					<label for="basicInputTypeText">
+					<label for="_c0phn4u3q">
 						Screen Name
 						<span class="reference-mark">
 							<svg class="lexicon-icon lexicon-icon-asterisk" focusable="false" role="presentation">
@@ -290,31 +290,31 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 							</svg>
 						</span>
 					</label>
-					<input class="form-control" id="basicInputTypeText" placeholder="Placeholder" type="text">
+					<input class="form-control" id="_c0phn4u3q" placeholder="Placeholder" type="text">
 				</div>
 				<div class="form-group-item">
-					<label for="basicInputTypeText">Birthday</label>
-					<input class="form-control" id="basicInputTypeText" placeholder="Placeholder" type="text" value="01/01/1970">
-				</div>
-			</div>
-			<div class="form-group-autofit">
-				<div class="form-group-item">
-					<label for="basicInputTypeEmail">Email</label>
-					<input class="form-control" id="basicInputTypeEmail" type="email">
-				</div>
-				<div class="form-group-item">
-					<label for="basicInputTypeText">Gender</label>
-					<input class="form-control" id="basicInputTypeText" placeholder="Gender" type="text">
+					<label for="_2nwkgln2x">Birthday</label>
+					<input class="form-control" id="_2nwkgln2x" placeholder="Placeholder" type="text" value="01/01/1970">
 				</div>
 			</div>
 			<div class="form-group-autofit">
 				<div class="form-group-item">
-					<label for="basicInputTypeText">Name</label>
-					<input class="form-control" id="basicInputTypeText" placeholder="Name" type="text">
+					<label for="_iyygmg1c5">Email</label>
+					<input class="form-control" id="_iyygmg1c5" type="email">
 				</div>
 				<div class="form-group-item">
-					<label for="basicInputTypeText">Job Title</label>
-					<input class="form-control" id="basicInputTypeText" placeholder="Job Title" type="text">
+					<label for="_xyx7wo9lq">Gender</label>
+					<input class="form-control" id="_xyx7wo9lq" placeholder="Gender" type="text">
+				</div>
+			</div>
+			<div class="form-group-autofit">
+				<div class="form-group-item">
+					<label for="_hizl88js7">Name</label>
+					<input class="form-control" id="_hizl88js7" placeholder="Name" type="text">
+				</div>
+				<div class="form-group-item">
+					<label for="_3ud138ywq">Job Title</label>
+					<input class="form-control" id="_3ud138ywq" placeholder="Job Title" type="text">
 				</div>
 			</div>
 		</div>
@@ -343,7 +343,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 	<div class="sheet-section">
 		<div class="form-group-autofit">
 			<div class="form-group-item">
-				<label for="basicInputTypeText">
+				<label for="_cab0u4dgi">
 					Screen Name
 					<span class="reference-mark">
 						<svg
@@ -357,16 +357,16 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 				</label>
 				<input
 					class="form-control"
-					id="basicInputTypeText"
+					id="_cab0u4dgi"
 					placeholder="Placeholder"
 					type="text"
 				/>
 			</div>
 			<div class="form-group-item">
-				<label for="basicInputTypeText">Birthday</label>
+				<label for="_y1mdflpv9">Birthday</label>
 				<input
 					class="form-control"
-					id="basicInputTypeText"
+					id="_y1mdflpv9"
 					placeholder="Placeholder"
 					type="text"
 					value="01/01/1970"
@@ -375,18 +375,14 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 		</div>
 		<div class="form-group-autofit">
 			<div class="form-group-item">
-				<label for="basicInputTypeEmail">Email</label>
-				<input
-					class="form-control"
-					id="basicInputTypeEmail"
-					type="email"
-				/>
+				<label for="_jcrc07o9v">Email</label>
+				<input class="form-control" id="_jcrc07o9v" type="email" />
 			</div>
 			<div class="form-group-item">
-				<label for="basicInputTypeText">Gender</label>
+				<label for="_17obpdwz0">Gender</label>
 				<input
 					class="form-control"
-					id="basicInputTypeText"
+					id="_17obpdwz0"
 					placeholder="Gender"
 					type="text"
 				/>
@@ -394,19 +390,19 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 		</div>
 		<div class="form-group-autofit">
 			<div class="form-group-item">
-				<label for="basicInputTypeText">Name</label>
+				<label for="_kcnx64qkv">Name</label>
 				<input
 					class="form-control"
-					id="basicInputTypeText"
+					id="_kcnx64qkv"
 					placeholder="Name"
 					type="text"
 				/>
 			</div>
 			<div class="form-group-item">
-				<label for="basicInputTypeText">Job Title</label>
+				<label for="_8awy2608y">Job Title</label>
 				<input
 					class="form-control"
-					id="basicInputTypeText"
+					id="_8awy2608y"
 					placeholder="Job Title"
 					type="text"
 				/>

--- a/clayui.com/content/docs/css/content/index.md
+++ b/clayui.com/content/docs/css/content/index.md
@@ -1,6 +1,4 @@
 ---
-layout: 'redirect'
-redirect: '/docs/css/content/typography.html'
 title: 'Content'
 order: 5
 ---

--- a/clayui.com/content/docs/css/utilities/index.md
+++ b/clayui.com/content/docs/css/utilities/index.md
@@ -1,6 +1,4 @@
 ---
-layout: 'redirect'
-redirect: '/docs/css/utilities/autofit.html'
 title: 'Utilities'
 order: 6
 ---

--- a/clayui.com/content/docs/examples.mdx
+++ b/clayui.com/content/docs/examples.mdx
@@ -23,51 +23,59 @@ You can use Storybook for inspiration, as well as guidelines, for your use case 
 
 Here are our demos we have in Storybook that utilize Clay components showcasing some common use cases.
 
-<ClayLayout.Container>
-	<ClayLayout.Row justify="start">
-		<ClayLayout.Col md={4} size={4}>
-			<ClayLink
-				className="d-block"
-				href="https://storybook.clayui.com/?path=/story/demos-templates--list-page"
-				target="_blank"
-			>
-				List Page
-			</ClayLink>
-			<ClayLink
-				className="d-block"
-				href="https://storybook.clayui.com/?path=/story/demos-templates--files-page"
-				target="_blank"
-			>
-				Files Page
-			</ClayLink>
-			<ClayLink
-				className="d-block"
-				href="https://storybook.clayui.com/?path=/story/demos-templates--form-page"
-				target="_blank"
-			>
-				Form Page
-			</ClayLink>
-			<ClayLink
-				className="d-block"
-				href="https://storybook.clayui.com/?path=/story/demos-templates--table-rows-drag-drop"
-				target="_blank"
-			>
-				Table Rows Drag & Drop
-			</ClayLink>
-			<ClayLink
-				className="d-block"
-				href="https://storybook.clayui.com/?path=/story/demos-templates--table-columns-drag-drop"
-				target="_blank"
-			>
-				Table Columns Drag & drop
-			</ClayLink>
-			<ClayLink
-				className="d-block"
-				href="https://storybook.clayui.com/?path=/story/demos-templates--drag-drop"
-				target="_blank"
-			>
-				List Drag & Drop
-			</ClayLink>
-		</ClayLayout.Col>
-	</ClayLayout.Row>
-</ClayLayout.Container>
+<ul class="c-pl-3 list-unstyled">
+	<li>
+		<a
+			href="https://storybook.clayui.com/?path=/story/demos-templates--list-page"
+			rel="noreferrer noopener"
+			target="_blank"
+		>
+			List Page
+		</a>
+	</li>
+	<li>
+		<a
+			href="https://storybook.clayui.com/?path=/story/demos-templates--files-page"
+			rel="noreferrer noopener"
+			target="_blank"
+		>
+			Files Page
+		</a>
+	</li>
+	<li>
+		<a
+			href="https://storybook.clayui.com/?path=/story/demos-templates--form-page"
+			rel="noreferrer noopener"
+			target="_blank"
+		>
+			Form Page
+		</a>
+	</li>
+	<li>
+		<a
+			href="https://storybook.clayui.com/?path=/story/demos-templates--table-rows-drag-drop"
+			rel="noreferrer noopener"
+			target="_blank"
+		>
+			Table Rows Drag & Drop
+		</a>
+	</li>
+	<li>
+		<a
+			href="https://storybook.clayui.com/?path=/story/demos-templates--table-columns-drag-drop"
+			rel="noreferrer noopener"
+			target="_blank"
+		>
+			Table Columns Drag & Drop
+		</a>
+	</li>
+	<li>
+		<a
+			href="https://storybook.clayui.com/?path=/story/demos-templates--drag-drop"
+			rel="noreferrer noopener"
+			target="_blank"
+		>
+			List Drag & Drop
+		</a>
+	</li>
+</ul>

--- a/clayui.com/src/components/LayoutNav/LayoutNav.js
+++ b/clayui.com/src/components/LayoutNav/LayoutNav.js
@@ -15,7 +15,7 @@ const spritemap = '/images/icons/icons.svg';
 
 const DEV = process.env.GATSBY_CLAY_NIGHTLY === 'true';
 
-export default () => {
+export default (location) => {
 	const [showAtlas, setShowAtlas] = useStateWithLocalStorage(
 		true,
 		'clay.showAtlas'
@@ -25,6 +25,8 @@ export default () => {
 		true,
 		'clay.showSiteCss'
 	);
+
+	const pathname = location.pathname || '';
 
 	return (
 		<nav className="navbar navbar-clay-site navbar-expand-lg navbar-light">
@@ -36,10 +38,13 @@ export default () => {
 					<ul className="ml-auto navbar-nav">
 						<li className="nav-item">
 							<Link
-								activeStyle={{color: '#b3472d'}}
 								className="nav-link"
-								partiallyActive
-								to="/docs/"
+								style={{
+									color: pathname.match(/docs\//g)
+										? '#b3472d'
+										: '',
+								}}
+								to="/docs/get-started/index.html"
 							>
 								<span className="c-inner" tabIndex="-1">
 									{'Docs'}
@@ -149,6 +154,7 @@ export default () => {
 										<ClayButtonWithIcon
 											className="nav-link"
 											displayType="unstyled"
+											spritemap={spritemap}
 											symbol="cog"
 										/>
 									}

--- a/clayui.com/src/templates/blog.js
+++ b/clayui.com/src/templates/blog.js
@@ -41,7 +41,7 @@ export default ({data, location}) => {
 					<div className="flex-xl-nowrap row">
 						<Sidebar data={list} location={location} />
 						<div className="col-xl sidebar-offset">
-							<LayoutNav />
+							<LayoutNav pathname={location.pathname} />
 							<div className="clay-blog-content">
 								<header>
 									<div className="clay-site-container container-fluid">

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -217,7 +217,9 @@ export default (props) => {
 										location={location}
 									/>
 									<div className="col-xl sidebar-offset">
-										<LayoutNav />
+										<LayoutNav
+											pathname={location.pathname}
+										/>
 										<header>
 											<div className="clay-site-container container-fluid">
 												<div className="row">


### PR DESCRIPTION
- chore(clayui.com): Supress console warning `A page wasn't found for index.html`
- fix(clayui.com): `/docs/examples.html` links are prefixed with `https://clayui.com/`
- fix(clayui.com): A page wasn't found for "/docs" message in browser console (hover over Docs on top nav)
- fix(clayui.com): Blogs `Warning: ClayIcon requires a `spritemap` via prop or ClayIconSpriteContext` in console (`yarn develop`)
- fix(clayui.com): Removes `13:7  warning  'spritemap' is assigned a value but never used  no-unused-vars` from blog.js (`yarn develop`)