### PR TITLE
feat(clayui.com): Put form components under Form folder in the navigation

### DIFF
--- a/clayui.com/gatsby/createPages.js
+++ b/clayui.com/gatsby/createPages.js
@@ -153,6 +153,7 @@ module.exports = async ({actions, graphql}) => {
 				edges {
 					node {
 						fields {
+							formPackageMember
 							layout
 							nightly
 							redirect

--- a/clayui.com/gatsby/createPages.js
+++ b/clayui.com/gatsby/createPages.js
@@ -153,8 +153,8 @@ module.exports = async ({actions, graphql}) => {
 				edges {
 					node {
 						fields {
-							formPackageMember
 							layout
+							navigationParent
 							nightly
 							redirect
 							redirectFrom

--- a/clayui.com/gatsby/onCreateNode.js
+++ b/clayui.com/gatsby/onCreateNode.js
@@ -28,6 +28,7 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 			description,
 			disableTOC,
 			draft,
+			formPackageMember,
 			indexVisible,
 			layout,
 			lexiconDefinition = '',
@@ -228,6 +229,12 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 			name: 'mainTabURL',
 			node,
 			value: mainTabURL || '',
+		});
+
+		createNodeField({
+			name: 'formPackageMember',
+			node,
+			value: formPackageMember || false,
 		});
 
 		createNodeField({

--- a/clayui.com/gatsby/onCreateNode.js
+++ b/clayui.com/gatsby/onCreateNode.js
@@ -28,11 +28,11 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 			description,
 			disableTOC,
 			draft,
-			formPackageMember,
 			indexVisible,
 			layout,
 			lexiconDefinition = '',
 			mainTabURL,
+			navigationParent,
 			nightly,
 			order,
 			packageNpm,
@@ -232,9 +232,9 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 		});
 
 		createNodeField({
-			name: 'formPackageMember',
+			name: 'navigationParent',
 			node,
-			value: formPackageMember || false,
+			value: navigationParent || '',
 		});
 
 		createNodeField({

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -366,7 +366,7 @@ export const pageQuery = graphql`
 			frontmatter {
 				description
 				disableTOC
-				formPackageMember
+				navigationParent
 				lexiconDefinition
 				packageNpm
 				title
@@ -407,7 +407,7 @@ export const pageQuery = graphql`
 				node {
 					fields {
 						alwaysActive
-						formPackageMember
+						navigationParent
 						layout
 						packageVersion
 						packageStatus

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -366,6 +366,7 @@ export const pageQuery = graphql`
 			frontmatter {
 				description
 				disableTOC
+				formPackageMember
 				lexiconDefinition
 				packageNpm
 				title
@@ -406,6 +407,7 @@ export const pageQuery = graphql`
 				node {
 					fields {
 						alwaysActive
+						formPackageMember
 						layout
 						packageVersion
 						packageStatus

--- a/clayui.com/src/utils/getSection.js
+++ b/clayui.com/src/utils/getSection.js
@@ -20,6 +20,10 @@ const sortByOrderAndTitle = (a, b) => {
 	}
 };
 
+const navigationRelationships = {
+	'/docs/components/form.html': [],
+};
+
 const toSectionElements = (
 	slug,
 	pathname,
@@ -38,7 +42,6 @@ const toSectionElements = (
 	const link = `/${slug}`;
 	const parentLink = `/${slug.substring(0, slug.lastIndexOf('/') + 1)}`;
 	const isFolder = lastSlug === 'index';
-	const isFormFolder = lastSlug === 'form';
 	const isRoot =
 		(slugs.length === 3 && isFolder) || (slugs.length === 2 && !isFolder);
 
@@ -48,7 +51,6 @@ const toSectionElements = (
 		id,
 		indexVisible,
 		isFolder,
-		isFormFolder,
 		isRoot,
 		link,
 		navigationParent,
@@ -60,8 +62,14 @@ const toSectionElements = (
 };
 
 const toSectionItem = (item, paths) => {
-	if (item.isFormFolder) {
-		item.isFolder = true;
+	const isParentPackage = Object.keys(navigationRelationships).includes(
+		`/${item.pathname}`
+	);
+
+	if (item.navigationParent) {
+		navigationRelationships[item.navigationParent].push(
+			`/${item.pathname}`
+		);
 	}
 
 	if (item.isFolder) {
@@ -75,14 +83,14 @@ const toSectionItem = (item, paths) => {
 			.filter((path) => !path.navigationParent)
 			.map((path) => toSectionItem(path, paths))
 			.sort(sortByOrderAndTitle);
+	}
 
-		if (item.isFormFolder) {
-			item.items = paths
-				.filter((path) => path.navigationParent)
-				.filter((path) => path.link !== item.link)
-				.map((path) => toSectionItem(path, paths))
-				.sort(sortByOrderAndTitle);
-		}
+	if (isParentPackage) {
+		item.items = paths
+			.filter((path) => path.navigationParent)
+			.filter((path) => path.link !== item.link)
+			.map((path) => toSectionItem(path, paths))
+			.sort(sortByOrderAndTitle);
 	}
 
 	return item;

--- a/clayui.com/src/utils/getSection.js
+++ b/clayui.com/src/utils/getSection.js
@@ -27,7 +27,7 @@ const toSectionElements = (
 	order,
 	alwaysActive,
 	draft,
-	formPackageMember,
+	navigationParent,
 	indexVisible
 ) => {
 	const slugs = slug.split('/');
@@ -45,13 +45,13 @@ const toSectionElements = (
 	return {
 		alwaysActive,
 		draft,
-		formPackageMember,
 		id,
 		indexVisible,
 		isFolder,
 		isFormFolder,
 		isRoot,
 		link,
+		navigationParent,
 		order,
 		parentLink,
 		pathname,
@@ -72,13 +72,13 @@ const toSectionItem = (item, paths) => {
 					path.link ===
 					item.parentLink + path.id + (path.isFolder ? '/index' : '')
 			)
-			.filter((path) => !path.formPackageMember)
+			.filter((path) => !path.navigationParent)
 			.map((path) => toSectionItem(path, paths))
 			.sort(sortByOrderAndTitle);
 
 		if (item.isFormFolder) {
 			item.items = paths
-				.filter((path) => path.formPackageMember)
+				.filter((path) => path.navigationParent)
 				.filter((path) => path.link !== item.link)
 				.map((path) => toSectionItem(path, paths))
 				.sort(sortByOrderAndTitle);
@@ -94,8 +94,8 @@ const getSection = (data) => {
 			fields: {
 				alwaysActive,
 				draft,
-				formPackageMember,
 				indexVisible,
+				navigationParent,
 				order,
 				slug,
 				title,
@@ -109,7 +109,7 @@ const getSection = (data) => {
 			order,
 			alwaysActive,
 			draft,
-			formPackageMember,
+			navigationParent,
 			indexVisible
 		);
 	});

--- a/clayui.com/src/utils/getSection.js
+++ b/clayui.com/src/utils/getSection.js
@@ -60,29 +60,29 @@ const toSectionElements = (
 const toSectionItem = (item, paths, parentPaths) => {
 	if (item.isFolder) {
 		item.items = paths
-			.filter(path => path.link !== item.link)
+			.filter((path) => path.link !== item.link)
 			.filter(
-				path =>
+				(path) =>
 					path.link ===
 					item.parentLink + path.id + (path.isFolder ? '/index' : '')
 			)
-			.filter(path => !path.navigationParent)
-			.map(path => toSectionItem(path, paths, parentPaths))
+			.filter((path) => !path.navigationParent)
+			.map((path) => toSectionItem(path, paths, parentPaths))
 			.sort(sortByOrderAndTitle);
 	}
 
 	if (parentPaths.includes(item.pathname)) {
 		item.items = paths
-			.filter(path => path.navigationParent === item.pathname)
-			.filter(path => path.link !== item.link)
-			.map(path => toSectionItem(path, paths, parentPaths))
+			.filter((path) => path.navigationParent === item.pathname)
+			.filter((path) => path.link !== item.link)
+			.map((path) => toSectionItem(path, paths, parentPaths))
 			.sort(sortByOrderAndTitle);
 	}
 
 	return item;
 };
 
-const getSection = data => {
+const getSection = (data) => {
 	const elements = data.map(({node}) => {
 		const {
 			fields: {
@@ -108,7 +108,7 @@ const getSection = data => {
 		);
 	});
 
-	const rootElements = elements.filter(path => path.isRoot);
+	const rootElements = elements.filter((path) => path.isRoot);
 
 	const parentPaths = elements.reduce((acc, {navigationParent}) => {
 		return navigationParent && !acc.includes(navigationParent)
@@ -117,7 +117,7 @@ const getSection = data => {
 	}, []);
 
 	return rootElements
-		.map(path => toSectionItem(path, elements, parentPaths))
+		.map((path) => toSectionItem(path, elements, parentPaths))
 		.sort(sortByOrderAndTitle);
 };
 

--- a/clayui.com/src/utils/getSection.js
+++ b/clayui.com/src/utils/getSection.js
@@ -27,6 +27,7 @@ const toSectionElements = (
 	order,
 	alwaysActive,
 	draft,
+	formPackageMember,
 	indexVisible
 ) => {
 	const slugs = slug.split('/');
@@ -37,15 +38,18 @@ const toSectionElements = (
 	const link = `/${slug}`;
 	const parentLink = `/${slug.substring(0, slug.lastIndexOf('/') + 1)}`;
 	const isFolder = lastSlug === 'index';
+	const isFormFolder = lastSlug === 'form';
 	const isRoot =
 		(slugs.length === 3 && isFolder) || (slugs.length === 2 && !isFolder);
 
 	return {
 		alwaysActive,
 		draft,
+		formPackageMember,
 		id,
 		indexVisible,
 		isFolder,
+		isFormFolder,
 		isRoot,
 		link,
 		order,
@@ -56,6 +60,10 @@ const toSectionElements = (
 };
 
 const toSectionItem = (item, paths) => {
+	if (item.isFormFolder) {
+		item.isFolder = true;
+	}
+
 	if (item.isFolder) {
 		item.items = paths
 			.filter((path) => path.link !== item.link)
@@ -64,8 +72,17 @@ const toSectionItem = (item, paths) => {
 					path.link ===
 					item.parentLink + path.id + (path.isFolder ? '/index' : '')
 			)
+			.filter((path) => !path.formPackageMember)
 			.map((path) => toSectionItem(path, paths))
 			.sort(sortByOrderAndTitle);
+
+		if (item.isFormFolder) {
+			item.items = paths
+				.filter((path) => path.formPackageMember)
+				.filter((path) => path.link !== item.link)
+				.map((path) => toSectionItem(path, paths))
+				.sort(sortByOrderAndTitle);
+		}
 	}
 
 	return item;
@@ -74,7 +91,15 @@ const toSectionItem = (item, paths) => {
 const getSection = (data) => {
 	const elements = data.map(({node}) => {
 		const {
-			fields: {alwaysActive, draft, indexVisible, order, slug, title},
+			fields: {
+				alwaysActive,
+				draft,
+				formPackageMember,
+				indexVisible,
+				order,
+				slug,
+				title,
+			},
 		} = node;
 
 		return toSectionElements(
@@ -84,6 +109,7 @@ const getSection = (data) => {
 			order,
 			alwaysActive,
 			draft,
+			formPackageMember,
 			indexVisible
 		);
 	});

--- a/packages/clay-form/CHECKBOX.mdx
+++ b/packages/clay-form/CHECKBOX.mdx
@@ -3,7 +3,7 @@ title: 'Checkbox'
 description: 'A checkbox is a component that lets the user select the value that is written in its corresponding text label. A user can select multiple checkboxes from a group at the same time.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/'
 packageNpm: '@clayui/form'
-formPackageMember: true
+navigationParent: '/docs/components/form.html'
 ---
 
 import {

--- a/packages/clay-form/CHECKBOX.mdx
+++ b/packages/clay-form/CHECKBOX.mdx
@@ -3,7 +3,7 @@ title: 'Checkbox'
 description: 'A checkbox is a component that lets the user select the value that is written in its corresponding text label. A user can select multiple checkboxes from a group at the same time.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/'
 packageNpm: '@clayui/form'
-navigationParent: '/docs/components/form.html'
+navigationParent: 'docs/components/form.html'
 ---
 
 import {

--- a/packages/clay-form/CHECKBOX.mdx
+++ b/packages/clay-form/CHECKBOX.mdx
@@ -3,6 +3,7 @@ title: 'Checkbox'
 description: 'A checkbox is a component that lets the user select the value that is written in its corresponding text label. A user can select multiple checkboxes from a group at the same time.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/'
 packageNpm: '@clayui/form'
+formPackageMember: true
 ---
 
 import {

--- a/packages/clay-form/DUAL_LIST_BOX.mdx
+++ b/packages/clay-form/DUAL_LIST_BOX.mdx
@@ -3,7 +3,7 @@ title: 'Dual List Box'
 description: 'Dual List Box provides users with two Select Boxes with the ability to move items between lists.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
-formPackageMember: true
+navigationParent: '/docs/components/form.html'
 ---
 
 import {DualListBox} from '$packages/clay-form/docs/duallistbox';

--- a/packages/clay-form/DUAL_LIST_BOX.mdx
+++ b/packages/clay-form/DUAL_LIST_BOX.mdx
@@ -3,6 +3,7 @@ title: 'Dual List Box'
 description: 'Dual List Box provides users with two Select Boxes with the ability to move items between lists.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
+formPackageMember: true
 ---
 
 import {DualListBox} from '$packages/clay-form/docs/duallistbox';

--- a/packages/clay-form/DUAL_LIST_BOX.mdx
+++ b/packages/clay-form/DUAL_LIST_BOX.mdx
@@ -3,7 +3,7 @@ title: 'Dual List Box'
 description: 'Dual List Box provides users with two Select Boxes with the ability to move items between lists.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
-navigationParent: '/docs/components/form.html'
+navigationParent: 'docs/components/form.html'
 ---
 
 import {DualListBox} from '$packages/clay-form/docs/duallistbox';

--- a/packages/clay-form/INPUT.mdx
+++ b/packages/clay-form/INPUT.mdx
@@ -3,7 +3,7 @@ title: 'Input'
 description: 'This section demonstrates the different text input types.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input/'
 packageNpm: '@clayui/form'
-navigationParent: '/docs/components/form.html'
+navigationParent: 'docs/components/form.html'
 ---
 
 import {

--- a/packages/clay-form/INPUT.mdx
+++ b/packages/clay-form/INPUT.mdx
@@ -3,7 +3,7 @@ title: 'Input'
 description: 'This section demonstrates the different text input types.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input/'
 packageNpm: '@clayui/form'
-formPackageMember: true
+navigationParent: '/docs/components/form.html'
 ---
 
 import {

--- a/packages/clay-form/INPUT.mdx
+++ b/packages/clay-form/INPUT.mdx
@@ -3,6 +3,7 @@ title: 'Input'
 description: 'This section demonstrates the different text input types.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input/'
 packageNpm: '@clayui/form'
+formPackageMember: true
 ---
 
 import {

--- a/packages/clay-form/RADIO_GROUP.mdx
+++ b/packages/clay-form/RADIO_GROUP.mdx
@@ -2,7 +2,7 @@
 title: 'Radio Group'
 description: 'Radios provide users with different selection and activation tools.'
 packageNpm: '@clayui/form'
-navigationParent: '/docs/components/form.html'
+navigationParent: 'docs/components/form.html'
 ---
 
 import {RadioGroup} from '$packages/clay-form/docs/radiogroup';

--- a/packages/clay-form/RADIO_GROUP.mdx
+++ b/packages/clay-form/RADIO_GROUP.mdx
@@ -2,7 +2,7 @@
 title: 'Radio Group'
 description: 'Radios provide users with different selection and activation tools.'
 packageNpm: '@clayui/form'
-formPackageMember: true
+navigationParent: '/docs/components/form.html'
 ---
 
 import {RadioGroup} from '$packages/clay-form/docs/radiogroup';

--- a/packages/clay-form/RADIO_GROUP.mdx
+++ b/packages/clay-form/RADIO_GROUP.mdx
@@ -2,6 +2,7 @@
 title: 'Radio Group'
 description: 'Radios provide users with different selection and activation tools.'
 packageNpm: '@clayui/form'
+formPackageMember: true
 ---
 
 import {RadioGroup} from '$packages/clay-form/docs/radiogroup';

--- a/packages/clay-form/README.mdx
+++ b/packages/clay-form/README.mdx
@@ -3,6 +3,7 @@ title: 'Form'
 description: 'Forms obtain user data and transmit it to the system to either store the data, produce an action, or both.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 packageNpm: '@clayui/form'
+alwaysActive: true
 ---
 
 import {Form, FormValidation, FormText} from '$packages/clay-form/docs/index';

--- a/packages/clay-form/SELECT.mdx
+++ b/packages/clay-form/SELECT.mdx
@@ -3,7 +3,7 @@ title: 'Select'
 description: 'A form control element used to select from several provided options and enter data.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selector/'
 packageNpm: '@clayui/form'
-formPackageMember: true
+navigationParent: '/docs/components/form.html'
 ---
 
 import {Select, SelectWithOption} from '$packages/clay-form/docs/select';

--- a/packages/clay-form/SELECT.mdx
+++ b/packages/clay-form/SELECT.mdx
@@ -3,6 +3,7 @@ title: 'Select'
 description: 'A form control element used to select from several provided options and enter data.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selector/'
 packageNpm: '@clayui/form'
+formPackageMember: true
 ---
 
 import {Select, SelectWithOption} from '$packages/clay-form/docs/select';

--- a/packages/clay-form/SELECT.mdx
+++ b/packages/clay-form/SELECT.mdx
@@ -3,7 +3,7 @@ title: 'Select'
 description: 'A form control element used to select from several provided options and enter data.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selector/'
 packageNpm: '@clayui/form'
-navigationParent: '/docs/components/form.html'
+navigationParent: 'docs/components/form.html'
 ---
 
 import {Select, SelectWithOption} from '$packages/clay-form/docs/select';

--- a/packages/clay-form/SELECT_BOX.mdx
+++ b/packages/clay-form/SELECT_BOX.mdx
@@ -3,7 +3,7 @@ title: 'Select Box'
 description: 'Select Box allows users to select multiple options and if needed the ability to reorder selected options.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
-formPackageMember: true
+navigationParent: '/docs/components/form.html'
 ---
 
 import {SelectBox} from '$packages/clay-form/docs/selectbox';

--- a/packages/clay-form/SELECT_BOX.mdx
+++ b/packages/clay-form/SELECT_BOX.mdx
@@ -3,7 +3,7 @@ title: 'Select Box'
 description: 'Select Box allows users to select multiple options and if needed the ability to reorder selected options.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
-navigationParent: '/docs/components/form.html'
+navigationParent: 'docs/components/form.html'
 ---
 
 import {SelectBox} from '$packages/clay-form/docs/selectbox';

--- a/packages/clay-form/SELECT_BOX.mdx
+++ b/packages/clay-form/SELECT_BOX.mdx
@@ -3,6 +3,7 @@ title: 'Select Box'
 description: 'Select Box allows users to select multiple options and if needed the ability to reorder selected options.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
+formPackageMember: true
 ---
 
 import {SelectBox} from '$packages/clay-form/docs/selectbox';

--- a/packages/clay-form/TOGGLE_SWITCH.mdx
+++ b/packages/clay-form/TOGGLE_SWITCH.mdx
@@ -3,7 +3,7 @@ title: 'Toggle Switch'
 description: 'Toggle provide users with different selection and activation tools.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/#toggle'
 packageNpm: '@clayui/form'
-formPackageMember: true
+navigationParent: '/docs/components/form.html'
 ---
 
 import {RadioToggle, Toggle} from '$packages/clay-form/docs/toggle';

--- a/packages/clay-form/TOGGLE_SWITCH.mdx
+++ b/packages/clay-form/TOGGLE_SWITCH.mdx
@@ -3,7 +3,7 @@ title: 'Toggle Switch'
 description: 'Toggle provide users with different selection and activation tools.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/#toggle'
 packageNpm: '@clayui/form'
-navigationParent: '/docs/components/form.html'
+navigationParent: 'docs/components/form.html'
 ---
 
 import {RadioToggle, Toggle} from '$packages/clay-form/docs/toggle';

--- a/packages/clay-form/TOGGLE_SWITCH.mdx
+++ b/packages/clay-form/TOGGLE_SWITCH.mdx
@@ -3,6 +3,7 @@ title: 'Toggle Switch'
 description: 'Toggle provide users with different selection and activation tools.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/#toggle'
 packageNpm: '@clayui/form'
+formPackageMember: true
 ---
 
 import {RadioToggle, Toggle} from '$packages/clay-form/docs/toggle';


### PR DESCRIPTION
Fixes #3736 

I'm pretty happy with this result, and I learned how the navigation get's prepared and filled up.

It's pretty simple, even though i took me a couple days to get here, but I did the following:
- added a `formPackageMember` to the frontmatter of components that belong to the `@clayui/form` package
- made Form a folder by assigning it in `getSection`, not sure if we can add that too to its frontmatter
- made the Form always open by adding `alwaysActive` to its frontmatter
- move components that belong to `@clayui/form` to that folder and remove them from the regular nav