### PR TITLE
chore(lexicon-ux): Update release tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is the repo of Liferay's Lexicon Design Language, and an implementation of 
 
 They are meant to help explain our design principles, offer direction and best practices in building your web apps, and provide a documented HTML and CSS API.
 
-You can view the guidelines on [the Lexicon site](https://liferay.github.io/lexicon).
+You can view the guidelines on [the Lexicon site](https://liferay.github.io/lexiconcss).
 
 ## Building
 If you would like to contribute to the guidelines, or make changes on your system you need to do the following:
@@ -29,12 +29,12 @@ If you would like to contribute to the guidelines, or make changes on your syste
 ### Clone the repo
 Clone the repo to your computer
 
-### Install Node.js (v4.6.0 LTS) and NPM
+### Install Node.js (v4.6.0 - v7.7.1) and NPM
 If you don't already have it installed. You can find more info here: http://nodejs.org/
 Node and NPM come bundled together, so you only need to install one package.
 
 ### Install the NPM modules
-Run `npm install` inside of the `lexicon` directory
+Run `npm install` inside of the `clay` directory
 
 ### Modify files in src/
 The files are generated from the `src/` directory, however, most of the files you'd be interested in changing are in `src/content/`. Files can be either HTML (`.html`) or Markdown (`.md`).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,7 +80,7 @@ gulp.task(
 		var questions = [
 			{
 				default: false,
-				message: 'Do you want to create a git tag and push to gh-pages?',
+				message: 'Do you want to create a git tag?',
 				name: 'publish',
 				type: 'confirm'
 			},

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -15,8 +15,6 @@ module.exports = function(gulp, plugins, _, config) {
 
 	var TEMP_PATH = path.join(process.cwd(), 'temp');
 
-	var BRANCH_DEV = '1.x-develop';
-
 	var BRANCH_RELEASE = '1.x';
 
 	var getGitRemote = function() {
@@ -120,7 +118,6 @@ module.exports = function(gulp, plugins, _, config) {
 		function(done) {
 			var branchName = 'bower-staging-' + Math.random().toString(16).replace(/[^0-9a-fA-F]/g, '');
 			var browserCommitMessage = 'Browser files for v' + bumpedVersion;
-			var mergeCommitMessage = 'Merging ' + BRANCH_RELEASE + '@v' + bumpedVersion + ' into ' + BRANCH_DEV;
 			var rebuildCommitMessage = 'Rebuild v' + bumpedVersion;
 			var releaseCommitMessage = 'Release v' + bumpedVersion;
 			var tagMessage = 'Version ' + bumpedVersion;
@@ -136,10 +133,9 @@ module.exports = function(gulp, plugins, _, config) {
 			};
 
 			cmdPromise.resolve()
-				.git('checkout', BRANCH_DEV)
+				.git('checkout', BRANCH_RELEASE)
 				.cmd('gulp', 'build:svg:scss-icons')
 				.git('status', '--porcelain', './src/scss/lexicon-base/mixins/_global-functions.scss').then(checkStatus('It appears that there are new icons. Please commit the modified Sass functions file.'))
-				.git('checkout', BRANCH_RELEASE)
 				.git('status', '--porcelain').then(checkStatus('working directory not clean, aborting'))
 				.then(getGitRemote)
 				.then(function(remote) {
@@ -179,8 +175,6 @@ module.exports = function(gulp, plugins, _, config) {
 				.git('branch', '-D', branchName)
 				.git('checkout', tagName, '--', 'release')
 				.git('reset')
-				.git('checkout', BRANCH_DEV)
-				.git('merge', BRANCH_RELEASE, '-m', mergeCommitMessage)
 				.then(function() {
 					done();
 				});
@@ -193,7 +187,7 @@ module.exports = function(gulp, plugins, _, config) {
 			cmdPromise.resolve()
 				.then(getGitRemote)
 				.then(function(remote){
-					return cmdPromise.resolve().git('push', remote, '--tags', BRANCH_RELEASE, BRANCH_DEV);
+					return cmdPromise.resolve().git('push', remote, '--tags', BRANCH_RELEASE);
 				})
 				.then(function() {
 					done();


### PR DESCRIPTION
- Remove message `and push to gh-pages` from release task we removed it a while ago (this is being done manually at the moment)
- Release task is based only on 1.x now
- ~Release task should push changes to 1.x-stable instead of 1.x-develop, also changed this a while ago~ 