### PR TITLE
fix(clayui.com): Linking to CSS pages doesn't take you to the correct place

### DIFF
--- a/clayui.com/content/docs/components/css-alerts.md
+++ b/clayui.com/content/docs/components/css-alerts.md
@@ -7,19 +7,19 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/alerts/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Colors](#colors)
-    -   [Non-standard colors](#non-standard-colors)
--   [Examples](#examples)
-    -   [Toast](#toast)
-    -   [Embedded](#embedded)
-    -   [Stripe](#stripe)
--   [Non-standard examples](#non-standard-examples)
-    -   [Alert Lists](#alert-lists)
--   [Additional Options](#additional-options)
-    -   [Mixed HTML Content](#mixed-html-content)
-    -   [Dismissible Alerts](#dismissible-alerts)
-    -   [Alert Notifications Absolute](#alert-notifications-absolute)
-    -   [Fixed Notifications](#fixed-notifications)
+-   [Colors](#css-colors)
+    -   [Non-standard Colors](#css-non-standard-colors)
+-   [Examples](#css-examples)
+    -   [Toast](#css-toast)
+    -   [Embedded](#css-embedded)
+    -   [Stripe](#css-stripe)
+-   [Non-standard Examples](#css-non-standard-examples)
+    -   [Alert Lists](#css-alert-lists)
+-   [Additional Options](#css-additional-options)
+    -   [Mixed HTML Content](#css-mixed-html-content)
+    -   [Dismissible Alerts](#css-dismissible-alerts)
+    -   [Alert Notifications Absolute](#css-alert-notifications-absolute)
+    -   [Fixed Notifications](#css-fixed-notifications)
 
 </div>
 </div>
@@ -28,7 +28,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/alerts/'
 	Don't forget to check <a href="https://www.w3.org/TR/wai-aria-practices/#alert">WAI-ARIA</a> accessibility pratices for alerts when writting your markup.
 </div>
 
-## Colors
+## Colors(#css-colors)
 
 Lexicon adopts in its design system the following colors below:
 
@@ -55,7 +55,7 @@ Lexicon adopts in its design system the following colors below:
 	</div>
 </div>
 
-### Non-standard colors
+### Non-standard Colors(#css-non-standard-colors)
 
 The colors below do not follow Lexicon standards but follow the idea of [​​satellite components](https://liferay.design/lexicon), Clay provides non-standard colors to give you more flexibility to build UI that belong to the product.
 
@@ -82,9 +82,9 @@ The colors below do not follow Lexicon standards but follow the idea of [​​s
 	</div>
 </div>
 
-## Examples
+## Examples(#css-examples)
 
-### Toast
+### Toast(#css-toast)
 
 This type of alert is specific for toast messages. These type of messages appear on the top right corner of the screen. The maximum width of a toast message is 360px, and the height can vary depending on the number of rows. It always has a close action.
 
@@ -215,7 +215,7 @@ This type of alert is specific for toast messages. These type of messages appear
 </div>
 ```
 
-### Embedded
+### Embedded(#css-embedded)
 
 Embedded alerts are meant for use in forms. Usually you will only need to use the information once. Its width depends on the width of the container it is placed in, always respecting the container margins to the content. The close action is not required for embedded alerts.
 
@@ -284,7 +284,7 @@ Embedded alerts are meant for use in forms. Usually you will only need to use th
 </div>
 ```
 
-### Stripe
+### Stripe(#css-stripe)
 
 Stripe alerts are always placed below the last navigation element, either the header or the navigation bar. This alert usually appears on "Save" action, communicating the status of the action once received from the server. The close action is mandatory in this alert type. Its width is always full container width and pushes all the content below it.
 
@@ -421,11 +421,11 @@ Stripe alerts are always placed below the last navigation element, either the he
 </div>
 ```
 
-## Non-standard examples
+## Non-standard Examples(#css-non-standard-examples)
 
 These examples are not included in the Lexicon design system but they are built using foundations and Lexicon core components, these components may belong to the product or application.
 
-### Alert Lists
+### Alert Lists(#css-alert-lists)
 
 <div class="sheet-example">
 	<ul class="alert-list">
@@ -694,9 +694,9 @@ These examples are not included in the Lexicon design system but they are built 
 </ul>
 ```
 
-## Additional Options
+## Additional Options(#css-additional-options)
 
-### Mixed HTML Content
+### Mixed HTML Content(#css-mixed-html-content)
 
 All alerts accept HTML as their content. You can use the following modifiers:
 
@@ -724,7 +724,7 @@ All alerts accept HTML as their content. You can use the following modifiers:
 </div>
 ```
 
-### Dismissible Alerts
+### Dismissible Alerts(#css-dismissible-alerts)
 
 <div class="sheet-example">
 	<div class="alert alert-dismissible alert-success" role="alert">
@@ -754,7 +754,7 @@ All alerts accept HTML as their content. You can use the following modifiers:
 </div>
 ```
 
-### Alert Notifications Absolute
+### Alert Notifications Absolute(#css-alert-notifications-absolute)
 
 An absolute positioned container for placing alerts on the top right corner relative to `.alert-container`. Use this to create sticky positioned alerts with javascript, modifying the CSS property `transform: translateY();` or `margin-top` when `scrollY` reaches a specific threshold. This component should generally be placed at the top of the page for sticky alerts aligned at the top.
 
@@ -766,7 +766,7 @@ An absolute positioned container for placing alerts on the top right corner rela
 </div>
 ```
 
-### Fixed Notifications
+### Fixed Notifications(#css-fixed-notifications)
 
 A fixed positioned container for placing alerts on the top right corner of the page. This component can generally be placed anywhere on the page.
 

--- a/clayui.com/content/docs/components/css-application-bar.md
+++ b/clayui.com/content/docs/components/css-application-bar.md
@@ -7,9 +7,8 @@ lexiconDefinition: 'https://liferay.design/lexicon/satellite-components/navigati
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Light](#light)
--   [Secondary](#secondary)
--   [Using Buttons](#using-buttons)
+-   [Dark](#css-dark)
+-   [Using Buttons](#css-using-buttons)
 
 </div>
 </div>
@@ -18,7 +17,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/satellite-components/navigati
     Bootstrap 4 doesn't support Dropdown Menu's with Popper.js positioning inside Navbars. They align them manually via CSS classes. See <a href="/docs/components/drop-down.html#alignment">Dropdown Alignment</a>.
 </div>
 
-## Default
+## Dark(#css-dark)
 
 <div class="sheet-example">
     <nav class="application-bar application-bar-dark navbar navbar-expand-md">
@@ -189,7 +188,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/satellite-components/navigati
 </nav>
 ```
 
-## Using Buttons
+## Using Buttons(#css-using-buttons)
 
 <div class="sheet-example">
     <nav class="application-bar application-bar-dark navbar navbar-expand-md">

--- a/clayui.com/content/docs/components/css-badges.md
+++ b/clayui.com/content/docs/components/css-badges.md
@@ -7,11 +7,11 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/badges/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Variations](#variations)
--   [Pill badges](#pill-badges)
--   [Anchor](#anchor)
--   [Links inside](#links-inside)
--   [Text truncate](#text-truncate)
+-   [Variations](#css-variations)
+-   [Pill Badges](#css-pill-badges)
+-   [Anchor](#css-anchor)
+-   [Links Inside](#css-links-inside)
+-   [Text Truncate](#css-text-truncate)
 
 </div>
 </div>
@@ -20,7 +20,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/badges/'
 	Badge Sizes have been removed. Use the <a href="https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/mixins/_badges.scss#L19">clay-badge-size($map) mixin</a> to create custom badge sizes for your app.
 </div>
 
-## Variations
+## Variations(#css-variations)
 
 Add any of the below mentioned modifier classes to change the appearance of a badge.
 
@@ -85,7 +85,7 @@ Add any of the below mentioned modifier classes to change the appearance of a ba
 </span>
 ```
 
-## Pill badges
+## Pill Badges(#css-pill-badges)
 
 Use the `.badge-pill` modifier class to make badges more rounded.
 
@@ -150,7 +150,7 @@ Use the `.badge-pill` modifier class to make badges more rounded.
 </span>
 ```
 
-## Anchor
+## Anchor(#css-anchor)
 
 <div class="sheet-example">
 	<a class="badge badge-primary" href="#1">
@@ -164,7 +164,7 @@ Use the `.badge-pill` modifier class to make badges more rounded.
 </a>
 ```
 
-## Links inside
+## Links Inside(#css-links-inside)
 
 <div class="sheet-example">
 	<span class="badge badge-secondary badge-pill">
@@ -218,7 +218,7 @@ Use the `.badge-pill` modifier class to make badges more rounded.
 </span>
 ```
 
-## Text truncate
+## Text Truncate(#css-text-truncate)
 
 Wrap the text inside the `.text-truncate-inline` and `.text-truncate` modifier class.
 

--- a/clayui.com/content/docs/components/css-button-group.md
+++ b/clayui.com/content/docs/components/css-button-group.md
@@ -7,16 +7,16 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Examples](#examples)
--   [Split Button](#split-button)
--   [Button toolbar](#button-toolbar)
--   [Sizes](#sizes)
--   [Vertical variation](#vertical-variation)
+-   [Examples](#css-examples)
+-   [Split Button](#css-split-button)
+-   [Button Toolbar](#css-button-toolbar)
+-   [Sizes](#css-sizes)
+-   [Vertical Variation](#css-vertical-variation)
 
 </div>
 </div>
 
-## Examples
+## Examples(#css-examples)
 
 <div class="sheet-example">
 	<div class="btn-group" role="group">
@@ -34,7 +34,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
 </div>
 ```
 
-## Split Button
+## Split Button(#css-split-button)
 
 <div class="sheet-example">
 	<div class="btn-group" role="group">
@@ -86,7 +86,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
 </div>
 ```
 
-## Button toolbar
+## Button Toolbar(#css-button-toolbar)
 
 Combine sets of button groups into button toolbars for more complex components. Use utility classes as needed to space out groups, buttons, and more.
 
@@ -152,7 +152,7 @@ Combine sets of button groups into button toolbars for more complex components. 
 </div>
 ```
 
-## Sizes
+## Sizes(#css-sizes)
 
 Instead of applying button sizing classes to every button in a group, just add `.btn-group-*` to each `.btn-group`, including each one when nesting multiple groups.
 
@@ -186,7 +186,7 @@ Instead of applying button sizing classes to every button in a group, just add `
 </div>
 ```
 
-## Vertical variation
+## Vertical Variation(#css-vertical-variation)
 
 <div class="sheet-example">
 	<div class="btn-group-vertical" role="group">

--- a/clayui.com/content/docs/components/css-buttons.md
+++ b/clayui.com/content/docs/components/css-buttons.md
@@ -7,12 +7,12 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Examples](#examples)
--   [Sizes](#sizes)
--   [Active state](#active-state)
--   [Disabled State](#disabled-state)
--   [Icons](#icons)
-    -   [With text button](#with-text-button)
+-   [Examples](#css-examples)
+-   [Sizes](#css-sizes)
+-   [Active state](#css-active-state)
+-   [Disabled State](#css-disabled-state)
+-   [Icons](#css-icons)
+    -   [With text button](#css-with-text-button)
 
 </div>
 </div>
@@ -21,7 +21,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
 	Don't forget to check <a href="https://www.w3.org/TR/wai-aria-practices/#button">WAI-ARIA</a> accessibility pratices for buttons when writting your markup.
 </div>
 
-## Examples
+## Examples(#css-examples)
 
 <div class="sheet-example">
 	<button class="btn btn-primary" type="button">Primary</button>
@@ -43,7 +43,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
 <button class="btn btn-link" type="button">Link</button>
 ```
 
-## Sizes
+## Sizes(#css-sizes)
 
 <div class="sheet-example">
 	<button class="btn btn-primary" type="button">Default</button>
@@ -71,7 +71,7 @@ Create block level buttons—those that span the full width of a parent—by add
 </button>
 ```
 
-## Active state
+## Active State(#css-active-state)
 
 Buttons will appear pressed when active. However, you can still force the same active appearance with `.active` (and include the `aria-pressed="true"` attribute) should you need to replicate the state programmatically.
 
@@ -85,7 +85,7 @@ Buttons will appear pressed when active. However, you can still force the same a
 <button class="active btn btn-secondary" type="button">Secondary</button>
 ```
 
-## Disabled State
+## Disabled State(#css-disabled-state)
 
 Make buttons look inactive by adding the `disabled` boolean attribute to any `<button>` element.
 
@@ -99,7 +99,7 @@ Make buttons look inactive by adding the `disabled` boolean attribute to any `<b
 <button class="btn btn-secondary" disabled="" type="button">Secondary</button>
 ```
 
-## Icons
+## Icons(#css-icons)
 
 Buttons can display icons instead of text. The icons, however, must be monospaced inside the button. Lexicon doesn't use buttons with text and icons or text and loading indicators. Icon buttons are used primarily in management bars. This button variation can be primary, secondary, or borderless type.
 
@@ -139,7 +139,7 @@ Try adding the modifier class `.btn-monospaced`.
 </button>
 ```
 
-### With text button
+### With Text Button(#css-with-text-button)
 
 This button type is only used in sites, outside of administration. The icon emphasizes and helps communicate the action. The label must match the icon's purpose.
 

--- a/clayui.com/content/docs/components/css-cards.md
+++ b/clayui.com/content/docs/components/css-cards.md
@@ -7,29 +7,29 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/cards/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Content Types](#content-types)
-    -   [Body](#body)
-    -   [Captions](#captions)
-    -   [Images](#images)
-    -   [Header and footer](#header-and-footer)
-    -   [Dividers](#dividers)
--   [Variations](#variations)
-    -   [Image Card](#image-card)
-    -   [File Card](#file-card)
-    -   [User Card](#user-card)
-    -   [Horizontal Card](#horizontal-card)
-    -   [Interactive Card](#interactive-card)
--   [States](#states)
-    -   [Hover](#hover)
-    -   [Active](#active)
-    -   [Empty](#empty)
--   [Helpers](#helpers)
+-   [Example](#css-example)
+-   [Content Types](#css-content-types)
+    -   [Body](#css-body)
+    -   [Captions](#css-captions)
+    -   [Images](#css-images)
+    -   [Header and Footer](#css-header-and-footer)
+    -   [Dividers](#css-dividers)
+-   [Variations](#css-variations)
+    -   [Image Card](#css-image-card)
+    -   [File Card](#css-file-card)
+    -   [User Card](#css-user-card)
+    -   [Horizontal Card](#css-horizontal-card)
+    -   [Interactive Card](#css-interactive-card)
+-   [States](#css-states)
+    -   [Hover](#css-hover)
+    -   [Active](#css-active)
+    -   [Empty](#css-empty)
+-   [Helpers](#css-helpers)
 
 </div>
 </div>
 
-# Example
+# Example(#css-example)
 
 <div class="sheet-example">
     <div class="card" style="width: 18rem;">
@@ -54,11 +54,11 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/cards/'
 </div>
 ```
 
-# Content Types
+# Content Types(#css-content-types)
 
 Cards support a wide variety of content, including images, text, list groups, links, and more. Below are examples of what’s supported.
 
-## Body
+## Body(#css-body)
 
 The building block of a card is the `.card-body`. Use it whenever you need a padded section within a card.
 
@@ -78,7 +78,7 @@ The building block of a card is the `.card-body`. Use it whenever you need a pad
 </div>
 ```
 
-## Captions
+## Captions(#css-captions)
 
 Card titles are used by adding `.card-title` to a `<h*>` tag. In the same way, links are added and placed next to each other by adding `.card-link` to an `<a>` tag.
 
@@ -112,7 +112,7 @@ Subtitles are used by adding a `.card-subtitle` to a `<h*>` tag. If the `.card-t
 </div>
 ```
 
-## Images
+## Images(#css-images)
 
 Use classes `card-item-first` and `card-item-last` on elements that appear at the beginning or ending of your card. It styles the `border-radius` to match the card's `border-radius`. These classes work similar to Bootstrap 4's `.card-img-top` and `.card-img-bottom` but also covers left and right.
 
@@ -189,7 +189,7 @@ Use classes `card-item-first` and `card-item-last` on elements that appear at th
 </div>
 ```
 
-## Header and Footer
+## Header and Footer(#css-header-and-footer)
 
 Add an optional header and/or footer within a card.
 
@@ -249,7 +249,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 </div>
 ```
 
-## Dividers
+## Dividers(#css-dividers)
 
 Use `<div class="card-divider"></div>` to create a horizontal division between content inside a card.
 
@@ -291,9 +291,9 @@ Use `<div class="card-divider"></div>` to create a horizontal division between c
 </div>
 ```
 
-# Variations
+# Variations(#css-variations)
 
-## Image Card
+## Image Card(#css-image-card)
 
 Just add `image-card` class on the same element that `card` class have being added.
 
@@ -483,7 +483,7 @@ Just add `image-card` class on the same element that `card` class have being add
 </div>
 ```
 
-## File Card
+## File Card(#css-file-card)
 
 <div class="sheet-example">
     <div class="col-md-4">
@@ -569,7 +569,7 @@ Just add `image-card` class on the same element that `card` class have being add
 </div>
 ```
 
-## User Card
+## User Card(#css-user-card)
 
 <div class="sheet-example">
     <div class="row">
@@ -680,7 +680,7 @@ Just add `image-card` class on the same element that `card` class have being add
 </div>
 ```
 
-## Horizontal Card
+## Horizontal Card(#css-horizontal-card)
 
 <div class="sheet-example">
     <div class="col-md-4">
@@ -747,9 +747,9 @@ Just add `image-card` class on the same element that `card` class have being add
 </div>
 ```
 
-## Interactive Card
+## Interactive Card(#css-interactive-card)
 
-### Default
+### Default(#css-default)
 
 <div class="sheet-example">
     <div class="row">
@@ -854,7 +854,7 @@ Just add `image-card` class on the same element that `card` class have being add
 </div>
 ```
 
-### Horizontal
+### Horizontal(#css-horizontal)
 
 <div class="sheet-example">
     <div class="row">
@@ -1042,9 +1042,9 @@ Just add `image-card` class on the same element that `card` class have being add
 </div>
 ```
 
-# States
+# States(#css-states)
 
-## Hover
+## Hover(#css-hover)
 
 <div class="sheet-example">
     <div class="col-md-4">
@@ -1181,7 +1181,7 @@ Just add `image-card` class on the same element that `card` class have being add
 </div>
 ```
 
-## Active
+## Active(#css-active)
 
 Just add `active` class on the element where `card` class was placed.
 
@@ -1220,7 +1220,7 @@ Just add `active` class on the element where `card` class was placed.
 </div>
 ```
 
-## Empty
+## Empty(#css-empty)
 
 By default, when adding `image-card` class and inside the element that contains `image-card`, exists a `aspect-ratio` class. A transparent background will be setted.
 
@@ -1280,9 +1280,9 @@ By default, when adding `image-card` class and inside the element that contains 
 </div>
 ```
 
-# Helpers
+# Helpers(#css-helpers)
 
-## Checkbox
+## Checkbox(#css-checkbox)
 
 To make the whole card clickable just wrap the checkbox and card in:
 
@@ -1541,7 +1541,7 @@ To make the whole card clickable just wrap the checkbox and card in:
 </div>
 ```
 
-## Radio
+## Radio(#css-radio)
 
 To make the whole card clickable just wrap the radio input and card in:
 
@@ -1994,7 +1994,7 @@ Two `.autofit-col-expand`'s no `.autofit-col`.
 </div>
 ```
 
-## Padded Horizontal Cards
+## Padded Horizontal Cards(#css-padded-horizontal-cards)
 
 Nest `card-row` in `card-body` on to add some spacing around a horizontal card.
 
@@ -2039,7 +2039,7 @@ Nest `card-row` in `card-body` on to add some spacing around a horizontal card.
 </div>
 ```
 
-## Truncating Text Inside Card
+## Truncating Text Inside Card(#css-truncating-text-inside-card)
 
 Add class `text-truncate` on whatever text you want to be truncated.
 
@@ -2095,7 +2095,7 @@ Add class `text-truncate` on whatever text you want to be truncated.
 </div>
 ```
 
-## Card Row Content Alignment Helpers
+## Card Row Content Alignment Helpers(#css-card-row-content-alignment-helpers)
 
 Vertically align content by setting `justify-content` to `flex-start`, `center`, or `flex-end` on `autofit-col`.
 
@@ -2180,7 +2180,7 @@ Add gutters to a specific card card column by using the class `autofit-col-gutte
 </div>
 ```
 
-### Rounded
+### Rounded(#css-rounded)
 
 Use classes `rounded`, `rounded-circle`, or `rounded-0` on the card to quickly shape the borders.
 

--- a/clayui.com/content/docs/components/css-checkbox-radio.md
+++ b/clayui.com/content/docs/components/css-checkbox-radio.md
@@ -7,11 +7,11 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-c
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Default](#default)
+-   [Default](#css-default)
 -   [Inline](#css-inline)
--   [Disabled](#disabled)
--   [Without labels](#without-labels)
--   [Custom](#custom)
+-   [Disabled](#css-disabled)
+-   [Without Labels](#css-without-labels)
+-   [Custom](#css-custom)
 
 </div>
 </div>
@@ -23,11 +23,11 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-c
 Default checkboxes and radios are improved upon with the help of `.form-check`, **a single class for both input types that improves the layout and behavior of their HTML elements**. Checkboxes are for selecting one or several options in a list, while radios are for selecting one option from many.
 By [Bootstrap](https://getbootstrap.com/docs/4.1/components/forms/#checkboxes-and-radios)
 
-## Default
+## Default(#css-default)
 
 By default, any number of checkboxes and radios that are immediate sibling will be vertically stacked and appropriately spaced with `.form-check`.
 
-### Checkboxes
+### Checkboxes(#css-default-checkboxes)
 
 <div class="sheet-example">
 	<div class="form-check">
@@ -70,7 +70,7 @@ By default, any number of checkboxes and radios that are immediate sibling will 
 </div>
 ```
 
-### Radios
+### Radios(#css-default-radios)
 
 <div class="sheet-example">
 	<div class="form-check">
@@ -138,7 +138,7 @@ By default, any number of checkboxes and radios that are immediate sibling will 
 
 Group checkboxes or radios on the same horizontal row by adding `.form-check-inline` to any `.form-check`.
 
-### Checkbox
+### Checkbox(#css-inline-checkbox)
 
 <div class="sheet-example">
 	<div class="form-check form-check-inline">
@@ -181,7 +181,7 @@ Group checkboxes or radios on the same horizontal row by adding `.form-check-inl
 </div>
 ```
 
-### Radio
+### Radio(#css-inline-radio)
 
 <div class="sheet-example">
 	<div class="form-check form-check-inline">
@@ -226,7 +226,7 @@ Group checkboxes or radios on the same horizontal row by adding `.form-check-inl
 </div>
 ```
 
-## Disabled
+## Disabled(#css-disabled)
 
 Disable checkboxes or radios by adding a `disabled` prop.
 
@@ -283,7 +283,7 @@ Disable checkboxes or radios by adding a `disabled` prop.
 </div>
 ```
 
-## Without labels
+## Without Labels(#css-without-labels)
 
 Remember to still provide some form of label for assistive technologies (for instance, using `aria-label`).
 
@@ -323,7 +323,7 @@ Remember to still provide some form of label for assistive technologies (for ins
 </div>
 ```
 
-## Custom
+## Custom(#css-custom)
 
 The two ways for you to structure the marking of a Checkbox and Radio:
 
@@ -355,7 +355,7 @@ Using the `id` binding engine with `<label />`and `<input />`.
 </div>
 ```
 
-### Checkboxes
+### Checkboxes(#css-custom-checkboxes)
 
 <div class="sheet-example">
 	<div class="custom-control custom-checkbox">
@@ -394,7 +394,7 @@ Custom checkboxes can also utilize the `:indeterminate` pseudo class when manual
 	</div>
 </div>
 
-### Radios
+### Radios(#css-custom-radios)
 
 <div class="sheet-example">
 	<div class="custom-control custom-radio">

--- a/clayui.com/content/docs/components/css-color-picker.md
+++ b/clayui.com/content/docs/components/css-color-picker.md
@@ -7,9 +7,9 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Variations](#variations)
--   [Sizes](#sizes)
+-   [Example](#css-example)
+-   [Variations](#css-variations)
+-   [Sizes](#css-sizes)
 
 </div>
 </div>
@@ -18,7 +18,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 	This requires custom javascript.
 </div>
 
-## Example
+## Example(#css-example)
 
 <div class="sheet-example">
 	<label for="clayColor1DropdownToggle">Background Color</label>
@@ -253,7 +253,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 </div>
 ```
 
-## Variations
+## Variations(#css-variations)
 
 <div class="sheet-example">
 	<div class="clay-site-dropdown-menu-container">
@@ -737,7 +737,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 </div>
 ```
 
-## Sizes
+## Sizes(#css-sizes)
 
 <div class="sheet-example">
 	<div class="form-group form-group-sm">

--- a/clayui.com/content/docs/components/css-date-and-time-pickers.md
+++ b/clayui.com/content/docs/components/css-date-and-time-pickers.md
@@ -7,10 +7,10 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Field](#field)
--   [Date Picker](#date-picker)
--   [Time Picker](#time-picker)
+-   [Example](#css-example)
+-   [Field](#css-field)
+-   [Date Picker](#css-date-picker)
+-   [Time Picker](#css-time-picker)
 
 </div>
 </div>
@@ -19,7 +19,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-
 	This requires custom javascript.
 </div>
 
-## Example
+## Example(#css-example)
 
 The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`. `Footer`: You can add elements that complement the Date Picker like the Time Picker.
 
@@ -604,7 +604,7 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 </div>
 ```
 
-## Field
+## Field(#css-field)
 
 <div class="sheet-example">
 	<div class="input-group">
@@ -650,7 +650,7 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 </div>
 ```
 
-## Date Picker
+## Date Picker(#css-date-picker)
 
 <div class="sheet-example">
 	<div class="date-picker">
@@ -1180,7 +1180,7 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 </div>
 ```
 
-## Time Picker
+## Time Picker(#css-time-picker)
 
 <div class="sheet-example">
 	<div class="col-md-5">

--- a/clayui.com/content/docs/components/css-dropdown.md
+++ b/clayui.com/content/docs/components/css-dropdown.md
@@ -7,37 +7,37 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/dropdowns/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Variations](#variations)
-    -   [Default](#default)
-    -   [Wide](#wide)
-    -   [Full](#full)
--   [Content Types](#content-types)
-    -   [Dividers](#dividers)
-    -   [Form Elements](#form-elements)
-        -   [Checkbox or Radio](#checkbox-or-radio)
-        -   [Search](#search)
-        -   [Form Groups](#form-groups)
-    -   [Indicators](#indicators)
-        -   [Start](#start)
-        -   [End](#end)
-        -   [Start and End](#start-and-end)
-    -   [Keyboard Shortcuts](#keyboard-shortcuts)
-    -   [Scrolling Content](#scrolling-content)
--   [Actions](#actions)
-    -   [Buttons](#buttons)
-    -   [Anchors](#anchors)
--   [Alignment](#alignment)
-    -   [Corners](#corners)
-    -   [Sides](#sides)
-    -   [Middle](#middle)
-    -   [Center](#center)
+-   [Variations](#css-variations)
+    -   [Default](#css-default)
+    -   [Wide](#css-wide)
+    -   [Full](#css-full)
+-   [Content Types](#css-content-types)
+    -   [Dividers](#css-dividers)
+    -   [Form Elements](#css-form-elements)
+        -   [Checkbox or Radio](#css-checkbox-or-radio)
+        -   [Search](#css-search)
+        -   [Form Groups](#css-form-groups)
+    -   [Indicators](#css-indicators)
+        -   [Start](#css-start)
+        -   [End](#css-end)
+        -   [Start and End](#css-start-and-end)
+    -   [Keyboard Shortcuts](#css-keyboard-shortcuts)
+    -   [Scrolling Content](#css-scrolling-content)
+-   [Actions](#css-actions)
+    -   [Buttons](#css-buttons)
+    -   [Anchors](#css-anchors)
+-   [Alignment](#css-alignment)
+    -   [Corners](#css-corners)
+    -   [Sides](#css-sides)
+    -   [Middle](#css-middle)
+    -   [Center](#css-center)
 
 </div>
 </div>
 
-## Variations
+## Variations(#css-variations)
 
-### Default
+### Default(#css-default)
 
 The default dropdown is a panel that does not support scrolling of the content inside it. Use this type when the number of options you want to offer is short or the panel is big enough to contain all the elements you want to use.
 
@@ -67,7 +67,7 @@ The default dropdown is a panel that does not support scrolling of the content i
 </div>
 ```
 
-### Wide
+### Wide(#css-wide)
 
 Use `.dropdown-wide` with `.dropdown` to make the dropdown menu big. The default width is 500px.
 
@@ -234,7 +234,7 @@ Use `.dropdown-wide` with `.dropdown` to make the dropdown menu big. The default
 </div>
 ```
 
-### Full
+### Full(#css-full)
 
 Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 
@@ -403,9 +403,9 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 </div>
 ```
 
-## Content Types
+## Content Types(#css-content-types)
 
-### Dividers
+### Dividers(#css-dividers)
 
 <div class="sheet-example">
     <div class="clay-site-dropdown-menu-container">
@@ -437,9 +437,9 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 </ul>
 ```
 
-### Form Elements
+### Form Elements(#css-form-elements)
 
-#### Checkbox or Radio
+#### Checkbox or Radio(#css-checkbox-or-radio)
 
 <div class="sheet-example">
     <div class="row">
@@ -646,7 +646,7 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 </ul>
 ```
 
-#### Search
+#### Search(#css-search)
 
 <div class="sheet-example">
     <div class="clay-site-dropdown-menu-container">
@@ -730,7 +730,7 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 </ul>
 ```
 
-#### Form Groups
+#### Form Groups(#css-form-groups)
 
 <div class="sheet-example">
     <div class="clay-site-dropdown-menu-container">
@@ -827,9 +827,9 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 </ul>
 ```
 
-### Indicators
+### Indicators(#css-indicators)
 
-#### Start
+#### Start(#css-start)
 
 <div class="sheet-example">
     <div class="clay-site-dropdown-menu-container">
@@ -930,7 +930,7 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 </ul>
 ```
 
-#### End
+#### End(#css-end)
 
 <div class="sheet-example">
     <div class="clay-site-dropdown-menu-container">
@@ -1031,7 +1031,7 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 </ul>
 ```
 
-#### Start and End
+#### Start and End(#css-start-and-end)
 
 <div class="sheet-example">
     <div class="clay-site-dropdown-menu-container">
@@ -1146,7 +1146,7 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 </ul>
 ```
 
-### Keyboard Shortcuts
+### Keyboard Shortcuts(#css-keyboard-shortcuts)
 
 <div class="sheet-example">
 	<div class="clay-site-dropdown-menu-container">
@@ -1331,7 +1331,7 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 </ul>
 ```
 
-### Scrolling Content
+### Scrolling Content(#css-scrolling-content)
 
 Nest `<div class="inline-scroller"></div>` inside a `.dropdown-menu` list item to create a scrollable dropdown. The maximum height is 200px on screen sizes 768px and above, on screen sizes 767px and below the overflow is handled by `.dropdown-menu`.
 
@@ -1397,11 +1397,11 @@ Nest `<div class="inline-scroller"></div>` inside a `.dropdown-menu` list item t
 </ul>
 ```
 
-## Actions
+## Actions(#css-actions)
 
 A monospaced `dropdown-toggle` for a dropdown containing several actions, add `dropdown-action` to `dropdown`.
 
-### Anchors
+### Anchors(#css-anchors)
 
 <div class="sheet-example">
     <div class="clay-site-dropdown-menu-container">
@@ -1452,7 +1452,7 @@ A monospaced `dropdown-toggle` for a dropdown containing several actions, add `d
 </div>
 ```
 
-### Buttons
+### Buttons(#css-buttons)
 
 <div class="sheet-example">
     <div class="clay-site-dropdown-menu-container">
@@ -1502,9 +1502,9 @@ A monospaced `dropdown-toggle` for a dropdown containing several actions, add `d
 </div>
 ```
 
-## Alignment
+## Alignment(#css-alignment)
 
-### Corners
+### Corners(#css-corners)
 
 Align a dropdown menu on the top or bottom side with classes `dropdown-menu`, `dropdown-menu-right`, `dropdown-menu-top`, or `dropdown-menu-top-right`.
 
@@ -1676,7 +1676,7 @@ Align a dropdown menu on the top or bottom side with classes `dropdown-menu`, `d
 </div>
 ```
 
-### Sides
+### Sides(#css-sides)
 
 Add the `dropdown-menu-right-side`, `dropdown-menu-left-side`, `dropdown-menu-right-side-bottom`, or `dropdown-menu-left-side-bottom` class to a dropdown menu to align it with the right side, left side, bottom-right side, or bottom-left side of the dropdown menu trigger, respectively:
 
@@ -1878,7 +1878,7 @@ Add the `dropdown-menu-right-side`, `dropdown-menu-left-side`, `dropdown-menu-ri
 </div>
 ```
 
-### Middle
+### Middle(#css-middle)
 
 You can also center the dropdown menu to its trigger with these four helper classes: `dropdown-menu-center`, `dropdown-menu-top-center`, `dropdown-menu-left-side-middle`, or `dropdown-menu-right-side-middle`.
 
@@ -1976,7 +1976,7 @@ You can also center the dropdown menu to its trigger with these four helper clas
 </div>
 ```
 
-### Center
+### Center(#css-center)
 
 To center the dropdown menu in browsers that don't support CSS transforms, set a negative `margin-left` equal to the width of the `dropdown-menu` divided by two. To vertically align left-side and right-side dropdown-menus, set a negative `margin-top` equal to the height of the dropdown-menu divided by two.
 

--- a/clayui.com/content/docs/components/css-empty-state.md
+++ b/clayui.com/content/docs/components/css-empty-state.md
@@ -8,10 +8,10 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/empty-states/
 <div class="nav-toc">
 
 -   [Without Animation](#css-without-animation)
--   [Empty State](#empty-state)
--   [Search State](#search-state)
--   [Success State](#success-state)
--   [With imageProps](#with-imageprops)
+-   [Empty State](#css-empty-state)
+-   [Search State](#css-search-state)
+-   [Success State](#css-success-state)
+-   [With imageProps](#css-with-imageprops)
 
 </div>
 </div>
@@ -46,7 +46,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/empty-states/
 </div>
 ```
 
-## Empty State
+## Empty State(#css-empty-state)
 
 <div class="sheet-example">
 	<div class="c-empty-state c-empty-state-animation">
@@ -94,7 +94,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/empty-states/
 </div>
 ```
 
-## Search State
+## Search State(#css-search-state)
 
 <div class="sheet-example">
 	<div class="c-empty-state c-empty-state-animation">
@@ -140,7 +140,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/empty-states/
 </div>
 ```
 
-## Success State
+## Success State(#css-success-state)
 
 <div class="sheet-example">
 	<div class="c-empty-state c-empty-state-animation">
@@ -186,7 +186,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/empty-states/
 </div>
 ```
 
-## With imageProps
+## With imageProps(#css-with-imageprops)
 
 <div class="sheet-example">
 	<div class="c-empty-state c-empty-state-animation">

--- a/clayui.com/content/docs/components/css-form-group.md
+++ b/clayui.com/content/docs/components/css-form-group.md
@@ -7,8 +7,8 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Autofit](#autofit)
--   [Horizontal](#horizontal)
+-   [Autofit](#css-autofit)
+-   [Horizontal](#css-horizontal)
 
 </div>
 </div>
@@ -53,7 +53,7 @@ The `.form-group` class is the easiest way to add some structure to forms. It pr
 </form>
 ```
 
-## Autofit
+## Autofit(#css-autofit)
 
 Equally spaced form inputs based on the number of items inside `.form-group-autofit`. Each `input` and `label` group should be wrapped inside `.form-group-item`. `form-group-autofit` stacks all inputs at `max-width: 575px` (breakpoint sm).
 
@@ -390,7 +390,7 @@ To make a `.form-group-item` shrink to the size of its content add `.form-group-
 </form>
 ```
 
-## Horizontal
+## Horizontal(#css-horizontal)
 
 Create horizontal forms by placing each `input` inside `form-group-item` and `label` inside `form-group-item form-group-item-label form-group-item-shrink` and set a min-width on `.form-group-item-label`.
 

--- a/clayui.com/content/docs/components/css-forms-hierarchy.md
+++ b/clayui.com/content/docs/components/css-forms-hierarchy.md
@@ -7,9 +7,9 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [One column](#one-column)
--   [Two columns](#two-columns)
+-   [Example](#css-example)
+-   [One Column](#css-one-column)
+-   [Two Columns](#css-two-columns)
 
 </div>
 </div>
@@ -18,7 +18,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 	Don't forget to check <a href="https://www.w3.org/TR/wai-aria-practices/#accordion">WAI-ARIA</a> accessibility pratices for Forms Hierarchy when writting your markup.
 </div>
 
-## Example
+## Example(#css-example)
 
 <div class="sheet-example">
 	<div class="sheet sheet-lg">
@@ -170,7 +170,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 </div>
 ```
 
-## One column
+## One Column(#css-one-column)
 
 <div class="sheet-example">
 	<div class="sheet sheet-lg">
@@ -271,7 +271,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 </div>
 ```
 
-## Two columns
+## Two Columns(#css-two-columns)
 
 <div class="sheet-example">
 	<div class="sheet sheet-lg">

--- a/clayui.com/content/docs/components/css-labels.md
+++ b/clayui.com/content/docs/components/css-labels.md
@@ -7,19 +7,19 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/labels/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Colors](#colors)
--   [Sizes](#sizes)
--   [Variations](#variations)
-    -   [Simple](#simple)
-    -   [Dismissible](#dismissible)
-    -   [Link](#link)
-    -   [Interactive](#interactive)
-    -   [Anchor Tag](#anchor-tag)
+-   [Colors](#css-colors)
+-   [Sizes](#css-sizes)
+-   [Variations](#css-variations)
+    -   [Simple](#css-simple)
+    -   [Dismissible](#css-dismissible)
+    -   [Link](#css-link)
+    -   [Interactive](#css-interactive)
+    -   [Anchor Tag](#css-anchor-tag)
 
 </div>
 </div>
 
-## Colors
+## Colors(#css-colors)
 
 <div class="sheet-example">
 	<span class="label label-primary"><span class="label-item label-item-expand">Primary</span></span>
@@ -97,7 +97,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/labels/'
 </span>
 ```
 
-## Sizes
+## Sizes(#css-sizes)
 
 Use `label-lg` to make the label larger, or use the mixin `label-size($sassMap)` to create a custom sized label:
 
@@ -119,9 +119,9 @@ Use `label-lg` to make the label larger, or use the mixin `label-size($sassMap)`
 </span>
 ```
 
-## Variations
+## Variations(#css-variations)
 
-### Simple
+### Simple(#css-simple)
 
 <div class="sheet-example">
 	<span class="label label-secondary"><span class="label-item label-item-expand">Simple Label</span></span>
@@ -135,7 +135,7 @@ Use `label-lg` to make the label larger, or use the mixin `label-size($sassMap)`
 </span>
 ```
 
-### Dismissible
+### Dismissible(#css-dismissible)
 
 <div class="sheet-example">
 	<span class="label label-dismissible label-secondary">
@@ -195,7 +195,7 @@ Use `label-lg` to make the label larger, or use the mixin `label-size($sassMap)`
 </span>
 ```
 
-### Link
+### Link(#css-link)
 
 <div class="sheet-example">
 	<span class="label label-dismissible label-lg label-success">
@@ -253,7 +253,7 @@ Use `label-lg` to make the label larger, or use the mixin `label-size($sassMap)`
 </span>
 ```
 
-### Interactive
+### Interactive(#css-interactive)
 
 Add the `tabindex="0"` attribute to the `.label` element to create an interactive label with multiple controls inside. The inner controls should have the attribute `tabindex="-1"` to remove them from the tab order. The inner controls can be placed back in the tab order by changing back to `tabindex="0"` with javascript.
 
@@ -347,7 +347,7 @@ Implementing Interactive Labels require custom javascript.
 </span>
 ```
 
-### Anchor Tag
+### Anchor Tag(#css-anchor-tag)
 
 <div class="sheet-example">
 	<a class="label label-primary" href="#1">

--- a/clayui.com/content/docs/components/css-links.md
+++ b/clayui.com/content/docs/components/css-links.md
@@ -7,17 +7,17 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/link/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Styles](#styles)
--   [Single Link](#single-link)
--   [Component Links](#component-links)
--   [Component Action](#component-action)
-    -   [Anchor](#anchor)
-    -   [Button](#button)
--   [Outline](#outline)
--   [Outline Borderless](#outline-borderless)
--   [External Link](#external-link)
--   [Monospaced](#monospaced)
--   [Title Link](#title-link)
+-   [Styles](#css-styles)
+-   [Single Link](#css-single-link)
+-   [Component Links](#css-component-links)
+-   [Component Action](#css-component-action)
+    -   [Anchor](#css-anchor)
+    -   [Button](#css-button)
+-   [Outline](#css-outline)
+-   [Outline Borderless](#css-outline-borderless)
+-   [External Link](#css-external-link)
+-   [Monospaced](#css-monospaced)
+-   [Title Link](#css-title-link)
 
 </div>
 </div>
@@ -28,7 +28,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/link/'
 
 These elements should be used to style links based on the global link, primary, and secondary colors.
 
-## Styles
+## Styles(#css-styles)
 
 <div class="sheet-example">
 	<div><a href="#1">Regular Anchor Tag</a></div>
@@ -42,7 +42,7 @@ These elements should be used to style links based on the global link, primary, 
 <div><a class="link-secondary" href="#1">.link-secondary</a></div>
 ```
 
-## Single Link
+## Single Link(#css-single-link)
 
 Use `.single-link` on an anchor to add a semi-bold style to the link and should be used for standalone links defined by https://liferay.design/lexicon/core-components/link/.
 
@@ -56,7 +56,7 @@ Use `.single-link` on an anchor to add a semi-bold style to the link and should 
 <a class="link-secondary single-link" href="#1">.link-secondary.single-link</a>
 ```
 
-## Component Links
+## Component Links(#css-component-links)
 
 Use these patterns for links, titles, subtitles in components.
 
@@ -78,11 +78,11 @@ The colors, sizing, and other CSS Properties can change for these items dependin
 <p class="component-subtitle"><a href="#1">.component-subtitle a</a></p>
 ```
 
-## Component Action
+## Component Action(#css-component-action)
 
 Use these patterns for actions in components.
 
-### Anchor
+### Anchor(#css-anchor)
 
 <div class="sheet-example">
 	<a class="component-action" href="#1" role="button">
@@ -118,7 +118,7 @@ Use these patterns for actions in components.
 </a>
 ```
 
-### Button
+### Button(#css-button)
 
 <div class="sheet-example">
 	<button class="component-action" role="button">
@@ -154,7 +154,7 @@ Use these patterns for actions in components.
 </button>
 ```
 
-## Outline
+## Outline(#css-outline)
 
 <div class="sheet-example">
 	<a class="link-outline link-outline-primary" href="#1">Primary</a>
@@ -166,7 +166,7 @@ Use these patterns for actions in components.
 <a class="link-outline link-outline-secondary" href="#1">Secondary</a>
 ```
 
-## Outline Borderless
+## Outline Borderless(#css-outline-borderless)
 
 <div class="sheet-example">
 	<a class="link-outline link-outline-borderless link-outline-primary" href="#1">Primary</a>
@@ -182,7 +182,7 @@ Use these patterns for actions in components.
 >
 ```
 
-## External Link
+## External Link(#css-external-link)
 
 <div class="sheet-example">
 	<a aria-label="External Link" class="link-secondary" href="#link-styles" title="External Link">
@@ -201,7 +201,7 @@ Use these patterns for actions in components.
 </a>
 ```
 
-## Monospaced
+## Monospaced(#css-monospaced)
 
 <div class="sheet-example">
 	<a class="link-monospaced link-outline link-outline-primary" href="#1">
@@ -290,7 +290,7 @@ Use these patterns for actions in components.
 </a>
 ```
 
-## Title Link
+## Title Link(#css-title-link)
 
 <div class="sheet-example">
 	<a aria-label="Title Link" class="component-title link-secondary" href="#title-link" title="Title">

--- a/clayui.com/content/docs/components/css-list.md
+++ b/clayui.com/content/docs/components/css-list.md
@@ -7,21 +7,21 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/list/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Variations](#variations)
-    -   [Bordered](#bordered)
-    -   [Default](#default)
-    -   [Notification](#notification)
--   [Group Elements](#group-elements)
-    -   [Header](#header)
-    -   [Items](#items)
-        -   [Colors](#colors)
-        -   [Active Colors](#active-colors)
-        -   [Items as Links and Buttons](#items-as-links-and-buttons)
-        -   [Actions on Hover](#actions-on-hover)
-            -   [Anchors](#anchors)
-            -   [Buttons](#buttons)
-        -   [Active](#active)
+-   [Example](#css-example)
+-   [Variations](#css-variations)
+    -   [Bordered](#css-bordered)
+    -   [Default](#css-default)
+    -   [Notification](#css-notification)
+-   [Group Elements](#css-group-elements)
+    -   [Header](#css-header)
+    -   [Items](#css-items)
+        -   [Colors](#css-colors)
+        -   [Active Colors](#css-active-colors)
+        -   [Items as Links and Buttons](#css-items-as-links-and-buttons)
+        -   [Actions on Hover](#css-actions-on-hover)
+            -   [Anchors](#css-anchors)
+            -   [Buttons](#css-buttons)
+        -   [Active](#css-active)
 
 </div>
 </div>
@@ -30,7 +30,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/list/'
 
 List sections help separate content by a specific category or type.
 
-## Example
+## Example(#css-example)
 
 Align content inside a `.list-group-item` element with a flexbox with `.list-group-item-flex`.
 
@@ -302,9 +302,9 @@ Add the class `show-dropdown-action-on-active` to display `dropdown-menu`s when 
 </ul>
 ```
 
-## Variations
+## Variations(#css-variations)
 
-### Bordered
+### Bordered(#css-bordered)
 
 Use `.list-group-bordered` on `.list-group` to style `.list-group-item-flex` like a table.
 
@@ -545,7 +545,7 @@ Use `.list-group-bordered` on `.list-group` to style `.list-group-item-flex` lik
 </ul>
 ```
 
-### Default
+### Default(#css-default)
 
 <div class="sheet-example">
     <ul class="list-group">
@@ -625,7 +625,7 @@ Use `.list-group-bordered` on `.list-group` to style `.list-group-item-flex` lik
 </ul>
 ```
 
-### Notification
+### Notification(#css-notification)
 
 <div class="sheet-example">
     <ul class="list-group list-group-notification">
@@ -776,9 +776,9 @@ Use `.list-group-bordered` on `.list-group` to style `.list-group-item-flex` lik
 </ul>
 ```
 
-## Group Elements
+## Group Elements(#css-group-elements)
 
-### Header
+### Header(#css-header)
 
 Use the `.list-group-header` and `.list-group-header-title` class.
 
@@ -895,9 +895,9 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 </ul>
 ```
 
-### Items
+### Items(#css-items)
 
-#### Colors
+#### Colors(#css-colors)
 
 <div class="sheet-example">
     <ul class="list-group">
@@ -923,7 +923,7 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 </ul>
 ```
 
-#### Active Colors
+#### Active Colors(#css-active-colors)
 
 <div class="sheet-example">
     <div class="list-group">
@@ -975,7 +975,7 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 </div>
 ```
 
-#### Items as Links and Buttons
+#### Items as Links and Buttons(#css-items-as-links-and-buttons)
 
 <div class="sheet-example">
     <div class="list-group">
@@ -997,9 +997,9 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 </div>
 ```
 
-#### Actions on Hover
+#### Actions on Hover(#css-actions-on-hover)
 
-##### Anchors
+##### Anchors(#css-anchors)
 
 <div class="sheet-example">
     <ul class="list-group show-quick-actions-on-hover">
@@ -1150,7 +1150,7 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 </ul>
 ```
 
-##### Buttons
+##### Buttons(#css-buttons)
 
 <div class="sheet-example">
     <ul class="list-group show-quick-actions-on-hover">
@@ -1319,7 +1319,7 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 </ul>
 ```
 
-#### Active
+#### Active(#css-active)
 
 Use the `.active` class on the same element that you putted `.list-group-item`.
 

--- a/clayui.com/content/docs/components/css-loading-indicator.md
+++ b/clayui.com/content/docs/components/css-loading-indicator.md
@@ -7,13 +7,13 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/loading-indic
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Sizes](#sizes)
--   [Variations](#variations)
-    -   [Regular](#regular)
-    -   [Light](#light)
--   [Compositions](#compositions)
-    -   [Button](#button)
-    -   [Autocomplete](#autocomplete)
+-   [Sizes](#css-sizes)
+-   [Variations](#css-variations)
+    -   [Regular](#css-regular)
+    -   [Light](#css-light)
+-   [Compositions](#css-compositions)
+    -   [Button](#css-button)
+    -   [Autocomplete](#css-autocomplete)
 
 </div>
 </div>
@@ -22,7 +22,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/loading-indic
 	These animations are made using only CSS.
 </div>
 
-## Sizes
+## Sizes(#css-sizes)
 
 <div class="sheet-example">
 	<div class="row">
@@ -36,9 +36,9 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/loading-indic
 <span aria-hidden="true" class="loading-animation"></span>
 ```
 
-## Variations
+## Variations(#css-variations)
 
-### Regular
+### Regular(#css-regular)
 
 <div class="sheet-example">
 	<span aria-hidden="true" class="loading-animation loading-animation"></span>
@@ -48,7 +48,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/loading-indic
 <span aria-hidden="true" class="loading-animation loading-animation"></span>
 ```
 
-### Light
+### Light(#css-light)
 
 <div class="bg-dark sheet-example">
 	<span aria-hidden="true" class="loading-animation loading-animation-light"></span>
@@ -61,9 +61,9 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/loading-indic
 ></span>
 ```
 
-## Compositions
+## Compositions(#css-compositions)
 
-### Button
+### Button(#css-button)
 
 <div class="sheet-example">
 	<button class="btn btn-primary" type="button">

--- a/clayui.com/content/docs/components/css-management-toolbar.md
+++ b/clayui.com/content/docs/components/css-management-toolbar.md
@@ -7,18 +7,18 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/mana
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Light](#light)
--   [Primary](#primary)
--   [Overlay](#overlay)
-    -   [Breakpoints](#breakpoints)
--   [Only Search](#only-search)
-    -   [Always Open](#always-open)
-    -   [Collapses in Mobile](#collapses-in-mobile)
+-   [Light](#css-light)
+-   [Primary](#css-primary)
+-   [Overlay](#css-overlay)
+    -   [Breakpoints](#css-breakpoints)
+-   [Only Search](#css-only-search)
+    -   [Always Open](#css-always-open)
+    -   [Collapses in Mobile](#css-collapses-in-mobile)
 -   [Search](#css-markup-search)
-    -   [Summary](#summary)
-    -   [Results](#results)
-    -   [Results with Filter](#results-with-filter)
--   [Using Buttons](#using-buttons)
+    -   [Summary](#css-summary)
+    -   [Results](#css-results)
+    -   [Results with Filter](#css-results-with-filter)
+-   [Using Buttons](#css-using-buttons)
 
 </div>
 </div>
@@ -31,7 +31,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/mana
     Bootstrap 4 doesn't support Dropdown Menu's with Popper.js positioning inside Navbars. They align them manually via CSS classes. See <a href="/docs/components/drop-down.html#alignment">Dropdown Alignment</a>.
 </div>
 
-## Light
+## Light(#css-light)
 
 <div class="sheet-example">
     <nav class="management-bar management-bar-light navbar navbar-expand-md">
@@ -187,7 +187,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/mana
 </nav>
 ```
 
-## Primary
+## Primary(#css-primary)
 
 <div class="sheet-example">
     <nav class="management-bar management-bar-primary navbar navbar-expand-md">
@@ -343,7 +343,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/mana
 </nav>
 ```
 
-## Overlay
+## Overlay(#css-overlay)
 
 Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to create an overlay on top of the navbar with alternate content, useful for expanding search bars or an alternate navbar that depends on some state in your application. Toggle the `navbar-overlay`'s visibility by adding or removing the class `show` to `navbar-overlay`.
 
@@ -740,7 +740,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 </nav>
 ```
 
-### Breakpoints
+### Breakpoints(#css-breakpoints)
 
 `navbar-overlay-up` overlays the navbar at all screen widths.
 `navbar-overlay-lg-down`: 1199px and below
@@ -1135,9 +1135,9 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 </nav>
 ```
 
-## Only Search
+## Only Search(#css-only-search)
 
-### Always Open
+### Always Open(#css-always-open)
 
 <div class="sheet-example">
     <nav class="management-bar management-bar-light navbar navbar-expand-md">
@@ -1217,7 +1217,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 </nav>
 ```
 
-### Collapses in Mobile
+### Collapses in Mobile(#css-collapses-in-mobile)
 
 <div class="sheet-example">
     <nav class="management-bar management-bar-light navbar navbar-expand-md">
@@ -1327,7 +1327,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 
 ## Search(#css-markup-search)
 
-### Summary
+### Summary(#css-summary)
 
 <div class="sheet-example">
     <nav class="tbar subnav-tbar subnav-tbar-primary">
@@ -1363,7 +1363,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 </nav>
 ```
 
-### Results
+### Results(#css-results)
 
 <div class="sheet-example">
     <nav class="tbar subnav-tbar subnav-tbar-primary">
@@ -1414,7 +1414,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 </nav>
 ```
 
-### Results with Filter
+### Results with Filter(#css-results-with-filter)
 
 <div class="sheet-example">
     <nav class="tbar tbar-inline-md-down subnav-tbar subnav-tbar-primary">
@@ -1572,7 +1572,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 </nav>
 ```
 
-## Using Buttons
+## Using Buttons(#css-using-buttons)
 
 <div class="sheet-example">
     <nav class="management-bar management-bar-primary navbar navbar-expand-md">

--- a/clayui.com/content/docs/components/css-modals.md
+++ b/clayui.com/content/docs/components/css-modals.md
@@ -7,42 +7,42 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/modals/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Sizes](#sizes)
-    -   [Small](#small)
-    -   [Default](#default)
-    -   [Large](#large)
-    -   [Full Screen](#full-screen)
-        -   [All Screen Sizes](#all-screen-sizes)
-        -   [Sm Down](#sm-down)
-    -   [Height](#height)
-        -   [Small](#height-small)
-        -   [Medium](#height-medium)
-        -   [Large](#height-large)
-        -   [Extra Large](#height-extra-large)
-        -   [Full Screen](#height-full-screen)
--   [Configurations](#configurations)
-    -   [Header, Body and Footer](#header,-body-and-footer)
-    -   [Header and Body](#header-and-body)
-    -   [Body and Footer](#body-and-footer)
--   [Grid](#grid)
--   [Iframe](#iframe)
--   [Status Messages](#status-messages)
-    -   [Success](#success)
-    -   [Info](#info)
-    -   [Warning](#warning)
-    -   [Danger](#danger)
--   [Helpers](#helpers)
-    -   [Footer Alignment](#footer-alignment)
-    -   [Vertically Centered](#vertically-centered)
-    -   [Remove Animation](#remove-animation)
-    -   [Inline Scroller](#inline-scroller)
+-   [Sizes](#css-sizes)
+    -   [Small](#css-small)
+    -   [Default](#css-default)
+    -   [Large](#css-large)
+    -   [Full Screen](#css-full-screen)
+        -   [All Screen Sizes](#css-all-screen-sizes)
+        -   [Sm Down](#css-sm-down)
+    -   [Height](#css-height)
+        -   [Small](#css-height-small)
+        -   [Medium](#css-height-medium)
+        -   [Large](#css-height-large)
+        -   [Extra Large](#css-height-extra-large)
+        -   [Full Screen](#css-height-full-screen)
+-   [Configurations](#css-configurations)
+    -   [Header, Body and Footer](#css-header,-body-and-footer)
+    -   [Header and Body](#css-header-and-body)
+    -   [Body and Footer](#css-body-and-footer)
+-   [Grid](#css-grid)
+-   [Iframe](#css-iframe)
+-   [Status Messages](#css-status-messages)
+    -   [Success](#css-success)
+    -   [Info](#css-info)
+    -   [Warning](#css-warning)
+    -   [Danger](#css-danger)
+-   [Helpers](#css-helpers)
+    -   [Footer Alignment](#css-footer-alignment)
+    -   [Vertically Centered](#css-vertically-centered)
+    -   [Remove Animation](#css-remove-animation)
+    -   [Inline Scroller](#css-inline-scroller)
 
 </div>
 </div>
 
-## Sizes
+## Sizes(#css-sizes)
 
-### Small
+### Small(#css-small)
 
 300px wide modal window, expands full width of screen at 575px and below.
 
@@ -147,7 +147,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/modals/'
 </div>
 ```
 
-### Default
+### Default(#css-default)
 
 500px wide modal window, expands full width of screen at 575px and below.
 
@@ -243,7 +243,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/modals/'
 </div>
 ```
 
-### Large
+### Large(#css-large)
 
 The large modal is an 800px wide window on displays greater than 992px. It is a 500px wide modal on displays between 576px and 991px. It expands full screen width on displays 575px and below.
 
@@ -339,9 +339,9 @@ The large modal is an 800px wide window on displays greater than 992px. It is a 
 </div>
 ```
 
-### Full Screen
+### Full Screen(#css-full-screen)
 
-#### All Screen Sizes
+#### All Screen Sizes(#css-all-screen-sizes)
 
 The full screen modal stretches to fit the browser window, with 45px spacing on every side, and expands to fill the screen on displays 767px and below.
 
@@ -495,7 +495,7 @@ The full screen modal stretches to fit the browser window, with 45px spacing on 
 </div>
 ```
 
-#### Sm Down
+#### Sm Down(#css-sm-down)
 
 Add `modal-full-screen-sm-down` to any `modal-dialog` to stretch to fit the browser window at screen widths 767px and below.
 
@@ -621,9 +621,9 @@ Add `modal-full-screen-sm-down` to any `modal-dialog` to stretch to fit the brow
 </div>
 ```
 
-### Height
+### Height(#css-height)
 
-#### Small(#height-small)
+#### Small(#css-height-small)
 
 Add the class `modal-height-sm` to the `modal` or `modal-dialog` element to fix the height of the modal to 250px.
 
@@ -739,7 +739,7 @@ Add the class `modal-height-sm` to the `modal` or `modal-dialog` element to fix 
 </div>
 ```
 
-#### Medium(#height-medium)
+#### Medium(#css-height-medium)
 
 Add the class `modal-height-md` to the `modal` or `modal-dialog` element to fix the height of the modal to 450px.
 
@@ -855,7 +855,7 @@ Add the class `modal-height-md` to the `modal` or `modal-dialog` element to fix 
 </div>
 ```
 
-#### Large(#height-large)
+#### Large(#css-height-large)
 
 Add the class `modal-height-lg` to the `modal` or `modal-dialog` element to fix the height of the modal to 650px.
 
@@ -971,7 +971,7 @@ Add the class `modal-height-lg` to the `modal` or `modal-dialog` element to fix 
 </div>
 ```
 
-#### Extra Large(#height-extra-large)
+#### Extra Large(#css-height-extra-large)
 
 Add the class `modal-height-xl` to the `modal` or `modal-dialog` element to fix the height of the modal to 800px.
 
@@ -1087,7 +1087,7 @@ Add the class `modal-height-xl` to the `modal` or `modal-dialog` element to fix 
 </div>
 ```
 
-#### Full Screen(#height-full-screen)
+#### Full Screen(#css-height-full-screen)
 
 Add the class `modal-height-full` to the `modal` or `modal-dialog` element to expand the modal to fit to the height of the browser's window.
 
@@ -1203,11 +1203,11 @@ Add the class `modal-height-full` to the `modal` or `modal-dialog` element to ex
 </div>
 ```
 
-## Configurations
+## Configurations(#css-configurations)
 
 Lexicon allows your modal window to have different configurations to suite your needs. Because these needs can vary greatly, there are certain rules your modal must follow.
 
-### Header, Body and Footer
+### Header, Body and Footer(#css-header,-body-and-footer)
 
 A classic modal window is composed of three main parts: header, body, and footer.
 
@@ -1303,7 +1303,7 @@ A classic modal window is composed of three main parts: header, body, and footer
 </div>
 ```
 
-### Header and Body
+### Header and Body(#css-header-and-body)
 
 When you don't need a footer bar to place your icons, you can just have a header and body element in your modal, as shown below:
 
@@ -1374,7 +1374,7 @@ When you don't need a footer bar to place your icons, you can just have a header
 </div>
 ```
 
-### Body and Footer
+### Body and Footer(#css-body-and-footer)
 
 When you just need to show text and buttons to agree or cancel, you can just have a body and footer element in your modal, as shown below:
 
@@ -1442,7 +1442,7 @@ When you just need to show text and buttons to agree or cancel, you can just hav
 </div>
 ```
 
-## Grid
+## Grid(#css-grid)
 
 Utilize the Bootstrap grid system within a modal by nesting `.container-fluid` within the `.modal-body`. Then, use the normal grid system classes as you would anywhere else.
 
@@ -1580,7 +1580,7 @@ Utilize the Bootstrap grid system within a modal by nesting `.container-fluid` w
 </div>
 ```
 
-## Iframe
+## Iframe(#css-iframe)
 
 You can add an Iframe to the modal body.
 
@@ -1691,13 +1691,13 @@ In mobile safari (iOS 8.3), any content inside an iframe that triggers a browser
 </div>
 ```
 
-## Status Messages
+## Status Messages(#css-status-messages)
 
 Modal headers can be configured to use modals as status messages. This emphasizes blocking actions that the user must read and pay careful attention to.
 
 Add one of the following helper classes to the `modal-dialog` element to style is with corresponding state: `modal-danger`, `modal-info`, `modal-success`, or `modal-warning`.
 
-### Success
+### Success(#css-success)
 
 <div class="sheet-example">
     <button class="btn btn-success" data-target="#clayModalSuccess" data-toggle="modal" type="button">Modal Success</button>
@@ -1816,7 +1816,7 @@ Add one of the following helper classes to the `modal-dialog` element to style i
 </div>
 ```
 
-### Info
+### Info(#css-info)
 
 <div class="sheet-example">
     <button class="btn btn-primary" data-target="#clayModalInfo" data-toggle="modal" type="button">Modal Info</button>
@@ -1927,7 +1927,7 @@ Add one of the following helper classes to the `modal-dialog` element to style i
 </div>
 ```
 
-### Warning
+### Warning(#css-warning)
 
 <div class="sheet-example">
     <button class="btn btn-warning" data-target="#clayModalWarning" data-toggle="modal" type="button">Modal Warning</button>
@@ -2038,7 +2038,7 @@ Add one of the following helper classes to the `modal-dialog` element to style i
 </div>
 ```
 
-### Danger
+### Danger(#css-danger)
 
 <div class="sheet-example">
     <button class="btn btn-danger" data-target="#clayModalDanger" data-toggle="modal" type="button">Modal Danger</button>
@@ -2161,13 +2161,13 @@ Add one of the following helper classes to the `modal-dialog` element to style i
 </div>
 ```
 
-## Helpers
+## Helpers(#css-helpers)
 
-### Footer alignment
+### Footer Alignment(#css-footer-alignment)
 
 Use classes `modal-item-first`, `modal-item`, and `modal-item-last` inside `modal-footer` to align content left, middle, and right.
 
-### Vertically centered
+### Vertically Centered(#css-vertically-centered)
 
 Add `.modal-dialog-centered` to `.modal-dialog` to vertically center the modal.
 
@@ -2251,11 +2251,11 @@ Add `.modal-dialog-centered` to `.modal-dialog` to vertically center the modal.
 </div>
 ```
 
-### Remove animation
+### Remove Animation(#css-remove-animation)
 
 For modals that simply appear rather than fade in to view, remove the `.fade` class from your modal markup.
 
-### Inline Scroller
+### Inline Scroller(#css-inline-scroller)
 
 `inline-scroller` is a helper class that sizes `modal-body` to a fixed height and scrolls any overflowing content. Add it to `modal-body` when you want `modal-body` to be a fixed height. It defaults to height 125px.
 

--- a/clayui.com/content/docs/components/css-multi-step-form.md
+++ b/clayui.com/content/docs/components/css-multi-step-form.md
@@ -7,16 +7,16 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/multi-s
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Fixed width items](#fixed-width-items)
--   [Title](#title)
--   [Buttons](#buttons)
--   [Simplified](#simplified)
+-   [Example](#css-example)
+-   [Fixed Width Items](#css-fixed-width-items)
+-   [Title](#css-title)
+-   [Buttons](#css-buttons)
+-   [Simplified](#css-simplified)
 
 </div>
 </div>
 
-## Example
+## Example(#css-example)
 
 <div class="sheet-example">
 	<ol class="multi-step-nav multi-step-nav-collapse-sm multi-step-indicator-label-top">
@@ -231,7 +231,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/multi-s
 </ol>
 ```
 
-## Fixed width items
+## Fixed Width Items(#css-fixed-width-items)
 
 To set the fixed width between items so they are not dynamic by adding the `.multi-step-item-fixed-width` class.
 
@@ -344,7 +344,7 @@ To set the fixed width between items so they are not dynamic by adding the `.mul
 </ol>
 ```
 
-## Title
+## Title(#css-title)
 
 Add the title in the multi step item to provide more context by adding `.multi-step-title` wrapped with the text.
 
@@ -378,7 +378,7 @@ Add the title in the multi step item to provide more context by adding `.multi-s
 </ol>
 ```
 
-## Buttons
+## Buttons(#css-buttons)
 
 You may want to control the click of the icon to do some manipulation so you can replace `<a class="multi-step-icon" />` with a `<button class="multi-step-icon" />`.
 
@@ -591,7 +591,7 @@ You may want to control the click of the icon to do some manipulation so you can
 </ol>
 ```
 
-## Simplified
+## Simplified(#css-simplified)
 
 Multi step form simplified is a more lightweight version of the multi step form. Rather than provide a complete interactive wizard display as the multi step form does, multi step form simplified simply displays text that indicates the users progress in completing the main task, guiding the user through a task divided in several steps in a light way.
 

--- a/clayui.com/content/docs/components/css-nav.md
+++ b/clayui.com/content/docs/components/css-nav.md
@@ -5,11 +5,11 @@ title: 'Nav'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Nav Stacked](#nav-stacked)
--   [Nav Nested](#nav-nested)
--   [Nav Nested Margins](#nav-nested-margins)
--   [Nav Unstyled](#nav-unstyled)
--   [Helpers](#helpers)
+-   [Nav Stacked](#css-nav-stacked)
+-   [Nav Nested](#css-nav-nested)
+-   [Nav Nested Margins](#css-nav-nested-margins)
+-   [Nav Unstyled](#css-nav-unstyled)
+-   [Helpers](#css-helpers)
 
 </div>
 </div>
@@ -38,7 +38,7 @@ title: 'Nav'
 </ul>
 ```
 
-### Nav Stacked
+### Nav Stacked(#css-nav-stacked)
 
 Use `.nav-stacked` class alongside with `.nav`.
 
@@ -66,7 +66,7 @@ Use `.nav-stacked` class alongside with `.nav`.
 </ul>
 ```
 
-### Nav Nested
+### Nav Nested(#css-nav-nested)
 
 Add class `nav-nested` to the outermost nav to use padding to indent each nested nav.
 
@@ -354,11 +354,11 @@ Also collapsible when used with [Bootstrap Collapse Plugin](https://getbootstrap
 </ul>
 ```
 
-### Nav Nested Margins
+### Nav Nested Margins(#css-nav-nested-margins)
 
 The same of [Nav Nested](#nav-nested-margins) but instead of use `nav-nested` class, use `nav-nested-margins`.
 
-### Nav Unstyled
+### Nav Unstyled(#css-nav-unstyled)
 
 Add `nav-unstyled` to your nav to remove spacing around `nav-link` and `nav-btn`.
 
@@ -382,7 +382,7 @@ Add `nav-unstyled` to your nav to remove spacing around `nav-link` and `nav-btn`
 </ul>
 ```
 
-### Helpers
+### Helpers(#css-helpers)
 
 Dropdown toggle with anchor: `dropdown-toggle nav-link`.
 

--- a/clayui.com/content/docs/components/css-navigation-bar.md
+++ b/clayui.com/content/docs/components/css-navigation-bar.md
@@ -7,9 +7,9 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/ho
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Light](#light)
--   [Secondary](#secondary)
--   [Using Buttons](#using-buttons)
+-   [Light](#css-light)
+-   [Secondary](#css-secondary)
+-   [Using Buttons](#css-using-buttons)
 
 </div>
 </div>
@@ -26,7 +26,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/ho
 	Don't forget to check <a href="https://www.w3.org/TR/wai-aria-practices/#aria_lh_navigation">WAI-ARIA</a> accessibility pratices for alerts when writting your markup.
 </div>
 
-## Light
+## Light(#css-light)
 
 <div class="sheet-example">
     <nav class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-light">
@@ -165,7 +165,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/ho
 </nav>
 ```
 
-## Secondary
+## Secondary(#css-secondary)
 
 <div class="sheet-example">
     <nav class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary">
@@ -304,7 +304,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/ho
 </nav>
 ```
 
-## Using Buttons
+## Using Buttons(#css-using-buttons)
 
 <div class="sheet-example">
     <nav class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-light">

--- a/clayui.com/content/docs/components/css-pagination.md
+++ b/clayui.com/content/docs/components/css-pagination.md
@@ -7,11 +7,11 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/pagination/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Sizes](#sizes)
-    -   [Small](#small)
-    -   [Default](#default)
-    -   [Large](#large)
--   [Using Buttons](#using-buttons)
+-   [Sizes](#css-sizes)
+    -   [Small](#css-small)
+    -   [Default](#css-default)
+    -   [Large](#css-large)
+-   [Using Buttons](#css-using-buttons)
 
 </div>
 </div>
@@ -163,11 +163,11 @@ Use `pagination-bar`'s preset styles to give your users more control over the co
 </div>
 ```
 
-## Sizes
+## Sizes(#css-sizes)
 
 More sizing options, add `pagination-sm` or `pagination-lg` to any pagination component to make it smaller or larger. It can be added to the parent container, such as `pagination-bar`, to size all the pagination components that reside within.
 
-### Small
+### Small(#css-small)
 
 <div class="sheet-example">
     <div class="pagination-bar pagination-sm">
@@ -314,7 +314,7 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
 </div>
 ```
 
-### Default
+### Default(#css-default)
 
 <div class="sheet-example">
     <div class="pagination-bar">
@@ -461,7 +461,7 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
 </div>
 ```
 
-### Large
+### Large(#css-large)
 
 <div class="sheet-example">
     <div class="pagination-bar pagination-lg">
@@ -608,7 +608,7 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
 </div>
 ```
 
-### Using Buttons
+### Using Buttons(#css-using-buttons)
 
 <div class="sheet-example">
     <div class="pagination-bar">

--- a/clayui.com/content/docs/components/css-panel.md
+++ b/clayui.com/content/docs/components/css-panel.md
@@ -6,16 +6,16 @@ description: 'Panel provides an expandable details-summary view.'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Basic Usage](#basic-usage)
--   [Collapsable](#collapsable)
--   [Groups](#groups)
--   [With Sheets](#with-sheets)
--   [With a custom Title](#with-a-custom-title)
+-   [Basic Usage](#css-basic-usage)
+-   [Collapsible](#css-collapsible)
+-   [Groups](#css-groups)
+-   [With Sheets](#css-with-sheets)
+-   [With a Custom Title](#css-with-a-custom-title)
 
 </div>
 </div>
 
-## Basic Usage
+## Basic Usage(#css-basic-usage)
 
 <div class="sheet-example">
     <div class="panel" role="tablist">
@@ -39,7 +39,7 @@ description: 'Panel provides an expandable details-summary view.'
 </div>
 ```
 
-## Collapsable
+## Collapsible(#css-collapsible)
 
 Collapsable panels provide you with the ability to expand and collapse content as needed. They can simplify the interface by hiding content until it is needed.
 
@@ -119,7 +119,7 @@ Collapsable panels provide you with the ability to expand and collapse content a
 </div>
 ```
 
-## Groups
+## Groups(#css-groups)
 
 Grouped panels provide you with the ability of making accordion-like elements with multiple collapsable panels.
 
@@ -298,7 +298,7 @@ Grouped panels provide you with the ability of making accordion-like elements wi
 </div>
 ```
 
-## With Sheets
+## With Sheets(#css-with-sheets)
 
 Sometimes you might want to place a panel inside of a card or a sheet, in that case, wrap the Panel component in a `sheet` wrapper like below.
 
@@ -497,7 +497,7 @@ Sometimes you might want to place a panel inside of a card or a sheet, in that c
 </div>
 ```
 
-## With a custom Title
+## With a Custom Title(#css-with-a-custom-title)
 
 Sometimes you want to have some custom content that's not a string or a number in your title, that's where `ClayPanel.Title` comes in handy. It allows you to add custom content to the title of the panel as seen in this example using `ClayLabels`.
 

--- a/clayui.com/content/docs/components/css-popovers.md
+++ b/clayui.com/content/docs/components/css-popovers.md
@@ -7,18 +7,18 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tool
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Position](#position)
-    -   [Top](#top)
-    -   [Right](#right)
-    -   [Bottom](#bottom)
-    -   [Left](#left)
+-   [Position](#css-position)
+    -   [Top](#css-top)
+    -   [Right](#css-right)
+    -   [Bottom](#css-bottom)
+    -   [Left](#css-left)
 
 </div>
 </div>
 
-### Position
+### Position(#css-position)
 
-#### Top
+#### Top(#css-top)
 
 <div class="sheet-example">
     <div class="clay-site-popover-display">
@@ -88,7 +88,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tool
 </div>
 ```
 
-#### Right
+#### Right(#css-right)
 
 <div class="sheet-example">
     <div class="clay-site-popover-display">
@@ -158,7 +158,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tool
 </div>
 ```
 
-#### Bottom
+#### Bottom(#css-bottom)
 
 <div class="sheet-example">
     <div class="clay-site-popover-display">
@@ -228,7 +228,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tool
 </div>
 ```
 
-#### Left
+#### Left(#css-left)
 
 <div class="sheet-example">
     <div class="clay-site-popover-display">

--- a/clayui.com/content/docs/components/css-progress-bars.md
+++ b/clayui.com/content/docs/components/css-progress-bars.md
@@ -7,21 +7,21 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/progress-bars
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Colors](#colors)
-    -   [Group](#group)
--   [Sizes](#sizes)
--   [Groups](#groups)
-    -   [Addon](#addon)
-    -   [Stacked](#stacked)
--   [Multiple Progress Bars](#multiple-progress-bars)
--   [Labels](#labels)
--   [Striped](#striped)
--   [Animated Stripes](#animated-stripes)
+-   [Colors](#css-colors)
+    -   [Group](#css-group)
+-   [Sizes](#css-sizes)
+-   [Groups](#css-groups)
+    -   [Addon](#css-addon)
+    -   [Stacked](#css-stacked)
+-   [Multiple Progress Bars](#css-multiple-progress-bars)
+-   [Labels](#css-labels)
+-   [Striped](#css-striped)
+-   [Animated Stripes](#css-animated-stripes)
 
 </div>
 </div>
 
-## Colors
+## Colors(#css-colors)
 
 Add `progress-danger`, `progress-info`, `progress-success`, or `progress-warning` to `progress-group` or `progress` to provide visual feedback for different progress states. Color a block of text or icon by wrapping it with progress-group-feedback.
 
@@ -110,7 +110,7 @@ Add `progress-danger`, `progress-info`, `progress-success`, or `progress-warning
 </div>
 ```
 
-### Group
+### Group(#css-group)
 
 <div class="sheet-example">
     <div class="progress-group">
@@ -277,7 +277,7 @@ Add `progress-danger`, `progress-info`, `progress-success`, or `progress-warning
 </div>
 ```
 
-## Sizes
+## Sizes(#css-sizes)
 
 We only set a `height` value on the `.progress`, so if you change that value the inner `.progress-bar` will automatically resize accordingly.
 
@@ -368,9 +368,9 @@ We only set a `height` value on the `.progress`, so if you change that value the
 </div>
 ```
 
-## Groups
+## Groups(#css-groups)
 
-### Addon
+### Addon(#css-addon)
 
 Place an addon on either side of a progress component with `progress-group` and `progress-group-addon`.
 
@@ -488,7 +488,7 @@ Place an addon on either side of a progress component with `progress-group` and 
 </div>
 ```
 
-### Stacked
+### Stacked(#css-stacked)
 
 Add `progress-group-stacked` to `progress-group` stack the addons and progress component.
 
@@ -531,7 +531,7 @@ Add `progress-group-stacked` to `progress-group` stack the addons and progress c
 </div>
 ```
 
-## Multiple Progress Bars
+## Multiple Progress Bars(#css-multiple-progress-bars)
 
 If you need multiple progress bars, use [Bootstrap 4's background utilities](https://getbootstrap.com/docs/4.3/components/progress/#multiple-bars), `bg-primary`, `bg-success`, `bg-info`, `bg-warning`, and `bg-danger` on `progress-bar`.
 
@@ -635,7 +635,7 @@ If you need multiple progress bars, use [Bootstrap 4's background utilities](htt
 </div>
 ```
 
-## Labels
+## Labels(#css-labels)
 
 Add labels to your progress bars by placing text within the `.progress-bar`.
 
@@ -660,7 +660,7 @@ Add labels to your progress bars by placing text within the `.progress-bar`.
 </div>
 ```
 
-## Striped
+## Striped(#css-striped)
 
 Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gradient over the progress bar’s background color.
 
@@ -735,7 +735,7 @@ Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gra
 </div>
 ```
 
-## Animated Stripes
+## Animated Stripes(#css-animated-stripes)
 
 The striped gradient can also be animated. Add `.progress-bar-animated` to `.progress-bar` to animate the stripes right to left via CSS3 animations.
 

--- a/clayui.com/content/docs/components/css-select-box.md
+++ b/clayui.com/content/docs/components/css-select-box.md
@@ -7,20 +7,20 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Utilities](#utilities)
-    -   [Buttons on the right](#buttons-on-the-right)
-    -   [Buttons in the center](#buttons-in-the-center)
+-   [Utilities](#css-utilities)
+    -   [Buttons on the Right](#css-buttons-on-the-right)
+    -   [Buttons in the Center](#css-buttons-in-the-center)
 
 </div>
 </div>
 
-## Utilities
+## Utilities(#css-utilities)
 
 <div class="clay-site-alert alert alert-info">
     Add the class <code>clay-reorder-footer-end</code> or <code>clay-reorder-footer-center</code> on <code>clay-reorder</code> to align footer content to the right or center, respectively.
 </div>
 
-### Buttons on the right
+### Buttons on the Right(#css-buttons-on-the-right)
 
 <div class="sheet-example">
     <div class="clay-reorder clay-reorder-footer-end">
@@ -100,7 +100,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/
 </div>
 ```
 
-### Buttons in the center
+### Buttons in the Center(#css-buttons-in-the-center)
 
 <div class="sheet-example">
     <div class="clay-reorder clay-reorder-footer-center">

--- a/clayui.com/content/docs/components/css-sidebar.md
+++ b/clayui.com/content/docs/components/css-sidebar.md
@@ -7,14 +7,14 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/sidebar/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Structure](#structure)
--   [Variations](#variation)
-    -   [Light](#light)
+-   [Structure](#css-structure)
+-   [Variations](#css-variation)
+    -   [Light](#css-light)
 
 </div>
 </div>
 
-## Structure
+## Structure(#css-structure)
 
 Sidebar is an opinionated container to display related content.
 
@@ -38,9 +38,9 @@ Is composed by:
 </div>
 ```
 
-## Variations
+## Variations(#css-variations)
 
-### Sidebar Light
+### Sidebar Light(#css-sidebar-light)
 
 Just add `sidebar-light` class on the same element that you are using `sidebar`.
 

--- a/clayui.com/content/docs/components/css-slider.md
+++ b/clayui.com/content/docs/components/css-slider.md
@@ -7,18 +7,18 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/slider/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Input](#input)
--   [Custom Slider](#custom-slider)
-    -   [Disabled](#disabled)
-    -   [Tooltip](#tooltip)
-    -   [References](#references)
-    -   [Label](#clayRangeLabel)
-    -   [Title](#clayRangeTitle)
+-   [Input](#css-input)
+-   [Custom Slider](#css-custom-slider)
+    -   [Disabled](#css-disabled)
+    -   [Tooltip](#css-tooltip)
+    -   [References](#css-references)
+    -   [Label](#css-clay-range-label)
+    -   [Title](#css-clay-range-title)
 
 </div>
 </div>
 
-## Input
+## Input(#css-input)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -34,7 +34,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/slider/'
 </div>
 ```
 
-## Custom Slider
+## Custom Slider(#css-custom-slider)
 
 Add `clay-range-progress-none` to `clay-range` for a basic range input that works without JavaScript.
 
@@ -200,7 +200,7 @@ The attribute `data-toggle="clay-css-range"` is only required if using the JavaS
 </script>
 ```
 
-### Disabled
+### Disabled(#css-disabled)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -296,7 +296,7 @@ The attribute `data-toggle="clay-css-range"` is only required if using the JavaS
 </div>
 ```
 
-### Tooltip
+### Tooltip(#css-tooltip)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -398,7 +398,7 @@ The attribute `data-toggle="clay-css-range"` is only required if using the JavaS
 </div>
 ```
 
-### References
+### References(#css-references)
 
 These are visual indicators placed at the beginning and end of Clay Range; use the attributes `data-label-min="{value}"` and `data-label-max="{value}"` on `clay-range-input` to display them.
 
@@ -445,7 +445,7 @@ These are visual indicators placed at the beginning and end of Clay Range; use t
 </div>
 ```
 
-### Label(#clayRangeLabel)
+### Label(#css-clay-range-label)
 
 Labels are visual indicators appended to the beginning or end of Clay Range. These are used to display the current position of Clay Range.
 
@@ -564,7 +564,7 @@ Labels are visual indicators appended to the beginning or end of Clay Range. The
 </div>
 ```
 
-### Title(#clayRangeTitle)
+### Title(#css-clay-range-title)
 
 Titles are visual indicators placed at the top of Clay Range. These are used to display the current position of Clay Range.
 

--- a/clayui.com/content/docs/components/css-sticker.md
+++ b/clayui.com/content/docs/components/css-sticker.md
@@ -7,18 +7,18 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/stickers/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Colors](#colors)
--   [Position](#position)
--   [Sizes](#sizes)
--   [Variations](#variations)
-    -   [Overlay](#overlay)
-    -   [Outside](#outside)
-    -   [User Icon](#user-icon)
+-   [Colors](#css-colors)
+-   [Position](#css-position)
+-   [Sizes](#css-sizes)
+-   [Variations](#css-variations)
+    -   [Overlay](#css-overlay)
+    -   [Outside](#css-outside)
+    -   [User Icon](#css-user-icon)
 
 </div>
 </div>
 
-## Colors
+## Colors(#css-colors)
 
 Lexicon adopts in its design system the following colors below:
 
@@ -40,7 +40,7 @@ Lexicon adopts in its design system the following colors below:
 <span class="sticker sticker-danger">133</span>
 ```
 
-## Position
+## Position(#css-position)
 
 Place them anywhere relative to your container using positional sticker classes `sticker-top-left`, `sticker-bottom-left`, `sticker-top-right`, and `sticker-bottom-right`.
 
@@ -124,7 +124,7 @@ Place them anywhere relative to your container using positional sticker classes 
 </div>
 ```
 
-## Sizes
+## Sizes(#css-sizes)
 
 Stickers come in 4 sizes `sm`, default, `lg`, and `xl`. Create your own custom size with the `sticker-size` mixin.
 
@@ -214,9 +214,9 @@ Stickers come in 4 sizes `sm`, default, `lg`, and `xl`. Create your own custom s
 </span>
 ```
 
-## Variations
+## Variations(#css-variations)
 
-### Overlay
+### Overlay(#css-overlay)
 
 Overlay content over stickers by nesting `sticker-overlay` inside `sticker`.
 
@@ -292,7 +292,7 @@ Overlay content over stickers by nesting `sticker-overlay` inside `sticker`.
 </span>
 ```
 
-### Outside
+### Outside(#css-outside)
 
 Add class `sticker-outside` in conjunction with sticker positions to position the sticker on the outside corners.
 
@@ -356,7 +356,7 @@ Add class `sticker-outside` in conjunction with sticker positions to position th
 </button>
 ```
 
-### User Icon
+### User Icon(#css-user-icon)
 
 <div class="sheet-example">
     <div class="col-md-12">

--- a/clayui.com/content/docs/components/css-table.md
+++ b/clayui.com/content/docs/components/css-table.md
@@ -7,23 +7,23 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/table/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Variants](#variants)
-    -   [Striped](#striped)
-    -   [Bordered](#bordered)
-    -   [Hoverable](#hoverable)
-    -   [Small](#small)
--   [Responsiveness](#responsiveness)
-    -   [Always Responsive](#always-responsive)
-    -   [Breakpoints](#breakpoints)
--   [Helpers](#helpers)
-    -   [Autofit](#autofit)
-    -   [Alignment](#alignment)
-        -   [Vertical](#vertical)
-        -   [Horizontal](#horizontal)
-    -   [Cell Utilities](#cell-utilities)
-    -   [Heading No Wrap](#heading-no-wrap)
-    -   [Table No Wrap](#table-no-wrap)
-    -   [Image](#image)
+-   [Variants](#css-variants)
+    -   [Striped](#css-striped)
+    -   [Bordered](#css-bordered)
+    -   [Hoverable](#css-hoverable)
+    -   [Small](#css-small)
+-   [Responsiveness](#css-responsiveness)
+    -   [Always Responsive](#css-always-responsive)
+    -   [Breakpoints](#css-breakpoints)
+-   [Helpers](#css-helpers)
+    -   [Autofit](#css-autofit)
+    -   [Alignment](#css-alignment)
+        -   [Vertical](#css-vertical)
+        -   [Horizontal](#css-horizontal)
+    -   [Cell Utilities](#css-cell-utilities)
+    -   [Heading No Wrap](#css-heading-no-wrap)
+    -   [Table No Wrap](#css-table-no-wrap)
+    -   [Image](#css-image)
 
 </div>
 </div>
@@ -346,9 +346,9 @@ A table is styled like a list. The active state can be invoked by adding class `
 </table>
 ```
 
-## Variants
+## Variants(#css-variants)
 
-### Striped
+### Striped(#css-striped)
 
 Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`.
 
@@ -462,7 +462,7 @@ Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`
 </table>
 ```
 
-### Bordered
+### Bordered(#css-bordered)
 
 Add `.table-bordered` for borders on all sides of the table and cells.
 
@@ -576,7 +576,7 @@ Add `.table-bordered` for borders on all sides of the table and cells.
 </table>
 ```
 
-### Hoverable
+### Hoverable(#css-hoverable)
 
 <div class="sheet-example">
     <table class="table table-hover">
@@ -688,7 +688,7 @@ Add `.table-bordered` for borders on all sides of the table and cells.
 </table>
 ```
 
-### Small
+### Small(#css-small)
 
 Add `.table-sm` to make tables more compact by cutting cell padding in half.
 
@@ -802,7 +802,7 @@ Add `.table-sm` to make tables more compact by cutting cell padding in half.
 </table>
 ```
 
-## Inline Edit Table
+## Inline Edit Table(#css-inline-edit-table)
 
 <div class="sheet-example">
     <table class="table table-autofit table-list table-nowrap table-responsive">
@@ -1041,11 +1041,11 @@ Add `.table-sm` to make tables more compact by cutting cell padding in half.
 </table>
 ```
 
-## Responsiveness
+## Responsiveness(#css-responsiveness)
 
 Responsive tables allow tables to be scrolled horizontally with ease. Make any table responsive across all viewports by wrapping a `.table` with `.table-responsive`. Or, pick a maximum breakpoint with which to have a responsive table up to by using `.table-responsive{-sm|-md|-lg|-xl}`.
 
-### Always Responsive
+### Always Responsive(#css-always-responsive)
 
 Across every breakpoint, use `.table-responsive` for horizontally scrolling tables.
 
@@ -1104,7 +1104,7 @@ Across every breakpoint, use `.table-responsive` for horizontally scrolling tabl
     </div>
 </div>
 
-### Breakpoints
+### Breakpoints(#css-breakpoints)
 
 Use `.table-responsive{-sm|-md|-lg|-xl}` as needed to create responsive tables up to a particular breakpoint. From that breakpoint and up, the table will behave normally and not scroll horizontally.
 
@@ -1295,17 +1295,17 @@ Use `.table-responsive{-sm|-md|-lg|-xl}` as needed to create responsive tables u
 </div>
 ```
 
-## Helpers
+## Helpers(#css-helpers)
 
-### Autofit
+### Autofit(#css-autofit)
 
 `table-autofit` constrains table columns to be only as wide as its content, but must be used with `table-cell-expand`. `table-cell-expand` will fill the remaining space.
 
-### Alignment
+### Alignment(#css-alignment)
 
 You can align table items either vertically or horizontally following the rules below.
 
-#### Vertical
+#### Vertical(#css-vertical)
 
 We have added some classes to help vertically align contents inside a table. The classes `table-valign-bottom`, `table-valign-middle`, and `table-valign-top` on `<table>` will vertically align table cell contents on the bottom, middle, and top, respectively.
 
@@ -1313,11 +1313,11 @@ The classes `thead-valign-bottom`, `thead-valign-middle`, and `thead-valign-top`
 
 The classes `tbody-valign-bottom`, `tbody-valign-middle`, and `tbody-valign-top` on `<table>` will vertically align the contents inside the table body.
 
-#### Horizontal
+#### Horizontal(#css-horizontal)
 
 We have added some classes to help horizontally align contents inside a table column. The classes `table-column-text-start`, `table-column-text-center`, and `table-column-text-end` will align text left, center, and right respectively.
 
-### Cell Utilities
+### Cell Utilities(#css-cell-utilities)
 
 Use `table-cell-expand-small`, `table-cell-expand-smaller`, `table-cell-expand-smallest` with `table-cell-expand` to size columns smaller relative to the widest column.
 
@@ -1426,7 +1426,7 @@ The helpers `table-cell-ws-normal` and `table-cell-ws-nowrap` sets `white-space`
 </table>
 ```
 
-### Heading No Wrap
+### Heading No Wrap(#css-heading-no-wrap)
 
 `table-heading-nowrap` keeps headings on one line.
 
@@ -1527,7 +1527,7 @@ The helpers `table-cell-ws-normal` and `table-cell-ws-nowrap` sets `white-space`
 </table>
 ```
 
-### Table No Wrap
+### Table No Wrap(#css-table-no-wrap)
 
 `table-nowrap` keeps everything on one line.
 
@@ -1577,7 +1577,7 @@ The helpers `table-cell-ws-normal` and `table-cell-ws-nowrap` sets `white-space`
     </table>
 </div>
 
-### Image
+### Image(#css-image)
 
 `table-img` is a helper that sets the max-height to 100px on an image inside a table. Depending on your use case, you may need to use it with the `autofit-row` pattern.
 

--- a/clayui.com/content/docs/components/css-tabs.md
+++ b/clayui.com/content/docs/components/css-tabs.md
@@ -7,12 +7,12 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/tabs/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Classic](#classic)
--   [Modern](#modern)
--   [Variations](#variations)
-    -   [Buttons](#buttons)
-    -   [Justified](#justified)
-    -   [Grid](#grid)
+-   [Classic](#css-classic)
+-   [Modern](#css-modern)
+-   [Variations](#css-variations)
+    -   [Buttons](#css-buttons)
+    -   [Justified](#css-justified)
+    -   [Grid](#css-grid)
 
 </div>
 </div>
@@ -21,7 +21,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/tabs/'
 	Don't forget to check <a href="https://www.w3.org/TR/wai-aria-practices/#tabpanel">WAI-ARIA</a> accessibility pratices for Tabs when writting your markup.
 </div>
 
-## Classic
+## Classic(#css-classic)
 
 <div class="sheet-example">
     <ul class="nav nav-tabs" role="tablist">
@@ -236,7 +236,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/tabs/'
 </div>
 ```
 
-## Modern
+## Modern(#css-modern)
 
 Use `.nav-underline` instead of `.nav-tabs`.
 
@@ -459,9 +459,9 @@ Use `.nav-underline` instead of `.nav-tabs`.
 </div>
 ```
 
-## Variations
+## Variations(#css-variations)
 
-### Buttons
+### Buttons(#css-buttons)
 
 You can use buttons for tab items.
 
@@ -699,7 +699,7 @@ You can use buttons for tab items.
 </div>
 ```
 
-### Justified
+### Justified(#css-justified)
 
 You can justify the nav items according the tab content just adding `.nav-justified` class on the `.ul` element.
 
@@ -931,7 +931,7 @@ You can justify the nav items according the tab content just adding `.nav-justif
 </div>
 ```
 
-### Grid
+### Grid(#css-grid)
 
 Use bootstrap's grid inside list items in `nav-tabs`.
 

--- a/clayui.com/content/docs/components/css-text-input-autocomplete.md
+++ b/clayui.com/content/docs/components/css-text-input-autocomplete.md
@@ -7,14 +7,14 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-in
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Search Field](#search-field)
--   [Loading](#loading)
+-   [Example](#css-example)
+-   [Search Field](#css-search-field)
+-   [Loading](#css-loading)
 
 </div>
 </div>
 
-## Example
+## Example(#css-example)
 
 Add the class `.autocomplete-dropdown-menu` to `dropdown-menu` to size the Dropdown Menu according to Lexicon Design specifications.
 
@@ -100,7 +100,7 @@ Add the class `.autocomplete-dropdown-menu` to `dropdown-menu` to size the Dropd
 </div>
 ```
 
-## Search Field
+## Search Field(#css-search-field)
 
 <div class="sheet-example" style="height:18rem;">
 	<div class="form-group">
@@ -204,7 +204,7 @@ Add the class `.autocomplete-dropdown-menu` to `dropdown-menu` to size the Dropd
 </div>
 ```
 
-## Loading
+## Loading(#css-loading)
 
 <div class="sheet-example" style="height:11rem;">
 	<div class="form-group">

--- a/clayui.com/content/docs/components/css-text-input-localizable.md
+++ b/clayui.com/content/docs/components/css-text-input-localizable.md
@@ -7,13 +7,13 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-in
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Textarea](#textarea)
+-   [Example](#css-example)
+-   [Textarea](#css-textarea)
 
 </div>
 </div>
 
-## Example
+## Example(#css-example)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -273,7 +273,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-in
 </div>
 ```
 
-## Textarea
+## Textarea(#css-textarea)
 
 <div class="sheet-example">
 	<div class="form-group">

--- a/clayui.com/content/docs/components/css-text-input-multi-select.md
+++ b/clayui.com/content/docs/components/css-text-input-multi-select.md
@@ -7,10 +7,10 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selecto
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Labels](#labels)
--   [Loading](#loading)
--   [Contenteditable Elements](#contenteditable-elements)
+-   [Example](#css-example)
+-   [Labels](#css-labels)
+-   [Loading](#css-loading)
+-   [Contenteditable Elements](#css-contenteditable-elements)
 
 </div>
 </div>
@@ -23,7 +23,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selecto
 	Don't forget to check <a href="https://www.w3.org/TR/wai-aria-practices/#aria_lh_search">WAI-ARIA</a> accessibility pratices for <b>search</b> when writting your markup.
 </div>
 
-## Example
+## Example(#css-example)
 
 <div class="clay-site-alert alert alert-warning">
 	This requires external javascript to populate, add labels, and show/hide the <code class="gatsby-code-text">dropdown-menu</code>.
@@ -100,7 +100,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selecto
 </div>
 ```
 
-## Labels
+## Labels(#css-labels)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -395,7 +395,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selecto
 </div>
 ```
 
-## Loading
+## Loading(#css-loading)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -627,7 +627,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selecto
 </div>
 ```
 
-## Contenteditable Elements
+## Contenteditable Elements(#css-contenteditable-elements)
 
 <div class="sheet-example">
 	<div class="form-group">

--- a/clayui.com/content/docs/components/css-text-input.md
+++ b/clayui.com/content/docs/components/css-text-input.md
@@ -7,30 +7,30 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-in
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Disabled](#disabled)
--   [Read only](#read-only)
--   [Sizes](#sizes)
--   [Textarea](#textarea)
--   [Select menu](#select-menu)
--   [Validations](#validations)
-    -   [Success](#success)
-    -   [Warning](#warning)
-    -   [Error](#error)
+-   [Example](#css-example)
+-   [Disabled](#css-disabled)
+-   [Readonly](#css-readonly)
+-   [Sizes](#css-sizes)
+-   [Textarea](#css-textarea)
+-   [Select Menu](#css-select-menu)
+-   [Validations](#css-validations)
+    -   [Success](#css-success)
+    -   [Warning](#css-warning)
+    -   [Error](#css-error)
 -   [Groups](#css-markup-groups)
--   [Example](#example)
--   [Sizes](#sizes)
--   [Checkboxes and radios](#checkboxes-and-radios)
--   [Button addons](#button-addons)
--   [Multiple addons](#multiple-addons)
--   [Separated addons](#separated-addons)
--   [Mixed addons](#mixed-addons)
--   [Inset](#inset)
+-   [Example](#css-markup-groups-example)
+-   [Sizes](#css-markup-groups-sizes)
+-   [Checkboxes and Radios](#css-checkboxes-and-radios)
+-   [Button Addons](#css-button-addons)
+-   [Multiple Addons](#css-multiple-addons)
+-   [Separated Addons](#css-separated-addons)
+-   [Mixed Addons](#css-mixed-addons)
+-   [Inset](#css-inset)
 
 </div>
 </div>
 
-## Example
+## Example(#css-example)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -53,7 +53,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-in
 
 > Be sure to use an appropriate `type` attribute on all inputs (e.g., `email` for email address or number for numerical information) to take advantage of newer input controls like email verification, number selection, and more.
 
-## Disabled
+## Disabled(#css-disabled)
 
 Add the `disabled` boolean attribute on an input to prevent user interactions and make it appear lighter.
 
@@ -77,7 +77,7 @@ Add the `disabled` boolean attribute on an input to prevent user interactions an
 </div>
 ```
 
-## Read only
+## Readonly(#css-readonly)
 
 Add the `readonly` boolean attribute on an input to prevent modification of the input’s value. Read-only inputs appear lighter (just like disabled inputs), but retain the standard cursor.
 
@@ -101,7 +101,7 @@ Add the `readonly` boolean attribute on an input to prevent modification of the 
 </div>
 ```
 
-## Sizes
+## Sizes(#css-sizes)
 
 Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 
@@ -150,7 +150,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 </div>
 ```
 
-## Textarea
+## Textarea(#css-textarea)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -170,7 +170,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 </div>
 ```
 
-## Select menu
+## Select Menu(#css-select-menu)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -232,9 +232,9 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 </div>
 ```
 
-## Validations
+## Validations(#css-validations)
 
-### Success
+### Success(#css-success)
 
 <div class="sheet-example">
 	<div class="form-group has-success">
@@ -292,7 +292,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 </div>
 ```
 
-### Warning
+### Warning(#css-warning)
 
 <div class="sheet-example">
 	<div class="form-group has-warning">
@@ -350,7 +350,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 </div>
 ```
 
-### Error
+### Error(#css-error)
 
 <div class="sheet-example">
 	<div class="form-group has-error">
@@ -382,7 +382,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 	Clay Input Group markup deviates from Bootstrap 4's Input Groups.
 </div>
 
-### Example
+### Example(#css-markup-groups-example)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -445,7 +445,7 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 </div>
 ```
 
-### Sizes
+### Sizes(#css-markup-groups-sizes)
 
 Add the relative form sizing classes to the `.input-group` itself and contents within will automatically resize—no need for repeating the form control size classes on each element.
 
@@ -557,7 +557,7 @@ Add the relative form sizing classes to the `.input-group` itself and contents w
 </div>
 ```
 
-### Checkboxes and radios
+### Checkboxes and Radios(#css-checkboxes-and-radios)
 
 Place any checkbox or radio option within an input group’s addon instead of text.
 
@@ -658,7 +658,7 @@ Place any checkbox or radio option within an input group’s addon instead of te
 </div>
 ```
 
-### Button addons
+### Button Addons(#css-button-addons)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -826,7 +826,7 @@ Place any checkbox or radio option within an input group’s addon instead of te
 </div>
 ```
 
-### Multiple addons
+### Multiple Addons(#css-multiple-addons)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -874,7 +874,7 @@ Place any checkbox or radio option within an input group’s addon instead of te
 </div>
 ```
 
-### Separated addons
+### Separated Addons(#css-separated-addons)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -941,7 +941,7 @@ Place any checkbox or radio option within an input group’s addon instead of te
 </div>
 ```
 
-### Mixed addons
+### Mixed Addons(#css-mixed-addons)
 
 <div class="sheet-example">
 	<div class="form-group">
@@ -983,7 +983,7 @@ Place any checkbox or radio option within an input group’s addon instead of te
 </div>
 ```
 
-### Inset
+### Inset(#css-inset)
 
 You can insert buttons and links into input group items with the following helper classes: `.input-group-inset`, `.input-group-inset-before`, `.input-group-inset-after`, `.input-group-inset-item`, `.input-group-inset-item-before`, and `.input-group-inset-item-after.` Use the -before classes to inset the button/link at the beginning of the input group, or use the -after classes to inset the button/link at the end of the input group.
 
@@ -1187,7 +1187,7 @@ You can insert buttons and links into input group items with the following helpe
 </div>
 ```
 
-### Password
+### Password(#css-password)
 
 A pattern for displaying the content inside a password input. Use `.input-text-label` inside `.input-group-inset-item` to display specific content for `.form-control[type="text"]` and `.input-password-label` for `.form-control[type="password"]`.
 

--- a/clayui.com/content/docs/components/css-timelines.md
+++ b/clayui.com/content/docs/components/css-timelines.md
@@ -7,15 +7,15 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/timelines/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Default](#default)
--   [Variations](#variations)
-    -   [Increment with Text](#increment-with-text)
-    -   [Right](#right)
-    -   [Center](#center)
-    -   [Even](#even)
-    -   [Odd](#odd)
-    -   [Timeline Right XS Only](#timeline-right-xs-only)
--   [Spacing](#spacing)
+-   [Default](#css-default)
+-   [Variations](#css-variations)
+    -   [Increment with Text](#css-increment-with-text)
+    -   [Right](#css-right)
+    -   [Center](#css-center)
+    -   [Even](#css-even)
+    -   [Odd](#css-odd)
+    -   [Timeline Right XS Only](#css-timeline-right-xs-only)
+-   [Spacing](#css-spacing)
 
 </div>
 </div>
@@ -24,7 +24,7 @@ Place `.timeline-increment` inside whatever element you want it to be aligned to
 
 The icon can be any size as long as it is wrapped inside `timeline-increment`. For larger icons, the spacing between the content and increment ([Timeline Spacing](#spacing)) must be adjusted to accomodate it.
 
-## Default
+## Default(#css-default)
 
 <div class="sheet-example">
     <ul class="timeline">
@@ -166,9 +166,9 @@ The icon can be any size as long as it is wrapped inside `timeline-increment`. F
 </ul>
 ```
 
-## Variations
+## Variations(#css-variations)
 
-### Increment with Text
+### Increment with Text(#css-increment-with-text)
 
 Place text inside `timeline-increment` by wrapping the text with `<span class="timeline-increment-text"></span>`.
 
@@ -226,7 +226,7 @@ Place text inside `timeline-increment` by wrapping the text with `<span class="t
 </ul>
 ```
 
-### Right
+### Right(#css-right)
 
 Align increments to the right with `timeline-right`.
 
@@ -324,7 +324,7 @@ Align increments to the right with `timeline-right`.
 </ul>
 ```
 
-### Center
+### Center(#css-center)
 
 Add class `timeline-center` to center your timeline, it displays items on the right by default. To display items on the left, add class `timeline-item-reverse` to a timeline item.
 
@@ -450,7 +450,7 @@ Add class `timeline-center` to center your timeline, it displays items on the ri
 </ul>
 ```
 
-### Even
+### Even(#css-even)
 
 Alternate every other timeline item on the left with class `timeline-even`.
 
@@ -542,7 +542,7 @@ Alternate every other timeline item on the left with class `timeline-even`.
 </ul>
 ```
 
-### Odd
+### Odd(#css-odd)
 
 Alternate every other timeline item on the right with class `timeline-odd`.
 
@@ -634,7 +634,7 @@ Alternate every other timeline item on the right with class `timeline-odd`.
 </ul>
 ```
 
-### Timeline Right XS Only
+### Timeline Right XS Only(#css-timeline-right-xs-only)
 
 Align timeline to the right at screen widths 767px and below with `timeline-right-xs-only`.
 
@@ -726,7 +726,7 @@ Align timeline to the right at screen widths 767px and below with `timeline-righ
 </ul>
 ```
 
-## Spacing
+## Spacing(#css-spacing)
 
 Adjust the spacing around the timeline with `@include timeline-spacing($outer-spacing, $inner-spacing, $item-padding-y)`. The last argument is not required and has a default value of 10px.
 

--- a/clayui.com/content/docs/components/css-toggle-switch.md
+++ b/clayui.com/content/docs/components/css-toggle-switch.md
@@ -7,20 +7,20 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-c
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Example](#example)
--   [Behavioral](#behavioral)
-    -   [Checkbox](#checkbox)
-    -   [Radio](#radio)
--   [Disabled](#disabled)
--   [Composable](#composable)
-    -   [With Text](#with-text)
-    -   [With Icons](#with-icons)
--   [Extending Toggles](#extending-toggles)
+-   [Example](#css-example)
+-   [Behavioral](#css-behavioral)
+    -   [Checkbox](#css-checkbox)
+    -   [Radio](#css-radio)
+-   [Disabled](#css-disabled)
+-   [Composable](#css-composable)
+    -   [With Text](#css-with-text)
+    -   [With Icons](#css-with-icons)
+-   [Extending Toggles](#css-extending-toggles)
 
 </div>
 </div>
 
-## Example
+## Example(#css-example)
 
 <div class="sheet-example">
 	<label class="toggle-switch">
@@ -86,11 +86,11 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-c
 </label>
 ```
 
-## Behavioral
+## Behavioral(#css-behavioral)
 
 You may want the Toggle Switch to behave with a Radio or Checkbox but have the appearance of a switch.
 
-### Checkbox
+### Checkbox(#css-checkbox)
 
 <div class="sheet-example">
 	<label class="toggle-switch">
@@ -116,7 +116,7 @@ You may want the Toggle Switch to behave with a Radio or Checkbox but have the a
 </label>
 ```
 
-### Radio
+### Radio(#css-radio)
 
 <div class="sheet-example">
 	<label class="toggle-switch">
@@ -175,7 +175,7 @@ You may want the Toggle Switch to behave with a Radio or Checkbox but have the a
 </label>
 ```
 
-## Disabled
+## Disabled(#css-disabled)
 
 <div class="sheet-example">
 	<label class="toggle-switch">
@@ -214,9 +214,9 @@ You may want the Toggle Switch to behave with a Radio or Checkbox but have the a
 </label>
 ```
 
-## Composable
+## Composable(#css-composable)
 
-### With Text
+### With Text(#css-with-text)
 
 You can display additional text with the toggle switch by adding the `.toggle-switch-text` class to the text element. Use the `.toggle-switch-text-left` and `.toggle-switch-text-right` classes to position the text on the left and right side of the toggle switch, respectively.
 
@@ -336,7 +336,7 @@ You can display additional text with the toggle switch by adding the `.toggle-sw
 </label>
 ```
 
-### With Icons
+### With Icons(#css-with-icons)
 
 Add `<span class="button-icon button-icon-on icon-volume-up toggle-switch-icon"/>` to add an icon to the switch for the on position.
 
@@ -456,7 +456,7 @@ Alternatively, you can add `<span class="icon-remove toggle-switch-icon toggle-s
 </label>
 ```
 
-## Extending Toggles
+## Extending Toggles(#css-extending-toggles)
 
 This section explains how to customize toggles. Use at your own risk.
 

--- a/clayui.com/content/docs/components/css-toolbar.md
+++ b/clayui.com/content/docs/components/css-toolbar.md
@@ -7,11 +7,11 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Subnav](#subnav)
-    -   [Subnav Light](#subnav-light)
-    -   [Subnav Primary](#subnav-primary)
-    -   [Subnav Primary Disabled](#subnav-primary-disabled)
--   [Helper Classes](#helper-classes)
+-   [Subnav](#css-subnav)
+    -   [Subnav Light](#css-subnav-light)
+    -   [Subnav Primary](#css-subnav-primary)
+    -   [Subnav Primary Disabled](#css-subnav-primary-disabled)
+-   [Helper Classes](#css-helper-classes)
 
 </div>
 </div>
@@ -110,7 +110,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/'
 </nav>
 ```
 
-## Subnav
+## Subnav(#css-subnav)
 
 Subnavigation to use with main navigations such as [Management Toolbar](/docs/components/management-toolbar.html).
 
@@ -170,7 +170,7 @@ Subnavigation to use with main navigations such as [Management Toolbar](/docs/co
 </nav>
 ```
 
-### Subnav Light
+### Subnav Light(#css-subnav-light)
 
 Subnavigation used in [Modals](/docs/components/modal.html)
 
@@ -212,7 +212,7 @@ Subnavigation used in [Modals](/docs/components/modal.html)
 </div>
 ```
 
-### Subnav Primary
+### Subnav Primary(#css-subnav-primary)
 
 Subnavigation used in [Management Toolbar](/docs/components/management-toolbar.html).
 
@@ -416,7 +416,7 @@ Subnavigation used in [Management Toolbar](/docs/components/management-toolbar.h
 </nav>
 ```
 
-### Subnav Primary Disabled
+### Subnav Primary Disabled(#css-subnav-primary-disabled)
 
 Disabled sub-navigation used in [Management Toolbar](/docs/components/management-toolbar.html), just add `subnav-tbar-disabled`. The `disabled` attribute must be added to any `button` tag. The class `disabled` and attribute `tabindex="-1"` must be added to any `anchor` tag and clicks disabled via javascript.
 
@@ -625,16 +625,16 @@ Disabled sub-navigation used in [Management Toolbar](/docs/components/management
 </nav>
 ```
 
-## Helper Classes
+## Helper Classes(#css-helper-classes)
 
-### `tbar-inline-{xs|sm|md|lg|xl}-down`
+**`tbar-inline-{xs|sm|md|lg|xl}-down`**
 
 A helper class on `tbar` that turns `tbar-nav`, `tbar-item`, `tbar-section`, and `component-title` inline at specific breakpoints.
 
-### `tbar-nav-wrap`
+**`tbar-nav-wrap`**
 
 A helper class on `tbar-nav` that breaks `tbar-nav` content to new line when the container becomes too small.
 
-### `tbar-nav-shrink`
+**`tbar-nav-shrink`**
 
 A helper class on `tbar-nav` that makes it only as wide as its content, use with other `tbar-nav`'s.

--- a/clayui.com/content/docs/components/css-tooltips.md
+++ b/clayui.com/content/docs/components/css-tooltips.md
@@ -7,18 +7,18 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tool
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Position](#position)
-    -   [Top](#top)
-    -   [Right](#right)
-    -   [Bottom](#bottom)
-    -   [Left](#left)
+-   [Position](#css-position)
+    -   [Top](#css-top)
+    -   [Right](#css-right)
+    -   [Bottom](#css-bottom)
+    -   [Left](#css-left)
 
 </div>
 </div>
 
-### Position
+### Position(#css-position)
 
-#### Top
+#### Top(#css-top)
 
 <div class="sheet-example">
     <div class="clay-site-tooltip-display">
@@ -52,7 +52,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tool
 </div>
 ```
 
-#### Right
+#### Right(#css-right)
 
 <div class="sheet-example">
     <div class="clay-site-tooltip-display">
@@ -86,7 +86,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tool
 </div>
 ```
 
-#### Bottom
+#### Bottom(#css-bottom)
 
 <div class="sheet-example">
     <div class="clay-site-tooltip-display">
@@ -120,7 +120,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tool
 </div>
 ```
 
-#### Left
+#### Left(#css-left)
 
 <div class="sheet-example">
     <div class="clay-site-tooltip-display">

--- a/clayui.com/content/docs/css/content/c-kbd.md
+++ b/clayui.com/content/docs/css/content/c-kbd.md
@@ -6,30 +6,31 @@ order: 4
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Base](#base)
-    -   [Nested Kbd](#nested-c-kbd)
-    -   [Monospaced](#c-kbd-monospaced)
-    -   [Inline](#c-kbd-inline)
-    -   [Group](#c-kbd-group)
--   [Color Variants](#color-variants)
-    -   [Light](#c-kbd-light)
-    -   [Dark](#c-kbd-dark)
-    -   [Group Light](#c-kbd-group-light)
-    -   [Group Dark](#c-kbd-group-dark)
--   [Size Variants](#size-variants)
-    -   [Small](#c-kbd-sm)
-    -   [Large](#c-kbd-lg)
--   [Unicode Character List](#unicode-character-list)
-    -   [Standard](<#standard-0-255-(utf-8)-character-set>)
-    -   [General Punctuation](<#general-punctuation-(u+2000-to-u+206f)>)
-    -   [Superscripts and Subscripts](<#superscripts-and-subscripts-(u+2070-to-u+209f)>)
-    -   [Currency Symbols](<#currency-symbols-(u+20a0-to-u+20cf)>)
-    -   [Letterlike Symbols](<#letterlike-symbols-(u+2100-to-u+214f)>)
-    -   [Greek Characters](<#greek-characters-(u+0391-to-u+03c9)>)
-    -   [Number Forms](<#number-forms-(u+2150-to-u+218f)>)
-    -   [Supplemental Arrows - A](<#supplemental-arrows---a-(u+27f0-to-u+27ff)>)
-    -   [Supplemental Arrows - B](<#supplemental-arrows---b-(u+2900-to-u+297f)>)
-    -   [Mathematical Operators](<#mathematical-operators-(u+2200-to-u+22ff)>)
+-   [Base](#css-base)
+    -   [Nested Kbd](#css-nested-c-kbd)
+    -   [Monospaced](#css-c-kbd-monospaced)
+    -   [Inline](#css-c-kbd-inline)
+    -   [Group](#css-c-kbd-group)
+-   [Color Variants](#css-color-variants)
+    -   [Light](#css-c-kbd-light)
+    -   [Dark](#css-c-kbd-dark)
+    -   [Group Light](#css-c-kbd-group-light)
+    -   [Group Dark](#css-c-kbd-group-dark)
+-   [Size Variants](#css-size-variants)
+    -   [Small](#css-c-kbd-sm)
+    -   [Large](#css-c-kbd-lg)
+-   [Unicode Character List](#css-unicode-character-list)
+    -   [Standard](#css-standard)
+    -   [General Punctuation](#css-general-punctuation)
+    -   [Superscripts and Subscripts](#css-superscripts-and-subscripts)
+    -   [Currency Symbols](#css-currency-symbols)
+    -   [Letterlike Symbols](#css-letterlike-symbols)
+    -   [Greek Characters](#css-greek-characters)
+    -   [Number Forms](#css-number-forms)
+    -   [Arrows](#css-arrows)
+    -   [Supplemental Arrows - A](#css-supplemental-arrows-a)
+    -   [Supplemental Arrows - B](#css-supplemental-arrows-b)
+    -   [Mathematical Operators](#css-mathematical-operators)
 
 </div>
 </div>
@@ -40,7 +41,7 @@ A visual pattern used to allow users to learn how to access actions via keyboard
 	Check the <a href="https://liferay.design/lexicon">Lexicon</a> <a href="https://liferay.design/lexicon/core-components/keys/">Keys Pattern</a> for a more in-depth look at the motivations and proper usage of this component.
 </div>
 
-## Base
+## Base(#css-base)
 
 The `c-kbd` component provides base size and spacing styles for the `kbd` HTML element.
 
@@ -82,7 +83,7 @@ The `c-kbd` component provides base size and spacing styles for the `kbd` HTML e
 </kbd>
 ```
 
-### Nested C Kbd
+### Nested C Kbd(#css-nested-c-kbd)
 
 Nest multiple `.c-kbd` elements inside a single `.c-kbd` element to describe a keyboard command comprising of multiple keys.
 
@@ -176,7 +177,7 @@ Nest multiple `.c-kbd` elements inside a single `.c-kbd` element to describe a k
 </kbd>
 ```
 
-### C Kbd Monospaced
+### C Kbd Monospaced(#css-c-kbd-monospaced)
 
 1.5rem (24px) minimum width and 1.5rem (24px) tall `kbd` element with no `padding` and `border-width: 1px`. This is generally used to display single characters.
 
@@ -216,7 +217,7 @@ Nest multiple `.c-kbd` elements inside a single `.c-kbd` element to describe a k
 </kbd>
 ```
 
-### C Kbd Inline
+### C Kbd Inline(#css-c-kbd-inline)
 
 No minimum width or height `kbd` element with `padding: 0` and `border-width: 0`. This is used to display keyboard shortcuts in small spaces such as `dropdown-item`.
 
@@ -279,7 +280,7 @@ works as well.
 </kbd>
 ```
 
-### C Kbd Group
+### C Kbd Group(#css-c-kbd-group)
 
 A container element for grouping text with several `kbd` elements together. This is also useful inside `autofit-col` if you don't want several `kbd` elements to break to a new line.
 
@@ -307,11 +308,11 @@ A container element for grouping text with several `kbd` elements together. This
 </span>
 ```
 
-## Color Variants
+## Color Variants(#css-color-variants)
 
 The color variants are modifier classes added to any of the base components listed above.
 
-### C Kbd Light
+### C Kbd Light(#css-c-kbd-light)
 
 A color modifier on `c-kbd` to style the `kbd` element with dark text, light background and border.
 
@@ -342,7 +343,7 @@ A color modifier on `c-kbd` to style the `kbd` element with dark text, light bac
 </kbd>
 ```
 
-### C Kbd Dark
+### C Kbd Dark(#css-c-kbd-dark)
 
 A color modifier on `c-kbd` to style the `kbd` element with light text, dark background and border.
 
@@ -373,7 +374,7 @@ A color modifier on `c-kbd` to style the `kbd` element with light text, dark bac
 </kbd>
 ```
 
-### C Kbd Group Light
+### C Kbd Group Light(#css-c-kbd-group-light)
 
 A color modifier on `c-kbd-group`, for use with light backgrounds, that sets the text color to `\$secondary`. This can be used with `c-kbd-light` and `c-kbd-dark`.
 
@@ -422,7 +423,7 @@ A color modifier on `c-kbd-group`, for use with light backgrounds, that sets the
 </span>
 ```
 
-### C Kbd Group Dark
+### C Kbd Group Dark(#css-c-kbd-group-dark)
 
 A color modifier on `c-kbd-group`, for use with dark backgrounds, that sets the text color to `\$white`. This can be used with `c-kbd-light` and `c-kbd-dark`.
 
@@ -473,11 +474,11 @@ A color modifier on `c-kbd-group`, for use with dark backgrounds, that sets the 
 </span>
 ```
 
-## Size Variants
+## Size Variants(#css-size-variants)
 
 Size variants are modifier classes added to the base component to change the font size.
 
-### C Kbd Sm
+### C Kbd Sm(#css-c-kbd-sm)
 
 `c-kbd-sm` and `c-kbd-group-sm` are size modifiers that sets `font-size: 0.75rem` (12px).
 
@@ -550,7 +551,7 @@ Size variants are modifier classes added to the base component to change the fon
 </span>
 ```
 
-### C Kbd Lg
+### C Kbd Lg(#css-c-kbd-lg)
 
 `c-kbd-lg` and `c-kbd-group-lg` are size modifiers that sets `font-size: 1rem` (16px).
 
@@ -623,9 +624,9 @@ Size variants are modifier classes added to the base component to change the fon
 </span>
 ```
 
-## Unicode Character List
+## Unicode Character List(#css-unicode-character-list)
 
-### Standard 0-255 (UTF-8) Character Set
+### Standard 0-255 (UTF-8) Character Set(#css-standard)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0033;">&#0033;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0034;">&#0034;</kbd>
@@ -843,7 +844,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0254;">&#0254;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#0255;">&#0255;</kbd>
 
-### General Punctuation (U+2000 to U+206F)
+### General Punctuation (U+2000 to U+206F)(#css-general-punctuation)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8208;">&#8208;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8209;">&#8209;</kbd>
@@ -917,7 +918,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8285;">&#8285;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8286;">&#8286;</kbd>
 
-### Superscripts and Subscripts (U+2070 to U+209F)
+### Superscripts and Subscripts (U+2070 to U+209F)(#css-superscripts-and-subscripts)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8304;">&#8304;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8305;">&#8305;</kbd>
@@ -954,7 +955,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8339;">&#8339;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8340;">&#8340;</kbd>
 
-### Currency Symbols (U+20A0 to U+20CF)
+### Currency Symbols (U+20A0 to U+20CF)(#css-currency-symbols)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8352;">&#8352;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8353;">&#8353;</kbd>
@@ -989,7 +990,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8382;">&#8382;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8383;">&#8383;</kbd>
 
-### Letterlike Symbols (U+2100 to U+214F)
+### Letterlike Symbols (U+2100 to U+214F)(#css-letterlike-symbols)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8448;">&#8448;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8449;">&#8449;</kbd>
@@ -1071,7 +1072,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8525;">&#8525;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8526;">&#8526;</kbd>
 
-### Greek Characters (U+0391 to U+03C9)
+### Greek Characters (U+0391 to U+03C9)(#css-greek-characters)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#913;">&#913;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#914;">&#914;</kbd>
@@ -1131,7 +1132,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#968;">&#968;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#969;">&#969;</kbd>
 
-### Number Forms (U+2150 to U+218F)
+### Number Forms (U+2150 to U+218F)(#css-number-forms)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8528;">&#8528;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8529;">&#8529;</kbd>
@@ -1189,7 +1190,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8581;">&#8581;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8582;">&#8582;</kbd>
 
-### Arrows (U+2190 to U+21FF)
+### Arrows (U+2190 to U+21FF)(#css-arrows)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8592;">&#8592;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8593;">&#8593;</kbd>
@@ -1304,7 +1305,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8702;">&#8702;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8703;">&#8703;</kbd>
 
-### Supplemental Arrows - A (U+27F0 to U+27FF)
+### Supplemental Arrows - A (U+27F0 to U+27FF)(#css-supplemental-arrows-a)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#10224;">&#10224;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#10225;">&#10225;</kbd>
@@ -1322,7 +1323,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#10237;">&#10237;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#10238;">&#10238;</kbd>
 
-### Supplemental Arrows - B (U+2900 to U+297F)
+### Supplemental Arrows - B (U+2900 to U+297F)(#css-supplemental-arrows-b)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#10496;">&#10496;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#10497;">&#10497;</kbd>
@@ -1457,7 +1458,7 @@ Size variants are modifier classes added to the base component to change the fon
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#10626;">&#10626;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#10627;">&#10627;</kbd>
 
-### Mathematical Operators (U+2200 to U+22FF)
+### Mathematical Operators (U+2200 to U+22FF)(#css-mathematical-operators)
 
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8704;">&#8704;</kbd>
 <kbd class="c-kbd c-kbd-monospaced c-kbd-light" data-entity="&amp;#8705;">&#8705;</kbd>

--- a/clayui.com/content/docs/css/content/typography.md
+++ b/clayui.com/content/docs/css/content/typography.md
@@ -9,25 +9,25 @@ order: 3
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Headings](#headings)
--   [Lead](#lead)
--   [Inline Text Elements](#inline-text-elements)
--   [Reference Mark](#reference-mark)
--   [Text Truncate](#text-truncate)
-    -   [Text Truncate Inline](#text-truncate-inline)
--   [Contextual Texts](#contextual-texts)
-    -   [Contextual Backgrounds](#contextual-backgrounds)
--   [Address](#address)
--   [Inline Code](#inline-code)
--   [User Input](#user-input)
--   [Variables](#variables)
--   [Sample Output](#sample-output)
--   [Blockquote](#blockquote)
+-   [Headings](#css-headings)
+-   [Lead](#css-lead)
+-   [Inline Text Elements](#css-inline-text-elements)
+-   [Reference Mark](#css-reference-mark)
+-   [Text Truncate](#css-text-truncate)
+    -   [Text Truncate Inline](#css-text-truncate-inline)
+-   [Contextual Texts](#css-contextual-texts)
+    -   [Contextual Backgrounds](#css-contextual-backgrounds)
+-   [Address](#css-address)
+-   [Inline Code](#css-inline-code)
+-   [User Input](#css-user-input)
+-   [Variables](#css-variables)
+-   [Sample Output](#css-sample-output)
+-   [Blockquote](#css-blockquote)
 
 </div>
 </div>
 
-## Headings
+## Headings(#css-headings)
 
 <div class="sheet-example">
     <h1>h1 Article Heading <small>Sub text</small></h1>
@@ -47,7 +47,7 @@ order: 3
 <h6>h6 Article Heading <small>Sub text</small></h6>
 ```
 
-## Lead
+## Lead(#css-lead)
 
 <div class="sheet-example">
     <p class="lead"> Lead Body Text: Milk filter lungo as galão roast that crema blue mountain shop turkish. </p>
@@ -60,7 +60,7 @@ order: 3
 </p>
 ```
 
-## Inline Text Elements
+## Inline Text Elements(#css-inline-text-elements)
 
 <div class="sheet-example">
     <p><a href="#1">Anchor Text: Milk filter lungo as galão roast that crema blue mountain shop turkish.</a></p>
@@ -146,7 +146,7 @@ order: 3
 <p>capitalized text: <span class="text-capitalize">capitalized text</span></p>
 ```
 
-## Reference Mark
+## Reference Mark(#css-reference-mark)
 
 Use `<span class="reference-mark"></span>` to add a reference mark next to some text.
 
@@ -192,7 +192,7 @@ Use `<span class="reference-mark"></span>` to add a reference mark next to some 
 </div>
 ```
 
-## Text Truncate
+## Text Truncate(#css-text-truncate)
 
 Shorten long lines of text with the `text-truncate` class. This uses `display: block;` and should be used to truncate text in block level elements.
 
@@ -208,7 +208,7 @@ Shorten long lines of text with the `text-truncate` class. This uses `display: b
 </p>
 ```
 
-### Text Truncate Inline
+### Text Truncate Inline(#css-text-truncate-inline)
 
 You can also use the `text-truncate-inline` class to shorten long lines of text.
 
@@ -232,7 +232,7 @@ Milk filter lungo as galão roast that crema
 ></a>
 ```
 
-## Contextual Texts
+## Contextual Texts(#css-contextual-texts)
 
 <div class="sheet-example">
     <div>
@@ -289,7 +289,7 @@ Milk filter lungo as galão roast that crema
 >
 ```
 
-### Contextual Backgrounds
+### Contextual Backgrounds(#css-contextual-backgrounds)
 
 <div class="sheet-example">
     <div>
@@ -339,7 +339,7 @@ Milk filter lungo as galão roast that crema
 >
 ```
 
-## Address
+## Address(#css-address)
 
 <div class="sheet-example">
     <address>
@@ -368,7 +368,7 @@ Milk filter lungo as galão roast that crema
 </address>
 ```
 
-## Inline Code
+## Inline Code(#css-inline-code)
 
 <div class="sheet-example">
     <p>For example, <code>&lt;section&gt;</code> should be wrapped as inline.</p>
@@ -378,7 +378,7 @@ Milk filter lungo as galão roast that crema
 <p>For example, <code>&lt;section&gt;</code> should be wrapped as inline.</p>
 ```
 
-## User Input
+## User Input(#css-user-input)
 
 <div class="sheet-example">
     <p>For example, press <kbd><kbd>ctrl</kbd> + <kbd>,</kbd></kbd> to edit settings.</p>
@@ -391,7 +391,7 @@ Milk filter lungo as galão roast that crema
 </p>
 ```
 
-## Variables
+## Variables(#css-variables)
 
 <div class="sheet-example">
     <p>For example, <var>y</var> = <var>m</var><var>x</var> + <var>b</var></p>
@@ -401,7 +401,7 @@ Milk filter lungo as galão roast that crema
 <p>For example, <var>y</var> = <var>m</var><var>x</var> + <var>b</var></p>
 ```
 
-## Sample Output
+## Sample Output(#css-sample-output)
 
 <div class="sheet-example">
     <samp>This text is meant to be treated as sample output from a computer program.</samp>
@@ -414,7 +414,7 @@ Milk filter lungo as galão roast that crema
 >
 ```
 
-## Blockquote
+## Blockquote(#css-blockquote)
 
 <div class="sheet-example">
     <blockquote class="blockquote">

--- a/clayui.com/content/docs/css/grid.md
+++ b/clayui.com/content/docs/css/grid.md
@@ -9,15 +9,15 @@ order: 4
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Container](#container)
--   [Container Fluid](#container-fluid)
--   [Container Form Lg](#container-form-lg)
--   [Container View](#container-view)
+-   [Container](#css-container)
+-   [Container Fluid](#css-container-fluid)
+-   [Container Form Lg](#css-container-form-lg)
+-   [Container View](#css-container-view)
 
 </div>
 </div>
 
-## Container
+## Container(#css-container)
 
 `.container` has a specific `max-width` for each grid breakpoint (e.g., Atlas 540px wide, 720px wide, 960px wide, and 1248px wide).
 
@@ -93,7 +93,7 @@ order: 4
 <div class="container"></div>
 ```
 
-## Container Fluid
+## Container Fluid(#css-container-fluid)
 
 Use the `.container-fluid` class with the `.container-fluid-max-{sm|md|lg|xl}` class to create fluid containers that don't expand beyond a set width (e.g., For Atlas xl => 1248px).
 
@@ -191,7 +191,7 @@ Use the `.container-fluid` class with the `.container-fluid-max-{sm|md|lg|xl}` c
 <div class="container-fluid container-fluid-max-xl"></div>
 ```
 
-## Container Form Lg
+## Container Form Lg(#css-container-form-lg)
 
 Use the `.container-form-lg` class with the `.container` class or `.container-fluid` class to properly space between application controls and the form. This class only modifies the `padding` on the container.
 
@@ -248,7 +248,7 @@ f you need additional breakpoints such as <code>.container-form-sm|md|xl</code>,
 <div class="container-fluid container-fluid-max-xl container-form-lg"></div>
 ```
 
-## Container View
+## Container View(#css-container-view)
 
 Use the `.container-view` class with the `.container` class or `.container-fluid` class to properly space between application controls and view pages (e.g., Card View, Table View, or List View). This class only modifies the `padding` on the container.
 

--- a/clayui.com/content/docs/css/index.md
+++ b/clayui.com/content/docs/css/index.md
@@ -8,17 +8,17 @@ version: 'v2.8.0'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Overview](#overview)
--   [Base Theme](#base-theme)
--   [Atlas Theme](#atlas-theme)
--   [Liferay Portal](#liferay-portal)
--   [Customizing Clay CSS](#customizing-clay-css)
--   [Adding CSS Rulesets to Clay CSS](#adding-css-rulesets-to-clay-css)
+-   [Overview](#css-overview)
+-   [Base Theme](#css-base-theme)
+-   [Atlas Theme](#css-atlas-theme)
+-   [Liferay Portal](#css-liferay-portal)
+-   [Customizing Clay CSS](#css-customizing-clay-css)
+-   [Adding CSS Rulesets to Clay CSS](#css-adding-css-rulesets-to-clay-css)
 
 </div>
 </div>
 
-## Overview
+## Overview(#css-overview)
 
 Clay CSS is the web implementation of <a href="https://liferay.design/lexicon/get-started/" rel="noreferrer noopener" target="_blank">Liferay’s Experience Language</a>. This is a system for building applications in and outside of Liferay, designed to be fluid and extensible, as well as provide a consistent and documented API.
 
@@ -26,7 +26,7 @@ Clay CSS is based on <a href="https://getbootstrap.com/docs/4.4/getting-started/
 
 Clay CSS is shipped with two flavors, `Base` and `Atlas` Theme. The Base Theme is bundled with `frontend-theme-styled` in Liferay Portal. Atlas Theme is our flagship theme that is bundled with `frontend-theme-classic`.
 
-## Base Theme
+## Base Theme(#css-base-theme)
 
 The Base Theme provides a familiar starting point to develop your own custom theme by preserving default Bootstrap styles such as colors and sizing. It contains all CSS rulesets for both themes. You can toggle Base Theme by clicking the cog icon inside the top right nav.
 
@@ -37,7 +37,7 @@ The Base Theme provides a familiar starting point to develop your own custom the
 |-- SCSS
 </pre>
 
-## Atlas Theme
+## Atlas Theme(#css-atlas-theme)
 
 Atlas Theme is a set of Sass variables that are applied on top of the Base Theme. The variables change everything from colors to sizing and spacing. No additional rulesets are required. This allows us to reuse a CSS ruleset instead of having to duplicate and overwrite it in `frontend-theme-classic`, saving us from CSS bloat.
 
@@ -49,7 +49,7 @@ Atlas Theme is a set of Sass variables that are applied on top of the Base Theme
 |-- SCSS
 </pre>
 
-## Liferay Portal
+## Liferay Portal(#css-liferay-portal)
 
 Clay CSS is installed during build time in Liferay Portal. There is a placeholder file `clay.scss` where Clay CSS should be imported. This file is included inside the `head` tag as an external stylesheet in Portal.
 
@@ -57,10 +57,10 @@ If you are using <a href="https://github.com/liferay/liferay-js-themes-toolkit/t
 
 You can switch between Base and Atlas Theme at any time by creating a file `clay.scss` in `your-theme/src/css/clay.scss` and importing Base or Atlas. This will overwrite the default `clay.scss` file used by Portal.
 
-## Customizing Clay CSS
+## Customizing Clay CSS(#css-customizing-clay-css)
 
 Liferay Portal provides a placeholder file `_clay_variables.scss` and imports it at the top of `base.scss` and `atlas.scss`. This file should contain all your Clay CSS Variable overwrites. You can change the primary color to red by creating a new file named `your-theme/src/css/_clay_variables.scss` and adding the line `$primary: red;`. Clay CSS has thousands of customization options that gives you full control over the styles of each component.
 
-## Adding CSS Rulesets to Clay CSS
+## Adding CSS Rulesets to Clay CSS(#css-adding-css-rulesets-to-clay-css)
 
 You can add CSS rulesets to the `clay.scss` file by creating a file called `_clay_custom.scss` in the `your-theme/src/css` directory. `_clay_custom.scss` is imported at the bottom of `base.scss` and `atlas.scss`.

--- a/clayui.com/content/docs/css/scss.md
+++ b/clayui.com/content/docs/css/scss.md
@@ -7,14 +7,14 @@ description: 'Clay CSS Framework provides some utilities for you to work with SC
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Variables](#variables)
--   [Mixins](#mixins)
--   [Functions](#functions)
+-   [Variables](#css-variables)
+-   [Mixins](#css-mixins)
+-   [Functions](#css-functions)
 
 </div>
 </div>
 
-## Variables
+## Variables(#css-variables)
 
 Think of variables as a way to store information that you want to reuse throughout your stylesheet. You can store things like colors, font stacks, or any CSS value you think you'll want to reuse. Sass uses the \$ symbol to make something a variable. [SASS](https://sass-lang.com/guide)
 
@@ -31,7 +31,7 @@ $alert-dismissible-padding-top: null !default;
 
 > [All **variables** available](https://github.com/liferay/clay/tree/master/packages/clay-css/src/scss/variables)
 
-## Mixins
+## Mixins(#css-mixins)
 
 Some things in CSS are a bit tedious to write, especially with CSS3 and the many vendor prefixes that exist. A mixin lets you make groups of CSS declarations that you want to reuse throughout your site. You can even pass in values to make your mixin more flexible. A good use of a mixin is for vendor prefixes. Here's an example for transform. [SASS](https://sass-lang.com/guide)
 
@@ -51,7 +51,7 @@ You can find all mixins available by component if you want to create a component
 
 > [All **mixins** available](https://github.com/liferay/clay/tree/master/packages/clay-css/src/scss/mixins)
 
-## Functions
+## Functions(#css-functions)
 
 Clay CSS provides some **SCSS** functions that help you be more productive. To learn more about **functions** see [sass-lang.com](https://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives).
 

--- a/clayui.com/content/docs/css/utilities/autofit.md
+++ b/clayui.com/content/docs/css/utilities/autofit.md
@@ -5,18 +5,18 @@ title: 'Autofit'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Row](#row)
--   [Spacing](#spacing)
--   [Row Vertical Alignment](#row-vertical-alignment)
--   [Float](#float)
--   [Float End](#float-end)
--   [Float with Autofit Col End](#float-with-autofit-col-end)
--   [Nesting Autofit Rows](#nesting-autofit-rows)
+-   [Row](#css-row)
+-   [Spacing](#css-spacing)
+-   [Row Vertical Alignment](#css-row-vertical-alignment)
+-   [Float](#css-float)
+-   [Float End](#css-float-end)
+-   [Float with Autofit Col End](#css-float-with-autofit-col-end)
+-   [Nesting Autofit Rows](#css-nesting-autofit-rows)
 
 </div>
 </div>
 
-## Row
+## Row(#css-row)
 
 Make content expand to fill remaining space or create equally spaced content with the `.autofit-row`, `.autofit-col`, and `.autofit-col-expand` classes.
 
@@ -252,7 +252,7 @@ Make content expand to fill remaining space or create equally spaced content wit
 </div>
 ```
 
-## Spacing
+## Spacing(#css-spacing)
 
 The `autofit-padded` class should be added to `autofit-row` to give padding to all `autofit-col`s that are direct children of `autofit-row`.
 
@@ -262,7 +262,7 @@ The `autofit-padded-no-gutters-y` class gives padding to all `autofit-col`s that
 
 The `autofit-padded-no-gutters` class gives padding to all `autofit-col`s that are direct children of `autofit-row`. It has negative margins on the top, right, bottom, and left to offset the padding (Generally used if nesting `.autofit-row`).
 
-# Row Vertical Alignment
+# Row Vertical Alignment(#css-row-vertical-alignment)
 
 Autofit Row vertically aligns to the top by default.
 
@@ -270,7 +270,7 @@ The `autofit-row-center` class vertically aligns items in `autofit-row` to the m
 
 The `autofit-row-end` class vertically aligns items in `autofit-row` to the bottom.
 
-## Float
+## Float(#css-float)
 
 The component `autofit-float` or `.autofit-float-{sm|md}-down` simulates the behavior of floated elements in `.autofit-row`. Items that break to a new line will be aligned to the left.
 
@@ -414,7 +414,7 @@ This pattern provides the benefit of aligning content via flexbox without losing
 </div>
 ```
 
-## Float End
+## Float End(#css-float-end)
 
 Mimic "right floated" elements.
 
@@ -568,7 +568,7 @@ Aligning items to the left will require nesting `autofit-float autofit-row` insi
 </div>
 ```
 
-## Float with Autofit Col End
+## Float with Autofit Col End(#css-float-with-autofit-col-end)
 
 Another way to mimic "right floated" elements without using `autofit-float-end` and `autofit-col-expand`. This pattern can duplicate floated layouts without the need for a clearfix.
 
@@ -694,7 +694,7 @@ Another way to mimic "right floated" elements without using `autofit-float-end` 
 </div>
 ```
 
-## Nesting Autofit Rows
+## Nesting Autofit Rows(#css-nesting-autofit-rows)
 
 <div class="sheet-example">
 	<div class="card">

--- a/clayui.com/content/docs/css/utilities/c-focus-inset.md
+++ b/clayui.com/content/docs/css/utilities/c-focus-inset.md
@@ -5,19 +5,19 @@ title: 'C Focus Inset'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Examples](#examples)
-    -   [Button](#button)
-    -   [Link](#link)
-    -   [Form](#form-control)
+-   [Examples](#css-examples)
+    -   [Button](#css-button)
+    -   [Link](#css-link)
+    -   [Form](#css-form-control)
 
 </div>
 </div>
 
 A bailout utility to set the focus border inside the element, just add the class `c-focus-inset`.
 
-## Examples
+## Examples(#css-examples)
 
-### Button
+### Button(#css-button)
 
 <button class="btn btn-primary c-focus-inset" type="button">Primary</button>
 <button class="btn btn-secondary c-focus-inset" type="button">Secondary</button>
@@ -34,7 +34,7 @@ A bailout utility to set the focus border inside the element, just add the class
 <button class="btn btn-primary c-focus-inset" type="button">Primary</button>
 ```
 
-### Link
+### Link(#css-link)
 
 <div><a class="c-focus-inset" href="javascript:;">Regular Anchor Tag</a></div>
 <div><a class="c-focus-inset link-primary single-link" href="javascript:;">.link-primary.single-link</a></div>
@@ -47,7 +47,7 @@ A bailout utility to set the focus border inside the element, just add the class
 <a class="c-focus-inset" href="javascript:;">Regular Anchor Tag</a>
 ```
 
-### Form Control
+### Form Control(#css-form-control)
 
 <div class="sheet">
     <div class="form-group">

--- a/clayui.com/content/docs/css/utilities/c-inner.md
+++ b/clayui.com/content/docs/css/utilities/c-inner.md
@@ -5,15 +5,15 @@ title: 'C Inner'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Examples](#examples)
-    -   [Buttons](#buttons)
-    -   [Links](#links)
-    -   [Close](#close)
-    -   [Badge](#badge)
-    -   [Label](#label)
-    -   [Breadcrumb](#breadcrumb)
-    -   [Card Interactive](#card-interactive)
-    -   [Dropdown](#dropdown)
+-   [Examples](#css-examples)
+    -   [Buttons](#css-buttons)
+    -   [Links](#css-links)
+    -   [Close](#css-close)
+    -   [Badge](#css-badge)
+    -   [Label](#css-label)
+    -   [Breadcrumb](#css-breadcrumb)
+    -   [Card Interactive](#css-card-interactive)
+    -   [Dropdown](#css-dropdown)
 
 </div>
 </div>
@@ -24,9 +24,9 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
     To disable style output from this utility set <code>$enable-c-inner: false;</code>.
 </div>
 
-## Examples
+## Examples(#css-examples)
 
-### Buttons
+### Buttons(#css-buttons)
 
 <button class="btn btn-unstyled" type="button">
     <span class="c-inner" tabindex="-1">.btn.btn-unstyled</span>
@@ -129,7 +129,7 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 </button>
 ```
 
-### Links
+### Links(#css-links)
 
 <div><a href="javascript:;"><span class="c-inner" tabindex="-1">Regular Anchor Tag</span></a></div>
 <div><a class="link-primary" href="javascript:;"><span class="c-inner" tabindex="-1">.link-primary</span></a></div>
@@ -186,7 +186,7 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 </a>
 ```
 
-### Close
+### Close(#css-close)
 
 <button aria-label="Close" class="close" type="button">
     <span class="c-inner" tabindex="-1">
@@ -262,7 +262,7 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 </a>
 ```
 
-### Badge
+### Badge(#css-badge)
 
 <a class="badge badge-primary" href="javascript:;">
     <span class="c-inner" tabindex="-1">
@@ -317,7 +317,7 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 </a>
 ```
 
-### Label
+### Label(#css-label)
 
 <a class="label label-primary" href="javascript:;">
     <span class="c-inner" tabindex="-1">
@@ -494,7 +494,7 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
 </a>
 ```
 
-### Breadcrumb
+### Breadcrumb(#css-breadcrumb)
 
 <ol class="breadcrumb">
     <li class="breadcrumb-item dropdown">
@@ -545,7 +545,7 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
     </li>
 </ol>
 
-### Card Interactive
+### Card Interactive(#css-card-interactive)
 
 <div class="row">
     <div class="col-md-4">
@@ -590,7 +590,7 @@ A utility to help manage focus styles in an interactive component. Wrap the cont
     </div>
 </div>
 
-### Dropdown
+### Dropdown(#css-dropdown)
 
 <div class="clay-site-alert alert alert-warning">
     Bootstrap's Dropdown Plugin focuses <code>dropdown-toggle</code> on show. You will need to manually undo the focus via blur or focus <code>c-inner</code> on show.

--- a/clayui.com/content/docs/css/utilities/c-spacing.md
+++ b/clayui.com/content/docs/css/utilities/c-spacing.md
@@ -5,16 +5,16 @@ title: 'C Spacing Utilities'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [How to read the class](#how-to-read–the–class)
--   [How to understand the class](#how-to-understand–the–class)
--   [How to use the class](#how-to-use–the–class)
+-   [How to Read the Class](#css-read)
+-   [How to Understand the Class](#css-understand)
+-   [How to Use the Class](#css-use)
 
 </div>
 </div>
 
 Utility classes for the spacing in your pages. (without the `!important` attribute)
 
-## How to read the class
+## How to Read the Class(#css-read)
 
 Example: `c-mt-sm-3`.
 
@@ -24,7 +24,7 @@ SCSS: `@include media-breakpoint-up(sm) { margin-top: 1rem; }`.
 
 CSS: `@media(min-width: 576px) { margin-top: 1rem; }`. _(576px can change depending on the site's configuration)_
 
-## How to understand the class
+## How to Understand the Class(#css-understand)
 
 `c` is the **prefix** and it stands for **Clay**. All the new classes have this prefix to avoid conflicts with other frameworks.
 
@@ -70,7 +70,7 @@ These spaces can be negative if we use `n` before the value, that means:
 -   `n7` | **-6rem** | _-96px_
 -   `n8` | **-7.5rem** | _-120px_
 
-## How to use the class
+## How to Use the Class(#css-use)
 
 The best usage of these classes take place in a responsive scenario:
 

--- a/clayui.com/content/docs/css/utilities/inline-item.md
+++ b/clayui.com/content/docs/css/utilities/inline-item.md
@@ -5,13 +5,13 @@ title: 'Inline Item'
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Link without Whitespace](#link-without-whitespace)
--   [Link with Whitespace](#link-with-whitespace)
--   [Button without Whitespace](#button-without-whitespace)
--   [Button with Whitespace](#button-with-whitespace)
--   [Close](#close)
-    -   [Anchor](#anchor)
-    -   [Button](#button)
+-   [Link Without Whitespace](#css-link-without-whitespace)
+-   [Link With Whitespace](#css-link-with-whitespace)
+-   [Button Without Whitespace](#css-button-without-whitespace)
+-   [Button With Whitespace](#css-button-with-whitespace)
+-   [Close](#css-close)
+    -   [Anchor](#css-anchor)
+    -   [Button](#css-button)
 
 </div>
 </div>
@@ -22,7 +22,7 @@ Use the `inline-item inline-item-before`, `inline-item inline-item-middle`, and 
 	For this component to function and space properly, the white space must be removed between text and icons from the markup inside the component. It's generally easier to remove all white space inside the link, button, or component. In the examples below, whitespaces in button and link are slightly off and the link underline on hover is a bit wide.
 </div>
 
-## Link without Whitespace
+## Link Without Whitespace(#css-link-without-whitespace)
 
 <div class="sheet-example">
 	<a href="#1">
@@ -71,7 +71,7 @@ Use the `inline-item inline-item-before`, `inline-item inline-item-middle`, and 
 </a>
 ```
 
-## Link with Whitespace
+## Link With Whitespace(#css-link-with-whitespace)
 
 <div class="sheet-example">
 	<a href="#1">
@@ -113,7 +113,7 @@ Use the `inline-item inline-item-before`, `inline-item inline-item-middle`, and 
 </a>
 ```
 
-## Button without Whitespace
+## Button Without Whitespace(#css-button-without-whitespace)
 
 <div class="sheet-example">
 	<button class="btn btn-secondary" type="button"><span class="inline-item inline-item-before"><svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation"><use href="/images/icons/icons.svg#plus" /></svg></span>Secondary<span class="inline-item inline-item-after"><svg class="lexicon-icon lexicon-icon-camera" focusable="false" role="presentation"><use href="/images/icons/icons.svg#camera" /></svg></span></button>
@@ -143,7 +143,7 @@ Use the `inline-item inline-item-before`, `inline-item inline-item-middle`, and 
 </button>
 ```
 
-## Button with Whitespace
+## Button With Whitespace(#css-button-with-whitespace)
 
 <div class="sheet-example">
 	<button class="btn btn-secondary" type="button">
@@ -183,11 +183,11 @@ Use the `inline-item inline-item-before`, `inline-item inline-item-middle`, and 
 </button>
 ```
 
-## Close
+## Close(#css-close)
 
 A Button or Link for closing stuff.
 
-### Anchor
+### Anchor(#css-anchor)
 
 <div class="sheet-example">
 	<a aria-label="Close" class="close" href="#1" role="button">
@@ -247,7 +247,7 @@ A Button or Link for closing stuff.
 </a>
 ```
 
-### Button
+### Button(#css-button)
 
 <div class="sheet-example">
 	<button aria-label="Close" class="close" type="button">

--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -45,6 +45,7 @@
 		"@mdx-js/mdx": "^1.6.16",
 		"@mdx-js/react": "^1.6.16",
 		"@mdx-js/tag": "^0.20.3",
+		"@reach/router": "1.3.4",
 		"classnames": "^2.2.6",
 		"clipboard": "^2.0.4",
 		"dotenv": "^6.0.0",
@@ -55,6 +56,7 @@
 		"gatsby-plugin-react-helmet": "^3.3.10",
 		"gatsby-plugin-sass": "^2.3.12",
 		"gatsby-plugin-typescript": "^2.4.18",
+		"gatsby-react-router-scroll": "3.0.0",
 		"gatsby-remark-prismjs": "^3.2.8",
 		"gatsby-source-filesystem": "^2.3.24",
 		"gatsby-transformer-remark": "^2.8.28",
@@ -70,5 +72,8 @@
 	"devDependencies": {
 		"cpx": "^1.5.0",
 		"strip-loader": "^0.1.2"
+	},
+	"resolutions": {
+		"gatsby-react-router-scroll": "3.0.0"
 	}
 }

--- a/clayui.com/src/components/LayoutNavHome/index.js
+++ b/clayui.com/src/components/LayoutNavHome/index.js
@@ -21,7 +21,7 @@ const LayoutNavHome = () => {
 
 	return (
 		<nav className="navbar navbar-clay-site navbar-expand-lg navbar-light">
-			<div className="container-fluid container-fluid-max-lg">
+			<div className="container-fluid container-fluid-max-xl">
 				<div className="autofit-float-sm-down autofit-padded autofit-row">
 					<div className="autofit-col autofit-col-expand">
 						<div className="d-inline-block text-decoration-none text-reset">

--- a/clayui.com/src/pages/index.js
+++ b/clayui.com/src/pages/index.js
@@ -24,7 +24,7 @@ export default () => {
 				className="alert alert-dismissible alert-fluid alert-light"
 				role="alert"
 			>
-				<div className="container-fluid container-fluid-max-lg">
+				<div className="container-fluid container-fluid-max-xl">
 					{
 						'This site is for version 3.x. If you are looking for version 2.x documentation, it has been moved to '
 					}

--- a/clayui.com/src/styles/_guide.scss
+++ b/clayui.com/src/styles/_guide.scss
@@ -202,7 +202,7 @@
 		@media (min-width: $screen-lg) {
 			background-color: white;
 			margin-bottom: 0;
-			max-height: 100vh;
+			max-height: calc(100vh - 84px);
 			overflow-y: auto;
 			top: 84px;
 			width: 280px;

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -173,8 +173,16 @@ export default (props) => {
 	const containsReact = !!(body || tab.body);
 
 	const [activeIndex, setActiveIndex] = React.useState(
-		location.hash === '#css' || !containsReact ? CSS_INDEX : REACT_INDEX
+		location.hash.match(/#css/g) || !containsReact ? CSS_INDEX : REACT_INDEX
 	);
+
+	useEffect(() => {
+		const hash = window.location.hash;
+
+		if (hash !== '') {
+			window.location.href = hash;
+		}
+	}, []);
 
 	useEffect(() => {
 		document

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,7 +1009,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.6":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -2404,7 +2404,7 @@
     prop-types "^15.7.2"
     tslib "^2.0.0"
 
-"@reach/router@^1.2.1", "@reach/router@^1.3.4":
+"@reach/router@1.3.4", "@reach/router@^1.2.1", "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
   integrity sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==
@@ -11128,6 +11128,15 @@ gatsby-plugin-typescript@^2.4.18:
     "@babel/preset-typescript" "^7.10.1"
     "@babel/runtime" "^7.10.3"
     babel-plugin-remove-graphql-queries "^2.9.17"
+
+gatsby-react-router-scroll@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-3.0.0.tgz#ad2afdfa6052d9e1b5add053fec1b545fc369474"
+  integrity sha512-vaXYQgGkBrrUHy+uyyxy2aj5TZOuuO4U8mHgVKKSFyLIZPk35wknifFsPYVyyYqi2zxdKiFkYKfHDWlQHxMlzA==
+  dependencies:
+    "@babel/runtime" "^7.9.6"
+    scroll-behavior "^0.9.12"
+    warning "^3.0.0"
 
 gatsby-react-router-scroll@^3.0.12:
   version "3.0.12"
@@ -21692,6 +21701,14 @@ schema-utils@^2.0.1, schema-utils@^2.5.0, schema-utils@^2.6.4, schema-utils@^2.6
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
+scroll-behavior@^0.9.12:
+  version "0.9.12"
+  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.12.tgz#1c22d273ec4ce6cd4714a443fead50227da9424c"
+  integrity sha512-18sirtyq1P/VsBX6O/vgw20Np+ngduFXEMO4/NDFXabdOKBL2kjPVUpz1y0+jm99EWwFJafxf5/tCyMeXt9Xyg==
+  dependencies:
+    dom-helpers "^3.4.0"
+    invariant "^2.2.4"
+
 scss-comment-parser@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/scss-comment-parser/-/scss-comment-parser-0.8.4.tgz#8e82c3fcf7fdbbb7f172f8955e2aa88b685f86d8"
@@ -25016,6 +25033,13 @@ ware@^1.2.0:
   integrity sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=
   dependencies:
     wrap-fn "^0.1.0"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
 
 warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
This fixes an issue where linking to https://clayui.com/docs/components/input.html#textarea, which is in the CSS/Markup section doesn't take you there.