### PR TITLE
fix(@clayui/form): Fix custom radio button image

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
@@ -114,7 +114,8 @@ $custom-checkbox-indicator-border-radius: 0.125rem !default; // 2px
 
 // Custom Radio
 
-$custom-radio-indicator-icon-checked-bg-size: 0.625rem !default;
+$custom-radio-indicator-icon-checked: clay-icon(circle, $white) !default;
+$custom-radio-indicator-icon-checked-bg-size: 50% !default;
 
 $custom-radio-indicator-disabled-border-color: $custom-control-indicator-disabled-bg !default;
 


### PR DESCRIPTION
In the [ticket LPS-121351](https://issues.liferay.com/browse/LPS-121351), we had a minor visual bug in Windows OS due to the [Bootstrap background image](https://getbootstrap.com/docs/4.5/components/forms/#radios) we were using for the custom radio button and the size of our radio button defined by lexicon. I've updated the image and the size following the [Lexicon specification for radio buttons](https://www.figma.com/file/A7ZNuyNHxj7kzJ6SYwQbQ3/Component-Library-Template-(Intra-Test)?node-id=1096%3A11397) and the [Clay pattern for the custom checkbox](https://github.com/liferay/clay/blob/master/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss#L105)

__Before:__
![Capture2](https://user-images.githubusercontent.com/46778114/95566442-d80f1e00-0a21-11eb-93ac-53505f294a2b.JPG)

__After:__
![Capture](https://user-images.githubusercontent.com/46778114/95566435-d47b9700-0a21-11eb-87de-1202fd8fbdb2.JPG)
