### PR TITLE
fix(@clayui/css): Management Bar set min-height for desktop / mobile views

### DIFF
--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -18,6 +18,7 @@
 	$border-top-width: setter(map-get($map, border-top-width), 0);
 	$box-shadow: map-get($map, box-shadow);
 	$font-size: setter(map-get($map, font-size), $font-size-base);
+	$min-height: map-get($map, min-height);
 	$padding-x: setter(map-get($map, padding-x), $navbar-padding-x);
 	$padding-y: setter(map-get($map, padding-y), $navbar-padding-y);
 	$link-height: setter(
@@ -85,6 +86,7 @@
 
 	$height-mobile: setter(map-get($map, height-mobile), $height);
 	$font-size-mobile: setter(map-get($map, font-size-mobile), $font-size);
+	$min-height-mobile: map-get($map, min-height-mobile);
 	$link-height-mobile: setter(
 		map-get($map, link-height-mobile),
 		$height-mobile - $border-bottom-width - $border-top-width -
@@ -250,6 +252,7 @@
 		@include box-shadow($box-shadow);
 
 		font-size: $font-size;
+		min-height: $min-height;
 		padding: $padding-y $padding-x;
 
 		.container,
@@ -425,6 +428,8 @@
 					@if not($infix == '') {
 						// .navbar-expand-sm, md, lg, xl
 						@include media-breakpoint-down($breakpoint) {
+							min-height: $min-height-mobile;
+
 							&.navbar-collapse-absolute {
 								.navbar-collapse {
 									border-color: transparent;

--- a/packages/clay-css/src/scss/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/variables/_management-bar.scss
@@ -4,12 +4,14 @@ $management-bar-size: () !default;
 $management-bar-size: map-deep-merge(
 	(
 		scaling-navbar: true,
+		border-bottom-width: 0.0625rem,
 		font-size: $navbar-font-size,
 		height: 4rem,
-		height-mobile: 3rem,
-		border-bottom-width: 0.0625rem,
+		min-height: 4rem,
 		padding-x: 0,
 		padding-y: 0,
+		height-mobile: 3rem,
+		min-height-mobile: 3rem,
 		btn-monospaced-font-size: 1rem,
 		link-height: 2rem,
 		link-height-mobile: 2rem,


### PR DESCRIPTION
fixes #3855

This sets a `min-height` on `management-bar` so swapping out contents via js doesn't resize the bar.