### PR TITLE
fix(@clayui/css): Atlas `color-yiq` function not useable in Atlas var…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -166,6 +166,7 @@ $theme-colors: map-deep-merge(
 	$theme-colors
 );
 
+$yiq-contrasted-threshold: 150 !default;
 $yiq-text-dark: $gray-900 !default;
 $yiq-text-light: $white !default;
 


### PR DESCRIPTION
…iables due to `$yiq-contrasted-threshold` undefined

fixes #3708