### PR TITLE
fix(@clayui/card): Set display type of dropdown triggers to `unstyled`

### DIFF
--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -104,6 +104,7 @@ export const ClayCardWithHorizontal: React.FunctionComponent<IProps> = ({
 									{...dropDownTriggerProps}
 									className="component-action"
 									disabled={disabled}
+									displayType="unstyled"
 									spritemap={spritemap}
 									symbol="ellipsis-v"
 								/>

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -223,6 +223,7 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 										{...dropDownTriggerProps}
 										className="component-action"
 										disabled={disabled}
+										displayType="unstyled"
 										spritemap={spritemap}
 										symbol="ellipsis-v"
 									/>

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -165,6 +165,7 @@ export const ClayCardWithUser: React.FunctionComponent<IProps> = ({
 										{...dropDownTriggerProps}
 										className="component-action"
 										disabled={disabled}
+										displayType="unstyled"
 										spritemap={spritemap}
 										symbol="ellipsis-v"
 									/>

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -1445,6 +1445,27 @@ exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
               </span>
             </p>
           </div>
+          <div
+            class="autofit-col"
+          >
+            <div
+              class="dropdown"
+            >
+              <button
+                class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-ellipsis-v"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#ellipsis-v"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -1708,6 +1729,27 @@ exports[`ClayCardWithInfo renders as not selectable 1`] = `
                 Awesome
               </span>
             </span>
+          </div>
+        </div>
+        <div
+          class="autofit-col"
+        >
+          <div
+            class="dropdown"
+          >
+            <button
+              class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-ellipsis-v"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/some/spritemap#ellipsis-v"
+                />
+              </svg>
+            </button>
           </div>
         </div>
       </div>
@@ -2222,6 +2264,27 @@ exports[`ClayCardWithUser renders as selectable 1`] = `
                 </span>
               </span>
             </p>
+          </div>
+          <div
+            class="autofit-col"
+          >
+            <div
+              class="dropdown"
+            >
+              <button
+                class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-ellipsis-v"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#ellipsis-v"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -611,6 +611,11 @@ describe('ClayCardWithUser', () => {
 
 		const {container} = render(
 			<ClayCardWithUser
+				actions={[
+					{
+						onClick: () => {},
+					},
+				]}
 				description="Test"
 				href="#"
 				name="Foo Bar"
@@ -711,6 +716,11 @@ describe('ClayCardWithHorizontal', () => {
 	it('renders as not selectable', () => {
 		const {container} = render(
 			<ClayCardWithHorizontal
+				actions={[
+					{
+						onClick: () => {},
+					},
+				]}
 				href="#"
 				spritemap="/path/to/some/resource.svg"
 				title="Foo Bar"
@@ -762,6 +772,11 @@ describe('ClayCardWithInfo', () => {
 	it('renders as not selectable', () => {
 		const {container} = render(
 			<ClayCardWithInfo
+				actions={[
+					{
+						onClick: () => {},
+					},
+				]}
 				description="A cool description"
 				href="#"
 				labels={[


### PR DESCRIPTION
This PR fixes the bug in https://github.com/liferay/clay/issues/3807

There is no need to update tags on the portal side, we are [already setting](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownActionsTag.java#L31) the `unstlyed` display style in server-side rendering.

This issue was unnoticed because button styles were overriden by `.component-action` styles, that is why trigger looks correct in the storybook. But, in recent portal changes, higher priority was given to `btn-primary` class, that exposed the issue.

To test without portal, just on storybook:
1. Remove `color` and `background-color` from `.component-action`
2. Compare before and after PR

@julien @carloslancha 

Before PR:
![before](https://user-images.githubusercontent.com/5435511/99964444-8f25e580-2d93-11eb-9955-4e2edcb2d6d9.png)

After PR:
![after](https://user-images.githubusercontent.com/5435511/99964452-9220d600-2d93-11eb-87b5-c9ee4dfd7394.png)
