### PR TITLE
feat(@clayui/drop-down): add props for making menu different widths

### DIFF
--- a/packages/clay-drop-down/README.mdx
+++ b/packages/clay-drop-down/README.mdx
@@ -18,6 +18,7 @@ import {
     -   [Using dropdown without a trigger](#using-dropdown-without-a-trigger)
 -   [DropDownWithItems](#dropdownwithitems)
 -   [DropDownWithDrilldown](#dropdownwithdrilldown)
+-   [Caveats](#caveats)
 
 </div>
 </div>
@@ -116,3 +117,7 @@ const menus = {
 	of09: [{title: 'Three'}],
 };
 ```
+
+## Caveats
+
+One caveat with the drop down menu is that it is rendered inside of a [React Portal](https://reactjs.org/docs/portals.html) and is rendered directly to the `body` element. This means if you are using the `menuWidth` prop set to `auto`, it will not respect the size of the node parent of the drop down, since the menu is rendered directly to the body.

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -49,6 +49,10 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement | HTMLLIElement> {
 	 */
 	menuElementAttrs?: React.HTMLAttributes<HTMLDivElement>;
 
+	menuHeight?: React.ComponentProps<typeof Menu>['height'];
+
+	menuWidth?: React.ComponentProps<typeof Menu>['width'];
+
 	/**
 	 * Callback for when the active state changes.
 	 */
@@ -87,6 +91,8 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 	hasLeftSymbols,
 	hasRightSymbols,
 	menuElementAttrs,
+	menuHeight,
+	menuWidth,
 	offsetFn,
 	onActiveChange,
 	trigger,
@@ -152,9 +158,11 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 					alignmentPosition={alignmentPosition}
 					hasLeftSymbols={hasLeftSymbols}
 					hasRightSymbols={hasRightSymbols}
+					height={menuHeight}
 					offsetFn={offsetFn}
 					onSetActive={onActiveChange}
 					ref={menuElementRef}
+					width={menuWidth}
 				>
 					{children}
 				</Menu>

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 import ClayDropDown from './DropDown';
-import ClayMenu from './Menu';
+import ClayDropDownMenu from './Menu';
 import Drilldown from './drilldown';
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -15,7 +15,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * Default position of menu element. Values come from `./Menu`.
 	 */
 	alignmentPosition?: React.ComponentProps<
-		typeof ClayMenu
+		typeof ClayDropDownMenu
 	>['alignmentPosition'];
 
 	/**
@@ -44,6 +44,10 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 		[id: string]: React.ComponentProps<typeof Drilldown.Menu>['items'];
 	};
 
+	menuHeight?: React.ComponentProps<typeof ClayDropDown>['menuHeight'];
+
+	menuWidth?: React.ComponentProps<typeof ClayDropDown>['menuWidth'];
+
 	/**
 	 * Function for setting the offset of the menu from the trigger.
 	 */
@@ -71,6 +75,8 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	containerElement,
 	initialActiveMenu,
 	menuElementAttrs,
+	menuHeight,
+	menuWidth,
 	menus,
 	offsetFn,
 	spritemap,
@@ -94,6 +100,8 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 				...menuElementAttrs,
 				className: classNames(menuElementAttrs?.className, 'drilldown'),
 			}}
+			menuHeight={menuHeight}
+			menuWidth={menuWidth}
 			offsetFn={offsetFn}
 			onActiveChange={setActive}
 			trigger={trigger}

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -12,7 +12,7 @@ import Divider from './Divider';
 import ClayDropDown from './DropDown';
 import ClayDropDownGroup from './Group';
 import Help from './Help';
-import ClayMenu from './Menu';
+import ClayDropDownMenu from './Menu';
 import Search from './Search';
 
 type TType = 'checkbox' | 'group' | 'item' | 'radio' | 'radiogroup' | 'divider';
@@ -50,7 +50,7 @@ export interface IProps extends IDropDownContentProps {
 	 * Default position of menu element. Values come from `./Menu`.
 	 */
 	alignmentPosition?: React.ComponentProps<
-		typeof ClayMenu
+		typeof ClayDropDownMenu
 	>['alignmentPosition'];
 
 	/**
@@ -89,6 +89,10 @@ export interface IProps extends IDropDownContentProps {
 	menuElementAttrs?: React.ComponentProps<
 		typeof ClayDropDown
 	>['menuElementAttrs'];
+
+	menuHeight?: React.ComponentProps<typeof ClayDropDown>['menuHeight'];
+
+	menuWidth?: React.ComponentProps<typeof ClayDropDown>['menuWidth'];
 
 	/**
 	 * Function for setting the offset of the menu from the trigger.
@@ -295,6 +299,8 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 	helpText,
 	items,
 	menuElementAttrs,
+	menuHeight,
+	menuWidth,
 	offsetFn,
 	onSearchValueChange = () => {},
 	searchable,
@@ -324,6 +330,8 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 			hasLeftSymbols={hasLeftSymbols}
 			hasRightSymbols={hasRightSymbols}
 			menuElementAttrs={menuElementAttrs}
+			menuHeight={menuHeight}
+			menuWidth={menuWidth}
 			offsetFn={offsetFn}
 			onActiveChange={setActive}
 			trigger={trigger}

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -131,6 +131,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	hasRightSymbols?: boolean;
 
 	/**
+	 * Adds utility class name `dropdown-menu-height-${height}`
+	 */
+	height?: 'auto';
+
+	/**
 	 * Element ref to call focus() on after menu is closed via Escape key
 	 */
 	focusRefOnEsc?: React.RefObject<HTMLElement>;
@@ -144,6 +149,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * Callback function for when active state changes.
 	 */
 	onSetActive: (val: boolean) => void;
+
+	/**
+	 * `dropdown-menu-width-${width}`
+	 */
+	width?: 'sm' | 'auto';
 }
 
 const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
@@ -157,6 +167,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 			className,
 			hasLeftSymbols,
 			hasRightSymbols,
+			height,
 			focusRefOnEsc,
 			offsetFn = (points) =>
 				OFFSET_MAP[points.join('') as keyof typeof OFFSET_MAP] as [
@@ -164,6 +175,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 					number
 				],
 			onSetActive,
+			width,
 			...otherProps
 		}: IProps,
 		// TS + refs don't always play nicely together, which is why it is casted
@@ -259,6 +271,8 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 						className={classNames('dropdown-menu', className, {
 							'dropdown-menu-indicator-end': hasRightSymbols,
 							'dropdown-menu-indicator-start': hasLeftSymbols,
+							[`dropdown-menu-height-${height}`]: height,
+							[`dropdown-menu-width-${width}`]: width,
 							show: active,
 						})}
 						ref={ref}

--- a/packages/clay-drop-down/stories/index.tsx
+++ b/packages/clay-drop-down/stories/index.tsx
@@ -32,6 +32,8 @@ const DropDownWithState: React.FunctionComponent<any> = ({
 				Align,
 				Align.BottomLeft
 			)}
+			menuHeight={select('Height', ['', 'auto'], '')}
+			menuWidth={select('Width', ['', 'sm', 'full'], '')}
 			onActiveChange={(newVal) => setActive(newVal)}
 			trigger={<ClayButton>{'Click Me'}</ClayButton>}
 		>


### PR DESCRIPTION
fixes #3790

This adds the css utils to the react components.

@pat270, would you mind just verifying this is how its supposed to work? You can check out the storybook preview here and then toggle the "knobs" to see the different widths.