### PR TITLE
chore: add gh action for commenting DXP release on closed issues in a milestone

### DIFF
--- a/.github/workflows/dxp-release-labeler.yml
+++ b/.github/workflows/dxp-release-labeler.yml
@@ -1,0 +1,36 @@
+name: 'DXP Release Commenter'
+on:
+    milestone:
+        types: [closed]
+
+jobs:
+    labeler:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/github-script@v3
+              with:
+                  github-token: ${{secrets.GITHUB_TOKEN}}
+                  script: |
+                      const jiraIssueMatch = context.payload.milestone.title.match(/^LPS-\d+/);
+
+                      if (jiraIssueMatch) {
+                        const LPS = jiraIssueMatch;
+
+                        const issues = await github.issues.listForRepo({
+                          milestone: context.payload.milestone.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          state: 'closed'
+                        });
+
+                        if (issues.data) {
+                          for (const issue of issues.data) {
+                            await github.issues.createComment({
+                              issue_number: issue.number,
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              body: `This issue has been merged and will be released in DXP at https://https://issues.liferay.com/browse/${LPS}`
+                            });
+                          }
+                        } 
+                      }


### PR DESCRIPTION
fixes #3898

This action works as follows

Event: Whenever we close a milestone
- Gets every closed issue in a milestone
- Grabs the Jira issue from the milestone title
- Comments on each issue and adds the link to track the LPS