### PR TITLE
fix(@clayui/css): Adapt Sheet to fit Commerce patterns

### DIFF
--- a/clayui.com/content/docs/components/markup-forms-hierarchy.md
+++ b/clayui.com/content/docs/components/markup-forms-hierarchy.md
@@ -13,6 +13,10 @@ lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 -   [Sheet Title](#css-sheet-title)
 -   [Sheet Subtitle](#css-sheet-subtitle)
 -   [Sheet Tertiary Title](#css-sheet-tertiary-title)
+-   [Variants](#css-variants)
+    -   [Sheet Multiple Form](#css-sheet-multiple-form)
+    -   [Commerce Product Screen](#css-commerce-product-screen)
+    -   [Sheet Dataset Content](#css-sheet-dataset-content)
 
 </div>
 </div>
@@ -651,4 +655,895 @@ Nest `autofit` utilities with `component-title` in `sheet-subtitle` to verticall
 		</span>
 	</span>
 </h4>
+```
+
+## Variants(#css-variants)
+
+## Sheet Multiple Form(#css-sheet-multiple-form)
+
+The modifier class `sheet-multiple-form` on `sheet` provides alternative sizing and spacing to `sheet-header` to be used in specific situations explained below.
+
+This pattern is used in form scenarios, usually to display a form, multiple forms or a combination of single/multiple forms and one or several sheets to display information. See <a href="https://liferay.design/lexicon/core-components/forms/forms-sheet/#multiple-form" rel="noopener noreferrer" target="_blank">Lexicon</a>.
+
+<div class="sheet-example">
+	<div class="sheet sheet-multiple-form">
+		<div class="sheet-header">
+			<div class="autofit-row autofit-padded-no-gutters">
+				<div class="autofit-col autofit-col-shrink">
+					<h4 class="sheet-title">
+						<span class="component-title">Sheet Header</span>
+					</h4>
+				</div>
+				<div class="autofit-col">
+					<div class="dropdown dropdown-action">
+						<button aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" id="dropdownSites5" type="button">
+							<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+							</svg>
+						</button>
+						<ul aria-labelledby="dropdownSites5" class="dropdown-menu">
+							<li><a class="dropdown-item" href="#1">Download</a></li>
+							<li><a class="dropdown-item" href="#1">Edit</a></li>
+							<li><a class="dropdown-item" href="#1">Move</a></li>
+							<li><a class="dropdown-item" href="#1">Checkout</a></li>
+							<li><a class="dropdown-item" href="#1">Permissions</a></li>
+							<li><a class="dropdown-item" href="#1">Move to Recycle Bin</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="sheet-section">
+			<h5 class="sheet-title">Sheet Title</h5>
+			<p class="sheet-text">Sheet text should be used for any kind of explanatory text. The Sheet Title and Sheet Text are contained inside a sheet-section.</p>
+		</div>
+		<div class="sheet-section">
+			<h6 class="sheet-subtitle">Sheet Subtitle 01</h6>
+			<div class="form-group">
+				<label for="basicInputTypeTextarea">Textarea</label>
+				<textarea class="form-control" id="basicInputTypeTextarea" name="basicInputTypeTextarea" placeholder="Placeholder"></textarea>
+			</div>
+		</div>
+		<div class="sheet-section">
+			<h6 class="sheet-subtitle">Sheet Subtitle 02</h6>
+		</div>
+		<div class="sheet-footer sheet-footer-btn-block-sm-down">
+			<div class="btn-group">
+				<div class="btn-group-item">
+					<button class="btn btn-primary" type="button">Primary</button>
+				</div>
+				<div class="btn-group-item">
+					<button class="btn btn-secondary" type="button">Secondary</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="sheet sheet-multiple-form">
+	<div class="sheet-header">
+		<div class="autofit-row autofit-padded-no-gutters">
+			<div class="autofit-col autofit-col-shrink">
+				<h4 class="sheet-title">
+					<span class="component-title">Sheet Header</span>
+				</h4>
+			</div>
+			<div class="autofit-col">
+				<div class="dropdown dropdown-action">
+					<button
+						aria-expanded="false"
+						aria-haspopup="true"
+						class="component-action dropdown-toggle"
+						data-toggle="dropdown"
+						id="dropdownSites5"
+						type="button"
+					>
+						<svg
+							class="lexicon-icon lexicon-icon-ellipsis-v"
+							focusable="false"
+							role="presentation"
+						>
+							<use
+								xlink:href="/images/icons/icons.svg#ellipsis-v"
+							/>
+						</svg>
+					</button>
+					<ul aria-labelledby="dropdownSites5" class="dropdown-menu">
+						<li><a class="dropdown-item" href="#1">Download</a></li>
+						<li><a class="dropdown-item" href="#1">Edit</a></li>
+						<li><a class="dropdown-item" href="#1">Move</a></li>
+						<li><a class="dropdown-item" href="#1">Checkout</a></li>
+						<li>
+							<a class="dropdown-item" href="#1">Permissions</a>
+						</li>
+						<li>
+							<a class="dropdown-item" href="#1"
+								>Move to Recycle Bin</a
+							>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="sheet-section">
+		<h5 class="sheet-title">Sheet Title</h5>
+		<p class="sheet-text">
+			Sheet text should be used for any kind of explanatory text. The
+			Sheet Title and Sheet Text are contained inside a sheet-section.
+		</p>
+	</div>
+	<div class="sheet-section">
+		<h6 class="sheet-subtitle">Sheet Subtitle 01</h6>
+		<div class="form-group">
+			<label for="basicInputTypeTextarea">Textarea</label>
+			<textarea
+				class="form-control"
+				id="basicInputTypeTextarea"
+				name="basicInputTypeTextarea"
+				placeholder="Placeholder"
+			></textarea>
+		</div>
+	</div>
+	<div class="sheet-section">
+		<h6 class="sheet-subtitle">Sheet Subtitle 02</h6>
+	</div>
+	<div class="sheet-footer sheet-footer-btn-block-sm-down">
+		<div class="btn-group">
+			<div class="btn-group-item">
+				<button class="btn btn-primary" type="button">Primary</button>
+			</div>
+			<div class="btn-group-item">
+				<button class="btn btn-secondary" type="button">
+					Secondary
+				</button>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+## Commerce Product Screen(#css-commerce-product-screen)
+
+This is an example of the `sheet-multiple-form` modifier with `card-page card-page-equal-height` used to layout the Commerce Product Screen.
+
+<div class="sheet-example">
+	<div class="container-fluid container-fluid-max-xl">
+		<div class="card-page card-page-equal-height">
+			<div class="card-page-item col-lg-4 col-sm-6">
+				<div class="sheet">
+					<div class="autofit-padded-no-gutters autofit-row autofit-row-center">
+						<div class="autofit-col">
+							<div class="sticker sticker-success sticker-xl">
+								<svg class="lexicon-icon lexicon-icon-document-pending" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#document-pending" />
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<div>Units Sold</div>
+							<div><span>128</span><span> / Sales </span><strong>$459k</strong></div>
+							<div>27% last 30 days</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="card-page-item col-lg-4 col-sm-6">
+				<div class="sheet">
+					<div class="autofit-padded-no-gutters autofit-row autofit-row-center">
+						<div class="autofit-col">
+							<div class="sticker sticker-success sticker-xl">
+								<svg class="lexicon-icon lexicon-icon-document-pending" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#document-pending" />
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<div>Units Sold</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="card-page-item col-lg-4 col-sm-6">
+				<div class="sheet">
+					<div class="autofit-padded-no-gutters autofit-row autofit-row-center">
+						<div class="autofit-col">
+							<div class="sticker sticker-success sticker-xl">
+								<svg class="lexicon-icon lexicon-icon-document-pending" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#document-pending" />
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<div>Units Sold</div>
+							<div><span>128</span><span> / Sales </span><strong>$459k</strong></div>
+							<div>27% last 30 days</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="card-page card-page-equal-height">
+			<div class="card-page-item col-12">
+				<div class="sheet sheet-multiple-form">
+					<div class="sheet-header">
+						<h4 class="sheet-title">SEO</h4>
+					</div>
+					<div class="row">
+						<div class="col-md-6">
+							<div class="form-group">
+								<label for="commerceFriendlyURL">Friendly URL</label>
+								<div class="form-text">https://www.your-domain.com</div>
+								<div class="input-group">
+									<div class="input-group-item input-group-item-shrink input-group-prepend">
+										<span class="input-group-text">/p/</span>
+									</div>
+									<div class="input-group-append input-group-item">
+										<input class="form-control" id="commerceFriendlyURL" placeholder="design/lexicon" type="text" value="design/lexicon">
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="col-md-6">
+							<div class="form-group">
+								<div class="form-group-item form-group-item-label-spacer">
+									<label for="HTMLTitle">
+										HTML Title
+									</label>
+									<div class="input-group">
+										<div class="input-group-item">
+											<input aria-label="Amount" class="form-control" id="HTMLTitle" placeholder="Some placeholder text..." type="text" value="This is an example of a very long title...">
+											<div class="form-feedback-group">
+												<div class="autofit-row">
+													<div class="autofit-col autofit-col-expand">
+														<div class="form-text">Title length should be under 60 characters</div>
+													</div>
+													<div class="autofit-col">
+														<div class="form-text">56/60</div>
+													</div>
+												</div>
+											</div>
+										</div>
+										<div class="input-group-item input-group-item-shrink">
+											<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary dropdown-toggle" data-toggle="dropdown" type="button">
+												<span class="inline-item">
+													<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+														<use xlink:href="/images/icons/icons.svg#es-es"></use>
+													</svg>
+												</span>
+												<span class="btn-section">es-ES</span>
+											</button>
+											<ul class="dropdown-menu dropdown-menu-right">
+												<li>
+													<a class="autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-en-us" focusable="false" role="presentation">
+																		<use xlink:href="/images/icons/icons.svg#en-us"></use>
+																	</svg>
+																</span>
+																en-US
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-info">
+																<span class="label-item label-item-expand">Default</span>
+															</span>
+														</span>
+													</a>
+												</li>
+												<li>
+													<a class="autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-en-gb" focusable="false" role="presentation">
+																		<use xlink:href="/images/icons/icons.svg#en-gb"></use>
+																	</svg>
+																</span>
+																en-GB
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-success">
+																<span class="label-item label-item-expand">Translated</span>
+															</span>
+														</span>
+													</a>
+												</li>
+												<li>
+													<a class="active autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+																		<use xlink:href="/images/icons/icons.svg#es-es"></use>
+																	</svg>
+																</span>
+																es-ES
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-success">
+																<span class="label-item label-item-expand">Translated</span>
+															</span>
+														</span>
+													</a>
+												</li>
+												<li>
+													<a class="autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-fr-fr" focusable="false" role="presentation">
+																		<use xlink:href="/images/icons/icons.svg#fr-fr"></use>
+																	</svg>
+																</span>
+																fr-FR
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-warning">
+																<span class="label-item label-item-expand">Not Translated</span>
+															</span>
+														</span>
+													</a>
+												</li>
+											</ul>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="row">
+						<div class="col-md-6">
+							<div class="form-group">
+								<label for="productDescription">Description</label>
+								<div class="input-group">
+									<div class="input-group-item">
+										<textarea aria-label="Amount" class="form-control" id="productDescription" placeholder="Some placeholder text...">El ratón inalámbrico Liferay es el ratón estelar de Liferay, diseñado para ofrecer a los usuarios avanzados comodidad, control y precisión superiores</textarea>
+										<div class="form-feedback-group">
+											<div class="autofit-row">
+												<div class="autofit-col autofit-col-expand">
+													<div class="form-text">Description should be under 155 characters</div>
+												</div>
+												<div class="autofit-col">
+													<div class="form-text">114/160</div>
+												</div>
+											</div>
+										</div>
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary dropdown-toggle" data-toggle="dropdown" type="button">
+											<span class="inline-item">
+												<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#es-es"></use>
+												</svg>
+											</span>
+											<span class="btn-section">es-ES</span>
+										</button>
+										<ul class="dropdown-menu dropdown-menu-right">
+											<li>
+												<a class="autofit-row dropdown-item" href="#1">
+													<span class="autofit-col autofit-col-expand">
+														<span class="autofit-section">
+															<span class="inline-item inline-item-before">
+																<svg class="lexicon-icon lexicon-icon-en-us" focusable="false" role="presentation">
+																	<use xlink:href="/images/icons/icons.svg#en-us"></use>
+																</svg>
+															</span>
+															en-US
+														</span>
+													</span>
+													<span class="autofit-col">
+														<span class="label label-info">
+															<span class="label-item label-item-expand">Default</span>
+														</span>
+													</span>
+												</a>
+											</li>
+											<li>
+												<a class="autofit-row dropdown-item" href="#1">
+													<span class="autofit-col autofit-col-expand">
+														<span class="autofit-section">
+															<span class="inline-item inline-item-before">
+																<svg class="lexicon-icon lexicon-icon-en-gb" focusable="false" role="presentation">
+																	<use xlink:href="/images/icons/icons.svg#en-gb"></use>
+																</svg>
+															</span>
+															en-GB
+														</span>
+													</span>
+													<span class="autofit-col">
+														<span class="label label-success">
+															<span class="label-item label-item-expand">Translated</span>
+														</span>
+													</span>
+												</a>
+											</li>
+											<li>
+												<a class="active autofit-row dropdown-item" href="#1">
+													<span class="autofit-col autofit-col-expand">
+														<span class="autofit-section">
+															<span class="inline-item inline-item-before">
+																<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+																	<use xlink:href="/images/icons/icons.svg#es-es"></use>
+																</svg>
+															</span>
+															es-ES
+														</span>
+													</span>
+													<span class="autofit-col">
+														<span class="label label-success">
+															<span class="label-item label-item-expand">Translated</span>
+														</span>
+													</span>
+												</a>
+											</li>
+											<li>
+												<a class="autofit-row dropdown-item" href="#1">
+													<span class="autofit-col autofit-col-expand">
+														<span class="autofit-section">
+															<span class="inline-item inline-item-before">
+																<svg class="lexicon-icon lexicon-icon-fr-fr" focusable="false" role="presentation">
+																	<use xlink:href="/images/icons/icons.svg#fr-fr"></use>
+																</svg>
+															</span>
+															fr-FR
+														</span>
+													</span>
+													<span class="autofit-col">
+														<span class="label label-warning">
+															<span class="label-item label-item-expand">Not Translated</span>
+														</span>
+													</span>
+												</a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="col-md-6">
+							<div class="form-group">
+								<label for="commerceKeywords">Keywords</label>
+								<div class="input-group">
+									<div class="input-group-item">
+										<textarea aria-label="Amount" class="form-control" id="commerceKeywords" placeholder="Keywords"></textarea>
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary dropdown-toggle" data-toggle="dropdown" type="button">
+											<span class="inline-item">
+												<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#es-es"></use>
+												</svg>
+											</span>
+											<span class="btn-section">es-ES</span>
+										</button>
+										<ul class="dropdown-menu dropdown-menu-right">
+											<li>
+												<a class="autofit-row dropdown-item" href="#1">
+													<span class="autofit-col autofit-col-expand">
+														<span class="autofit-section">
+															<span class="inline-item inline-item-before">
+																<svg class="lexicon-icon lexicon-icon-en-us" focusable="false" role="presentation">
+																	<use xlink:href="/images/icons/icons.svg#en-us"></use>
+																</svg>
+															</span>
+															en-US
+														</span>
+													</span>
+													<span class="autofit-col">
+														<span class="label label-info">
+															<span class="label-item label-item-expand">Default</span>
+														</span>
+													</span>
+												</a>
+											</li>
+											<li>
+												<a class="autofit-row dropdown-item" href="#1">
+													<span class="autofit-col autofit-col-expand">
+														<span class="autofit-section">
+															<span class="inline-item inline-item-before">
+																<svg class="lexicon-icon lexicon-icon-en-gb" focusable="false" role="presentation">
+																	<use xlink:href="/images/icons/icons.svg#en-gb"></use>
+																</svg>
+															</span>
+															en-GB
+														</span>
+													</span>
+													<span class="autofit-col">
+														<span class="label label-success">
+															<span class="label-item label-item-expand">Translated</span>
+														</span>
+													</span>
+												</a>
+											</li>
+											<li>
+												<a class="active autofit-row dropdown-item" href="#1">
+													<span class="autofit-col autofit-col-expand">
+														<span class="autofit-section">
+															<span class="inline-item inline-item-before">
+																<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+																	<use xlink:href="/images/icons/icons.svg#es-es"></use>
+																</svg>
+															</span>
+															es-ES
+														</span>
+													</span>
+													<span class="autofit-col">
+														<span class="label label-success">
+															<span class="label-item label-item-expand">Translated</span>
+														</span>
+													</span>
+												</a>
+											</li>
+											<li>
+												<a class="autofit-row dropdown-item" href="#1">
+													<span class="autofit-col autofit-col-expand">
+														<span class="autofit-section">
+															<span class="inline-item inline-item-before">
+																<svg class="lexicon-icon lexicon-icon-fr-fr" focusable="false" role="presentation">
+																	<use xlink:href="/images/icons/icons.svg#fr-fr"></use>
+																</svg>
+															</span>
+															fr-FR
+														</span>
+													</span>
+													<span class="autofit-col">
+														<span class="label label-warning">
+															<span class="label-item label-item-expand">Not Translated</span>
+														</span>
+													</span>
+												</a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="row">
+						<div class="col-md-6">
+							<div class="form-group">
+								<label>Preview</label>
+								<div class="card card-type-template">
+									<div class="card-body">
+										<a href="#1"><strong>This is an example of a very long title</strong></a>
+										<div class="text-success">https://liferay.com</div>
+										<div>Optimal title length Google typically displays the first 50-60 characters of a title tag. If you keep your titles under 60 characters, our research suggest...</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="container-fluid container-fluid-max-xl">
+	<div class="card-page card-page-equal-height">
+		<div class="card-page-item col-lg-4 col-sm-6">
+			<div class="sheet">
+				<div
+					class="autofit-padded-no-gutters autofit-row autofit-row-center"
+				>
+					<div class="autofit-col"></div>
+					<div class="autofit-col autofit-col-expand"></div>
+				</div>
+			</div>
+		</div>
+		<div class="card-page-item col-lg-4 col-sm-6">
+			<div class="sheet">
+				<div
+					class="autofit-padded-no-gutters autofit-row autofit-row-center"
+				>
+					<div class="autofit-col"></div>
+					<div class="autofit-col autofit-col-expand"></div>
+				</div>
+			</div>
+		</div>
+		<div class="card-page-item col-lg-4 col-sm-6">
+			<div class="sheet">
+				<div
+					class="autofit-padded-no-gutters autofit-row autofit-row-center"
+				>
+					<div class="autofit-col"></div>
+					<div class="autofit-col autofit-col-expand"></div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="card-page card-page-equal-height">
+		<div class="card-page-item col-12">
+			<div class="sheet sheet-multiple-form">
+				<div class="sheet-header">
+					<h4 class="sheet-title">SEO</h4>
+				</div>
+				<div class="row">
+					<div class="col-md-6"></div>
+					<div class="col-md-6"></div>
+				</div>
+				<div class="row">
+					<div class="col-md-6"></div>
+					<div class="col-md-6"></div>
+				</div>
+				<div class="row">
+					<div class="col-md-6"></div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+## Sheet Dataset Content(#css-sheet-dataset-content)
+
+The modifier `sheet-dataset-content` should be added to `sheet` for sheets containing datasets.
+
+A common usage of the `sheet` is to present a dataset display inside. This case benefits of the `sheet-title` and the content free space to place elements such as the dataset display. See <a href="https://liferay.design/lexicon/core-components/forms/forms-sheet/#dataset-content" rel="noopener noreferrer" target="_blank">Lexicon</a>.
+
+<div class="sheet-example">
+	<div class="container-fluid container-fluid-max-xl">
+		<div class="sheet sheet-dataset-content">
+			<div class="sheet-header">
+				<h4 class="sheet-title">
+					<span class="autofit-row autofit-padded-no-gutters">
+						<span class="autofit-col autofit-col-shrink">
+							<span class="component-title">col1</span>
+						</span>
+						<span class="autofit-col">
+							<button class="component-action" type="button">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</button>
+						</span>
+					</span>
+				</h4>
+			</div>
+			<nav class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-light">
+				<div class="container-fluid container-fluid-max-xl">
+					<a aria-controls="navigationBarCollapse00" aria-expanded="false" aria-label="Toggle Navigation" class="collapsed navbar-toggler navbar-toggler-link" data-toggle="collapse" href="#navigationBarCollapse00" role="button">
+						<span class="navbar-text-truncate">Fragments</span>
+						<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+							<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+						</svg>
+					</a>
+					<div class="collapse navbar-collapse" id="navigationBarCollapse00" style="z-index: 505;">
+						<div class="container-fluid container-fluid-max-xl">
+							<ul class="navbar-nav">
+								<li aria-label="Current Page" class="nav-item">
+									<a class="active nav-link" href="#1">
+										<span class="navbar-text-truncate">Fragments</span>
+									</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link" href="#1">
+										<span class="navbar-text-truncate">Resources</span>
+									</a>
+								</li>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</nav>
+			<nav class="management-bar management-bar-light navbar navbar-expand-md">
+				<div class="container-fluid container-fluid-max-xl">
+					<ul class="navbar-nav">
+						<li class="nav-item">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input class="custom-control-input" type="checkbox">
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</li>
+						<li class="dropdown nav-item">
+							<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link navbar-breakpoint-down-d-none" data-toggle="dropdown" href="#1" role="button">
+								<span class="navbar-text-truncate">Filter and Order</span>
+								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+								</svg>
+							</a>
+							<a aria-expanded="false" aria-haspopup="true" class="nav-link nav-link-monospaced dropdown-toggle navbar-breakpoint-d-none" data-toggle="dropdown" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-filter" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#filter" />
+								</svg>
+							</a>
+							<ul class="dropdown-menu">
+								<li><a class="dropdown-item" href="#1" role="button">Filter Action 1</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Filter Action 2</a></li>
+								<li><a class="dropdown-item" href="#1" role="button">Filter Action 3</a></li>
+							</ul>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link nav-link-monospaced order-arrow-down-active" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-order-arrow" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#order-arrow" />
+								</svg>
+							</a>
+						</li>
+					</ul>
+					<div class="navbar-form navbar-form-autofit navbar-overlay navbar-overlay-sm-down">
+						<div class="container-fluid container-fluid-max-xl">
+							<form role="search">
+								<div class="input-group">
+									<div class="input-group-item">
+										<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
+										<span class="input-group-inset-item input-group-inset-item-after">
+											<button class="btn btn-unstyled" type="submit">
+												<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#search" />
+												</svg>
+											</button>
+											<button class="btn btn-unstyled d-none" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times" />
+												</svg>
+											</button>
+										</span>
+									</div>
+								</div>
+							</form>
+						</div>
+					</div>
+					<ul class="navbar-nav">
+						<li class="nav-item navbar-breakpoint-d-none">
+							<a class="nav-link nav-link-monospaced" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#search" />
+								</svg>
+							</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link nav-link-monospaced" href="#uniqueSidenavCollapseId2" id="uniqueSidenavToggler2" role="button">
+								<svg class="lexicon-icon lexicon-icon-info-circle-open" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#info-circle-open" />
+								</svg>
+							</a>
+						</li>
+						<li class="dropdown nav-item">
+							<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced" data-toggle="dropdown" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-list" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#list" />
+								</svg>
+							</a>
+							<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
+								<li>
+									<a class="active dropdown-item" href="#1">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-list" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#list" />
+											</svg>
+										</span>
+										List View
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-table" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#table" />
+											</svg>
+										</span>
+										Table View
+									</a>
+								</li>
+								<li>
+									<a class="dropdown-item" href="#1">
+										<span class="dropdown-item-indicator-start">
+											<svg class="lexicon-icon lexicon-icon-cards2" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#cards2" />
+											</svg>
+										</span>
+										Card View
+									</a>
+								</li>
+							</ul>
+						</li>
+						<li class="nav-item">
+							<a class="btn btn-primary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none" href="#1" role="button">
+								<svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#plus" />
+								</svg>
+							</a>
+						</li>
+					</ul>
+				</div>
+			</nav>
+			<div class="container-view">
+				<div class="sheet">
+					<div class="c-empty-state c-empty-state-animation">
+						<div class="c-empty-state-image">
+							<div class="c-empty-state-aspect-ratio">
+								<img alt="Image of a satellite in space" class="aspect-ratio-item aspect-ratio-item-fluid" src="/images/empty_state.gif" />
+							</div>
+						</div>
+						<div class="c-empty-state-title">
+							<span class="text-truncate-inline">
+								<span class="text-truncate">No page templates yet</span>
+							</span>
+						</div>
+						<div class="c-empty-state-text">Page Templates allow you to create pages faster with reusable elements.</div>
+						<div class="c-empty-state-footer">
+							<button class="btn btn-secondary btn-sm" type="button">New Document</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="container-fluid container-fluid-max-xl">
+	<div class="sheet sheet-dataset-content">
+		<div class="sheet-header">
+			<h4 class="sheet-title">
+				<span class="autofit-row autofit-padded-no-gutters">
+					<span class="autofit-col autofit-col-shrink">
+						<span class="component-title">col1</span>
+					</span>
+					<span class="autofit-col">
+						<button class="component-action" type="button">
+							<svg
+								class="lexicon-icon lexicon-icon-ellipsis-v"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#ellipsis-v"
+								/>
+							</svg>
+						</button>
+					</span>
+				</span>
+			</h4>
+		</div>
+		<nav
+			class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
+		></nav>
+		<nav
+			class="management-bar management-bar-light navbar navbar-expand-md"
+		></nav>
+		<div class="container-view">
+			<div class="sheet">
+				<div class="c-empty-state c-empty-state-animation">
+					<div class="c-empty-state-image">
+						<div class="c-empty-state-aspect-ratio">
+							<img
+								alt="Image of a satellite in space"
+								class="aspect-ratio-item aspect-ratio-item-fluid"
+								src="/images/empty_state.gif"
+							/>
+						</div>
+					</div>
+					<div class="c-empty-state-title">
+						<span class="text-truncate-inline">
+							<span class="text-truncate"
+								>No page templates yet</span
+							>
+						</span>
+					</div>
+					<div class="c-empty-state-text">
+						Page Templates allow you to create pages faster with
+						reusable elements.
+					</div>
+					<div class="c-empty-state-footer">
+						<button class="btn btn-secondary btn-sm" type="button">
+							New Document
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
 ```

--- a/clayui.com/content/docs/css/utilities/autofit.md
+++ b/clayui.com/content/docs/css/utilities/autofit.md
@@ -18,16 +18,16 @@ title: 'Autofit'
 
 ## Row(#css-row)
 
-Make content expand to fill remaining space or create equally spaced content with the `.autofit-row`, `.autofit-col`, and `.autofit-col-expand` classes.
+Make content expand to fill remaining space or create equally spaced content with `.autofit-row`, `.autofit-col`, `.autofit-col-shrink`, and `.autofit-col-expand`.
 
 <div class="clay-site-alert alert alert-warning">
 	<strong class="lead">Warning</strong>
-	<code>.autofit-row</code>, <code>.autofit-col</code>, <code>.autofit-col-expand</code> shouldn't be used for laying out site pages, rather it's most useful for small chunks of content inside other components (e.g. cards or list-groups).
+	`.autofit-row`, `.autofit-col`, `.autofit-col-shrink`, and `.autofit-col-expand` shouldn't be used for laying out site pages, rather it's most useful for small chunks of content inside other components (e.g. cards or list-groups).
 </div>
 
 <div class="clay-site-alert alert alert-warning">
 	<strong class="lead">Warning</strong>
-	Direct descendants of <code>.autofit-col</code> are <code>flex-direction: column;</code> (IE 10-11 workaround because they don't respect min/max width or min/max height in flex items) become block level elements by default, see <a href="https://www.w3.org/TR/css-flexbox-1/#flex-items">https://www.w3.org/TR/css-flexbox-1/#flex-items</a>. If you want to display content inside <code>.autofit-col</code> using <code>floats</code>, <code>inline</code>, or <code>inline-block</code>, wrap the content with <code>.autofit-section</code>.
+	Direct descendants of `.autofit-col` are `flex-direction: column;` (IE 10-11 workaround because they don't respect min/max width or min/max height in flex items) become block level elements by default, see <a href="https://www.w3.org/TR/css-flexbox-1/#flex-items">https://www.w3.org/TR/css-flexbox-1/#flex-items</a>. If you want to display content inside `.autofit-col` using `floats`, `inline`, or `inline-block`, wrap the content with `.autofit-section`.
 </div>
 
 <div class="sheet-example">
@@ -213,27 +213,98 @@ Make content expand to fill remaining space or create equally spaced content wit
 </div>
 ```
 
+## Autofit Col Shrink(#css-autofit-col-shrink)
+
+The modifier `autofit-col-shrink` makes the column only as wide as its content and will grow to fill the remaining space depending on the length of the content. This should be used with variable width content such as title text with adjoining buttons.
+
 <div class="sheet-example">
-	<div class="card">
-		<div class="card-body">
-			<div class="autofit-padded-no-gutters-x autofit-row">
-				<div class="autofit-col autofit-col-expand">
-					<h2 class="component-title" style="font-size:1.25rem;font-weight:700;">
-						ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
-					</h2>
-					<div>Sept 25 - 3 Views</div>
-				</div>
-				<div class="autofit-col">
-					<button class="btn btn-monospaced btn-outline-primary btn-outline-borderless btn-sm" type="button">
-						<span class="inline-item">
-							<svg class="lexicon-icon lexicon-icon-pencil" focusable="false" role="presentation">
-								<use href="/images/icons/icons.svg#pencil" />
+	<div class="sheet">
+		<h4 class="sheet-title">
+			<span class="autofit-padded-no-gutters autofit-row">
+				<span class="autofit-col autofit-col-shrink">
+					<span class="component-title">Collection</span>
+				</span>
+				<span class="autofit-col">
+					<button class="component-action" type="button">
+						<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+							<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</button>
+				</span>
+			</span>
+		</h4>
+		<h4 class="sheet-title">
+			<span class="autofit-padded-no-gutters autofit-row">
+				<span class="autofit-col">
+					<button class="component-action" type="button">
+						<svg class="lexicon-icon lexicon-icon-link" focusable="false" role="presentation">
+							<use xlink:href="/images/icons/icons.svg#link" />
+						</svg>
+					</button>
+				</span>
+				<span class="autofit-col autofit-col-shrink">
+					<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+				</span>
+				<span class="autofit-col">
+					<button class="component-action" type="button">
+						<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+							<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</button>
+				</span>
+			</span>
+		</h4>
+	</div>
+</div>
+
+## Autofit Col Expand(#css-autofit-col-expand)
+
+The modifier `autofit-col-expand` makes the column fill the remaining space.
+
+<div class="sheet-example">
+	<div class="sheet">
+		<h4 class="sheet-title">
+			<span class="autofit-padded-no-gutters autofit-row">
+				<span class="autofit-col autofit-col-expand">
+					<span class="component-title">Collection</span>
+				</span>
+				<span class="autofit-col">
+					<button class="btn component-action" type="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-cog" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#cog" />
 							</svg>
 						</span>
 					</button>
-				</div>
-			</div>
-		</div>
+				</span>
+				<span class="autofit-col">
+					<button class="btn component-action" type="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+							</svg>
+						</span>
+					</button>
+				</span>
+			</span>
+		</h4>
+		<h4 class="sheet-title">
+			<span class="autofit-padded-no-gutters-x autofit-row">
+				<span class="autofit-col autofit-col-expand">
+					<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+					<small>Sept 25 - 3 Views</small>
+				</span>
+				<span class="autofit-col">
+					<button class="btn btn-monospaced btn-outline-primary btn-outline-borderless btn-sm" type="button">
+						<span class="inline-item">
+							<svg class="lexicon-icon lexicon-icon-pencil" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#pencil" />
+							</svg>
+						</span>
+					</button>
+				</span>
+			</span>
+		</h4>
 	</div>
 </div>
 

--- a/packages/clay-css/src/content/sheet.html
+++ b/packages/clay-css/src/content/sheet.html
@@ -137,34 +137,32 @@ section: Components
 		</blockquote>
 
 		<div class="sheet sheet-lg">
-			<div class="sheet-header">
-				<h4 class="sheet-title">
-					<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-title">One Line Title</span>
-						</span>
-						<span class="autofit-col">
-							<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-secondary btn-sm" type="button">Remove</button>
-						</span>
+			<h4 class="sheet-title">
+				<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-title">One Line Title</span>
 					</span>
-				</h4>
-				<h4 class="sheet-title">
-					<span class="autofit-padded-no-gutters autofit-row">
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
-						</span>
-						<span class="autofit-col">
-							<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-secondary btn-sm" type="button">Remove</button>
-						</span>
+					<span class="autofit-col">
+						<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
 					</span>
-				</h4>
-			</div>
+					<span class="autofit-col">
+						<button class="btn btn-secondary btn-sm" type="button">Remove</button>
+					</span>
+				</span>
+			</h4>
+			<h4 class="sheet-title">
+				<span class="autofit-padded-no-gutters autofit-row">
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+					</span>
+					<span class="autofit-col">
+						<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-secondary btn-sm" type="button">Remove</button>
+					</span>
+				</span>
+			</h4>
 		</div>
 
 	</div>
@@ -179,34 +177,32 @@ section: Components
 		</blockquote>
 
 		<div class="sheet sheet-lg">
-			<div class="sheet-section">
-				<h4 class="sheet-subtitle">
-					<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-title">One Line Subtitle</span>
-						</span>
-						<span class="autofit-col">
-							<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-secondary btn-sm" type="button">Remove</button>
-						</span>
+			<h4 class="sheet-subtitle">
+				<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-title">One Line Subtitle</span>
 					</span>
-				</h4>
-				<h4 class="sheet-subtitle">
-					<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
-						</span>
-						<span class="autofit-col">
-							<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-secondary btn-sm" type="button">Remove</button>
-						</span>
+					<span class="autofit-col">
+						<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
 					</span>
-				</h4>
-			</div>
+					<span class="autofit-col">
+						<button class="btn btn-secondary btn-sm" type="button">Remove</button>
+					</span>
+				</span>
+			</h4>
+			<h4 class="sheet-subtitle">
+				<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+					</span>
+					<span class="autofit-col">
+						<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-secondary btn-sm" type="button">Remove</button>
+					</span>
+				</span>
+			</h4>
 		</div>
 
 	</div>
@@ -217,34 +213,32 @@ section: Components
 		<h3>Component Title with Sheet Tertiary Title</h3>
 
 		<div class="sheet sheet-lg">
-			<div class="sheet-section">
-				<h4 class="sheet-tertiary-title">
-					<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-title">One Line Tertiary Title</span>
-						</span>
-						<span class="autofit-col">
-							<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-secondary btn-sm" type="button">Remove</button>
-						</span>
+			<h4 class="sheet-tertiary-title">
+				<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-title">One Line Tertiary Title</span>
 					</span>
-				</h4>
-				<h4 class="sheet-tertiary-title">
-					<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
-						</span>
-						<span class="autofit-col">
-							<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-secondary btn-sm" type="button">Remove</button>
-						</span>
+					<span class="autofit-col">
+						<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
 					</span>
-				</h4>
-			</div>
+					<span class="autofit-col">
+						<button class="btn btn-secondary btn-sm" type="button">Remove</button>
+					</span>
+				</span>
+			</h4>
+			<h4 class="sheet-tertiary-title">
+				<span class="autofit-float-sm-down autofit-padded-no-gutters autofit-row">
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+					</span>
+					<span class="autofit-col">
+						<a class="btn btn-secondary btn-sm" href="#1" role="button">Add</a>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-secondary btn-sm" type="button">Remove</button>
+					</span>
+				</span>
+			</h4>
 		</div>
 
 	</div>
@@ -255,15 +249,74 @@ section: Components
 		<h3>Multiple Sheets in Same Column</h3>
 
 		<div class="sheet sheet-lg">
-			<div class="sheet-section">
-				<h4 class="sheet-title">Sheet 1</h4>
-			</div>
+			<h4 class="sheet-title">Sheet 1</h4>
 		</div>
 		<div class="sheet sheet-lg">
-			<div class="sheet-section">
-				<h4 class="sheet-title">Sheet 2</h4>
-			</div>
+			<h4 class="sheet-title">Sheet 2</h4>
 		</div>
 
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Sheet Multiple Form</h3>
+
+		<blockquote class="blockquote">
+			This pattern is used in form scenarios, usually to display a form, multiple forms or a combination of single/multiple forms and one or several sheets to display information. We will see this in the following sections and its examples.
+		</blockquote>
+
+		<div class="sheet sheet-multiple-form">
+			<div class="sheet-header">
+				<div class="autofit-row autofit-padded-no-gutters">
+					<div class="autofit-col autofit-col-shrink">
+						<h4 class="sheet-title">
+							<span class="component-title">Sheet Header</span>
+						</h4>
+					</div>
+					<div class="autofit-col">
+						<div class="dropdown dropdown-action">
+							<button aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" id="dropdownSites5" type="button">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</button>
+							<ul aria-labelledby="dropdownSites5" class="dropdown-menu">
+								<li><a class="dropdown-item" href="#1">Download</a></li>
+								<li><a class="dropdown-item" href="#1">Edit</a></li>
+								<li><a class="dropdown-item" href="#1">Move</a></li>
+								<li><a class="dropdown-item" href="#1">Checkout</a></li>
+								<li><a class="dropdown-item" href="#1">Permissions</a></li>
+								<li><a class="dropdown-item" href="#1">Move to Recycle Bin</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="sheet-section">
+				<h5 class="sheet-title">Sheet Title</h5>
+				<p class="sheet-text">Sheet text should be used for any kind of explanatory text. The Sheet Title and Sheet Text are contained inside a sheet-section.</p>
+			</div>
+			<div class="sheet-section">
+				<h6 class="sheet-subtitle">Sheet Subtitle 01</h6>
+				<div class="form-group">
+					<label for="basicInputTypeTextarea">Textarea</label>
+					<textarea class="form-control" id="basicInputTypeTextarea" name="basicInputTypeTextarea" placeholder="Placeholder"></textarea>
+				</div>
+			</div>
+			<div class="sheet-section">
+				<h6 class="sheet-subtitle">Sheet Subtitle 02</h6>
+			</div>
+			<div class="sheet-footer sheet-footer-btn-block-sm-down">
+				<div class="btn-group">
+					<div class="btn-group-item">
+						<button class="btn btn-primary" type="button">Primary</button>
+					</div>
+					<div class="btn-group-item">
+						<button class="btn btn-secondary" type="button">Secondary</button>
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
 </div>

--- a/packages/clay-css/src/content/test_sheet_commerce.html
+++ b/packages/clay-css/src/content/test_sheet_commerce.html
@@ -1,0 +1,716 @@
+---
+title: Sheet (Commerce)
+section: Visual Tests
+---
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Commerce Example</h3>
+
+		<div class="container-fluid container-fluid-max-xl">
+			<div class="card-page card-page-equal-height">
+				<div class="card-page-item col-lg-4 col-sm-6">
+					<div class="sheet">
+						<div class="autofit-padded-no-gutters autofit-row autofit-row-center">
+							<div class="autofit-col">
+								<div class="sticker sticker-success sticker-xl">
+									<svg class="lexicon-icon lexicon-icon-document-pending" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#document-pending" />
+									</svg>
+								</div>
+							</div>
+							<div class="autofit-col autofit-col-expand">
+								<div>Units Sold</div>
+								<div><span>128</span><span> / Sales </span><strong>$459k</strong></div>
+								<div>27% last 30 days</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="card-page-item col-lg-4 col-sm-6">
+					<div class="sheet">
+						<div class="autofit-padded-no-gutters autofit-row autofit-row-center">
+							<div class="autofit-col">
+								<div class="sticker sticker-success sticker-xl">
+									<svg class="lexicon-icon lexicon-icon-document-pending" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#document-pending" />
+									</svg>
+								</div>
+							</div>
+							<div class="autofit-col autofit-col-expand">
+								<div>Units Sold</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="card-page-item col-lg-4 col-sm-6">
+					<div class="sheet">
+						<div class="autofit-padded-no-gutters autofit-row autofit-row-center">
+							<div class="autofit-col">
+								<div class="sticker sticker-success sticker-xl">
+									<svg class="lexicon-icon lexicon-icon-document-pending" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#document-pending" />
+									</svg>
+								</div>
+							</div>
+							<div class="autofit-col autofit-col-expand">
+								<div>Units Sold</div>
+								<div><span>128</span><span> / Sales </span><strong>$459k</strong></div>
+								<div>27% last 30 days</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="card-page card-page-equal-height">
+				<div class="card-page-item col-12 col-lg-8">
+					<div class="sheet sheet-multiple-form">
+						<div class="sheet-header">
+							<h4 class="sheet-title">Details</h4>
+						</div>
+						<div class="row">
+							<div class="col-sm-6">
+								<div class="form-group">
+									<label for="basicInputTypeText">Name</label>
+									<input class="form-control" id="basicInputTypeText" name="basicInputTypeText" placeholder="Placeholder" type="text">
+								</div>
+							</div>
+							<div class="col-sm-6">
+								<div class="form-group">
+									<label>Catalog</label>
+									<div class="form-control-plaintext">Winter Shoes 2020 Sneakers</div>
+								</div>
+							</div>
+						</div>
+						<div class="form-group">
+							<label for="basicInputTypeText1">Short Description</label>
+							<input class="form-control" id="basicInputTypeText1" name="basicInputTypeText" placeholder="Placeholder" type="text">
+						</div>
+						<div class="form-group">
+							<div class="autofit-float-sm-down autofit-row autofit-row-end c-pr-5">
+								<div class="autofit-col autofit-col-expand">
+									<div class="autofit-section">
+										<label for="localizableInput1">Full Description</label>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-shrink">
+									<div aria-label="First group" class="btn-group btn-group-sm" role="group">
+										<div class="btn-group-item">
+											<button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary" type="button">
+												<span class="c-inner" tabindex="-1">
+													<svg class="lexicon-icon lexicon-icon-text-editor" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#text-editor"></use>
+													</svg>
+												</span>
+											</button>
+										</div>
+										<div class="btn-group-item">
+											<button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary" type="button">
+												<span class="c-inner" tabindex="-1">
+													<svg class="lexicon-icon lexicon-icon-list-ol" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#list-ol"></use>
+													</svg>
+												</span>
+											</button>
+										</div>
+										<div class="btn-group-item">
+											<button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary" type="button">
+												<span class="c-inner" tabindex="-1">
+													<svg class="lexicon-icon lexicon-icon-list-ul" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#list-ul"></use>
+													</svg>
+												</span>
+											</button>
+										</div>
+										<div class="btn-group-item">
+											<button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary" type="button">
+												<span class="c-inner" tabindex="-1">
+													<svg class="lexicon-icon lexicon-icon-indent-more" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#indent-more"></use>
+													</svg>
+												</span>
+											</button>
+										</div>
+										<div class="btn-group-item">
+											<button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary" type="button">
+												<span class="c-inner" tabindex="-1">
+													<svg class="lexicon-icon lexicon-icon-link" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#link"></use>
+													</svg>
+												</span>
+											</button>
+										</div>
+									</div>
+								</div>
+							</div>
+							<div class="input-group">
+								<div class="input-group-item">
+									<textarea class="form-control" id="localizableInput1" placeholder="design/lexicon" type="text" value="soluciones"></textarea>
+								</div>
+								<div class="input-group-item input-group-item-shrink">
+									<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary dropdown-toggle" data-toggle="dropdown" type="button">
+										<span class="inline-item">
+											<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+											</svg>
+										</span>
+										<span class="btn-section">es-ES</span>
+									</button>
+									<ul class="dropdown-menu dropdown-menu-right">
+										<li>
+											<a class="autofit-row dropdown-item" href="#1">
+												<span class="autofit-col autofit-col-expand">
+													<span class="autofit-section">
+														<span class="inline-item inline-item-before">
+															<svg class="lexicon-icon lexicon-icon-en-us" focusable="false" role="presentation">
+																<use xlink:href="{{rootPath}}/images/icons/icons.svg#en-us"></use>
+															</svg>
+														</span>
+														en-US
+													</span>
+												</span>
+												<span class="autofit-col">
+													<span class="label label-info">
+														<span class="label-item label-item-expand">Default</span>
+													</span>
+												</span>
+											</a>
+										</li>
+										<li>
+											<a class="autofit-row dropdown-item" href="#1">
+												<span class="autofit-col autofit-col-expand">
+													<span class="autofit-section">
+														<span class="inline-item inline-item-before">
+															<svg class="lexicon-icon lexicon-icon-en-gb" focusable="false" role="presentation">
+																<use xlink:href="{{rootPath}}/images/icons/icons.svg#en-gb"></use>
+															</svg>
+														</span>
+														en-GB
+													</span>
+												</span>
+												<span class="autofit-col">
+													<span class="label label-success">
+														<span class="label-item label-item-expand">Translated</span>
+													</span>
+												</span>
+											</a>
+										</li>
+										<li>
+											<a class="active autofit-row dropdown-item" href="#1">
+												<span class="autofit-col autofit-col-expand">
+													<span class="autofit-section">
+														<span class="inline-item inline-item-before">
+															<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+																<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+															</svg>
+														</span>
+														es-ES
+													</span>
+												</span>
+												<span class="autofit-col">
+													<span class="label label-success">
+														<span class="label-item label-item-expand">Translated</span>
+													</span>
+												</span>
+											</a>
+										</li>
+										<li>
+											<a class="autofit-row dropdown-item" href="#1">
+												<span class="autofit-col autofit-col-expand">
+													<span class="autofit-section">
+														<span class="inline-item inline-item-before">
+															<svg class="lexicon-icon lexicon-icon-fr-fr" focusable="false" role="presentation">
+																<use xlink:href="{{rootPath}}/images/icons/icons.svg#fr-fr"></use>
+															</svg>
+														</span>
+														fr-FR
+													</span>
+												</span>
+												<span class="autofit-col">
+													<span class="label label-warning">
+														<span class="label-item label-item-expand">Not Translated</span>
+													</span>
+												</span>
+											</a>
+										</li>
+									</ul>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="card-page-item col-12 col-lg-4">
+					<div class="sheet sheet-multiple-form">
+						<div class="sheet-header">
+							<h4 class="sheet-title">Categorization</h4>
+						</div>
+						<div class="form-group">
+							<div class="clay-multiselect">
+								<label for="commerceCategories">Categories</label>
+								<div class="input-group input-group-stacked-sm-down">
+									<div class="input-group-item">
+										<div class="dropdown">
+											<div class="form-control form-control-tag-group input-group">
+												<div class="input-group-item">
+													<span class="label label-dismissible label-secondary" tabindex="0">
+														<span class="label-item label-item-before c-mr-1">
+															<span class="sticker sticker-danger">
+																<span class="sticker-overlay">
+																	<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#simple-circle"></use>
+																	</svg>
+																</span>
+															</span>
+														</span>
+														<span class="label-item label-item-expand">Running</span>
+														<span class="label-item label-item-after">
+															<button aria-label="Close" class="close" tabindex="-1" type="button">
+																<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+																</svg>
+															</button>
+														</span>
+													</span>
+													<span class="label label-dismissible label-secondary" tabindex="0">
+														<span class="label-item label-item-before c-mr-1">
+															<span class="sticker sticker-primary">
+																<span class="sticker-overlay">
+																	<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#simple-circle"></use>
+																	</svg>
+																</span>
+															</span>
+														</span>
+														<span class="label-item label-item-expand">Lifestyle</span>
+														<span class="label-item label-item-after">
+															<button aria-label="Close" class="close" tabindex="-1" type="button">
+																<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+																</svg>
+															</button>
+														</span>
+													</span>
+													<span class="label label-dismissible label-secondary" tabindex="0">
+														<span class="label-item label-item-before c-mr-1">
+															<span class="sticker sticker-success">
+																<span class="sticker-overlay">
+																	<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#simple-circle"></use>
+																	</svg>
+																</span>
+															</span>
+														</span>
+														<span class="label-item label-item-expand">Basketball</span>
+														<span class="label-item label-item-after">
+															<button aria-label="Close" class="close" tabindex="-1" type="button">
+																<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+																</svg>
+															</button>
+														</span>
+													</span>
+													<span class="label label-dismissible label-secondary" tabindex="0">
+														<span class="label-item label-item-before c-mr-1">
+															<span class="sticker sticker-warning">
+																<span class="sticker-overlay">
+																	<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#simple-circle"></use>
+																	</svg>
+																</span>
+															</span>
+														</span>
+														<span class="label-item label-item-expand">Basketball</span>
+														<span class="label-item label-item-after">
+															<button aria-label="Close" class="close" tabindex="-1" type="button">
+																<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+																</svg>
+															</button>
+														</span>
+													</span>
+													<span class="autofit-row">
+														<span class="autofit-col autofit-col-expand">
+															<input class="form-control-inset" id="commerceCategories" type="text" value="">
+														</span>
+													</span>
+												</div>
+												<div class="input-group-item input-group-item-shrink">
+													<button class="component-action" type="submit">
+														<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#search"></use>
+														</svg>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="card-page card-page-equal-height">
+				<div class="card-page-item col-12">
+					<div class="sheet sheet-multiple-form">
+						<div class="sheet-header">
+							<h4 class="sheet-title">SEO</h4>
+						</div>
+						<div class="row">
+							<div class="col-md-6">
+								<div class="form-group">
+									<label for="commerceFriendlyURL">Friendly URL</label>
+									<div class="form-text">https://www.your-domain.com</div>
+									<div class="input-group">
+										<div class="input-group-item input-group-item-shrink input-group-prepend">
+											<span class="input-group-text">/p/</span>
+										</div>
+										<div class="input-group-append input-group-item">
+											<input class="form-control" id="commerceFriendlyURL" placeholder="design/lexicon" type="text" value="design/lexicon">
+										</div>
+									</div>
+								</div>
+							</div>
+							<div class="col-md-6">
+								<div class="form-group">
+									<div class="form-group-item form-group-item-label-spacer">
+										<label for="HTMLTitle">
+											HTML Title
+										</label>
+										<div class="input-group">
+											<div class="input-group-item">
+												<input aria-label="Amount" class="form-control" id="HTMLTitle" placeholder="Some placeholder text..." type="text" value="This is an example of a very long title...">
+												<div class="form-feedback-group">
+													<div class="autofit-row">
+														<div class="autofit-col autofit-col-expand">
+															<div class="form-text">Title length should be under 60 characters</div>
+														</div>
+														<div class="autofit-col">
+															<div class="form-text">56/60</div>
+														</div>
+													</div>
+												</div>
+											</div>
+											<div class="input-group-item input-group-item-shrink">
+												<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary dropdown-toggle" data-toggle="dropdown" type="button">
+													<span class="inline-item">
+														<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+														</svg>
+													</span>
+													<span class="btn-section">es-ES</span>
+												</button>
+												<ul class="dropdown-menu dropdown-menu-right">
+													<li>
+														<a class="autofit-row dropdown-item" href="#1">
+															<span class="autofit-col autofit-col-expand">
+																<span class="autofit-section">
+																	<span class="inline-item inline-item-before">
+																		<svg class="lexicon-icon lexicon-icon-en-us" focusable="false" role="presentation">
+																			<use xlink:href="{{rootPath}}/images/icons/icons.svg#en-us"></use>
+																		</svg>
+																	</span>
+																	en-US
+																</span>
+															</span>
+															<span class="autofit-col">
+																<span class="label label-info">
+																	<span class="label-item label-item-expand">Default</span>
+																</span>
+															</span>
+														</a>
+													</li>
+													<li>
+														<a class="autofit-row dropdown-item" href="#1">
+															<span class="autofit-col autofit-col-expand">
+																<span class="autofit-section">
+																	<span class="inline-item inline-item-before">
+																		<svg class="lexicon-icon lexicon-icon-en-gb" focusable="false" role="presentation">
+																			<use xlink:href="{{rootPath}}/images/icons/icons.svg#en-gb"></use>
+																		</svg>
+																	</span>
+																	en-GB
+																</span>
+															</span>
+															<span class="autofit-col">
+																<span class="label label-success">
+																	<span class="label-item label-item-expand">Translated</span>
+																</span>
+															</span>
+														</a>
+													</li>
+													<li>
+														<a class="active autofit-row dropdown-item" href="#1">
+															<span class="autofit-col autofit-col-expand">
+																<span class="autofit-section">
+																	<span class="inline-item inline-item-before">
+																		<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+																			<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+																		</svg>
+																	</span>
+																	es-ES
+																</span>
+															</span>
+															<span class="autofit-col">
+																<span class="label label-success">
+																	<span class="label-item label-item-expand">Translated</span>
+																</span>
+															</span>
+														</a>
+													</li>
+													<li>
+														<a class="autofit-row dropdown-item" href="#1">
+															<span class="autofit-col autofit-col-expand">
+																<span class="autofit-section">
+																	<span class="inline-item inline-item-before">
+																		<svg class="lexicon-icon lexicon-icon-fr-fr" focusable="false" role="presentation">
+																			<use xlink:href="{{rootPath}}/images/icons/icons.svg#fr-fr"></use>
+																		</svg>
+																	</span>
+																	fr-FR
+																</span>
+															</span>
+															<span class="autofit-col">
+																<span class="label label-warning">
+																	<span class="label-item label-item-expand">Not Translated</span>
+																</span>
+															</span>
+														</a>
+													</li>
+												</ul>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="row">
+							<div class="col-md-6">
+								<div class="form-group">
+									<label for="productDescription">Description</label>
+									<div class="input-group">
+										<div class="input-group-item">
+											<textarea aria-label="Amount" class="form-control" id="productDescription" placeholder="Some placeholder text...">El ratón inalámbrico Liferay es el ratón estelar de Liferay, diseñado para ofrecer a los usuarios avanzados comodidad, control y precisión superiores</textarea>
+											<div class="form-feedback-group">
+												<div class="autofit-row">
+													<div class="autofit-col autofit-col-expand">
+														<div class="form-text">Description should be under 155 characters</div>
+													</div>
+													<div class="autofit-col">
+														<div class="form-text">114/160</div>
+													</div>
+												</div>
+											</div>
+										</div>
+										<div class="input-group-item input-group-item-shrink">
+											<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary dropdown-toggle" data-toggle="dropdown" type="button">
+												<span class="inline-item">
+													<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+													</svg>
+												</span>
+												<span class="btn-section">es-ES</span>
+											</button>
+											<ul class="dropdown-menu dropdown-menu-right">
+												<li>
+													<a class="autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-en-us" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#en-us"></use>
+																	</svg>
+																</span>
+																en-US
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-info">
+																<span class="label-item label-item-expand">Default</span>
+															</span>
+														</span>
+													</a>
+												</li>
+												<li>
+													<a class="autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-en-gb" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#en-gb"></use>
+																	</svg>
+																</span>
+																en-GB
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-success">
+																<span class="label-item label-item-expand">Translated</span>
+															</span>
+														</span>
+													</a>
+												</li>
+												<li>
+													<a class="active autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+																	</svg>
+																</span>
+																es-ES
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-success">
+																<span class="label-item label-item-expand">Translated</span>
+															</span>
+														</span>
+													</a>
+												</li>
+												<li>
+													<a class="autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-fr-fr" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#fr-fr"></use>
+																	</svg>
+																</span>
+																fr-FR
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-warning">
+																<span class="label-item label-item-expand">Not Translated</span>
+															</span>
+														</span>
+													</a>
+												</li>
+											</ul>
+										</div>
+									</div>
+								</div>
+							</div>
+							<div class="col-md-6">
+								<div class="form-group">
+									<label for="commerceKeywords">Keywords</label>
+									<div class="input-group">
+										<div class="input-group-item">
+											<textarea aria-label="Amount" class="form-control" id="commerceKeywords" placeholder="Keywords"></textarea>
+										</div>
+										<div class="input-group-item input-group-item-shrink">
+											<button aria-expanded="false" aria-haspopup="true" class="btn btn-monospaced btn-secondary dropdown-toggle" data-toggle="dropdown" type="button">
+												<span class="inline-item">
+													<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+													</svg>
+												</span>
+												<span class="btn-section">es-ES</span>
+											</button>
+											<ul class="dropdown-menu dropdown-menu-right">
+												<li>
+													<a class="autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-en-us" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#en-us"></use>
+																	</svg>
+																</span>
+																en-US
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-info">
+																<span class="label-item label-item-expand">Default</span>
+															</span>
+														</span>
+													</a>
+												</li>
+												<li>
+													<a class="autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-en-gb" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#en-gb"></use>
+																	</svg>
+																</span>
+																en-GB
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-success">
+																<span class="label-item label-item-expand">Translated</span>
+															</span>
+														</span>
+													</a>
+												</li>
+												<li>
+													<a class="active autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-es-es" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#es-es"></use>
+																	</svg>
+																</span>
+																es-ES
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-success">
+																<span class="label-item label-item-expand">Translated</span>
+															</span>
+														</span>
+													</a>
+												</li>
+												<li>
+													<a class="autofit-row dropdown-item" href="#1">
+														<span class="autofit-col autofit-col-expand">
+															<span class="autofit-section">
+																<span class="inline-item inline-item-before">
+																	<svg class="lexicon-icon lexicon-icon-fr-fr" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#fr-fr"></use>
+																	</svg>
+																</span>
+																fr-FR
+															</span>
+														</span>
+														<span class="autofit-col">
+															<span class="label label-warning">
+																<span class="label-item label-item-expand">Not Translated</span>
+															</span>
+														</span>
+													</a>
+												</li>
+											</ul>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="row">
+							<div class="col-md-6">
+								<div class="form-group">
+									<label>Preview</label>
+									<div class="card card-type-template">
+										<div class="card-body">
+											<a href="#1"><strong>This is an example of a very long title</strong></a>
+											<div class="text-success">https://liferay.com</div>
+											<div>Optimal title length Google typically displays the first 50-60 characters of a title tag. If you keep your titles under 60 characters, our research suggest...</div>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+		</div>
+
+	</div>
+</div>

--- a/packages/clay-css/src/content/test_sheet_dataset.html
+++ b/packages/clay-css/src/content/test_sheet_dataset.html
@@ -1,0 +1,201 @@
+---
+title: Sheet (Dataset Content)
+section: Visual Tests
+---
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Dataset Example</h3>
+
+		<div class="container-fluid container-fluid-max-xl">
+			<div class="sheet sheet-dataset-content">
+				<div class="sheet-header">
+					<h4 class="sheet-title">
+						<span class="autofit-row autofit-padded-no-gutters">
+							<span class="autofit-col autofit-col-shrink">
+								<span class="component-title">col1</span>
+							</span>
+							<span class="autofit-col">
+								<button class="component-action" type="button">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</button>
+							</span>
+						</span>
+					</h4>
+				</div>
+				<nav class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-light">
+					<div class="container-fluid container-fluid-max-xl">
+						<a aria-controls="navigationBarCollapse00" aria-expanded="false" aria-label="Toggle Navigation" class="collapsed navbar-toggler navbar-toggler-link" data-toggle="collapse" href="#navigationBarCollapse00" role="button">
+							<span class="navbar-text-truncate">Fragments</span>
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</a>
+						<div class="collapse navbar-collapse" id="navigationBarCollapse00" style="z-index: 505;">
+							<div class="container-fluid container-fluid-max-xl">
+								<ul class="navbar-nav">
+									<li aria-label="Current Page" class="nav-item">
+										<a class="active nav-link" href="#1">
+											<span class="navbar-text-truncate">Fragments</span>
+										</a>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1">
+											<span class="navbar-text-truncate">Resources</span>
+										</a>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</nav>
+				<nav class="management-bar management-bar-light navbar navbar-expand-md">
+					<div class="container-fluid container-fluid-max-xl">
+						<ul class="navbar-nav">
+							<li class="nav-item">
+								<div class="custom-control custom-checkbox">
+									<label>
+										<input class="custom-control-input" type="checkbox">
+										<span class="custom-control-label"></span>
+									</label>
+								</div>
+							</li>
+							<li class="dropdown nav-item">
+								<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link navbar-breakpoint-down-d-none" data-toggle="dropdown" href="#1" role="button">
+									<span class="navbar-text-truncate">Filter and Order</span>
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</a>
+								<a aria-expanded="false" aria-haspopup="true" class="nav-link nav-link-monospaced dropdown-toggle navbar-breakpoint-d-none" data-toggle="dropdown" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-filter" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#filter" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu">
+									<li><a class="dropdown-item" href="#1" role="button">Filter Action 1</a></li>
+									<li><a class="dropdown-item" href="#1" role="button">Filter Action 2</a></li>
+									<li><a class="dropdown-item" href="#1" role="button">Filter Action 3</a></li>
+								</ul>
+							</li>
+							<li class="nav-item">
+								<a class="nav-link nav-link-monospaced order-arrow-down-active" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-order-arrow" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#order-arrow" />
+									</svg>
+								</a>
+							</li>
+						</ul>
+						<div class="navbar-form navbar-form-autofit navbar-overlay navbar-overlay-sm-down">
+							<div class="container-fluid container-fluid-max-xl">
+								<form role="search">
+									<div class="input-group">
+										<div class="input-group-item">
+											<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
+											<span class="input-group-inset-item input-group-inset-item-after">
+												<button class="btn btn-unstyled" type="submit">
+													<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+													</svg>
+												</button>
+												<button class="btn btn-unstyled d-none" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+													</svg>
+												</button>
+											</span>
+										</div>
+									</div>
+								</form>
+							</div>
+						</div>
+						<ul class="navbar-nav">
+							<li class="nav-item navbar-breakpoint-d-none">
+								<a class="nav-link nav-link-monospaced" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+									</svg>
+								</a>
+							</li>
+							<li class="nav-item">
+								<a class="nav-link nav-link-monospaced" href="#uniqueSidenavCollapseId2" id="uniqueSidenavToggler2" role="button">
+									<svg class="lexicon-icon lexicon-icon-info-circle-open" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#info-circle-open" />
+									</svg>
+								</a>
+							</li>
+							<li class="dropdown nav-item">
+								<a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced" data-toggle="dropdown" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-list" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right dropdown-menu-indicator-start">
+									<li>
+										<a class="active dropdown-item" href="#1">
+											<span class="dropdown-item-indicator-start">
+												<svg class="lexicon-icon lexicon-icon-list" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
+												</svg>
+											</span>
+											List View
+										</a>
+									</li>
+									<li>
+										<a class="dropdown-item" href="#1">
+											<span class="dropdown-item-indicator-start">
+												<svg class="lexicon-icon lexicon-icon-table" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#table" />
+												</svg>
+											</span>
+											Table View
+										</a>
+									</li>
+									<li>
+										<a class="dropdown-item" href="#1">
+											<span class="dropdown-item-indicator-start">
+												<svg class="lexicon-icon lexicon-icon-cards2" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
+												</svg>
+											</span>
+											Card View
+										</a>
+									</li>
+								</ul>
+							</li>
+							<li class="nav-item">
+								<a class="btn btn-primary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none" href="#1" role="button">
+									<svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#plus" />
+									</svg>
+								</a>
+							</li>
+						</ul>
+					</div>
+				</nav>
+				<div class="container-view">
+					<div class="sheet">
+						<div class="c-empty-state c-empty-state-animation">
+							<div class="c-empty-state-image">
+								<div class="c-empty-state-aspect-ratio">
+									<img alt="Image of a satellite in space" class="aspect-ratio-item aspect-ratio-item-fluid" src="{{rootPath}}/images/images/empty_state.gif" />
+								</div>
+							</div>
+							<div class="c-empty-state-title">
+								<span class="text-truncate-inline">
+									<span class="text-truncate">No page templates yet</span>
+								</span>
+							</div>
+							<div class="c-empty-state-text">Page Templates allow you to create pages faster with reusable elements.</div>
+							<div class="c-empty-state-footer">
+								<button class="btn btn-secondary btn-sm" type="button">New Document</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/packages/clay-css/src/content/utilities.html
+++ b/packages/clay-css/src/content/utilities.html
@@ -8,11 +8,11 @@ section: Components
 		<h3>Autofit Row</h3>
 
 		<blockquote class="blockquote">
-			<p>Make content expand to fill remaining space or create equally spaced content with <code>.autofit-row</code>, <code>.autofit-col</code>, and <code>.autofit-col-expand</code>.</p>
+			<p>Make content expand to fill remaining space or create equally spaced content with <code>.autofit-row</code>, <code>.autofit-col</code>, <code>.autofit-col-shrink</code>, and <code>.autofit-col-expand</code>.</p>
 		</blockquote>
 
 		<div class="alert alert-warning">
-			<code>.autofit-row</code>, <code>.autofit-col</code>, <code>.autofit-col-expand</code> shouldn't be used for laying out site pages, rather it's most useful for small chunks of content inside other components e.g. cards or list-groups.
+			<code>.autofit-row</code>, <code>.autofit-col</code>, <code>.autofit-col-shrink</code>, and <code>.autofit-col-expand</code> shouldn't be used for laying out site pages, rather it's most useful for small chunks of content inside other components e.g. cards or list-groups.
 		</div>
 
 		<div class="alert alert-warning">
@@ -167,16 +167,94 @@ section: Components
 
 <div class="clay-site-row-spacer row">
 	<div class="col-md-12">
-		<div class="card">
-			<div class="card-body">
-				<div class="autofit-padded-no-gutters-x autofit-row">
-					<div class="autofit-col autofit-col-expand">
-						<h2 class="component-title" style="font-size:1.25rem;font-weight:700;">
-							ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
-						</h2>
-						<div>Sept 25 - 3 Views</div>
-					</div>
-					<div class="autofit-col">
+		<h3>Autofit Col Shrink</h3>
+
+		<blockquote class="blockquote">
+			<p>The modifier `autofit-col-shrink` makes the column only as wide as its content and will grow to fill the remaining space depending on the length of the content. This should be used with variable width content such as title text with adjoining buttons.</p>
+		</blockquote>
+
+		<div class="sheet">
+			<h4 class="sheet-title">
+				<span class="autofit-padded-no-gutters autofit-row">
+					<span class="autofit-col autofit-col-shrink">
+						<span class="component-title">Collection</span>
+					</span>
+					<span class="autofit-col">
+						<button class="component-action" type="button">
+							<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+							</svg>
+						</button>
+					</span>
+				</span>
+			</h4>
+			<h4 class="sheet-title">
+				<span class="autofit-padded-no-gutters autofit-row">
+					<span class="autofit-col">
+						<button class="component-action" type="button">
+							<svg class="lexicon-icon lexicon-icon-link" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#link" />
+							</svg>
+						</button>
+					</span>
+					<span class="autofit-col autofit-col-shrink">
+						<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+					</span>
+					<span class="autofit-col">
+						<button class="component-action" type="button">
+							<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+							</svg>
+						</button>
+					</span>
+				</span>
+			</h4>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Autofit Col Expand</h3>
+
+		<blockquote class="blockquote">
+			<p>The modifier `autofit-col-expand` makes the column fill the remaining space.</p>
+		</blockquote>
+
+		<div class="sheet">
+			<h4 class="sheet-title">
+				<span class="autofit-padded-no-gutters autofit-row">
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-title">Collection</span>
+					</span>
+					<span class="autofit-col">
+						<button class="btn component-action" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-cog" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#cog" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn component-action" type="button">
+							<span class="c-inner" tabindex="-1">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</h4>
+
+			<h4 class="sheet-title">
+				<span class="autofit-padded-no-gutters-x autofit-row">
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-title">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+						<small>Sept 25 - 3 Views</small>
+					</span>
+					<span class="autofit-col">
 						<button class="btn btn-monospaced btn-outline-primary btn-outline-borderless btn-sm" type="button">
 							<span class="inline-item">
 								<svg class="lexicon-icon lexicon-icon-pencil" focusable="false" role="presentation">
@@ -184,9 +262,9 @@ section: Components
 								</svg>
 							</span>
 						</button>
-					</div>
-				</div>
-			</div>
+					</span>
+				</span>
+			</h4>
 		</div>
 	</div>
 </div>

--- a/packages/clay-css/src/scss/components/_sheets.scss
+++ b/packages/clay-css/src/scss/components/_sheets.scss
@@ -22,6 +22,16 @@
 		padding-top: $sheet-padding-top-mobile;
 	}
 
+	&::after {
+		content: '';
+		display: block;
+		margin-top: $sheet-padding-top;
+
+		@include clay-scale-component {
+			margin-top: $sheet-padding-top-mobile;
+		}
+	}
+
 	+ .sheet {
 		@include clay-css($sheet-plus-sheet);
 	}
@@ -151,6 +161,10 @@ fieldset {
 		font-size: $sheet-title-font-size-mobile;
 		margin-bottom: $sheet-title-margin-bottom-mobile;
 	}
+
+	.autofit-padded-no-gutters {
+		@extend %#{$sheet-title-autofit-padded-no-gutters-ext} !optional;
+	}
 }
 
 // Sheet Subtitle
@@ -275,4 +289,56 @@ a.sheet-subtitle {
 		font-size: $sheet-text-font-size-mobile;
 		margin-bottom: $sheet-text-margin-bottom-mobile;
 	}
+}
+
+// Sheet Multiple Form Variant
+
+.sheet-multiple-form {
+	@include clay-css($sheet-multiple-form);
+
+	.sheet-header {
+		@include clay-css($sheet-multiple-form-sheet-header);
+
+		@include clay-scale-component {
+			@include clay-css($sheet-multiple-form-sheet-header-mobile);
+		}
+
+		.sheet-title {
+			@include clay-css($sheet-multiple-form-sheet-title);
+		}
+	}
+}
+
+// Sheet Dataset Content Variant
+
+.sheet-dataset-content {
+	@include clay-css($sheet-dataset-content);
+
+	.sheet-header {
+		@include clay-css($sheet-dataset-content-sheet-header);
+
+		@include clay-scale-component {
+			@include clay-css($sheet-dataset-content-sheet-header-mobile);
+		}
+
+		.sheet-title {
+			@include clay-css($sheet-dataset-content-sheet-title);
+		}
+	}
+}
+
+// Sheet in Card Page
+
+.card-page-equal-height .sheet {
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+
+	> .autofit-row {
+		flex-grow: 1;
+	}
+}
+
+.card-page-item .sheet {
+	@include clay-css($card-page-item-sheet);
 }

--- a/packages/clay-css/src/scss/components/_utilities.scss
+++ b/packages/clay-css/src/scss/components/_utilities.scss
@@ -77,7 +77,7 @@
 
 // Autofit Padded
 
-.autofit-padded {
+%autofit-padded {
 	> .autofit-col {
 		padding-bottom: $autofit-padded-col-padding-y;
 		padding-left: $autofit-padded-col-padding-x;
@@ -86,7 +86,11 @@
 	}
 }
 
-.autofit-padded-no-gutters-x {
+.autofit-padded {
+	@extend %autofit-padded !optional;
+}
+
+%autofit-padded-no-gutters-x {
 	margin-left: math-sign($autofit-padded-col-padding-x);
 	margin-right: math-sign($autofit-padded-col-padding-x);
 	width: auto;
@@ -99,8 +103,31 @@
 	}
 }
 
-.autofit-padded-no-gutters-y {
+.autofit-padded-no-gutters-x {
+	@extend %autofit-padded-no-gutters-x !optional;
+}
+
+%autofit-padded-no-gutters-y {
 	margin-bottom: math-sign($autofit-padded-col-padding-y);
+	margin-top: math-sign($autofit-padded-col-padding-y);
+	width: auto;
+
+	> .autofit-col {
+		padding-bottom: $autofit-padded-col-padding-y;
+		padding-left: $autofit-padded-col-padding-x;
+		padding-right: $autofit-padded-col-padding-x;
+		padding-top: $autofit-padded-col-padding-y;
+	}
+}
+
+.autofit-padded-no-gutters-y {
+	@extend %autofit-padded-no-gutters-y !optional;
+}
+
+%autofit-padded-no-gutters {
+	margin-bottom: math-sign($autofit-padded-col-padding-y);
+	margin-left: math-sign($autofit-padded-col-padding-x);
+	margin-right: math-sign($autofit-padded-col-padding-x);
 	margin-top: math-sign($autofit-padded-col-padding-y);
 	width: auto;
 
@@ -113,18 +140,15 @@
 }
 
 .autofit-padded-no-gutters {
-	margin-bottom: math-sign($autofit-padded-col-padding-y);
-	margin-left: math-sign($autofit-padded-col-padding-x);
-	margin-right: math-sign($autofit-padded-col-padding-x);
-	margin-top: math-sign($autofit-padded-col-padding-y);
-	width: auto;
+	@extend %autofit-padded-no-gutters !optional;
+}
 
-	> .autofit-col {
-		padding-bottom: $autofit-padded-col-padding-y;
-		padding-left: $autofit-padded-col-padding-x;
-		padding-right: $autofit-padded-col-padding-x;
-		padding-top: $autofit-padded-col-padding-y;
-	}
+%autofit-padded-no-gutters-sm {
+	@include clay-autofit-row($autofit-padded-no-gutters-sm);
+}
+
+.autofit-padded-no-gutters-sm {
+	@extend %autofit-padded-no-gutters-sm !optional;
 }
 
 // Autofit Columns
@@ -139,6 +163,12 @@
 
 .autofit-col {
 	@extend %autofit-col;
+}
+
+.autofit-col-shrink {
+	flex-shrink: 1;
+	min-width: 1rem;
+	word-wrap: break-word;
 }
 
 %autofit-col-expand {

--- a/packages/clay-css/src/scss/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/variables/_sheets.scss
@@ -77,6 +77,8 @@ $sheet-title-font-weight: $font-weight-semi-bold !default;
 $sheet-title-line-height: $headings-line-height !default; // 1.2
 $sheet-title-margin-bottom: 1.5rem !default; // 24px
 
+$sheet-title-autofit-padded-no-gutters-ext: 'autofit-padded-no-gutters-sm' !default;
+
 $sheet-title-font-size-mobile: 1.25rem !default; // 20px
 $sheet-title-margin-bottom-mobile: null !default;
 
@@ -155,3 +157,77 @@ $sheet-text-margin-bottom: 1.5rem !default; // 24px
 
 $sheet-text-font-size-mobile: null !default;
 $sheet-text-margin-bottom-mobile: null !default;
+
+// Sheet Multiple Form Variant
+
+$sheet-multiple-form: () !default;
+
+$sheet-multiple-form-sheet-header: () !default;
+$sheet-multiple-form-sheet-header: map-merge(
+	(
+		border-color: $gray-300,
+		border-style: solid,
+		border-width: 0 0 1px,
+		margin: -1.5rem -1.5rem 1.5rem,
+		padding: 1rem 1.5rem,
+	),
+	$sheet-multiple-form-sheet-header
+);
+
+$sheet-multiple-form-sheet-header-mobile: () !default;
+$sheet-multiple-form-sheet-header-mobile: map-merge(
+	(
+		margin: -1rem -1rem 1rem,
+		padding: 1rem,
+	),
+	$sheet-multiple-form-sheet-header-mobile
+);
+
+$sheet-multiple-form-sheet-title: () !default;
+$sheet-multiple-form-sheet-title: map-merge(
+	(
+		margin-bottom: 0,
+	),
+	$sheet-multiple-form-sheet-title
+);
+
+// Sheet Dataset Content Variant
+
+$sheet-dataset-content: () !default;
+
+$sheet-dataset-content-sheet-header: () !default;
+$sheet-dataset-content-sheet-header: map-merge(
+	(
+		border-width: 0,
+		margin: -1.5rem -1.5rem 1.5rem,
+		padding: 1rem 1.5rem,
+	),
+	$sheet-dataset-content-sheet-header
+);
+
+$sheet-dataset-content-sheet-header-mobile: () !default;
+$sheet-dataset-content-sheet-header-mobile: map-merge(
+	(
+		margin: -1rem -1rem 1rem,
+		padding: 1rem,
+	),
+	$sheet-dataset-content-sheet-header-mobile
+);
+
+$sheet-dataset-content-sheet-title: () !default;
+$sheet-dataset-content-sheet-title: map-merge(
+	(
+		margin-bottom: 0,
+	),
+	$sheet-dataset-content-sheet-title
+);
+
+// Sheet in Card Page
+
+$card-page-item-sheet: () !default;
+$card-page-item-sheet: map-merge(
+	(
+		margin-bottom: $grid-gutter-width,
+	),
+	$card-page-item-sheet
+);

--- a/packages/clay-css/src/scss/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/variables/_utilities.scss
@@ -8,6 +8,18 @@ $autofit-col-expand-min-width: 3.125rem !default; // 50px
 $autofit-padded-col-padding-x: 0.5rem !default; // 8px
 $autofit-padded-col-padding-y: 0.25rem !default; // 4px
 
+$autofit-padded-no-gutters-sm: () !default;
+$autofit-padded-no-gutters-sm: map-merge(
+	(
+		margin: -0.25rem,
+		width: auto,
+		autofit-col: (
+			padding: 0.25rem,
+		),
+	),
+	$autofit-padded-no-gutters-sm
+);
+
 // Close
 
 $close: () !default;


### PR DESCRIPTION
We should be able to use `sheet` for these components:
https://liferay.design/lexicon/core-components/forms/forms-sheet/#multiple-form
https://liferay.design/lexicon/core-components/forms/forms-sheet/#dataset-content

fixes #3762