### PR TITLE
fix(@clayui/css): Tables set background-color on thead, tbody, tfoot …

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_tables.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tables.scss
@@ -24,6 +24,26 @@ $table-head-link: map-deep-merge(
 	$table-head-link
 );
 
+// Table Body
+
+$c-table-tbody: () !default;
+$c-table-tbody: map-merge(
+	(
+		background-color: $white,
+	),
+	$c-table-tbody
+);
+
+// Table Footer
+
+$c-table-tfoot: () !default;
+$c-table-tfoot: map-merge(
+	(
+		background-color: $table-bg,
+	),
+	$c-table-tfoot
+);
+
 $table-caption-color: $gray-900 !default;
 
 $table-divider-bg: $gray-100 !default;

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -35,6 +35,10 @@ caption {
 	width: 100%;
 
 	thead {
+		// Chrome 87 rendering issue. See https://github.com/liferay/clay/issues/3847.
+
+		@include clay-css($c-table-thead);
+
 		td,
 		th {
 			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
@@ -89,18 +93,34 @@ caption {
 		padding-right: $table-cell-gutters;
 	}
 
-	tbody,
-	tfoot {
+	tbody {
+		// Chrome 87 rendering issue. See https://github.com/liferay/clay/issues/3847.
+
+		@include clay-css($c-table-tbody);
+
 		td,
 		th {
 			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 
-			background-color: $table-bg;
+			background-color: map-get($c-table-tbody, background-color);
 		}
 	}
 
 	tbody + tbody {
 		border-top: (2 * $table-border-width) solid $table-border-color;
+	}
+
+	tfoot {
+		// Chrome 87 rendering issue. See https://github.com/liferay/clay/issues/3847.
+
+		@include clay-css($c-table-tfoot);
+
+		td,
+		th {
+			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
+
+			background-color: map-get($c-table-tfoot, background-color);
+		}
 	}
 
 	caption {
@@ -427,6 +447,10 @@ caption {
 	}
 
 	thead {
+		// Chrome 87 rendering issue. See https://github.com/liferay/clay/issues/3847.
+
+		@include clay-css($c-table-list-thead);
+
 		td,
 		th {
 			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
@@ -443,13 +467,28 @@ caption {
 		}
 	}
 
-	tbody,
-	tfoot {
+	tbody {
+		// Chrome 87 rendering issue. See https://github.com/liferay/clay/issues/3847.
+
+		@include clay-css($c-table-list-tbody);
+
 		td,
 		th {
 			// Webkit (Safari 11) rendering issue with responsive-tables. See https://github.com/liferay/clay/issues/950
 
-			background-color: $table-list-bg;
+			background-color: map-get($c-table-list-tbody, background-color);
+			vertical-align: middle;
+		}
+	}
+
+	tfoot {
+		// Chrome 87 rendering issue. See https://github.com/liferay/clay/issues/3847.
+
+		@include clay-css($c-table-list-tfoot);
+
+		td,
+		th {
+			background-color: map-get($c-table-list-tfoot, background-color);
 			vertical-align: middle;
 		}
 	}

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -35,11 +35,21 @@ $table-disabled-color: #acacac !default;
 $table-disabled-cursor: $disabled-cursor !default;
 $table-disabled-pointer-events: none !default;
 
+// Table Header
+
 $table-head-border-bottom-width: 2 * $table-border-width !default;
 $table-head-border-top-width: 0 !default;
 $table-head-font-size: null !default;
 $table-head-font-weight: null !default;
 $table-head-height: 36px !default;
+
+$c-table-thead: () !default;
+$c-table-thead: map-merge(
+	(
+		background-color: $table-head-bg,
+	),
+	$c-table-thead
+);
 
 $table-head-link: () !default;
 
@@ -47,6 +57,10 @@ $table-head-title-inline-item-spacer-x: 0.25rem !default; // 4px
 $table-head-title-text-truncate-max-width: calc(
 	100% - 1em - #{$table-head-title-inline-item-spacer-x}
 ) !default;
+
+// Table Body
+
+$c-table-tbody: () !default;
 
 $table-data-border-bottom-width: $table-border-width !default;
 $table-data-border-left-width: 0 !default;
@@ -85,6 +99,10 @@ $table-cell-expand-smaller-width: 15% !default;
 
 $table-cell-expand-smallest-max-width: 12.5rem !default; // 200px
 $table-cell-expand-smallest-width: 10% !default;
+
+// Table Footer
+
+$c-table-tfoot: () !default;
 
 // Table Caption
 
@@ -221,7 +239,7 @@ $c-table-list-cell: map-merge(
 
 // .table-list thead {th,td}
 
-$table-list-head-bg: null !default;
+$table-list-head-bg: $white !default;
 $table-list-head-font-size: null !default;
 $table-list-head-font-weight: null !default;
 $table-list-head-height: null !default;
@@ -230,6 +248,36 @@ $table-list-head-vertical-alignment: null !default;
 // .table-list thead th a
 
 $table-list-head-link: () !default;
+
+// Table List Thead
+
+$c-table-list-thead: () !default;
+$c-table-list-thead: map-merge(
+	(
+		background-color: $table-list-head-bg,
+	),
+	$c-table-list-thead
+);
+
+// Table List Tbody
+
+$c-table-list-tbody: () !default;
+$c-table-list-tbody: map-merge(
+	(
+		background-color: $white,
+	),
+	$c-table-list-tbody
+);
+
+// Table List Tfoot
+
+$c-table-list-tfoot: () !default;
+$c-table-list-tfoot: map-merge(
+	(
+		background-color: $white,
+	),
+	$c-table-list-tfoot
+);
 
 // .table-list.table-bordered {thead,tbody,tfoot} {th,td}
 


### PR DESCRIPTION
…for Table and Table List. This is for a Chrome 87 bug.

fix(@clayui/css): Tables adds Sass maps `$c-table-thead`, `$c-table-tbody`, `$c-table-tfoot`, `$c-table-list-thead`, `$c-table-list-tbody`, `$c-table-list-tfoot`

fixes #3847