### PR TITLE
fix(@clayui/card): Use ClayButtonWithIcon instead of vanilla button in clay-card

### DIFF
--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
@@ -212,16 +213,13 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 								items={actions}
 								spritemap={spritemap}
 								trigger={
-									<button
+									<ClayButtonWithIcon
 										{...dropDownTriggerProps}
 										className="component-action"
 										disabled={disabled}
-									>
-										<ClayIcon
-											spritemap={spritemap}
-											symbol="ellipsis-v"
-										/>
-									</button>
+										spritemap={spritemap}
+										symbol="ellipsis-v"
+									/>
 								}
 							/>
 						</ClayLayout.ContentCol>

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
@@ -178,16 +179,13 @@ export const ClayCardWithUser: React.FunctionComponent<IProps> = ({
 								items={actions}
 								spritemap={spritemap}
 								trigger={
-									<button
+									<ClayButtonWithIcon
 										{...dropDownTriggerProps}
 										className="component-action"
 										disabled={disabled}
-									>
-										<ClayIcon
-											spritemap={spritemap}
-											symbol="ellipsis-v"
-										/>
-									</button>
+										spritemap={spritemap}
+										symbol="ellipsis-v"
+									/>
 								}
 							/>
 						</ClayLayout.ContentCol>


### PR DESCRIPTION
This is a followup on https://github.com/liferay/clay/pull/3794, applying the same change to `ClayCardWithInfo` and `ClayCardWithUser`.