### PR TITLE
brainstorm of @clayui/core package

### DIFF
--- a/packages/clay-core/.yarnrc
+++ b/packages/clay-core/.yarnrc
@@ -1,0 +1,3 @@
+# Make `yarn version` produce the right commit message and tag for this package.
+version-tag-prefix "@clayui/core@"
+version-git-message "chore: prepare @clayui/core@%s"

--- a/packages/clay-core/CHANGELOG.md
+++ b/packages/clay-core/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/clay-core/README.mdx
+++ b/packages/clay-core/README.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Core'
+description: 'Collection of all Clay components'
+packageNpm: '@clayui/core'
+---
+
+## Overview
+
+This package exposed the majority of `@clayui` components in a single import. Each component is named export.
+
+For Example:
+
+```js
+// Before
+import ClayAlert from '@clayui/alert';
+import ClayModal, {ClayModalProvider, useModal} from '@clayui/modal';
+
+() => {
+	const {observer, onClose} = useModal();
+
+	return (
+		<ClayModalProvider>
+			<ClayAlert />
+		</ClayModalProvider>
+	);
+};
+
+// After
+import {ClayAlert, ClayModal} from '@clayui/core';
+
+() => {
+	const {observer, onClose} = ClayModal.useModal();
+
+	return (
+		<ClayModal.ClayModalProvider>
+			<ClayAlert />
+		</ClayModal.ClayModalProvider>
+	);
+};
+```
+
+### Packages Not Included:
+
+-   `@clayui/charts` (Not commonly used and drastically increases library size)
+-   `@clayui/shared` (internal use only)
+-   `@clayui/upper-toolbar` (deprecated)

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -1,0 +1,74 @@
+{
+	"name": "@clayui/core",
+	"version": "3.0.0",
+	"description": "Collection of the core @clayui components",
+	"license": "BSD-3-Clause",
+	"repository": "https://github.com/liferay/clay",
+	"engines": {
+		"node": ">=0.12.0",
+		"npm": ">=3.0.0"
+	},
+	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
+	"ts:main": "src/index.tsx",
+	"files": [
+		"lib",
+		"src"
+	],
+	"scripts": {
+		"build": "cross-env NODE_ENV=production babel src --root-mode upward --out-dir lib --extensions .ts,.tsx",
+		"build:types": "cross-env NODE_ENV=production tsc --project ./tsconfig.declarations.json",
+		"prepublishOnly": "yarn build && yarn build:types",
+		"test": "jest --config ../../jest.config.js"
+	},
+	"keywords": [
+		"clay",
+		"react"
+	],
+	"dependencies": {
+		"@clayui/alert": "3.x",
+		"@clayui/autocomplete": "3.x",
+		"@clayui/badge": "3.x",
+		"@clayui/breadcrumb": "3.x",
+		"@clayui/button": "3.x",
+		"@clayui/card": "3.x",
+		"@clayui/color-picker": "3.x",
+		"@clayui/date-picker": "3.x",
+		"@clayui/drop-down": "3.x",
+		"@clayui/empty-state": "3.x",
+		"@clayui/form": "3.x",
+		"@clayui/icon": "3.x",
+		"@clayui/label": "3.x",
+		"@clayui/layout": "3.x",
+		"@clayui/link": "3.x",
+		"@clayui/list": "3.x",
+		"@clayui/loading-indicator": "3.x",
+		"@clayui/localized-input": "3.x",
+		"@clayui/management-toolbar": "3.x",
+		"@clayui/modal": "3.x",
+		"@clayui/multi-select": "3.x",
+		"@clayui/multi-step-nav": "3.x",
+		"@clayui/nav": "3.x",
+		"@clayui/navigation-bar": "3.x",
+		"@clayui/pagination": "3.x",
+		"@clayui/pagination-bar": "3.x",
+		"@clayui/panel": "3.x",
+		"@clayui/popover": "3.x",
+		"@clayui/progress-bar": "3.x",
+		"@clayui/slider": "3.x",
+		"@clayui/sticker": "3.x",
+		"@clayui/table": "3.x",
+		"@clayui/tabs": "3.x",
+		"@clayui/time-picker": "3.x",
+		"@clayui/toolbar": "3.x",
+		"@clayui/tooltip": "3.x"
+	},
+	"peerDependencies": {
+		"@clayui/css": "^3.x",
+		"react": "^16.8.1",
+		"react-dom": "^16.8.1"
+	},
+	"browserslist": [
+		"extends browserslist-config-clay"
+	]
+}

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/core",
-	"version": "3.0.0",
+	"version": "3.0.0-alpha",
 	"description": "Collection of the core @clayui components",
 	"license": "BSD-3-Clause",
 	"repository": "https://github.com/liferay/clay",

--- a/packages/clay-core/src/index.tsx
+++ b/packages/clay-core/src/index.tsx
@@ -1,0 +1,120 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Packages Not Included:
+ * - @clayui/charts (Not commonly used)
+ * - @clayui/shared (internal use only)
+ * - @clayui/upper-toolbar (deprecated)
+ */
+
+export {default as ClayAlert} from '@clayui/alert';
+export * from '@clayui/alert';
+
+export {default as ClayAutocomplete} from '@clayui/autocomplete';
+export * from '@clayui/autocomplete';
+
+export {default as ClayBadge} from '@clayui/badge';
+export * from '@clayui/badge';
+
+export {default as ClayBreadcrumb} from '@clayui/breadcrumb';
+export * from '@clayui/breadcrumb';
+
+export {default as ClayButton} from '@clayui/button';
+export * from '@clayui/button';
+
+export {default as ClayCard} from '@clayui/card';
+export * from '@clayui/card';
+
+export {default as ClayColorPicker} from '@clayui/color-picker';
+export * from '@clayui/color-picker';
+
+export {default as ClayDatePicker} from '@clayui/date-picker';
+export * from '@clayui/date-picker';
+
+export {default as ClayDropDown} from '@clayui/drop-down';
+export * from '@clayui/drop-down';
+
+export {default as ClayEmptyState} from '@clayui/empty-state';
+export * from '@clayui/empty-state';
+
+export {default as ClayForm} from '@clayui/form';
+export * from '@clayui/form';
+
+export {default as ClayIcon} from '@clayui/icon';
+export * from '@clayui/icon';
+
+export {default as ClayLabel} from '@clayui/label';
+export * from '@clayui/label';
+
+export {default as ClayLayout} from '@clayui/layout';
+export * from '@clayui/layout';
+
+export {default as ClayLink} from '@clayui/link';
+export * from '@clayui/link';
+
+export {default as ClayList} from '@clayui/list';
+export * from '@clayui/list';
+
+export {default as ClayLoadingIndicator} from '@clayui/loading-indicator';
+export * from '@clayui/loading-indicator';
+
+export {default as ClayLocalizedInput} from '@clayui/localized-input';
+export * from '@clayui/localized-input';
+
+export {default as ClayManagementToolbar} from '@clayui/management-toolbar';
+export * from '@clayui/management-toolbar';
+
+export {default as ClayModal} from '@clayui/modal';
+export * from '@clayui/modal';
+
+export {default as ClayMultiSelect} from '@clayui/multi-select';
+export * from '@clayui/multi-select';
+
+export {default as ClayMultiStepNav} from '@clayui/multi-step-nav';
+export * from '@clayui/multi-step-nav';
+
+export {default as ClayNav} from '@clayui/nav';
+export * from '@clayui/nav';
+
+export {default as ClayNavigationBar} from '@clayui/navigation-bar';
+export * from '@clayui/navigation-bar';
+
+export {default as ClayPagination} from '@clayui/pagination';
+export * from '@clayui/pagination';
+
+export {default as ClayPaginationBar} from '@clayui/pagination-bar';
+export * from '@clayui/pagination-bar';
+
+export {default as ClayPanel} from '@clayui/panel';
+export * from '@clayui/panel';
+
+export {default as ClayPopover} from '@clayui/popover';
+export * from '@clayui/popover';
+
+export {default as ClayProgressBar} from '@clayui/progress-bar';
+export * from '@clayui/progress-bar';
+
+export {default as ClaySlider} from '@clayui/slider';
+export * from '@clayui/slider';
+
+export {default as ClaySticker} from '@clayui/sticker';
+// @ts-ignore this is for ignoring the DisplayType warning since both Sticker and Alert import DisplayType
+export * from '@clayui/sticker';
+
+export {default as ClayTable} from '@clayui/table';
+export * from '@clayui/table';
+
+export {default as ClayTabs} from '@clayui/tabs';
+export * from '@clayui/tabs';
+
+export {default as ClayTimePicker} from '@clayui/time-picker';
+export * from '@clayui/time-picker';
+
+export {default as ClayToolbar} from '@clayui/toolbar';
+export * from '@clayui/toolbar';
+
+export {default as ClayTooltip} from '@clayui/tooltip';
+export * from '@clayui/tooltip';

--- a/packages/clay-core/stories/DragDrop.tsx
+++ b/packages/clay-core/stories/DragDrop.tsx
@@ -1,0 +1,188 @@
+/**
+ * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {XYCoord} from 'dnd-core';
+import React, {useCallback, useRef, useState} from 'react';
+import {DropTargetMonitor, useDrag, useDrop} from 'react-dnd';
+
+import {ClayList} from '../src';
+
+interface IDraggableListItemProps {
+	/**
+	 * List Item unique identifier
+	 */
+	id: any;
+
+	/**
+	 * The text displayed in the List Item
+	 */
+	text: string;
+
+	/**
+	 * Index of the List Item in order to keep track of it's positioning within the array
+	 */
+	index: number;
+
+	/**
+	 * Function that handles the moving of List Items
+	 */
+	onMove: (dragIndex: number, hoverIndex: number) => void;
+}
+
+interface IDragItem {
+	/**
+	 * List Item unique identifier
+	 */
+	id: string;
+
+	/**
+	 * Index of the List Item in order to keep track of it's positioning within the array
+	 */
+	index: number;
+
+	/**
+	 * Type of data that is allowed to be dragged
+	 */
+	type: string;
+}
+
+const DraggableListItem: React.FunctionComponent<IDraggableListItemProps> = ({
+	id,
+	index,
+	onMove,
+	text,
+}) => {
+	const ref = useRef<HTMLLIElement>(null);
+
+	const [, drop] = useDrop({
+		accept: 'listItem',
+		hover(item: IDragItem, monitor: DropTargetMonitor) {
+			const dragIndex = item.index;
+
+			const hoverIndex = index;
+
+			if (!ref.current || dragIndex === hoverIndex) {
+				return;
+			}
+
+			const hoverBoundingRect = ref.current!.getBoundingClientRect();
+
+			const verticalMiddle =
+				(hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+
+			const mousePosition = monitor.getClientOffset();
+
+			const pixelsToTop =
+				(mousePosition as XYCoord).y - hoverBoundingRect.top;
+
+			const draggingUpwards =
+				dragIndex > hoverIndex && pixelsToTop > verticalMiddle * 1.5;
+
+			const draggingDownwards =
+				dragIndex < hoverIndex && pixelsToTop < verticalMiddle / 2;
+
+			if (draggingDownwards || draggingUpwards) {
+				return;
+			}
+
+			onMove(dragIndex, hoverIndex);
+
+			item.index = hoverIndex;
+		},
+	});
+
+	const [{isDragging, itemBeingDragged}, drag] = useDrag({
+		collect: (monitor: any) => ({
+			isDragging: monitor.isDragging(),
+			itemBeingDragged: monitor.getItem() || {id: 0},
+		}),
+		item: {id, index, type: 'listItem'},
+	});
+
+	const isItemBeingDragged = itemBeingDragged.id === id;
+
+	drag(drop(ref));
+
+	const style = {
+		backgroundColor: isItemBeingDragged ? '#EFEFEF' : '',
+		border: isItemBeingDragged ? '2px solid #555555' : '',
+		cursor: 'grab',
+		opacity: isDragging ? 0 : 1,
+	};
+
+	return (
+		<ClayList.Item flex id={`listItem${id}`} ref={ref} style={style}>
+			<ClayList.ItemField>{`Item ${id}`}</ClayList.ItemField>
+
+			<ClayList.ItemField expand>
+				<ClayList.ItemTitle>{`Item ${id} Title`}</ClayList.ItemTitle>
+				<ClayList.ItemText>{text}</ClayList.ItemText>
+			</ClayList.ItemField>
+		</ClayList.Item>
+	);
+};
+
+const DraggableList: React.FunctionComponent = () => {
+	const [listItems, setListItems] = useState([
+		{
+			id: 1,
+			text: 'Write a cool JS library',
+		},
+		{
+			id: 2,
+			text: 'Make it generic enough',
+		},
+		{
+			id: 3,
+			text: 'Write README',
+		},
+		{
+			id: 4,
+			text: 'Create some examples',
+		},
+		{
+			id: 5,
+			text:
+				'Spam in Twitter and IRC to promote it (note that this element is taller than the others)',
+		},
+		{
+			id: 6,
+			text: '???',
+		},
+		{
+			id: 7,
+			text: 'PROFIT',
+		},
+	]);
+
+	const onMove = useCallback(
+		(dragIndex: number, hoverIndex: number) => {
+			const tempList = [...listItems];
+
+			tempList.splice(dragIndex, 1);
+
+			tempList.splice(hoverIndex, 0, listItems[dragIndex]);
+
+			setListItems(tempList);
+		},
+		[listItems]
+	);
+
+	return (
+		<ClayList className="col-4">
+			{listItems.map((listItem, index) => (
+				<DraggableListItem
+					id={listItem.id}
+					index={index}
+					key={listItem.id}
+					onMove={onMove}
+					text={listItem.text}
+				/>
+			))}
+		</ClayList>
+	);
+};
+
+export default DraggableList;

--- a/packages/clay-core/stories/FilesPage.tsx
+++ b/packages/clay-core/stories/FilesPage.tsx
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import React from 'react';
+
+import {
+	ClayButtonWithIcon,
+	ClayCard,
+	ClayCardWithInfo,
+	ClayInput,
+	ClayLayout,
+	ClayManagementToolbar,
+} from '../src';
+
+export default function DemosPage() {
+	const [value, setValue] = React.useState('');
+
+	const dogNames: Array<[string, number]> = [
+		['Bailey', 1],
+		['Max', 2],
+		['Charlie', 3],
+		['Buddy', 4],
+		['Rocky', 5],
+		['Jake', 6],
+		['Jack', 7],
+		['Sadie', 8],
+		['Toby', 9],
+		['Chloe', 10],
+		['Cody', 11],
+		['Buster', 12],
+	];
+
+	return (
+		<div>
+			<ClayManagementToolbar>
+				<ClayManagementToolbar.Search onlySearch>
+					<ClayInput.Group>
+						<ClayInput.GroupItem>
+							<ClayInput
+								aria-label="Search"
+								className="form-control input-group-inset input-group-inset-after"
+								onChange={(event) =>
+									setValue(event.target.value)
+								}
+								type="text"
+								value={value}
+							/>
+							<ClayInput.GroupInsetItem after tag="span">
+								<ClayButtonWithIcon
+									displayType="unstyled"
+									spritemap={spritemap}
+									symbol="search"
+									type="submit"
+								/>
+							</ClayInput.GroupInsetItem>
+						</ClayInput.GroupItem>
+					</ClayInput.Group>
+				</ClayManagementToolbar.Search>
+			</ClayManagementToolbar>
+
+			<ClayLayout.ContainerFluid view>
+				<ClayCard.Group label="Good Boys">
+					{dogNames
+						.filter(([name]) =>
+							name.toLowerCase().match(value.toLowerCase())
+						)
+						.map(([doggoName, doggoId]) => (
+							<ClayCardWithInfo
+								description="the goodest boy"
+								href={`https://placedog.net/1000?id=${doggoId}`}
+								imgProps={{
+									src: `https://placedog.net/640/480?id=${doggoId}`,
+								}}
+								key={doggoId}
+								spritemap={spritemap}
+								title={`${doggoName}.jpg`}
+							/>
+						))}
+				</ClayCard.Group>
+			</ClayLayout.ContainerFluid>
+		</div>
+	);
+}

--- a/packages/clay-core/stories/FormPage.tsx
+++ b/packages/clay-core/stories/FormPage.tsx
@@ -1,0 +1,206 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import React from 'react';
+
+import {
+	ClayButton,
+	ClayDatePicker,
+	ClayForm,
+	ClayLayout,
+	ClayMultiSelect,
+	ClayNav,
+	ClayPanel,
+} from '../src';
+
+const ClayDatePickerWithState = (props: {[key: string]: any}) => {
+	const [value, setValue] = React.useState<string | Date>('');
+
+	return (
+		<ClayDatePicker
+			{...props}
+			onValueChange={setValue}
+			spritemap={spritemap}
+			value={value as string}
+		/>
+	);
+};
+
+export default () => {
+	const [formValues, setFormValues] = React.useState<any>({});
+	const [activePage, setActivePage] = React.useState(0);
+	const [value, setValue] = React.useState('');
+	const [selectedItems, setSelectedItems] = React.useState<any>([]);
+
+	return (
+		<ClayLayout.ContainerFluid>
+			<div className="row">
+				<div className="col col-3 col-sm-2">
+					<ClayNav.ClayVerticalNav
+						items={[
+							{
+								active: activePage === 0,
+								label: 'Form Page',
+								onClick: () => setActivePage(0),
+							},
+							{
+								active: activePage === 1,
+								label: 'Other Page',
+								onClick: () => setActivePage(1),
+							},
+						]}
+						spritemap={spritemap}
+					/>
+				</div>
+
+				<div className="col col-8">
+					{activePage === 0 && (
+						<ClayForm
+							className="sheet"
+							onSubmit={() => alert(JSON.stringify(formValues))}
+						>
+							<div className="sheet-header">
+								<h2 className="sheet-title">{'Form Input'}</h2>
+							</div>
+
+							<ClayPanel.Group>
+								<ClayPanel
+									displayTitle={'Organization Information'}
+									displayType="unstyled"
+									spritemap={spritemap}
+								>
+									<ClayPanel.Body>
+										<ClayForm.Group>
+											<label>{'Name'}</label>
+											<ClayForm.ClayInput
+												onChange={(e) =>
+													setFormValues({
+														...formValues,
+														name: e.target.value,
+													})
+												}
+												placeholder="Name"
+											/>
+										</ClayForm.Group>
+										<ClayForm.Group>
+											<label>{'Country'}</label>
+											<ClayForm.ClayInput
+												onChange={(e) =>
+													setFormValues({
+														...formValues,
+														country: e.target.value,
+													})
+												}
+												placeholder="Country"
+											/>
+										</ClayForm.Group>
+
+										<ClayForm.Group>
+											<label>{'Date'}</label>
+											<ClayDatePickerWithState />
+										</ClayForm.Group>
+
+										<ClayForm.Group>
+											<label>{'State'}</label>
+											<select
+												className="form-control"
+												onChange={(e) =>
+													setFormValues({
+														...formValues,
+														state: e.target.value,
+													})
+												}
+											>
+												<option disabled selected>
+													{'-- select an option --'}
+												</option>
+												<option>{'Happy'}</option>
+												<option>{'Mad'}</option>
+												<option>{'Sad'}</option>
+											</select>
+										</ClayForm.Group>
+									</ClayPanel.Body>
+								</ClayPanel>
+
+								<ClayPanel
+									collapsable
+									defaultExpanded
+									displayTitle={'More Information'}
+									displayType="unstyled"
+									showCollapseIcon
+									spritemap={spritemap}
+								>
+									<ClayPanel.Body>
+										<ClayForm.Group>
+											<ClayForm.Text>
+												{
+													'You can use this space to provide more information in this form.'
+												}
+											</ClayForm.Text>
+										</ClayForm.Group>
+
+										<ClayForm.Group>
+											<label>{'Tags'}</label>
+
+											<ClayForm.ClayInput.Group>
+												<ClayForm.ClayInput.GroupItem>
+													<ClayMultiSelect
+														inputValue={value}
+														items={selectedItems}
+														onChange={setValue}
+														onItemsChange={(
+															items
+														) => {
+															setFormValues({
+																...formValues,
+																tags: items,
+															});
+
+															setSelectedItems(
+																items
+															);
+														}}
+														placeholder="Tags..."
+														spritemap={spritemap}
+													/>
+
+													<ClayForm.FeedbackGroup>
+														<ClayForm.Text>
+															{
+																'Use comma to enter tags'
+															}
+														</ClayForm.Text>
+													</ClayForm.FeedbackGroup>
+												</ClayForm.ClayInput.GroupItem>
+											</ClayForm.ClayInput.Group>
+										</ClayForm.Group>
+									</ClayPanel.Body>
+								</ClayPanel>
+							</ClayPanel.Group>
+
+							<div className="sheet-footer">
+								<ClayButton.Group>
+									<div className="btn-group-item">
+										<ClayButton type="submit">
+											{'Submit'}
+										</ClayButton>
+									</div>
+									<div className="btn-group-item">
+										<ClayButton displayType="secondary">
+											{'Cancel'}
+										</ClayButton>
+									</div>
+								</ClayButton.Group>
+							</div>
+						</ClayForm>
+					)}
+
+					{activePage === 1 && <div>{'Some other page...'}</div>}
+				</div>
+			</div>
+		</ClayLayout.ContainerFluid>
+	);
+};

--- a/packages/clay-core/stories/index.tsx
+++ b/packages/clay-core/stories/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import '@clayui/css/lib/css/atlas.css';
+import {storiesOf} from '@storybook/react';
+import React from 'react';
+import {DndProvider} from 'react-dnd';
+import Backend from 'react-dnd-html5-backend';
+
+import DragDrop from './DragDrop';
+import FilesPage from './FilesPage';
+import FormPage from './FormPage';
+
+storiesOf('DemosCore|Templates', module).add('Files Page', () => <FilesPage />);
+// .add('Form Page', () => <FormPage />)
+// .add('Drag & Drop', () => (
+// 	<DndProvider backend={Backend}>
+// 		<DragDrop />
+// 	</DndProvider>
+// ));

--- a/packages/clay-core/tsconfig.declarations.json
+++ b/packages/clay-core/tsconfig.declarations.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"declarationDir": "./lib"
+	},
+	"extends": "../../tsconfig.declarations.json",
+	"include": ["src"]
+}

--- a/packages/clay-core/tsconfig.json
+++ b/packages/clay-core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["src"]
+}


### PR DESCRIPTION
Just an idea we had talked about in a few threads, potentially combine all of our  packages into a singular release.

Note that I left out the following packages
- @clayui/css (since its css specific)
- @clayui/charts (excluded since we aren't encouraging its use and it significantly increases the size)
- @clayui/shared (not intended to be used externally)


Happy to brainstorm on this more. I created a npm release of `@clayui/corev3.0.0-alpha`. Feel free to test in CSB.