### PR TITLE
fix(clay-css): [2.x] Atlas Theme Select Element IE11 should show caret-doub…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -141,7 +141,7 @@ $input-warning-select-icon: clay-icon(caret-double-l, $input-warning-select-icon
 // Select Element
 
 $input-select-bg-position: right 0.5em center !default;
-$input-select-bg-size: 1.5em auto !default;
+$input-select-bg-size: 1.5em 1.5em !default;
 $input-select-padding-right: 2em !default;
 
 $input-select-icon-color: $gray-600 !default;


### PR DESCRIPTION
…le-l icon

fixes #3922