### PR TITLE
fix(@clayui/css): Atlas Select Element IE11 should hide default icon …

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -164,7 +164,7 @@ $input-warning-select-icon: clay-icon(
 // Select Element
 
 $input-select-bg-position: right 0.5em center !default;
-$input-select-bg-size: 1.5em auto !default;
+$input-select-bg-size: 1.5em 1.5em !default;
 $input-select-padding-right: 2em !default;
 
 $input-select-icon-color: $gray-600 !default;

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -305,11 +305,10 @@ div {
 select.form-control {
 	@include clay-select-variant($input-select);
 
-	// Unstyle the caret on `<select>`s in IE10+.
+	// Unstyle the caret on `<select>`s in IE11.
 
 	&::-ms-expand {
-		background-color: transparent;
-		border: 0;
+		display: none;
 	}
 
 	// Remove dotted outline from select box in FF


### PR DESCRIPTION
…and use caret-double-l instead

fixes #3922