### PR TITLE
feat(clayui.com): Add Code Sample Info to HTML/CSS collapsed code samples

### DIFF
--- a/clayui.com/plugins/gatsby-remark-use-clipboard/index.js
+++ b/clayui.com/plugins/gatsby-remark-use-clipboard/index.js
@@ -35,6 +35,10 @@ module.exports = ({markdownAST}) => {
 					</div>
 				</div>
 
+				<span class="clay-p code-sample-info">
+					Code Sample (expand to see it)
+				</span>
+
 				<button class="btn btn-sm btn-copy btn-monospaced btn-unstyled" title="Copy">
 					<svg class="lexicon-icon" focusable="false" role="presentation">
 						<use xlink:href="/images/icons/icons.svg#paste"></use>

--- a/clayui.com/src/components/CodeToggle/index.js
+++ b/clayui.com/src/components/CodeToggle/index.js
@@ -7,12 +7,18 @@ import {useEffect} from 'react';
 
 const CodeToggle = (props) => {
 	const handleCodeCollapse = (e) => {
-		const isCodeCollapse =
+		const isCodeCollapseBtn =
 			e.target.classList.contains('btn-collapse--collapse') ||
 			e.target.closest('.btn-collapse--collapse');
 
-		if (isCodeCollapse) {
+		if (isCodeCollapseBtn) {
 			const codeContainer = e.target.closest('.code-container');
+
+			const codeSampleInfo = codeContainer.querySelector(
+				'.code-sample-info'
+			);
+
+			codeSampleInfo.classList.toggle('hide');
 
 			const isVisible = codeContainer.classList.contains('expanded');
 

--- a/clayui.com/src/styles/_code.scss
+++ b/clayui.com/src/styles/_code.scss
@@ -29,6 +29,19 @@
 	}
 }
 
+.docs .code-sample-info.clay-p {
+	align-items: center;
+	display: flex;
+	margin-top: 0;
+	padding: 8px;
+	position: absolute;
+	z-index: 999;
+
+	&.hide {
+		display: none;
+	}
+}
+
 .btn-copy,
 .btn-collapse {
 	animation: fadeIn 0.5s cubic-bezier(0.3, 0, 0.3, 1) 0s 1 forwards;


### PR DESCRIPTION
Fixes #3610 

Single commit in this PR touches on 3 files:

- `gatsby-remark-use-clipboard/index.js`: I've added the HTML to display the text
- `CodeToggle/index.js`: rename `isCodeCollapse` to `isCodeCollapseBtn` as it confused me for some time, to explicitly say it means that it references the button, not a state
- `styles/_code.scss`: Styles for this `span`, initially I went with the classic Bootstrap classes, but I needed to add `z-index` which I didn't find covered by a class in the docs, so I moved it all into CSS