### PR TITLE
fix(@clayui/localized-input): Add separate state for the URL example and SF

### DIFF
--- a/packages/clay-localized-input/stories/index.tsx
+++ b/packages/clay-localized-input/stories/index.tsx
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/**
- * © 2019 Liferay, Inc. <https://liferay.com>
- *
- * SPDX-License-Identifier: BSD-3-Clause
- */
-
 import '@clayui/css/lib/css/atlas.css';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
 import {storiesOf} from '@storybook/react';
@@ -42,6 +36,14 @@ storiesOf('Components|ClayLocalizedInput', module).add('default', () => {
 		'es-ES': 'Manzana',
 	});
 
+	const [selectedLocaleURL, setSelectedLocaleURL] = React.useState(
+		locales[0]
+	);
+	const [translationsURL, setTranslationsURL] = React.useState<any>({
+		'en-US': 'Apple',
+		'es-ES': 'Manzana',
+	});
+
 	const prepend = '/home/';
 
 	return (
@@ -55,19 +57,20 @@ storiesOf('Components|ClayLocalizedInput', module).add('default', () => {
 				spritemap={spritemap}
 				translations={translations}
 			/>
+
 			<br />
 
 			<ClayLocalizedInput
 				id="locale2"
 				label="As a URL"
 				locales={locales}
-				onSelectedLocaleChange={setSelectedLocale}
-				onTranslationsChange={setTranslations}
+				onSelectedLocaleChange={setSelectedLocaleURL}
+				onTranslationsChange={setTranslationsURL}
 				prependContent={prepend}
 				resultFormatter={(val) => `https://liferay.com${prepend}${val}`}
-				selectedLocale={selectedLocale}
+				selectedLocale={selectedLocaleURL}
 				spritemap={spritemap}
-				translations={translations}
+				translations={translationsURL}
 			/>
 		</div>
 	);


### PR DESCRIPTION
Fixes #3605 

Pretty simple fix, for the sake of simplicity when I made the story initially, I had two inputs share the same state as not to clutter the code. Now I added a set of states for the 2nd input as well, and also removed the old notice header.