### PR TITLE
fix(@clayui/color-picker): RGB inputs should only accept numeric values from 0 to 255

### DIFF
--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -55,6 +55,8 @@ const RGBInput: React.FunctionComponent<IRGBInputProps> = ({
 					<ClayInput
 						data-testid={`${name}Input`}
 						insetBefore
+						max="255"
+						min="0"
 						onChange={(event) => {
 							const newVal = Number(event.target.value);
 
@@ -63,7 +65,7 @@ const RGBInput: React.FunctionComponent<IRGBInputProps> = ({
 							onChange({[name]: newVal});
 						}}
 						ref={inputRef}
-						type="text"
+						type="number"
 						value={inputValue}
 					/>
 					<ClayInput.GroupInsetItem before tag="label">


### PR DESCRIPTION
fixes #3949

follow up from https://github.com/liferay/clay/pull/3950


@carloslancha I took a look into this and I think all we actually needed was just the type on the input and also the min/max. I removed the other changes you made and squashed it into your commit.

Let me know if I missed something