### PR TITLE
fix(@clayui/css): Btn Group `.btn-monospaced.btn-sm` doesn't work ins…

### DIFF
--- a/packages/clay-css/src/scss/components/_button-groups.scss
+++ b/packages/clay-css/src/scss/components/_button-groups.scss
@@ -161,6 +161,14 @@
 
 	> .btn-monospaced {
 		width: $btn-monospaced-size;
+
+		&.btn-lg {
+			@extend %clay-btn-monospaced-lg !optional;
+		}
+
+		&.btn-sm {
+			@extend %clay-btn-monospaced-sm !optional;
+		}
 	}
 }
 


### PR DESCRIPTION
…ide `.btn-group-vertical` and same for `.btn-monospaced.btn-lg`

fixes #3685