### PR TITLE
refactor(clayui.com): Changes the implementation of Tabs from a single page to multiple pages

### DIFF
--- a/clayui.com/content/docs/components/css-alerts.md
+++ b/clayui.com/content/docs/components/css-alerts.md
@@ -2,6 +2,7 @@
 title: 'Alerts'
 description: 'Alerts are used to capture the attention of the user in an intrusive way. They can be used just to say that something went right, or perhaps to say that something needs to be reviewed.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/alerts/'
+mainTabLink: 'docs/components/alert.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-alerts.md
+++ b/clayui.com/content/docs/components/css-alerts.md
@@ -2,7 +2,7 @@
 title: 'Alerts'
 description: 'Alerts are used to capture the attention of the user in an intrusive way. They can be used just to say that something went right, or perhaps to say that something needs to be reviewed.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/alerts/'
-mainTabLink: 'docs/components/alert.html'
+mainTabURL: 'docs/components/alert.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-badges.md
+++ b/clayui.com/content/docs/components/css-badges.md
@@ -2,6 +2,7 @@
 title: 'Badges'
 description: 'Badges help highlight important information, such as notifications or new and unread messages. Badges have circular borders and are only used to specify a number.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/badges/'
+mainTabLink: 'docs/components/badge.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-badges.md
+++ b/clayui.com/content/docs/components/css-badges.md
@@ -2,7 +2,7 @@
 title: 'Badges'
 description: 'Badges help highlight important information, such as notifications or new and unread messages. Badges have circular borders and are only used to specify a number.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/badges/'
-mainTabLink: 'docs/components/badge.html'
+mainTabURL: 'docs/components/badge.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-breadcrumbs.md
+++ b/clayui.com/content/docs/components/css-breadcrumbs.md
@@ -2,7 +2,7 @@
 title: 'Breadcrumb'
 description: 'Breadcrumb is a secondary navigation pattern that identifies the page position inside a hierarchy.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/breadcrumb/'
-mainTabLink: 'docs/components/breadcrumb.html'
+mainTabURL: 'docs/components/breadcrumb.html'
 ---
 
 A navigation aid for your site, provide a quick way to jump back to previously viewed pages or sections.

--- a/clayui.com/content/docs/components/css-breadcrumbs.md
+++ b/clayui.com/content/docs/components/css-breadcrumbs.md
@@ -2,6 +2,7 @@
 title: 'Breadcrumb'
 description: 'Breadcrumb is a secondary navigation pattern that identifies the page position inside a hierarchy.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/breadcrumb/'
+mainTabLink: 'docs/components/breadcrumb.html'
 ---
 
 A navigation aid for your site, provide a quick way to jump back to previously viewed pages or sections.

--- a/clayui.com/content/docs/components/css-button-group.md
+++ b/clayui.com/content/docs/components/css-button-group.md
@@ -2,7 +2,7 @@
 title: 'Button Group'
 description: 'Button groups are used to switch between complementary views for example, but they must never be used for complementary actions, "Change and Cancel" actions, or "Save and Cancel" actions. In those cases, single buttons are the correct solution.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
-mainTabLink: 'docs/components/button-group.html'
+mainTabURL: 'docs/components/button-group.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-button-group.md
+++ b/clayui.com/content/docs/components/css-button-group.md
@@ -2,6 +2,7 @@
 title: 'Button Group'
 description: 'Button groups are used to switch between complementary views for example, but they must never be used for complementary actions, "Change and Cancel" actions, or "Save and Cancel" actions. In those cases, single buttons are the correct solution.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
+mainTabLink: 'docs/components/button-group.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-buttons.md
+++ b/clayui.com/content/docs/components/css-buttons.md
@@ -2,6 +2,7 @@
 title: 'Buttons'
 description: 'Buttons communicate an action to happen on user interaction.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
+mainTabLink: 'docs/components/button.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-buttons.md
+++ b/clayui.com/content/docs/components/css-buttons.md
@@ -2,7 +2,7 @@
 title: 'Buttons'
 description: 'Buttons communicate an action to happen on user interaction.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
-mainTabLink: 'docs/components/button.html'
+mainTabURL: 'docs/components/button.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-cards.md
+++ b/clayui.com/content/docs/components/css-cards.md
@@ -2,6 +2,7 @@
 title: 'Cards'
 description: 'Cards are a specific form of data visualization focused mainly on displaying images.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/cards/'
+mainTabLink: 'docs/components/card.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-cards.md
+++ b/clayui.com/content/docs/components/css-cards.md
@@ -2,7 +2,7 @@
 title: 'Cards'
 description: 'Cards are a specific form of data visualization focused mainly on displaying images.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/cards/'
-mainTabLink: 'docs/components/card.html'
+mainTabURL: 'docs/components/card.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-checkbox-radio.md
+++ b/clayui.com/content/docs/components/css-checkbox-radio.md
@@ -2,7 +2,7 @@
 title: 'Checkbox and Radio'
 description: 'Checkboxes and radios provide users with different selection and activation tools.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/'
-mainTabLink: 'docs/components/checkbox.html'
+mainTabURL: 'docs/components/checkbox.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-checkbox-radio.md
+++ b/clayui.com/content/docs/components/css-checkbox-radio.md
@@ -2,6 +2,7 @@
 title: 'Checkbox and Radio'
 description: 'Checkboxes and radios provide users with different selection and activation tools.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/'
+mainTabLink: 'docs/components/checkbox.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-color-picker.md
+++ b/clayui.com/content/docs/components/css-color-picker.md
@@ -2,7 +2,7 @@
 title: 'Color Picker'
 description: 'Color picker lets users select a color from a predefined palette, specify a color via its hexadecimal value, sample a color, and explore color values to create a custom color variation.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-color/'
-mainTabLink: 'docs/components/color-picker.html'
+mainTabURL: 'docs/components/color-picker.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-color-picker.md
+++ b/clayui.com/content/docs/components/css-color-picker.md
@@ -2,6 +2,7 @@
 title: 'Color Picker'
 description: 'Color picker lets users select a color from a predefined palette, specify a color via its hexadecimal value, sample a color, and explore color values to create a custom color variation.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-color/'
+mainTabLink: 'docs/components/color-picker.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-date-and-time-pickers.md
+++ b/clayui.com/content/docs/components/css-date-and-time-pickers.md
@@ -2,6 +2,7 @@
 title: 'Date & Time Pickers'
 description: 'Date and Time pickers let users select a date and time for a form.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-date-time/'
+mainTabLink: 'docs/components/date-picker.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-date-and-time-pickers.md
+++ b/clayui.com/content/docs/components/css-date-and-time-pickers.md
@@ -2,7 +2,7 @@
 title: 'Date & Time Pickers'
 description: 'Date and Time pickers let users select a date and time for a form.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-date-time/'
-mainTabLink: 'docs/components/date-picker.html'
+mainTabURL: 'docs/components/date-picker.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-dropdown.md
+++ b/clayui.com/content/docs/components/css-dropdown.md
@@ -2,6 +2,7 @@
 title: 'Dropdown'
 description: 'A dropdown menu displays a list of options for the element that triggers it.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dropdowns/'
+mainTabLink: 'docs/components/drop-down.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-dropdown.md
+++ b/clayui.com/content/docs/components/css-dropdown.md
@@ -2,7 +2,7 @@
 title: 'Dropdown'
 description: 'A dropdown menu displays a list of options for the element that triggers it.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dropdowns/'
-mainTabLink: 'docs/components/drop-down.html'
+mainTabURL: 'docs/components/drop-down.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-dual-list-box.md
+++ b/clayui.com/content/docs/components/css-dual-list-box.md
@@ -2,7 +2,7 @@
 title: 'Dual List Box'
 description: 'Dual List Box provides users with two Select Boxes with the ability to move items between lists.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
-mainTabLink: 'docs/components/dual-list_box.html'
+mainTabURL: 'docs/components/dual-list_box.html'
 ---
 
 <div class="clay-site-alert alert alert-warning">

--- a/clayui.com/content/docs/components/css-dual-list-box.md
+++ b/clayui.com/content/docs/components/css-dual-list-box.md
@@ -2,6 +2,7 @@
 title: 'Dual List Box'
 description: 'Dual List Box provides users with two Select Boxes with the ability to move items between lists.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
+mainTabLink: 'docs/components/dual-list_box.html'
 ---
 
 <div class="clay-site-alert alert alert-warning">

--- a/clayui.com/content/docs/components/css-empty-state.md
+++ b/clayui.com/content/docs/components/css-empty-state.md
@@ -2,7 +2,7 @@
 title: 'Empty State'
 description: 'Empty states provide users with feedback on the reasons behind the empty state and what they can do to move out of the empty state.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/empty-states/'
-mainTabLink: 'docs/components/empty-state.html'
+mainTabURL: 'docs/components/empty-state.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-empty-state.md
+++ b/clayui.com/content/docs/components/css-empty-state.md
@@ -2,6 +2,7 @@
 title: 'Empty State'
 description: 'Empty states provide users with feedback on the reasons behind the empty state and what they can do to move out of the empty state.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/empty-states/'
+mainTabLink: 'docs/components/empty-state.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-form-group.md
+++ b/clayui.com/content/docs/components/css-form-group.md
@@ -2,6 +2,7 @@
 title: 'Form Group'
 description: 'Forms obtain user data and transmit it to the system to either store the data, produce an action, or both.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
+mainTabLink: 'docs/components/form.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-form-group.md
+++ b/clayui.com/content/docs/components/css-form-group.md
@@ -2,7 +2,7 @@
 title: 'Form Group'
 description: 'Forms obtain user data and transmit it to the system to either store the data, produce an action, or both.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
-mainTabLink: 'docs/components/form.html'
+mainTabURL: 'docs/components/form.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-icons.mdx
+++ b/clayui.com/content/docs/components/css-icons.mdx
@@ -2,7 +2,7 @@
 title: 'Icons'
 description: 'Icons are a visual representation of an idea and/or action.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/icons/'
-mainTabLink: 'docs/components/icon.html'
+mainTabURL: 'docs/components/icon.html'
 ---
 
 import IconSearch from '$clayui.com/src/components/IconSearch';

--- a/clayui.com/content/docs/components/css-icons.mdx
+++ b/clayui.com/content/docs/components/css-icons.mdx
@@ -2,6 +2,7 @@
 title: 'Icons'
 description: 'Icons are a visual representation of an idea and/or action.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/icons/'
+mainTabLink: 'docs/components/icon.html'
 ---
 
 import IconSearch from '$clayui.com/src/components/IconSearch';

--- a/clayui.com/content/docs/components/css-labels.md
+++ b/clayui.com/content/docs/components/css-labels.md
@@ -2,7 +2,7 @@
 title: 'Labels'
 description: 'Labels categorize information, providing quick recognition.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/labels/'
-mainTabLink: 'docs/components/label.html'
+mainTabURL: 'docs/components/label.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-labels.md
+++ b/clayui.com/content/docs/components/css-labels.md
@@ -2,6 +2,7 @@
 title: 'Labels'
 description: 'Labels categorize information, providing quick recognition.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/labels/'
+mainTabLink: 'docs/components/label.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-links.md
+++ b/clayui.com/content/docs/components/css-links.md
@@ -2,6 +2,7 @@
 title: 'Links'
 description: 'Also known as a hyperlink, a link is a clickable (text or image) element used for navigation purposes.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/link/'
+mainTabLink: 'docs/components/link.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-links.md
+++ b/clayui.com/content/docs/components/css-links.md
@@ -2,7 +2,7 @@
 title: 'Links'
 description: 'Also known as a hyperlink, a link is a clickable (text or image) element used for navigation purposes.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/link/'
-mainTabLink: 'docs/components/link.html'
+mainTabURL: 'docs/components/link.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-list.md
+++ b/clayui.com/content/docs/components/css-list.md
@@ -2,6 +2,7 @@
 title: 'List'
 description: 'List is a visual representation of a dataset that provides more flexibility for arranging the data than a table and is less visually explicit than a card view.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/list/'
+mainTabLink: 'docs/components/list.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-list.md
+++ b/clayui.com/content/docs/components/css-list.md
@@ -2,7 +2,7 @@
 title: 'List'
 description: 'List is a visual representation of a dataset that provides more flexibility for arranging the data than a table and is less visually explicit than a card view.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/list/'
-mainTabLink: 'docs/components/list.html'
+mainTabURL: 'docs/components/list.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-loading-indicator.md
+++ b/clayui.com/content/docs/components/css-loading-indicator.md
@@ -2,6 +2,7 @@
 title: 'Loading Indicator'
 description: 'The loading indicator shows the user that an external process, like a connection, is being executed.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/loading-indicator/'
+mainTabLink: 'docs/components/loading-indicator.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-loading-indicator.md
+++ b/clayui.com/content/docs/components/css-loading-indicator.md
@@ -2,7 +2,7 @@
 title: 'Loading Indicator'
 description: 'The loading indicator shows the user that an external process, like a connection, is being executed.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/loading-indicator/'
-mainTabLink: 'docs/components/loading-indicator.html'
+mainTabURL: 'docs/components/loading-indicator.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-management-toolbar.md
+++ b/clayui.com/content/docs/components/css-management-toolbar.md
@@ -2,6 +2,7 @@
 title: 'Management Toolbar'
 description: 'Management toolbar is an extension of Toolbar. It is a combination of different components, including filters, orders, search, visualization select, and other actions that let users manage a dataset.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/management-bar/'
+mainTabLink: 'docs/components/management-toolbar.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-management-toolbar.md
+++ b/clayui.com/content/docs/components/css-management-toolbar.md
@@ -2,7 +2,7 @@
 title: 'Management Toolbar'
 description: 'Management toolbar is an extension of Toolbar. It is a combination of different components, including filters, orders, search, visualization select, and other actions that let users manage a dataset.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/management-bar/'
-mainTabLink: 'docs/components/management-toolbar.html'
+mainTabURL: 'docs/components/management-toolbar.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-modals.md
+++ b/clayui.com/content/docs/components/css-modals.md
@@ -2,7 +2,7 @@
 title: 'Modals'
 description: 'A modal is a secondary window that communicates or provides an action inside the same process.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/modals/'
-mainTabLink: 'docs/components/modal.html'
+mainTabURL: 'docs/components/modal.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-modals.md
+++ b/clayui.com/content/docs/components/css-modals.md
@@ -2,6 +2,7 @@
 title: 'Modals'
 description: 'A modal is a secondary window that communicates or provides an action inside the same process.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/modals/'
+mainTabLink: 'docs/components/modal.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-multi-step-form.md
+++ b/clayui.com/content/docs/components/css-multi-step-form.md
@@ -2,6 +2,7 @@
 title: 'Multi Step Form'
 description: 'A multi step form, also known as a wizard, is a determinate progress bar used in long processes that divides the main task into subtasks. The wizard lets the user quickly identify their current progress in completing the task and navigate forwards and backwards between steps if needed.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/multi-step-form/'
+mainTabLink: 'docs/components/multi-step-nav.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-multi-step-form.md
+++ b/clayui.com/content/docs/components/css-multi-step-form.md
@@ -2,7 +2,7 @@
 title: 'Multi Step Form'
 description: 'A multi step form, also known as a wizard, is a determinate progress bar used in long processes that divides the main task into subtasks. The wizard lets the user quickly identify their current progress in completing the task and navigate forwards and backwards between steps if needed.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/multi-step-form/'
-mainTabLink: 'docs/components/multi-step-nav.html'
+mainTabURL: 'docs/components/multi-step-nav.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-nav.md
+++ b/clayui.com/content/docs/components/css-nav.md
@@ -1,6 +1,6 @@
 ---
 title: 'Nav'
-mainTabLink: 'docs/components/nav.html'
+mainTabURL: 'docs/components/nav.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-nav.md
+++ b/clayui.com/content/docs/components/css-nav.md
@@ -1,5 +1,6 @@
 ---
 title: 'Nav'
+mainTabLink: 'docs/components/nav.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-navigation-bar.md
+++ b/clayui.com/content/docs/components/css-navigation-bar.md
@@ -2,7 +2,7 @@
 title: 'Navigation Bar'
 description: 'A navigation bar, is a horizontal bar that provides several access points to different parts of a system.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/horizontal-nav/'
-mainTabLink: 'docs/components/navigation-bar.html'
+mainTabURL: 'docs/components/navigation-bar.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-navigation-bar.md
+++ b/clayui.com/content/docs/components/css-navigation-bar.md
@@ -2,6 +2,7 @@
 title: 'Navigation Bar'
 description: 'A navigation bar, is a horizontal bar that provides several access points to different parts of a system.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/horizontal-nav/'
+mainTabLink: 'docs/components/navigation-bar.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-pagination.md
+++ b/clayui.com/content/docs/components/css-pagination.md
@@ -2,6 +2,7 @@
 title: 'Pagination'
 description: 'Preset pagination styles helps divide up large blocks of content on your site or app.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/pagination/'
+mainTabLink: 'docs/components/pagination.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-pagination.md
+++ b/clayui.com/content/docs/components/css-pagination.md
@@ -2,7 +2,7 @@
 title: 'Pagination'
 description: 'Preset pagination styles helps divide up large blocks of content on your site or app.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/pagination/'
-mainTabLink: 'docs/components/pagination.html'
+mainTabURL: 'docs/components/pagination.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-panel.md
+++ b/clayui.com/content/docs/components/css-panel.md
@@ -1,6 +1,7 @@
 ---
 title: 'Panel'
 description: 'Panel provides an expandable details-summary view.'
+mainTabLink: 'docs/components/panel.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-panel.md
+++ b/clayui.com/content/docs/components/css-panel.md
@@ -1,7 +1,7 @@
 ---
 title: 'Panel'
 description: 'Panel provides an expandable details-summary view.'
-mainTabLink: 'docs/components/panel.html'
+mainTabURL: 'docs/components/panel.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-popovers.md
+++ b/clayui.com/content/docs/components/css-popovers.md
@@ -2,6 +2,7 @@
 title: 'Popover'
 description: 'Popovers contain helpful information such as an explanation of a context.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tooltips/'
+mainTabLink: 'docs/components/popover.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-popovers.md
+++ b/clayui.com/content/docs/components/css-popovers.md
@@ -2,7 +2,7 @@
 title: 'Popover'
 description: 'Popovers contain helpful information such as an explanation of a context.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tooltips/'
-mainTabLink: 'docs/components/popover.html'
+mainTabURL: 'docs/components/popover.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-progress-bars.md
+++ b/clayui.com/content/docs/components/css-progress-bars.md
@@ -2,6 +2,7 @@
 title: 'Progress Bars'
 description: 'Progress bar indicates the percentage completed of a task.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/progress-bars/'
+mainTabLink: 'docs/components/progress-bar.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-progress-bars.md
+++ b/clayui.com/content/docs/components/css-progress-bars.md
@@ -2,7 +2,7 @@
 title: 'Progress Bars'
 description: 'Progress bar indicates the percentage completed of a task.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/progress-bars/'
-mainTabLink: 'docs/components/progress-bar.html'
+mainTabURL: 'docs/components/progress-bar.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-select-box.md
+++ b/clayui.com/content/docs/components/css-select-box.md
@@ -2,6 +2,7 @@
 title: 'Select Box'
 description: 'This section demonstrates the different text input types, including usage and validation states.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
+mainTabLink: 'docs/components/select-box.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-select-box.md
+++ b/clayui.com/content/docs/components/css-select-box.md
@@ -2,7 +2,7 @@
 title: 'Select Box'
 description: 'This section demonstrates the different text input types, including usage and validation states.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
-mainTabLink: 'docs/components/select-box.html'
+mainTabURL: 'docs/components/select-box.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-slider.md
+++ b/clayui.com/content/docs/components/css-slider.md
@@ -2,6 +2,7 @@
 title: 'Slider'
 description: 'A Slider allows the user to select values in a linear range of values.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/slider/'
+mainTabLink: 'docs/components/slider.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-slider.md
+++ b/clayui.com/content/docs/components/css-slider.md
@@ -2,7 +2,7 @@
 title: 'Slider'
 description: 'A Slider allows the user to select values in a linear range of values.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/slider/'
-mainTabLink: 'docs/components/slider.html'
+mainTabURL: 'docs/components/slider.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-sticker.md
+++ b/clayui.com/content/docs/components/css-sticker.md
@@ -2,7 +2,7 @@
 title: 'Stickers'
 description: 'Stickers are a visual way to quickly identify content.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/stickers/'
-mainTabLink: 'docs/components/sticker.html'
+mainTabURL: 'docs/components/sticker.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-sticker.md
+++ b/clayui.com/content/docs/components/css-sticker.md
@@ -2,6 +2,7 @@
 title: 'Stickers'
 description: 'Stickers are a visual way to quickly identify content.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/stickers/'
+mainTabLink: 'docs/components/sticker.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-table.md
+++ b/clayui.com/content/docs/components/css-table.md
@@ -2,7 +2,7 @@
 title: 'Tables'
 description: 'A table is a specific pattern for comparing datasets in a very direct and analytical way.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/table/'
-mainTabLink: 'docs/components/table.html'
+mainTabURL: 'docs/components/table.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-table.md
+++ b/clayui.com/content/docs/components/css-table.md
@@ -2,6 +2,7 @@
 title: 'Tables'
 description: 'A table is a specific pattern for comparing datasets in a very direct and analytical way.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/table/'
+mainTabLink: 'docs/components/table.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-tabs.md
+++ b/clayui.com/content/docs/components/css-tabs.md
@@ -2,6 +2,7 @@
 title: 'Tabs'
 description: 'Tabs organize similar content together into individual sections in the same page.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/tabs/'
+mainTabLink: 'docs/components/tabs.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-tabs.md
+++ b/clayui.com/content/docs/components/css-tabs.md
@@ -2,7 +2,7 @@
 title: 'Tabs'
 description: 'Tabs organize similar content together into individual sections in the same page.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/tabs/'
-mainTabLink: 'docs/components/tabs.html'
+mainTabURL: 'docs/components/tabs.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-text-input-autocomplete.md
+++ b/clayui.com/content/docs/components/css-text-input-autocomplete.md
@@ -2,6 +2,7 @@
 title: 'Input Autocomplete'
 description: 'An autocomplete text field is an input that offers the user text suggestions while they type.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input-variations/'
+mainTabLink: 'docs/components/autocomplete.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-text-input-autocomplete.md
+++ b/clayui.com/content/docs/components/css-text-input-autocomplete.md
@@ -2,7 +2,7 @@
 title: 'Input Autocomplete'
 description: 'An autocomplete text field is an input that offers the user text suggestions while they type.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input-variations/'
-mainTabLink: 'docs/components/autocomplete.html'
+mainTabURL: 'docs/components/autocomplete.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-text-input-localizable.md
+++ b/clayui.com/content/docs/components/css-text-input-localizable.md
@@ -2,6 +2,7 @@
 title: 'Input Localizable'
 description: 'A text input variation used in fields that can be translated into multiple languages.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input-localizable/'
+mainTabLink: 'docs/components/localized-input.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-text-input-localizable.md
+++ b/clayui.com/content/docs/components/css-text-input-localizable.md
@@ -2,7 +2,7 @@
 title: 'Input Localizable'
 description: 'A text input variation used in fields that can be translated into multiple languages.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input-localizable/'
-mainTabLink: 'docs/components/localized-input.html'
+mainTabURL: 'docs/components/localized-input.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-text-input-multi-select.md
+++ b/clayui.com/content/docs/components/css-text-input-multi-select.md
@@ -2,6 +2,7 @@
 title: 'Multi Select'
 description: 'Multi select is the field type that allows writing text to create “tags” that are represented in the shape of labels.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selector/'
+mainTabLink: 'docs/components/multi-select.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-text-input-multi-select.md
+++ b/clayui.com/content/docs/components/css-text-input-multi-select.md
@@ -2,7 +2,7 @@
 title: 'Multi Select'
 description: 'Multi select is the field type that allows writing text to create “tags” that are represented in the shape of labels.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selector/'
-mainTabLink: 'docs/components/multi-select.html'
+mainTabURL: 'docs/components/multi-select.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-text-input.md
+++ b/clayui.com/content/docs/components/css-text-input.md
@@ -2,7 +2,7 @@
 title: 'Input'
 description: 'This section demonstrates the different text input types, including usage and validation states.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input/'
-mainTabLink: 'docs/components/input.html'
+mainTabURL: 'docs/components/input.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-text-input.md
+++ b/clayui.com/content/docs/components/css-text-input.md
@@ -2,6 +2,7 @@
 title: 'Input'
 description: 'This section demonstrates the different text input types, including usage and validation states.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input/'
+mainTabLink: 'docs/components/input.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-toggle-switch.md
+++ b/clayui.com/content/docs/components/css-toggle-switch.md
@@ -2,6 +2,7 @@
 title: 'Toggle Switch'
 description: 'Toggle provide users with different selection and activation tools.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/#toggle'
+mainTabLink: 'docs/components/toggle-switch.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-toggle-switch.md
+++ b/clayui.com/content/docs/components/css-toggle-switch.md
@@ -2,7 +2,7 @@
 title: 'Toggle Switch'
 description: 'Toggle provide users with different selection and activation tools.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/#toggle'
-mainTabLink: 'docs/components/toggle-switch.html'
+mainTabURL: 'docs/components/toggle-switch.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-toolbar.md
+++ b/clayui.com/content/docs/components/css-toolbar.md
@@ -2,7 +2,7 @@
 title: 'Toolbar'
 description: 'Toolbar used as part of some Clay components like Management Toolbar and Modal'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/'
-mainTabLink: 'docs/components/toolbar.html'
+mainTabURL: 'docs/components/toolbar.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-toolbar.md
+++ b/clayui.com/content/docs/components/css-toolbar.md
@@ -2,6 +2,7 @@
 title: 'Toolbar'
 description: 'Toolbar used as part of some Clay components like Management Toolbar and Modal'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/'
+mainTabLink: 'docs/components/toolbar.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-tooltips.md
+++ b/clayui.com/content/docs/components/css-tooltips.md
@@ -2,6 +2,7 @@
 title: 'Tooltips'
 description: 'Tooltips are brief pieces of information that appear on hover state over an element to clarify its meaning or use for the user.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tooltips/'
+mainTabLink: 'docs/components/tooltip.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/content/docs/components/css-tooltips.md
+++ b/clayui.com/content/docs/components/css-tooltips.md
@@ -2,7 +2,7 @@
 title: 'Tooltips'
 description: 'Tooltips are brief pieces of information that appear on hover state over an element to clarify its meaning or use for the user.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tooltips/'
-mainTabLink: 'docs/components/tooltip.html'
+mainTabURL: 'docs/components/tooltip.html'
 ---
 
 <div class="nav-toc-absolute">

--- a/clayui.com/gatsby/createPages.js
+++ b/clayui.com/gatsby/createPages.js
@@ -27,9 +27,9 @@ const getTabs = (permalink, pathGroup) => {
 	const tabs = pathGroup.filter(
 		({
 			node: {
-				fields: {mainTabLink},
+				fields: {mainTabURL},
 			},
-		}) => mainTabLink === permalink
+		}) => mainTabURL === permalink
 	);
 
 	if (tabs.length === 0) {
@@ -60,7 +60,7 @@ const createDocs = (actions, edges, mdx, pathGroup) => {
 		.forEach(
 			({
 				node: {
-					fields: {layout, mainTabLink, redirect, redirectFrom, slug},
+					fields: {layout, mainTabURL, redirect, redirectFrom, slug},
 				},
 			}) => {
 				if (redirect) {
@@ -110,7 +110,7 @@ const createDocs = (actions, edges, mdx, pathGroup) => {
 					createPage({
 						component: template,
 						context: {
-							mainTabLink,
+							mainTabURL,
 							pathGroup: pathGroup.map(
 								({
 									node: {
@@ -119,7 +119,7 @@ const createDocs = (actions, edges, mdx, pathGroup) => {
 								}) => slug
 							),
 							slug,
-							tabs: getTabs(mainTabLink || slug, pathGroup),
+							tabs: getTabs(mainTabURL || slug, pathGroup),
 						},
 						path: slug,
 					});
@@ -153,7 +153,7 @@ module.exports = async ({actions, graphql}) => {
 							redirect
 							redirectFrom
 							slug
-							mainTabLink
+							mainTabURL
 						}
 						body
 					}
@@ -168,7 +168,7 @@ module.exports = async ({actions, graphql}) => {
 							redirect
 							redirectFrom
 							slug
-							mainTabLink
+							mainTabURL
 						}
 					}
 				}
@@ -185,9 +185,9 @@ module.exports = async ({actions, graphql}) => {
 		].filter(
 			({
 				node: {
-					fields: {mainTabLink},
+					fields: {mainTabURL},
 				},
-			}) => mainTabLink
+			}) => mainTabURL
 		);
 
 		if (data.allMdx.edges) {

--- a/clayui.com/gatsby/createPages.js
+++ b/clayui.com/gatsby/createPages.js
@@ -13,15 +13,42 @@ require('dotenv').config({
 
 const path = require('path');
 
-/* eslint-enable liferay/imports-first */
-
 const {GATSBY_CLAY_NIGHTLY} = process.env;
+
+const TAB_MAP_NAME = {
+	css: 'CSS / Markup',
+};
 
 const slugWithBar = (path) => {
 	return path.startsWith('/') ? path : `/${path}`;
 };
 
-const createDocs = (actions, edges, mdx, blacklist = []) => {
+const getTabs = (permalink, pathGroup) => {
+	const tabs = pathGroup.filter(
+		({
+			node: {
+				fields: {mainTabLink},
+			},
+		}) => mainTabLink === permalink
+	);
+
+	if (tabs.length === 0) {
+		return [];
+	}
+
+	return [
+		{
+			href: permalink,
+			name: 'React Component',
+		},
+		...tabs.map(({node: {fields: {slug}}}) => ({
+			href: slug,
+			name: TAB_MAP_NAME[path.basename(slug, '.html')],
+		})),
+	];
+};
+
+const createDocs = (actions, edges, mdx, pathGroup) => {
 	const {createPage, createRedirect} = actions;
 	const docsTemplate = path.resolve(__dirname, '../src/templates/docs.js');
 	const blogTemplate = path.resolve(__dirname, '../src/templates/blog.js');
@@ -33,21 +60,9 @@ const createDocs = (actions, edges, mdx, blacklist = []) => {
 		.forEach(
 			({
 				node: {
-					fields: {layout, redirect, redirectFrom, sibling, slug},
+					fields: {layout, mainTabLink, redirect, redirectFrom, slug},
 				},
 			}) => {
-				const hasSibling = blacklist.find(
-					({
-						node: {
-							fields: {sibling},
-						},
-					}) => sibling === slug
-				);
-
-				if (hasSibling) {
-					return;
-				}
-
 				if (redirect) {
 					const slugBar = slugWithBar(slug);
 					const fromPath = slugBar.endsWith('index.html')
@@ -92,21 +107,19 @@ const createDocs = (actions, edges, mdx, blacklist = []) => {
 					(slug.includes('docs/') || slug.includes('blog/')) &&
 					layout !== 'redirect'
 				) {
-					const blacklistSlugs = blacklist.map(
-						({
-							node: {
-								fields: {sibling},
-							},
-						}) => sibling
-					);
-
 					createPage({
 						component: template,
 						context: {
-							blacklist: blacklistSlugs,
-							markdownJsx: mdx,
-							sibling,
+							mainTabLink,
+							pathGroup: pathGroup.map(
+								({
+									node: {
+										fields: {slug},
+									},
+								}) => slug
+							),
 							slug,
+							tabs: getTabs(mainTabLink || slug, pathGroup),
 						},
 						path: slug,
 					});
@@ -140,7 +153,7 @@ module.exports = async ({actions, graphql}) => {
 							redirect
 							redirectFrom
 							slug
-							sibling
+							mainTabLink
 						}
 						body
 					}
@@ -155,7 +168,7 @@ module.exports = async ({actions, graphql}) => {
 							redirect
 							redirectFrom
 							slug
-							sibling
+							mainTabLink
 						}
 					}
 				}
@@ -166,22 +179,22 @@ module.exports = async ({actions, graphql}) => {
 			return Promise.reject(errors);
 		}
 
-		const blacklist = [
+		const pathGroup = [
 			...data.allMdx.edges,
 			...data.allMarkdownRemark.edges,
 		].filter(
 			({
 				node: {
-					fields: {sibling},
+					fields: {mainTabLink},
 				},
-			}) => sibling
+			}) => mainTabLink
 		);
 
 		if (data.allMdx.edges) {
-			createDocs(actions, data.allMdx.edges, true, blacklist);
+			createDocs(actions, data.allMdx.edges, true, pathGroup);
 		}
 
-		createDocs(actions, data.allMarkdownRemark.edges, false, blacklist);
+		createDocs(actions, data.allMarkdownRemark.edges, false, pathGroup);
 
 		const newestBlogEntry = await graphql(
 			`

--- a/clayui.com/gatsby/onCreateNode.js
+++ b/clayui.com/gatsby/onCreateNode.js
@@ -31,7 +31,7 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 			indexVisible,
 			layout,
 			lexiconDefinition = '',
-			mainTabLink,
+			mainTabURL,
 			nightly,
 			order,
 			packageNpm,
@@ -92,8 +92,8 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 					slug = relativePath.replace('.mdx', '.html');
 				}
 
-				if (mainTabLink) {
-					slug = generateTabSlug(slug, mainTabLink);
+				if (mainTabURL) {
+					slug = generateTabSlug(slug, mainTabURL);
 				}
 			}
 
@@ -225,9 +225,9 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 		});
 
 		createNodeField({
-			name: 'mainTabLink',
+			name: 'mainTabURL',
 			node,
-			value: mainTabLink || '',
+			value: mainTabURL || '',
 		});
 
 		createNodeField({

--- a/clayui.com/gatsby/onCreateNode.js
+++ b/clayui.com/gatsby/onCreateNode.js
@@ -10,6 +10,12 @@ const getPackageConfig = require('../src/utils/getPackageConfig');
 // eslint-disable-next-line no-useless-escape
 const BLOG_POST_FILENAME_REGEX = /([0-9]+)\-([0-9]+)\-([0-9]+)\-(.+)\.md$/;
 
+const generateTabSlug = (slug, groupLink) => {
+	const tabName = path.basename(slug).split('-')[0];
+
+	return groupLink.replace('.html', `/${tabName}.html`);
+};
+
 module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 	const {createNodeField} = actions;
 
@@ -25,6 +31,7 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 			indexVisible,
 			layout,
 			lexiconDefinition = '',
+			mainTabLink,
 			nightly,
 			order,
 			packageNpm,
@@ -33,7 +40,6 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 			path: permalink,
 			redirect,
 			redirectFrom,
-			sibling,
 			title,
 			version,
 		} = node.frontmatter;
@@ -84,6 +90,10 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 					slug = relativePath.replace('.md', '.html');
 				} else {
 					slug = relativePath.replace('.mdx', '.html');
+				}
+
+				if (mainTabLink) {
+					slug = generateTabSlug(slug, mainTabLink);
 				}
 			}
 
@@ -215,9 +225,9 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 		});
 
 		createNodeField({
-			name: 'sibling',
+			name: 'mainTabLink',
 			node,
-			value: sibling || '',
+			value: mainTabLink || '',
 		});
 
 		createNodeField({

--- a/clayui.com/src/components/Sidebar/Navigation.js
+++ b/clayui.com/src/components/Sidebar/Navigation.js
@@ -46,22 +46,21 @@ class Navigation extends Component {
 			return true;
 		}
 
-		const {location} = this.props;
+		const {active = [], location} = this.props;
 		const match = location.pathname.split('/');
-		const id = match[match.length - 1].split('.');
 
 		if (section.items) {
 			return match.includes(section.id);
 		}
 
-		return id[0] === section.id;
+		return active.includes(section.pathname);
 	}
 
 	/**
 	 * @return {React.Component}
 	 */
 	renderNavigationItems() {
-		const {depth = 0, location, sectionList} = this.props;
+		const {active, depth = 0, location, sectionList} = this.props;
 
 		return sectionList.map((section, index) => {
 			const style = classNames({
@@ -90,6 +89,7 @@ class Navigation extends Component {
 
 					{section.items && (
 						<Navigation
+							active={active}
 							depth={depth + 1}
 							location={location}
 							onNavigation={() => this.handleOnNavigation()}

--- a/clayui.com/src/components/Sidebar/Sidebar.js
+++ b/clayui.com/src/components/Sidebar/Sidebar.js
@@ -41,7 +41,7 @@ const SideNavScroll = (props) => {
 	);
 };
 
-export default (props) => (
+export default ({active, data, location}) => (
 	<>
 		<nav
 			className="sidebar-toggler-content sidenav-menu-slider sidenav-sticky"
@@ -97,8 +97,9 @@ export default (props) => (
 				<div className="p-0 sidebar-body">
 					<div className="mt-3">
 						<Navigation
-							location={props.location}
-							sectionList={props.data}
+							active={active}
+							location={location}
+							sectionList={data}
 						/>
 					</div>
 				</div>

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -149,8 +149,7 @@ export default (props) => {
 	const {
 		data,
 		location,
-		navigate,
-		pageContext: {tabs = []},
+		pageContext: {tabs = [], slug},
 	} = props;
 	const {allMarkdownRemark, allMdx, mainTab, pageMd, pageMdx} = data;
 
@@ -198,6 +197,10 @@ export default (props) => {
 							<div className="container-fluid">
 								<div className="flex-xl-nowrap row">
 									<Sidebar
+										active={[
+											slug,
+											...tabs.map(({href}) => href),
+										]}
 										data={getSection([
 											...allMarkdownRemark.edges,
 											...allMdx.edges,
@@ -229,7 +232,7 @@ export default (props) => {
 														)}
 													</div>
 													<div className="col-12">
-														{tabs && (
+														{tabs.length > 0 && (
 															<ClayTabs
 																className="border-bottom nav-clay"
 																modern
@@ -247,13 +250,9 @@ export default (props) => {
 																				`/${href}` ===
 																				location.pathname
 																			}
+																			href={`/${href}`}
 																			key={
 																				index
-																			}
-																			onClick={() =>
-																				navigate(
-																					`/${href}`
-																				)
 																			}
 																		>
 																			<span

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -357,7 +357,7 @@ export default (props) => {
 };
 
 export const pageQuery = graphql`
-	query($pathGroup: [String!], $slug: String!, $mainTabLink: String!) {
+	query($pathGroup: [String!], $slug: String!, $mainTabURL: String!) {
 		pageMdx: mdx(fields: {slug: {eq: $slug}}) {
 			excerpt
 			timeToRead
@@ -386,7 +386,7 @@ export const pageQuery = graphql`
 				version
 			}
 		}
-		mainTab: mdx(fields: {slug: {eq: $mainTabLink}}) {
+		mainTab: mdx(fields: {slug: {eq: $mainTabURL}}) {
 			frontmatter {
 				description
 				disableTOC

--- a/clayui.com/src/utils/getSection.js
+++ b/clayui.com/src/utils/getSection.js
@@ -22,6 +22,7 @@ const sortByOrderAndTitle = (a, b) => {
 
 const toSectionElements = (
 	slug,
+	pathname,
 	title,
 	order,
 	alwaysActive,
@@ -49,6 +50,7 @@ const toSectionElements = (
 		link,
 		order,
 		parentLink,
+		pathname,
 		title,
 	};
 };
@@ -77,6 +79,7 @@ const getSection = (data) => {
 
 		return toSectionElements(
 			slug.replace('.html', ''),
+			slug,
 			title,
 			order,
 			alwaysActive,

--- a/clayui.com/src/utils/getSection.js
+++ b/clayui.com/src/utils/getSection.js
@@ -69,15 +69,11 @@ const toSectionItem = (item, paths) => {
 	return item;
 };
 
-const getSection = (data, blacklist = []) => {
+const getSection = (data) => {
 	const elements = data.map(({node}) => {
 		const {
 			fields: {alwaysActive, draft, indexVisible, order, slug, title},
 		} = node;
-
-		if (blacklist.includes(slug)) {
-			return {};
-		}
 
 		return toSectionElements(
 			slug.replace('.html', ''),

--- a/packages/clay-alert/README.mdx
+++ b/packages/clay-alert/README.mdx
@@ -3,7 +3,6 @@ title: 'Alerts'
 description: 'Alerts are used to capture the attention of the user in an intrusive way.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/alerts/'
 packageNpm: '@clayui/alert'
-sibling: 'docs/components/css-alerts.html'
 ---
 
 import {

--- a/packages/clay-autocomplete/README.mdx
+++ b/packages/clay-autocomplete/README.mdx
@@ -3,7 +3,6 @@ title: 'Autocomplete'
 description: 'An autocomplete text field is an input that offers the user text suggestions while they type.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input-variations/'
 packageNpm: '@clayui/autocomplete'
-sibling: 'docs/components/css-text-input-autocomplete.html'
 ---
 
 import {

--- a/packages/clay-badge/README.mdx
+++ b/packages/clay-badge/README.mdx
@@ -3,7 +3,6 @@ title: 'Badge'
 description: 'Badges help highlight important information, such as notifications or new and unread messages.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/badges/'
 packageNpm: '@clayui/badge'
-sibling: 'docs/components/css-badges.html'
 ---
 
 import {Badge} from '$packages/clay-badge/docs/index';

--- a/packages/clay-breadcrumb/README.mdx
+++ b/packages/clay-breadcrumb/README.mdx
@@ -3,7 +3,6 @@ title: 'Breadcrumb'
 description: 'Breadcrumb is a secondary navigation pattern that identifies the page position inside a hierarchy.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/breadcrumb/'
 packageNpm: '@clayui/breadcrumb'
-sibling: 'docs/components/css-breadcrumbs.html'
 ---
 
 import {Breadcrumb} from '$packages/clay-breadcrumb/docs/index';

--- a/packages/clay-button/BUTTON_GROUP.mdx
+++ b/packages/clay-button/BUTTON_GROUP.mdx
@@ -3,7 +3,6 @@ title: 'Button Group'
 description: 'Button groups are used to switch between complementary views for example, but they must never be used for complementary actions, "Change and Cancel" actions, or "Save and Cancel" actions. In those cases, single buttons are the correct solution.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
 packageNpm: '@clayui/button'
-sibling: 'docs/components/css-button-group.html'
 ---
 
 import {ButtonGroup} from '$packages/clay-button/docs/index';

--- a/packages/clay-button/README.mdx
+++ b/packages/clay-button/README.mdx
@@ -3,7 +3,6 @@ title: 'Buttons'
 description: 'Buttons communicate an action to happen on user interaction.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/buttons/'
 packageNpm: '@clayui/button'
-sibling: 'docs/components/css-buttons.html'
 ---
 
 import {

--- a/packages/clay-card/README.mdx
+++ b/packages/clay-card/README.mdx
@@ -3,7 +3,6 @@ title: 'Card'
 description: 'Cards are a specific form of data visualization focused mainly on displaying images.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/cards/'
 packageNpm: '@clayui/card'
-sibling: 'docs/components/css-cards.html'
 ---
 
 import {

--- a/packages/clay-color-picker/README.mdx
+++ b/packages/clay-color-picker/README.mdx
@@ -3,7 +3,6 @@ title: 'Color Picker'
 description: 'Color picker lets users select a color from a predefined palette, specify a color via its hexadecimal value, sample a color, and explore color values to create a custom color variation.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-color/'
 packageNpm: '@clayui/color-picker'
-sibling: 'docs/components/css-color-picker.html'
 ---
 
 import {ColorPicker} from '$packages/clay-color-picker/docs/index';

--- a/packages/clay-date-picker/README.mdx
+++ b/packages/clay-date-picker/README.mdx
@@ -3,7 +3,6 @@ title: 'Date Picker'
 description: 'Date and Time pickers let users select a date and time for a form.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/picker-date-time/'
 packageNpm: '@clayui/date-picker'
-sibling: 'docs/components/css-date-and-time-pickers.html'
 ---
 
 import {

--- a/packages/clay-drop-down/README.mdx
+++ b/packages/clay-drop-down/README.mdx
@@ -3,7 +3,6 @@ title: 'Drop Down'
 description: 'A dropdown menu displays a list of options for the element that triggers it.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dropdowns/'
 packageNpm: '@clayui/drop-down'
-sibling: 'docs/components/css-dropdown.html'
 ---
 
 import {DropDown, DropDownWithItems} from '$packages/clay-drop-down/docs/index';

--- a/packages/clay-empty-state/README.mdx
+++ b/packages/clay-empty-state/README.mdx
@@ -3,7 +3,6 @@ title: 'Empty State'
 description: 'Empty states provide users with feedback on the reasons behind the empty state and what they can do to move out of the empty state.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/empty-states/'
 packageNpm: '@clayui/empty-state'
-sibling: 'docs/components/css-empty-state.html'
 ---
 
 import {

--- a/packages/clay-form/CHECKBOX.mdx
+++ b/packages/clay-form/CHECKBOX.mdx
@@ -3,7 +3,6 @@ title: 'Checkbox'
 description: 'A checkbox is a component that lets the user select the value that is written in its corresponding text label. A user can select multiple checkboxes from a group at the same time.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/'
 packageNpm: '@clayui/form'
-sibling: 'docs/components/css-checkbox-radio.html'
 ---
 
 import {

--- a/packages/clay-form/DUAL_LIST_BOX.mdx
+++ b/packages/clay-form/DUAL_LIST_BOX.mdx
@@ -3,7 +3,6 @@ title: 'Dual List Box'
 description: 'Dual List Box provides users with two Select Boxes with the ability to move items between lists.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
-sibling: 'docs/components/css-dual-list-box.html'
 ---
 
 import {DualListBox} from '$packages/clay-form/docs/duallistbox';

--- a/packages/clay-form/INPUT.mdx
+++ b/packages/clay-form/INPUT.mdx
@@ -3,7 +3,6 @@ title: 'Input'
 description: 'This section demonstrates the different text input types.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input/'
 packageNpm: '@clayui/form'
-sibling: 'docs/components/css-text-input.html'
 ---
 
 import {

--- a/packages/clay-form/README.mdx
+++ b/packages/clay-form/README.mdx
@@ -3,7 +3,6 @@ title: 'Form'
 description: 'Forms obtain user data and transmit it to the system to either store the data, produce an action, or both.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 packageNpm: '@clayui/form'
-sibling: 'docs/components/css-form-group.html'
 ---
 
 import {Form, FormValidation, FormText} from '$packages/clay-form/docs/index';

--- a/packages/clay-form/SELECT_BOX.mdx
+++ b/packages/clay-form/SELECT_BOX.mdx
@@ -3,7 +3,6 @@ title: 'Select Box'
 description: 'Select Box allows users to select multiple options and if needed the ability to reorder selected options.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
-sibling: 'docs/components/css-select-box.html'
 ---
 
 import {SelectBox} from '$packages/clay-form/docs/selectbox';

--- a/packages/clay-form/TOGGLE_SWITCH.mdx
+++ b/packages/clay-form/TOGGLE_SWITCH.mdx
@@ -3,7 +3,6 @@ title: 'Toggle Switch'
 description: 'Toggle provide users with different selection and activation tools.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/#toggle'
 packageNpm: '@clayui/form'
-sibling: 'docs/components/css-toggle-switch.html'
 ---
 
 import {RadioToggle, Toggle} from '$packages/clay-form/docs/toggle';

--- a/packages/clay-icon/README.mdx
+++ b/packages/clay-icon/README.mdx
@@ -3,7 +3,6 @@ title: 'Icon'
 description: 'Icons are a visual representation of an idea and/or action.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/icons/'
 packageNpm: '@clayui/icon'
-sibling: 'docs/components/css-icons.html'
 ---
 
 import {Icon, IconWithContext} from '$packages/clay-icon/docs/index';

--- a/packages/clay-label/README.mdx
+++ b/packages/clay-label/README.mdx
@@ -3,7 +3,6 @@ title: 'Label'
 description: 'Labels are a visual pattern used to categorize information providing quick and easy recognition.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/labels/'
 packageNpm: '@clayui/label'
-sibling: 'docs/components/css-labels.html'
 ---
 
 import {

--- a/packages/clay-link/README.mdx
+++ b/packages/clay-link/README.mdx
@@ -3,7 +3,6 @@ title: 'Link'
 description: 'Also known as a hyperlink, a link is a clickable (text or image) element used for navigation purposes.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/link/'
 packageNpm: '@clayui/link'
-sibling: 'docs/components/css-links.html'
 ---
 
 import {Link, LinkContext} from '$packages/clay-link/docs/index';

--- a/packages/clay-list/README.mdx
+++ b/packages/clay-list/README.mdx
@@ -3,7 +3,6 @@ title: 'List'
 description: 'Lists are a visual representation of a dataset, based on groups of related content, that is organized vertically.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/list/'
 packageNpm: '@clayui/list'
-sibling: 'docs/components/css-list.html'
 ---
 
 import {List, ListQuickActionsMenu} from '$packages/clay-list/docs/index';

--- a/packages/clay-loading-indicator/README.mdx
+++ b/packages/clay-loading-indicator/README.mdx
@@ -3,7 +3,6 @@ title: 'Loading Indicator'
 description: 'The loading indicator shows the user that an external process, like a connection, is being executed.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/loading-indicator/'
 packageNpm: '@clayui/loading-indicator'
-sibling: 'docs/components/css-loading-indicator.html'
 ---
 
 import {

--- a/packages/clay-localized-input/README.mdx
+++ b/packages/clay-localized-input/README.mdx
@@ -3,7 +3,6 @@ title: 'Localized Input'
 description: 'A text input variation used in fields that can be translated into multiple languages.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input-localizable/'
 packageNpm: '@clayui/localized-input'
-sibling: 'docs/components/css-text-input-localizable.html'
 ---
 
 import {

--- a/packages/clay-management-toolbar/README.mdx
+++ b/packages/clay-management-toolbar/README.mdx
@@ -3,7 +3,6 @@ title: 'Management Toolbar'
 description: 'Management toolbar is an extension of Toolbar. It is a combination of different components, including filters, orders, search, visualization select, and other actions that let users manage a dataset.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/management-bar/'
 packageNpm: '@clayui/management-toolbar'
-sibling: 'docs/components/css-management-toolbar.html'
 ---
 
 import {

--- a/packages/clay-modal/README.mdx
+++ b/packages/clay-modal/README.mdx
@@ -3,7 +3,6 @@ title: 'Modal'
 description: 'A modal is a secondary window that communicates or provides an action inside the same process.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/modals/'
 packageNpm: '@clayui/modal'
-sibling: 'docs/components/css-modals.html'
 ---
 
 import {ClayModalHeaderExamples, Modal} from '$packages/clay-modal/docs/index';

--- a/packages/clay-multi-select/README.mdx
+++ b/packages/clay-multi-select/README.mdx
@@ -3,7 +3,6 @@ title: 'Multi Select'
 description: 'Multi select is the field type that allows writing text to create “tags” that are represented in the shape of labels.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selector/'
 packageNpm: '@clayui/multi-select'
-sibling: 'docs/components/css-text-input-multi-select.html'
 ---
 
 import {

--- a/packages/clay-multi-step-nav/README.mdx
+++ b/packages/clay-multi-step-nav/README.mdx
@@ -3,7 +3,6 @@ title: 'Multi Step Nav'
 description: 'A multi step nav, also known as a wizard, is a determinate progress bar used in long processes that divides the main task into subtasks. The wizard lets the user quickly identify their current progress in completing the task and navigate forwards and backwards between steps if needed.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/multi-step-form/'
 packageNpm: '@clayui/multi-step-nav'
-sibling: 'docs/components/css-multi-step-form.html'
 ---
 
 import {

--- a/packages/clay-nav/README.mdx
+++ b/packages/clay-nav/README.mdx
@@ -2,7 +2,6 @@
 title: 'Nav'
 description: 'Clay Nav provides a clear and semantic navigation for your site'
 packageNpm: '@clayui/nav'
-sibling: 'docs/components/css-nav.html'
 ---
 
 import {Navigation, VerticalNavigation} from '$packages/clay-nav/docs/index';

--- a/packages/clay-navigation-bar/README.mdx
+++ b/packages/clay-navigation-bar/README.mdx
@@ -3,7 +3,6 @@ title: 'Navigation Bar'
 description: 'A navigation bar, navbar, is a horizontal bar that provides several access points to different parts of a system.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/horizontal-nav/'
 packageNpm: '@clayui/navigation-bar'
-sibling: 'docs/components/css-navigation-bar.html'
 ---
 
 import {

--- a/packages/clay-pagination-bar/README.mdx
+++ b/packages/clay-pagination-bar/README.mdx
@@ -3,7 +3,6 @@ title: 'Pagination Bar'
 description: 'Pagination bar provides navigation through datasets'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/pagination/'
 packageNpm: '@clayui/pagination-bar'
-sibling: 'docs/components/css-pagination.html'
 ---
 
 import {

--- a/packages/clay-pagination/README.mdx
+++ b/packages/clay-pagination/README.mdx
@@ -3,7 +3,6 @@ title: 'Pagination'
 description: 'Pagination provides horizontal navigation between chunks(pages) of a dataset.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/pagination/'
 packageNpm: '@clayui/pagination'
-sibling: 'docs/components/css-pagination.html'
 ---
 
 import {

--- a/packages/clay-panel/README.mdx
+++ b/packages/clay-panel/README.mdx
@@ -2,7 +2,6 @@
 title: 'Panel'
 description: 'Toggle content visibility using Panel.'
 packageNpm: '@clayui/panel'
-sibling: 'docs/components/css-panel.html'
 ---
 
 import {Panel, PanelWithCustomTitle} from '$packages/clay-panel/docs/index';

--- a/packages/clay-popover/README.mdx
+++ b/packages/clay-popover/README.mdx
@@ -3,7 +3,6 @@ title: 'Popover'
 description: 'Popovers contain helpful information such as an explanation of a context.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tooltips/'
 packageNpm: '@clayui/popover'
-sibling: 'docs/components/css-popovers.html'
 ---
 
 import {Popover} from '$packages/clay-popover/docs/index';

--- a/packages/clay-progress-bar/README.mdx
+++ b/packages/clay-progress-bar/README.mdx
@@ -3,7 +3,6 @@ title: 'Progress Bar'
 description: 'Progress bar indicates the percentage completed of a task.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/progress-bars/'
 packageNpm: '@clayui/progress-bar'
-sibling: 'docs/components/css-progress-bars.html'
 ---
 
 import {

--- a/packages/clay-slider/README.mdx
+++ b/packages/clay-slider/README.mdx
@@ -3,7 +3,6 @@ title: 'Slider'
 description: 'A Slider allows the user to select values in a linear range of values.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/slider/'
 packageNpm: '@clayui/slider'
-sibling: 'docs/components/css-slider.html'
 ---
 
 import {DecadeSlider, Slider} from '$packages/clay-slider/docs/index';

--- a/packages/clay-sticker/README.mdx
+++ b/packages/clay-sticker/README.mdx
@@ -3,7 +3,6 @@ title: 'Sticker'
 description: 'Stickers are a visual way to quickly identify content in a different way than badges and labels.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/stickers/'
 packageNpm: '@clayui/sticker'
-sibling: 'docs/components/css-sticker.html'
 ---
 
 import {

--- a/packages/clay-table/README.mdx
+++ b/packages/clay-table/README.mdx
@@ -3,7 +3,6 @@ title: 'Table'
 description: 'A table is a specific pattern for comparing datasets in a very direct and analytical way.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/table/'
 packageNpm: '@clayui/table'
-sibling: 'docs/components/css-table.html'
 ---
 
 import {Table} from '$packages/clay-table/docs/index';

--- a/packages/clay-tabs/README.mdx
+++ b/packages/clay-tabs/README.mdx
@@ -3,7 +3,6 @@ title: 'Tabs'
 description: 'Tabs organize similar content together into individual sections in the same page.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/tabs/'
 packageNpm: '@clayui/tabs'
-sibling: 'docs/components/css-tabs.html'
 ---
 
 import {Tabs, TabsDropdown} from '$packages/clay-tabs/docs/index';

--- a/packages/clay-toolbar/README.mdx
+++ b/packages/clay-toolbar/README.mdx
@@ -3,7 +3,6 @@ title: 'Toolbar'
 description: 'A toolbar is a set of actions related to a specific context that are grouped into a horizontal bar.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/'
 packageNpm: '@clayui/toolbar'
-sibling: 'docs/components/css-toolbar.html'
 ---
 
 import {ComplexToolbar, Toolbar} from '$packages/clay-toolbar/docs/index';

--- a/packages/clay-tooltip/README.mdx
+++ b/packages/clay-tooltip/README.mdx
@@ -3,7 +3,6 @@ title: 'Tooltip'
 description: 'Tooltips are brief pieces of information that appear on hover state over an element to clarify its meaning or use for the user.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/popovers-tooltips/'
 packageNpm: '@clayui/tooltip'
-sibling: 'docs/components/css-tooltips.html'
 ---
 
 import {


### PR DESCRIPTION
For context: https://github.com/liferay/clay/pull/3654#discussion_r481295365

Just a first implementation to change the current behavior of tabs from a single page to multiple pages. Further changes are still needed, I will work on that tomorrow. But it is very functional, I managed to remove some complications that we had in the `docs.js` template.