### PR TITLE
feat(@clayui/color-picker): add ability to use named colors

### DIFF
--- a/packages/clay-color-picker/src/Splotch.tsx
+++ b/packages/clay-color-picker/src/Splotch.tsx
@@ -29,7 +29,12 @@ interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
  */
 const ClayColorPickerSplotch = React.forwardRef<HTMLButtonElement, IProps>(
 	({active, className, size, value, ...otherProps}, ref) => {
-		const requireBorder = tinycolor.readability('#FFF', value) < 1.1;
+		const color = tinycolor(value);
+
+		const isHex = (color.getFormat() || '').match('hex');
+
+		const requireBorder =
+			!color.isValid() || tinycolor.readability('#FFF', value) < 1.1;
 
 		return (
 			<button
@@ -40,7 +45,7 @@ const ClayColorPickerSplotch = React.forwardRef<HTMLButtonElement, IProps>(
 				})}
 				ref={ref}
 				style={{
-					background: `#${value}`,
+					background: `${isHex ? '#' : ''}${value}`,
 					height: size,
 					width: size,
 				}}

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -1182,6 +1182,388 @@ exports[`Rendering disabled state 1`] = `
 </body>
 `;
 
+exports[`Rendering renders w/ var() 1`] = `
+<body>
+  <div>
+    <div
+      class="clay-color-picker"
+    >
+      <input
+        name="colorPicker1"
+        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
+        type="text"
+        value="var(--blue)"
+      />
+      <label>
+        Default
+      </label>
+      <div
+        class="input-group clay-color"
+      >
+        <div
+          class="input-group-item input-group-item-shrink input-group-prepend"
+        >
+          <div
+            class="input-group-text"
+          >
+            <button
+              aria-label="Select a color"
+              class="btn clay-color-btn dropdown-toggle clay-color-btn-bordered"
+              title="var(--blue)"
+              type="button"
+            />
+          </div>
+        </div>
+        <div
+          class="input-group-item input-group-append"
+        >
+          <input
+            aria-label="Color selection is var(--blue)"
+            class="form-control input-group-inset input-group-inset-before"
+            type="text"
+            value="var(--blue)"
+          />
+          <label
+            class="input-group-inset-item input-group-inset-item-before"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-color-picker"
+              role="presentation"
+              style="width: 10px;"
+            >
+              <use
+                xlink:href="/test/path#color-picker"
+              />
+            </svg>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div>
+      <div
+        class="dropdown-menu clay-color-dropdown-menu"
+      >
+        <div
+          class="clay-color-header"
+        >
+          <span
+            class="component-title"
+          >
+            Default Colors
+          </span>
+        </div>
+        <div
+          class="clay-color-swatch"
+        >
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(0, 0, 0);"
+              title="000000"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(95, 95, 95);"
+              title="5F5F5F"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(154, 154, 154);"
+              title="9A9A9A"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(203, 203, 203);"
+              title="CBCBCB"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(225, 225, 225);"
+              title="E1E1E1"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
+              title="FFFFFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 13, 13);"
+              title="FF0D0D"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 138, 28);"
+              title="FF8A1C"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(43, 166, 118);"
+              title="2BA676"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(0, 110, 248);"
+              title="006EF8"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(127, 38, 255);"
+              title="7F26FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 33, 160);"
+              title="FF21A0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 95, 95);"
+              title="FF5F5F"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 180, 110);"
+              title="FFB46E"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(80, 210, 160);"
+              title="50D2A0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(75, 155, 255);"
+              title="4B9BFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(175, 120, 255);"
+              title="AF78FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 115, 195);"
+              title="FF73C3"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 177, 177);"
+              title="FFB1B1"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 222, 192);"
+              title="FFDEC0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(145, 227, 195);"
+              title="91E3C3"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(157, 200, 255);"
+              title="9DC8FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(223, 202, 255);"
+              title="DFCAFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 197, 230);"
+              title="FFC5E6"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 217, 217);"
+              title="FFD9D9"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 243, 232);"
+              title="FFF3E8"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(177, 235, 213);"
+              title="B1EBD5"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(197, 223, 255);"
+              title="C5DFFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(248, 242, 255);"
+              title="F8F2FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 237, 247);"
+              title="FFEDF7"
+              type="button"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`Rendering renders with a hash for the value 1`] = `
 <body>
   <div>
@@ -1228,6 +1610,389 @@ exports[`Rendering renders with a hash for the value 1`] = `
             class="input-group-inset-item input-group-inset-item-before"
           >
             #
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div>
+      <div
+        class="dropdown-menu clay-color-dropdown-menu"
+      >
+        <div
+          class="clay-color-header"
+        >
+          <span
+            class="component-title"
+          >
+            Default Colors
+          </span>
+        </div>
+        <div
+          class="clay-color-swatch"
+        >
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(0, 0, 0);"
+              title="000000"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(95, 95, 95);"
+              title="5F5F5F"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(154, 154, 154);"
+              title="9A9A9A"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(203, 203, 203);"
+              title="CBCBCB"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(225, 225, 225);"
+              title="E1E1E1"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 255, 255);"
+              title="FFFFFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 13, 13);"
+              title="FF0D0D"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 138, 28);"
+              title="FF8A1C"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(43, 166, 118);"
+              title="2BA676"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(0, 110, 248);"
+              title="006EF8"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(127, 38, 255);"
+              title="7F26FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 33, 160);"
+              title="FF21A0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 95, 95);"
+              title="FF5F5F"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 180, 110);"
+              title="FFB46E"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(80, 210, 160);"
+              title="50D2A0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(75, 155, 255);"
+              title="4B9BFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(175, 120, 255);"
+              title="AF78FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 115, 195);"
+              title="FF73C3"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 177, 177);"
+              title="FFB1B1"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 222, 192);"
+              title="FFDEC0"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(145, 227, 195);"
+              title="91E3C3"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(157, 200, 255);"
+              title="9DC8FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(223, 202, 255);"
+              title="DFCAFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 197, 230);"
+              title="FFC5E6"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 217, 217);"
+              title="FFD9D9"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(255, 243, 232);"
+              title="FFF3E8"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(177, 235, 213);"
+              title="B1EBD5"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(197, 223, 255);"
+              title="C5DFFF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn clay-color-btn-bordered"
+              style="background: rgb(248, 242, 255);"
+              title="F8F2FF"
+              type="button"
+            />
+          </div>
+          <div
+            class="clay-color-swatch-item"
+          >
+            <button
+              class="btn clay-color-btn"
+              style="background: rgb(255, 237, 247);"
+              title="FFEDF7"
+              type="button"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Rendering renders with a named color for the value 1`] = `
+<body>
+  <div>
+    <div
+      class="clay-color-picker"
+    >
+      <input
+        name="colorPicker1"
+        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
+        type="text"
+        value="red"
+      />
+      <label>
+        Default
+      </label>
+      <div
+        class="input-group clay-color"
+      >
+        <div
+          class="input-group-item input-group-item-shrink input-group-prepend"
+        >
+          <div
+            class="input-group-text"
+          >
+            <button
+              aria-label="Select a color"
+              class="btn clay-color-btn dropdown-toggle"
+              style="background: red;"
+              title="red"
+              type="button"
+            />
+          </div>
+        </div>
+        <div
+          class="input-group-item input-group-append"
+        >
+          <input
+            aria-label="Color selection is red"
+            class="form-control input-group-inset input-group-inset-before"
+            type="text"
+            value="red"
+          />
+          <label
+            class="input-group-inset-item input-group-inset-item-before"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-color-picker"
+              role="presentation"
+              style="width: 10px;"
+            >
+              <use
+                xlink:href="/test/path#color-picker"
+              />
+            </svg>
           </label>
         </div>
       </div>

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -41,6 +41,21 @@ describe('Rendering', () => {
 		expect(document.body).toMatchSnapshot();
 	});
 
+	it('renders w/ var()', () => {
+		render(
+			<ClayColorPicker
+				label="Default Colors"
+				name="colorPicker1"
+				onValueChange={() => {}}
+				spritemap="/test/path"
+				title="Default"
+				value="var(--blue)"
+			/>
+		);
+
+		expect(document.body).toMatchSnapshot();
+	});
+
 	it('renders with a hash for the value', () => {
 		render(
 			<ClayColorPicker
@@ -50,6 +65,21 @@ describe('Rendering', () => {
 				spritemap="/test/path"
 				title="Default"
 				value="#FFF"
+			/>
+		);
+
+		expect(document.body).toMatchSnapshot();
+	});
+
+	it('renders with a named color for the value', () => {
+		render(
+			<ClayColorPicker
+				label="Default Colors"
+				name="colorPicker1"
+				onValueChange={() => {}}
+				spritemap="/test/path"
+				title="Default"
+				value="red"
 			/>
 		);
 

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import DropDown from '@clayui/drop-down';
+import ClayDropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
 import {FocusScope, sub} from '@clayui/shared';
 import React from 'react';
 import tinycolor from 'tinycolor2';
@@ -12,7 +13,6 @@ import tinycolor from 'tinycolor2';
 import Basic from './Basic';
 import Custom from './Custom';
 import Splotch from './Splotch';
-import {useHexInput} from './hooks';
 
 const DEFAULT_COLORS = [
 	'000000',
@@ -72,7 +72,6 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	 * Flag for adding ColorPicker in disabled state
 	 */
 	disabled?: boolean;
-
 	/**
 	 * The label describing the collection of colors in the menu
 	 */
@@ -137,7 +136,6 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	disabled,
 	label,
 	name,
-	onBlur = () => {},
 	onColorsChange,
 	onValueChange = () => {},
 	showHex = true,
@@ -149,7 +147,9 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	value = 'FFFFFF',
 	...otherProps
 }: IProps) => {
-	if (value.indexOf('#') === 0) {
+	const isHex = tinycolor(value).getFormat() === 'hex';
+
+	if (isHex && value.indexOf('#') === 0) {
 		value = value.slice(1);
 	}
 
@@ -175,13 +175,6 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	const splotchRef = React.useRef<HTMLButtonElement>(null);
 
 	const [active, setActive] = React.useState(false);
-	const [hexInputValue, setHexInputValue] = useHexInput(value);
-
-	React.useEffect(() => {
-		if (document.activeElement !== inputRef.current) {
-			setHexInputValue(value);
-		}
-	}, [value]);
 
 	return (
 		<FocusScope arrowKeysUpDown={false}>
@@ -201,7 +194,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 							width: 0,
 						}}
 						type={useNative ? 'color' : 'text'}
-						value={hexInputValue ? `#${hexInputValue}` : ''}
+						value={value ? `${isHex ? '#' : ''}${value}` : ''}
 					/>
 				)}
 
@@ -229,7 +222,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 						</ClayInput.GroupText>
 					</ClayInput.GroupItem>
 
-					<DropDown.Menu
+					<ClayDropDown.Menu
 						active={active}
 						alignElementRef={triggerElementRef}
 						className="clay-color-dropdown-menu"
@@ -241,8 +234,8 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 							<Basic
 								colors={colors || DEFAULT_COLORS}
 								label={label}
-								onChange={(value) => {
-									onValueChange(value);
+								onChange={(newVal) => {
+									onValueChange(newVal);
 									setActive((val: boolean) => !val);
 
 									if (splotchRef.current) {
@@ -262,15 +255,15 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 										: BLANK_COLORS
 								}
 								label={label}
-								onChange={(value) => {
-									onValueChange(value);
+								onChange={(newVal) => {
+									onValueChange(newVal);
 								}}
 								onColorsChange={onColorsChange}
 								showPalette={showPalette}
 								spritemap={spritemap}
 							/>
 						)}
-					</DropDown.Menu>
+					</ClayDropDown.Menu>
 
 					{showHex && (
 						<ClayInput.GroupItem append>
@@ -281,39 +274,24 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 								])}
 								disabled={disabled}
 								insetBefore
-								onBlur={(event) => {
-									const newColor = tinycolor(
-										event.target.value
-									);
-
-									const hexString = newColor.isValid()
-										? newColor.toHex()
-										: event.target.value;
-
-									onValueChange(hexString);
-									setHexInputValue(hexString);
-									onBlur(event);
-								}}
 								onChange={(event) => {
-									const newHexValue = event.target.value;
-
-									const newColor = tinycolor(newHexValue);
-
-									setHexInputValue(newHexValue);
-
-									if (newColor.isValid()) {
-										onValueChange(newColor.toHex());
-									}
+									onValueChange(event.target.value);
 								}}
 								ref={inputRef}
 								type="text"
-								value={hexInputValue
-									.toUpperCase()
-									.substring(0, 6)}
+								value={value}
 							/>
 
 							<ClayInput.GroupInsetItem before tag="label">
-								{'#'}
+								{isHex ? (
+									'#'
+								) : (
+									<ClayIcon
+										spritemap={spritemap}
+										style={{width: 10}}
+										symbol="color-picker"
+									/>
+								)}
 							</ClayInput.GroupInsetItem>
 						</ClayInput.GroupItem>
 					)}

--- a/packages/clay-color-picker/stories/index.tsx
+++ b/packages/clay-color-picker/stories/index.tsx
@@ -5,6 +5,7 @@
 
 import '@clayui/css/lib/css/atlas.css';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import ClayForm from '@clayui/form';
 import {boolean, text} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
@@ -29,6 +30,10 @@ const ClayColorPickerWithCustomColors = (props: any) => {
 		'008000',
 		'00FFFF',
 		'0000FF',
+		'blue',
+		'black',
+		'var(--blue)',
+		'inherit',
 	]);
 
 	const [color, setColor] = React.useState(customColors[0]);
@@ -92,4 +97,31 @@ storiesOf('Components|ClayColorPicker', module)
 			small={boolean('Small', true)}
 			title={text('Title', 'Default')}
 		/>
-	));
+	))
+	.add('w/ validation', () => {
+		const [color, setColor] = React.useState('');
+
+		const valid = color.length === 6;
+
+		return (
+			<ClayForm.Group className={!valid ? 'has-error' : ''}>
+				<ClayColorPicker
+					onValueChange={setColor}
+					spritemap={spritemap}
+					value={color}
+				/>
+
+				{!valid && (
+					<ClayForm.FeedbackGroup>
+						<ClayForm.FeedbackItem>
+							<ClayForm.FeedbackIndicator
+								spritemap={spritemap}
+								symbol="exclamation-full"
+							/>
+							{'Input must be 6 letters long'}
+						</ClayForm.FeedbackItem>
+					</ClayForm.FeedbackGroup>
+				)}
+			</ClayForm.Group>
+		);
+	});


### PR DESCRIPTION
fixes #3681


Are there any edge cases I missed here? You should now be able to used named colors and hex values
