### PR TITLE
fix(@clayui/localized-input): Dropdown Item should use autofit pattern to position labels

### DIFF
--- a/packages/clay-localized-input/package.json
+++ b/packages/clay-localized-input/package.json
@@ -31,6 +31,7 @@
 		"@clayui/form": "^3.10.0",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/label": "^3.3.1",
+		"@clayui/layout": "^3.2.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
@@ -20,6 +20,7 @@ exports[`ClayLocalizedInput renders 1`] = `
           class="form-control"
           id="locale1"
           placeholder="Text to translate..."
+          type="text"
           value="Apple"
         />
       </div>
@@ -30,18 +31,27 @@ exports[`ClayLocalizedInput renders 1`] = `
           class="dropdown"
         >
           <button
-            class="dropdown-toggle btn btn-monospaced btn-unstyled"
+            class="dropdown-toggle btn btn-monospaced btn-secondary"
             title="Open Localizations"
             type="button"
           >
-            <svg
-              class="lexicon-icon lexicon-icon-en-us"
-              role="presentation"
+            <span
+              class="inline-item"
             >
-              <use
-                xlink:href="/path/to/svg#en-us"
-              />
-            </svg>
+              <svg
+                class="lexicon-icon lexicon-icon-en-us"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/path/to/svg#en-us"
+                />
+              </svg>
+            </span>
+            <span
+              class="btn-section"
+            >
+              en-US
+            </span>
           </button>
         </div>
       </div>
@@ -78,12 +88,13 @@ exports[`ClayLocalizedInput renders with prepend content and result formatter 1`
         </div>
       </div>
       <div
-        class="input-group-item"
+        class="input-group-item input-group-append"
       >
         <input
           class="form-control"
           id="locale1"
           placeholder="Text to translate..."
+          type="text"
           value="Apple"
         />
       </div>
@@ -94,18 +105,27 @@ exports[`ClayLocalizedInput renders with prepend content and result formatter 1`
           class="dropdown"
         >
           <button
-            class="dropdown-toggle btn btn-monospaced btn-unstyled"
+            class="dropdown-toggle btn btn-monospaced btn-secondary"
             title="Open Localizations"
             type="button"
           >
-            <svg
-              class="lexicon-icon lexicon-icon-en-us"
-              role="presentation"
+            <span
+              class="inline-item"
             >
-              <use
-                xlink:href="/path/to/svg#en-us"
-              />
-            </svg>
+              <svg
+                class="lexicon-icon lexicon-icon-en-us"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/path/to/svg#en-us"
+                />
+              </svg>
+            </span>
+            <span
+              class="btn-section"
+            >
+              en-US
+            </span>
           </button>
         </div>
       </div>

--- a/packages/clay-localized-input/src/index.tsx
+++ b/packages/clay-localized-input/src/index.tsx
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayButtonWithIcon} from '@clayui/button';
+import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
+import ClayLayout from '@clayui/layout';
 import React from 'react';
 
 interface IItem {
@@ -125,7 +126,7 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 						</ClayInput.GroupItem>
 					)}
 
-					<ClayInput.GroupItem>
+					<ClayInput.GroupItem append={prependContent ? true : false}>
 						<ClayInput
 							{...otherProps}
 							id={id}
@@ -137,6 +138,7 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 							}}
 							placeholder={placeholder}
 							ref={ref}
+							type="text"
 							value={translations[selectedLocale.label] || ''}
 						/>
 					</ClayInput.GroupItem>
@@ -144,16 +146,24 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 					<ClayInput.GroupItem shrink>
 						<ClayDropDown
 							active={active}
-							hasRightSymbols
 							onActiveChange={setActive}
 							trigger={
-								<ClayButtonWithIcon
-									displayType="unstyled"
+								<ClayButton
+									displayType="secondary"
+									monospaced
 									onClick={() => setActive(!active)}
-									spritemap={spritemap}
-									symbol={selectedLocale.symbol}
 									title={ariaLabels.openLocalizations}
-								/>
+								>
+									<span className="inline-item">
+										<ClayIcon
+											spritemap={spritemap}
+											symbol={selectedLocale.symbol}
+										/>
+									</span>
+									<span className="btn-section">
+										{selectedLocale.label}
+									</span>
+								</ClayButton>
 							}
 						>
 							<ClayDropDown.ItemList>
@@ -167,32 +177,47 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 												onSelectedLocaleChange(locale)
 											}
 										>
-											<ClayIcon
-												className="inline-item inline-item-before"
-												spritemap={spritemap}
-												symbol={locale.symbol}
-											/>
+											<ClayLayout.ContentRow containerElement="span">
+												<ClayLayout.ContentCol
+													containerElement="span"
+													expand
+												>
+													<ClayLayout.ContentSection>
+														<ClayIcon
+															className="inline-item inline-item-before"
+															spritemap={
+																spritemap
+															}
+															symbol={
+																locale.symbol
+															}
+														/>
 
-											{locale.label}
-
-											<ClayLabel
-												className="dropdown-item-indicator-end"
-												displayType={
-													locale.label ===
-													defaultLanguage.label
-														? 'info'
-														: value
-														? 'success'
-														: 'warning'
-												}
-											>
-												{locale.label ===
-												defaultLanguage.label
-													? ariaLabels.default
-													: value
-													? ariaLabels.translated
-													: ariaLabels.untranslated}
-											</ClayLabel>
+														{locale.label}
+													</ClayLayout.ContentSection>
+												</ClayLayout.ContentCol>
+												<ClayLayout.ContentCol containerElement="span">
+													<ClayLayout.ContentSection>
+														<ClayLabel
+															displayType={
+																locale.label ===
+																defaultLanguage.label
+																	? 'info'
+																	: value
+																	? 'success'
+																	: 'warning'
+															}
+														>
+															{locale.label ===
+															defaultLanguage.label
+																? ariaLabels.default
+																: value
+																? ariaLabels.translated
+																: ariaLabels.untranslated}
+														</ClayLabel>
+													</ClayLayout.ContentSection>
+												</ClayLayout.ContentCol>
+											</ClayLayout.ContentRow>
 										</ClayDropDown.Item>
 									);
 								})}


### PR DESCRIPTION
fix(@clayui/localized-input): Language Dropdown Toggle should display selected locale text and use `btn-secondary`

fix(@clayui/localized-input): `input-group-prepend` adjacent sibling should have `input-group-append`

fix(@clayui/localized-input): ClayInput should have attribute `type="text"` because devs sometimes use the CSS selector `input[type="text"]` to style all text inputs

fixes #3591