### PR TITLE
fix: issue 3958 (LPS-128384 removing firefox styles for fieldsets)

### DIFF
--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -5,10 +5,6 @@ input[type="radio"] {
 
 fieldset {
 	word-wrap: break-word;
-
-	@-moz-document url-prefix() { // FF Fieldset workaround
-		display: table-cell;
-	}
 }
 
 label,


### PR DESCRIPTION
Fixes: #3958

Basically in older versions of firefox we add this piece of code to workaround fieldset behavior in firefox.
From firefox v86 this workaround doesn't behave as in older versions and prevents fieldset and their children nodes to get 100% of width of their parent node