### PR TITLE
feat(@clayui/form): Add Radio JSP code example

### DIFF
--- a/packages/clay-form/docs/radiogroup.js
+++ b/packages/clay-form/docs/radiogroup.js
@@ -7,8 +7,7 @@ import Editor from '$clayui.com/src/components/Editor';
 import {ClayRadio, ClayRadioGroup} from '@clayui/form';
 import React from 'react';
 
-const radioGroupImportsCode = `import {ClayRadio, ClayRadioGroup} from '@clayui/form';
-`;
+const radioGroupImportsCode = `import {ClayRadio, ClayRadioGroup} from '@clayui/form';`;
 
 const radioGroupCode = `const Component = () => {
 	const [value, setValue] = useState('one');
@@ -28,16 +27,46 @@ const radioGroupCode = `const Component = () => {
 
 render(<Component />)`;
 
+const radioGroupJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
+
+const RadioGroupJSPCode = `<clay:radio
+	checked="<%= true %>"
+	label="One"
+	name="one"
+/>
+	
+<clay:radio
+	disabled="<%= true %>"
+	label="Two"
+	name="two"
+/>
+	
+<clay:radio
+	checked="<%= true %>"
+	disabled="<%= true %>"
+	label="Three"
+	name="three"
+	showLabel="<%= false %>"
+/>`;
+
 const RadioGroup = () => {
 	const scope = {ClayRadio, ClayRadioGroup};
 
-	return (
-		<Editor
-			code={radioGroupCode}
-			imports={radioGroupImportsCode}
-			scope={scope}
-		/>
-	);
+	const codeSnippets = [
+		{
+			imports: radioGroupImportsCode,
+			name: 'React',
+			value: radioGroupCode,
+		},
+		{
+			disabled: true,
+			imports: radioGroupJSPImportsCode,
+			name: 'JSP',
+			value: RadioGroupJSPCode,
+		},
+	];
+
+	return <Editor code={codeSnippets} scope={scope} />;
 };
 
 export {RadioGroup};


### PR DESCRIPTION
Fixes #3647 

Simple PR, I made the examples not match the React ones 1:1, but instead opted for more 3 different Radios showcasing all of the available props