### PR TITLE
feat(@clayui/dual-list-box): Make reorder & transfer button state more consistent

### DIFF
--- a/packages/clay-form/src/SelectBox.tsx
+++ b/packages/clay-form/src/SelectBox.tsx
@@ -154,18 +154,13 @@ const ClaySelectBox: React.FunctionComponent<IProps> = ({
 		Array.isArray(value) ? value : [value]
 	);
 
-	const selectedIndex = selectedIndexes.length === 1 && selectedIndexes[0];
-
 	const noItems = !items.length;
 
 	const noItemsSelected = !selectedIndexes.length;
 
-	const firstItemSelected =
-		selectedIndex === 0 || selectedIndexes.includes(0);
+	const firstItemSelected = selectedIndexes.includes(0);
 
-	const lastItemSelected =
-		selectedIndex === items.length - 1 ||
-		selectedIndexes.includes(items.length - 1);
+	const lastItemSelected = selectedIndexes.includes(items.length - 1);
 
 	return (
 		<div className={classNames(className, 'form-group')}>

--- a/packages/clay-form/src/SelectBox.tsx
+++ b/packages/clay-form/src/SelectBox.tsx
@@ -156,6 +156,17 @@ const ClaySelectBox: React.FunctionComponent<IProps> = ({
 
 	const selectedIndex = selectedIndexes.length === 1 && selectedIndexes[0];
 
+	const noItems = !items.length;
+
+	const noItemsSelected = !selectedIndexes.length;
+
+	const firstItemSelected =
+		selectedIndex === 0 || selectedIndexes.includes(0);
+
+	const lastItemSelected =
+		selectedIndex === items.length - 1 ||
+		selectedIndexes.includes(items.length - 1);
+
 	return (
 		<div className={classNames(className, 'form-group')}>
 			{label && (
@@ -215,11 +226,9 @@ const ClaySelectBox: React.FunctionComponent<IProps> = ({
 								aria-label={ariaLabels.reorderUp}
 								className="reorder-button reorder-button-up"
 								disabled={
-									!value.length ||
-									selectedIndex === 0 ||
-									selectedIndexes.includes(0) ||
-									!items.length ||
-									selectedIndexes.length === 0
+									firstItemSelected ||
+									noItemsSelected ||
+									noItems
 								}
 								displayType="secondary"
 								onClick={() =>
@@ -236,13 +245,9 @@ const ClaySelectBox: React.FunctionComponent<IProps> = ({
 								aria-label={ariaLabels.reorderDown}
 								className="reorder-button reorder-button-down"
 								disabled={
-									!value.length ||
-									selectedIndex === items.length - 1 ||
-									selectedIndexes.includes(
-										items.length - 1
-									) ||
-									!items.length ||
-									selectedIndexes.length === 0
+									lastItemSelected ||
+									noItemsSelected ||
+									noItems
 								}
 								displayType="secondary"
 								onClick={() =>

--- a/packages/clay-form/src/SelectBox.tsx
+++ b/packages/clay-form/src/SelectBox.tsx
@@ -154,6 +154,8 @@ const ClaySelectBox: React.FunctionComponent<IProps> = ({
 		Array.isArray(value) ? value : [value]
 	);
 
+	const selectedIndex = selectedIndexes.length === 1 && selectedIndexes[0];
+
 	return (
 		<div className={classNames(className, 'form-group')}>
 			{label && (
@@ -212,7 +214,13 @@ const ClaySelectBox: React.FunctionComponent<IProps> = ({
 							<ClayButtonWithIcon
 								aria-label={ariaLabels.reorderUp}
 								className="reorder-button reorder-button-up"
-								disabled={!value.length}
+								disabled={
+									!value.length ||
+									selectedIndex === 0 ||
+									selectedIndexes.includes(0) ||
+									!items.length ||
+									selectedIndexes.length === 0
+								}
 								displayType="secondary"
 								onClick={() =>
 									onItemsChange(
@@ -227,7 +235,15 @@ const ClaySelectBox: React.FunctionComponent<IProps> = ({
 							<ClayButtonWithIcon
 								aria-label={ariaLabels.reorderDown}
 								className="reorder-button reorder-button-down"
-								disabled={!value.length}
+								disabled={
+									!value.length ||
+									selectedIndex === items.length - 1 ||
+									selectedIndexes.includes(
+										items.length - 1
+									) ||
+									!items.length ||
+									selectedIndexes.length === 0
+								}
 								displayType="secondary"
 								onClick={() =>
 									onItemsChange(

--- a/packages/clay-form/src/__tests__/__snapshots__/DualListBox.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/DualListBox.tsx.snap
@@ -56,6 +56,7 @@ exports[`Rendering renders ClayDualListBox 1`] = `
               <button
                 aria-label="Reorder Up"
                 class="reorder-button reorder-button-up btn btn-monospaced btn-sm btn-secondary"
+                disabled=""
                 type="button"
               >
                 <svg
@@ -70,6 +71,7 @@ exports[`Rendering renders ClayDualListBox 1`] = `
               <button
                 aria-label="Reorder Down"
                 class="reorder-button reorder-button-down btn btn-monospaced btn-sm btn-secondary"
+                disabled=""
                 type="button"
               >
                 <svg

--- a/packages/clay-form/src/__tests__/__snapshots__/SelectBox.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/SelectBox.tsx.snap
@@ -84,6 +84,7 @@ exports[`Rendering renders ClaySelectBox with buttons to reorder options 1`] = `
           <button
             aria-label="Reorder Up"
             class="reorder-button reorder-button-up btn btn-monospaced btn-sm btn-secondary"
+            disabled=""
             type="button"
           >
             <svg

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -87,11 +87,15 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 		<ClayDualListBox
 			disableLTR={
 				boolean('disableLTR', false) ||
-				secondSelectBoxItems.length >= rightMaxItems
+				secondSelectBoxItems.length >= rightMaxItems ||
+				!firstSelectBoxItems.length ||
+				!leftSelected.length
 			}
 			disableRTL={
 				boolean('disableRTL', false) ||
-				firstSelectBoxItems.length >= leftMaxItems
+				firstSelectBoxItems.length >= leftMaxItems ||
+				!secondSelectBoxItems.length ||
+				!rightSelected.length
 			}
 			items={items}
 			left={{

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -87,15 +87,11 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 		<ClayDualListBox
 			disableLTR={
 				boolean('disableLTR', false) ||
-				secondSelectBoxItems.length >= rightMaxItems ||
-				!firstSelectBoxItems.length ||
-				!leftSelected.length
+				secondSelectBoxItems.length >= rightMaxItems
 			}
 			disableRTL={
 				boolean('disableRTL', false) ||
-				firstSelectBoxItems.length >= leftMaxItems ||
-				!secondSelectBoxItems.length ||
-				!rightSelected.length
+				firstSelectBoxItems.length >= leftMaxItems
 			}
 			items={items}
 			left={{


### PR DESCRIPTION
Fixes #3682 

I believe I've handled all cases of buttons being disabled except for one, and that is something has been transferred between select boxes but nothing is visually selected. After investigating, I noticed that the transferred item (or items if more have been selected), is kept in the `leftSelected` variable (in the case when transfering from left to right). I couldn't figure out a clean way of resetting the `leftSelected` value back to an empty array.