### PR TITLE
feat(@clayui/card): add API to pass props to the checkbox

### DIFF
--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -16,6 +16,11 @@ interface IProps {
 	actions?: React.ComponentProps<typeof ClayDropDownWithItems>['items'];
 
 	/**
+	 * Props to add to the checkbox element
+	 */
+	checkboxProps?: React.HTMLAttributes<HTMLInputElement>;
+
+	/**
 	 * Flag to indicate that all interactions on the card will be disabled.
 	 */
 	disabled?: boolean;
@@ -58,6 +63,7 @@ interface IProps {
 
 export const ClayCardWithHorizontal: React.FunctionComponent<IProps> = ({
 	actions,
+	checkboxProps = {},
 	disabled,
 	dropDownTriggerProps = {},
 	href,
@@ -114,6 +120,7 @@ export const ClayCardWithHorizontal: React.FunctionComponent<IProps> = ({
 		<ClayCard horizontal selectable={!!onSelectChange}>
 			{onSelectChange && (
 				<ClayCheckbox
+					{...checkboxProps}
 					checked={selected}
 					disabled={disabled}
 					onChange={() => onSelectChange(!selected)}

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -21,6 +21,11 @@ interface IProps {
 	actions?: React.ComponentProps<typeof ClayDropDownWithItems>['items'];
 
 	/**
+	 * Props to add to the checkbox element
+	 */
+	checkboxProps?: React.HTMLAttributes<HTMLInputElement>;
+
+	/**
 	 * Description of the file
 	 */
 	description?: React.ReactText;
@@ -100,6 +105,7 @@ interface IProps {
 
 export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 	actions,
+	checkboxProps = {},
 	description,
 	disabled,
 	dropDownTriggerProps = {},
@@ -161,6 +167,7 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 		>
 			{onSelectChange && (
 				<ClayCheckbox
+					{...checkboxProps}
 					checked={selected}
 					disabled={disabled}
 					onChange={() => onSelectChange(!selected)}


### PR DESCRIPTION
Fixes #3752

I have the feeling that we should be avoiding props that serve to pass props to sub-components nested within the high-level... I don't have a strong opinion on that yet but I think we should put it in mind.