### PR TITLE
fix(clayui.com): Code examples on certain parts of the documentation …

### DIFF
--- a/clayui.com/content/docs/components/css-sidebar.md
+++ b/clayui.com/content/docs/components/css-sidebar.md
@@ -20,19 +20,19 @@ Sidebar is an opinionated container to display related content.
 
 Is composed by:
 
-```html
+```html{expanded}
 <div class="sidebar-header">
 	Sidebar Header
 </div>
 ```
 
-```html
+```html{expanded}
 <div class="sidebar-body">
 	Sidebar Body
 </div>
 ```
 
-```html
+```html{expanded}
 <div class="sidebar-footer">
 	Sidebar Footer
 </div>

--- a/clayui.com/content/docs/css/playground.mdx
+++ b/clayui.com/content/docs/css/playground.mdx
@@ -2,6 +2,7 @@
 title: 'Playground'
 description: 'Live editor for testing out @clayui/css'
 disableTOC: true
+order: 7
 ---
 
 import Playground from '../../../src/components/Playground/index';

--- a/clayui.com/content/docs/css/scss.md
+++ b/clayui.com/content/docs/css/scss.md
@@ -8,7 +8,10 @@ description: 'Clay CSS Framework provides some utilities for you to work with SC
 <div class="nav-toc">
 
 -   [Variables](#css-variables)
+    -   [Default Flag](#css-default-flag)
+    -   [Sass Maps](#css-sass-maps)
 -   [Mixins](#css-mixins)
+    -   [Extending With Mixins](#css-extending-with-mixins)
 -   [Functions](#css-functions)
 
 </div>
@@ -16,11 +19,11 @@ description: 'Clay CSS Framework provides some utilities for you to work with SC
 
 ## Variables(#css-variables)
 
-Think of variables as a way to store information that you want to reuse throughout your stylesheet. You can store things like colors, font stacks, or any CSS value you think you'll want to reuse. Sass uses the \$ symbol to make something a variable. [SASS](https://sass-lang.com/guide)
+Think of variables as a way to store information that you want to reuse throughout your stylesheet. You can store things like colors, font stacks, or any CSS value you think you'll want to reuse. <a href="https://sass-lang.com/guide" rel="noopener noreferrer" target="_blank">Sass</a> uses the `$` symbol to make something a variable.
 
 Example:
 
-```scss
+```scss{expanded}
 // Alert Dismissible
 
 $alert-dismissible-padding-bottom: null !default;
@@ -31,46 +34,279 @@ $alert-dismissible-padding-top: null !default;
 
 > [All **variables** available](https://github.com/liferay/clay/tree/master/packages/clay-css/src/scss/variables)
 
-## Mixins(#css-mixins)
+### Default Flag(#css-default-flag)
 
-Some things in CSS are a bit tedious to write, especially with CSS3 and the many vendor prefixes that exist. A mixin lets you make groups of CSS declarations that you want to reuse throughout your site. You can even pass in values to make your mixin more flexible. A good use of a mixin is for vendor prefixes. Here's an example for transform. [SASS](https://sass-lang.com/guide)
+All variables provided by Clay CSS are defined with the `!default` flag. Default values in Sass are only assigned if the variable isn't defined or its value is `null`. This allows Clay CSS variables to be overwritten by variables placed or imported at the top of `base.scss` and `atlas.scss`.
 
-```scss
-$map: (
-	bg: '#0B5FFF',
+<div class="clay-site-alert alert alert-warning">Unfortunately, Clay CSS variables with the <code>!default</code> flag can't be overwritten with a <code>null !default</code> value due to the Sass spec. We work around this with Sass maps. Nested Sass map values don't use the <code>!default</code> flag allowing us to skirt the rule.</div>
+
+The snippet below illustrates how values get assigned to variables in Sass:
+
+```scss{expanded}
+// Overwrites
+
+$primary: red !default;
+$secondary: null !default;
+$info: #2e5aac !default;
+$success: null;
+$danger: #da1414 !default;
+
+// Original Values
+
+$primary: #0b5fff !default;
+$secondary: #6b6c7e !default;
+$info: null !default;
+$success: #287d3c !default;
+$danger: null;
+```
+
+Result:
+
+```text{expanded}
+$primary   => red
+$secondary => #6b6c7e
+$info      => #2e5aac
+$success   => #287d3c
+$danger    => null
+```
+
+### Sass Maps(#css-sass-maps)
+
+Clay CSS heavily leverages <a href="https://sass-lang.com/documentation/values/maps" rel="noopener noreferrer" target="_blank">Sass maps</a>. The main reason is to be able to reset values to `null` since Sass doesn't output a CSS declaration if its value is `null`. This is a great feature. It lets us reuse CSS rulesets instead of having to redeclare and overwrite. This saves a lot in terms of file size.
+
+<div class="clay-site-alert alert alert-warning">Assigning a <code>null</code> value to a CSS Custom Property (CSS Variable) generated with Sass will still be output.</div>
+
+The <a href="https://sass-lang.com/documentation/modules/map#merge" rel="noopener noreferrer" target="_blank">map-merge</a> is a Sass function that takes two maps as parameters and combines them. The second parameter wins over the first. This means, if there are duplicate keys, the key value pair in the second map will win. We pass in our default values as the first parameter and an empty map as the second. The empty map `$my-component: () !default` can be filled with overwrites that will win over the defaults.
+
+If we start with the code below:
+
+```scss{expanded}
+$my-component: () !default;
+$my-component: map-merge(
+	(
+		background-color: null,
+		color: #000,
+	),
+	$my-component
 );
 
-.my-button {
-	@include clay-button-variant($map);
+.my-component {
+	background-color: map-get($my-component, background-color);
+	color: map-get($my-component, color);
 }
 ```
 
-[clay-button-variant#L1](https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/mixins/_buttons.scss#L1)
+Output:
+
+```css{expanded}
+.my-component {
+	color: #000;
+}
+```
+
+We can overwrite the original `$my-component: () !default;` with our new Sass map below. This tells Sass to output no properties.
+
+```scss{expanded}
+// Overwrite
+
+$my-component: (
+	background-color: null,
+	color: null,
+) !default;
+
+// Original
+
+$my-component: () !default;
+$my-component: map-merge(
+	(
+		background-color: null,
+		color: #000,
+	),
+	$my-component
+);
+
+.my-component {
+	background-color: map-get($my-component, background-color);
+	color: map-get($my-component, color);
+}
+```
+
+Output:
+
+```css{expanded}
+/* Nothing is output because both values are `null` */
+```
+
+## Mixins(#css-mixins)
+
+<a href="https://sass-lang.com/documentation/at-rules/mixin" rel="noopener noreferrer" target="_blank">Sass mixins</a> are used in Clay CSS to define custom CSS components, such as `.btn`, `.dropdown-menu`, and `.label`. Mixins help normalize the CSS selector output and are mostly used to generate variants of an existing CSS component. Take <a href="https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/mixins/_buttons.scss#L79" rel="noopener noreferrer" target="_blank">clay-button-variant</a> for example, it accepts a Sass map as a parameter with several predefined keys. We can create our own purple `btn` variant in our `_custom.scss` with:
+
+\_custom.scss
+
+```scss{expanded}
+$btn-custom: (
+	background-color: #6200ee,
+	color: #fff,
+	font-size: 0.875rem,
+	letter-spacing: 0.0892857143em,
+	text-transform: uppercase,
+	hover: (
+		background-color: #651fff,
+		color: #fff,
+	),
+	focus: (
+		background-color: #7c4dff,
+	),
+	active: (
+		background-color: #b388ff,
+	),
+	disabled: (
+		background-color: #e0e0e0,
+		color: #9e9e9e,
+	),
+);
+
+.btn-custom {
+	@include clay-button-variant($btn-custom);
+}
+```
+
+Output:
+
+```css{expanded}
+.btn-custom {
+	background-color: #6200ee;
+	color: #fff;
+	font-size: 0.875rem;
+	letter-spacing: 0.08928571em;
+	text-transform: uppercase;
+}
+
+.btn-custom:hover {
+	background-color: #651fff;
+	color: #fff;
+}
+
+.btn-custom:focus,
+.btn-custom.focus {
+	background-color: #7c4dff;
+}
+
+.btn-custom:active,
+.btn-custom.active,
+.show > .btn-custom.dropdown-toggle {
+	background-color: #b388ff;
+}
+
+.btn-custom:disabled,
+.btn-custom.disabled {
+	background-color: #e0e0e0;
+	color: #9e9e9e;
+}
+```
+
+Your html:
+
+```html{expanded}
+<button class="btn btn-custom" type="button">Custom Btn</button>
+<a class="btn btn-custom" href="#" role="button"
+	>Custom Anchor that Looks Like a Button</a
+>
+```
+
+<div class="clay-site-alert alert alert-warning">Modifying the <code>btn</code> or variant classes like <code>btn-primary</code> directly can have unintended consequences. Liferay uses these classes in all admin controls, modifying them will change styles there as well. We recommend extending by creating your own modifier classes.</div>
+
+### Extending With Mixins(#css-extending-with-mixins)
+
+The proper way to extend components in your theme is to piggy back of the base class and add modifier classes to change them. We will continue with our Custom Button example. In Atlas Theme (Classic), `btn` is 40px tall by default. If we want to make our default `btn` shorter (36px) and narrower we can create our own base modifier.
+
+```scss{expanded}
+$my-btn-base: (
+	padding: 0.40625rem 0.5rem,
+);
+
+$btn-custom: (...);
+
+.my-btn-base {
+	@include clay-button-variant($my-btn-base);
+}
+
+.btn-custom {
+	@include clay-button-variant($btn-custom);
+}
+```
+
+Your html:
+
+```html{expanded}
+<button class="btn my-btn-base btn-custom" type="button">Custom Btn</button>
+<a class="btn my-btn-base btn-custom" href="#" role="button"
+	>Custom Anchor that Looks Like a Button</a
+>
+```
+
+This gives us the most compatibility with default Liferay styles and our custom styles. This pattern will also make it a lot easier to integrate with Clay React Components.
+
+<div class="clay-site-alert alert alert-info">If you are up for the task of unifying admin controls with your site's theme, go ahead and modify all our components directly.</div>
 
 You can find all mixins available by component if you want to create a component extension.
 
-> [All **mixins** available](https://github.com/liferay/clay/tree/master/packages/clay-css/src/scss/mixins)
+<blockquote>
+	<p class="clay-p">
+		<a href="https://github.com/liferay/clay/tree/master/packages/clay-css/src/scss/mixins" rel="noopener noreferrer" target="_blank">All <strong>mixins</strong> available</a>
+	</p>
+</blockquote>
 
 ## Functions(#css-functions)
 
-Clay CSS provides some **SCSS** functions that help you be more productive. To learn more about **functions** see [sass-lang.com](https://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives).
+Clay CSS <a href="https://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives" rel="noopener noreferrer" target="_blank">Sass functions</a> are generally only for internal use. Many of our functions were written so we could comply with Bootstrap 4's patterns as well as providing support for variable themeing.
 
-Sass ternary shorthand: `if($variable-name, true, false);`. See [setter#L5](https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/functions/_global-functions.scss#L5)
+We do provide some functions that may help you be more productive. Some of the noteworthy ones are `clay-icon($name, $color)`, `clay-svg-url($svg)`, and `math-sign($num)`.
 
-```scss
-// @param $var - The variable name
-// @param $val - The default value
+The function <a href="https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/functions/_global-functions.scss#L310" rel="noopener noreferrer" target="_blank">clay-icon($name, $color)</a> takes a Clay SVG icon name and color. It returns the icon as a data uri to be used as a `background-image`.
 
-setter($var, $val);
+```scss{expanded}
+.check-icon-bg {
+	background-image: clay-icon(
+		check,
+		orange
+	); // check svg icon as background image
+	background-repeat: no-repeat;
+	background-size: contain;
+	display: inline-block;
+	margin-bottom: 10px;
+	margin-right: 15px;
+	padding-left: 28px;
+}
 ```
 
-Helper for displaying warning messages for required variables. See [required#L29](https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/functions/_global-functions.scss#29)
+<a href="https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/functions/_global-functions.scss#L279" rel="noopener noreferrer" target="_blank">clay-svg-url(\$svg)</a> accepts an SVG as a parameter. The SVG must be wrapped in single quotes ('') or double quotes ("") depending on whether attributes are delimited by double quotes or single quotes.
 
-```scss
-// @param $var - The variable to check
-// @param $msg - The error message
-
-required($var, $msg);
+```scss{expanded}
+.check-icon-bg {
+	background-image: clay-svg-url(
+		'<svg id="check" viewBox="0 0 512 512"><path class="lexicon-icon-outline" d="M192.9,429.5c-8.3,0-16.4-3.3-22.3-9.2L44.5,294.1C15,263.2,62.7,222,89.1,249.5L191.5,352l230-258.9 c27.2-30.5,74.3,11.5,47.1,41.9L216.4,418.9c-5.8,6.5-14,10.3-22.6,10.6C193.5,429.5,193.2,429.5,192.9,429.5z"></path>
+</svg>'
+	);
+	background-repeat: no-repeat;
+	background-size: contain;
+	display: inline-block;
+	margin-bottom: 10px;
+	margin-right: 15px;
+	padding-left: 28px;
+}
 ```
 
-> [All **functions** available](https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/functions/_global-functions.scss)
+<a href="https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/functions/_global-functions.scss#L279" rel="noopener noreferrer" target="_blank">math-sign(\$number)</a> takes a number as a parameter and returns the opposite value, generally used for `null` values so Sass doesn't output a value `-null` This is useful for offseting `border-width` among other things.
+
+```scss{expanded}
+.offset-border {
+	padding-top: math-sign(0.5rem - $border-top-width);
+}
+```
+
+<blockquote>
+	<p class="clay-p">
+		<a href="https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/functions/_global-functions.scss" rel="noopener noreferrer" target="_blank">All <strong>functions</strong> available</a>
+	</p>
+</blockquote>

--- a/clayui.com/content/docs/get-started/composing.md
+++ b/clayui.com/content/docs/get-started/composing.md
@@ -23,7 +23,7 @@ We believe that using composition is helpful and is a widely used standard in th
 
 The composition is very common in React because the JSX syntactic sugar makes it very powerful and more viable when coupled with the `children` prop for passing arbitrary child elements. Props in React components allows us to pass objects and consequently React elements since they are objects.
 
-```jsx
+```jsx{expanded}
 <ClayModal>
 	<ClayModal.Footer
 		first={
@@ -83,7 +83,7 @@ Clay follows a namespace pattern for low-level layer components, components are 
 
 </div>
 
-```jsx
+```jsx{expanded}
 <ClayDropDown
 	active={expand}
 	onActiveChange={setExpand}
@@ -117,7 +117,7 @@ The standard for differentiating high-level components from low-level components
    There are some exceptions to some components, Date Picker, Color Picker and Time Picker are examples of this.
 </div>
 
-```jsx
+```jsx{expanded}
 <ClayDropDownWithItems
 	items={[
 		{

--- a/clayui.com/content/docs/get-started/how-to-use-clay.md
+++ b/clayui.com/content/docs/get-started/how-to-use-clay.md
@@ -32,13 +32,13 @@ You can check out the full list of [packages available in NPM](https://www.npmjs
 
 #### NPM
 
-```shell
+```shell{expanded}
 npm install @clayui/css @clayui/*
 ```
 
 #### Yarn
 
-```shell
+```shell{expanded}
 yarn add @clayui/css @clayui/*
 ```
 
@@ -46,7 +46,7 @@ yarn add @clayui/css @clayui/*
 
 We provide Clay CSS via CDN, which is an option when you do not want to install the clay package via NPM or Yarn.
 
-```html
+```html{expanded}
 <link
 	rel="stylesheet"
 	href="https://cdn.jsdelivr.net/npm/@clayui/css/lib/css/atlas.css"
@@ -57,7 +57,7 @@ If you want a specific version of CSS, specify the desired version.
 
 Example:
 
-```diff
+```diff{expanded}
 - https://cdn.jsdelivr.net/npm/@clayui/css/lib/css/atlas.css
 + https://cdn.jsdelivr.net/npm/@clayui/css@3.0.0/lib/css/atlas.css
 ```
@@ -89,7 +89,7 @@ Let's use the **DropDown** component (`@clayui/drop-down`) and understand how th
 
 Before we get started, let's import the main packages that we will use to create a low-level Drop Down with Clay components.
 
-```js
+```js{expanded}
 import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
@@ -102,13 +102,13 @@ import ClayDropDown from '@clayui/drop-down';
 
 As you learned from [Clay's compositional philosophy](/docs/get-started/composing.html), we are using a low-level DropDown component, as its essence is a controlled component and for that you need to control DropDown's expand state. Let's use React's [`useState`](https://reactjs.org/docs/hooks-reference.html#usestate) to control the state.
 
-```js
+```js{expanded}
 const [expand, setExpand] = useState(false);
 ```
 
 Soon after we can add the components to see rendered on the screen.
 
-```jsx
+```jsx{expanded}
 <ClayDropDown
 	active={expand}
 	onActiveChange={setExpand}
@@ -120,7 +120,7 @@ At first we are seeing only ClayButton being rendered with empty DropDown, as it
 
 Try this:
 
-```jsx
+```jsx{expanded}
 <ClayDropDown
 	active={expand}
 	onActiveChange={setExpand}
@@ -132,7 +132,7 @@ Try this:
 
 Now we can compose with other Clay components and add a Checkbox and Radio to the content.
 
-```jsx
+```jsx{expanded}
 <ClayDropDown
 	active={expand}
 	onActiveChange={setExpand}
@@ -154,11 +154,11 @@ Low-level components in Clay allow you to compose and add your own rules, allowi
 
 See the same example above being reflected in a high-level component.
 
-```js
+```js{expanded}
 import ClayDropDown, {ClayDropDownWithItems} from '@clayui/drop-down';
 ```
 
-```jsx
+```jsx{expanded}
 <ClayDropDownWithItems
 	items={[
 		{

--- a/clayui.com/content/docs/get-started/migrate-the-clay-components-from-v2-to-v3.md
+++ b/clayui.com/content/docs/get-started/migrate-the-clay-components-from-v2-to-v3.md
@@ -55,7 +55,7 @@ To symbolize this change, Clay is distributing the new packages on the scope npm
 
 ClayAlert v3 combines Alert, Stripe Alert, and Toast Notifications all in one.
 
-```jsx
+```jsx{expanded}
 import ClayAlert from '@clayui/alert';
 ```
 
@@ -78,7 +78,7 @@ To get to the behavior of Clay Toast Notifications, you need to use `ClayAlert.T
 
 For Example:
 
-```jsx
+```jsx{expanded}
 <ClayAlert.ToastContainer>
 	<ClayAlert title="One!" />
 	<ClayAlert title="Two!" />
@@ -88,7 +88,7 @@ For Example:
 
 **Note:** If you use `autoClose` and `onClose` is setting state, you need to make sure that `onClose` does so asynchronously. For example below, if you are using the `useState` hook, you need to make sure to use a callback for `setAlerts`.
 
-```diff
+```diff{expanded}
 const [alerts, setAlerts] = useState([]);
 
 {alerts.map(alertItem => (
@@ -113,11 +113,11 @@ const [alerts, setAlerts] = useState([]);
 
 Use `<ClayButton />` to compose with any element. A common case is to have a button with icon, so use `<ClayButtonWithIcon />`.
 
-```jsx
+```jsx{expanded}
 import ClayButton from '@clayui/button';
 ```
 
-```diff
+```diff{expanded}
 <Button
 -	label="Icon positioned at right"
 -	icon="plus"
@@ -134,11 +134,11 @@ import ClayButton from '@clayui/button';
 
 ClayCard v3 is offered in composable components such as `ClayCard.AspectRatio`, `ClayCard.Body`, `ClayCard.Description`, `ClayCard.Caption`, and `ClayCard.Header`.
 
-```jsx
+```jsx{expanded}
 import ClayCard from '@clayui/card';
 ```
 
-```diff
+```diff{expanded}
 - <ClayUserCard name="User Name" spritemap={spritemap} selectable />
 + <ClayCard displayType="user" selectable>
 + 		<ClayCard.Header>
@@ -188,7 +188,7 @@ import ClayCard from '@clayui/card';
 
 To get to the behavior of having a ClayCard with an image, use the following composition with ClayCard:
 
-```diff
+```diff{expanded}
 - <ClayImageCard labels={[label: 'Approved']} imageSrc="https://via.placeholder.com/256" spritemap={spritemap} subtitle="Author Action" title="My Title" />
 + <ClayCard displayType="image">
 + 		<ClayCard.Header>
@@ -224,7 +224,7 @@ To get to the behavior of having a ClayCard with an image, use the following com
 
 To get to the behavior of having a ClayCard with a user image, use the following composition with ClayCard:
 
-```diff
+```diff{expanded}
 - <ClayUserCard labels={[label: 'Approved']} spritemap={spritemap} subtitle="Author Action" title="Adélaide" />
 + <ClayCard displayType="user">
 + 		<ClayCard.Header>
@@ -257,7 +257,7 @@ To get to the behavior of having a ClayCard with a user image, use the following
 
 To get to the behavior of having a ClayCard with a horizontal, use the following composition with ClayCard:
 
-```diff
+```diff{expanded}
 - <ClayHorizontalCard spritemap={spritemap} icon="folder" title="Very Large Folder" />
 + <ClayCard displayType="directory">
 + 	<ClayCard.Body>
@@ -279,7 +279,7 @@ To get to the behavior of having a ClayCard with a horizontal, use the following
 
 To get to the behavior of having a ClayCard with a folder, use the following composition with ClayCard:
 
-```diff
+```diff{expanded}
 - <ClayCardFile labels={[{label: 'Approved'}]} spritemap={spritemap} title="deliverable.doc" subtitle="Stevie Ray Vaughn" />
 + <ClayCard displayType="file" selectable>
 + 	<ClayCard.Header>
@@ -312,7 +312,7 @@ To get to the behavior of having a ClayCard with a folder, use the following com
 
 To get the behavior of having a ClayCardGrid with Cards, use the following composition with ClayCard:
 
-```diff
+```diff{expanded}
 - <ClayCardGrid spritemap={spritemap} items={items} schema={schema} />
 + <ClayCard.Group label="Test Files">
 +	<CardFile spritemap={imageOrSpritemap} />
@@ -330,7 +330,7 @@ Also, Clay V3 offers you some high-levels cards:
 
 #### Clay Card with User
 
-```diff
+```diff{expanded}
 - <ClayUserCard
 	spritemap={spritemap}
 -	userColor="danger"
@@ -349,7 +349,7 @@ Also, Clay V3 offers you some high-levels cards:
 
 #### Clay Card Horizontal
 
-```diff
+```diff{expanded}
 - <ClayHorizontalCard
 	spritemap={spritemap}
 	title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
@@ -362,7 +362,7 @@ Also, Clay V3 offers you some high-levels cards:
 
 #### Clay File Card
 
-```diff
+```diff{expanded}
 - <ClayFileCard
 -	actionItems={items}
 -	stickerLabel="PDF"
@@ -397,7 +397,7 @@ Also, Clay V3 offers you some high-levels cards:
 
 #### Clay Card Image
 
-```diff
+```diff{expanded}
 - <ClayImageCard
 -	actionItems={items}
 	href="#image-card-block"
@@ -424,7 +424,7 @@ Also, Clay V3 offers you some high-levels cards:
 
 ClayCardGrid was deprecated due to ClayCard.Group.
 
-```jsx
+```jsx{expanded}
 import ClayCard, {ClayCardWithInfo} from '@clayui/card';
 
 <ClayCard.Group label="files">
@@ -436,7 +436,7 @@ import ClayCard, {ClayCardWithInfo} from '@clayui/card';
 
 ## ClayCheckbox
 
-```jsx
+```jsx{expanded}
 import {ClayCheckbox} from '@clayui/form';
 
 <ClayCheckbox aria-label="hello! Can you see me?" checked={true} readOnly />;
@@ -446,11 +446,11 @@ import {ClayCheckbox} from '@clayui/form';
 
 ClayLink has become simpler with v3, removing APIs from `icon` and `image`, making it flexible for you to define your content but complying with [Lexicon specifications](http://lexicondesign.io).
 
-```jsx
+```jsx{expanded}
 import ClayLink from '@clayui/link';
 ```
 
-```diff
+```diff{expanded}
 <ClayLink
 	href="#link-styles"
 -	label="Default"
@@ -482,7 +482,7 @@ import ClayLink from '@clayui/link';
 
 To get to the behavior of having a ClayLink with icon, use the composition with ClayIcon:
 
-```diff
+```diff{expanded}
 <ClayLink
 	href="#link-icons"
 -	icon="add-cell"
@@ -497,7 +497,7 @@ To get to the behavior of having a ClayLink with icon, use the composition with 
 
 To get to the behavior of having a ClayLink with image, use the composition with the `<img />` tag:
 
-```diff
+```diff{expanded}
 <ClayLink
 	href="#link-icons"
 -	imageSrc="image.jpg"
@@ -511,11 +511,11 @@ To get to the behavior of having a ClayLink with image, use the composition with
 
 ClayNavigationBar has become simpler than the version `v2`, removing APIs from `items` and making the development more flexible passing elements by composition.
 
-```jsx
+```jsx{expanded}
 import ClayNavigationBar from '@clayui/navigation-bar';
 ```
 
-```diff
+```diff{expanded}
  <ClayNavigationBar
 -    items={[{ label: 'Page 1', href: '#1' }, { label: 'Page 2', href: '#2' }]}
      inverted
@@ -557,11 +557,11 @@ To get the behavior of having a ClayNavigationBar using Buttons instead of Link 
 
 ## ClaySticker
 
-```jsx
+```jsx{expanded}
 import ClaySticker from '@clayui/sticker';
 ```
 
-```diff
+```diff{expanded}
 <ClaySticker
 	shape="circle"
 -	label="A"
@@ -591,7 +591,7 @@ import ClaySticker from '@clayui/sticker';
 
 To get to the behavior of having a ClaySticker with image, use the composition with the `<img />` tag:
 
-```diff
+```diff{expanded}
 -<ClaySticker
 -	imageSrc="image.jpg"
 -	imageAlt="my image"
@@ -603,7 +603,7 @@ To get to the behavior of having a ClaySticker with image, use the composition w
 
 To get to the behavior of having a ClaySticker with icon, use the composition with the `<ClayIcon />` component:
 
-```diff
+```diff{expanded}
 -<ClaySticker
 -	spritemap="icons.svg"
 -	symbol="user"
@@ -617,11 +617,11 @@ To get to the behavior of having a ClaySticker with icon, use the composition wi
 
 ClayTable has become more simpler than v2 with Table Head, Body, Row and Cell compositions. Removing all necessary schemas and complex APIs from the component and possibiliting a lot of variations with compositions.
 
-```jsx
+```jsx{expanded}
 import ClayTable from '@clayui/table';
 ```
 
-```diff
+```diff{expanded}
 - <ClayTable
 -     items={[
 -         {
@@ -707,7 +707,7 @@ Take a look at the [ClayTable documentation](/docs/components/table.html) for mo
 
 Added ability to utilize context for passing spritemap down instead of having to pass the prop everywhere.
 
-```jsx
+```jsx{expanded}
 import {ClayIconSpriteContext} from '@clayui/icon';
 import React from 'react';
 
@@ -728,7 +728,7 @@ Become a low-level API, you can compose Modal's small blocks to get the results 
 
 Read more about using [ClayModal in the documentation](/docs/components/modal.html).
 
-```jsx
+```jsx{expanded}
 import ClayButton from '@clayui/button';
 import ClayModal, {useModal} from '@clayui/modal';
 import React, {useState} from 'react';
@@ -798,7 +798,7 @@ const Component = () => {
 
 To render an iframe inside Modal, you can compose with the `<ClayModal.Body />` component by passing the url to the prop `url`.
 
-```jsx
+```jsx{expanded}
 <ClayModal>
 	<ClayModal.Header>{'Title'}</ClayModal.Header>
 	<ClayModal.Body url="https://clayui.com" />
@@ -809,7 +809,7 @@ To render an iframe inside Modal, you can compose with the `<ClayModal.Body />` 
 
 Using a radio by itself doesn't make much sense, only when 2+ exist does the functionality of radio actually work, which is why we moved from `radio` to `radio-group`. The functionality is the same, but by being grouped together it should make it easier to use because the `ClayRadioGroup` component will internally handle which radio is checked and requires less re-duplication of `inline` and `name` props.
 
-```jsx
+```jsx{expanded}
 import {ClayRadio, ClayRadioGroup} from '@clayui/form';
 
 //v2
@@ -837,7 +837,7 @@ import {ClayRadio, ClayRadioGroup} from '@clayui/form';
 
 Read more about using [ClayLabel in the documentation](/docs/components/label.html).
 
-```jsx
+```jsx{expanded}
 import ClayLabel from '@clayui/label';
 
 <ClayLabel displayType="success">Label Success</ClayLabel>;
@@ -861,7 +861,7 @@ ClayProgressBar has become simpler with v3 by defaulting many styles based off o
 
 For example:
 
-```jsx
+```jsx{expanded}
 import ClayProgressBar from '@clayui/progress-bar';
 
 <ClayProgressBar value={value}>
@@ -888,7 +888,7 @@ ClayList has changed quite a bit. Instead of being "one size fits all" it is now
 
 For example:
 
-```jsx
+```jsx{expanded}
 import ClayList from '@clayui/list';
 
 <ClayList>
@@ -951,7 +951,7 @@ ClayCollapse has been renamed to ClayPanel due to collapse being just a part of 
 
 For example:
 
-```jsx
+```jsx{expanded}
 import ClayPanel from '@clayui/panel';
 
 <ClayPanel>
@@ -988,7 +988,7 @@ import ClayPanel from '@clayui/panel';
 
 ClayDropDown's API has been refactored quite a bit and is now created via composition. This gives the end user greater flexibility in how the dropdown is created and what the dropdown is used for. The following components are available for composition.
 
-```jsx
+```jsx{expanded}
 import ClayDropDown from '@clayui/drop-down';
 
 <ClayDropDown>
@@ -1007,7 +1007,7 @@ ClayDropDown also exports `<ClayDropDown.Menu>` which can be used independently 
 
 #### Compositions
 
-```jsx
+```jsx{expanded}
 <ClayDropDown
 	active={active}
 	onActiveChange={(newVal) => setActive(newVal)}
@@ -1033,7 +1033,7 @@ ClayPaginationWithBasicItems's high-level API is very similar to v2.x with a few
 
 Usage Example:
 
-```jsx
+```jsx{expanded}
 import {ClayPaginationWithBasicItems} from '@clayui/pagination';
 
 <ClayPaginationWithBasicItems
@@ -1066,11 +1066,11 @@ Receiving improvements in the mechanism of failed requests attempts, avoiding th
 
 See the [documentation](/docs/components/data-provider.html) to get the most out of the component.
 
-```jsx
+```jsx{expanded}
 import ClayDataProvider from '@clayui/data-provider';
 ```
 
-```diff
+```diff{expanded}
 <ClayDataProvider
 -	content={...}
 -	dataSource={...}
@@ -1120,11 +1120,11 @@ Autocomplete has received many changes due to the change of approach we had in v
 
 For example purposes you can get to the same result you had in v2 using composition, autocomplete alone does not do what it really promises, you need to compose with other components, ClayDropDown, ClayDataProvider and LoadingIndicator is where all the beauty of it is, it decreases the coupling and gigantic lists of API descriptions and offers flexibility for customizing and implementing new rules.
 
-```jsx
+```jsx{expanded}
 import ClayAutocomplete from '@clayui/autocomplete';
 ```
 
-```diff
+```diff{expanded}
 <ClayAutocomplete
 -	dataSource={dataSource}
 -	placeholder="Placeholder"
@@ -1159,7 +1159,7 @@ import ClayAutocomplete from '@clayui/autocomplete';
 
 If you use ClaySelect only for simple cases that do not need props for `options`, you can use `<ClaySelectWithOption />` which will have the same result as the previous version.
 
-```jsx
+```jsx{expanded}
 import {ClaySelect} from '@clayui/form';
 
 <ClaySelectWithOption
@@ -1194,7 +1194,7 @@ import {ClaySelect} from '@clayui/form';
 
 Still you can take advantage of composition if you think `ClaySelectWithOption` does not cover your cases.
 
-```jsx
+```jsx{expanded}
 <ClaySelect aria-label="Select Label" id="mySelectId">
 	<ClaySelect.Option label="Option 1" value="1" />
 	<ClaySelect.Option label="Option 2" value="2" />
@@ -1205,7 +1205,7 @@ Still you can take advantage of composition if you think `ClaySelectWithOption` 
 
 With the new clay-charts, we removed the dependency of `react-billboardjs` and implemented the interaction with Billboard ourself to give us more leverage. There are not many other changes and the component should be very similar to how it was used before in metal-jsx.
 
-```jsx
+```jsx{expanded}
 import ClayChart from '@clayui/charts';
 
 <ClayChart

--- a/clayui.com/content/docs/get-started/using-clay-in-jsps.md
+++ b/clayui.com/content/docs/get-started/using-clay-in-jsps.md
@@ -16,19 +16,19 @@ order: 6
 
 Add the following snippet into either the JSP file you're using the component in, or in the module's `init.jsp` file:
 
-```jsx
+```jsx{expanded}
 <%@ taglib prefix="clay" uri="http://liferay.com/tld/clay" %>
 ```
 
 The syntax for using Clay taglibs follows this principle:
 
-```jsx
+```jsx{expanded}
 <clay:componentName backendProperty="<%= Value %>" property="Property Value" />
 ```
 
 This is how it's supposed to look like with a ClayButton:
 
-```jsx
+```jsx{expanded}
 <clay:button label="<%= Button Label %>" style="primary" />
 ```
 

--- a/clayui.com/plugins/gatsby-remark-use-clipboard/index.js
+++ b/clayui.com/plugins/gatsby-remark-use-clipboard/index.js
@@ -5,14 +5,39 @@
 
 const visit = require('unist-util-visit');
 
+const parseOptions = (meta) => {
+	const availableOptions = {};
+
+	if (meta) {
+		meta.map((option) => {
+			const key = option.match(/.*(?=:)|.*$/);
+			const value = option.match(/(?<=:).+/);
+
+			if (key) {
+				availableOptions[key[0].trim()] =
+					value === null ? true : value[0].trim();
+			}
+		});
+	}
+
+	return availableOptions;
+};
+
 module.exports = ({markdownAST}) => {
 	visit(markdownAST, 'html', (node) => {
 		if (typeof node.lang === 'undefined') {
 			return;
 		}
 
+		const language = node.meta ? node.lang + node.meta : node.lang;
+
+		const {expanded} = parseOptions(language.match(/(?<=\{).+?(?=\})/g));
+
+		const expandedClass = expanded ? ' expanded' : '';
+		const hideClass = expanded ? ' hide' : '';
+
 		node.value = `
-			<div class="code-container">
+			<div class="code-container${expandedClass}">
 				<div class="copied-alert alert alert-fluid alert-info d-none" role="alert">
 					<div class="container">
 						<div class="alert-autofit-row autofit-row">
@@ -35,7 +60,7 @@ module.exports = ({markdownAST}) => {
 					</div>
 				</div>
 
-				<span class="clay-p code-sample-info">
+				<span class="clay-p code-sample-info${hideClass}">
 					Code Sample (expand to see it)
 				</span>
 

--- a/clayui.com/src/styles/_prismjs.scss
+++ b/clayui.com/src/styles/_prismjs.scss
@@ -29,6 +29,10 @@ $insertedBack: #f0fff4;
 	overflow: auto;
 	position: relative;
 	tab-size: 1.5em;
+
+	.gatsby-code-text {
+		background-color: inherit;
+	}
 }
 
 .gatsby-highlight pre[class*='gatsby-code-'],


### PR DESCRIPTION
…should be expanded by default

docs(clayui.com): SCSS add more details about variables, functions, mixins

Couldn't figure out an elegant way to keep certain CSS code examples examples expanded on first load with prism js or gatsby-transformer-remark. I just hacked it with the keyword `code_expand`.

This also updates the SCSS page with more detail about variables, mixins, and functions