### PR TITLE
chore: add breaking change note for 4.x

### DIFF
--- a/packages/clay-card/BREAKING.md
+++ b/packages/clay-card/BREAKING.md
@@ -1,1 +1,3 @@
 # List of Breaking Changes for 4.x
+
+[Update `stickerProps`](https://github.com/liferay/clay/issues/3773#issuecomment-720658343)


### PR DESCRIPTION
Stems from discussion at https://github.com/liferay/clay/issues/3773

This gives us a way to remember requests like these when we decide to break at 4.x