### PR TITLE
fix(@clayui/multi-select): Use `btn-outline-secondary btn-outline-bor…

### DIFF
--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -121,7 +121,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -370,7 +370,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -489,7 +489,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -528,7 +528,7 @@ exports[`Interactions add non-sequential text should filter the items when it is
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -595,7 +595,7 @@ exports[`Interactions adding text doesn not filter the items with a custom funct
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -678,7 +678,7 @@ exports[`Interactions adding text filters the items 1`] = `
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -747,7 +747,7 @@ exports[`Interactions adding text filters the items with a custom function 1`] =
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -816,7 +816,7 @@ exports[`Interactions adding upper or lower case text should filter the items wh
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -361,8 +361,9 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 						(inputValue || items.length > 0) && (
 							<ClayInput.GroupItem shrink>
 								<ClayButtonWithIcon
+									borderless
 									className="component-action"
-									displayType="unstyled"
+									displayType="secondary"
 									onClick={() => {
 										onClearAllButtonClick();
 
@@ -370,6 +371,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 											inputRef.current.focus();
 										}
 									}}
+									outline
 									spritemap={spritemap}
 									symbol="times-circle"
 									title={clearAllTitle}


### PR DESCRIPTION
…derless` instead of `btn-unstyled` for Clear All Button

fixes #3962

![clear-all](https://user-images.githubusercontent.com/788266/110845008-f55d4800-825e-11eb-8eca-9c194205d974.jpg)

The clear all button on input focus should be color `$secondary` instead of `$dark`. 