### PR TITLE
fix(@clayui/css): Mixins clay-link active-class should also style `&[…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -351,6 +351,8 @@
 			@include clay-css($active);
 		}
 
+		&[aria-expanded='true'],
+		&.show,
 		.show > &,
 		&.active {
 			@include clay-css($active-class);


### PR DESCRIPTION
…aria-expanded='true']` and `&.show` so we can style collapse plugin open state

fixes #3767