### PR TITLE
chore: fix jira link in github action

### DIFF
--- a/.github/workflows/dxp-release-labeler.yml
+++ b/.github/workflows/dxp-release-labeler.yml
@@ -29,7 +29,7 @@ jobs:
                               issue_number: issue.number,
                               owner: context.repo.owner,
                               repo: context.repo.repo,
-                              body: `This issue has been merged and will be released in DXP at https://https://issues.liferay.com/browse/${LPS}`
+                              body: `This issue has been merged and will be released in DXP at https://issues.liferay.com/browse/${LPS}`
                             });
                           }
                         } 


### PR DESCRIPTION
Accidentally had `https://https://...`