### PR TITLE
feat: PoC for Recharts by Clay implementation

### DIFF
--- a/packages/clay-recharts/.yarnrc
+++ b/packages/clay-recharts/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/recharts@"
+version-git-message "chore: prepare @clayui/recharts@%s"

--- a/packages/clay-recharts/BREAKING.md
+++ b/packages/clay-recharts/BREAKING.md
@@ -1,0 +1,1 @@
+# List of Breaking Changes for 4.x

--- a/packages/clay-recharts/CHANGELOG.md
+++ b/packages/clay-recharts/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/clay-recharts/README.mdx
+++ b/packages/clay-recharts/README.mdx
@@ -1,0 +1,8 @@
+---
+title: 'Recharts'
+description: ''
+lexiconDefinition: 'https://liferay.design/lexicon/core-components/charts/'
+packageNpm: '@clayui/recharts'
+---
+
+This section defines and describes Lexicon Charts as a main graphical pattern to analyze data.

--- a/packages/clay-recharts/package.json
+++ b/packages/clay-recharts/package.json
@@ -1,0 +1,40 @@
+{
+	"name": "@clayui/recharts",
+	"version": "3.0.0",
+	"description": "ClayCharts component",
+	"license": "BSD-3-Clause",
+	"repository": "https://github.com/liferay/clay",
+	"engines": {
+		"node": ">=0.12.0",
+		"npm": ">=3.0.0"
+	},
+	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
+	"scripts": {
+		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
+		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
+		"prepublishOnly": "yarn build && yarn build:types",
+		"test": "jest --config ../../jest.config.js"
+	},
+	"keywords": [
+		"clay",
+		"react"
+	],
+	"dependencies": {
+		"classnames": "^2.2.6",
+		"recharts": "1.8.5"
+	},
+	"peerDependencies": {
+		"@clayui/css": "3.x",
+		"react": "^16.8.1",
+		"react-dom": "^16.8.1"
+	},
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
+}

--- a/packages/clay-recharts/src/index.tsx
+++ b/packages/clay-recharts/src/index.tsx
@@ -1,0 +1,272 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+import {
+	Bar as ReBar,
+	CartesianGrid as ReCartesianGrid,
+	Legend as ReLegend,
+	Line as ReLine,
+	Pie as RePie,
+	Tooltip as ReTooltip,
+	TooltipPayload,
+	TooltipProps,
+	XAxis as ReXAxis,
+	YAxis as ReYAxis,
+} from 'recharts';
+
+const COLOR_MAP = {
+	Dothraki: '#AF78FF',
+	Kashtark: '#FFD76E',
+	Lannister: '#FF5F5F',
+	Martell: '#50D2A0',
+	Mormont: '#FFB46E',
+	Stark: '#4B9BFF',
+	Targaryen: '#9CE269',
+	Tarly: '#5FC8FF',
+	Tyrell: '#FF73C3',
+};
+
+const COLORS = [
+	COLOR_MAP.Stark,
+	COLOR_MAP.Mormont,
+	COLOR_MAP.Lannister,
+	COLOR_MAP.Martell,
+	COLOR_MAP.Tyrell,
+	COLOR_MAP.Targaryen,
+	COLOR_MAP.Dothraki,
+	COLOR_MAP.Kashtark,
+	COLOR_MAP.Tarly,
+];
+
+const WRAPPER_STYLE: any = {
+	center: {
+		horizontal: {
+			bottom: {paddingTop: 20},
+			middle: {},
+			top: {paddingBottom: 10},
+		},
+		vertical: {
+			bottom: {paddingTop: 20},
+			middle: {},
+			top: {paddingBottom: 20},
+		},
+	},
+	left: {
+		horizontal: {
+			bottom: {paddingTop: 20},
+			middle: {},
+			top: {paddingBottom: 10},
+		},
+		vertical: {
+			bottom: {paddingBottom: 40, paddingRight: 32},
+			middle: {paddingRight: 32},
+			top: {paddingRight: 32, paddingTop: 20},
+		},
+	},
+	right: {
+		horizontal: {
+			bottom: {paddingTop: 20},
+			middle: {},
+			top: {paddingBottom: 10},
+		},
+		vertical: {
+			bottom: {paddingBottom: 40, paddingLeft: 32},
+			middle: {paddingLeft: 32},
+			top: {paddingLeft: 32, paddingTop: 20},
+		},
+	},
+};
+
+const Legend = React.forwardRef(
+	(
+		{
+			align = 'right',
+			layout = 'vertical',
+			verticalAlign = 'bottom',
+			...otherProps
+		}: any,
+		ref
+	) => (
+		<ReLegend
+			align={align}
+			iconSize={16}
+			layout={layout}
+			ref={ref}
+			verticalAlign={verticalAlign}
+			wrapperStyle={WRAPPER_STYLE[align][layout][verticalAlign]}
+			{...otherProps}
+		/>
+	)
+);
+
+Legend.displayName = 'Legend';
+
+const XAxis: React.FunctionComponent<React.ComponentProps<typeof ReXAxis>> = (
+	props: React.ComponentProps<typeof ReXAxis>
+) => null;
+
+XAxis.defaultProps = {
+	...(ReXAxis as any).defaultProps,
+	axisLine: {opacity: 0},
+	tickLine: false,
+	tickMargin: 12,
+};
+XAxis.displayName = 'XAxis';
+
+const YAxis: React.FunctionComponent<React.ComponentProps<typeof ReYAxis>> = (
+	props: React.ComponentProps<typeof ReYAxis>
+) => null;
+
+YAxis.defaultProps = {
+	...(ReYAxis as any).defaultProps,
+	axisLine: {opacity: 0},
+	tickLine: false,
+	tickMargin: 16,
+};
+YAxis.displayName = 'YAxis';
+
+const Tooltip = (props: any) => (
+	<ReTooltip
+		content={({active, label, payload}: TooltipProps) => {
+			if (active) {
+				return (
+					<div className="popover" style={{position: 'static'}}>
+						<div className="popover-header">{label}</div>
+
+						<div className="popover-body">
+							{payload &&
+								payload.map((item: TooltipPayload) => (
+									<div
+										key={`${item.payload.name}:${item.dataKey}`}
+									>
+										{`${item.name}: ${item.value}`}
+									</div>
+								))}
+						</div>
+					</div>
+				);
+			}
+
+			return null;
+		}}
+		{...props}
+	/>
+);
+
+Tooltip.displayName = 'Tooltip';
+Tooltip.defaultProps = {
+	...(ReTooltip as any).defaultProps,
+	cursor: false,
+};
+
+const CartesianGrid = ({offset, vertical = false, ...otherProps}: any) => {
+	const {height, left, top, width} = offset;
+
+	return (
+		<g>
+			<rect
+				fill="transparent"
+				height={height}
+				pointerEvents="none"
+				rx="3.5"
+				stroke="#E7E7ED"
+				width={width}
+				x={left}
+				y={top}
+			/>
+			<ReCartesianGrid
+				offset={offset}
+				stroke="#E7E7ED"
+				strokeDasharray="3 3"
+				vertical={vertical}
+				{...otherProps}
+			/>
+		</g>
+	);
+};
+
+CartesianGrid.displayName = 'CartesianGrid';
+
+const Bar = ({active, dataKey, onActive, ...otherProps}: any) => (
+	<ReBar
+		dataKey={dataKey}
+		fillOpacity={active === dataKey ? 1 : active === '' ? 1 : 0.25}
+		onMouseOut={() => onActive('')}
+		onMouseOver={() => onActive(dataKey)}
+		{...otherProps}
+	/>
+);
+
+Bar.displayName = 'Bar';
+Bar.defaultProps = {
+	...(ReBar as any).defaultProps,
+	legendType: 'square',
+};
+Bar.getComposedData = (ReBar as any).getComposedData;
+Bar.renderRectangle = (ReBar as any).renderRectangle;
+
+const getDotStyle = (color: string) => ({
+	active: {
+		fill: 'white',
+		r: 4,
+		stroke: color,
+		strokeWidth: 3,
+	},
+	default: {
+		fill: color,
+		r: 4,
+		strokeWidth: 0,
+	},
+});
+
+const Line = ({active, dataKey, onActive, stroke, ...otherProps}: any) => {
+	const dotStyle = getDotStyle(stroke);
+
+	return (
+		<ReLine
+			onMouseOut={() => onActive('')}
+			onMouseOver={() => onActive(dataKey)}
+			stroke={stroke}
+			strokeDasharray="3 3"
+			strokeOpacity={active === dataKey ? 1 : active === '' ? 1 : 0.25}
+			strokeWidth={2}
+			{...otherProps}
+			activeDot={dotStyle.active}
+			dot={{
+				...dotStyle.default,
+				opacity: active === dataKey ? 1 : active === '' ? 1 : 0.25,
+			}}
+		/>
+	);
+};
+
+Line.defaultProps = {
+	...(ReLine as any).defaultProps,
+	strokeWidth: 1.5,
+};
+Line.displayName = 'Line';
+Line.getComposedData = (ReLine as any).getComposedData;
+
+const Pie = (props: any) => <RePie {...props} />;
+
+Pie.displayName = 'Pie';
+Pie.defaultProps = {
+	...(RePie as any).defaultProps,
+	activeShape: {
+		outerRadius: 95,
+	},
+	innerRadius: 45,
+	label: false,
+	legendType: 'square',
+	outerRadius: 85,
+	paddingAngle: 3,
+};
+Pie.parseDeltaAngle = (RePie as any).parseDeltaAngle;
+Pie.getRealPieData = (RePie as any).getRealPieData;
+Pie.parseCoordinateOfPie = (RePie as any).parseCoordinateOfPie;
+Pie.getComposedData = (RePie as any).getComposedData;
+
+export {Bar, COLORS, CartesianGrid, Legend, Line, Pie, XAxis, YAxis, Tooltip};

--- a/packages/clay-recharts/src/index.tsx
+++ b/packages/clay-recharts/src/index.tsx
@@ -104,9 +104,9 @@ const Legend = React.forwardRef(
 
 Legend.displayName = 'Legend';
 
-const XAxis: React.FunctionComponent<React.ComponentProps<typeof ReXAxis>> = (
-	props: React.ComponentProps<typeof ReXAxis>
-) => null;
+const XAxis: React.FunctionComponent<React.ComponentProps<
+	typeof ReXAxis
+>> = () => null;
 
 XAxis.defaultProps = {
 	...(ReXAxis as any).defaultProps,
@@ -116,9 +116,9 @@ XAxis.defaultProps = {
 };
 XAxis.displayName = 'XAxis';
 
-const YAxis: React.FunctionComponent<React.ComponentProps<typeof ReYAxis>> = (
-	props: React.ComponentProps<typeof ReYAxis>
-) => null;
+const YAxis: React.FunctionComponent<React.ComponentProps<
+	typeof ReYAxis
+>> = () => null;
 
 YAxis.defaultProps = {
 	...(ReYAxis as any).defaultProps,

--- a/packages/clay-recharts/src/styles.css
+++ b/packages/clay-recharts/src/styles.css
@@ -1,0 +1,32 @@
+.recharts-cartesian-axis {
+	font-size: 14px;
+}
+
+.recharts-cartesian-grid-vertical line:first-child,
+.recharts-cartesian-grid-vertical line:last-child,
+.recharts-cartesian-grid-horizontal line:first-child,
+.recharts-cartesian-grid-horizontal line:last-child {
+	opacity: 0;
+}
+
+.recharts-legend-item {
+	margin-bottom: 9px;
+	margin-right: 20px !important;
+}
+
+.recharts-legend-item:last-child {
+	margin-bottom: 0;
+}
+
+.recharts-legend-item svg {
+	margin-right: 12px !important;
+}
+
+.recharts-legend-item-text {
+	font-size: 14px;
+	color: #6B6C7E;
+}
+
+.recharts-legend-item-text:hover {
+	color: #272833;
+}

--- a/packages/clay-recharts/stories/index.tsx
+++ b/packages/clay-recharts/stories/index.tsx
@@ -124,7 +124,7 @@ storiesOf('Components|ClayRecharts', module)
 							['vertical', 'horizontal'],
 							'vertical'
 						)}
-						onMouseEnter={({dataKey}) => setActive(dataKey)}
+						onMouseEnter={({dataKey}: any) => setActive(dataKey)}
 						onMouseLeave={() => setActive('')}
 						verticalAlign={select(
 							'Legend Vertical Align',
@@ -197,7 +197,7 @@ storiesOf('Components|ClayRecharts', module)
 							['vertical', 'horizontal'],
 							'vertical'
 						)}
-						onMouseEnter={({dataKey}) => setActive(dataKey)}
+						onMouseEnter={({dataKey}: any) => setActive(dataKey)}
 						onMouseLeave={() => setActive('')}
 						verticalAlign={select(
 							'Legend Vertical Align',
@@ -333,7 +333,7 @@ storiesOf('Components|ClayRecharts', module)
 							['vertical', 'horizontal'],
 							'horizontal'
 						)}
-						onMouseEnter={({value}) => setActive(value)}
+						onMouseEnter={({value}: any) => setActive(value)}
 						onMouseLeave={() => setActive('')}
 						verticalAlign={select(
 							'Legend Vertical Align',
@@ -394,7 +394,7 @@ storiesOf('Components|ClayRecharts', module)
 							['vertical', 'horizontal'],
 							'horizontal'
 						)}
-						onMouseEnter={({value}) => setActive(value)}
+						onMouseEnter={({value}: any) => setActive(value)}
 						onMouseLeave={() => setActive('')}
 						verticalAlign={select(
 							'Legend Vertical Align',

--- a/packages/clay-recharts/stories/index.tsx
+++ b/packages/clay-recharts/stories/index.tsx
@@ -1,0 +1,408 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import '@clayui/css/lib/css/atlas.css';
+
+import '../src/styles.css';
+
+import {select} from '@storybook/addon-knobs';
+import {storiesOf} from '@storybook/react';
+import React from 'react';
+import {BarChart, Cell, LineChart, PieChart} from 'recharts';
+
+import {
+	Bar,
+	COLORS,
+	CartesianGrid,
+	Legend,
+	Line,
+	Pie,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from '../src';
+
+const DATA = [
+	{
+		amt: 2400,
+		name: 'Jan',
+		pv: 2400,
+		uv: 4000,
+	},
+	{
+		amt: 2210,
+		name: 'Feb',
+		pv: 1398,
+		uv: 3000,
+	},
+	{
+		amt: 2290,
+		name: 'Mar',
+		pv: 5400,
+		uv: 2000,
+	},
+	{
+		amt: 2000,
+		name: 'Apr',
+		pv: 3908,
+		uv: 2780,
+	},
+	{
+		amt: 2181,
+		name: 'May',
+		pv: 4800,
+		uv: 1890,
+	},
+	{
+		amt: 2500,
+		name: 'Jun',
+		pv: 3800,
+		uv: 2390,
+	},
+	{
+		amt: 2100,
+		name: 'Jul',
+		pv: 4300,
+		uv: 3490,
+	},
+	{
+		amt: 2200,
+		name: 'Aug',
+		pv: 4100,
+		uv: 3590,
+	},
+	{
+		amt: 2150,
+		name: 'Sep',
+		pv: 4350,
+		uv: 3560,
+	},
+	{
+		amt: 2100,
+		name: 'Oct',
+		pv: 4300,
+		uv: 3490,
+	},
+	{
+		amt: 2100,
+		name: 'Nov',
+		pv: 4300,
+		uv: 3490,
+	},
+	{
+		amt: 2100,
+		name: 'Dec',
+		pv: 4300,
+		uv: 3490,
+	},
+];
+
+storiesOf('Components|ClayRecharts', module)
+	.add('Line', () => {
+		const [active, setActive] = React.useState('');
+
+		return (
+			<div className="sheet">
+				<LineChart
+					data={DATA}
+					height={350}
+					margin={{bottom: 30, left: 0, right: 0, top: 5}}
+					width={700}
+				>
+					<XAxis dataKey="name" />
+					<YAxis />
+					<Legend
+						align={select(
+							'Legend Align',
+							['center', 'right', 'left'],
+							'right'
+						)}
+						layout={select(
+							'Legend Layout',
+							['vertical', 'horizontal'],
+							'vertical'
+						)}
+						onMouseEnter={({dataKey}) => setActive(dataKey)}
+						onMouseLeave={() => setActive('')}
+						verticalAlign={select(
+							'Legend Vertical Align',
+							['bottom', 'middle', 'top'],
+							'bottom'
+						)}
+					/>
+					<CartesianGrid />
+					<Tooltip />
+					<Line
+						active={active}
+						dataKey="pv"
+						name="pv of pages"
+						onActive={setActive}
+						stroke={COLORS[0]}
+					/>
+					<Line
+						active={active}
+						dataKey="uv"
+						name="uv of pages"
+						onActive={setActive}
+						stroke={COLORS[1]}
+					/>
+				</LineChart>
+			</div>
+		);
+	})
+	.add('Bar grouped', () => {
+		const [active, setActive] = React.useState('');
+
+		const data = [
+			{
+				desktop: 320,
+				mobile: 235,
+				name: 'First quarter',
+				tablet: 220,
+				tv: 270,
+			},
+			{
+				desktop: 220,
+				mobile: 320,
+				name: 'First quarter',
+				tablet: 340,
+				tv: 180,
+			},
+			{
+				desktop: 170,
+				mobile: 120,
+				name: 'First quarter',
+				tablet: 190,
+				tv: 70,
+			},
+		];
+
+		return (
+			<div className="sheet">
+				<BarChart barGap={8} data={data} height={350} width={700}>
+					<CartesianGrid />
+					<XAxis dataKey="name" />
+					<YAxis tickCount={4} />
+					<Tooltip />
+					<Legend
+						align={select(
+							'Legend Align',
+							['center', 'right', 'left'],
+							'right'
+						)}
+						layout={select(
+							'Legend Layout',
+							['vertical', 'horizontal'],
+							'vertical'
+						)}
+						onMouseEnter={({dataKey}) => setActive(dataKey)}
+						onMouseLeave={() => setActive('')}
+						verticalAlign={select(
+							'Legend Vertical Align',
+							['bottom', 'middle', 'top'],
+							'bottom'
+						)}
+					/>
+					<Bar
+						active={active}
+						dataKey="desktop"
+						fill={COLORS[0]}
+						name="Desktop"
+						onActive={setActive}
+					/>
+					<Bar
+						active={active}
+						dataKey="mobile"
+						fill={COLORS[1]}
+						name="Mobile"
+						onActive={setActive}
+					/>
+					<Bar
+						active={active}
+						dataKey="tablet"
+						fill={COLORS[2]}
+						name="Tablet"
+						onActive={setActive}
+					/>
+					<Bar
+						active={active}
+						dataKey="tv"
+						fill={COLORS[3]}
+						name="TV"
+						onActive={setActive}
+					/>
+				</BarChart>
+			</div>
+		);
+	})
+	.add('Bar non-grouped', () => {
+		const [active, setActive] = React.useState('');
+
+		const data = [
+			{
+				name: '18-24',
+				value: 64000,
+			},
+			{
+				name: '25-34',
+				value: 80000,
+			},
+			{
+				name: '35-44',
+				value: 64000,
+			},
+			{
+				name: '45-54',
+				value: 61000,
+			},
+			{
+				name: '55-64',
+				value: 40000,
+			},
+			{
+				name: '65+',
+				value: 10000,
+			},
+		];
+
+		return (
+			<div className="sheet">
+				<BarChart
+					data={data}
+					height={350}
+					layout="vertical"
+					maxBarSize={24}
+					width={320}
+				>
+					<CartesianGrid horizontal={false} vertical />
+					<XAxis dataKey="value" tickCount={4} type="number" />
+					<YAxis dataKey="name" type="category" />
+					<Tooltip />
+					<Bar
+						active={active}
+						dataKey="value"
+						fill={COLORS[0]}
+						onActive={setActive}
+					/>
+				</BarChart>
+			</div>
+		);
+	})
+	.add('Donut', () => {
+		const [active, setActive] = React.useState('');
+
+		const data = [
+			{name: 'Facebook', value: 30},
+			{name: 'Twitter', value: 30},
+			{name: 'Linkedin', value: 20},
+			{name: 'Other', value: 20},
+		];
+
+		const activeIndex = data.findIndex(({name}) => name === active);
+
+		return (
+			<div className="sheet">
+				<PieChart height={350} width={400}>
+					<Pie activeIndex={activeIndex} data={data} dataKey="value">
+						{data.map((entry: any, index: any) => (
+							<Cell
+								fill={COLORS[index]}
+								fillOpacity={
+									active === entry.name || active === ''
+										? 1
+										: 0.25
+								}
+								key={entry.name}
+								onMouseEnter={() => setActive(entry.name)}
+								onMouseLeave={() => setActive('')}
+							/>
+						))}
+					</Pie>
+					<CartesianGrid />
+					<Tooltip />
+					<Legend
+						align={select(
+							'Legend Align',
+							['center', 'right', 'left'],
+							'left'
+						)}
+						layout={select(
+							'Legend Layout',
+							['vertical', 'horizontal'],
+							'horizontal'
+						)}
+						onMouseEnter={({value}) => setActive(value)}
+						onMouseLeave={() => setActive('')}
+						verticalAlign={select(
+							'Legend Vertical Align',
+							['bottom', 'middle', 'top'],
+							'top'
+						)}
+					/>
+				</PieChart>
+			</div>
+		);
+	})
+	.add('Pie', () => {
+		const [active, setActive] = React.useState('');
+
+		const data = [
+			{name: 'Facebook', value: 30},
+			{name: 'Twitter', value: 30},
+			{name: 'Linkedin', value: 20},
+			{name: 'Other', value: 20},
+		];
+
+		const activeIndex = data.findIndex(({name}) => name === active);
+
+		return (
+			<div className="sheet">
+				<PieChart height={350} width={400}>
+					<Pie
+						activeIndex={activeIndex}
+						data={data}
+						dataKey="value"
+						innerRadius={0}
+					>
+						{data.map((entry: any, index: any) => (
+							<Cell
+								dx={0}
+								fill={COLORS[index]}
+								fillOpacity={
+									active === entry.name || active === ''
+										? 1
+										: 0.25
+								}
+								key={entry.name}
+								onMouseEnter={() => setActive(entry.name)}
+								onMouseLeave={() => setActive('')}
+							/>
+						))}
+					</Pie>
+					<CartesianGrid />
+					<Tooltip />
+					<Legend
+						align={select(
+							'Legend Align',
+							['center', 'right', 'left'],
+							'left'
+						)}
+						layout={select(
+							'Legend Layout',
+							['vertical', 'horizontal'],
+							'horizontal'
+						)}
+						onMouseEnter={({value}) => setActive(value)}
+						onMouseLeave={() => setActive('')}
+						verticalAlign={select(
+							'Legend Vertical Align',
+							['bottom', 'middle', 'top'],
+							'top'
+						)}
+					/>
+				</PieChart>
+			</div>
+		);
+	});

--- a/packages/clay-recharts/tsconfig.declarations.json
+++ b/packages/clay-recharts/tsconfig.declarations.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"declarationDir": "./lib"
+	},
+	"extends": "../../tsconfig.declarations.json",
+	"include": ["src"]
+}

--- a/packages/clay-recharts/tsconfig.json
+++ b/packages/clay-recharts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}


### PR DESCRIPTION
From #3734

> Don't look at the code so much yet, I still need to adjust a lot of details and TypeScript interfaces. Sorry!

This PR is a bit of my view of how we could approach a Clay implementation for Recharts, initially, it’s not just creating a wrapper but making Recharts’s visual base Lexicon, so we won’t limit any Recharts API or create high-level components.

At first, I created some wrappings on some primitive Recharts components that only have some configurations as default following Lexicon standards, spacing, size and etc... if you notice some fine adjustments are still missing, this is why we need to dig more APIs from Recharts or build our own content for example the case of the `Legend` component or provide an additional API to the `Line` component to define the shapes.

- Bar
- CartesianGrid
- Legend
- Line
- Pie
- Tooltip
- XAxis
- YAxis

Some things said in the documents of the Lexicon website are the interactions with the Charts, showing the tooltip about the Axis legend (it also depends on the component), in Legend component, and some behaviors such as the single bar interaction on a grouped chart, this diverges from the interactions Recharts standards, are things that we could facilitate. I haven't worked in all cases yet but some interactions with the legend have been made but are not done by the wrappers, still, the developer will have to control the active state and add some props, so as not to take away the flexibility that Recharts has or the proposal offered by them.

Creating some wrappers on the components of Recharts has some problems, it is quite strange how it works. Although if you see some components in your component tree-like `XAxis`, `YAxis`, `Line`, `Pie`... they don´t really render the components, it´s funny that Recharts uses `children` from the parent component to navigate the settings to draw the chart, so when your configuration is not on the `children` of the parent component Recharts will not recognize and render, think of it as fake components does not seem to be true for some components but for the most majority. To make the wrapper we also need to replicate some statistical methods of these components in the prototype of our wrappers so that it works well, otherwise, it will not work.

Overall I had some difficulties trying to reproduce Lexicon's behaviors and fine adjustments, there are still some places that need to be adjusted but some Recharts APIs are limiting. I think this is the value here, adding these "behaviors" and fine visual adjustments as a Recharts standard without compromising Recharts' proposal or its natural form of composition, so the developer can make the composition he wants as he was doing with Recharts but without having to customize it so much to get the Lexicon look.

- [Demos](https://deploy-preview-3745--next-storybook-clayui.netlify.app/?path=/story/components-clayrecharts--line)

---

Hey @victorvalle and @hold-shift, I had trouble finding the charts in the Figma to try to get the measurements, colors and etc... I'm also not sure if the documents on the Lexicon website are really up to date, I see some very different adjustments on other charts that I found on Figma.