### PR TITLE
feat(@clayui/modal): Add zIndex prop 

### DIFF
--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -41,6 +41,11 @@ interface IProps
 	 * hook, adds observer from `useModal` hook here.
 	 */
 	observer: Observer;
+
+	/**
+	 * Allows setting a custom z-index value, overriding the default one which is 1040, modal body z-index will be +10 of this value
+	 */
+	zIndex?: number;
 }
 
 const warningMessage = `You need to pass the 'observer' prop to ClayModal for everything to work fine, use the 'useModal' hook that exposes the observer.
@@ -62,6 +67,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 	size,
 	spritemap,
 	status,
+	zIndex,
 	...otherProps
 }: IProps) => {
 	const modalElementRef = useRef<HTMLDivElement | null>(null);
@@ -84,6 +90,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 				className={classNames('modal-backdrop fade', {
 					show,
 				})}
+				style={{zIndex}}
 			/>
 			<div
 				{...otherProps}
@@ -91,6 +98,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 					show,
 				})}
 				ref={modalElementRef}
+				style={{zIndex: zIndex && zIndex + 10}}
 			>
 				<div
 					className={classNames('modal-dialog', {


### PR DESCRIPTION
Fixes #3643 

Modal window's zIndex is set to the value provided by the user, and the backdrop value is decreased by 10 to maintain the connection between the 2 elements. I've tested this in storybook to make sure both styles are applying properly and overriding the default ones.