### PR TITLE
fix(@clayui/shared): fixes side effect of focusing on the first element when the active element does not exist in the scope

### DIFF
--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -208,6 +208,11 @@ export function useFocusManagement(scope: React.RefObject<null | HTMLElement>) {
 		const lastPosition = elements.length - 1;
 		let nextElement = null;
 
+		// Ignore when the active element is not in the scope.
+		if (position < 0) {
+			return null;
+		}
+
 		if (backwards) {
 			if (position === 0) {
 				// is out of scope, so we go back through the fiber to pick up the


### PR DESCRIPTION
Fixes #3656

This is a very specific case that can happen in IE 11 when there are svg elements. We will probably have to make a release and send about the ticket https://issues.liferay.com/browse/LPS-119771.