### PR TITLE
feat(@clayui/form): Adds Textarea component

### DIFF
--- a/packages/clay-form/src/Textarea.tsx
+++ b/packages/clay-form/src/Textarea.tsx
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+interface ITextareaProps
+	extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+	/**
+	 * Textarea component to render. Can either be a string like 'textarea' or a component.
+	 */
+	component?: 'textarea' | React.ForwardRefExoticComponent<any>;
+
+	/**
+	 * Flag to indicate if `input-group-inset-after` class should be applied
+	 */
+	insetAfter?: boolean;
+
+	/**
+	 * Flag to indicate if `input-group-inset-before` class should be applied
+	 */
+	insetBefore?: boolean;
+
+	/**
+	 * Selects the height of the input.
+	 */
+	sizing?: 'lg' | 'sm';
+}
+
+const ClayTextarea = React.forwardRef<HTMLTextAreaElement, ITextareaProps>(
+	(
+		{
+			className,
+			component: Component = 'textarea',
+			insetAfter,
+			insetBefore,
+			sizing,
+			...otherProps
+		}: ITextareaProps,
+		ref
+	) => (
+		<Component
+			{...otherProps}
+			className={classNames('form-control', className, {
+				[`form-control-${sizing}`]: sizing,
+				['input-group-inset']: insetAfter || insetBefore,
+				['input-group-inset-after']: insetAfter,
+				['input-group-inset-before']: insetBefore,
+			})}
+			ref={ref}
+		/>
+	)
+);
+
+export default ClayTextarea;

--- a/packages/clay-form/src/index.tsx
+++ b/packages/clay-form/src/index.tsx
@@ -12,6 +12,7 @@ import ClayRadioGroup from './RadioGroup';
 import ClaySelect from './Select';
 import ClaySelectBox from './SelectBox';
 import ClaySelectWithOption from './SelectWithOption';
+import ClayTextarea from './Textarea';
 import ClayToggle from './Toggle';
 
 export {
@@ -23,6 +24,7 @@ export {
 	ClaySelect,
 	ClaySelectBox,
 	ClaySelectWithOption,
+	ClayTextarea,
 	ClayToggle,
 };
 

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -15,6 +15,7 @@ import {
 	ClaySelect,
 	ClaySelectBox,
 	ClaySelectWithOption,
+	ClayTextarea,
 	ClayToggle,
 } from '../src';
 import ClayForm from '../src/Form';
@@ -297,6 +298,124 @@ storiesOf('Components|ClayInput', module)
 							aria-label="Username"
 							placeholder="Username"
 							type="text"
+						/>
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem append shrink>
+						<button className="btn btn-secondary" type="submit">
+							{'Submit'}
+						</button>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+			</ClayForm.Group>
+		</div>
+	));
+
+storiesOf('Components|ClayTextarea', module)
+	.add('default', () => (
+		<div className="sheet">
+			<ClayForm.Group>
+				<label htmlFor="basicInputText">{'Name'}</label>
+				<ClayTextarea
+					disabled={boolean('Disabled ', false)}
+					id="basicInputText"
+					placeholder="Insert your name here"
+					readOnly={boolean('Read Only ', false)}
+					sizing={select(
+						'Sizing',
+						{
+							lg: 'lg',
+							sm: 'sm',
+						},
+						undefined
+					)}
+				/>
+			</ClayForm.Group>
+		</div>
+	))
+	.add('group separated', () => (
+		<div className="sheet">
+			<ClayForm.Group>
+				<ClayInput.Group>
+					<ClayInput.GroupItem shrink>
+						<ClayInput.GroupText>{'@'}</ClayInput.GroupText>
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem>
+						<ClayTextarea
+							aria-label="Username"
+							insetBefore
+							placeholder="Username"
+						/>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+			</ClayForm.Group>
+			<ClayForm.Group>
+				<ClayInput.Group>
+					<ClayInput.GroupItem>
+						<ClayTextarea aria-label="Email" placeholder="Email" />
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem shrink>
+						<ClayInput.GroupText>{'@'}</ClayInput.GroupText>
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem>
+						<ClayTextarea
+							aria-label="Email Host"
+							placeholder="liferay"
+						/>
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem shrink>
+						<ClayInput.GroupText>{'.com'}</ClayInput.GroupText>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+			</ClayForm.Group>
+		</div>
+	))
+	.add('group connected', () => (
+		<div className="sheet">
+			<ClayForm.Group>
+				<ClayInput.Group>
+					<ClayInput.GroupItem prepend shrink>
+						<ClayInput.GroupText>{'@'}</ClayInput.GroupText>
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem append>
+						<ClayTextarea
+							aria-label="Username"
+							placeholder="Username"
+						/>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+			</ClayForm.Group>
+			<ClayForm.Group>
+				<ClayInput.Group>
+					<ClayInput.GroupItem prepend>
+						<ClayTextarea aria-label="Email" placeholder="Email" />
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem prepend shrink>
+						<ClayInput.GroupText>{'@'}</ClayInput.GroupText>
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem prepend>
+						<ClayTextarea
+							aria-label="Email Host"
+							placeholder="liferay"
+						/>
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem append shrink>
+						<ClayInput.GroupText>{'.com'}</ClayInput.GroupText>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+			</ClayForm.Group>
+		</div>
+	))
+	.add('group mixed', () => (
+		<div className="sheet">
+			<ClayForm.Group>
+				<ClayInput.Group>
+					<ClayInput.GroupItem shrink>
+						<ClayInput.GroupText>{'@'}</ClayInput.GroupText>
+					</ClayInput.GroupItem>
+					<ClayInput.GroupItem prepend>
+						<ClayTextarea
+							aria-label="Username"
+							placeholder="Username"
 						/>
 					</ClayInput.GroupItem>
 					<ClayInput.GroupItem append shrink>


### PR DESCRIPTION
From https://github.com/liferay/clay/pull/3608 conversations:

I tried to use Storybook to see if all styles(combining via props) of ClayInput can be applied on the `ClayTextarea` component.

See the following storybook examples with our current input styles/props:

Textarea with Group Separated:
<img width="1576" alt="textarea_group_separated" src="https://user-images.githubusercontent.com/7663513/90448804-8484f180-e0bc-11ea-845a-c6054b2bb057.png">


Textarea with Group Connected:
<img width="1564" alt="textarea_group_connected" src="https://user-images.githubusercontent.com/7663513/90448811-89e23c00-e0bc-11ea-9927-190228ec6e5e.png">


Textarea with Group Mixed:
<img width="1560" alt="textarea_group_mixed" src="https://user-images.githubusercontent.com/7663513/90448816-8cdd2c80-e0bc-11ea-8afc-e1fdaa2a0fbd.png">


I’m not sure if we support (textarea input groups)[https://liferay.design/lexicon/core-components/forms/text-input-group/]

#### Inset properties:

With insetAfter:

<img width="995" alt="textarea_insetAfter" src="https://user-images.githubusercontent.com/7663513/90448840-96ff2b00-e0bc-11ea-91bc-68c455533345.png">


With insetBefore:

<img width="990" alt="textarea_insetBefore" src="https://user-images.githubusercontent.com/7663513/90448850-99fa1b80-e0bc-11ea-9bd4-cf0d9da7b251.png">


Apparently insetAfter and insetBefore classes works on the textarea component  

### Additional Information

#### When auditing DXP:

I found we probably have an issue when autoFocus a textArea, that calling textAreaRef.focus() is required. (See https://github.com/liferay/liferay-portal/blob/a0397bf6adc1a9d6e60fb43579475241720f6526/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/Textarea.js)

**In this PR?** ❌ 

#### When auditing other component libraries I found some interesting. props that can be added:

`autoSize`: Height autosize feature, can be set to true\\|false or an object { minRows: 2, maxRows: 6 }

From rc-textarea(antd): https://react-component.github.io/textarea/?path=/story/rc-textarea--readme

Similar to https://github.com/liferay/liferay-portal/blob/ac2a395b4c1eee877498c87db48a1fe619e79cdc/portal-web/docroot/html/taglib/aui/input/page.jsp#L353 (It needs a AUI plugin to resize it, maybe We need to apply this logic of autoSize for all our input fields.

**In this PR?** ❌ 

----- 

`onResize`: Whether We need width/height values updated on the textarea when resizing

From rc-textarea(antd): https://react-component.github.io/textarea/?path=/story/rc-textarea--readme

**In this PR?** ❌ 

----- 

`rowsMax`, `rowsMin`: The maximum and minimum amount of rows to be displayed

From mui(materia-ui): https://material-ui.com/pt/api/textarea-autosize/#textareaautosize-api

**In this PR?** ❌ 

### Question:

What are you thoughts on these properties? Should we add it carefully when people need or should We be add it proactively?