### PR TITLE
fix(@clayui/css): Table List use `border-collapse` and `border-width` instead of `box-shadow` hack for rounded corners

### DIFF
--- a/packages/clay-css/src/content/tables.html
+++ b/packages/clay-css/src/content/tables.html
@@ -19,295 +19,297 @@ section: Components
 			<code>show-quick-actions-on-hover</code> will need Javascript to add class <code>table-focus</code> on the table row when an item inside is focused to make it keyboard accessible.
 		</div>
 
-<div class="table-responsive">
-	<table class="show-quick-actions-on-hover table table-autofit table-list table-nowrap">
-		<thead>
-			<tr>
-				<th></th>
-				<th class="table-head-title">
-					<span class="inline-item inline-item-before">
-						<a href="#1">
-							<svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#drag" />
-							</svg>
+<div class="container-fluid container-fluid-max-xl">
+	<div class="table-responsive">
+		<table class="show-quick-actions-on-hover table table-autofit table-list table-nowrap">
+			<thead>
+				<tr>
+					<th></th>
+					<th class="table-head-title">
+						<span class="inline-item inline-item-before">
+							<a href="#1">
+								<svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#drag" />
+								</svg>
+							</a>
+						</span><a class="inline-item text-truncate-inline" href="#1">
+							<span class="text-truncate" title="ID">ID</span><span class="inline-item inline-item-after">
+								<svg class="lexicon-icon lexicon-icon-order-arrow-down" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#order-arrow-down" />
+								</svg>
+							</span>
 						</a>
-					</span><a class="inline-item text-truncate-inline" href="#1">
-						<span class="text-truncate" title="ID">ID</span><span class="inline-item inline-item-after">
-							<svg class="lexicon-icon lexicon-icon-order-arrow-down" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#order-arrow-down" />
-							</svg>
-						</span>
-					</a>
-				</th>
-				<th class="table-cell-expand table-head-title">
-					<span class="inline-item inline-item-before">
-						<a href="#1">
-							<svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#drag" />
-							</svg>
+					</th>
+					<th class="table-cell-expand table-head-title">
+						<span class="inline-item inline-item-before">
+							<a href="#1">
+								<svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#drag" />
+								</svg>
+							</a>
+						</span><a class="inline-item text-truncate-inline" href="#1">
+							<span class="text-truncate" title="Title">Title</span><span class="inline-item inline-item-after">
+								<svg class="lexicon-icon lexicon-icon-order-arrow-down" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#order-arrow-down" />
+								</svg>
+							</span>
 						</a>
-					</span><a class="inline-item text-truncate-inline" href="#1">
-						<span class="text-truncate" title="Title">Title</span><span class="inline-item inline-item-after">
-							<svg class="lexicon-icon lexicon-icon-order-arrow-down" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#order-arrow-down" />
-							</svg>
-						</span>
-					</a>
-				</th>
-				<th><span class="inline-item">Status</span></th>
-				<th class="table-head-title">
-					<span class="inline-item inline-item-before">
-						<a href="#1">
-							<svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#drag" />
-							</svg>
+					</th>
+					<th><span class="inline-item">Status</span></th>
+					<th class="table-head-title">
+						<span class="inline-item inline-item-before">
+							<a href="#1">
+								<svg class="lexicon-icon lexicon-icon-drag" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#drag" />
+								</svg>
+							</a>
+						</span><a class="inline-item text-truncate-inline" href="#1">
+							<span class="text-truncate" title="Modified Date">Modified Date</span>
 						</a>
-					</span><a class="inline-item text-truncate-inline" href="#1">
-						<span class="text-truncate" title="Modified Date">Modified Date</span>
-					</a>
-				</th>
-				<th><span class="inline-item">Display Date</span></th>
-				<th class="table-head-title">
-					<a class="inline-item text-truncate-inline" href="#1">
-						<span class="text-truncate" title="Author">Author</span><span class="inline-item inline-item-after">
-							<svg class="lexicon-icon lexicon-icon-order-arrow-up" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#order-arrow-up" />
-							</svg>
-						</span>
-					</a>
-				</th>
-				<th><span class="inline-item">Type</span></th>
-				<th></th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr class="table-divider">
-				<td colspan="9">Group 1</td>
-			</tr>
-			<tr>
-				<td>
-					<div class="custom-control custom-checkbox">
-						<label>
-							<input class="custom-control-input" type="checkbox">
-							<span class="custom-control-label"></span>
-						</label>
-					</div>
-				</td>
-				<td>21146</td>
-				<td class="table-cell-expand">
-					<div class="table-list-title">
-						.table-list-title (not a link)
-					</div>
-					<div class="table-list-title">
-						<a href="#1">.table-list-title a</a>
-					</div>
-					<div><a class="table-list-link" href="#1">.table-list-link</a></div>
-					<div><a href="#1">link</a></div>
-					<div>Some regular text</div>
-				</td>
-				<td>--</td>
-				<td>2 Hours Ago</td>
-				<td>--</td>
-				<td>Stanley Nelson</td>
-				<td>Folder</td>
-				<td>
-					<div class="quick-action-menu">
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
-							</svg>
+					</th>
+					<th><span class="inline-item">Display Date</span></th>
+					<th class="table-head-title">
+						<a class="inline-item text-truncate-inline" href="#1">
+							<span class="text-truncate" title="Author">Author</span><span class="inline-item inline-item-after">
+								<svg class="lexicon-icon lexicon-icon-order-arrow-up" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#order-arrow-up" />
+								</svg>
+							</span>
 						</a>
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
-							</svg>
-						</a>
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
-							</svg>
-						</a>
-					</div>
-					<div class="dropdown dropdown-action">
-						<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
-							<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
-							</svg>
-						</a>
-						<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
-							<li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
-							<li><a class="dropdown-item" href="#1" role="button">Download</a></li>
-							<li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
-						</ul>
-					</div>
-				</td>
-			</tr>
-			<tr class="table-active">
-				<td>
-					<div class="custom-control custom-checkbox">
-						<label>
-							<input checked class="custom-control-input" type="checkbox">
-							<span class="custom-control-label"></span>
-						</label>
-					</div>
-				</td>
-				<td>
-					21148
-				</td>
-				<td class="table-cell-expand">
-					<div class="table-list-title">
-						<a class="text-truncate-inline" href="#1">
-							<span class="text-truncate" title="Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.">Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</span>
-						</a>
-					</div>
-				</td>
-				<td>--</td>
-				<td>2 Hours Ago</td>
-				<td>--</td>
-				<td>Stanley Nelson</td>
-				<td>Folder</td>
-				<td>
-					<div class="quick-action-menu">
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
-							</svg>
-						</a>
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
-							</svg>
-						</a>
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
-							</svg>
-						</a>
-					</div>
-					<div class="dropdown dropdown-action">
-						<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
-							<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
-							</svg>
-						</a>
-						<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
-							<li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
-							<li><a class="dropdown-item" href="#1" role="button">Download</a></li>
-							<li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
-						</ul>
-					</div>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					<div class="custom-control custom-checkbox">
-						<label>
-							<input class="custom-control-input" type="checkbox">
-							<span class="custom-control-label"></span>
-						</label>
-					</div>
-				</td>
-				<td>21149</td>
-				<td class="table-cell-expand">
-					<div class="table-list-title">
-						<span class="text-truncate-inline">
-							<span class="text-truncate" title="Cultivar extra">Cultivar extra</span>
-						</span>
-					</div>
-				</td>
-				<td>--</td>
-				<td>2 Hours Ago</td>
-				<td>--</td>
-				<td>Stanley Nelson</td>
-				<td>Folder</td>
-				<td>
-					<div class="quick-action-menu">
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
-							</svg>
-						</a>
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
-							</svg>
-						</a>
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
-							</svg>
-						</a>
-					</div>
-					<div class="dropdown dropdown-action">
-						<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
-							<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
-							</svg>
-						</a>
-						<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
-							<li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
-							<li><a class="dropdown-item" href="#1" role="button">Download</a></li>
-							<li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
-						</ul>
-					</div>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					<div class="custom-control custom-checkbox">
-						<label>
-							<input class="custom-control-input" type="checkbox">
-							<span class="custom-control-label"></span>
-						</label>
-					</div>
-				</td>
-				<td>21150</td>
-				<td class="table-cell-expand">
-					<div class="table-list-title">
-						<span class="text-truncate-inline">
-							<span class="text-truncate" title="Cultivar extra">Cultivar extra</span>
-						</span>
-					</div>
-				</td>
-				<td>--</td>
-				<td>2 Hours Ago</td>
-				<td>--</td>
-				<td>Stanley Nelson</td>
-				<td>Folder</td>
-				<td>
-					<div class="quick-action-menu">
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
-							</svg>
-						</a>
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
-							</svg>
-						</a>
-						<a class="component-action quick-action-item" href="#1" role="button">
-							<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
-							</svg>
-						</a>
-					</div>
-					<div class="dropdown dropdown-action">
-						<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
-							<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
-							</svg>
-						</a>
-						<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
-							<li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
-							<li><a class="dropdown-item" href="#1" role="button">Download</a></li>
-							<li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
-						</ul>
-					</div>
-				</td>
-			</tr>
-		</tbody>
-	</table>
+					</th>
+					<th><span class="inline-item">Type</span></th>
+					<th></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr class="table-divider">
+					<td colspan="9">Group 1</td>
+				</tr>
+				<tr>
+					<td>
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input class="custom-control-input" type="checkbox">
+								<span class="custom-control-label"></span>
+							</label>
+						</div>
+					</td>
+					<td>21146</td>
+					<td class="table-cell-expand">
+						<div class="table-list-title">
+							.table-list-title (not a link)
+						</div>
+						<div class="table-list-title">
+							<a href="#1">.table-list-title a</a>
+						</div>
+						<div><a class="table-list-link" href="#1">.table-list-link</a></div>
+						<div><a href="#1">link</a></div>
+						<div>Some regular text</div>
+					</td>
+					<td>--</td>
+					<td>2 Hours Ago</td>
+					<td>--</td>
+					<td>Stanley Nelson</td>
+					<td>Folder</td>
+					<td>
+						<div class="quick-action-menu">
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+								</svg>
+							</a>
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+								</svg>
+							</a>
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+								</svg>
+							</a>
+						</div>
+						<div class="dropdown dropdown-action">
+							<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+								<li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Download</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
+							</ul>
+						</div>
+					</td>
+				</tr>
+				<tr class="table-active">
+					<td>
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input checked class="custom-control-input" type="checkbox">
+								<span class="custom-control-label"></span>
+							</label>
+						</div>
+					</td>
+					<td>
+						21148
+					</td>
+					<td class="table-cell-expand">
+						<div class="table-list-title">
+							<a class="text-truncate-inline" href="#1">
+								<span class="text-truncate" title="Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.">Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</span>
+							</a>
+						</div>
+					</td>
+					<td>--</td>
+					<td>2 Hours Ago</td>
+					<td>--</td>
+					<td>Stanley Nelson</td>
+					<td>Folder</td>
+					<td>
+						<div class="quick-action-menu">
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+								</svg>
+							</a>
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+								</svg>
+							</a>
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+								</svg>
+							</a>
+						</div>
+						<div class="dropdown dropdown-action">
+							<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+								<li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Download</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
+							</ul>
+						</div>
+					</td>
+				</tr>
+				<tr>
+					<td>
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input class="custom-control-input" type="checkbox">
+								<span class="custom-control-label"></span>
+							</label>
+						</div>
+					</td>
+					<td>21149</td>
+					<td class="table-cell-expand">
+						<div class="table-list-title">
+							<span class="text-truncate-inline">
+								<span class="text-truncate" title="Cultivar extra">Cultivar extra</span>
+							</span>
+						</div>
+					</td>
+					<td>--</td>
+					<td>2 Hours Ago</td>
+					<td>--</td>
+					<td>Stanley Nelson</td>
+					<td>Folder</td>
+					<td>
+						<div class="quick-action-menu">
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+								</svg>
+							</a>
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+								</svg>
+							</a>
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+								</svg>
+							</a>
+						</div>
+						<div class="dropdown dropdown-action">
+							<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+								<li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Download</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
+							</ul>
+						</div>
+					</td>
+				</tr>
+				<tr>
+					<td>
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input class="custom-control-input" type="checkbox">
+								<span class="custom-control-label"></span>
+							</label>
+						</div>
+					</td>
+					<td>21150</td>
+					<td class="table-cell-expand">
+						<div class="table-list-title">
+							<span class="text-truncate-inline">
+								<span class="text-truncate" title="Cultivar extra">Cultivar extra</span>
+							</span>
+						</div>
+					</td>
+					<td>--</td>
+					<td>2 Hours Ago</td>
+					<td>--</td>
+					<td>Stanley Nelson</td>
+					<td>Folder</td>
+					<td>
+						<div class="quick-action-menu">
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+								</svg>
+							</a>
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#download" />
+								</svg>
+							</a>
+							<a class="component-action quick-action-item" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#expand" />
+								</svg>
+							</a>
+						</div>
+						<div class="dropdown dropdown-action">
+							<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul aria-labelledby="" class="dropdown-menu dropdown-menu-right">
+								<li><a class="dropdown-item" href="#1" role="button">Remove</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Download</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Checkout</a></li>
+							</ul>
+						</div>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
 </div>
 
 	</div>

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -358,6 +358,7 @@ th {
 				width: 100%;
 
 				// Prevent double border on horizontal scroll due to use of `display: block;`
+
 				> .table-bordered {
 					border-width: 0;
 				}
@@ -369,18 +370,23 @@ th {
 // Table List Skin
 
 .table-list {
-	border-collapse: separate;
-	border-radius: clay-enable-rounded($table-list-border-radius);
-	color: $table-list-color;
-	font-size: $table-list-font-size;
-	margin-bottom: $table-list-margin-bottom;
-	margin-top: $table-list-margin-top;
+	@include clay-css($c-table-list);
 
 	thead,
 	tbody,
 	tfoot {
+		td,
+		th {
+			@include clay-css($c-table-list-cell);
+		}
+
 		&:first-child {
 			tr:first-child {
+				th,
+				td {
+					border-top-width: 0;
+				}
+
 				th:first-child,
 				td:first-child,
 				.table-cell-start {
@@ -420,6 +426,34 @@ th {
 		}
 	}
 
+	thead {
+		td,
+		th {
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
+
+			background-color: $table-list-head-bg;
+			font-size: $table-list-head-font-size;
+			font-weight: $table-list-head-font-weight;
+			height: $table-list-head-height;
+			vertical-align: $table-list-head-vertical-alignment;
+		}
+
+		th a {
+			@include clay-link($table-list-head-link);
+		}
+	}
+
+	tbody,
+	tfoot {
+		td,
+		th {
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
+
+			background-color: $table-list-bg;
+			vertical-align: middle;
+		}
+	}
+
 	.table-row-start {
 		.table-cell-start {
 			border-top-left-radius: clay-enable-rounded(
@@ -447,115 +481,23 @@ th {
 			);
 		}
 	}
-
-	th,
-	td {
-		// top, bottom
-		box-shadow: inset 0 #{$table-list-border-y-width} $table-list-border-color,
-			0 #{$table-list-border-y-width} $table-list-border-color;
-		padding-top: $table-list-border-y-width + $table-cell-padding;
-
-		&:first-child {
-			// top, bottom, left
-			box-shadow: inset 0 #{$table-list-border-y-width} $table-list-border-color,
-				0 #{$table-list-border-y-width} $table-list-border-color,
-				inset #{$table-list-border-x-width} 0 $table-list-border-color;
-			padding-left: $table-list-border-x-width + $table-cell-padding;
-			padding-top: $table-list-border-y-width + $table-cell-padding;
-		}
-
-		&:last-child {
-			// top, right, bottom
-			box-shadow: inset 0 #{$table-list-border-y-width} $table-list-border-color,
-				inset #{-$table-list-border-x-width} 0 $table-list-border-color,
-				0 #{$table-list-border-y-width} $table-list-border-color;
-			padding-right: $table-list-border-x-width + $table-cell-padding;
-			padding-top: $table-list-border-y-width + $table-cell-padding;
-		}
-
-		&:only-child {
-			// top, right, bottom, left
-			box-shadow: inset 0 #{$table-list-border-y-width} $table-list-border-color,
-				inset #{-$table-list-border-x-width} 0 $table-list-border-color,
-				0 #{$table-list-border-y-width} $table-list-border-color,
-				inset #{$table-list-border-x-width} 0 $table-list-border-color;
-			padding-left: $table-list-border-x-width + $table-cell-padding;
-			padding-right: $table-list-border-x-width + $table-cell-padding;
-			padding-top: $table-list-border-y-width + $table-cell-padding;
-		}
-	}
-
-	.table-cell-start {
-		// top, bottom, left
-		box-shadow: inset 0 #{$table-list-border-y-width} $table-list-border-color,
-			0 #{$table-list-border-y-width} $table-list-border-color,
-			inset #{$table-list-border-x-width} 0 $table-list-border-color;
-		padding-left: $table-list-border-x-width + $table-cell-padding;
-		padding-top: $table-list-border-y-width + $table-cell-padding;
-	}
-
-	.table-cell-end {
-		// top, right, bottom
-		box-shadow: inset 0 #{$table-list-border-y-width} $table-list-border-color,
-			inset #{-$table-list-border-x-width} 0 $table-list-border-color,
-			0 #{$table-list-border-y-width} $table-list-border-color;
-		padding-right: $table-list-border-x-width + $table-cell-padding;
-		padding-top: $table-list-border-y-width + $table-cell-padding;
-	}
-
-	thead {
-		td,
-		th {
-			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
-
-			background-color: $table-list-head-bg;
-			border-width: 0;
-			font-size: $table-list-head-font-size;
-			font-weight: $table-list-head-font-weight;
-			height: $table-list-head-height;
-			vertical-align: $table-list-head-vertical-alignment;
-		}
-
-		th a {
-			@include clay-link($table-list-head-link);
-		}
-	}
-
-	tbody,
-	tfoot {
-		td,
-		th {
-			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
-
-			background-color: $table-list-bg;
-			border-width: 0;
-			vertical-align: middle;
-		}
-	}
 }
 
+// Table List Bordered
+
 .table-list.table-bordered {
-	border-width: 0;
-
-	th,
-	td {
-		// top, right, bottom
-		box-shadow: inset 0 #{$table-list-border-y-width} #{$table-list-border-color},
-			inset #{-$table-list-border-x-width} 0 #{$table-list-border-color},
-			0 #{$table-list-border-y-width} #{$table-list-border-color};
-		padding-right: $table-list-border-x-width + $table-cell-padding;
-		padding-top: $table-list-border-y-width + $table-cell-padding;
-
-		&:first-child {
-			// top, right, bottom, left
-			box-shadow: inset 0 #{$table-list-border-y-width} #{$table-list-border-color},
-				inset #{-$table-list-border-x-width} 0 #{$table-list-border-color},
-				0 #{$table-list-border-y-width} #{$table-list-border-color},
-				inset #{$table-list-border-x-width} 0 #{$table-list-border-color};
-			padding-left: $table-list-border-x-width + $table-cell-padding;
-			padding-right: $table-list-border-x-width + $table-cell-padding;
-			padding-top: $table-list-border-y-width + $table-cell-padding;
+	thead,
+	tbody,
+	tfoot {
+		th,
+		td {
+			@include clay-css($c-table-list-bordered-cell);
 		}
+	}
+
+	th:first-child,
+	td:first-child {
+		border-left-width: 0;
 	}
 }
 
@@ -730,10 +672,9 @@ th {
 	td,
 	th {
 		padding-bottom: $table-list-divider-padding-y;
-		padding-left: $table-list-border-x-width + $table-list-divider-padding-x;
-		padding-right: $table-list-border-x-width +
-			$table-list-divider-padding-x;
-		padding-top: $table-list-border-y-width + $table-list-divider-padding-y;
+		padding-left: $table-list-divider-padding-x;
+		padding-right: $table-list-divider-padding-x;
+		padding-top: $table-list-divider-padding-y;
 	}
 }
 
@@ -937,7 +878,7 @@ th {
 		align-items: $table-list-quick-action-menu-align-items;
 		background-color: $table-list-quick-action-menu-bg;
 		bottom: 0;
-		top: $table-list-border-y-width;
+		top: 0;
 	}
 }
 

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -160,14 +160,54 @@ $table-list-font-size: null !default;
 $table-list-margin-bottom: $table-list-border-y-width !default;
 $table-list-margin-top: null !default;
 
+$c-table-list: () !default;
+$c-table-list: map-merge(
+	(
+		border-collapse: separate,
+		border-color: $table-list-border-color,
+		border-style: solid,
+		border-width: $table-list-border-y-width $table-list-border-x-width,
+		border-radius: clay-enable-rounded($table-list-border-radius),
+		color: $table-list-color,
+		font-size: $table-list-font-size,
+		margin-bottom: $table-list-margin-bottom,
+		margin-top: $table-list-margin-top,
+	),
+	$c-table-list
+);
+
+// .table-list.table-striped
+
 $table-list-accent-bg: #f2f2f2 !default;
+
+// .table-list.table-hover tbody tr:hover
+
 $table-list-hover-bg: #ececec !default;
+
+// .table-list.table-active
+
 $table-list-active-bg: #dadada !default;
+
+// .table-list .table-disabled
 
 $table-list-disabled-bg: $white !default;
 $table-list-disabled-color: #acacac !default;
 $table-list-disabled-cursor: $disabled-cursor !default;
 $table-list-disabled-pointer-events: none !default;
+
+// .table-list {thead,tbody,tfoot} {th,td}
+
+$c-table-list-cell: () !default;
+$c-table-list-cell: map-merge(
+	(
+		border-color: $table-list-border-color,
+		border-style: solid,
+		border-width: $table-list-border-y-width 0 0 0,
+	),
+	$c-table-list-cell
+);
+
+// .table-list thead {th,td}
 
 $table-list-head-bg: null !default;
 $table-list-head-font-size: null !default;
@@ -175,10 +215,26 @@ $table-list-head-font-weight: null !default;
 $table-list-head-height: null !default;
 $table-list-head-vertical-alignment: null !default;
 
+// .table-list thead th a
+
 $table-list-head-link: () !default;
 
-$table-list-divider-padding-x: 0.75rem !default; // 12px
-$table-list-divider-padding-y: 0.75rem !default; // 12px
+// .table-list.table-bordered {thead,tbody,tfoot} {th,td}
+
+$c-table-list-bordered-cell: () !default;
+$c-table-list-bordered-cell: map-merge(
+	(
+		border-left-width: $table-list-border-x-width,
+	),
+	$c-table-list-bordered-cell
+);
+
+// .table-list .table-divider
+
+$table-list-divider-padding-x: 0.75rem !default;
+$table-list-divider-padding-y: 0.75rem !default;
+
+// .table-list .quick-action-menu
 
 $table-list-quick-action-menu-align-items: center !default;
 $table-list-quick-action-menu-bg: $table-list-bg !default;


### PR DESCRIPTION
`table-list` should now work for IE11, Chrome, Safari 11+, and FF.  

fixes #3624

@matuzalemsteles @jbalsas @brunobasto 