### PR TITLE
fix(clay-css): display the dropdown arrow icon on IE11

### DIFF
--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -286,7 +286,8 @@ select.form-control:not([multiple]):not([size]),
 	-webkit-appearance: none;
 
 	&::-ms-expand {
-		display: none;
+		background-color: transparent;
+		border: 0;
 	}
 
 	background-color: $input-select-bg;


### PR DESCRIPTION
Hi Team,

could you please check my fix?

Thanks, Roland

https://github.com/liferay/clay/issues/3922