### PR TITLE
refactor(@clayui/card): Simplifies the use of the ClayCard component and separates it into components by responsibilities

### DIFF
--- a/packages/clay-card/src/Body.tsx
+++ b/packages/clay-card/src/Body.tsx
@@ -11,21 +11,15 @@ import Context from './Context';
 const ClayCardBody: React.FunctionComponent<React.HTMLAttributes<
 	HTMLDivElement
 >> = ({children, className, ...otherProps}) => {
-	const {horizontal, interactive} = React.useContext(Context);
+	const {interactive} = React.useContext(Context);
 
 	const TagName = interactive ? 'span' : 'div';
 
-	const content = (
+	return (
 		<TagName className={classNames('card-body', className)} {...otherProps}>
 			{children}
 		</TagName>
 	);
-
-	if (horizontal && !interactive) {
-		return <div className="card card-horizontal">{content}</div>;
-	}
-
-	return content;
 };
 
 export default ClayCardBody;

--- a/packages/clay-card/src/Card.tsx
+++ b/packages/clay-card/src/Card.tsx
@@ -3,25 +3,24 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
 
 import AspectRatio from './AspectRatio';
 import Body from './Body';
 import Caption from './Caption';
+import {ClayCardHorizontal} from './CardHorizontal';
+import {ClayCardNavigation} from './CardNavigation';
 import Context, {IContext} from './Context';
 import Description from './Description';
 import Group from './Group';
 import Row from './Row';
 
-type CardDisplayType = 'file' | 'image' | 'user';
-
 export interface ICardProps extends IContext {
 	/**
 	 * Determines the style of the card
 	 */
-	displayType?: CardDisplayType;
+	displayType?: 'file' | 'image' | 'user';
 
 	/**
 	 * Flag that indicates if the card can be selectable.
@@ -35,77 +34,69 @@ interface IProps
 			HTMLAnchorElement | HTMLSpanElement | HTMLDivElement
 		> {}
 
-const ClayCard: React.FunctionComponent<IProps> & {
-	AspectRatio: typeof AspectRatio;
-	Body: typeof Body;
-	Caption: typeof Caption;
-	Description: typeof Description;
-	Group: typeof Group;
-	Row: typeof Row;
-} = ({
+const ClayCard: React.FunctionComponent<IProps> = ({
 	children,
 	className,
 	displayType,
-	horizontal,
-	href,
-	interactive,
-	onClick,
 	selectable = false,
 	...otherProps
-}: IProps) => {
+}) => {
 	const isCardType = {
 		file: displayType === 'file',
 		image: displayType === 'image',
 		user: displayType === 'user',
 	};
 
-	const TagHeaderName = href ? ClayLink : 'div';
-
-	const TagName = interactive ? 'span' : 'div';
-
 	return (
-		<Context.Provider value={{horizontal, interactive}}>
-			<TagHeaderName
-				{...otherProps}
-				className={classNames(className, {
-					card: !selectable && (!horizontal || interactive),
-					'card-interactive card-interactive-primary card-type-template': interactive,
-					'card-type-asset':
-						isCardType.file || isCardType.image || isCardType.user,
-					'card-type-directory form-check form-check-card form-check-middle-left':
-						selectable && horizontal,
-					'file-card': isCardType.file,
-					'form-check form-check-card form-check-top-left':
-						selectable &&
-						(isCardType.file ||
-							isCardType.image ||
-							isCardType.user),
-					'image-card': isCardType.image,
-					'template-card': interactive && !horizontal,
-					'template-card-horizontal': horizontal && interactive,
-					'user-card': isCardType.user,
-				})}
-				href={interactive ? href : undefined}
-				onClick={onClick}
-				role={onClick ? 'button' : undefined}
-			>
-				{(selectable && !horizontal) ||
-				(selectable && isCardType.image) ||
-				isCardType.user ? (
-					<TagName className="card">{children}</TagName>
-				) : (
-					<>{children}</>
+		<Context.Provider value={{horizontal: false, interactive: false}}>
+			<div
+				className={classNames(
+					className,
+					{
+						card: !selectable,
+						'file-card': isCardType.file,
+						'form-check-card form-check form-check-top-left': selectable,
+						'image-card': isCardType.image,
+						'user-card': isCardType.user,
+					},
+					'card-type-asset'
 				)}
-			</TagHeaderName>
+				{...otherProps}
+			>
+				{selectable ? <div className="card">{children}</div> : children}
+			</div>
 		</Context.Provider>
 	);
 };
 
-ClayCard.AspectRatio = AspectRatio;
-ClayCard.Body = Body;
-ClayCard.Caption = Caption;
-ClayCard.Description = Description;
-ClayCard.Group = Group;
-ClayCard.Row = Row;
+const ClayCardHybrid: React.FunctionComponent<IProps> & {
+	AspectRatio: typeof AspectRatio;
+	Body: typeof Body;
+	Caption: typeof Caption;
+	Description: typeof Description;
+	Group: typeof Group;
+	Row: typeof Row;
+} = ({children, horizontal, interactive, ...otherProps}: IProps) => {
+	const Container = interactive
+		? ClayCardNavigation
+		: horizontal
+		? ClayCardHorizontal
+		: ClayCard;
 
-export default ClayCard;
+	return (
+		<Container horizontal={horizontal} {...otherProps}>
+			{children}
+		</Container>
+	);
+};
+
+ClayCardHybrid.displayName = 'ClayCard';
+
+ClayCardHybrid.AspectRatio = AspectRatio;
+ClayCardHybrid.Body = Body;
+ClayCardHybrid.Caption = Caption;
+ClayCardHybrid.Description = Description;
+ClayCardHybrid.Group = Group;
+ClayCardHybrid.Row = Row;
+
+export default ClayCardHybrid;

--- a/packages/clay-card/src/CardHorizontal.tsx
+++ b/packages/clay-card/src/CardHorizontal.tsx
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+import Context from './Context';
+
+interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
+	/**
+	 * Flag that indicates if the card can be selectable.
+	 */
+	selectable?: boolean;
+}
+
+const ClayCardHorizontalBody: React.FunctionComponent<React.HTMLAttributes<
+	HTMLDivElement
+>> = ({children, className, ...otherProps}) => (
+	<div
+		className={classNames('card card-horizontal', className)}
+		{...otherProps}
+	>
+		{children}
+	</div>
+);
+
+export const ClayCardHorizontal: React.FunctionComponent<IProps> & {
+	Body: typeof ClayCardHorizontalBody;
+} = ({children, className, selectable, ...otherProps}) => (
+	<Context.Provider value={{horizontal: true, interactive: false}}>
+		<div
+			className={classNames(
+				className,
+				{
+					'card card-horizontal': !selectable,
+					'form-check-card form-check form-check-middle-left': selectable,
+				},
+				'card-type-directory'
+			)}
+			{...otherProps}
+		>
+			{children}
+		</div>
+	</Context.Provider>
+);
+
+ClayCardHorizontal.Body = ClayCardHorizontalBody;

--- a/packages/clay-card/src/CardNavigation.tsx
+++ b/packages/clay-card/src/CardNavigation.tsx
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayLink from '@clayui/link';
+import classNames from 'classnames';
+import React from 'react';
+
+import Context, {IContext} from './Context';
+
+interface IProps
+	extends Omit<IContext, 'interactive'>,
+		React.BaseHTMLAttributes<HTMLAnchorElement | HTMLDivElement> {}
+
+export const ClayCardNavigation: React.FunctionComponent<IProps> = ({
+	children,
+	className,
+	horizontal,
+	href,
+	onClick,
+	...otherProps
+}) => {
+	const Container = href ? ClayLink : 'div';
+
+	return (
+		<Context.Provider value={{horizontal, interactive: true}}>
+			<Container
+				className={classNames(
+					className,
+					'card card-interactive card-interactive-primary card-type-template',
+					{
+						'template-card': !horizontal,
+						'template-card-horizontal': horizontal,
+					}
+				)}
+				href={href}
+				onClick={onClick}
+				role={onClick ? 'button' : undefined}
+				{...otherProps}
+			>
+				{children}
+			</Container>
+		</Context.Provider>
+	);
+};

--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -12,6 +12,7 @@ import ClaySticker from '@clayui/sticker';
 import React from 'react';
 
 import ClayCard from './Card';
+import {ClayCardHorizontal} from './CardHorizontal';
 
 interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	actions?: React.ComponentProps<typeof ClayDropDownWithItems>['items'];
@@ -117,7 +118,7 @@ export const ClayCardWithHorizontal: React.FunctionComponent<IProps> = ({
 	);
 
 	return (
-		<ClayCard {...otherProps} horizontal selectable={!!onSelectChange}>
+		<ClayCardHorizontal {...otherProps} selectable={!!onSelectChange}>
 			{onSelectChange && (
 				<ClayCheckbox
 					{...checkboxProps}
@@ -125,11 +126,11 @@ export const ClayCardWithHorizontal: React.FunctionComponent<IProps> = ({
 					disabled={disabled}
 					onChange={() => onSelectChange(!selected)}
 				>
-					{content}
+					<ClayCardHorizontal.Body>{content}</ClayCardHorizontal.Body>
 				</ClayCheckbox>
 			)}
 
 			{!onSelectChange && content}
-		</ClayCard>
+		</ClayCardHorizontal>
 	);
 };

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -10,6 +10,7 @@ import ClaySticker from '@clayui/sticker';
 import React from 'react';
 
 import ClayCard from './Card';
+import {ClayCardNavigation} from './CardNavigation';
 
 interface IProps
 	extends React.BaseHTMLAttributes<HTMLAnchorElement | HTMLDivElement> {
@@ -71,11 +72,10 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 	...otherProps
 }: IProps) => {
 	return (
-		<ClayCard
+		<ClayCardNavigation
 			{...otherProps}
 			horizontal={horizontal}
 			href={href}
-			interactive
 			onClick={onClick}
 			onKeyDown={(event: React.KeyboardEvent) => {
 				if (
@@ -151,6 +151,6 @@ export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
 					)}
 				</ClayCard.Body>
 			)}
-		</ClayCard>
+		</ClayCardNavigation>
 	);
 };

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -3,58 +3,54 @@
 exports[`ClayCard renders a ClayCard as a directory 1`] = `
 <div>
   <div
-    class=""
+    class="card card-horizontal card-type-directory"
   >
     <div
-      class="card card-horizontal"
+      class="card-body"
     >
       <div
-        class="card-body"
+        class="card-row"
       >
         <div
-          class="card-row"
+          class="flex-col"
         >
-          <div
-            class="flex-col"
+          <span
+            class="sticker sticker-secondary"
           >
             <span
-              class="sticker sticker-secondary"
+              class="sticker-overlay inline-item"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-folder"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/path/to/some/resource.svg#folder"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <div
+          class="autofit-col autofit-col-expand autofit-col-gutters"
+        >
+          <div
+            class="autofit-section"
+          >
+            <p
+              class="card-title"
+              title="Very Large Folder"
             >
               <span
-                class="sticker-overlay inline-item"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-folder"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="/path/to/some/resource.svg#folder"
-                  />
-                </svg>
-              </span>
-            </span>
-          </div>
-          <div
-            class="autofit-col autofit-col-expand autofit-col-gutters"
-          >
-            <div
-              class="autofit-section"
-            >
-              <p
-                class="card-title"
-                title="Very Large Folder"
+                class="text-truncate-inline"
               >
                 <span
-                  class="text-truncate-inline"
+                  class="text-truncate"
                 >
-                  <span
-                    class="text-truncate"
-                  >
-                    Very Large Folder
-                  </span>
+                  Very Large Folder
                 </span>
-              </p>
-            </div>
+              </span>
+            </p>
           </div>
         </div>
       </div>
@@ -66,7 +62,7 @@ exports[`ClayCard renders a ClayCard as a directory 1`] = `
 exports[`ClayCard renders a ClayCard as a file card 1`] = `
 <div>
   <div
-    class="card card-type-asset file-card"
+    class="card file-card card-type-asset"
   >
     <div
       class="card-item-first aspect-ratio"
@@ -157,7 +153,7 @@ exports[`ClayCard renders a ClayCard as a file card 1`] = `
 exports[`ClayCard renders a ClayCard as a selectable file card 1`] = `
 <div>
   <div
-    class="card-type-asset file-card form-check form-check-card form-check-top-left"
+    class="file-card form-check-card form-check form-check-top-left card-type-asset"
   >
     <div
       class="card"
@@ -265,7 +261,7 @@ exports[`ClayCard renders a ClayCard as a selectable file card 1`] = `
 exports[`ClayCard renders a ClayCard as a selectable folder 1`] = `
 <div>
   <div
-    class="card-type-directory form-check form-check-card form-check-middle-left"
+    class="form-check-card form-check form-check-middle-left card-type-directory"
   >
     <div
       class="custom-control custom-checkbox"
@@ -279,52 +275,48 @@ exports[`ClayCard renders a ClayCard as a selectable folder 1`] = `
           class="custom-control-label"
         />
         <div
-          class="card card-horizontal"
+          class="card-body"
         >
           <div
-            class="card-body"
+            class="card-row"
           >
             <div
-              class="card-row"
+              class="autofit-col"
             >
-              <div
-                class="autofit-col"
+              <span
+                class="sticker sticker-secondary"
               >
                 <span
-                  class="sticker sticker-secondary"
+                  class="sticker-overlay inline-item"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-folder"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/path/to/some/resource.svg#folder"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </div>
+            <div
+              class="autofit-col autofit-col-expand autofit-col-gutters"
+            >
+              <p
+                class="card-title"
+                title="Very Large Folder"
+              >
+                <span
+                  class="text-truncate-inline"
                 >
                   <span
-                    class="sticker-overlay inline-item"
+                    class="text-truncate"
                   >
-                    <svg
-                      class="lexicon-icon lexicon-icon-folder"
-                      role="presentation"
-                    >
-                      <use
-                        xlink:href="/path/to/some/resource.svg#folder"
-                      />
-                    </svg>
+                    Very Large Folder
                   </span>
                 </span>
-              </div>
-              <div
-                class="autofit-col autofit-col-expand autofit-col-gutters"
-              >
-                <p
-                  class="card-title"
-                  title="Very Large Folder"
-                >
-                  <span
-                    class="text-truncate-inline"
-                  >
-                    <span
-                      class="text-truncate"
-                    >
-                      Very Large Folder
-                    </span>
-                  </span>
-                </p>
-              </div>
+              </p>
             </div>
           </div>
         </div>
@@ -337,7 +329,7 @@ exports[`ClayCard renders a ClayCard as a selectable folder 1`] = `
 exports[`ClayCard renders a ClayCard as a selectable image card 1`] = `
 <div>
   <div
-    class="card-type-asset form-check form-check-card form-check-top-left image-card"
+    class="form-check-card form-check form-check-top-left image-card card-type-asset"
   >
     <div
       class="card"
@@ -491,7 +483,7 @@ exports[`ClayCard renders a ClayCard as a template navigation card truncating te
 exports[`ClayCard renders a ClayCard as image card 1`] = `
 <div>
   <div
-    class="card card-type-asset image-card"
+    class="card image-card card-type-asset"
   >
     <div
       class="card-item-first aspect-ratio"
@@ -736,85 +728,81 @@ exports[`ClayCard renders a ClayCard as template navigation card with icon inste
 exports[`ClayCard renders a ClayCard as user card 1`] = `
 <div>
   <div
-    class="card card-type-asset user-card"
+    class="card user-card card-type-asset"
   >
     <div
-      class="card"
+      class="card-item-first aspect-ratio"
     >
       <div
-        class="card-item-first aspect-ratio"
+        class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
       >
-        <div
-          class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
+        <span
+          class="sticker sticker-user-icon sticker-circle sticker-secondary"
         >
           <span
-            class="sticker sticker-user-icon sticker-circle sticker-secondary"
+            class="sticker-overlay"
           >
-            <span
-              class="sticker-overlay"
+            <svg
+              class="lexicon-icon lexicon-icon-user"
+              role="presentation"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-user"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/path/to/some/resource.svg#user"
-                />
-              </svg>
-            </span>
+              <use
+                xlink:href="/path/to/some/resource.svg#user"
+              />
+            </svg>
           </span>
-        </div>
+        </span>
       </div>
+    </div>
+    <div
+      class="card-body"
+    >
       <div
-        class="card-body"
+        class="card-row"
       >
         <div
-          class="card-row"
+          class="autofit-col autofit-col-expand"
         >
-          <div
-            class="autofit-col autofit-col-expand"
+          <p
+            class="card-title"
+            title="Adélaide"
           >
-            <p
-              class="card-title"
-              title="Adélaide"
+            <span
+              class="text-truncate-inline"
             >
               <span
-                class="text-truncate-inline"
+                class="text-truncate"
               >
-                <span
-                  class="text-truncate"
-                >
-                  Adélaide
-                </span>
+                Adélaide
               </span>
-            </p>
-            <p
-              class="card-subtitle"
-              title="Author Action"
+            </span>
+          </p>
+          <p
+            class="card-subtitle"
+            title="Author Action"
+          >
+            <span
+              class="text-truncate-inline"
             >
               <span
-                class="text-truncate-inline"
+                class="text-truncate"
               >
-                <span
-                  class="text-truncate"
-                >
-                  Author Action
-                </span>
+                Author Action
               </span>
-            </p>
-            <div
-              class="card-detail"
+            </span>
+          </p>
+          <div
+            class="card-detail"
+          >
+            <span
+              class="label label-success"
             >
               <span
-                class="label label-success"
+                class="label-item label-item-expand"
               >
-                <span
-                  class="label-item label-item-expand"
-                >
-                  Approved
-                </span>
+                Approved
               </span>
-            </div>
+            </span>
           </div>
         </div>
       </div>
@@ -826,7 +814,7 @@ exports[`ClayCard renders a ClayCard as user card 1`] = `
 exports[`ClayCard renders a ClayCard as user selectable card 1`] = `
 <div>
   <div
-    class="card-type-asset form-check form-check-card form-check-top-left user-card"
+    class="form-check-card form-check form-check-top-left user-card card-type-asset"
   >
     <div
       class="card"
@@ -948,7 +936,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
       class="card-page-item card-page-item-directory"
     >
       <div
-        class="card card-type-asset file-card"
+        class="card file-card card-type-asset"
       >
         <div
           class="card-item-first aspect-ratio"
@@ -1038,7 +1026,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
       class="card-page-item card-page-item-directory"
     >
       <div
-        class="card card-type-asset file-card"
+        class="card file-card card-type-asset"
       >
         <div
           class="card-item-first aspect-ratio"
@@ -1141,85 +1129,81 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
       class="card-page-item card-page-item-directory"
     >
       <div
-        class="card card-type-asset user-card"
+        class="card user-card card-type-asset"
       >
         <div
-          class="card"
+          class="card-item-first aspect-ratio"
         >
           <div
-            class="card-item-first aspect-ratio"
+            class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
           >
-            <div
-              class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
+            <span
+              class="sticker sticker-user-icon sticker-circle sticker-secondary"
             >
               <span
-                class="sticker sticker-user-icon sticker-circle sticker-secondary"
+                class="sticker-overlay"
               >
-                <span
-                  class="sticker-overlay"
+                <svg
+                  class="lexicon-icon lexicon-icon-user"
+                  role="presentation"
                 >
-                  <svg
-                    class="lexicon-icon lexicon-icon-user"
-                    role="presentation"
-                  >
-                    <use
-                      xlink:href="/path/to/some/resource.svg#user"
-                    />
-                  </svg>
-                </span>
+                  <use
+                    xlink:href="/path/to/some/resource.svg#user"
+                  />
+                </svg>
               </span>
-            </div>
+            </span>
           </div>
+        </div>
+        <div
+          class="card-body"
+        >
           <div
-            class="card-body"
+            class="card-row"
           >
             <div
-              class="card-row"
+              class="autofit-col autofit-col-expand"
             >
-              <div
-                class="autofit-col autofit-col-expand"
+              <p
+                class="card-title"
+                title="Adélaide"
               >
-                <p
-                  class="card-title"
-                  title="Adélaide"
+                <span
+                  class="text-truncate-inline"
                 >
                   <span
-                    class="text-truncate-inline"
+                    class="text-truncate"
                   >
-                    <span
-                      class="text-truncate"
-                    >
-                      Adélaide
-                    </span>
+                    Adélaide
                   </span>
-                </p>
-                <p
-                  class="card-subtitle"
-                  title="Author Action"
+                </span>
+              </p>
+              <p
+                class="card-subtitle"
+                title="Author Action"
+              >
+                <span
+                  class="text-truncate-inline"
                 >
                   <span
-                    class="text-truncate-inline"
+                    class="text-truncate"
                   >
-                    <span
-                      class="text-truncate"
-                    >
-                      Author Action
-                    </span>
+                    Author Action
                   </span>
-                </p>
-                <div
-                  class="card-detail"
+                </span>
+              </p>
+              <div
+                class="card-detail"
+              >
+                <span
+                  class="label label-success"
                 >
                   <span
-                    class="label label-success"
+                    class="label-item label-item-expand"
                   >
-                    <span
-                      class="label-item label-item-expand"
-                    >
-                      Approved
-                    </span>
+                    Approved
                   </span>
-                </div>
+                </span>
               </div>
             </div>
           </div>
@@ -1230,85 +1214,81 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
       class="card-page-item card-page-item-directory"
     >
       <div
-        class="card card-type-asset user-card"
+        class="card user-card card-type-asset"
       >
         <div
-          class="card"
+          class="card-item-first aspect-ratio"
         >
           <div
-            class="card-item-first aspect-ratio"
+            class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
           >
-            <div
-              class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon"
+            <span
+              class="sticker sticker-user-icon sticker-circle sticker-secondary"
             >
               <span
-                class="sticker sticker-user-icon sticker-circle sticker-secondary"
+                class="sticker-overlay"
               >
-                <span
-                  class="sticker-overlay"
+                <svg
+                  class="lexicon-icon lexicon-icon-user"
+                  role="presentation"
                 >
-                  <svg
-                    class="lexicon-icon lexicon-icon-user"
-                    role="presentation"
-                  >
-                    <use
-                      xlink:href="/path/to/some/resource.svg#user"
-                    />
-                  </svg>
-                </span>
+                  <use
+                    xlink:href="/path/to/some/resource.svg#user"
+                  />
+                </svg>
               </span>
-            </div>
+            </span>
           </div>
+        </div>
+        <div
+          class="card-body"
+        >
           <div
-            class="card-body"
+            class="card-row"
           >
             <div
-              class="card-row"
+              class="autofit-col autofit-col-expand"
             >
-              <div
-                class="autofit-col autofit-col-expand"
+              <p
+                class="card-title"
+                title="Adélaide"
               >
-                <p
-                  class="card-title"
-                  title="Adélaide"
+                <span
+                  class="text-truncate-inline"
                 >
                   <span
-                    class="text-truncate-inline"
+                    class="text-truncate"
                   >
-                    <span
-                      class="text-truncate"
-                    >
-                      Adélaide
-                    </span>
+                    Adélaide
                   </span>
-                </p>
-                <p
-                  class="card-subtitle"
-                  title="Author Action"
+                </span>
+              </p>
+              <p
+                class="card-subtitle"
+                title="Author Action"
+              >
+                <span
+                  class="text-truncate-inline"
                 >
                   <span
-                    class="text-truncate-inline"
+                    class="text-truncate"
                   >
-                    <span
-                      class="text-truncate"
-                    >
-                      Author Action
-                    </span>
+                    Author Action
                   </span>
-                </p>
-                <div
-                  class="card-detail"
+                </span>
+              </p>
+              <div
+                class="card-detail"
+              >
+                <span
+                  class="label label-success"
                 >
                   <span
-                    class="label label-success"
+                    class="label-item label-item-expand"
                   >
-                    <span
-                      class="label-item label-item-expand"
-                    >
-                      Approved
-                    </span>
+                    Approved
                   </span>
-                </div>
+                </span>
               </div>
             </div>
           </div>
@@ -1322,7 +1302,7 @@ exports[`ClayCard renders a group of ClayCards 1`] = `
 exports[`ClayCardWithHorizontal renders as disabled 1`] = `
 <div>
   <div
-    class="card-type-directory form-check form-check-card form-check-middle-left"
+    class="form-check-card form-check form-check-middle-left card-type-directory"
   >
     <div
       class="custom-control custom-checkbox"
@@ -1395,76 +1375,72 @@ exports[`ClayCardWithHorizontal renders as disabled 1`] = `
 exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
 <div>
   <div
-    class=""
+    class="card card-horizontal card-type-directory"
   >
     <div
-      class="card card-horizontal"
+      class="card-body"
     >
       <div
-        class="card-body"
+        class="card-row"
       >
         <div
-          class="card-row"
+          class="autofit-col"
         >
-          <div
-            class="autofit-col"
+          <span
+            class="sticker"
           >
             <span
-              class="sticker"
+              class="sticker-overlay inline-item"
             >
-              <span
-                class="sticker-overlay inline-item"
+              <svg
+                class="lexicon-icon lexicon-icon-folder"
+                role="presentation"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-folder"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="/path/to/some/resource.svg#folder"
-                  />
-                </svg>
-              </span>
+                <use
+                  xlink:href="/path/to/some/resource.svg#folder"
+                />
+              </svg>
             </span>
-          </div>
-          <div
-            class="autofit-col autofit-col-expand autofit-col-gutters"
+          </span>
+        </div>
+        <div
+          class="autofit-col autofit-col-expand autofit-col-gutters"
+        >
+          <p
+            class="card-title"
+            title="Foo Bar"
           >
-            <p
-              class="card-title"
-              title="Foo Bar"
+            <span
+              class="text-truncate-inline"
             >
-              <span
-                class="text-truncate-inline"
+              <a
+                class="text-truncate"
+                href="#"
               >
-                <a
-                  class="text-truncate"
-                  href="#"
-                >
-                  Foo Bar
-                </a>
-              </span>
-            </p>
-          </div>
+                Foo Bar
+              </a>
+            </span>
+          </p>
+        </div>
+        <div
+          class="autofit-col"
+        >
           <div
-            class="autofit-col"
+            class="dropdown"
           >
-            <div
-              class="dropdown"
+            <button
+              class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+              type="button"
             >
-              <button
-                class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
-                type="button"
+              <svg
+                class="lexicon-icon lexicon-icon-ellipsis-v"
+                role="presentation"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-ellipsis-v"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="/path/to/some/resource.svg#ellipsis-v"
-                  />
-                </svg>
-              </button>
-            </div>
+                <use
+                  xlink:href="/path/to/some/resource.svg#ellipsis-v"
+                />
+              </svg>
+            </button>
           </div>
         </div>
       </div>
@@ -1476,7 +1452,7 @@ exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
 exports[`ClayCardWithHorizontal renders as selectable 1`] = `
 <div>
   <div
-    class="card-type-directory form-check form-check-card form-check-middle-left"
+    class="form-check-card form-check form-check-middle-left card-type-directory"
   >
     <div
       class="custom-control custom-checkbox"
@@ -1549,7 +1525,7 @@ exports[`ClayCardWithHorizontal renders as selectable 1`] = `
 exports[`ClayCardWithInfo renders as disabled 1`] = `
 <div>
   <div
-    class="card-type-asset file-card form-check form-check-card form-check-top-left"
+    class="file-card form-check-card form-check form-check-top-left card-type-asset"
   >
     <div
       class="card"
@@ -1634,7 +1610,7 @@ exports[`ClayCardWithInfo renders as disabled 1`] = `
 exports[`ClayCardWithInfo renders as file card specifying the displayType 1`] = `
 <div>
   <div
-    class="card-type-asset file-card form-check form-check-card form-check-top-left"
+    class="file-card form-check-card form-check form-check-top-left card-type-asset"
   >
     <div
       class="card"
@@ -1719,7 +1695,7 @@ exports[`ClayCardWithInfo renders as file card specifying the displayType 1`] = 
 exports[`ClayCardWithInfo renders as image card specifying imageProps and not the displayType 1`] = `
 <div>
   <div
-    class="card-type-asset form-check form-check-card form-check-top-left image-card"
+    class="form-check-card form-check form-check-top-left image-card card-type-asset"
   >
     <div
       class="card"
@@ -1796,7 +1772,7 @@ exports[`ClayCardWithInfo renders as image card specifying imageProps and not th
 exports[`ClayCardWithInfo renders as image card specifying the displayType and imageProps 1`] = `
 <div>
   <div
-    class="card-type-asset form-check form-check-card form-check-top-left image-card"
+    class="form-check-card form-check form-check-top-left image-card card-type-asset"
   >
     <div
       class="card"
@@ -1873,7 +1849,7 @@ exports[`ClayCardWithInfo renders as image card specifying the displayType and i
 exports[`ClayCardWithInfo renders as image card specifying the displayType and no imageProps 1`] = `
 <div>
   <div
-    class="card-type-asset form-check form-check-card form-check-top-left image-card"
+    class="form-check-card form-check form-check-top-left image-card card-type-asset"
   >
     <div
       class="card"
@@ -1958,7 +1934,7 @@ exports[`ClayCardWithInfo renders as image card specifying the displayType and n
 exports[`ClayCardWithInfo renders as image card with flush horizontal 1`] = `
 <div>
   <div
-    class="card-type-asset form-check form-check-card form-check-top-left image-card"
+    class="form-check-card form-check form-check-top-left image-card card-type-asset"
   >
     <div
       class="card"
@@ -2035,7 +2011,7 @@ exports[`ClayCardWithInfo renders as image card with flush horizontal 1`] = `
 exports[`ClayCardWithInfo renders as image card with flush vertical 1`] = `
 <div>
   <div
-    class="card-type-asset form-check form-check-card form-check-top-left image-card"
+    class="form-check-card form-check form-check-top-left image-card card-type-asset"
   >
     <div
       class="card"
@@ -2112,7 +2088,7 @@ exports[`ClayCardWithInfo renders as image card with flush vertical 1`] = `
 exports[`ClayCardWithInfo renders as not selectable 1`] = `
 <div>
   <div
-    class="card card-type-asset file-card"
+    class="card file-card card-type-asset"
   >
     <div
       class="card-item-first aspect-ratio"
@@ -2214,7 +2190,7 @@ exports[`ClayCardWithInfo renders as not selectable 1`] = `
 exports[`ClayCardWithInfo renders as selectable 1`] = `
 <div>
   <div
-    class="card-type-asset file-card form-check form-check-card form-check-top-left"
+    class="file-card form-check-card form-check form-check-top-left card-type-asset"
   >
     <div
       class="card"
@@ -2299,7 +2275,7 @@ exports[`ClayCardWithInfo renders as selectable 1`] = `
 exports[`ClayCardWithInfo renders with custom sticker 1`] = `
 <div>
   <div
-    class="card card-type-asset file-card"
+    class="card file-card card-type-asset"
   >
     <div
       class="card-item-first aspect-ratio"
@@ -2380,7 +2356,7 @@ exports[`ClayCardWithInfo renders with custom sticker 1`] = `
 exports[`ClayCardWithInfo renders with custom sticker with custom Icon 1`] = `
 <div>
   <div
-    class="card card-type-asset file-card"
+    class="card file-card card-type-asset"
   >
     <div
       class="card-item-first aspect-ratio"
@@ -2461,7 +2437,7 @@ exports[`ClayCardWithInfo renders with custom sticker with custom Icon 1`] = `
 exports[`ClayCardWithInfo renders with description 1`] = `
 <div>
   <div
-    class="card-type-asset file-card form-check form-check-card form-check-top-left"
+    class="file-card form-check-card form-check form-check-top-left card-type-asset"
   >
     <div
       class="card"
@@ -2560,7 +2536,7 @@ exports[`ClayCardWithInfo renders with description 1`] = `
 exports[`ClayCardWithInfo renders with no sticker 1`] = `
 <div>
   <div
-    class="card-type-asset file-card form-check form-check-card form-check-top-left"
+    class="file-card form-check-card form-check form-check-top-left card-type-asset"
   >
     <div
       class="card"
@@ -2686,7 +2662,7 @@ exports[`ClayCardWithUser renders ClayCardWithNavigation with image 1`] = `
 exports[`ClayCardWithUser renders as disabled 1`] = `
 <div>
   <div
-    class="card-type-asset form-check form-check-card form-check-top-left user-card"
+    class="form-check-card form-check form-check-top-left user-card card-type-asset"
   >
     <div
       class="card"
@@ -2763,7 +2739,7 @@ exports[`ClayCardWithUser renders as disabled 1`] = `
 exports[`ClayCardWithUser renders as selectable 1`] = `
 <div>
   <div
-    class="card-type-asset form-check form-check-card form-check-top-left user-card"
+    class="form-check-card form-check form-check-top-left user-card card-type-asset"
   >
     <div
       class="card"
@@ -2861,74 +2837,70 @@ exports[`ClayCardWithUser renders as selectable 1`] = `
 exports[`ClayCardWithUser renders with description 1`] = `
 <div>
   <div
-    class="card card-type-asset user-card"
+    class="card user-card card-type-asset"
   >
     <div
-      class="card"
+      class="card-item-first aspect-ratio"
     >
       <div
-        class="card-item-first aspect-ratio"
+        class="aspect-ratio-item-center-middle card-type-asset-icon"
       >
-        <div
-          class="aspect-ratio-item-center-middle card-type-asset-icon"
+        <span
+          class="sticker sticker-user-icon sticker-circle"
         >
           <span
-            class="sticker sticker-user-icon sticker-circle"
+            class="sticker-overlay"
           >
-            <span
-              class="sticker-overlay"
+            <svg
+              class="lexicon-icon lexicon-icon-user"
+              role="presentation"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-user"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/path/to/some/resource.svg#user"
-                />
-              </svg>
-            </span>
+              <use
+                xlink:href="/path/to/some/resource.svg#user"
+              />
+            </svg>
           </span>
-        </div>
+        </span>
       </div>
+    </div>
+    <div
+      class="card-body"
+    >
       <div
-        class="card-body"
+        class="card-row"
       >
         <div
-          class="card-row"
+          class="autofit-col autofit-col-expand"
         >
-          <div
-            class="autofit-col autofit-col-expand"
+          <p
+            class="card-title"
+            title="Foo Bar"
           >
-            <p
-              class="card-title"
-              title="Foo Bar"
+            <span
+              class="text-truncate-inline"
+            >
+              <a
+                class="text-truncate"
+                href="#"
+              >
+                Foo Bar
+              </a>
+            </span>
+          </p>
+          <p
+            class="card-subtitle"
+            title="Awesome description of the user"
+          >
+            <span
+              class="text-truncate-inline"
             >
               <span
-                class="text-truncate-inline"
+                class="text-truncate"
               >
-                <a
-                  class="text-truncate"
-                  href="#"
-                >
-                  Foo Bar
-                </a>
+                Awesome description of the user
               </span>
-            </p>
-            <p
-              class="card-subtitle"
-              title="Awesome description of the user"
-            >
-              <span
-                class="text-truncate-inline"
-              >
-                <span
-                  class="text-truncate"
-                >
-                  Awesome description of the user
-                </span>
-              </span>
-            </p>
-          </div>
+            </span>
+          </p>
         </div>
       </div>
     </div>
@@ -2939,60 +2911,56 @@ exports[`ClayCardWithUser renders with description 1`] = `
 exports[`ClayCardWithUser renders with icon 1`] = `
 <div>
   <div
-    class="card card-type-asset user-card"
+    class="card user-card card-type-asset"
   >
     <div
-      class="card"
+      class="card-item-first aspect-ratio"
     >
       <div
-        class="card-item-first aspect-ratio"
+        class="aspect-ratio-item-center-middle card-type-asset-icon"
       >
-        <div
-          class="aspect-ratio-item-center-middle card-type-asset-icon"
+        <span
+          class="sticker sticker-user-icon sticker-circle"
         >
           <span
-            class="sticker sticker-user-icon sticker-circle"
+            class="sticker-overlay"
           >
-            <span
-              class="sticker-overlay"
+            <svg
+              class="lexicon-icon lexicon-icon-custom-icon"
+              role="presentation"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-custom-icon"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/path/to/some/resource.svg#custom-icon"
-                />
-              </svg>
-            </span>
+              <use
+                xlink:href="/path/to/some/resource.svg#custom-icon"
+              />
+            </svg>
           </span>
-        </div>
+        </span>
       </div>
+    </div>
+    <div
+      class="card-body"
+    >
       <div
-        class="card-body"
+        class="card-row"
       >
         <div
-          class="card-row"
+          class="autofit-col autofit-col-expand"
         >
-          <div
-            class="autofit-col autofit-col-expand"
+          <p
+            class="card-title"
+            title="Foo Bar"
           >
-            <p
-              class="card-title"
-              title="Foo Bar"
+            <span
+              class="text-truncate-inline"
             >
-              <span
-                class="text-truncate-inline"
+              <a
+                class="text-truncate"
+                href="#"
               >
-                <a
-                  class="text-truncate"
-                  href="#"
-                >
-                  Foo Bar
-                </a>
-              </span>
-            </p>
-          </div>
+                Foo Bar
+              </a>
+            </span>
+          </p>
         </div>
       </div>
     </div>
@@ -3003,57 +2971,53 @@ exports[`ClayCardWithUser renders with icon 1`] = `
 exports[`ClayCardWithUser renders with image 1`] = `
 <div>
   <div
-    class="card card-type-asset user-card"
+    class="card user-card card-type-asset"
   >
     <div
-      class="card"
+      class="card-item-first aspect-ratio"
     >
       <div
-        class="card-item-first aspect-ratio"
+        class="aspect-ratio-item-center-middle card-type-asset-icon"
       >
-        <div
-          class="aspect-ratio-item-center-middle card-type-asset-icon"
+        <span
+          class="sticker sticker-user-icon sticker-circle"
         >
           <span
-            class="sticker sticker-user-icon sticker-circle"
+            class="sticker-overlay"
           >
-            <span
-              class="sticker-overlay"
-            >
-              <img
-                alt="thumbnail"
-                class="sticker-img"
-                src="/path/to/image.jpg"
-              />
-            </span>
+            <img
+              alt="thumbnail"
+              class="sticker-img"
+              src="/path/to/image.jpg"
+            />
           </span>
-        </div>
+        </span>
       </div>
+    </div>
+    <div
+      class="card-body"
+    >
       <div
-        class="card-body"
+        class="card-row"
       >
         <div
-          class="card-row"
+          class="autofit-col autofit-col-expand"
         >
-          <div
-            class="autofit-col autofit-col-expand"
+          <p
+            class="card-title"
+            title="Foo Bar"
           >
-            <p
-              class="card-title"
-              title="Foo Bar"
+            <span
+              class="text-truncate-inline"
             >
-              <span
-                class="text-truncate-inline"
+              <a
+                class="text-truncate"
+                href="#"
               >
-                <a
-                  class="text-truncate"
-                  href="#"
-                >
-                  Foo Bar
-                </a>
-              </span>
-            </p>
-          </div>
+                Foo Bar
+              </a>
+            </span>
+          </p>
         </div>
       </div>
     </div>

--- a/packages/clay-card/stories/index.tsx
+++ b/packages/clay-card/stories/index.tsx
@@ -247,17 +247,16 @@ storiesOf('Components|ClayCard', module)
 						disabled={boolean('Disabled', false)}
 						href="#"
 						name="Abraham Kuyper"
-						onSelectChange={() => {}}
-						selected={boolean('selected', false)}
+						onSelectChange={setValue}
+						selected={value}
 						spritemap={spritemap}
 					/>
-
+				</div>
+				<div className="col-md-4">
 					<ClayCardWithUser
 						description="Assistant to the regional manager"
 						disabled={boolean('Disabled', false)}
 						name="Abraham Kuyper"
-						onSelectChange={setValue}
-						selected={value}
 						spritemap={spritemap}
 						userImageSrc="https://via.placeholder.com/256"
 					/>


### PR DESCRIPTION
Fixes #3789

This is an initial implementation to start simplifying the low-level component of ClayCard, it is currently very complex and was in [our sights for improvements and revision for v4](https://paper.dropbox.com/doc/Clay-4.x-API-review-and-improvements--BAejQ~GmATHhMLeDKFcBBZqqAQ-uUNnd4tTNFTU7lNP6yQfP). The changes here do not break the API, consequently, it corrects #3789 and there were many changes in the snapshot due to the fact that we removed the double declaration from `card` to horizontal and changes in class ordering.

The idea here was to break the ClayCard component into two more new components `<ClayCardHorizontal />` and `<ClayCardNavigation />`. These two new components are being used only internally but are not yet being public, we will work on that in the next interaction.

In the next major version, the idea is to deprecate the `interactive` API and the respective behaviors of the created components and remove the `ClayCardHybrid` component, which at the moment we will publicly mask as `ClayCard`.

- CardNavigation is a component that deals with a totally different template than ClayCard, visually speaking and markup, so we can start to separate it from the traditional Card we have to avoid confusion and complexity within the code.
- CardHorizontal follows the same idea as the component above, the markup structure is different in the `selectable` mode compared to the other ClayCard options.

Probably a change in the taglib, I am adding the `.card-type-directory` class together with the `.card card-horizontal` class.