### PR TITLE
 feat(@clayui/css): Dropdown adds `.dropdown-menu-width-full`, `.dropdown-menu-width-sm`, `dropdown-menu-height-auto` modifier classes for larger dropdown menus with the Clay Drop Down plugin

### DIFF
--- a/packages/clay-css/src/content/dropdowns.html
+++ b/packages/clay-css/src/content/dropdowns.html
@@ -1169,6 +1169,56 @@ section: Components
 </div>
 
 <div class="clay-site-row-spacer row">
+	<div class="col-md-12 position-static">
+		<h3>Dropdown Menu Width Full</h3>
+
+		<blockquote class="blockquote">
+			<p>The modifier class `dropdown-menu-width-full` on `dropdown-menu` makes the menu expand the full width of the page. This should be used with the Clay Drop Down plugin which renders the `dropdown-menu` as a direct child of the `body` element.</p>
+		</blockquote>
+
+		<button class="btn btn-primary" id="dropdownMenuFull1" type="button">Doesn't Work Button</button>
+		<ul aria-labelledby="dropdownMenuFull1" class="dropdown-menu dropdown-menu-width-full" style="display:block;">
+			<li class="dropdown-header">Dropdown Header</li>
+			<li><a class="dropdown-item" href="#1">Action</a></li>
+			<li><a class="disabled dropdown-item" href="#1" tabindex="-1">Disabled</a></li>
+			<li class="dropdown-divider"></li>
+			<li><a class="dropdown-item" href="#1">Scope</a></li>
+		</ul>
+		<div style="padding-bottom: 180px;"></div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12 position-static">
+		<h3>Dropdown Menu Width Sm</h3>
+
+		<blockquote class="blockquote">
+			<p>The modifier class `dropdown-menu-width-sm` on `dropdown-menu` makes the menu 500px wide. The `dropdown-menu` becomes 100% wide at screen sizes 767px and below. This should be used with the Clay Drop Down plugin which renders the `dropdown-menu` as a direct child of the `body` element.</p>
+		</blockquote>
+
+		<button class="btn btn-primary" id="dropdownMenuWide1" type="button">Doesn't Work Button</button>
+		<ul aria-labelledby="dropdownMenuWide1" class="dropdown-menu dropdown-menu-width-sm" style="display:block;">
+			<li class="dropdown-header">Dropdown Header</li>
+			<li><a class="dropdown-item" href="#1">Action</a></li>
+			<li><a class="disabled dropdown-item" href="#1" tabindex="-1">Disabled</a></li>
+			<li class="dropdown-divider"></li>
+			<li><a class="dropdown-item" href="#1">Scope</a></li>
+		</ul>
+		<div style="padding-bottom: 180px;"></div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dropdown Menu Height Auto</h3>
+
+		<blockquote class="blockquote">
+			<p>The modifier class `dropdown-menu-height-auto` on `dropdown-menu` removes the `max-height` on the `dropdown-menu`.</p>
+		</blockquote>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
 	<div class="col-md-12">
 		<h3>Dropdown Alignment</h3>
 
@@ -1666,4 +1716,21 @@ section: Components
 	$('.input-group-inset').on('focusout', function(event) {
 		$(this).closest('.input-group-item').removeClass('focus');
 	});
+
+	var dropdownTriggerFull1 = document.querySelector('#dropdownMenuFull1');
+	var dropdownMenuFull1 = dropdownTriggerFull1.nextElementSibling;
+
+	var dropdownTriggerWide1 = document.querySelector('#dropdownMenuWide1');
+	var dropdownMenuWide1 = dropdownTriggerWide1.nextElementSibling;
+
+	dropdownMenuFull1.style.top = dropdownTriggerFull1.offsetTop + 40 + 'px';
+	dropdownMenuWide1.style.top = dropdownTriggerWide1.offsetTop + 40 + 'px';
+	dropdownMenuWide1.style.left = dropdownTriggerWide1.offsetLeft + 'px';
+
+	window.addEventListener('resize', function(event) {
+		dropdownMenuFull1.style.top = dropdownTriggerFull1.offsetTop + 40 + 'px';
+		dropdownMenuWide1.style.top = dropdownTriggerWide1.offsetTop + 40 + 'px';
+		dropdownMenuWide1.style.left = dropdownTriggerWide1.offsetLeft + 'px';
+	});
+
 </script>

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -579,6 +579,26 @@
 	}
 }
 
+// Dropdown Menu Width
+
+.dropdown-menu-width-full {
+	@include clay-css($dropdown-menu-width-full);
+}
+
+.dropdown-menu-width-sm {
+	@include clay-css($dropdown-menu-width-sm);
+
+	@include media-breakpoint-down(sm) {
+		@include clay-css($dropdown-menu-width-sm-sm-down);
+	}
+}
+
+// Dropdown Menu Height
+
+.dropdown-menu-height-auto {
+	@include clay-css($dropdown-menu-height-auto);
+}
+
 // Dropdown Menu Autocomplete
 
 .dropdown-full .autocomplete-dropdown-menu,

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -229,6 +229,52 @@ $dropdown-footer: map-merge(
 	$dropdown-footer
 );
 
+// Dropdown Menu Width
+
+$dropdown-menu-width-full: () !default;
+$dropdown-menu-width-full: map-merge(
+	(
+		left: 12px !important,
+		right: 12px !important,
+		max-width: none,
+		min-width: 0,
+		width: calc(100% - 24px),
+	),
+	$dropdown-menu-width-full
+);
+
+$dropdown-menu-width-sm: () !default;
+$dropdown-menu-width-sm: map-merge(
+	(
+		max-width: none,
+		min-width: 0,
+		width: 500px,
+	),
+	$dropdown-menu-width-sm
+);
+
+$dropdown-menu-width-sm-sm-down: () !default;
+$dropdown-menu-width-sm-sm-down: map-merge(
+	(
+		left: 12px !important,
+		right: 12px !important,
+		width: calc(100% - 24px),
+	),
+	$dropdown-menu-width-sm-sm-down
+);
+
+// Dropdown Menu Height
+
+$dropdown-menu-height-auto: () !default;
+$dropdown-menu-height-auto: map-merge(
+	(
+		height: auto,
+		max-height: none,
+		min-height: 0,
+	),
+	$dropdown-menu-height-auto
+);
+
 // Autocomplete Dropdown Menu
 
 $autocomplete-dropdown-menu: () !default;

--- a/packages/clay-drop-down/docs/markup-dropdown.md
+++ b/packages/clay-drop-down/docs/markup-dropdown.md
@@ -12,6 +12,9 @@ mainTabURL: 'docs/components/drop-down.html'
     -   [Default](#css-default)
     -   [Wide](#css-wide)
     -   [Full](#css-full)
+    -   [Width Full](#css-width-full)
+    -   [Width Sm](#css-width-sm)
+    -   [Height Auto](#css-height-auto)
 -   [Content Types](#css-content-types)
     -   [Dividers](#css-dividers)
     -   [Form Elements](#css-form-elements)
@@ -402,6 +405,67 @@ Use `.dropdown-full` to create a dropdown menu as wide as its relative parent.
 		</div>
 	</ul>
 </div>
+```
+
+### Dropdown Menu Width Full(#css-width-full)
+
+<div class="clay-site-alert alert alert-warning">This is a separate component from `.dropdown-full`, use one or the other.</div>
+
+The modifier class `dropdown-menu-width-full` on `dropdown-menu` makes the menu expand the full width of the page. This should be used with the Clay Drop Down plugin which renders the `dropdown-menu` as a direct child of the `body` element.
+
+```html
+<ul
+	aria-labelledby="theDropdownToggleId"
+	class="dropdown-menu dropdown-menu-width-full"
+>
+	<li class="dropdown-header">Dropdown Header</li>
+	<li><a class="dropdown-item" href="#1">Action</a></li>
+	<li>
+		<a class="disabled dropdown-item" href="#1" tabindex="-1">Disabled</a>
+	</li>
+	<li class="dropdown-divider"></li>
+	<li><a class="dropdown-item" href="#1">Scope</a></li>
+</ul>
+```
+
+### Dropdown Menu Width Sm(#css-width-sm)
+
+<div class="clay-site-alert alert alert-warning">This is a separate component from `.dropdown-wide`, use one or the other.</div>
+
+The modifier class `dropdown-menu-width-sm` on `dropdown-menu` makes the menu 500px wide. The `dropdown-menu` becomes 100% wide at screen sizes 767px and below. This should be used with the Clay Drop Down plugin which renders the `dropdown-menu` as a direct child of the `body` element.
+
+```html
+<ul
+	aria-labelledby="theDropdownToggleId"
+	class="dropdown-menu dropdown-menu-width-sm"
+>
+	<li class="dropdown-header">Dropdown Header</li>
+	<li><a class="dropdown-item" href="#1">Action</a></li>
+	<li>
+		<a class="disabled dropdown-item" href="#1" tabindex="-1">Disabled</a>
+	</li>
+	<li class="dropdown-divider"></li>
+	<li><a class="dropdown-item" href="#1">Scope</a></li>
+</ul>
+```
+
+### Dropdown Menu Height Auto(#css-height-auto)
+
+The modifier class `dropdown-menu-height-auto` on `dropdown-menu` removes the `max-height` on the `dropdown-menu`.
+
+```html
+<ul
+	aria-labelledby="theDropdownToggleId"
+	class="dropdown-menu dropdown-menu-height-auto"
+>
+	<li class="dropdown-header">Dropdown Header</li>
+	<li><a class="dropdown-item" href="#1">Action</a></li>
+	<li>
+		<a class="disabled dropdown-item" href="#1" tabindex="-1">Disabled</a>
+	</li>
+	<li class="dropdown-divider"></li>
+	<li><a class="dropdown-item" href="#1">Scope</a></li>
+</ul>
 ```
 
 ## Content Types(#css-content-types)


### PR DESCRIPTION
#3790