### PR TITLE
fix(shared): avoid race condition with Senna.js

### DIFF
--- a/packages/clay-shared/src/Portal.tsx
+++ b/packages/clay-shared/src/Portal.tsx
@@ -46,8 +46,12 @@ export const ClayPortal: React.FunctionComponent<
 		}
 
 		return () => {
-			if (elToMountTo && portalRef.current) {
-				elToMountTo.removeChild(portalRef.current);
+			if (portalRef.current) {
+				if (typeof portalRef.current.remove === 'function') {
+					portalRef.current.remove();
+				} else if (elToMountTo) {
+					elToMountTo.removeChild(portalRef.current);
+				}
 			}
 		};
 	}, [containerRef, parentPortalRef]);


### PR DESCRIPTION
For reasons that we haven't fully determined but which are [explained here](https://github.com/liferay-frontend/liferay-portal/pull/565#issuecomment-736854056) we see that unmounting portals sometimes fails because they get mounted on `document.body`, but by the time the portal gets mounted, they have somehow been "re-parented".

The simple-but-untested mitigation applied here is to use `remove()` which will remove the DOM node irrespective of parenthood. Note that [`remove()` isn't supported on IE11](https://caniuse.com/childnode-remove) so we include a `typeof` check to fall back to the old behavior which will at least work most of the time (and in DXP, we probably have this covered by our polyfill anyway on 7.3.x and older branches). As such, we expect this to be "backport-safe".

Test plan: Run tests.