### PR TITLE
fix(lexicon-css): Remove firefox `display: table-cell` CSS reset for …

### DIFF
--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -5,10 +5,6 @@ input[type="radio"] {
 
 fieldset {
 	word-wrap: break-word;
-
-	@-moz-document url-prefix() { // FF Fieldset workaround
-		display: table-cell;
-	}
 }
 
 label,


### PR DESCRIPTION
…`fieldsets`

https://issues.liferay.com/browse/LPS-128384

fixes #3958