### PR TITLE
chore(@clayui/tooltip): close the tooltip when pressing Esc

### DIFF
--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal} from '@clayui/shared';
+import {ClayPortal, Keys} from '@clayui/shared';
 import domAlign from 'dom-align';
-import React from 'react';
+import React, {useCallback} from 'react';
 import warning from 'warning';
 
 import ClayTooltip from './Tooltip';
@@ -139,7 +139,7 @@ const TooltipProvider: React.FunctionComponent<{
 	const titleNodeRef = React.useRef<HTMLElement | null>(null);
 	const tooltipRef = React.useRef<HTMLElement | null>(null);
 
-	const handleHide = ({target}: any) => {
+	const handleHide = useCallback(({target}: any) => {
 		if (!titleNodeRef.current) {
 			return;
 		}
@@ -147,6 +147,7 @@ const TooltipProvider: React.FunctionComponent<{
 		const dataTitle = titleNodeRef.current.getAttribute('data-title');
 
 		if (dataTitle) {
+			document.removeEventListener('keyup', handleEsc, true);
 			target.removeEventListener('click', handleHide);
 			titleNodeRef.current.setAttribute('title', dataTitle);
 			titleNodeRef.current.removeAttribute('data-title');
@@ -157,9 +158,16 @@ const TooltipProvider: React.FunctionComponent<{
 			dispatch({type: 'hide'});
 			clearTimeout(timeoutIdRef.current);
 		}
-	};
+	}, []);
 
-	const handleShow = ({target}: any) => {
+	const handleEsc = useCallback((event: KeyboardEvent) => {
+		if (event.key === Keys.Esc) {
+			event.stopImmediatePropagation();
+			handleHide(event);
+		}
+	}, []);
+
+	const handleShow = useCallback(({target}: any) => {
 		const hasTitle = target && target.hasAttribute('title');
 
 		const titleNode = hasTitle
@@ -172,6 +180,7 @@ const TooltipProvider: React.FunctionComponent<{
 			titleNodeRef.current = titleNode;
 			targetRef.current = target;
 
+			document.addEventListener('keyup', handleEsc, true);
 			target.addEventListener('click', handleHide);
 			titleNode.setAttribute('data-title', title);
 			titleNode.removeAttribute('title');
@@ -190,7 +199,7 @@ const TooltipProvider: React.FunctionComponent<{
 				customDelay ? Number(customDelay) : delay
 			);
 		}
-	};
+	}, []);
 
 	React.useEffect(() => {
 		if (


### PR DESCRIPTION
This is just an initial implementation of #3696, the problem with this is you can still close DropDown when it is open and there is a Tooltip, so I thought about adding the event in the capture phase so we could get the event first before others but it also depends when the event was added, the order influences, in this implementation here I always add the event when I open the tooltip and then remove it to avoid problems. I think we managed to get around some behaviors within Clay but not something in a DXP world where people can add events and we have no control. Suggestions?

I added the Tooltip to the Button inside the Modal with an Autocomplete in the ClayModal story for testing.