### PR TITLE
fix: Make stickerProps nullable and minor refactor

### DIFF
--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -93,11 +93,9 @@ interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * Values used in displaying bottom-left icon
 	 */
-	stickerProps?:
-		| (IClayStickerProps & {
-				content?: React.ReactNode;
-		  })
-		| null;
+	stickerProps?: IClayStickerProps & {
+		content?: React.ReactNode;
+	};
 
 	/**
 	 * Name of icon
@@ -125,7 +123,7 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 	onSelectChange,
 	selected = false,
 	spritemap,
-	stickerProps,
+	stickerProps = {},
 	symbol,
 	title,
 	...otherProps
@@ -171,22 +169,20 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 				/>
 			)}
 
-			{stickerProps !== null && (
+			{stickerProps && (
 				<ClaySticker
 					displayType={
-						stickerProps && stickerProps.displayType
+						stickerProps.displayType
 							? stickerProps.displayType
 							: 'primary'
 					}
 					position="bottom-left"
 					{...stickerProps}
 				>
-					{stickerProps ? (
-						stickerProps.children ? (
-							stickerProps.children
-						) : (
-							stickerProps.content
-						)
+					{stickerProps.children ? (
+						stickerProps.children
+					) : stickerProps.content ? (
+						stickerProps.content
 					) : (
 						<ClayIcon
 							spritemap={spritemap}

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -11,7 +11,7 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClaySticker, {IClayStickerProps} from '@clayui/sticker';
 import classNames from 'classnames';
-import React, {useMemo} from 'react';
+import React from 'react';
 
 import ClayCard from './Card';
 
@@ -135,25 +135,15 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 		image: displayType === 'image' || imgProps,
 	};
 
-	const contentSymbol = useMemo(() => {
-		if (!symbol) {
-			if (isCardType.image) {
-				return 'camera';
-			}
+	const contentSymbol = symbol
+		? symbol
+		: isCardType.image
+		? 'camera'
+		: 'documents-and-media';
 
-			return 'documents-and-media';
-		}
-
-		return symbol;
-	}, [isCardType]);
-
-	const stickerSymbol = useMemo(() => {
-		if (isCardType.image) {
-			return 'document-image';
-		}
-
-		return 'document-default';
-	}, [isCardType]);
+	const stickerSymbol = isCardType.image
+		? 'document-image'
+		: 'document-default';
 
 	const headerContent = (
 		<ClayCard.AspectRatio className="card-item-first">

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -11,11 +11,9 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClaySticker, {IClayStickerProps} from '@clayui/sticker';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import ClayCard from './Card';
-
-type CardWithInfoDisplayType = 'file' | 'image';
 
 interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
@@ -41,7 +39,7 @@ interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * Determines the style of the card
 	 */
-	displayType?: CardWithInfoDisplayType;
+	displayType?: 'file' | 'image';
 
 	/**
 	 * Props to add to the dropdown trigger element
@@ -95,9 +93,11 @@ interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * Values used in displaying bottom-left icon
 	 */
-	stickerProps?: IClayStickerProps & {
-		content?: React.ReactNode;
-	};
+	stickerProps?:
+		| (IClayStickerProps & {
+				content?: React.ReactNode;
+		  })
+		| null;
 
 	/**
 	 * Name of icon
@@ -135,20 +135,31 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 		image: displayType === 'image' || imgProps,
 	};
 
+	const contentSymbol = useMemo(() => {
+		if (!symbol) {
+			if (isCardType.image) {
+				return 'camera';
+			}
+
+			return 'documents-and-media';
+		}
+
+		return symbol;
+	}, [isCardType]);
+
+	const stickerSymbol = useMemo(() => {
+		if (isCardType.image) {
+			return 'document-image';
+		}
+
+		return 'document-default';
+	}, [isCardType]);
+
 	const headerContent = (
 		<ClayCard.AspectRatio className="card-item-first">
 			{!imgProps && (
 				<div className="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
-					<ClayIcon
-						spritemap={spritemap}
-						symbol={
-							symbol
-								? symbol
-								: isCardType.image
-								? 'camera'
-								: 'documents-and-media'
-						}
-					/>
+					<ClayIcon spritemap={spritemap} symbol={contentSymbol} />
 				</div>
 			)}
 
@@ -170,32 +181,30 @@ export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
 				/>
 			)}
 
-			<ClaySticker
-				displayType={
-					stickerProps && stickerProps.displayType
-						? stickerProps.displayType
-						: 'primary'
-				}
-				position="bottom-left"
-				{...stickerProps}
-			>
-				{stickerProps ? (
-					stickerProps.children ? (
-						stickerProps.children
+			{stickerProps !== null && (
+				<ClaySticker
+					displayType={
+						stickerProps && stickerProps.displayType
+							? stickerProps.displayType
+							: 'primary'
+					}
+					position="bottom-left"
+					{...stickerProps}
+				>
+					{stickerProps ? (
+						stickerProps.children ? (
+							stickerProps.children
+						) : (
+							stickerProps.content
+						)
 					) : (
-						stickerProps.content
-					)
-				) : (
-					<ClayIcon
-						spritemap={spritemap}
-						symbol={
-							isCardType.image
-								? 'document-image'
-								: 'document-default'
-						}
-					/>
-				)}
-			</ClaySticker>
+						<ClayIcon
+							spritemap={spritemap}
+							symbol={stickerSymbol}
+						/>
+					)}
+				</ClaySticker>
+			)}
 		</ClayCard.AspectRatio>
 	);
 

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -2321,7 +2321,16 @@ exports[`ClayCardWithInfo renders with custom sticker 1`] = `
       >
         <span
           class="sticker-overlay"
-        />
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-document-default"
+            role="presentation"
+          >
+            <use
+              xlink:href="/some/spritemap#document-default"
+            />
+          </svg>
+        </span>
       </span>
     </div>
     <div
@@ -2582,6 +2591,22 @@ exports[`ClayCardWithInfo renders with no sticker 1`] = `
                 />
               </svg>
             </div>
+            <span
+              class="sticker sticker-primary sticker-bottom-left"
+            >
+              <span
+                class="sticker-overlay"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-document-default"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#document-default"
+                  />
+                </svg>
+              </span>
+            </span>
           </div>
         </label>
       </div>

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -2548,6 +2548,75 @@ exports[`ClayCardWithInfo renders with description 1`] = `
 </div>
 `;
 
+exports[`ClayCardWithInfo renders with no sticker 1`] = `
+<div>
+  <div
+    class="card-type-asset file-card form-check form-check-card form-check-top-left"
+  >
+    <div
+      class="card"
+    >
+      <div
+        class="custom-control custom-checkbox"
+      >
+        <label>
+          <input
+            class="custom-control-input"
+            type="checkbox"
+          />
+          <span
+            class="custom-control-label"
+          />
+          <div
+            class="card-item-first aspect-ratio"
+          >
+            <div
+              class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-documents-and-media"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/path/to/some/resource.svg#documents-and-media"
+                />
+              </svg>
+            </div>
+          </div>
+        </label>
+      </div>
+      <div
+        class="card-body"
+      >
+        <div
+          class="card-row"
+        >
+          <div
+            class="autofit-col autofit-col-expand"
+          >
+            <p
+              class="card-title"
+              title="Foo Bar"
+            >
+              <span
+                class="text-truncate-inline"
+              >
+                <a
+                  class="text-truncate"
+                  href="#"
+                >
+                  Foo Bar
+                </a>
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ClayCardWithUser renders ClayCardWithNavigation with image 1`] = `
 <div>
   <a

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -850,21 +850,6 @@ describe('ClayCardWithInfo', () => {
 		expect(container).toMatchSnapshot();
 	});
 
-	it('renders with no sticker', () => {
-		const {container} = render(
-			<ClayCardWithInfo
-				href="#"
-				onSelectChange={jest.fn()}
-				selected={false}
-				spritemap="/path/to/some/resource.svg"
-				stickerProps={null}
-				title="Foo Bar"
-			/>
-		);
-
-		expect(container).toMatchSnapshot();
-	});
-
 	it('renders as file card specifying the displayType', () => {
 		const {container} = render(
 			<ClayCardWithInfo
@@ -1014,6 +999,21 @@ describe('ClayCardWithInfo', () => {
 					size: 'xl',
 				}}
 				title="Very Large File"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders with no sticker', () => {
+		const {container} = render(
+			<ClayCardWithInfo
+				href="#"
+				onSelectChange={jest.fn()}
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				stickerProps={undefined}
+				title="Foo Bar"
 			/>
 		);
 

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -850,6 +850,21 @@ describe('ClayCardWithInfo', () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it('renders with no sticker', () => {
+		const {container} = render(
+			<ClayCardWithInfo
+				href="#"
+				onSelectChange={jest.fn()}
+				selected={false}
+				spritemap="/path/to/some/resource.svg"
+				stickerProps={null}
+				title="Foo Bar"
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
 	it('renders as file card specifying the displayType', () => {
 		const {container} = render(
 			<ClayCardWithInfo


### PR DESCRIPTION
Fixes https://github.com/liferay/clay/issues/3816

With this pr we're adding support to pass `stickerProps={null}`, which will cause that the sticker will not be rendered.

In DXP we'll need to add a `showSticker` attribute to `vertical-card`, `file-card` and `image-card` tags, defaults to `true` and in `VerticalCard.js` pass `stickerProps={null}` if `showSticker` is `false`.

We'll need to add `isSticker` method to `VerticalCard.java` model, defaults to `true`.