### PR TITLE
fix(@clayui/css): Navigation Bar Light should have 1px gray bottom border

### DIFF
--- a/packages/clay-css/src/content/navigation-bar.html
+++ b/packages/clay-css/src/content/navigation-bar.html
@@ -61,6 +61,8 @@ section: Components
 	</div>
 </nav>
 
+<br>
+
 <nav class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary">
 	<div class="container-fluid container-fluid-max-xl">
 		<a aria-controls="navigationBarCollapse01" aria-expanded="false" aria-label="Toggle Navigation" class="collapsed navbar-toggler navbar-toggler-link" data-toggle="collapse" href="#navigationBarCollapse01" role="button">
@@ -159,6 +161,8 @@ section: Components
 				</div>
 			</div>
 		</nav>
+
+		<br>
 
 		<nav class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary">
 			<div class="container-fluid container-fluid-max-xl">

--- a/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
@@ -1,12 +1,12 @@
 $navigation-bar-size: () !default;
 $navigation-bar-size: map-deep-merge(
 	(
-		border-bottom-width: 0,
+		border-bottom-width: 0.0625rem,
 		collapse-dropdown-item-padding-y-mobile: 0.8125rem,
 		link-height-mobile: 2rem,
-		active-border-offset-bottom: -0.5rem,
+		active-border-offset-bottom: -0.53125rem,
 		toggler-link-height: 2rem,
-		toggler-link-margin-y: 0.5rem,
+		toggler-link-margin-y: 0.46875rem,
 		toggler-link-padding-y: 0,
 	),
 	$navigation-bar-size
@@ -27,6 +27,7 @@ $navigation-bar-light: () !default;
 $navigation-bar-light: map-deep-merge(
 	(
 		bg: $white,
+		border-color: $gray-200,
 		link-font-weight: $font-weight-semi-bold,
 		link-hover-color: $gray-900,
 		link-focus-color: $gray-900,


### PR DESCRIPTION
fixes #3862

This adds 1px gray bottom border to `navigation-bar-light` and minor spacing adjustments to align active highlight.