### PR TITLE
chore(@clayui/card): uses the ClaySticker.Image component internally

### DIFF
--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -118,11 +118,7 @@ export const ClayCardWithUser: React.FunctionComponent<IProps> = ({
 				shape="circle"
 			>
 				{userImageSrc && (
-					<img
-						alt={userImageAlt}
-						className="aspect-ratio-item-fluid"
-						src={userImageSrc}
-					/>
+					<ClaySticker.Image alt={userImageAlt} src={userImageSrc} />
 				)}
 				{!userImageSrc && (
 					<ClayIcon spritemap={spritemap} symbol={userSymbol} />

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -2191,7 +2191,7 @@ exports[`ClayCardWithUser renders with image 1`] = `
             >
               <img
                 alt="thumbnail"
-                class="aspect-ratio-item-fluid"
+                class="sticker-img"
                 src="/path/to/image.jpg"
               />
             </span>


### PR DESCRIPTION
Fixes #3765 and Fixes #3764

I removed the use of `aspect-ratio-item-fluid` that was being added because it ends up doing the same as `sticker-img`.