### PR TITLE
fix(clay-css): [2.x] Atlas `color-yiq` function not useable in Atlas variab…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -144,6 +144,7 @@ $theme-colors: map-deep-merge((
 	dark: $dark
 ), $theme-colors);
 
+$yiq-contrasted-threshold: 150 !default;
 $yiq-text-dark: $gray-900 !default;
 $yiq-text-light: $white !default;
 


### PR DESCRIPTION
…les due to `$yiq-contrasted-threshold` undefined

issue #3708