### PR TITLE
feat(@clayui/css): Utilities adds `.c-feedback` component

### DIFF
--- a/clayui.com/content/docs/css/utilities/c-feedback.md
+++ b/clayui.com/content/docs/css/utilities/c-feedback.md
@@ -1,0 +1,396 @@
+---
+title: 'C Feedback'
+---
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [C Feedback](#css-c-feedback)
+-   [C Feedback Group](#css-c-feedback-group)
+-   [C Feedback Variants](#css-c-feedback-variants)
+-   [C Feedback Inherit](#css-c-feedback-inherit)
+-   [C Feedback Trimmed](#css-c-feedback-trimmed)
+-   [Examples](#css-c-feedback-examples)
+
+</div>
+</div>
+
+## C Feedback(#css-c-feedback)
+
+A utility for providing feedback notices to communicate errors or issues that may impact a user's experience with the application. `c-feedback` is `display: inline` by default to make it easier to use with other text that is rendered inline. If you would like this component to occupy a full line, wrap it with `c-feedback-stacked`.
+
+<div class="c-feedback">
+	<span class="c-feedback-indicator">
+		<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-indicator">
+		<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-indicator">
+		<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-lead">c-feedback-lead: </span>
+	<span class="c-feedback-text">c-feedback-text with a <a href="#1">link</a>.</span>
+	<span class="c-feedback-indicator">
+		<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-indicator">
+		<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+</div>
+Some inline text outside of c-feedback.
+
+```html
+<div class="c-feedback">
+	<span class="c-feedback-indicator">
+		<svg
+			class="lexicon-icon lexicon-icon-question-circle-full"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-indicator">
+		<svg
+			class="lexicon-icon lexicon-icon-question-circle-full"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-indicator">
+		<svg
+			class="lexicon-icon lexicon-icon-question-circle-full"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-lead">c-feedback-lead: </span>
+	<span class="c-feedback-text"
+		>c-feedback-text with a <a href="#1">link</a>.</span
+	>
+	<span class="c-feedback-indicator">
+		<svg
+			class="lexicon-icon lexicon-icon-question-circle-full"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-indicator">
+		<svg
+			class="lexicon-icon lexicon-icon-question-circle-full"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#question-circle-full" />
+		</svg>
+	</span>
+</div>
+Some inline text outside of c-feedback.
+```
+
+## C Feedback Group(#css-c-feedback-group)
+
+The container `c-feedback-stacked` stacks feedback messages instead of rendering them inline. It provides 4px vertical spacing. This generally is used for providing feedback under form elements.
+
+<div class="c-feedback-stacked">
+	<span class="c-feedback c-feedback-danger">
+		<span class="c-feedback-indicator">
+			<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#exclamation-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">This field is empty, please introduce a valid name with at least two characters.</span>
+	</span>
+	<span class="c-feedback c-feedback-secondary">
+		<span class="c-feedback-lead">You can use the comma to enter tags.</span>
+	</span>
+</div>
+
+```html
+<div class="c-feedback-stacked">
+	<span class="c-feedback c-feedback-danger">
+		<span class="c-feedback-indicator">
+			<svg
+				class="lexicon-icon lexicon-icon-exclamation-full"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#exclamation-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead"
+			>This field is empty, please introduce a valid name with at least
+			two characters.</span
+		>
+	</span>
+	<span class="c-feedback c-feedback-secondary">
+		<span class="c-feedback-lead"
+			>You can use the comma to enter tags.</span
+		>
+	</span>
+</div>
+```
+
+## C Feedback Variants(#css-c-feedback-variants)
+
+<div class="c-feedback-stacked">
+	<span class="c-feedback c-feedback-danger">
+		<span class="c-feedback-indicator">
+			<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#exclamation-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Error Indicator</span>
+	</span>
+	<span class="c-feedback c-feedback-success">
+		<span class="c-feedback-indicator">
+			<svg class="lexicon-icon lexicon-icon-check-circle-full" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#check-circle-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Success Indicator</span>
+	</span>
+	<span class="c-feedback c-feedback-warning">
+		<span class="c-feedback-indicator">
+			<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#warning-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Warning Indicator</span>
+	</span>
+	<span class="c-feedback c-feedback-info">
+		<span class="c-feedback-indicator">
+			<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#exclamation-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Info Indicator</span>
+	</span>
+	<span class="c-feedback c-feedback-secondary">
+		<span class="c-feedback-lead">Help Text</span>
+	</span>
+</div>
+
+```html
+<div class="c-feedback-stacked">
+	<span class="c-feedback c-feedback-danger">
+		<span class="c-feedback-indicator">
+			<svg
+				class="lexicon-icon lexicon-icon-exclamation-full"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#exclamation-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Error Indicator</span>
+	</span>
+	<span class="c-feedback c-feedback-success">
+		<span class="c-feedback-indicator">
+			<svg
+				class="lexicon-icon lexicon-icon-check-circle-full"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#check-circle-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Success Indicator</span>
+	</span>
+	<span class="c-feedback c-feedback-warning">
+		<span class="c-feedback-indicator">
+			<svg
+				class="lexicon-icon lexicon-icon-warning-full"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#warning-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Warning Indicator</span>
+	</span>
+	<span class="c-feedback c-feedback-info">
+		<span class="c-feedback-indicator">
+			<svg
+				class="lexicon-icon lexicon-icon-exclamation-full"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#exclamation-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Info Indicator</span>
+	</span>
+	<span class="c-feedback c-feedback-secondary">
+		<span class="c-feedback-lead">Help Text</span>
+	</span>
+</div>
+```
+
+## C Feedback Inherit(#css-c-feedback-inherit)
+
+The `c-feedback-inherit` modifier sets `font-size: inherit` on `c-feedback` which takes on the font size of the parent element. The default `font-size` is 0.875rem or 14px.
+
+<div class="c-feedback c-feedback-inherit">
+	<span class="c-feedback-indicator">
+		<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+			<use xlink:href="/images/icons/icons.svg#exclamation-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-lead">c-feedback-lead</span>
+</div>
+
+```html
+<div class="c-feedback c-feedback-inherit">
+	<span class="c-feedback-indicator">
+		<svg
+			class="lexicon-icon lexicon-icon-exclamation-full"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#exclamation-full" />
+		</svg>
+	</span>
+	<span class="c-feedback-lead">c-feedback-lead</span>
+</div>
+```
+
+## C Feedback Trimmed(#css-c-feedback-trimmed)
+
+If you are trimming whitespace in your final markup, use the modifier `c-feedback-trimmed` on `c-feedback` to render the proper spacing between text and icons.
+
+<div class="c-feedback c-feedback-trimmed"><span class="c-feedback-indicator"><svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation"><use xlink:href="/images/icons/icons.svg#exclamation-full" /></svg></span><span class="c-feedback-lead">c-feedback-lead</span></div>
+
+```html
+<div class="c-feedback c-feedback-trimmed">
+	<span class="c-feedback-indicator"
+		><svg
+			class="lexicon-icon lexicon-icon-exclamation-full"
+			focusable="false"
+			role="presentation"
+		>
+			<use
+				xlink:href="/images/icons/icons.svg#exclamation-full"
+			/></svg></span
+	><span class="c-feedback-lead">c-feedback-lead</span>
+</div>
+```
+
+## Examples(#css-c-feedback-examples)
+
+<div>
+	<span class="c-feedback c-feedback-secondary">
+		<span class="c-feedback-text">Total Views</span>
+		<span class="c-feedback-indicator">
+			<svg class="lexicon-icon lexicon-icon-question-circle" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#question-circle" />
+			</svg>
+		</span>
+	</span>
+	<span class="c-feedback c-feedback-warning">
+		<span class="c-feedback-indicator">
+			<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#warning-full" />
+			</svg>
+		</span>
+	</span>
+</div>
+<div>
+	<span class="c-feedback c-feedback-secondary">
+		<span class="c-feedback-text">Total Reads</span>
+		<span class="c-feedback-indicator">
+			<svg class="lexicon-icon lexicon-icon-question-circle" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#question-circle" />
+			</svg>
+		</span>
+	</span>
+	<span class="c-feedback">
+		<span class="c-feedback-lead">121</span>
+	</span>
+</div>
+<div>
+	<div class="c-feedback c-feedback-warning">
+		<span class="c-feedback-indicator">
+			<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#warning-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Data is temporarily unavailable</span>
+	</div>
+</div>
+
+```html
+<div>
+	<span class="c-feedback c-feedback-secondary">
+		<span class="c-feedback-text">Total Views</span>
+		<span class="c-feedback-indicator">
+			<svg
+				class="lexicon-icon lexicon-icon-question-circle"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#question-circle" />
+			</svg>
+		</span>
+	</span>
+	<span class="c-feedback c-feedback-warning">
+		<span class="c-feedback-indicator">
+			<svg
+				class="lexicon-icon lexicon-icon-warning-full"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#warning-full" />
+			</svg>
+		</span>
+	</span>
+</div>
+<div>
+	<span class="c-feedback c-feedback-secondary">
+		<span class="c-feedback-text">Total Reads</span>
+		<span class="c-feedback-indicator">
+			<svg
+				class="lexicon-icon lexicon-icon-question-circle"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#question-circle" />
+			</svg>
+		</span>
+	</span>
+	<span class="c-feedback">
+		<span class="c-feedback-lead">121</span>
+	</span>
+</div>
+<div>
+	<div class="c-feedback c-feedback-warning">
+		<span class="c-feedback-indicator">
+			<svg
+				class="lexicon-icon lexicon-icon-warning-full"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#warning-full" />
+			</svg>
+		</span>
+		<span class="c-feedback-lead">Data is temporarily unavailable</span>
+	</div>
+</div>
+```

--- a/packages/clay-css/src/content/utilities.html
+++ b/packages/clay-css/src/content/utilities.html
@@ -755,6 +755,200 @@ section: Components
 
 <div class="clay-site-row-spacer row">
 	<div class="col-md-12">
+		<h3>C Feedback</h3>
+
+		<blockquote class="blockquote">
+			<p>A utility for providing feedback notices to communicate errors or issues that may impact a user's experience with the application. `c-feedback` is `display: inline` by default to make it easier to use with other text that is rendered inline. If you would like this component to occupy a full line, wrap it with `c-feedback-stacked`.</p>
+		</blockquote>
+
+		<div class="c-feedback">
+			<span class="c-feedback-indicator">
+				<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#question-circle-full" />
+				</svg>
+			</span>
+			<span class="c-feedback-indicator">
+				<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#question-circle-full" />
+				</svg>
+			</span>
+			<span class="c-feedback-indicator">
+				<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#question-circle-full" />
+				</svg>
+			</span>
+			<span class="c-feedback-lead">c-feedback-lead: </span>
+			<span class="c-feedback-text">c-feedback-text with a <a href="#1">link</a>.</span>
+			<span class="c-feedback-indicator">
+				<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#question-circle-full" />
+				</svg>
+			</span>
+			<span class="c-feedback-indicator">
+				<svg class="lexicon-icon lexicon-icon-question-circle-full" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#question-circle-full" />
+				</svg>
+			</span>
+		</div>
+		Some inline text outside of c-feedback.
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>C Feedback Group</h3>
+
+		<blockquote class="blockquote">
+			<p>The container `c-feedback-stacked` stacks feedback messages instead of rendering them inline. It provides 4px vertical spacing. This generally is used for providing feedback under form elements.</p>
+		</blockquote>
+
+		<div class="c-feedback-stacked">
+			<span class="c-feedback c-feedback-danger">
+				<span class="c-feedback-indicator">
+					<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#exclamation-full" />
+					</svg>
+				</span>
+				<span class="c-feedback-lead">This field is empty, please introduce a valid name with at least two characters.</span>
+			</span>
+			<span class="c-feedback c-feedback-secondary">
+				<span class="c-feedback-lead">You can use the comma to enter tags.</span>
+			</span>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>C Feedback Variants</h3>
+
+		<div class="c-feedback-stacked">
+			<span class="c-feedback c-feedback-danger">
+				<span class="c-feedback-indicator">
+					<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#exclamation-full" />
+					</svg>
+				</span>
+				<span class="c-feedback-lead">Error Indicator</span>
+			</span>
+			<span class="c-feedback c-feedback-success">
+				<span class="c-feedback-indicator">
+					<svg class="lexicon-icon lexicon-icon-check-circle-full" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#check-circle-full" />
+					</svg>
+				</span>
+				<span class="c-feedback-lead">Success Indicator</span>
+			</span>
+			<span class="c-feedback c-feedback-warning">
+				<span class="c-feedback-indicator">
+					<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#warning-full" />
+					</svg>
+				</span>
+				<span class="c-feedback-lead">Warning Indicator</span>
+			</span>
+			<span class="c-feedback c-feedback-info">
+				<span class="c-feedback-indicator">
+					<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#exclamation-full" />
+					</svg>
+				</span>
+				<span class="c-feedback-lead">Info Indicator</span>
+			</span>
+			<span class="c-feedback c-feedback-secondary">
+				<span class="c-feedback-lead">Help Text</span>
+			</span>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>C Feedback Inherit</h3>
+
+		<blockquote class="blockquote">
+			<p>The `c-feedback-inherit` modifier sets `font-size: inherit` on `c-feedback` which takes on the font size of the parent element. The default `font-size` is 0.875rem or 14px. </p>
+		</blockquote>
+
+		<div class="c-feedback c-feedback-inherit">
+			<span class="c-feedback-indicator">
+				<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#exclamation-full" />
+				</svg>
+			</span>
+			<span class="c-feedback-lead">c-feedback-lead</span>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>C Feedback Trimmed</h3>
+
+		<blockquote class="blockquote">
+			<p>If you are trimming whitespace in your final markup, use the modifier `c-feedback-trimmed` on `c-feedback` to render the proper spacing between text and icons.</p>
+		</blockquote>
+
+		<div class="c-feedback c-feedback-trimmed"><span class="c-feedback-indicator"><svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation"><use xlink:href="{{rootPath}}/images/icons/icons.svg#exclamation-full" /></svg></span><span class="c-feedback-lead">c-feedback-lead</span></div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>C Feedback Examples</h3>
+
+		<div>
+			<span class="c-feedback c-feedback-secondary">
+				<span class="c-feedback-text">Total Views</span>
+				<span class="c-feedback-indicator">
+					<svg class="lexicon-icon lexicon-icon-question-circle" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#question-circle" />
+					</svg>
+				</span>
+			</span>
+			<span class="c-feedback c-feedback-warning">
+				<span class="c-feedback-indicator">
+					<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#warning-full" />
+					</svg>
+				</span>
+			</span>
+		</div>
+
+		<div>
+			<span class="c-feedback c-feedback-secondary">
+				<span class="c-feedback-text">Total Reads</span>
+				<span class="c-feedback-indicator">
+					<svg class="lexicon-icon lexicon-icon-question-circle" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#question-circle" />
+					</svg>
+				</span>
+			</span>
+			<span class="c-feedback">
+				<span class="c-feedback-lead">121</span>
+			</span>
+		</div>
+
+		<div>
+			<div class="c-feedback c-feedback-warning">
+				<span class="c-feedback-indicator">
+					<svg class="lexicon-icon lexicon-icon-warning-full" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#warning-full" />
+					</svg>
+				</span>
+				<span class="c-feedback-lead">Data is temporarily unavailable</span>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
 		<h3>Inline Item</h3>
 
 		<blockquote class="blockquote">

--- a/packages/clay-css/src/scss/components/_utilities.scss
+++ b/packages/clay-css/src/scss/components/_utilities.scss
@@ -268,6 +268,106 @@
 	}
 }
 
+// Feedback
+
+.c-feedback {
+	@include clay-css($c-feedback);
+}
+
+.c-feedback-indicator {
+	@include clay-css($c-feedback-indicator);
+
+	&:only-child {
+		@include clay-css($c-feedback-indicator-only-child);
+	}
+}
+
+.c-feedback-lead {
+	@include clay-css($c-feedback-lead);
+}
+
+.c-feedback-text {
+	@include clay-css($c-feedback-text);
+}
+
+.c-feedback-inherit {
+	font-size: inherit;
+}
+
+.c-feedback-stacked {
+	@include clay-css($c-feedback-stacked);
+
+	.c-feedback {
+		@include clay-css($c-feedback-stacked-c-feedback);
+	}
+}
+
+.c-feedback-trimmed {
+	.c-feedback-indicator {
+		margin-right: $c-feedback-trimmed-spacer;
+
+		&:only-child {
+			margin-left: $c-feedback-trimmed-spacer;
+		}
+	}
+
+	.c-feedback-lead {
+		margin-right: $c-feedback-trimmed-spacer;
+	}
+
+	.c-feedback-text {
+		margin-right: $c-feedback-trimmed-spacer;
+	}
+}
+
+.c-feedback-secondary {
+	> .c-feedback-indicator,
+	> .c-feedback-lead,
+	> .c-feedback-text {
+		color: $c-feedback-secondary-color;
+	}
+}
+
+.c-feedback-success {
+	> .c-feedback-indicator,
+	> .c-feedback-lead,
+	> .c-feedback-text {
+		color: $c-feedback-success-color;
+	}
+}
+
+.c-feedback-info {
+	> .c-feedback-indicator,
+	> .c-feedback-lead,
+	> .c-feedback-text {
+		color: $c-feedback-info-color;
+	}
+}
+
+.c-feedback-warning {
+	> .c-feedback-indicator,
+	> .c-feedback-lead,
+	> .c-feedback-text {
+		color: $c-feedback-warning-color;
+	}
+}
+
+.c-feedback-danger {
+	> .c-feedback-indicator,
+	> .c-feedback-lead,
+	> .c-feedback-text {
+		color: $c-feedback-danger-color;
+	}
+}
+
+.c-feedback-dark {
+	> .c-feedback-indicator,
+	> .c-feedback-lead,
+	> .c-feedback-text {
+		color: $c-feedback-dark-color;
+	}
+}
+
 // Headings (h1-6)
 
 .heading-start {

--- a/packages/clay-css/src/scss/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/variables/_utilities.scss
@@ -110,6 +110,85 @@ $c-inner: map-deep-merge(
 	$c-inner
 );
 
+// Feedback
+
+$c-feedback: () !default;
+$c-feedback: map-merge(
+	(
+		display: inline,
+		font-size: 0.875rem,
+	),
+	$c-feedback
+);
+
+$c-feedback-indicator: () !default;
+$c-feedback-indicator: map-merge(
+	(
+		display: inline,
+		margin-right: 0.25em,
+	),
+	$c-feedback-indicator
+);
+
+$c-feedback-indicator-only-child: () !default;
+$c-feedback-indicator-only-child: map-merge(
+	(
+		margin-left: 0.25em,
+	),
+	$c-feedback-indicator-only-child
+);
+
+$c-feedback-lead: () !default;
+$c-feedback-lead: map-merge(
+	(
+		display: inline,
+		font-weight: $font-weight-semi-bold,
+		margin-right: 0.25em,
+	),
+	$c-feedback-lead
+);
+
+$c-feedback-text: () !default;
+$c-feedback-text: map-merge(
+	(
+		display: inline,
+		margin-right: 0.25em,
+	),
+	$c-feedback-text
+);
+
+$c-feedback-stacked: () !default;
+$c-feedback-stacked: map-merge(
+	(
+		display: block,
+	),
+	$c-feedback-stacked
+);
+
+$c-feedback-stacked-c-feedback: () !default;
+$c-feedback-stacked-c-feedback: map-merge(
+	(
+		display: block,
+		margin-top: 0.25rem,
+		overflow-wrap: break-word,
+	),
+	$c-feedback-stacked-c-feedback
+);
+
+$c-feedback-trimmed-spacer: 0.5rem !default;
+
+$c-feedback-secondary-color: $secondary !default;
+
+$c-feedback-success-color: $success !default;
+
+$c-feedback-info-color: $info !default;
+
+$c-feedback-warning-color: $warning !default;
+
+$c-feedback-danger-color: $danger !default;
+
+$c-feedback-dark-color: $dark !default;
+
 // Heading
 
 $heading-spacer-x: 1rem !default; // 16px


### PR DESCRIPTION
- Utilities adds Sass maps `$c-feedback`, `$c-feedback-indicator`,
    `$c-feedback-indicator-only-child`, `$c-feedback-lead`, `$c-feedback-text`, `$c-feedback-stacked`, `$c-feedback-stacked-c-feedback`
- Utilities adds variables `$c-feedback-trimmed-spacer`, `$c-feedback-secondary-color`, `$c-feedback-success-color`, `$c-feedback-info-color`, `$c-feedback-warning-color`, `$c-feedback-danger-color`, `$c-feedback-dark-color`
- Add docs

![c-feedback](https://user-images.githubusercontent.com/788266/110569637-9afea300-8109-11eb-8d7f-f1e0eb4b0e66.jpg)

fixes #3968