### PR TITLE
fix(clayui.com): Fix Contributing page not properly redirecting

### DIFF
--- a/clayui.com/content/docs/contributing.md
+++ b/clayui.com/content/docs/contributing.md
@@ -1,5 +1,6 @@
 ---
 title: 'Contributing'
 order: 4
-redirect: 'https://github.com/liferay/clay/blob/master/CONTRIBUTING.md'
 ---
+
+See [CONTRIBUTING doc](https://github.com/liferay/clay/blob/master/CONTRIBUTING.md) on our Github repository.


### PR DESCRIPTION
Hey, so this one is pretty simple but that might be not a good thing in this case (I might have made it too simple by not making it generic enough).

I wanted to make it generic so that the check isn't testing against this specific file (`contributing.html`), but I couldn't figure it out within the confines of the `writeRedirectsFile` function.

I attempted changing the `FILE_PATH` conditionally but I couldn't get to a simpler solution than what I ended up with in this PR.