### PR TITLE
fix(@clayui/label): close icon should be times-small

### DIFF
--- a/packages/clay-css/src/content/badges_and_labels.html
+++ b/packages/clay-css/src/content/badges_and_labels.html
@@ -407,8 +407,8 @@ section: Components
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -436,8 +436,8 @@ section: Components
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -470,8 +470,8 @@ section: Components
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -501,8 +501,8 @@ section: Components
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -532,8 +532,8 @@ section: Components
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -563,8 +563,8 @@ section: Components
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -594,8 +594,8 @@ section: Components
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -625,8 +625,8 @@ section: Components
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -657,8 +657,8 @@ section: Components
 			</span>
 			<span class="label-item label-item-after">
 				<button aria-label="Close" class="close" type="button">
-					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+					<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 					</svg>
 				</button>
 			</span>
@@ -689,8 +689,8 @@ section: Components
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -723,8 +723,8 @@ section: Components
 			</span>
 			<span class="label-item label-item-after">
 				<button aria-label="Close" class="close" type="button">
-					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+					<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 					</svg>
 				</button>
 			</span>
@@ -769,8 +769,8 @@ section: Components
 			</span>
 			<span class="label-item label-item-after">
 				<button aria-label="Close" class="close" tabindex="-1" type="button">
-					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+					<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 					</svg>
 				</button>
 			</span>
@@ -802,8 +802,8 @@ section: Components
 			</span>
 			<span class="label-item label-item-after">
 				<button aria-label="Close" class="close" tabindex="-1" type="button">
-					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+					<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 					</svg>
 				</button>
 			</span>
@@ -828,8 +828,8 @@ section: Components
 								<span class="label-item label-item-expand">winterfell</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -838,8 +838,8 @@ section: Components
 								<span class="label-item label-item-expand">Stark</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -872,8 +872,8 @@ section: Components
 								<span class="label-item label-item-expand">wall</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -889,8 +889,8 @@ section: Components
 								<span class="label-item label-item-expand">wallpaper</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -906,8 +906,8 @@ section: Components
 								<span class="label-item label-item-expand">wonderwall</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -916,8 +916,8 @@ section: Components
 								<span class="label-item label-item-expand">winterfell</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -926,8 +926,8 @@ section: Components
 								<span class="label-item label-item-expand">kings landing</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>

--- a/packages/clay-css/src/content/form_elements_input_groups.html
+++ b/packages/clay-css/src/content/form_elements_input_groups.html
@@ -827,8 +827,8 @@ section: Components
 									<span class="label-item label-item-expand">wall</span>
 									<span class="label-item label-item-after">
 										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 											</svg>
 										</button>
 									</span>
@@ -844,8 +844,8 @@ section: Components
 									<span class="label-item label-item-expand">wallpaper</span>
 									<span class="label-item label-item-after">
 										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 											</svg>
 										</button>
 									</span>
@@ -861,8 +861,8 @@ section: Components
 									<span class="label-item label-item-expand">wonderwall</span>
 									<span class="label-item label-item-after">
 										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 											</svg>
 										</button>
 									</span>
@@ -881,8 +881,8 @@ section: Components
 									<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
 									<span class="label-item label-item-after">
 										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 											</svg>
 										</button>
 									</span>
@@ -918,8 +918,8 @@ section: Components
 										<span class="label-item label-item-expand">wall</span>
 										<span class="label-item label-item-after">
 											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 												</svg>
 											</button>
 										</span>
@@ -935,8 +935,8 @@ section: Components
 										<span class="label-item label-item-expand">wallpaper</span>
 										<span class="label-item label-item-after">
 											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 												</svg>
 											</button>
 										</span>
@@ -952,8 +952,8 @@ section: Components
 										<span class="label-item label-item-expand">wonderwall</span>
 										<span class="label-item label-item-after">
 											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 												</svg>
 											</button>
 										</span>
@@ -962,8 +962,8 @@ section: Components
 										<span class="label-item label-item-expand">winterfell</span>
 										<span class="label-item label-item-after">
 											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 												</svg>
 											</button>
 										</span>
@@ -972,8 +972,8 @@ section: Components
 										<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
 										<span class="label-item label-item-after">
 											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 												</svg>
 											</button>
 										</span>
@@ -1055,8 +1055,8 @@ section: Components
 									<span class="label-item label-item-expand">wall</span>
 									<span class="label-item label-item-after">
 										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 											</svg>
 										</button>
 									</span>
@@ -1072,8 +1072,8 @@ section: Components
 									<span class="label-item label-item-expand">wallpaper</span>
 									<span class="label-item label-item-after">
 										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 											</svg>
 										</button>
 									</span>
@@ -1089,8 +1089,8 @@ section: Components
 									<span class="label-item label-item-expand">wonderwall</span>
 									<span class="label-item label-item-after">
 										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 											</svg>
 										</button>
 									</span>
@@ -1099,8 +1099,8 @@ section: Components
 									<span class="label-item label-item-expand">winterfell</span>
 									<span class="label-item label-item-after">
 										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 											</svg>
 										</button>
 									</span>
@@ -1109,8 +1109,8 @@ section: Components
 									<span class="label-item label-item-expand">kings landing</span>
 									<span class="label-item label-item-after">
 										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 											</svg>
 										</button>
 									</span>

--- a/packages/clay-css/src/content/form_elements_multiselect.html
+++ b/packages/clay-css/src/content/form_elements_multiselect.html
@@ -65,8 +65,8 @@ section: Components
 											<span class="label-item label-item-expand">wall</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -82,8 +82,8 @@ section: Components
 											<span class="label-item label-item-expand">wallpaper</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -99,8 +99,8 @@ section: Components
 											<span class="label-item label-item-expand">wonderwall</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -109,8 +109,8 @@ section: Components
 											<span class="label-item label-item-expand">winterfell</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -119,8 +119,8 @@ section: Components
 											<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -172,8 +172,8 @@ section: Components
 											<span class="label-item label-item-expand">wall</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -189,8 +189,8 @@ section: Components
 											<span class="label-item label-item-expand">wallpaper</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -206,8 +206,8 @@ section: Components
 											<span class="label-item label-item-expand">wonderwall</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -216,8 +216,8 @@ section: Components
 											<span class="label-item label-item-expand">winterfell</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -226,8 +226,8 @@ section: Components
 											<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -294,8 +294,8 @@ section: Components
 											<span class="label-item label-item-expand">wall</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -311,8 +311,8 @@ section: Components
 											<span class="label-item label-item-expand">wallpaper</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -328,8 +328,8 @@ section: Components
 											<span class="label-item label-item-expand">wonderwall</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -345,8 +345,8 @@ section: Components
 											<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
 											<span class="label-item label-item-after">
 												<button aria-label="Close" class="close" tabindex="-1" type="button">
-													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 													</svg>
 												</button>
 											</span>
@@ -458,8 +458,8 @@ section: Components
 										<span class="label-item label-item-expand">wall</span>
 										<span class="label-item label-item-after">
 											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 												</svg>
 											</button>
 										</span>
@@ -475,8 +475,8 @@ section: Components
 										<span class="label-item label-item-expand">wallpaper</span>
 										<span class="label-item label-item-after">
 											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 												</svg>
 											</button>
 										</span>
@@ -553,8 +553,8 @@ section: Components
 										<span class="label-item label-item-expand">wall</span>
 										<span class="label-item label-item-after">
 											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 												</svg>
 											</button>
 										</span>
@@ -570,8 +570,8 @@ section: Components
 										<span class="label-item label-item-expand">wallpaper</span>
 										<span class="label-item label-item-after">
 											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 												</svg>
 											</button>
 										</span>

--- a/packages/clay-css/src/content/tbar.html
+++ b/packages/clay-css/src/content/tbar.html
@@ -171,8 +171,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -187,8 +187,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -203,8 +203,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -240,8 +240,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -256,8 +256,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -272,8 +272,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -348,8 +348,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -364,8 +364,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -380,8 +380,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -417,8 +417,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -433,8 +433,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -449,8 +449,8 @@ section: Components
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>

--- a/packages/clay-css/src/content/test_labels.html
+++ b/packages/clay-css/src/content/test_labels.html
@@ -136,8 +136,8 @@ section: Visual Tests
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -179,8 +179,8 @@ section: Visual Tests
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -212,8 +212,8 @@ section: Visual Tests
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -245,8 +245,8 @@ section: Visual Tests
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -278,8 +278,8 @@ section: Visual Tests
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -311,8 +311,8 @@ section: Visual Tests
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -344,8 +344,8 @@ section: Visual Tests
 		</span>
 		<span class="label-item label-item-after">
 			<button aria-label="Close" class="close" type="button">
-				<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+				<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 				</svg>
 			</button>
 		</span>
@@ -378,8 +378,8 @@ section: Visual Tests
 			</span>
 			<span class="label-item label-item-after">
 				<button aria-label="Close" class="close" type="button">
-					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+					<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 					</svg>
 				</button>
 			</span>
@@ -413,8 +413,8 @@ section: Visual Tests
 			</span>
 			<span class="label-item label-item-after">
 				<button aria-label="Close" class="close" type="button">
-					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+					<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 					</svg>
 				</button>
 			</span>

--- a/packages/clay-css/src/content/test_subnav_tbar.html
+++ b/packages/clay-css/src/content/test_subnav_tbar.html
@@ -173,8 +173,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -189,8 +189,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -205,8 +205,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -245,8 +245,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -261,8 +261,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -277,8 +277,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -319,8 +319,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<a aria-label="Close" class="close disabled" href="#1" role="button" tabindex="-1">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</a>
 								</span>
@@ -335,8 +335,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -351,8 +351,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -391,8 +391,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<a aria-label="Close" class="close disabled" href="#1" role="button" tabindex="-1">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</a>
 								</span>
@@ -407,8 +407,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>
@@ -423,8 +423,8 @@ section: Visual Tests
 								</span>
 								<span class="label-item label-item-after">
 									<button aria-label="Close" class="close" disabled type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+										<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 										</svg>
 									</button>
 								</span>

--- a/packages/clay-css/src/content/utilities_c_inner.html
+++ b/packages/clay-css/src/content/utilities_c_inner.html
@@ -377,8 +377,8 @@ section: Components
 			<span class="label-item label-item-after">
 				<button aria-label="Close" class="close" type="button">
 					<span class="c-inner" tabindex="-1">
-						<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+						<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 						</svg>
 					</span>
 				</button>
@@ -410,8 +410,8 @@ section: Components
 			<span class="label-item label-item-after">
 				<button aria-label="Close" class="close" type="button">
 					<span class="c-inner" tabindex="-1">
-						<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-							<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+						<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 						</svg>
 					</span>
 				</button>
@@ -454,8 +454,8 @@ section: Components
 				<span class="label-item label-item-after">
 					<button aria-label="Close" class="close" tabindex="-1" type="button">
 						<span class="c-inner" tabindex="-1">
-							<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+							<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 							</svg>
 						</span>
 					</button>
@@ -497,8 +497,8 @@ section: Components
 				<span class="label-item label-item-after">
 					<button aria-label="Close" class="close" tabindex="-1" type="button">
 						<span class="c-inner" tabindex="-1">
-							<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+							<svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-small"></use>
 							</svg>
 						</span>
 					</button>

--- a/packages/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_labels.scss
@@ -39,9 +39,6 @@ $label-lg: map-deep-merge(
 		lexicon-icon-height: 1em,
 		lexicon-icon-width: 1em,
 		sticker-size: 0.875rem,
-		close: (
-			font-size: 0.625rem,
-		),
 	),
 	$label-lg
 );

--- a/packages/clay-css/src/scss/variables/_labels.scss
+++ b/packages/clay-css/src/scss/variables/_labels.scss
@@ -17,9 +17,9 @@ $label-spacer-x: 0.25rem !default; // 4px
 $label-spacer-y: 0.125rem !default; // 2px
 $label-text-transform: null !default;
 
-$label-lexicon-icon-height: 0.875em !default;
+$label-lexicon-icon-height: null !default;
 $label-lexicon-icon-margin-top: 0 !default;
-$label-lexicon-icon-width: 0.875em !default;
+$label-lexicon-icon-width: null !default;
 
 $label-sticker-border-radius: 100px !default;
 $label-sticker-size: 0.875em !default;
@@ -45,17 +45,19 @@ $label-border-width: 0.0625rem !default;
 $label-close: () !default;
 $label-close: map-deep-merge(
 	(
+		border-radius: 1px,
 		color: inherit,
+		display: inline-flex,
+		font-size: 1rem,
+		height: auto,
+		margin-bottom: -2px,
+		margin-top: -2px,
 		opacity: 1,
+		width: auto,
 		hover-color: inherit,
 		hover-opacity: 1,
 		focus-opacity: 1,
 		disabled-opacity: $btn-disabled-opacity,
-		border-radius: 1px,
-		display: inline-flex,
-		font-size: inherit,
-		height: auto,
-		width: auto,
 	),
 	$label-close
 );
@@ -65,12 +67,9 @@ $label-close: map-deep-merge(
 $label-lg: () !default;
 $label-lg: map-deep-merge(
 	(
-		// 14px
-			font-size: 0.875rem,
-		// 16px
-			padding-x: 1rem,
-		// 6px
-			padding-y: 0.375rem,
+		font-size: 0.875rem,
+		padding-x: 1rem,
+		padding-y: 0.375rem,
 		text-transform: none
 	),
 	$label-lg

--- a/packages/clay-css/src/scss/variables/_labels.scss
+++ b/packages/clay-css/src/scss/variables/_labels.scss
@@ -70,7 +70,7 @@ $label-lg: map-deep-merge(
 		font-size: 0.875rem,
 		padding-x: 1rem,
 		padding-y: 0.375rem,
-		text-transform: none
+		text-transform: none,
 	),
 	$label-lg
 );

--- a/packages/clay-label/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-label/src/__tests__/__snapshots__/index.tsx.snap
@@ -44,11 +44,11 @@ exports[`Rendering renders as a link and closable 1`] = `
       type="button"
     >
       <svg
-        className="lexicon-icon lexicon-icon-times"
+        className="lexicon-icon lexicon-icon-times-small"
         role="presentation"
       >
         <use
-          xlinkHref="path/to/spritemap#times"
+          xlinkHref="path/to/spritemap#times-small"
         />
       </svg>
     </button>
@@ -74,11 +74,11 @@ exports[`Rendering renders as closable 1`] = `
       type="button"
     >
       <svg
-        className="lexicon-icon lexicon-icon-times"
+        className="lexicon-icon lexicon-icon-times-small"
         role="presentation"
       >
         <use
-          xlinkHref="path/to/spritemap#times"
+          xlinkHref="path/to/spritemap#times-small"
         />
       </svg>
     </button>

--- a/packages/clay-label/src/index.tsx
+++ b/packages/clay-label/src/index.tsx
@@ -179,7 +179,7 @@ const ClayLabelHybrid = React.forwardRef<
 								>
 									<ClayIcon
 										spritemap={spritemap}
-										symbol="times"
+										symbol="times-small"
 									/>
 								</button>
 							</ClayLabelItemAfter>

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -47,11 +47,11 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -74,11 +74,11 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -101,11 +101,11 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -192,11 +192,11 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -220,11 +220,11 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -248,11 +248,11 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -296,11 +296,11 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -323,11 +323,11 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -350,11 +350,11 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -415,11 +415,11 @@ exports[`ClayMultiSelect renders with items 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -442,11 +442,11 @@ exports[`ClayMultiSelect renders with items 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>
@@ -469,11 +469,11 @@ exports[`ClayMultiSelect renders with items 1`] = `
               type="button"
             >
               <svg
-                class="lexicon-icon lexicon-icon-times"
+                class="lexicon-icon lexicon-icon-times-small"
                 role="presentation"
               >
                 <use
-                  xlink:href="/foo/bar#times"
+                  xlink:href="/foo/bar#times-small"
                 />
               </svg>
             </button>


### PR DESCRIPTION
Part of the fix for https://github.com/liferay/clay/issues/3879

@pat270 I wasn't totally sure what css changes to make for this, but I updated the components so that Label now uses times-small. Let me know what changes need to be made to address this issue in full.