### PR TITLE
feat(@clayui/css): Atlas Toggle Switch make it 40px by 24px in desktop views

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_toggle-switch.scss
@@ -2,7 +2,7 @@
 $toggle-switch-bar-padding: 4px !default; // space between button and bar, can be negative value
 $toggle-switch-bar-padding-mobile: 4px !default;
 
-$toggle-switch-button-width: 24px !default; // 24px
+$toggle-switch-button-width: 16px !default; // 24px
 $toggle-switch-button-width-mobile: 16px !default; // 16px
 
 $toggle-switch-bar-height: ($toggle-switch-bar-padding * 2) +
@@ -10,16 +10,16 @@ $toggle-switch-bar-height: ($toggle-switch-bar-padding * 2) +
 $toggle-switch-bar-height-mobile: ($toggle-switch-bar-padding-mobile * 2) +
 	$toggle-switch-button-width-mobile !default;
 
-$toggle-switch-bar-width: 60px !default; // width of switch bar
-$toggle-switch-bar-width-mobile: 44px !default; // width of switch bar
+$toggle-switch-bar-width: 40px !default; // width of switch bar
+$toggle-switch-bar-width-mobile: 40px !default; // width of switch bar
 // must all be same units--end
 
 $toggle-switch-bar-bg: $gray-500 !default;
 $toggle-switch-bar-border-color: $toggle-switch-bar-bg !default;
 $toggle-switch-bar-border-radius: 20px !default;
 $toggle-switch-bar-border-width: 1px !default;
-$toggle-switch-bar-font-size: 0.75rem !default; // 12px
-$toggle-switch-bar-font-size-mobile: 0.625rem !default; // 10px
+$toggle-switch-bar-font-size: 0.625rem !default;
+$toggle-switch-bar-font-size-mobile: 0.625rem !default;
 $toggle-switch-bar-icon-color: $white !default;
 $toggle-switch-bar-focus-box-shadow: $custom-control-indicator-focus-box-shadow !default;
 

--- a/packages/clay-css/src/scss/atlas/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_toggle-switch.scss
@@ -39,4 +39,4 @@ $toggle-switch-bar-on-icon-color: $white !default;
 $toggle-switch-button-on-bg: $white !default;
 $toggle-switch-button-on-border-color: $white !default;
 $toggle-switch-button-on-border-radius: $toggle-switch-button-border-radius !default;
-$toggle-switch-button-on-icon-color: $gray-900 !default;
+$toggle-switch-button-on-icon-color: $primary !default;

--- a/packages/clay-form/docs/markup-toggle-switch.md
+++ b/packages/clay-form/docs/markup-toggle-switch.md
@@ -25,24 +25,28 @@ mainTabURL: 'docs/components/toggle-switch.html'
 
 <div class="sheet-example">
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" type="checkbox" />
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle"></span>
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" type="checkbox" />
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle"></span>
+			</span>
 		</span>
 	</label>
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" type="checkbox">
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
-				<span class="button-icon button-icon-on toggle-switch-icon">
-					<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
-						<use href="/images/icons/icons.svg#live"></use>
-					</svg>
-				</span>
-				<span class="button-icon button-icon-off toggle-switch-icon">
-					<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
-						<use href="/images/icons/icons.svg#staging"></use>
-					</svg>
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" type="checkbox">
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
+					<span class="button-icon button-icon-on toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
+							<use href="/images/icons/icons.svg#live"></use>
+						</svg>
+					</span>
+					<span class="button-icon button-icon-off toggle-switch-icon">
+						<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
+							<use href="/images/icons/icons.svg#staging"></use>
+						</svg>
+					</span>
 				</span>
 			</span>
 		</span>
@@ -51,36 +55,40 @@ mainTabURL: 'docs/components/toggle-switch.html'
 
 ```html
 <label class="toggle-switch">
-	<input class="toggle-switch-check" type="checkbox" />
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle"></span>
+	<span class="toggle-switch-check-bar">
+		<input class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle"></span>
+		</span>
 	</span>
 </label>
 <label class="toggle-switch">
-	<input class="toggle-switch-check" type="checkbox" />
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span
-			class="toggle-switch-handle"
-			data-label-off=""
-			data-label-on="LIVE"
-		>
-			<span class="button-icon button-icon-on toggle-switch-icon">
-				<svg
-					class="lexicon-icon lexicon-icon-live"
-					focusable="false"
-					role="presentation"
-				>
-					<use href="/images/icons/icons.svg#live"></use>
-				</svg>
-			</span>
-			<span class="button-icon button-icon-off toggle-switch-icon">
-				<svg
-					class="lexicon-icon lexicon-icon-staging"
-					focusable="false"
-					role="presentation"
-				>
-					<use href="/images/icons/icons.svg#staging"></use>
-				</svg>
+	<span class="toggle-switch-check-bar">
+		<input class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span
+				class="toggle-switch-handle"
+				data-label-off=""
+				data-label-on="LIVE"
+			>
+				<span class="button-icon button-icon-on toggle-switch-icon">
+					<svg
+						class="lexicon-icon lexicon-icon-live"
+						focusable="false"
+						role="presentation"
+					>
+						<use href="/images/icons/icons.svg#live"></use>
+					</svg>
+				</span>
+				<span class="button-icon button-icon-off toggle-switch-icon">
+					<svg
+						class="lexicon-icon lexicon-icon-staging"
+						focusable="false"
+						role="presentation"
+					>
+						<use href="/images/icons/icons.svg#staging"></use>
+					</svg>
+				</span>
 			</span>
 		</span>
 	</span>
@@ -95,24 +103,30 @@ You may want the Toggle Switch to behave with a Radio or Checkbox but have the a
 
 <div class="sheet-example">
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" type="checkbox" />
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle"></span>
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" type="checkbox" />
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle"></span>
+			</span>
 		</span>
 	</label>
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" type="checkbox" />
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle"></span>
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" type="checkbox" />
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle"></span>
+			</span>
 		</span>
 	</label>
 </div>
 
 ```html
 <label class="toggle-switch">
-	<input class="toggle-switch-check" type="checkbox" />
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle"></span>
+	<span class="toggle-switch-check-bar">
+		<input class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle"></span>
+		</span>
 	</span>
 </label>
 ```
@@ -121,57 +135,69 @@ You may want the Toggle Switch to behave with a Radio or Checkbox but have the a
 
 <div class="sheet-example">
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option1"/>
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle"></span>
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option1"/>
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle"></span>
+			</span>
 		</span>
 	</label>
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option2"/>
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle"></span>
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option2"/>
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle"></span>
+			</span>
 		</span>
 	</label>
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option3"/>
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle"></span>
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option3"/>
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle"></span>
+			</span>
 		</span>
 	</label>
 </div>
 
 ```html
 <label class="toggle-switch">
-	<input
-		class="toggle-switch-check"
-		name="toggleSwitchRadio1"
-		type="radio"
-		value="option1"
-	/>
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle"></span>
+	<span class="toggle-switch-check-bar">
+		<input
+			class="toggle-switch-check"
+			name="toggleSwitchRadio1"
+			type="radio"
+			value="option1"
+		/>
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle"></span>
+		</span>
 	</span>
 </label>
 <label class="toggle-switch">
-	<input
-		class="toggle-switch-check"
-		name="toggleSwitchRadio1"
-		type="radio"
-		value="option2"
-	/>
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle"></span>
+	<span class="toggle-switch-check-bar">
+		<input
+			class="toggle-switch-check"
+			name="toggleSwitchRadio1"
+			type="radio"
+			value="option2"
+		/>
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle"></span>
+		</span>
 	</span>
 </label>
 <label class="toggle-switch">
-	<input
-		class="toggle-switch-check"
-		name="toggleSwitchRadio1"
-		type="radio"
-		value="option3"
-	/>
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle"></span>
+	<span class="toggle-switch-check-bar">
+		<input
+			class="toggle-switch-check"
+			name="toggleSwitchRadio1"
+			type="radio"
+			value="option3"
+		/>
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle"></span>
+		</span>
 	</span>
 </label>
 ```
@@ -180,37 +206,45 @@ You may want the Toggle Switch to behave with a Radio or Checkbox but have the a
 
 <div class="sheet-example">
 	<label class="toggle-switch">
-		<input disabled class="toggle-switch-check" type="checkbox" />
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle"></span>
+		<span class="toggle-switch-check-bar">
+			<input disabled class="toggle-switch-check" type="checkbox" />
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle"></span>
+			</span>
 		</span>
 	</label>
 	<label class="toggle-switch">
-		<input disabled checked class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option1"/>
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle"></span>
+		<span class="toggle-switch-check-bar">
+			<input disabled checked class="toggle-switch-check" name="toggleSwitchRadio1" type="radio" value="option1"/>
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle"></span>
+			</span>
 		</span>
 	</label>
 </div>
 
 ```html
 <label class="toggle-switch">
-	<input disabled class="toggle-switch-check" type="checkbox" />
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle"></span>
+	<span class="toggle-switch-check-bar">
+		<input disabled class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle"></span>
+		</span>
 	</span>
 </label>
 <label class="toggle-switch">
-	<input
-		disabled
-		checked
-		class="toggle-switch-check"
-		name="toggleSwitchRadio1"
-		type="radio"
-		value="option1"
-	/>
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle"></span>
+	<span class="toggle-switch-check-bar">
+		<input
+			disabled
+			checked
+			class="toggle-switch-check"
+			name="toggleSwitchRadio1"
+			type="radio"
+			value="option1"
+		/>
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle"></span>
+		</span>
 	</span>
 </label>
 ```
@@ -224,21 +258,25 @@ You can display additional text with the toggle switch by adding the `.toggle-sw
 <div class="sheet-example">
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox" />
 			<span class="toggle-switch-label">Adding Required Text</span>
 			<span class="toggle-switch-text">Required *</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox" />
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+					</span>
 				</span>
 			</span>
 		</label>
 	</div>
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox" />
 			<span class="toggle-switch-label">Adding Required Text</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox" />
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+					</span>
 				</span>
 			</span>
 			<span class="toggle-switch-text">Required *</span>
@@ -246,10 +284,12 @@ You can display additional text with the toggle switch by adding the `.toggle-sw
 	</div>
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox" />
 			<span class="toggle-switch-label">Required Text on Right</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox" />
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+					</span>
 				</span>
 			</span>
 			<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
@@ -257,23 +297,27 @@ You can display additional text with the toggle switch by adding the `.toggle-sw
 	</div>
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox" />
 			<span class="toggle-switch-label">Required Text on Left</span>
 			<span class="toggle-switch-text toggle-switch-text-left">Required *</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox" />
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+					</span>
 				</span>
 			</span>
 		</label>
 	</div>
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox" />
 			<span class="toggle-switch-label">The Kitchen Sink</span>
 			<span class="toggle-switch-text">Top Text</span>
 			<span class="toggle-switch-text toggle-switch-text-left">Error</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="OFF" data-label-on="ON">
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox" />
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="OFF" data-label-on="ON">
+					</span>
 				</span>
 			</span>
 			<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
@@ -284,52 +328,78 @@ You can display additional text with the toggle switch by adding the `.toggle-sw
 
 ```html
 <label class="toggle-switch">
-	<input class="toggle-switch-check" type="checkbox" />
 	<span class="toggle-switch-label">Adding Required Text</span>
 	<span class="toggle-switch-text">Required *</span>
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+	<span class="toggle-switch-check-bar">
+		<input class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span
+				class="toggle-switch-handle"
+				data-label-off=""
+				data-label-on="ON"
+			>
+			</span>
 		</span>
 	</span>
 </label>
 <label class="toggle-switch">
-	<input class="toggle-switch-check" type="checkbox" />
 	<span class="toggle-switch-label">Adding Required Text</span>
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+	<span class="toggle-switch-check-bar">
+		<input class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span
+				class="toggle-switch-handle"
+				data-label-off=""
+				data-label-on="ON"
+			>
+			</span>
 		</span>
 	</span>
 	<span class="toggle-switch-text">Required *</span>
 </label>
 <label class="toggle-switch">
-	<input class="toggle-switch-check" type="checkbox" />
 	<span class="toggle-switch-label">Required Text on Right</span>
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+	<span class="toggle-switch-check-bar">
+		<input class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span
+				class="toggle-switch-handle"
+				data-label-off=""
+				data-label-on="ON"
+			>
+			</span>
 		</span>
 	</span>
 	<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
 </label>
 <label class="toggle-switch">
-	<input class="toggle-switch-check" type="checkbox" />
 	<span class="toggle-switch-label">Required Text on Left</span>
 	<span class="toggle-switch-text toggle-switch-text-left">Required *</span>
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+	<span class="toggle-switch-check-bar">
+		<input class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span
+				class="toggle-switch-handle"
+				data-label-off=""
+				data-label-on="ON"
+			>
+			</span>
 		</span>
 	</span>
 </label>
 <label class="toggle-switch">
-	<input class="toggle-switch-check" type="checkbox" />
 	<span class="toggle-switch-label">The Kitchen Sink</span>
 	<span class="toggle-switch-text">Top Text</span>
 	<span class="toggle-switch-text toggle-switch-text-left">Error</span>
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span
-			class="toggle-switch-handle"
-			data-label-off="OFF"
-			data-label-on="ON"
-		>
+	<span class="toggle-switch-check-bar">
+		<input class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span
+				class="toggle-switch-handle"
+				data-label-off="OFF"
+				data-label-on="ON"
+			>
+			</span>
 		</span>
 	</span>
 	<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
@@ -346,18 +416,20 @@ Add `<span class="button-icon button-icon-off icon-volume-off toggle-switch-icon
 <div class="sheet-example">
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox" />
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="">
-					<span class="button-icon button-icon-on toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
-							<use href="/images/icons/icons.svg#unlock" />
-						</svg>
-					</span>
-					<span class="button-icon button-icon-off toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
-							<use href="/images/icons/icons.svg#lock" />
-						</svg>
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox" />
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="" data-label-on="">
+						<span class="button-icon button-icon-on toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-unlock" focusable="false" role="presentation">
+								<use href="/images/icons/icons.svg#unlock" />
+							</svg>
+						</span>
+						<span class="button-icon button-icon-off toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-lock" focusable="false" role="presentation">
+								<use href="/images/icons/icons.svg#lock" />
+							</svg>
+						</span>
 					</span>
 				</span>
 			</span>
@@ -365,19 +437,21 @@ Add `<span class="button-icon button-icon-off icon-volume-off toggle-switch-icon
 	</div>
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox" />
 			<span class="toggle-switch-label">Toggle Switch with data-label-on</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
-					<span class="button-icon button-icon-on toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
-							<use href="/images/icons/icons.svg#live" />
-						</svg>
-					</span>
-					<span class="button-icon button-icon-off toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
-							<use href="/images/icons/icons.svg#staging" />
-						</svg>
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox" />
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="" data-label-on="LIVE">
+						<span class="button-icon button-icon-on toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-live" focusable="false" role="presentation">
+								<use href="/images/icons/icons.svg#live" />
+							</svg>
+						</span>
+						<span class="button-icon button-icon-off toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-staging" focusable="false" role="presentation">
+								<use href="/images/icons/icons.svg#staging" />
+							</svg>
+						</span>
 					</span>
 				</span>
 			</span>
@@ -385,19 +459,21 @@ Add `<span class="button-icon button-icon-off icon-volume-off toggle-switch-icon
 	</div>
 	<div class="form-group">
 		<label class="toggle-switch">
-			<input class="toggle-switch-check" type="checkbox" />
 			<span class="toggle-switch-label">Toggle Switch with data-label on and data-label-off</span>
-			<span aria-hidden="true" class="toggle-switch-bar">
-				<span class="toggle-switch-handle" data-label-off="Product Menu Closed" data-label-on="Product Menu Open">
-					<span class="button-icon button-icon-on toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-product-menu-open" focusable="false" role="presentation">
-							<use href="/images/icons/icons.svg#product-menu-open" />
-						</svg>
-					</span>
-					<span class="button-icon button-icon-off toggle-switch-icon">
-						<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
-							<use href="/images/icons/icons.svg#product-menu-closed" />
-						</svg>
+			<span class="toggle-switch-check-bar">
+				<input class="toggle-switch-check" type="checkbox" />
+				<span aria-hidden="true" class="toggle-switch-bar">
+					<span class="toggle-switch-handle" data-label-off="Product Menu Closed" data-label-on="Product Menu Open">
+						<span class="button-icon button-icon-on toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-product-menu-open" focusable="false" role="presentation">
+								<use href="/images/icons/icons.svg#product-menu-open" />
+							</svg>
+						</span>
+						<span class="button-icon button-icon-off toggle-switch-icon">
+							<svg class="lexicon-icon lexicon-icon-product-menu-closed" focusable="false" role="presentation">
+								<use href="/images/icons/icons.svg#product-menu-closed" />
+							</svg>
+						</span>
 					</span>
 				</span>
 			</span>
@@ -411,18 +487,20 @@ Alternatively, you can add `<span class="icon-remove toggle-switch-icon toggle-s
 
 <div class="sheet-example">
 	<label class="toggle-switch">
-		<input class="toggle-switch-check" type="checkbox" />
-		<span aria-hidden="true" class="toggle-switch-bar">
-			<span class="toggle-switch-handle">
-				<span class="toggle-switch-icon toggle-switch-icon-on">
-					<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
-						<use href="/images/icons/icons.svg#check" />
-					</svg>
-				</span>
-				<span class="toggle-switch-icon toggle-switch-icon-off">
-					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-						<use href="/images/icons/icons.svg#times" />
-					</svg>
+		<span class="toggle-switch-check-bar">
+			<input class="toggle-switch-check" type="checkbox" />
+			<span aria-hidden="true" class="toggle-switch-bar">
+				<span class="toggle-switch-handle">
+					<span class="toggle-switch-icon toggle-switch-icon-on">
+						<svg class="lexicon-icon lexicon-icon-check" focusable="false" role="presentation">
+							<use href="/images/icons/icons.svg#check" />
+						</svg>
+					</span>
+					<span class="toggle-switch-icon toggle-switch-icon-off">
+						<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+							<use href="/images/icons/icons.svg#times" />
+						</svg>
+					</span>
 				</span>
 			</span>
 		</span>
@@ -431,26 +509,28 @@ Alternatively, you can add `<span class="icon-remove toggle-switch-icon toggle-s
 
 ```html
 <label class="toggle-switch">
-	<input class="toggle-switch-check" type="checkbox" />
-	<span aria-hidden="true" class="toggle-switch-bar">
-		<span class="toggle-switch-handle">
-			<span class="toggle-switch-icon toggle-switch-icon-on">
-				<svg
-					class="lexicon-icon lexicon-icon-check"
-					focusable="false"
-					role="presentation"
-				>
-					<use href="/images/icons/icons.svg#check" />
-				</svg>
-			</span>
-			<span class="toggle-switch-icon toggle-switch-icon-off">
-				<svg
-					class="lexicon-icon lexicon-icon-times"
-					focusable="false"
-					role="presentation"
-				>
-					<use href="/images/icons/icons.svg#times" />
-				</svg>
+	<span class="toggle-switch-check-bar">
+		<input class="toggle-switch-check" type="checkbox" />
+		<span aria-hidden="true" class="toggle-switch-bar">
+			<span class="toggle-switch-handle">
+				<span class="toggle-switch-icon toggle-switch-icon-on">
+					<svg
+						class="lexicon-icon lexicon-icon-check"
+						focusable="false"
+						role="presentation"
+					>
+						<use href="/images/icons/icons.svg#check" />
+					</svg>
+				</span>
+				<span class="toggle-switch-icon toggle-switch-icon-off">
+					<svg
+						class="lexicon-icon lexicon-icon-times"
+						focusable="false"
+						role="presentation"
+					>
+						<use href="/images/icons/icons.svg#times" />
+					</svg>
+				</span>
 			</span>
 		</span>
 	</span>


### PR DESCRIPTION
fix(@clayui/css): Atlas Toggle Switch change checked state button icon color to primary

docs(clayui.com): Toggle Switch update markup examples to 3.x. Wraps toggle-switch-check and toggle-switch-bar in toggle-switch-check-bar

fixes #3835, fixes #3872, fixes #3845