### PR TITLE
feat(@clayui/charts): Split API into it's file, add notice we're switching to Recharts, and cast props to IProps

### DIFF
--- a/packages/clay-charts/README.mdx
+++ b/packages/clay-charts/README.mdx
@@ -13,9 +13,17 @@ import {Chart, GeoMap, Predictive} from '$packages/clay-charts/docs/index';
 -   [Basic](#basic)
 -   [GeoMap](#geomap)
 -   [Predictive](#predictive)
--   [API](#api)
 
 </div>
+</div>
+
+<div class="clay-site-alert alert alert-warning">
+	Charts in its current state will be deprecated soon in favor of a wrapper
+	around <a href="https://recharts.org/">Recharts</a>. See examples of charts
+	built with recharts on&nbsp;
+	<a href="https://storybook.clayui.com/?path=/story/demos-recharts--line">
+		Storybook
+	</a>.
 </div>
 
 ## Basic
@@ -29,19 +37,3 @@ import {Chart, GeoMap, Predictive} from '$packages/clay-charts/docs/index';
 ## Predictive
 
 <Predictive />
-
-## API
-
-### Basic
-
-Clay Charts is primarily a wrapper around the [Billboard.js charting library](https://naver.github.io/billboard.js/), see Billboard.js API for more in-depth API.
-
-<div>[APITable "clay-charts/src/index.tsx"]</div>
-
-### GeoMap
-
-<div>[APITable "clay-charts/src/GeoMap.tsx"]</div>
-
-### Predictive
-
-<div>[APITable "clay-charts/src/Predictive.tsx"]</div>

--- a/packages/clay-charts/docs/api-chart.mdx
+++ b/packages/clay-charts/docs/api-chart.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Chart'
+description: 'Charts is a React wrapper around the Billboard.js library with a few additional charts provided.'
+lexiconDefinition: 'https://liferay.design/lexicon/core-components/charts/'
+mainTabURL: 'docs/components/charts.html'
+---
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Basic](#basic)
+-   [GeoMap](#geomap)
+-   [Predictive](#predictive)
+
+</div>
+</div>
+
+Clay Charts is primarily a wrapper around the [Billboard.js charting library](https://naver.github.io/billboard.js/), see Billboard.js API for more in-depth API.
+
+## Basic
+
+<div>[APITable "clay-charts/src/index.tsx"]</div>
+
+## GeoMap
+
+<div>[APITable "clay-charts/src/GeoMap.tsx"]</div>
+
+## Predictive
+
+<div>[APITable "clay-charts/src/Predictive.tsx"]</div>

--- a/packages/clay-charts/src/BillboardWrapper.tsx
+++ b/packages/clay-charts/src/BillboardWrapper.tsx
@@ -15,7 +15,7 @@ const BillboardWrapper: React.FunctionComponent<IProps> = ({
 	forwardRef,
 	elementProps = {},
 	...otherProps
-}) => {
+}: IProps) => {
 	const elementRef = React.useRef<HTMLDivElement>(null);
 
 	const updateChart = React.useCallback((args: any) => {

--- a/packages/clay-charts/src/GeoMap.tsx
+++ b/packages/clay-charts/src/GeoMap.tsx
@@ -235,7 +235,7 @@ const Geomap: React.FunctionComponent<IProps> = ({
 	elementProps = {},
 	forwardRef,
 	...otherProps
-}) => {
+}: IProps) => {
 	const elementRef = React.useRef<HTMLDivElement>(null);
 
 	React.useEffect(() => {

--- a/packages/clay-charts/src/Predictive.tsx
+++ b/packages/clay-charts/src/Predictive.tsx
@@ -18,7 +18,7 @@ interface IProps {
  * Predictive Chart component.
  */
 const PredictiveChart = React.forwardRef<HTMLDivElement, IProps>(
-	({data, predictionDate, ...otherProps}, ref) => {
+	({data, predictionDate, ...otherProps}: IProps, ref) => {
 		let columns = data.columns;
 
 		if (columns) {


### PR DESCRIPTION
Fixes #3714 

I went ahead and made this super simple in the end after pondering on the offered advice. Only meaningful thing I added is the notice that we're switching to Recharts, which from what I understand we will make a wrapper around, similar to how we did with Billboard?

Other than that, @matuzalemsteles :
> maybe write a documentation explaining better the examples we have in the Storybook and how you can reach the Lexicon specification with recharts.

Not a 100% sure what you meant with this, I do understand the idea behind it, but not sure how to explain the examples as they're pretty basic Rechart charts. As for reaching Lexicon specs, shouldn't Lexicon be enough for that?