### PR TITLE
fix(clay-dropdown) Passing  aria-label and placeholder as parameter so they can be localized

### DIFF
--- a/packages/clay-dropdown/src/ClayDropdownBase.soy
+++ b/packages/clay-dropdown/src/ClayDropdownBase.soy
@@ -156,7 +156,14 @@
 		<div class="dropdown-section">
 			<div class="input-group input-group-sm">
 				<div class="input-group-item">
-					<input aria-label="Search for..." class="form-control input-group-inset input-group-inset-after" data-oninput="{$_handleSearch}" placeholder="Search for..." type="text" ref="searchInput" />
+					<input 
+						aria-label="{msg desc=""}search-for{/msg}"
+						class="form-control input-group-inset input-group-inset-after" 
+						data-oninput="{$_handleSearch}" 
+						placeholder="{msg desc=""}search-for{/msg}" 
+						type="text" 
+						ref="searchInput" 
+					/>
 
 					<span class="input-group-inset-item input-group-inset-item-after">
 						{call ClayButton.render}


### PR DESCRIPTION
Hi guys,

Can you have a look at this pull request, please?

It's fixing [issue#3934](https://github.com/liferay/clay/issues/3934).

I ended up adding non-localized default values to avoid breaking changes. This way, nothing is going to change for those users who are already making use of clay-dropdown and once we publish the new version, we can modify the uses of it in Liferay Portal.

Thanks.

Regards.