### PR TITLE
fix(@clayui.com): Atlas Buttons `.btn-outline-secondary` should have …

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -270,7 +270,6 @@ $btn-outline-secondary: map-deep-merge(
 	(
 		bg: null,
 		border-color: $secondary-l2,
-		color: null,
 		hover-bg: rgba($gray-900, 0.03),
 		hover-border-color: transparent,
 		hover-color: map-get($btn-secondary, hover-color),


### PR DESCRIPTION
…color #6b6c7e, caused by #3149

fixes #3687