### PR TITLE
fix(@clayui/shared): useTransitionHeight should still expand and collapse if transitions aren't supported

### DIFF
--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -110,11 +110,11 @@ function Item({
 	const menuRef = React.useRef(null);
 	const [expanded, setExpaned] = React.useState(!initialExpanded);
 
-	const [
-		transitioning,
-		handleTransitionEnd,
-		handleClickToggler,
-	] = useTransitionHeight(expanded, setExpaned, menuRef);
+	const {animate, transitioning} = useTransitionHeight(
+		expanded,
+		setExpaned,
+		menuRef
+	);
 
 	const showIconCollapsed = !(
 		(!expanded && transitioning) ||
@@ -128,7 +128,7 @@ function Item({
 				collapsed={showIconCollapsed}
 				href={href}
 				onClick={(e) => {
-					handleClickToggler(e);
+					animate(e);
 
 					if (onClick) {
 						onClick();
@@ -148,7 +148,6 @@ function Item({
 						collapsing: transitioning,
 						show: expanded,
 					})}
-					onTransitionEnd={handleTransitionEnd}
 					ref={menuRef}
 				>
 					<Nav stacked>

--- a/packages/clay-navigation-bar/src/__tests__/index.tsx
+++ b/packages/clay-navigation-bar/src/__tests__/index.tsx
@@ -113,6 +113,8 @@ describe('ClayNavigationBar', () => {
 	});
 
 	it('collapses the previously expanded dropdown when trigger element is clicked', async () => {
+		jest.useFakeTimers();
+
 		const {container, getByTestId} = render(
 			<ClayNavigationBar
 				inverted
@@ -143,10 +145,16 @@ describe('ClayNavigationBar', () => {
 		);
 
 		fireEvent.click(getByTestId('navbarToggler'), 'Trigger Label');
-		fireEvent.transitionEnd(getByTestId('NavigationBarDropdown'));
+
+		act(() => {
+			jest.runAllTimers();
+		});
 
 		fireEvent.click(getByTestId('navbarToggler'), 'Trigger Label');
-		fireEvent.transitionEnd(getByTestId('NavigationBarDropdown'));
+
+		act(() => {
+			jest.runAllTimers();
+		});
 
 		let navigationBarDropdown;
 

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -47,11 +47,11 @@ const ClayNavigationBar: React.FunctionComponent<IProps> & {
 }: IProps) => {
 	const [visible, setVisible] = React.useState(false);
 	const contentRef = React.useRef<HTMLDivElement>(null);
-	const [
-		transitioning,
-		handleTransitionEnd,
-		handleClickToggler,
-	] = useTransitionHeight(visible, setVisible, contentRef);
+	const {animate, transitioning} = useTransitionHeight(
+		visible,
+		setVisible,
+		contentRef
+	);
 
 	const activeElementsCount = children.filter((child) => child.props.active)
 		.length;
@@ -89,7 +89,7 @@ const ClayNavigationBar: React.FunctionComponent<IProps> & {
 					)}
 					data-testid="navbarToggler"
 					displayType="unstyled"
-					onClick={handleClickToggler}
+					onClick={animate}
 				>
 					<span className="navbar-text-truncate">{triggerLabel}</span>
 
@@ -103,7 +103,6 @@ const ClayNavigationBar: React.FunctionComponent<IProps> & {
 						show: visible,
 					})}
 					data-testid="NavigationBarDropdown"
-					onTransitionEnd={handleTransitionEnd}
 					ref={contentRef}
 				>
 					<ClayLayout.ContainerFluid>

--- a/packages/clay-panel/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-panel/src/__tests__/__snapshots__/index.tsx.snap
@@ -75,7 +75,6 @@ exports[`ClayPanel renders with custom displayTitle 1`] = `
   </button>
   <div
     className="panel-collapse collapse"
-    onTransitionEnd={[Function]}
     role="tabpanel"
   >
     <div
@@ -215,7 +214,6 @@ exports[`ClayPanel renders with multiple panels 1`] = `
     </button>
     <div
       className="panel-collapse collapse"
-      onTransitionEnd={[Function]}
       role="tabpanel"
     >
       <div
@@ -266,7 +264,6 @@ exports[`ClayPanel renders without displayTitle 1`] = `
   </button>
   <div
     className="panel-collapse collapse"
-    onTransitionEnd={[Function]}
     role="tabpanel"
   >
     <div

--- a/packages/clay-panel/src/__tests__/index.tsx
+++ b/packages/clay-panel/src/__tests__/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import ClayPanel from '..';
-import {cleanup, fireEvent, render} from '@testing-library/react';
+import {act, cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
@@ -105,6 +105,7 @@ describe('ClayPanel Interactions', () => {
 	afterEach(cleanup);
 
 	it('clicking the title should expand and close the content', () => {
+		jest.useFakeTimers();
 		const {container} = render(
 			<ClayPanel
 				collapsable
@@ -130,12 +131,9 @@ describe('ClayPanel Interactions', () => {
 			container.querySelector('.panel-collapse.collapsing')
 		).toBeTruthy();
 
-		fireEvent.transitionEnd(
-			container.querySelector(
-				'.panel-collapse.collapsing'
-			) as HTMLDivElement,
-			{}
-		);
+		act(() => {
+			jest.runAllTimers();
+		});
 
 		expect(
 			container.querySelector('.panel-collapse.collapsing')
@@ -148,12 +146,9 @@ describe('ClayPanel Interactions', () => {
 			container.querySelector('.panel-collapse.collapsing')
 		).toBeTruthy();
 
-		fireEvent.transitionEnd(
-			container.querySelector(
-				'.panel-collapse.collapsing'
-			) as HTMLDivElement,
-			{}
-		);
+		act(() => {
+			jest.runAllTimers();
+		});
 
 		expect(container.querySelector('.panel-collapse.show')).toBeFalsy();
 		expect(

--- a/packages/clay-panel/src/index.tsx
+++ b/packages/clay-panel/src/index.tsx
@@ -72,11 +72,11 @@ const ClayPanel: React.FunctionComponent<IProps> & {
 	const panelRef = React.useRef<HTMLDivElement>(null);
 	const [expanded, setExpaned] = React.useState<boolean>(defaultExpanded);
 
-	const [
-		transitioning,
-		handleTransitionEnd,
-		handleClickToggler,
-	] = useTransitionHeight(expanded, setExpaned, panelRef);
+	const {animate, transitioning} = useTransitionHeight(
+		expanded,
+		setExpaned,
+		panelRef
+	);
 
 	const showIconCollapsed = !(
 		(!expanded && transitioning) ||
@@ -120,7 +120,7 @@ const ClayPanel: React.FunctionComponent<IProps> & {
 								collapsed: showIconCollapsed,
 							}
 						)}
-						onClick={handleClickToggler}
+						onClick={animate}
 						role="tab"
 					>
 						{displayTitle &&
@@ -160,7 +160,6 @@ const ClayPanel: React.FunctionComponent<IProps> & {
 								show: expanded,
 							}
 						)}
-						onTransitionEnd={handleTransitionEnd}
 						ref={panelRef}
 						role="tabpanel"
 					>


### PR DESCRIPTION
Fixes #3637, From #3677

I made some changes on top of @pat270's PR, instead of implementing a fallback in support of the `transitionEnd` event, I decided to remove it and rewrite the implementation on top of `setTimeout`.