### PR TITLE
fix(@clayui/card): Use ClayButtonWithIcon instead of vanilla button in CardWithHorizontal 

### DIFF
--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -26,6 +26,7 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/button": "^3.5.0",
 		"@clayui/drop-down": "^3.8.0",
 		"@clayui/form": "^3.12.0",
 		"@clayui/icon": "^3.1.0",

--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
@@ -99,16 +100,13 @@ export const ClayCardWithHorizontal: React.FunctionComponent<IProps> = ({
 							items={actions}
 							spritemap={spritemap}
 							trigger={
-								<button
+								<ClayButtonWithIcon
 									{...dropDownTriggerProps}
 									className="component-action"
 									disabled={disabled}
-								>
-									<ClayIcon
-										spritemap={spritemap}
-										symbol="ellipsis-v"
-									/>
-								</button>
+									spritemap={spritemap}
+									symbol="ellipsis-v"
+								/>
 							}
 						/>
 					</ClayLayout.ContentCol>


### PR DESCRIPTION
See the bug description in https://github.com/liferay/clay/issues/3781

In this PR we are replacing vanilla `<button>` with `ClayButtonWithIcon`. It adds `type='button'` by default, preventing form submission.