### PR TITLE
fix(@clayui/icon): Add svg4everybody to fix long loading of Icons page

### DIFF
--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -67,7 +67,8 @@
 		"react-docgen": "file:./react-docgen",
 		"react-dom": "^16.12.0",
 		"react-helmet": "^5.2.0",
-		"react-live": "^2.0.1"
+		"react-live": "^2.0.1",
+		"svg4everybody": "^2.1.9"
 	},
 	"devDependencies": {
 		"cpx": "^1.5.0",

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -12,6 +12,7 @@ import {Link, graphql} from 'gatsby';
 import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer';
 import React, {useEffect} from 'react';
 import Helmet from 'react-helmet';
+import svg4everybody from 'svg4everybody';
 
 import CodeClipboard from '../components/CodeClipboard';
 import CodeToggle from '../components/CodeToggle';
@@ -162,6 +163,12 @@ export default (props) => {
 	};
 
 	const title = `${frontmatter.title} - Clay`;
+
+	React.useEffect(() => {
+		svg4everybody({
+			polyfill: true,
+		});
+	}, []);
 
 	useEffect(() => {
 		const hash = window.location.hash;

--- a/yarn.lock
+++ b/yarn.lock
@@ -23299,6 +23299,11 @@ svg-tag-names@^2.0.1:
   resolved "https://registry.yarnpkg.com/svg-tag-names/-/svg-tag-names-2.0.1.tgz#acf5655faaa2e4b173007599226b906be1b38a29"
   integrity sha512-BEZ508oR+X/b5sh7bT0RqDJ7GhTpezjj3P1D4kugrOaPs6HijviWksoQ63PS81vZn0QCjZmVKjHDBniTo+Domg==
 
+svg4everybody@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/svg4everybody/-/svg4everybody-2.1.9.tgz#5bd9f6defc133859a044646d4743fabc28db7e2d"
+  integrity sha1-W9n23vwTOFmgRGRtR0P6vCjbfi0=
+
 svgo@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"


### PR DESCRIPTION
Fixes #3744 

Let me know if this is a suboptimal location to invoke `svg4everybody`, I tried it in `IconSearch` as that's the component that gets called but there it didn't do anything.

The red flag to me is the need for updating that many snapshots, but it might be okay.