### PR TITLE
chore(docs): add script for generating global changelog for each release

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
 		],
 		'@typescript-eslint/no-unused-vars': 'error',
 		'lines-around-comment': 'off',
+		'no-for-of-loops/no-for-of-loops': 'off',
 		'no-unused-vars': 'off',
 		'notice/notice': [
 			'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Change Log
+# CHANGELOG
+
+---
 
 ## v3.x
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"format:check": "prettier --list-different -- \"**/*.{js,ts,tsx,md,mdx,json,scss}\"",
 		"genBuildSize:compare": "NODE_ENV=production node scripts/check-size/index.js --compare",
 		"genBuildSize": "NODE_ENV=production node scripts/check-size/index.js",
+		"genGlobalChangeLog": "node scripts/generate-global-changelog.js && prettier --write -- \"CHANGELOG.md\"",
 		"lerna": "lerna bootstrap -- --no-optional --no-package-lock",
 		"lint:changed": "git ls-files -mz \"**/*.js\" \"**/*.ts\" \"**/*.tsx\" | xargs -0 eslint",
 		"lint:fix": "eslint --fix \".*.js\" \"**/*.{js,ts,tsx}\"",
@@ -33,7 +34,7 @@
 		"storybook:build": "build-storybook -c .storybook -o .storybook-static",
 		"storybook": "start-storybook -p 8888",
 		"test": "jest",
-		"version": "yarn run format:all"
+		"version": "yarn genGlobalChangeLog && prettier --write -- \"packages/**/CHANGELOG.md\" && git add -- \"CHANGELOG.md\" \"packages/clay-css/src/scss/_license-text.scss\""
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.10.1",

--- a/scripts/generate-global-changelog.js
+++ b/scripts/generate-global-changelog.js
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const {execSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const dateObj = new Date();
+
+const month = dateObj.getMonth() + 1;
+const day = dateObj.getDate();
+const year = dateObj.getFullYear();
+
+const releaseDateString = `${year}-${month}-${day}`;
+
+const globalChangeLog = path.join(__dirname, '../CHANGELOG.md');
+
+const VERSION_HEADING = /^#+ \[\d/;
+
+const VERSION_LINK = /^#+ (\[\d+\.\d+\.\d+\]\(\S+\))/;
+
+function getChanges(file, packageName) {
+	let latestVersionHeader;
+	const changes = [];
+
+	const lines = fs.readFileSync(file, 'utf8').split('\n');
+
+	for (const line of lines) {
+		if (VERSION_HEADING.test(line)) {
+			if (latestVersionHeader) {
+				// Making it into this block indicates that we are now looking at the
+				// second to last release, one that should already be in the CHANGELOG.
+				// This means we already have the content we need.
+				break;
+			}
+
+			latestVersionHeader = line;
+		}
+
+		// The second condition makes sure we don't add the header to our changes.
+		if (latestVersionHeader && line !== latestVersionHeader) {
+			/**
+			 * Be sure to properly nest headers in proper order.
+			 * This order of markdown is:
+			 * # CHANGELOG
+			 * ## {Release date}
+			 * ### {Package name}
+			 * #### {Fix type (feat, bug, etc.)}
+			 * - Commit message and reference
+			 */
+			let modifiedLine = line.replace(/^(#+)/gm, '$1#');
+
+			// Remove references to the package name since we already have a header
+			modifiedLine = modifiedLine.replace(`**${packageName}:**`, '');
+
+			changes.push(modifiedLine);
+		}
+	}
+
+	// Grabs the markdown link to the specific package version
+	const versionLinkMatch = latestVersionHeader.match(VERSION_LINK);
+
+	return {
+		changes: changes.join('\n'),
+		versionLink: versionLinkMatch ? versionLinkMatch[1] : null,
+	};
+}
+
+function logError(message) {
+	console.error(`Global CHANGELOG: Unable to generate, ${message}`);
+}
+
+function main() {
+	const diffOutput = execSync(
+		'git diff HEAD^ -z --name-only -- "packages/clay-*/CHANGELOG.md"'
+	).toString();
+
+	if (!diffOutput) {
+		logError(`no diff exists for CHANGELOGS in packages.`);
+
+		return;
+	}
+
+	const changelogContents = fs.readFileSync(globalChangeLog, 'utf8');
+
+	if (changelogContents.includes(`## ${releaseDateString}`)) {
+		logError(
+			`CHANGELOG has already been generated for the ${releaseDateString} release.`
+		);
+
+		return;
+	}
+
+	const files = diffOutput.split('\0').filter(Boolean);
+
+	let output = `# CHANGELOG\n## ${releaseDateString}\n`;
+
+	for (const file of files) {
+		try {
+			const packageName = file
+				.replace('packages/', '')
+				.replace('/CHANGELOG.md', '')
+				.replace('clay-', '@clayui/');
+
+			const {changes, versionLink} = getChanges(file, packageName);
+
+			const pkgJson = file.replace('CHANGELOG.md', 'package.json');
+
+			const {version} = JSON.parse(fs.readFileSync(pkgJson));
+
+			output += `\n### ${packageName} (${
+				versionLink ? versionLink : version
+			})\n`;
+
+			output += `${changes}`;
+		} catch (e) {
+			logError(
+				`unexpected error when trying to generate CHANGELOG for ${file}.`
+			);
+
+			return;
+		}
+	}
+
+	fs.writeFileSync(
+		globalChangeLog,
+		changelogContents
+			? changelogContents.replace(/^# CHANGELOG/, output)
+			: output
+	);
+}
+
+main();


### PR DESCRIPTION
Since we are planning on releasing tomorrow I thought I could throw together a super crude idea of auto-generating the global changelog with each release. Let me know what you think