### PR TITLE
fix(@clayui/drop-down): Increase clickable area of text and icon

### DIFF
--- a/packages/clay-css/src/content/dropdowns_drill_down.html
+++ b/packages/clay-css/src/content/dropdowns_drill_down.html
@@ -166,7 +166,7 @@ section: Components
 							<li>
 								<div class="dropdown-item">
 									<a class="dropdown-item-indicator-text-end" href="#1">Document</a>
-									<button class="btn btn-unstyled dropdown-item-indicator-end" data-drilldown="next" data-target="#_s950dwymf" role="button">
+									<button class="btn btn-unstyled dropdown-item-indicator-end" data-drilldown="next" data-target="#_s950dwymf" type="button">
 										<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
 										</svg>
@@ -295,19 +295,26 @@ section: Components
 								</a>
 							</li>
 							<li>
-								<a class="dropdown-item" data-drilldown="next" href="#_tggascnpo" role="button">
-									<span class="dropdown-item-indicator-start">
-										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-										</svg>
-									</span>
-									<span class="dropdown-item-indicator-text-end">Lexicon</span>
-									<span class="dropdown-item-indicator-end">
+								<div class="dropdown-item">
+									<a class="dropdown-item-indicator-text-end" href="#1" role="button">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+											</svg>
+										</span>
+										<span>Lexicon</span>
+										<span class="dropdown-item-indicator-end">
+											<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</a>
+									<button class="btn btn-unstyled dropdown-item-indicator-end" data-drilldown="next" href="#_tggascnpo" type="button">
 										<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
 										</svg>
-									</span>
-								</a>
+									</button>
+								</div>
 							</li>
 							<li>
 								<a class="dropdown-item" href="#1">

--- a/packages/clay-css/src/scss/components/_drilldown.scss
+++ b/packages/clay-css/src/scss/components/_drilldown.scss
@@ -62,6 +62,12 @@
 		.dropdown-item-indicator-text-start {
 			padding-left: 0;
 		}
+
+		.dropdown-item-indicator-text-end {
+			margin-left: math-sign(
+				map-get($drilldown-dropdown-menu-indicator-start, padding-left)
+			);
+		}
 	}
 }
 
@@ -71,6 +77,12 @@
 .drilldown .dropdown-menu-indicator-end {
 	.dropdown-item {
 		@include clay-css($drilldown-dropdown-menu-indicator-end);
+
+		.dropdown-item-indicator-text-start {
+			margin-right: math-sign(
+				map-get($drilldown-dropdown-menu-indicator-end, padding-right)
+			);
+		}
 
 		.dropdown-item-indicator-text-end {
 			padding-right: 0;

--- a/packages/clay-css/src/scss/variables/_drilldown.scss
+++ b/packages/clay-css/src/scss/variables/_drilldown.scss
@@ -139,7 +139,14 @@ $drilldown-dropdown-item-indicator-end: map-merge(
 $drilldown-dropdown-item-indicator-text-end: () !default;
 $drilldown-dropdown-item-indicator-text-end: map-merge(
 	(
+		margin-bottom: -0.59375rem,
+		margin-left: -1rem,
+		margin-top: -0.59375rem,
+		padding-bottom: inherit,
+		padding-left: inherit,
 		padding-right: 2rem,
+		padding-top: inherit,
+		width: auto,
 	),
 	$drilldown-dropdown-item-indicator-text-end
 );


### PR DESCRIPTION
Alrighty, it took me a bit of digging through my notes to find that in order to see this example I need to fire up a gulp server inside clay-css. We should definitely add that into the GitHub readme thingy.

Once I did get it fired up I realized the main culprit, `dropdown-item` is always the parent of the item, and always has the same `padding`, which makes sense. What doesn't make sense is that it's child in case of simple text, like `Folder` in the above example doesn't have an HTML element wrapped around it, so it's just `<div class="dropdown-item">Folder</div>`.

My proposal is to add another layer of HTML, like a `span` to that `Folder` text, so that we can target `dropdown-item` with CSS and remove the `padding` from it. 

I sent a WIP example of the styles just to get feedback from you @pat270 if I should be doing it in a different file, or a certain way with these variables and imports, haven't worked in a proper CSS project yet.

I also sent a commit that fixes a couple small things in Drilldown, lemme know what you feel about them @bryceosterhaus 