### PR TITLE
fix(@clayui/time-picker): make sure input always has a leading 0 for single digits

### DIFF
--- a/packages/clay-time-picker/src/__tests__/index.tsx
+++ b/packages/clay-time-picker/src/__tests__/index.tsx
@@ -226,8 +226,8 @@ describe('IncrementalInteractions', () => {
 			fireEvent.keyDown(minutesEl, {key: '1'});
 			fireEvent.keyDown(ampmEl, {key: 'ArrowUp'});
 
-			expect(hoursEl.value).toBe('1');
-			expect(minutesEl.value).toBe('1');
+			expect(hoursEl.value).toBe('01');
+			expect(minutesEl.value).toBe('01');
 			expect(ampmEl.value).toBe('PM');
 
 			fireEvent.click(
@@ -251,7 +251,7 @@ describe('IncrementalInteractions', () => {
 			fireEvent.focus(hoursEl, {});
 			fireEvent.click(spinIncEl, {});
 
-			expect(hoursEl.value).toBe('0');
+			expect(hoursEl.value).toBe('00');
 		});
 
 		it('increment the value of the minutes input with focus by clicking on the increment spin action', () => {
@@ -265,7 +265,7 @@ describe('IncrementalInteractions', () => {
 			fireEvent.focus(minutesEl, {});
 			fireEvent.click(spinIncEl, {});
 
-			expect(minutesEl.value).toBe('0');
+			expect(minutesEl.value).toBe('00');
 		});
 
 		it('increment the value of the am/pm input with focus by clicking on the increment spin action', () => {
@@ -347,7 +347,7 @@ describe('IncrementalInteractions', () => {
 
 			fireEvent.keyDown(hoursEl, {key: '1'});
 
-			expect(hoursEl.value).toBe('1');
+			expect(hoursEl.value).toBe('01');
 
 			fireEvent.keyDown(hoursEl, {key: 'Backspace'});
 
@@ -360,7 +360,7 @@ describe('IncrementalInteractions', () => {
 
 			fireEvent.keyDown(minutesEl, {key: '1'});
 
-			expect(minutesEl.value).toBe('1');
+			expect(minutesEl.value).toBe('01');
 
 			fireEvent.keyDown(minutesEl, {key: 'Backspace'});
 
@@ -388,7 +388,7 @@ describe('IncrementalInteractions', () => {
 
 			fireEvent.keyDown(hoursEl, {key: 'ArrowUp'});
 
-			expect(hoursEl.value).toBe('0');
+			expect(hoursEl.value).toBe('00');
 		});
 
 		it('pressing arrow up on the minutes input should increase value', () => {
@@ -397,7 +397,7 @@ describe('IncrementalInteractions', () => {
 
 			fireEvent.keyDown(minutesEl, {key: 'ArrowUp'});
 
-			expect(minutesEl.value).toBe('0');
+			expect(minutesEl.value).toBe('00');
 		});
 
 		it('pressing arrow down on the hour input should decrement value', () => {
@@ -446,7 +446,7 @@ describe('IncrementalInteractions', () => {
 				fireEvent.keyDown(hoursEl, {key: value});
 			});
 
-			expect(hoursEl.value).toBe('9');
+			expect(hoursEl.value).toBe('09');
 		});
 
 		it('only allows numbers to be entered in the input minutes', () => {
@@ -457,7 +457,7 @@ describe('IncrementalInteractions', () => {
 				fireEvent.keyDown(minutesEl, {key: value});
 			});
 
-			expect(minutesEl.value).toBe('9');
+			expect(minutesEl.value).toBe('09');
 		});
 
 		it('returns to the maximum value when it reaches the minimum value when pressing in the arrow down', () => {
@@ -468,8 +468,8 @@ describe('IncrementalInteractions', () => {
 			fireEvent.keyDown(hoursEl, {key: '0'});
 			fireEvent.keyDown(minutesEl, {key: '0'});
 
-			expect(hoursEl.value).toBe('0');
-			expect(minutesEl.value).toBe('0');
+			expect(hoursEl.value).toBe('00');
+			expect(minutesEl.value).toBe('00');
 
 			fireEvent.keyDown(hoursEl, {key: 'ArrowDown'});
 			fireEvent.keyDown(minutesEl, {key: 'ArrowDown'});
@@ -492,8 +492,8 @@ describe('IncrementalInteractions', () => {
 			fireEvent.keyDown(hoursEl, {key: 'ArrowUp'});
 			fireEvent.keyDown(minutesEl, {key: 'ArrowUp'});
 
-			expect(hoursEl.value).toBe('0');
-			expect(minutesEl.value).toBe('0');
+			expect(hoursEl.value).toBe('00');
+			expect(minutesEl.value).toBe('00');
 		});
 	});
 });

--- a/packages/clay-time-picker/src/index.tsx
+++ b/packages/clay-time-picker/src/index.tsx
@@ -193,18 +193,18 @@ const ClayTimePicker: React.FunctionComponent<IProps> = ({
 	) => {
 		const config = useConfig[configName];
 		const intrinsicValue = Number(value);
-		const setValue = (newValue: string | number) =>
-			onInputChange({
+		const setValue = (newValue: string | number) => {
+			const newVal =
+				configName === TimeType.ampm
+					? newValue
+					: handleMaxAndMin(String(newValue), config as ConfigMaxMin);
+
+			return onInputChange({
 				...values,
 				// eslint-disable-next-line sort-keys
-				[configName]:
-					configName === TimeType.ampm
-						? newValue
-						: handleMaxAndMin(
-								String(newValue),
-								config as ConfigMaxMin
-						  ),
+				[configName]: String(newVal).padStart(2, '0'),
 			});
+		};
 
 		switch (event.key) {
 			case 'Backspace':
@@ -238,11 +238,29 @@ const ClayTimePicker: React.FunctionComponent<IProps> = ({
 				break;
 			default:
 				if (regex.test(event.key) && configName !== TimeType.ampm) {
+					const maxFirstDigit =
+						configName === TimeType.hours
+							? use12Hours
+								? 1
+								: 2
+							: 5;
+
+					const newVal =
+						Number(value) > maxFirstDigit
+							? `0${event.key}`
+							: (value && value !== DEFAULT_VALUE ? value : '') +
+							  event.key;
+
+					setValue(newVal);
+				} else if (
+					configName === TimeType.ampm &&
+					(event.key === 'a' || event.key === 'p')
+				) {
 					setValue(
-						(value && value !== DEFAULT_VALUE ? value : '') +
-							event.key
+						event.key === 'a'
+							? (config as ConfigAmpm).am
+							: (config as ConfigAmpm).pm
 					);
-					(configName === TimeType.ampm && event.key === 'a') ||
 				}
 				break;
 		}
@@ -279,7 +297,7 @@ const ClayTimePicker: React.FunctionComponent<IProps> = ({
 		onInputChange({
 			...values,
 			// eslint-disable-next-line sort-keys
-			[configName]: value,
+			[configName]: String(value).padStart(2, '0'),
 		});
 	};
 

--- a/packages/clay-time-picker/src/index.tsx
+++ b/packages/clay-time-picker/src/index.tsx
@@ -113,7 +113,7 @@ const DEFAULT_CONFIG = {
 		},
 		hours: {
 			max: 12,
-			min: 0,
+			min: 1,
 		},
 		minutes: {
 			max: 59,
@@ -238,18 +238,22 @@ const ClayTimePicker: React.FunctionComponent<IProps> = ({
 				break;
 			default:
 				if (regex.test(event.key) && configName !== TimeType.ampm) {
-					const maxFirstDigit =
-						configName === TimeType.hours
-							? use12Hours
-								? 1
-								: 2
-							: 5;
+					const maxSecondDigit = Math.floor(
+						(config as ConfigMaxMin).max / 10
+					);
+
+					const minFirstDigit = (config as ConfigMaxMin).min;
+
+					const keyVal =
+						intrinsicValue < minFirstDigit
+							? minFirstDigit
+							: event.key;
 
 					const newVal =
-						Number(value) > maxFirstDigit
-							? `0${event.key}`
+						Number(value) > maxSecondDigit
+							? `0${keyVal}`
 							: (value && value !== DEFAULT_VALUE ? value : '') +
-							  event.key;
+							  keyVal;
 
 					setValue(newVal);
 				} else if (

--- a/packages/clay-time-picker/src/index.tsx
+++ b/packages/clay-time-picker/src/index.tsx
@@ -112,7 +112,7 @@ const DEFAULT_CONFIG = {
 			pm: 'PM',
 		},
 		hours: {
-			max: 11,
+			max: 12,
 			min: 0,
 		},
 		minutes: {
@@ -242,6 +242,7 @@ const ClayTimePicker: React.FunctionComponent<IProps> = ({
 						(value && value !== DEFAULT_VALUE ? value : '') +
 							event.key
 					);
+					(configName === TimeType.ampm && event.key === 'a') ||
 				}
 				break;
 		}


### PR DESCRIPTION
fixes #3784
fixes #3782


The interactions should now be more consistent with the html native time picker