### PR TITLE
fix(@clayui/color-picker): maintains the value entered by the user when the color is not valid

### DIFF
--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -201,7 +201,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 							width: 0,
 						}}
 						type={useNative ? 'color' : 'text'}
-						value={`#${hexInputValue}`}
+						value={hexInputValue ? `#${hexInputValue}` : ''}
 					/>
 				)}
 

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -288,7 +288,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 
 									const hexString = newColor.isValid()
 										? newColor.toHex()
-										: value;
+										: event.target.value;
 
 									onValueChange(hexString);
 									setHexInputValue(hexString);


### PR DESCRIPTION
Fixes #3651

This fixes an issue in issue #3651 but we still need to understand the other problem that I cannot reproduce. Marking this as a draft initially to correct the other problems, still ignoring the case of the ColorPicker accepting `transparent`, `red`, `black`... as colors.