### PR TITLE
fix(@clayui/nav): Fix the button that shows the vertical navigation when on mobile

### DIFF
--- a/packages/clay-nav/BREAKING.md
+++ b/packages/clay-nav/BREAKING.md
@@ -1,1 +1,3 @@
 # List of Breaking Changes for 4.x
+
+-   Remove `activeLabel` prop from Vertical component and make `triggerLabel` the one used instead

--- a/packages/clay-nav/README.mdx
+++ b/packages/clay-nav/README.mdx
@@ -16,6 +16,8 @@ import {Navigation, VerticalNavigation} from '$packages/clay-nav/docs/index';
     -   [ClayNav](#claynav)
     -   [ClayNav.Item](#claynav.item)
     -   [ClayNav.Link](#claynav.link)
+    -   [ClayVerticalNav](#clayverticalnav)
+    -   [ClayVerticalNav.Trigger](#clayverticalnav.trigger)
 
 </div>
 </div>
@@ -27,6 +29,42 @@ import {Navigation, VerticalNavigation} from '$packages/clay-nav/docs/index';
 ## Vertical Navigation
 
 <VerticalNavigation />
+
+### Custom Trigger
+
+In its mobile version, Vertical Navigation adds a trigger that is responsible for opening the menu, in some cases you may want to customize this trigger, for this use the `<ClayVerticalNav.Trigger />` component.
+
+```js
+<ClayVerticalNav
+	trigger={(props) => (
+		<ClayVerticalNav.Trigger {...props}>
+			<ClayIcon
+				focusable="false"
+				role="presentation"
+				spritemap={spritemap}
+				symbol="ellipsis-v"
+			/>
+		</ClayVerticalNav.Trigger>
+	)}
+/>
+```
+
+Your custom trigger receives the `children` property with the default content, for cases when you just want to change the Trigger Button and not its content.
+
+```js
+<ClayVerticalNav
+	trigger={({onClick}) => (
+		<button className="btn btn-secondary" onClick={onClick}>
+			<ClayIcon
+				focusable="false"
+				role="presentation"
+				spritemap={spritemap}
+				symbol="ellipsis-v"
+			/>
+		</button>
+	)}
+/>
+```
 
 ## API
 
@@ -47,3 +85,9 @@ import {Navigation, VerticalNavigation} from '$packages/clay-nav/docs/index';
 ### ClayVerticalNav
 
 <div>[APITable "clay-nav/src/Vertical.tsx"]</div>
+
+### ClayVerticalNav.Trigger
+
+<code class="list-api-item-type">
+	Extends from {`React.ComponentProps<typeof ClayButton>`}
+</code>

--- a/packages/clay-nav/docs/index.js
+++ b/packages/clay-nav/docs/index.js
@@ -47,7 +47,6 @@ const verticalNavigationImportsCode = `import {ClayVerticalNav} from '@clayui/na
 const VerticalNavigationCode = `const Component = () => {
 	return (
 		<ClayVerticalNav
-			activeLabel="Five"
 			items={[
 			{
 				initialExpanded: true,

--- a/packages/clay-nav/package.json
+++ b/packages/clay-nav/package.json
@@ -26,6 +26,7 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/button": "^3.4.0",
 		"@clayui/icon": "^3.0.5",
 		"@clayui/shared": "^3.2.1",
 		"classnames": "^2.2.6",

--- a/packages/clay-nav/src/Trigger.tsx
+++ b/packages/clay-nav/src/Trigger.tsx
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import React from 'react';
+
+export interface IProps extends React.ComponentProps<typeof ClayButton> {
+	/**
+	 * Label of the button that appears on smaller resolutions to open the vertical navigation.
+	 */
+	label?: string;
+
+	/**
+	 * Callback function when the trigger is clicked.
+	 */
+	handleClick?: () => void;
+
+	/**
+	 * Path to the spritemap that Icon should use when referencing symbols.
+	 */
+	spritemap?: string;
+}
+
+const Trigger: React.FunctionComponent<IProps> = ({
+	children,
+	className,
+	handleClick,
+	label = 'Menu',
+	spritemap,
+	...otherProps
+}) => (
+	<ClayButton
+		className={classNames(className, 'menubar-toggler')}
+		displayType="unstyled"
+		onClick={handleClick}
+		{...otherProps}
+	>
+		{children ? (
+			children
+		) : (
+			<>
+				<span className="inline-item inline-item-before">{label}</span>
+
+				<ClayIcon
+					focusable="false"
+					role="presentation"
+					spritemap={spritemap}
+					symbol="caret-bottom"
+				/>
+			</>
+		)}
+	</ClayButton>
+);
+
+export default Trigger;

--- a/packages/clay-nav/src/Trigger.tsx
+++ b/packages/clay-nav/src/Trigger.tsx
@@ -4,55 +4,22 @@
  */
 
 import ClayButton from '@clayui/button';
-import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import React from 'react';
 
-export interface IProps extends React.ComponentProps<typeof ClayButton> {
-	/**
-	 * Label of the button that appears on smaller resolutions to open the vertical navigation.
-	 */
-	label?: string;
-
-	/**
-	 * Callback function when the trigger is clicked.
-	 */
-	handleClick?: () => void;
-
-	/**
-	 * Path to the spritemap that Icon should use when referencing symbols.
-	 */
-	spritemap?: string;
-}
+export interface IProps extends React.ComponentProps<typeof ClayButton> {}
 
 const Trigger: React.FunctionComponent<IProps> = ({
 	children,
 	className,
-	handleClick,
-	label = 'Menu',
-	spritemap,
 	...otherProps
-}) => (
+}: IProps) => (
 	<ClayButton
 		className={classNames(className, 'menubar-toggler')}
 		displayType="unstyled"
-		onClick={handleClick}
 		{...otherProps}
 	>
-		{children ? (
-			children
-		) : (
-			<>
-				<span className="inline-item inline-item-before">{label}</span>
-
-				<ClayIcon
-					focusable="false"
-					role="presentation"
-					spritemap={spritemap}
-					symbol="caret-bottom"
-				/>
-			</>
-		)}
+		{children}
 	</ClayButton>
 );
 

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import ClayIcon from '@clayui/icon';
 import {useTransitionHeight} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
+import warning from 'warning';
 
 import Nav from './Nav';
 import Trigger from './Trigger';
@@ -68,7 +70,7 @@ interface IProps {
 	/**
 	 * Custom component that will be displayed on mobile resolutions that toggles the visibility of the navigation.
 	 */
-	trigger?: React.ReactElement;
+	trigger?: typeof Trigger;
 
 	/**
 	 * Path to the spritemap that Icon should use when referencing symbols.
@@ -167,11 +169,16 @@ const ClayVerticalNav: React.FunctionComponent<IProps> & {
 	items,
 	large,
 	spritemap,
-	trigger,
+	trigger: CustomTrigger = Trigger,
 	triggerLabel = 'Menu',
 	...otherProps
 }: IProps) => {
 	const [active, setActive] = React.useState(false);
+
+	warning(
+		!activeLabel,
+		'ClayVerticalNav: The `activeLabel` API has been deprecated in favor of `triggerLabel` and will be removed in the next major release.'
+	);
 
 	return (
 		<nav
@@ -181,21 +188,18 @@ const ClayVerticalNav: React.FunctionComponent<IProps> & {
 				['menubar-vertical-expand-md']: !large,
 			})}
 		>
-			{trigger ? (
-				<div
-					className="menubar-toggler"
-					onClick={() => setActive(!active)}
-					role="button"
-				>
-					{trigger}
-				</div>
-			) : (
-				<Trigger
-					handleClick={() => setActive(!active)}
-					label={activeLabel || triggerLabel}
+			<CustomTrigger onClick={() => setActive(!active)}>
+				<span className="inline-item inline-item-before">
+					{activeLabel || triggerLabel}
+				</span>
+
+				<ClayIcon
+					focusable="false"
+					role="presentation"
 					spritemap={spritemap}
+					symbol="caret-bottom"
 				/>
-			)}
+			</CustomTrigger>
 
 			<div
 				className={classNames('collapse menubar-collapse', {

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import {useTransitionHeight} from '@clayui/shared';
 import classNames from 'classnames';
@@ -48,7 +49,12 @@ interface IProps {
 	/**
 	 * Label of item that is currently active.
 	 */
-	activeLabel: string;
+	activeLabel?: string;
+
+	/**
+	 * Label of the button that appears on smaller resolutions to open the vertical navigation.
+	 */
+	buttonToggleLabel?: string;
 
 	/**
 	 * List of items.
@@ -59,6 +65,11 @@ interface IProps {
 	 * Flag to indicate if `menubar-vertical-expand-lg` class is applied.
 	 */
 	large?: boolean;
+
+	/**
+	 * Content of the Button trigger
+	 */
+	triggerContent?: any;
 
 	/**
 	 * Path to the spritemap that Icon should use when referencing symbols.
@@ -152,9 +163,11 @@ function renderItems(items: Array<IItem>, spritemap?: string, level = 0) {
 
 export const ClayVerticalNav: React.FunctionComponent<IProps> = ({
 	activeLabel,
+	buttonToggleLabel = 'Menu',
 	items,
 	large,
 	spritemap,
+	triggerContent,
 	...otherProps
 }: IProps) => {
 	const [active, setActive] = React.useState(false);
@@ -167,19 +180,28 @@ export const ClayVerticalNav: React.FunctionComponent<IProps> = ({
 				['menubar-vertical-expand-md']: !large,
 			})}
 		>
-			<button
+			<ClayButton
 				className="menubar-toggler"
+				displayType="unstyled"
 				onClick={() => setActive(!active)}
 			>
-				{activeLabel}
+				{triggerContent ? (
+					triggerContent
+				) : (
+					<>
+						<span className="inline-item inline-item-before">
+							{activeLabel ? activeLabel : buttonToggleLabel}
+						</span>
 
-				<ClayIcon
-					focusable="false"
-					role="presentation"
-					spritemap={spritemap}
-					symbol="caret-bottom"
-				/>
-			</button>
+						<ClayIcon
+							focusable="false"
+							role="presentation"
+							spritemap={spritemap}
+							symbol="caret-bottom"
+						/>
+					</>
+				)}
+			</ClayButton>
 
 			<div
 				className={classNames('collapse menubar-collapse', {

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -3,13 +3,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayButton from '@clayui/button';
-import ClayIcon from '@clayui/icon';
 import {useTransitionHeight} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
 import Nav from './Nav';
+import Trigger from './Trigger';
 
 interface IItem extends React.ComponentProps<typeof Nav.Item> {
 	/**
@@ -54,7 +53,7 @@ interface IProps {
 	/**
 	 * Label of the button that appears on smaller resolutions to open the vertical navigation.
 	 */
-	buttonToggleLabel?: string;
+	triggerLabel?: string;
 
 	/**
 	 * List of items.
@@ -67,9 +66,9 @@ interface IProps {
 	large?: boolean;
 
 	/**
-	 * Content of the Button trigger
+	 * Custom component that will be displayed on mobile resolutions that toggles the visibility of the navigation.
 	 */
-	triggerContent?: any;
+	trigger?: React.ReactElement;
 
 	/**
 	 * Path to the spritemap that Icon should use when referencing symbols.
@@ -161,13 +160,15 @@ function renderItems(items: Array<IItem>, spritemap?: string, level = 0) {
 	});
 }
 
-export const ClayVerticalNav: React.FunctionComponent<IProps> = ({
+const ClayVerticalNav: React.FunctionComponent<IProps> & {
+	Trigger: typeof Trigger;
+} = ({
 	activeLabel,
-	buttonToggleLabel = 'Menu',
 	items,
 	large,
 	spritemap,
-	triggerContent,
+	trigger,
+	triggerLabel = 'Menu',
 	...otherProps
 }: IProps) => {
 	const [active, setActive] = React.useState(false);
@@ -180,28 +181,21 @@ export const ClayVerticalNav: React.FunctionComponent<IProps> = ({
 				['menubar-vertical-expand-md']: !large,
 			})}
 		>
-			<ClayButton
-				className="menubar-toggler"
-				displayType="unstyled"
-				onClick={() => setActive(!active)}
-			>
-				{triggerContent ? (
-					triggerContent
-				) : (
-					<>
-						<span className="inline-item inline-item-before">
-							{activeLabel ? activeLabel : buttonToggleLabel}
-						</span>
-
-						<ClayIcon
-							focusable="false"
-							role="presentation"
-							spritemap={spritemap}
-							symbol="caret-bottom"
-						/>
-					</>
-				)}
-			</ClayButton>
+			{trigger ? (
+				<div
+					className="menubar-toggler"
+					onClick={() => setActive(!active)}
+					role="button"
+				>
+					{trigger}
+				</div>
+			) : (
+				<Trigger
+					handleClick={() => setActive(!active)}
+					label={activeLabel || triggerLabel}
+					spritemap={spritemap}
+				/>
+			)}
 
 			<div
 				className={classNames('collapse menubar-collapse', {
@@ -213,3 +207,7 @@ export const ClayVerticalNav: React.FunctionComponent<IProps> = ({
 		</nav>
 	);
 };
+
+ClayVerticalNav.Trigger = Trigger;
+
+export {ClayVerticalNav};

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -49,6 +49,7 @@ interface IItemWithItems extends IItem {
 interface IProps {
 	/**
 	 * Label of item that is currently active.
+	 * @deprecated since version 3.3.x
 	 */
 	activeLabel?: string;
 

--- a/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -22,7 +22,7 @@ exports[`ClayVerticalNav renders 1`] = `
       <span
         class="inline-item inline-item-before"
       >
-        Home
+        Menu
       </span>
       <svg
         class="lexicon-icon lexicon-icon-caret-bottom"

--- a/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -16,9 +16,14 @@ exports[`ClayVerticalNav renders 1`] = `
     class="menubar menubar-transparent menubar-vertical-expand-md"
   >
     <button
-      class="menubar-toggler"
+      class="menubar-toggler btn btn-unstyled"
+      type="button"
     >
-      Home
+      <span
+        class="inline-item inline-item-before"
+      >
+        Home
+      </span>
       <svg
         class="lexicon-icon lexicon-icon-caret-bottom"
         focusable="false"

--- a/packages/clay-nav/src/__tests__/index.tsx
+++ b/packages/clay-nav/src/__tests__/index.tsx
@@ -39,11 +39,7 @@ describe('ClayVerticalNav', () => {
 
 	it('renders', () => {
 		const {container} = render(
-			<ClayVerticalNav
-				buttonToggleLabel="Home"
-				items={items}
-				spritemap="/path/to"
-			/>
+			<ClayVerticalNav items={items} spritemap="/path/to" />
 		);
 
 		expect(container).toMatchSnapshot();
@@ -51,11 +47,7 @@ describe('ClayVerticalNav', () => {
 
 	it('expands items when clicked', () => {
 		const {container, getByText} = render(
-			<ClayVerticalNav
-				buttonToggleLabel="foo"
-				items={items}
-				spritemap="/path/to"
-			/>
+			<ClayVerticalNav items={items} spritemap="/path/to" />
 		);
 
 		expect(

--- a/packages/clay-nav/src/__tests__/index.tsx
+++ b/packages/clay-nav/src/__tests__/index.tsx
@@ -40,7 +40,7 @@ describe('ClayVerticalNav', () => {
 	it('renders', () => {
 		const {container} = render(
 			<ClayVerticalNav
-				activeLabel="Home"
+				buttonToggleLabel="Home"
 				items={items}
 				spritemap="/path/to"
 			/>
@@ -52,7 +52,7 @@ describe('ClayVerticalNav', () => {
 	it('expands items when clicked', () => {
 		const {container, getByText} = render(
 			<ClayVerticalNav
-				activeLabel="foo"
+				buttonToggleLabel="foo"
 				items={items}
 				spritemap="/path/to"
 			/>

--- a/packages/clay-nav/stories/index.tsx
+++ b/packages/clay-nav/stories/index.tsx
@@ -121,14 +121,16 @@ storiesOf('Components|ClayNav', module)
 				]}
 				large={boolean('large: ', false)}
 				spritemap={spritemap}
-				trigger={
-					<ClayIcon
-						focusable="false"
-						role="presentation"
-						spritemap={spritemap}
-						symbol="ellipsis-v"
-					/>
-				}
+				trigger={(props) => (
+					<ClayVerticalNav.Trigger {...props}>
+						<ClayIcon
+							focusable="false"
+							role="presentation"
+							spritemap={spritemap}
+							symbol="ellipsis-v"
+						/>
+					</ClayVerticalNav.Trigger>
+				)}
 			/>
 		);
 	});

--- a/packages/clay-nav/stories/index.tsx
+++ b/packages/clay-nav/stories/index.tsx
@@ -5,6 +5,7 @@
 
 import '@clayui/css/lib/css/atlas.css';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import ClayIcon from '@clayui/icon';
 import {boolean} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
@@ -34,7 +35,6 @@ storiesOf('Components|ClayNav', module)
 	.add('ClayVerticalNav', () => {
 		return (
 			<ClayVerticalNav
-				activeLabel="Five"
 				items={[
 					{
 						initialExpanded: true,
@@ -75,6 +75,55 @@ storiesOf('Components|ClayNav', module)
 				]}
 				large={boolean('large: ', false)}
 				spritemap={spritemap}
+			/>
+		);
+	})
+	.add('ClayVerticalNav w/ custom trigger', () => {
+		return (
+			<ClayVerticalNav
+				items={[
+					{
+						initialExpanded: true,
+						items: [
+							{
+								href: '#',
+								label: 'Nested1',
+							},
+						],
+						label: 'Home',
+					},
+					{
+						href: '#',
+						label: 'About',
+					},
+					{
+						href: '#',
+						label: 'Contact',
+					},
+					{
+						items: [
+							{
+								active: true,
+								href: '#',
+								label: 'Five',
+							},
+							{
+								href: '#',
+								label: 'Six',
+							},
+						],
+						label: 'Projects',
+					},
+					{
+						href: '#',
+						label: 'Seven',
+					},
+				]}
+				large={boolean('large: ', false)}
+				spritemap={spritemap}
+				triggerContent={
+					<ClayIcon spritemap={spritemap} symbol="ellipsis-h" />
+				}
 			/>
 		);
 	});

--- a/packages/clay-nav/stories/index.tsx
+++ b/packages/clay-nav/stories/index.tsx
@@ -121,8 +121,13 @@ storiesOf('Components|ClayNav', module)
 				]}
 				large={boolean('large: ', false)}
 				spritemap={spritemap}
-				triggerContent={
-					<ClayIcon spritemap={spritemap} symbol="ellipsis-h" />
+				trigger={
+					<ClayIcon
+						focusable="false"
+						role="presentation"
+						spritemap={spritemap}
+						symbol="ellipsis-v"
+					/>
 				}
 			/>
 		);

--- a/packages/demos/stories/FormPage.tsx
+++ b/packages/demos/stories/FormPage.tsx
@@ -35,9 +35,8 @@ export default () => {
 	return (
 		<ClayLayout.ContainerFluid>
 			<div className="row">
-				<div className="col col-2">
+				<div className="col col-3 col-sm-2">
 					<ClayVerticalNav
-						activeLabel="Five"
 						items={[
 							{
 								active: activePage === 0,


### PR DESCRIPTION
Fixes #2821

@kresimir-coko I went ahead and made some changes, I simplified the `ClayVerticalNav.Trigger` a little so it can be reused for other cases and removes the existing conditionals a little while still maintaining all the use cases. I also added some cases in the documentation and add the warning.