### PR TITLE
fix(@clayui/card): Avoid setting `href` on `span` element

### DIFF
--- a/packages/clay-card/src/Description.tsx
+++ b/packages/clay-card/src/Description.tsx
@@ -59,7 +59,10 @@ const ClayCardDescription: React.FunctionComponent<ICardDescriptionProps> = ({
 		>
 			{truncate ? (
 				<span className="text-truncate-inline">
-					<InnerTag className="text-truncate" href={href}>
+					<InnerTag
+						className="text-truncate"
+						href={disabled ? undefined : href}
+					>
 						{children}
 					</InnerTag>
 				</span>

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -1377,7 +1377,6 @@ exports[`ClayCardWithHorizontal renders as disabled 1`] = `
                   >
                     <span
                       class="text-truncate"
-                      href="#"
                     >
                       Foo Bar
                     </span>
@@ -1598,7 +1597,6 @@ exports[`ClayCardWithInfo renders as disabled 1`] = `
               >
                 <span
                   class="text-truncate"
-                  href="#"
                 >
                   Foo Bar
                 </span>
@@ -1933,7 +1931,6 @@ exports[`ClayCardWithUser renders as disabled 1`] = `
               >
                 <span
                   class="text-truncate"
-                  href="#"
                 >
                   Foo Bar
                 </span>


### PR DESCRIPTION
If the card is disabled, a `span` element will be rendered and no
`href` attribute is required

Fixes #3779