### PR TITLE
fix(@clayui/shared): ignores elements within the scope with tabindex="-1" from the focus manager

### DIFF
--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -30,7 +30,7 @@ export function useFocusManagement(scope: React.RefObject<null | HTMLElement>) {
 			return false;
 		}
 
-		const minTabIndex = -1;
+		const minTabIndex = 0;
 
 		if (
 			(memoizedProps.tabIndex != null &&


### PR DESCRIPTION
Fixes #3660

Elements within the scope with `tabindex="-1"` are no longer controlled by the focus manager, previously these elements received focus when tabbing occurred.