### PR TITLE
chore(@clayui/card): fixes the test of not rendering a sticker on CardWithInfo and improves type

### DIFF
--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -93,9 +93,11 @@ interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * Values used in displaying bottom-left icon
 	 */
-	stickerProps?: IClayStickerProps & {
-		content?: React.ReactNode;
-	};
+	stickerProps?:
+		| (IClayStickerProps & {
+				content?: React.ReactNode;
+		  })
+		| null;
 
 	/**
 	 * Name of icon

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -2567,22 +2567,6 @@ exports[`ClayCardWithInfo renders with no sticker 1`] = `
                 />
               </svg>
             </div>
-            <span
-              class="sticker sticker-primary sticker-bottom-left"
-            >
-              <span
-                class="sticker-overlay"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-document-default"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="/path/to/some/resource.svg#document-default"
-                  />
-                </svg>
-              </span>
-            </span>
           </div>
         </label>
       </div>

--- a/packages/clay-card/src/__tests__/index.tsx
+++ b/packages/clay-card/src/__tests__/index.tsx
@@ -1012,7 +1012,7 @@ describe('ClayCardWithInfo', () => {
 				onSelectChange={jest.fn()}
 				selected={false}
 				spritemap="/path/to/some/resource.svg"
-				stickerProps={undefined}
+				stickerProps={null}
 				title="Foo Bar"
 			/>
 		);


### PR DESCRIPTION
From https://github.com/liferay/clay/pull/3819#discussion_r534104466

We already had this behavior being done where setting `null` to `stickerProps` he did not render the Sticker in CardWithInfo and passing the `undefined` he would render the default Sticker. I just did correct the test, as we have a default value for `stickerProps`, when the value of `stickerProps` is `undefined` it starts with its default value so rendering the default Sticker ie just `null` will not render the sticker.