### PR TITLE
fix(@clayui/card): Change default symbols and add displayType attribute to CardWithInfo so the the correct default symbol and sticker symbol could be used depending on the displayType

### DIFF
--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -15,6 +15,8 @@ import React from 'react';
 
 import ClayCard from './Card';
 
+type CardWithInfoDisplayType = 'file' | 'image';
+
 interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * List of actions in the dropdown menu
@@ -35,6 +37,11 @@ interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	 * Flag to indicate that all interactions on the card will be disabled.
 	 */
 	disabled?: boolean;
+
+	/**
+	 * Determines the style of the card
+	 */
+	displayType?: CardWithInfoDisplayType;
 
 	/**
 	 * Props to add to the dropdown trigger element
@@ -108,6 +115,7 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 	checkboxProps = {},
 	description,
 	disabled,
+	displayType,
 	dropDownTriggerProps = {},
 	flushHorizontal,
 	flushVertical,
@@ -118,15 +126,29 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 	selected = false,
 	spritemap,
 	stickerProps,
-	symbol = 'documents-and-media',
+	symbol,
 	title,
 	...otherProps
 }: IProps) => {
+	const isCardType = {
+		file: displayType === 'file' && !imgProps,
+		image: displayType === 'image' || imgProps,
+	};
+
 	const headerContent = (
 		<ClayCard.AspectRatio className="card-item-first">
 			{!imgProps && (
 				<div className="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
-					<ClayIcon spritemap={spritemap} symbol={symbol} />
+					<ClayIcon
+						spritemap={spritemap}
+						symbol={
+							symbol
+								? symbol
+								: isCardType.image
+								? 'camera'
+								: 'documents-and-media'
+						}
+					/>
 				</div>
 			)}
 
@@ -162,7 +184,14 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 						stickerProps.content
 					)
 				) : (
-					<ClayIcon spritemap={spritemap} symbol="document-text" />
+					<ClayIcon
+						spritemap={spritemap}
+						symbol={
+							isCardType.image
+								? 'document-image'
+								: 'document-default'
+						}
+					/>
 				)}
 			</ClaySticker>
 		</ClayCard.AspectRatio>
@@ -171,7 +200,7 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 	return (
 		<ClayCard
 			{...otherProps}
-			displayType={imgProps ? 'image' : 'file'}
+			displayType={isCardType.image ? 'image' : 'file'}
 			selectable={!!onSelectChange}
 		>
 			{onSelectChange && (

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -1567,11 +1567,379 @@ exports[`ClayCardWithInfo renders as disabled 1`] = `
                 class="sticker-overlay"
               >
                 <svg
-                  class="lexicon-icon lexicon-icon-document-text"
+                  class="lexicon-icon lexicon-icon-document-default"
                   role="presentation"
                 >
                   <use
-                    xlink:href="/path/to/some/resource.svg#document-text"
+                    xlink:href="/path/to/some/resource.svg#document-default"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </label>
+      </div>
+      <div
+        class="card-body"
+      >
+        <div
+          class="card-row"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <p
+              class="card-title"
+              title="Foo Bar"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <span
+                  class="text-truncate"
+                >
+                  Foo Bar
+                </span>
+              </span>
+            </p>
+            <p
+              class="card-subtitle"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <span
+                  class="text-truncate"
+                />
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayCardWithInfo renders as file card specifying the displayType 1`] = `
+<div>
+  <div
+    class="card-type-asset file-card form-check form-check-card form-check-top-left"
+  >
+    <div
+      class="card"
+    >
+      <div
+        class="custom-control custom-checkbox"
+      >
+        <label>
+          <input
+            class="custom-control-input"
+            disabled=""
+            type="checkbox"
+          />
+          <span
+            class="custom-control-label"
+          />
+          <div
+            class="card-item-first aspect-ratio"
+          >
+            <div
+              class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-documents-and-media"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/path/to/some/resource.svg#documents-and-media"
+                />
+              </svg>
+            </div>
+            <span
+              class="sticker sticker-primary sticker-bottom-left"
+            >
+              <span
+                class="sticker-overlay"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-document-default"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#document-default"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </label>
+      </div>
+      <div
+        class="card-body"
+      >
+        <div
+          class="card-row"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <p
+              class="card-title"
+              title="Foo Bar"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <span
+                  class="text-truncate"
+                >
+                  Foo Bar
+                </span>
+              </span>
+            </p>
+            <p
+              class="card-subtitle"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <span
+                  class="text-truncate"
+                />
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayCardWithInfo renders as image card specifying imageProps and not the displayType 1`] = `
+<div>
+  <div
+    class="card-type-asset form-check form-check-card form-check-top-left image-card"
+  >
+    <div
+      class="card"
+    >
+      <div
+        class="custom-control custom-checkbox"
+      >
+        <label>
+          <input
+            class="custom-control-input"
+            disabled=""
+            type="checkbox"
+          />
+          <span
+            class="custom-control-label"
+          />
+          <div
+            class="card-item-first aspect-ratio"
+          >
+            <img
+              class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid"
+              src="path/to/an/image"
+            />
+            <span
+              class="sticker sticker-primary sticker-bottom-left"
+            >
+              <span
+                class="sticker-overlay"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-document-image"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#document-image"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </label>
+      </div>
+      <div
+        class="card-body"
+      >
+        <div
+          class="card-row"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <p
+              class="card-title"
+              title="Foo Bar"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <span
+                  class="text-truncate"
+                >
+                  Foo Bar
+                </span>
+              </span>
+            </p>
+            <p
+              class="card-subtitle"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <span
+                  class="text-truncate"
+                />
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayCardWithInfo renders as image card specifying the displayType and imageProps 1`] = `
+<div>
+  <div
+    class="card-type-asset form-check form-check-card form-check-top-left image-card"
+  >
+    <div
+      class="card"
+    >
+      <div
+        class="custom-control custom-checkbox"
+      >
+        <label>
+          <input
+            class="custom-control-input"
+            disabled=""
+            type="checkbox"
+          />
+          <span
+            class="custom-control-label"
+          />
+          <div
+            class="card-item-first aspect-ratio"
+          >
+            <img
+              class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid"
+              src="path/to/an/image"
+            />
+            <span
+              class="sticker sticker-primary sticker-bottom-left"
+            >
+              <span
+                class="sticker-overlay"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-document-image"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#document-image"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </label>
+      </div>
+      <div
+        class="card-body"
+      >
+        <div
+          class="card-row"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <p
+              class="card-title"
+              title="Foo Bar"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <span
+                  class="text-truncate"
+                >
+                  Foo Bar
+                </span>
+              </span>
+            </p>
+            <p
+              class="card-subtitle"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <span
+                  class="text-truncate"
+                />
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayCardWithInfo renders as image card specifying the displayType and no imageProps 1`] = `
+<div>
+  <div
+    class="card-type-asset form-check form-check-card form-check-top-left image-card"
+  >
+    <div
+      class="card"
+    >
+      <div
+        class="custom-control custom-checkbox"
+      >
+        <label>
+          <input
+            class="custom-control-input"
+            disabled=""
+            type="checkbox"
+          />
+          <span
+            class="custom-control-label"
+          />
+          <div
+            class="card-item-first aspect-ratio"
+          >
+            <div
+              class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-camera"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/path/to/some/resource.svg#camera"
+                />
+              </svg>
+            </div>
+            <span
+              class="sticker sticker-primary sticker-bottom-left"
+            >
+              <span
+                class="sticker-overlay"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-document-image"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#document-image"
                   />
                 </svg>
               </span>
@@ -1648,11 +2016,11 @@ exports[`ClayCardWithInfo renders as not selectable 1`] = `
           class="sticker-overlay"
         >
           <svg
-            class="lexicon-icon lexicon-icon-document-text"
+            class="lexicon-icon lexicon-icon-document-default"
             role="presentation"
           >
             <use
-              xlink:href="/some/spritemap#document-text"
+              xlink:href="/some/spritemap#document-default"
             />
           </svg>
         </span>
@@ -1757,11 +2125,11 @@ exports[`ClayCardWithInfo renders as selectable 1`] = `
                 class="sticker-overlay"
               >
                 <svg
-                  class="lexicon-icon lexicon-icon-document-text"
+                  class="lexicon-icon lexicon-icon-document-default"
                   role="presentation"
                 >
                   <use
-                    xlink:href="/path/to/some/resource.svg#document-text"
+                    xlink:href="/path/to/some/resource.svg#document-default"
                   />
                 </svg>
               </span>

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -837,6 +837,71 @@ describe('ClayCardWithInfo', () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it('renders as file card specifying the displayType', () => {
+		const {container} = render(
+			<ClayCardWithInfo
+				disabled
+				displayType="file"
+				href="#"
+				onSelectChange={jest.fn()}
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				title="Foo Bar"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders as image card specifying the displayType and no imageProps', () => {
+		const {container} = render(
+			<ClayCardWithInfo
+				disabled
+				displayType="image"
+				href="#"
+				onSelectChange={jest.fn()}
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				title="Foo Bar"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders as image card specifying the displayType and imageProps', () => {
+		const {container} = render(
+			<ClayCardWithInfo
+				disabled
+				displayType="image"
+				href="#"
+				imgProps="path/to/an/image"
+				onSelectChange={jest.fn()}
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				title="Foo Bar"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders as image card specifying imageProps and not the displayType', () => {
+		const {container} = render(
+			<ClayCardWithInfo
+				disabled
+				href="#"
+				imgProps="path/to/an/image"
+				onSelectChange={jest.fn()}
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				title="Foo Bar"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
 	it('renders with custom sticker', () => {
 		const {container} = render(
 			<ClayCardWithInfo


### PR DESCRIPTION
Fixes https://github.com/liferay/clay/issues/3786