### PR TITLE
feat(@clayui/card): add support for base HTMLDivElement and HTMLAnchorElement props in high-level components

### DIFF
--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 
 import ClayCard from './Card';
 
-interface IProps {
+interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	actions?: React.ComponentProps<typeof ClayDropDownWithItems>['items'];
 
 	/**
@@ -72,6 +72,7 @@ export const ClayCardWithHorizontal: React.FunctionComponent<IProps> = ({
 	spritemap,
 	symbol = 'folder',
 	title,
+	...otherProps
 }: IProps) => {
 	const content = (
 		<ClayCard.Body>
@@ -117,7 +118,7 @@ export const ClayCardWithHorizontal: React.FunctionComponent<IProps> = ({
 	);
 
 	return (
-		<ClayCard horizontal selectable={!!onSelectChange}>
+		<ClayCard {...otherProps} horizontal selectable={!!onSelectChange}>
 			{onSelectChange && (
 				<ClayCheckbox
 					{...checkboxProps}

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 
 import ClayCard from './Card';
 
-interface IProps {
+interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * List of actions in the dropdown menu
 	 */
@@ -120,6 +120,7 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 	stickerProps,
 	symbol = 'documents-and-media',
 	title,
+	...otherProps
 }: IProps) => {
 	const headerContent = (
 		<ClayCard.AspectRatio className="card-item-first">
@@ -162,6 +163,7 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 
 	return (
 		<ClayCard
+			{...otherProps}
 			displayType={imgProps ? 'image' : 'file'}
 			selectable={!!onSelectChange}
 		>

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -11,7 +11,8 @@ import React from 'react';
 
 import ClayCard from './Card';
 
-interface IProps {
+interface IProps
+	extends React.BaseHTMLAttributes<HTMLAnchorElement | HTMLDivElement> {
 	children?: React.ReactNode;
 
 	/**
@@ -52,7 +53,7 @@ interface IProps {
 	/**
 	 * Value displayed for the card's title
 	 */
-	title?: React.ReactText;
+	title?: string;
 }
 
 const noop = () => {};
@@ -67,9 +68,11 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 	onKeyDown = noop,
 	spritemap,
 	title,
+	...otherProps
 }: IProps) => {
 	return (
 		<ClayCard
+			{...otherProps}
 			horizontal={horizontal}
 			href={href}
 			interactive

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 
 import ClayCard from './Card';
 
-interface IProps {
+interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * List of actions in the dropdown menu
 	 */
@@ -108,6 +108,7 @@ export const ClayCardWithUser: React.FunctionComponent<IProps> = ({
 	userDisplayType,
 	userImageSrc,
 	userSymbol = 'user',
+	...otherProps
 }: IProps) => {
 	const content = (
 		<div className="aspect-ratio-item-center-middle card-type-asset-icon">
@@ -131,7 +132,11 @@ export const ClayCardWithUser: React.FunctionComponent<IProps> = ({
 	);
 
 	return (
-		<ClayCard displayType="user" selectable={!!onSelectChange}>
+		<ClayCard
+			{...otherProps}
+			displayType="user"
+			selectable={!!onSelectChange}
+		>
 			<ClayCard.AspectRatio className="card-item-first">
 				{onSelectChange && (
 					<ClayCheckbox


### PR DESCRIPTION
Fixes #3757

I ended up causing the components to extend the base HTML interfaces to extend the number of props that can be passed to the component so we don't have to add it in the future since `<ClayCard />` already does the same.