### PR TITLE
feat(@clayui/drop-down): Add JSP code example

### DIFF
--- a/packages/clay-drop-down/README.mdx
+++ b/packages/clay-drop-down/README.mdx
@@ -97,12 +97,6 @@ const Menu = ({children, hasLeftSymbols, hasRightSymbols}) => {
 };
 ```
 
-### Using dropdown in JSP files
-
-In JSP we have 2 variants of ClayDropDown: `<clay:dropdown-menu />` and `<clay:dropdown-action />`, with them sharing lots of props, like: `defaultEventHandler`, `displayType`, `label`, `small`, `searchable`, `itemsIconAlignment`, etc.
-
-The only difference between these 2 variants is that the trigger in `<clay:dropdown-action />` is always a vertical elipsis icon, whereas the trigger for `<clay:dropdown-menu />` can be fully customized.
-
 ## DropDownWithItems
 
 Allows you to create a simple DropDown, through its API you are able to create a Menu with groups of checkboxes and radios, links, buttons, search, caption, etc.

--- a/packages/clay-drop-down/README.mdx
+++ b/packages/clay-drop-down/README.mdx
@@ -13,7 +13,6 @@ import {DropDown, DropDownWithItems} from '$packages/clay-drop-down/docs/index';
 
 -   [Composing](#composing)
     -   [Using dropdown without a trigger](#using-dropdown-without-a-trigger)
-    -   [Using dropdown in JSP files](#using-dropdown-in-jsp-files)
 -   [DropDownWithItems](#dropdownwithitems)
 -   [API](#api)
     -   [ClayDropDown](#claydropdown)

--- a/packages/clay-drop-down/README.mdx
+++ b/packages/clay-drop-down/README.mdx
@@ -13,6 +13,7 @@ import {DropDown, DropDownWithItems} from '$packages/clay-drop-down/docs/index';
 
 -   [Composing](#composing)
     -   [Using dropdown without a trigger](#using-dropdown-without-a-trigger)
+    -   [Using dropdown in JSP files](#using-dropdown-in-jsp-files)
 -   [DropDownWithItems](#dropdownwithitems)
 -   [API](#api)
     -   [ClayDropDown](#claydropdown)
@@ -44,7 +45,7 @@ You may want to use only the content of DropDown for other cases, such as mounti
 	and uses it as the basis for aligning DropDown content.
 </div>
 
-#### Using dropdown without a trigger
+### Using dropdown without a trigger
 
 You may want to create a trigger that is not necessarily in the same tree as DropDown, due to HTML markup issues, for these cases you can use `<ClayDropDown.Menu />`.
 
@@ -95,6 +96,12 @@ const Menu = ({children, hasLeftSymbols, hasRightSymbols}) => {
 	);
 };
 ```
+
+### Using dropdown in JSP files
+
+In JSP we have 2 variants of ClayDropDown: `<clay:dropdown-menu />` and `<clay:dropdown-action />`, with them sharing lots of props, like: `defaultEventHandler`, `displayType`, `label`, `small`, `searchable`, `itemsIconAlignment`, etc.
+
+The only difference between these 2 variants is that the trigger in `<clay:dropdown-action />` is always a vertical elipsis icon, whereas the trigger for `<clay:dropdown-menu />` can be fully customized.
 
 ## DropDownWithItems
 

--- a/packages/clay-drop-down/docs/index.js
+++ b/packages/clay-drop-down/docs/index.js
@@ -47,7 +47,13 @@ const DropDownJSPCode = `<clay:dropdown-menu
 	dropdownItems="<%= customDropdownItems %>"
 />
 
-<clay:dropdown-action dropdownItems="<%= actionDropdownItems %>"`;
+<clay:dropdown-action dropdownItems="<%= actionDropdownItems %>"
+
+/*
+In JSP we have 2 variants of ClayDropDown: <clay:dropdown-menu /> and <clay:dropdown-action />, with them sharing lots of props, like: defaultEventHandler, displayType, label, small, searchable, itemsIconAlignment, etc.
+
+The only difference between these 2 variants is that the trigger in <clay:dropdown-action /> is always a vertical elipsis icon, whereas the trigger for <clay:dropdown-menu /> can be fully customized.
+*/`;
 
 const DropDown = () => {
 	const scope = {ClayDropDown};

--- a/packages/clay-drop-down/docs/index.js
+++ b/packages/clay-drop-down/docs/index.js
@@ -8,8 +8,7 @@ import ClayButton from '@clayui/button';
 import ClayDropDown, {ClayDropDownWithItems} from '@clayui/drop-down';
 import React from 'react';
 
-const dropDownImportsCode = `import ClayDropDown from '@clayui/drop-down';
-`;
+const dropDownImportsCode = `import ClayDropDown from '@clayui/drop-down';`;
 
 const dropDownCode = `const Component = () => {
 	const [active, setActive] = useState(false);
@@ -41,25 +40,39 @@ const dropDownCode = `const Component = () => {
 
 render(<Component />)`;
 
+const dropDownJSPImportsCode = `<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %>`;
+
+const DropDownJSPCode = `<clay:dropdown-menu
+	buttonLabel="Click here!"
+	dropdownItems="<%= customDropdownItems %>"
+/>
+
+<clay:dropdown-action dropdownItems="<%= actionDropdownItems %>"`;
+
 const DropDown = () => {
 	const scope = {ClayDropDown};
 
-	return (
-		<Editor
-			code={dropDownCode}
-			imports={dropDownImportsCode}
-			scope={scope}
-		/>
-	);
+	const codeSnippets = [
+		{
+			imports: dropDownImportsCode,
+			name: 'React',
+			value: dropDownCode,
+		},
+		{
+			disabled: true,
+			imports: dropDownJSPImportsCode,
+			name: 'JSP',
+			value: DropDownJSPCode,
+		},
+	];
+
+	return <Editor code={codeSnippets} scope={scope} />;
 };
 
 const dropDownWithItemsImportsCode = `import ClayButton from '@clayui/button';
-import {ClayDropDownWithItems} from '@clayui/drop-down';
-`;
+import {ClayDropDownWithItems} from '@clayui/drop-down';`;
 
-const dropDownWithItemsCode = `
-
-const Component = () => {
+const dropDownWithItemsCode = `const Component = () => {
 	const [value, setValue] = useState();
     const items = [
       {


### PR DESCRIPTION
Fixes #3649 

So this one is first of it's kind, as it has 2 JSP tags for one component, each represeting a variant.

The `<clay:dropdown-menu />` is the regular dropdown, whereas the `<clay:dropdown-action />` is a dropdown with an `ellipsis-v` icon as the trigger ([source](https://liferay.slack.com/archives/G3JBR21HA/p1598349490107100)).

This is why I added a section in the documentation describing this, while keeping the example simple to reflect the React example.