### PR TITLE
feat(@clayui/drop-down): add util for aligning dropdown on scroll

### DIFF
--- a/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
@@ -38,6 +38,7 @@ exports[`ClayBreadcrumb calls callback when an item is clicked 1`] = `
       <button
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
+        style=""
         type="button"
       >
         <svg
@@ -116,6 +117,7 @@ exports[`ClayBreadcrumb renders 1`] = `
       <button
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
+        style=""
         type="button"
       >
         <svg
@@ -195,6 +197,7 @@ exports[`ClayBreadcrumb renders with properties passed by \`ellipsisProps\` 1`] 
       <button
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
+        style=""
         type="button"
       >
         <svg

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -1430,6 +1430,7 @@ exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
           >
             <button
               class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+              style=""
               type="button"
             >
               <svg
@@ -2168,6 +2169,7 @@ exports[`ClayCardWithInfo renders as not selectable 1`] = `
           >
             <button
               class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+              style=""
               type="button"
             >
               <svg
@@ -2798,6 +2800,7 @@ exports[`ClayCardWithUser renders as selectable 1`] = `
             >
               <button
                 class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+                style=""
                 type="button"
               >
                 <svg

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -72,6 +72,7 @@ exports[`Rendering default 1`] = `
       </label>
       <div
         class="input-group clay-color"
+        style=""
       >
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
@@ -110,6 +111,7 @@ exports[`Rendering default 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <div
           class="clay-color-header"
@@ -447,6 +449,7 @@ exports[`Rendering disabled palette 1`] = `
       </label>
       <div
         class="input-group clay-color"
+        style=""
       >
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
@@ -485,6 +488,7 @@ exports[`Rendering disabled palette 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <div
           class="clay-color-header"
@@ -822,6 +826,7 @@ exports[`Rendering disabled state 1`] = `
       </label>
       <div
         class="input-group clay-color"
+        style=""
       >
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
@@ -862,6 +867,7 @@ exports[`Rendering disabled state 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <div
           class="clay-color-header"
@@ -1199,6 +1205,7 @@ exports[`Rendering renders w/ var() 1`] = `
       </label>
       <div
         class="input-group clay-color"
+        style=""
       >
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
@@ -1244,6 +1251,7 @@ exports[`Rendering renders w/ var() 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <div
           class="clay-color-header"
@@ -1581,6 +1589,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
       </label>
       <div
         class="input-group clay-color"
+        style=""
       >
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
@@ -1619,6 +1628,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <div
           class="clay-color-header"
@@ -1956,6 +1966,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
       </label>
       <div
         class="input-group clay-color"
+        style=""
       >
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
@@ -2002,6 +2013,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <div
           class="clay-color-header"
@@ -2339,6 +2351,7 @@ exports[`Rendering small color-picker 1`] = `
       </label>
       <div
         class="input-group clay-color input-group-sm"
+        style=""
       >
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
@@ -2377,6 +2390,7 @@ exports[`Rendering small color-picker 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <div
           class="clay-color-header"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -8,6 +8,7 @@ exports[`BasicRendering renders by default 1`] = `
     >
       <div
         class="input-group"
+        style=""
       >
         <div
           class="input-group-item"
@@ -50,6 +51,7 @@ exports[`BasicRendering renders by default 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
+        style="left: -999px; top: -995px;"
       >
         <div
           class="date-picker-calendar"

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -8,6 +8,8 @@ import classNames from 'classnames';
 import domAlign from 'dom-align';
 import React, {useEffect, useLayoutEffect, useRef} from 'react';
 
+import observeRect from './observeRect';
+
 export const Align = {
 	BottomCenter: 4,
 	BottomLeft: 5,
@@ -242,12 +244,8 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 			};
 		}, [active]);
 
-		useLayoutEffect(() => {
-			if (
-				alignElementRef.current &&
-				(ref as React.RefObject<HTMLDivElement>).current &&
-				active
-			) {
+		const align = React.useCallback(() => {
+			if (alignElementRef && alignElementRef.current) {
 				let points = alignmentPosition;
 
 				if (typeof points === 'number') {
@@ -269,7 +267,21 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 					}
 				);
 			}
+		}, [autoBestAlign, alignmentPosition]);
+
+		useLayoutEffect(() => {
+			if (active) {
+				align();
+			}
 		}, [active]);
+
+		useEffect(() => {
+			if (alignElementRef && alignElementRef.current) {
+				const unobserve = observeRect(alignElementRef.current, align);
+
+				return unobserve;
+			}
+		}, []);
 
 		return (
 			<ClayPortal subPortalRef={subPortalRef}>

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
@@ -8,6 +8,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems 1`] = `
     >
       <button
         class="dropdown-toggle btn btn-primary"
+        style=""
         type="button"
       >
         Click Me
@@ -18,6 +19,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems 1`] = `
     <div>
       <div
         class="dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
@@ -57,6 +59,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with caption 1`] = `
     >
       <button
         class="dropdown-toggle btn btn-primary"
+        style=""
         type="button"
       >
         Click Me
@@ -67,6 +70,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with caption 1`] = `
     <div>
       <div
         class="dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
@@ -99,6 +103,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with checkbox 1`] = `
     >
       <button
         class="dropdown-toggle btn btn-primary"
+        style=""
         type="button"
       >
         Click Me
@@ -109,6 +114,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with checkbox 1`] = `
     <div>
       <div
         class="dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
@@ -191,6 +197,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with footer content 1
     >
       <button
         class="dropdown-toggle btn btn-primary"
+        style=""
         type="button"
       >
         Click Me
@@ -201,6 +208,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with footer content 1
     <div>
       <div
         class="dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <form>
           <div
@@ -244,6 +252,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with help text 1`] = 
     >
       <button
         class="dropdown-toggle btn btn-primary"
+        style=""
         type="button"
       >
         Click Me
@@ -254,6 +263,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with help text 1`] = 
     <div>
       <div
         class="dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <div
           class="alert alert-fluid alert-info"
@@ -287,6 +297,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with radio group 1`] 
     >
       <button
         class="dropdown-toggle btn btn-primary"
+        style=""
         type="button"
       >
         Click Me
@@ -297,6 +308,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with radio group 1`] 
     <div>
       <div
         class="dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
@@ -389,6 +401,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with search 1`] = `
     >
       <button
         class="dropdown-toggle btn btn-primary"
+        style=""
         type="button"
       >
         Click Me
@@ -399,6 +412,7 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with search 1`] = `
     <div>
       <div
         class="dropdown-menu"
+        style="left: -999px; top: -995px;"
       >
         <form
           class=""

--- a/packages/clay-drop-down/src/observeRect.ts
+++ b/packages/clay-drop-down/src/observeRect.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const rectAttrs: Array<keyof DOMRect> = [
+	'bottom',
+	'height',
+	'left',
+	'right',
+	'top',
+	'width',
+];
+
+interface IRectState {
+	rect: DOMRect | undefined;
+	hasRectChanged: boolean;
+	callback: (rect?: DOMRect) => void;
+}
+
+const rectChanged = (a: DOMRect = {} as DOMRect, b: DOMRect = {} as DOMRect) =>
+	rectAttrs.some((prop) => a[prop] !== b[prop]);
+
+let rafId: number;
+
+const run = (node: Element, state: IRectState) => {
+	const newRect = node.getBoundingClientRect();
+
+	if (rectChanged(newRect, state.rect)) {
+		state.rect = newRect;
+
+		state.callback(state.rect);
+	}
+
+	rafId = window.requestAnimationFrame(() => run(node, state));
+};
+
+export default function observeRect(
+	node: Element,
+	callback: (rect?: DOMRect) => void
+) {
+	run(node, {callback, hasRectChanged: false, rect: undefined});
+
+	return () => {
+		cancelAnimationFrame(rafId);
+	};
+}

--- a/packages/clay-drop-down/stories/index.tsx
+++ b/packages/clay-drop-down/stories/index.tsx
@@ -6,7 +6,8 @@
 import '@clayui/css/lib/css/atlas.css';
 import ClayButton from '@clayui/button';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
-import {ClayCheckbox, ClayRadio} from '@clayui/form';
+import {ClayCheckbox, ClayInput, ClayRadio} from '@clayui/form';
+import ClayModal, {useModal} from '@clayui/modal';
 import {boolean, select} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
@@ -371,6 +372,94 @@ storiesOf('Components|ClayDropDown', module)
 				>
 					{'External Control'}
 				</button>
+			</>
+		);
+	})
+	.add('in modal', () => {
+		const [visible, setVisible] = React.useState(false);
+		const {observer, onClose} = useModal({
+			onClose: () => setVisible(false),
+		});
+		const inputRef = React.useRef(null);
+		const dropdownMenuRef = React.useRef(null);
+		const [panelVisibility, setPanelVisibility] = React.useState(false);
+
+		return (
+			<>
+				{visible && (
+					<ClayModal
+						observer={observer}
+						size="lg"
+						spritemap={spritemap}
+						status="info"
+					>
+						<ClayModal.Header>{'Title'}</ClayModal.Header>
+						<ClayModal.Body scrollable>
+							<ClayInput
+								onClick={() =>
+									setPanelVisibility(!panelVisibility)
+								}
+								placeholder={'meow'}
+								ref={inputRef}
+							/>
+							<ClayDropDown.Menu
+								active={panelVisibility}
+								alignElementRef={inputRef}
+								onSetActive={() =>
+									setPanelVisibility(!panelVisibility)
+								}
+								ref={dropdownMenuRef}
+							>
+								<ClayDropDown.Item>
+									{'my panel item'}
+								</ClayDropDown.Item>
+							</ClayDropDown.Menu>
+							<img
+								alt="cat"
+								src="https://cataas.com/cat/says/it"
+							/>
+							<img
+								alt="cat"
+								src="https://cataas.com/cat/says/will"
+							/>
+							<img
+								alt="cat"
+								src="https://cataas.com/cat/says/have"
+							/>
+							<img
+								alt="cat"
+								src="https://cataas.com/cat/says/a"
+							/>
+							<img
+								alt="cat"
+								src="https://cataas.com/cat/says/scroll"
+							/>
+						</ClayModal.Body>
+						<ClayModal.Footer
+							first={
+								<ClayButton.Group spaced>
+									<ClayButton displayType="secondary">
+										{'Secondary'}
+									</ClayButton>
+									<ClayButton displayType="secondary">
+										{'Secondary'}
+									</ClayButton>
+								</ClayButton.Group>
+							}
+							last={
+								<ClayButton onClick={onClose}>
+									{'Primary'}
+								</ClayButton>
+							}
+						/>
+					</ClayModal>
+				)}
+				<ClayButton
+					displayType="primary"
+					onClick={() => setVisible(true)}
+				>
+					{'Open modal'}
+				</ClayButton>
 			</>
 		);
 	});

--- a/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
@@ -32,6 +32,7 @@ exports[`ClayLocalizedInput renders 1`] = `
         >
           <button
             class="dropdown-toggle btn btn-monospaced btn-secondary"
+            style=""
             title="Open Localizations"
             type="button"
           >
@@ -106,6 +107,7 @@ exports[`ClayLocalizedInput renders with prepend content and result formatter 1`
         >
           <button
             class="dropdown-toggle btn btn-monospaced btn-secondary"
+            style=""
             title="Open Localizations"
             type="button"
           >

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -141,7 +141,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
     <div>
       <div
         class="dropdown-menu autocomplete-dropdown-menu show"
-        style="max-width: none; width: 0px; left: -999px; top: -995px;"
+        style="max-width: none; left: -999px; top: -995px; width: 0px;"
       >
         <ul
           class="list-unstyled"
@@ -548,7 +548,7 @@ exports[`Interactions add non-sequential text should filter the items when it is
     <div>
       <div
         class="dropdown-menu autocomplete-dropdown-menu show"
-        style="max-width: none; width: 0px; left: -999px; top: -995px;"
+        style="max-width: none; left: -999px; top: -995px; width: 0px;"
       >
         <ul
           class="list-unstyled"
@@ -615,7 +615,7 @@ exports[`Interactions adding text doesn not filter the items with a custom funct
     <div>
       <div
         class="dropdown-menu autocomplete-dropdown-menu show"
-        style="max-width: none; width: 0px; left: -999px; top: -995px;"
+        style="max-width: none; left: -999px; top: -995px; width: 0px;"
       >
         <ul
           class="list-unstyled"
@@ -698,7 +698,7 @@ exports[`Interactions adding text filters the items 1`] = `
     <div>
       <div
         class="dropdown-menu autocomplete-dropdown-menu show"
-        style="max-width: none; width: 0px; left: -999px; top: -995px;"
+        style="max-width: none; left: -999px; top: -995px; width: 0px;"
       >
         <ul
           class="list-unstyled"
@@ -767,7 +767,7 @@ exports[`Interactions adding text filters the items with a custom function 1`] =
     <div>
       <div
         class="dropdown-menu autocomplete-dropdown-menu show"
-        style="max-width: none; width: 0px; left: -999px; top: -995px;"
+        style="max-width: none; left: -999px; top: -995px; width: 0px;"
       >
         <ul
           class="list-unstyled"
@@ -836,7 +836,7 @@ exports[`Interactions adding upper or lower case text should filter the items wh
     <div>
       <div
         class="dropdown-menu autocomplete-dropdown-menu show"
-        style="max-width: none; width: 0px; left: -999px; top: -995px;"
+        style="max-width: none; left: -999px; top: -995px; width: 0px;"
       >
         <ul
           class="list-unstyled"

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -11,6 +11,7 @@ exports[`ClayPaginationBar renders 1`] = `
       <button
         class="dropdown-toggle btn btn-unstyled"
         data-testid="selectPaginationBar"
+        style=""
         type="button"
       >
         10 items
@@ -87,6 +88,7 @@ exports[`ClayPaginationBar renders 1`] = `
       >
         <button
           class="dropdown-toggle page-link btn btn-unstyled"
+          style=""
           type="button"
         >
           ...

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -39,6 +39,7 @@ exports[`ClayPagination renders 1`] = `
     >
       <button
         class="dropdown-toggle page-link btn btn-unstyled"
+        style=""
         type="button"
       >
         ...
@@ -99,6 +100,7 @@ exports[`ClayPagination renders 1`] = `
     >
       <button
         class="dropdown-toggle page-link btn btn-unstyled"
+        style=""
         type="button"
       >
         ...

--- a/packages/clay-upper-toolbar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-upper-toolbar/src/__tests__/__snapshots__/index.tsx.snap
@@ -123,6 +123,7 @@ exports[`ClayUpperToolbar renders 1`] = `
             >
               <button
                 class="dropdown-toggle btn btn-monospaced btn-sm btn-unstyled"
+                style=""
                 type="button"
               >
                 <svg


### PR DESCRIPTION
fixes #3804

I added our own observer util with inspiration from observe-rect and seems to work as intended.

There is still an issue with the z-index of the drop-down, and I'm not quite sure what we want to do about that. Perhaps the best option is to check if the dropdown is still in the view(modal or document) and if it is not, we close the drop-down. Although I am fearful that might lead to poor UX.

![Kapture 2021-02-10 at 15 33 09](https://user-images.githubusercontent.com/6843530/107586721-5852b500-6bb5-11eb-8721-7bf0a3183598.gif)
