### PR TITLE
fix(@clayui/card): prevent double 'card' class on ClayCardWithHorizontal

### DIFF
--- a/packages/clay-card/src/Card.tsx
+++ b/packages/clay-card/src/Card.tsx
@@ -69,8 +69,7 @@ const ClayCard: React.FunctionComponent<IProps> & {
 				{...otherProps}
 				className={classNames(className, {
 					card: !selectable && (!horizontal || interactive),
-					'card-interactive card-interactive-primary card-type-template':
-						interactive,
+					'card-interactive card-interactive-primary card-type-template': interactive,
 					'card-type-asset':
 						isCardType.file || isCardType.image || isCardType.user,
 					'card-type-directory form-check form-check-card form-check-middle-left':
@@ -85,7 +84,7 @@ const ClayCard: React.FunctionComponent<IProps> & {
 					'template-card': interactive && !horizontal,
 					'template-card-horizontal': horizontal && interactive,
 					'user-card': isCardType.user,
-				}) || undefined}
+				})}
 				href={interactive ? href : undefined}
 				onClick={onClick}
 				role={onClick ? 'button' : undefined}

--- a/packages/clay-card/src/Card.tsx
+++ b/packages/clay-card/src/Card.tsx
@@ -68,9 +68,9 @@ const ClayCard: React.FunctionComponent<IProps> & {
 			<TagHeaderName
 				{...otherProps}
 				className={classNames(className, {
-					card: !selectable,
+					card: !selectable && (!horizontal || interactive),
 					'card-interactive card-interactive-primary card-type-template':
-						(horizontal && interactive) || interactive,
+						interactive,
 					'card-type-asset':
 						isCardType.file || isCardType.image || isCardType.user,
 					'card-type-directory form-check form-check-card form-check-middle-left':
@@ -85,7 +85,7 @@ const ClayCard: React.FunctionComponent<IProps> & {
 					'template-card': interactive && !horizontal,
 					'template-card-horizontal': horizontal && interactive,
 					'user-card': isCardType.user,
-				})}
+				}) || undefined}
 				href={interactive ? href : undefined}
 				onClick={onClick}
 				role={onClick ? 'button' : undefined}

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -2,9 +2,7 @@
 
 exports[`ClayCard renders a ClayCard as a directory 1`] = `
 <div>
-  <div
-    class="card"
-  >
+  <div>
     <div
       class="card card-horizontal"
     >
@@ -1394,9 +1392,7 @@ exports[`ClayCardWithHorizontal renders as disabled 1`] = `
 
 exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
 <div>
-  <div
-    class="card"
-  >
+  <div>
     <div
       class="card card-horizontal"
     >

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`ClayCard renders a ClayCard as a directory 1`] = `
 <div>
-  <div>
+  <div
+    class=""
+  >
     <div
       class="card card-horizontal"
     >
@@ -1392,7 +1394,9 @@ exports[`ClayCardWithHorizontal renders as disabled 1`] = `
 
 exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
 <div>
-  <div>
+  <div
+    class=""
+  >
     <div
       class="card card-horizontal"
     >


### PR DESCRIPTION
Fixes: https://github.com/liferay/clay/issues/3789

In this PR we are removing the case of double `card` class:
- Outer class is [added](https://github.com/liferay/clay/blob/master/packages/clay-card/src/Card.tsx#L71) when `!selectable`
- Inner class is [added](https://github.com/liferay/clay/blob/master/packages/clay-card/src/Body.tsx#L24-L26) when the card is `horizontal` and `!interactive`. 

In analysis I found that removing inner card would we problematic, but removing outer would be doable after we remove the only case that relies on outer CSS class: horizontal interactive card. We achieved this with navigation card, so we're good to go.

As this is released, we need to update server side rendering in horizontal tag to match markup, specifically we need to delete [these three lines](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java#L114-L116):
```
else {
	cssClasses.add("card");
}
```

Notes:
- This is no longer a fix for a blocker, as the case in the original ticket was fixed by a different solution, a navigation card. This is now more of an improvement, to prevent future headaches.
- There is a bit of SF in this PR: `(horizontal && interactive) || interactive` is the same as `interactive`
- `|| undefined` on the end of `classNames` is to prevent `class=""` in markup. See more [here](https://github.com/JedWatson/classnames/issues/115).

@carloslancha @julien 