### PR TITLE
feat(clayui.com): Add a utility function for Local Storage

### DIFF
--- a/clayui.com/gatsby-browser.js
+++ b/clayui.com/gatsby-browser.js
@@ -3,22 +3,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import localStorage from './src/utils/localStorage';
+
 // A stub function is needed because gatsby won't load this file otherwise
 // (https://github.com/gatsbyjs/gatsby/issues/6759)
 export const onClientEntry = () => {
 	if (process.env.GATSBY_CLAY_NIGHTLY === 'true') {
 		const isNullOrTrue = (val) => val === 'true' || val === null;
 
-		let showAtlas = true;
-		let showSiteCss = true;
-
-		try {
-			showAtlas = isNullOrTrue(localStorage.getItem('clay.showAtlas'));
-
-			showSiteCss = isNullOrTrue(
-				localStorage.getItem('clay.showSiteCss')
-			);
-		} catch {} // eslint-disable-line no-empty
+		const showAtlas = isNullOrTrue(localStorage.getItem('clay.showAtlas'));
+		const showSiteCss = isNullOrTrue(
+			localStorage.getItem('clay.showSiteCss')
+		);
 
 		if (showAtlas) {
 			require('@clayui/css/src/scss/atlas.scss');

--- a/clayui.com/src/components/Hooks/useStateWithLocalStorage.js
+++ b/clayui.com/src/components/Hooks/useStateWithLocalStorage.js
@@ -5,45 +5,17 @@
 
 import React from 'react';
 
-const inBrowser = typeof window !== 'undefined';
-
-const localStorage = {
-	getItem(key) {
-		try {
-			return inBrowser ? window.localStorage.getItem(key) : null;
-		} catch {
-			return null;
-		}
-	},
-
-	setItem(key, value) {
-		if (inBrowser) {
-			try {
-				window.localStorage.setItem(key, value);
-			} catch {
-				return;
-			}
-		}
-	},
-};
+import localStorage from '../../utils/localStorage';
 
 function useStateWithLocalStorage(defaultValue, key) {
 	const [value, setValue] = React.useState(() => {
-		try {
-			const stickyValue = localStorage.getItem(key);
+		const stickyValue = localStorage.getItem(key);
 
-			return stickyValue === null
-				? defaultValue
-				: JSON.parse(stickyValue);
-		} catch {
-			return defaultValue;
-		}
+		return stickyValue === null ? defaultValue : JSON.parse(stickyValue);
 	});
 
 	React.useEffect(() => {
-		try {
-			localStorage.setItem(key, JSON.stringify(value));
-		} catch {} // eslint-disable-line no-empty
+		localStorage.setItem(key, JSON.stringify(value));
 	}, [key, value]);
 
 	return [value, setValue];

--- a/clayui.com/src/components/Hooks/useStateWithLocalStorage.js
+++ b/clayui.com/src/components/Hooks/useStateWithLocalStorage.js
@@ -9,9 +9,15 @@ import localStorage from '../../utils/localStorage';
 
 function useStateWithLocalStorage(defaultValue, key) {
 	const [value, setValue] = React.useState(() => {
-		const stickyValue = localStorage.getItem(key);
+		try {
+			const stickyValue = localStorage.getItem(key);
 
-		return stickyValue === null ? defaultValue : JSON.parse(stickyValue);
+			return stickyValue === null
+				? defaultValue
+				: JSON.parse(stickyValue);
+		} catch {
+			return defaultValue;
+		}
 	});
 
 	React.useEffect(() => {

--- a/clayui.com/src/utils/localStorage.tsx
+++ b/clayui.com/src/utils/localStorage.tsx
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const isSupported = () => {
+	try {
+		window.localStorage.setItem('_TEST_KEY_', '_TEST_KEY_');
+
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const getItem = (name: string): string | null => {
+	if (isSupported()) {
+		return window.localStorage.getItem(name);
+	}
+
+	return null;
+};
+
+const setItem = (name: string, value: string): void => {
+	if (isSupported()) {
+		window.localStorage.setItem(name, value);
+	}
+};
+
+const localStorage = {
+	getItem,
+	setItem,
+};
+
+export default localStorage;

--- a/clayui.com/src/utils/localStorage.tsx
+++ b/clayui.com/src/utils/localStorage.tsx
@@ -6,6 +6,7 @@
 const isSupported = () => {
 	try {
 		window.localStorage.setItem('_TEST_KEY_', '_TEST_KEY_');
+		window.localStorage.removeItem('_TEST_KEY_');
 
 		return true;
 	} catch {
@@ -13,23 +14,20 @@ const isSupported = () => {
 	}
 };
 
-const getItem = (name: string): string | null => {
-	if (isSupported()) {
-		return window.localStorage.getItem(name);
-	}
-
-	return null;
-};
-
-const setItem = (name: string, value: string): void => {
-	if (isSupported()) {
-		window.localStorage.setItem(name, value);
-	}
-};
-
 const localStorage = {
-	getItem,
-	setItem,
+	getItem(name: string): string | null {
+		if (isSupported()) {
+			return window.localStorage.getItem(name);
+		}
+
+		return null;
+	},
+
+	setItem(name: string, value: string): void {
+		if (isSupported()) {
+			window.localStorage.setItem(name, value);
+		}
+	},
 };
 
 export default localStorage;


### PR DESCRIPTION
Fixes #3611 

The goal of this factory function is to standardize the way we use `localStorage`, and even `sessionStorage` in a safe and consistent way.

### Steps Taken
1. I've thoroughly read and investigated the factory function from this [article](https://michalzalecki.com/why-using-localStorage-directly-is-a-bad-idea/) that @wincent linked in Slack a few days ago. I figured why reinvent the wheel and ported the function into our codebase.

2. I've adapted some small things to our ESLint rules but outside of that the code is the same. I'm unsure how we feel about "stealing" code from articles like this.

3. I tested this in-depth, making sure the site works on master and on my custom branch to make sure it works as intended considering I haven't written the implementation myself.

### Notes
- `localStorage` is used in `clay/packages/clay-css` in a couple files and I'm unsure if we can include the factory function in those files since the factory function is in `clay/clayui.com/