### PR TITLE
feat(@clayui/css): Date Picker adds Date Range styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ yarn workspace @clayui/css run build && yarn storybook
 yarn test
 ```
 
+8. Update snapshots:
+
+```
+yarn run jest --u
+```
+
 #### clayui.com
 
 To contribute to the documentation and the site in general, you can try to run locally to test your changes:

--- a/clayui.com/src/styles/site/_content-site.scss
+++ b/clayui.com/src/styles/site/_content-site.scss
@@ -118,8 +118,14 @@
 		margin-right: 15px;
 		vertical-align: top;
 
+		&.sheet-example {
+			display: block;
+			margin-right: 0;
+		}
+
 		.dropdown-menu {
 			display: block;
+			float: none;
 			position: static;
 		}
 

--- a/packages/clay-css/src/content/form_elements_date_picker.html
+++ b/packages/clay-css/src/content/form_elements_date_picker.html
@@ -5,6 +5,384 @@ section: Components
 
 <div class="clay-site-row-spacer row">
 	<div class="col-md-12">
+		<h3>Date Picker Date Range</h3>
+
+		<blockquote class="blockquote">
+			<p>The class `c-selected` must be added to `date-picker-col` for all dates in the range.</p>
+			<p>The modifier class `c-selected-start` must be added to `date-picker-col` for the first date in the range.</p>
+			<p>The class `c-selected-end` must be added to `date-picker-col` for the last date in the range.</p>
+		</blockquote>
+
+		<div class="date-picker-dropdown-menu dropdown-menu show" style="position:static;">
+			<div class="date-picker-calendar">
+				<div class="date-picker-calendar-header">
+					<div class="date-picker-nav">
+						<div class="date-picker-nav-item input-date-picker-month">
+							<select class="form-control" disabled name="month">
+								<option value="0">January</option>
+								<option value="1">February</option>
+								<option value="2">March</option>
+								<option value="3">April</option>
+								<option value="4">May</option>
+								<option value="5">June</option>
+								<option value="6">July</option>
+								<option value="7">August</option>
+								<option value="8">September</option>
+								<option value="9">October</option>
+								<option value="10">November</option>
+								<option value="11">December</option>
+							</select>
+						</div>
+						<div class="date-picker-nav-item input-date-picker-year">
+							<select class="form-control" name="year">
+								<option value="1997">1997</option>
+								<option value="1998">1998</option>
+								<option value="1999">1999</option>
+								<option value="2000">2000</option>
+								<option value="2001">2001</option>
+								<option value="2002">2002</option>
+								<option value="2003">2003</option>
+								<option value="2004">2004</option>
+								<option value="2005">2005</option>
+								<option value="2006">2006</option>
+								<option value="2007">2007</option>
+								<option value="2008">2008</option>
+								<option value="2009">2009</option>
+								<option value="2010">2010</option>
+								<option value="2011">2011</option>
+								<option value="2012">2012</option>
+								<option value="2013">2013</option>
+								<option value="2014">2014</option>
+								<option value="2015">2015</option>
+								<option value="2016">2016</option>
+								<option value="2017">2017</option>
+								<option value="2018">2018</option>
+								<option value="2019">2019</option>
+								<option value="2020">2020</option>
+								<option value="2021">2021</option>
+								<option value="2022">2022</option>
+								<option value="2023">2023</option>
+							</select>
+						</div>
+
+						<div class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls">
+							<button aria-label="Select the previous month" class="btn nav-btn nav-btn-monospaced" disabled type="button">
+								<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-left"></use>
+								</svg>
+							</button>
+							<button aria-label="Select current date" class="btn nav-btn nav-btn-monospaced" type="button">
+								<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#simple-circle"></use>
+								</svg>
+							</button>
+							<button aria-label="Select the next month" class="btn nav-btn nav-btn-monospaced" type="button">
+								<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right"></use>
+								</svg>
+							</button>
+						</div>
+					</div>
+				</div>
+
+				<div class="date-picker-calendar-body">
+					<div class="date-picker-days-row date-picker-row">
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Mon</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Tues</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Wed</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Thu</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Fri</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Sat</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Sun</abbr></div>
+						</div>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<div class="date-picker-col">
+							<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">29</span></button>
+						</div>
+						<div class="c-selected c-selected-start date-picker-col">
+							<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" tabindex="-1" type="button"><span class="c-inner" tabindex="-1">30</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">31</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+						</div>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button">3</button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button">4</button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button">5</button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button">6</button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button">7</button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button">8</button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button">9</button>
+						</div>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button">10</button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button">11</button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button">12</button>
+						</div>
+						<div class="c-selected c-selected-end date-picker-col">
+							<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item active" tabindex="-1" type="button">13</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button">14</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button">15</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button">16</button>
+						</div>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<div class="date-picker-col">
+							<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button">17</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button">18</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button">19</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button">20</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button">21</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button">22</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button">23</button>
+						</div>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<div class="date-picker-col">
+							<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button">24</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button">25</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button">26</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button">27</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button">28</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 03 01" class="date-picker-date date-picker-calendar-item next-month-date" type="button">1</button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button">2</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Date Picker Old Markup</h3>
+
+		<blockquote class="blockquote">
+			<p>In Clay CSS versions 3.24.1 and below, Date Picker days and dates weren't wrapped in an extra element `date-picker-col`. We added the wrapping element for highlighting a range of dates. See <a href="https://github.com/liferay/clay/issues/3986" rel="noreferrer noopener">#3986</a>. This old pattern is still supported, but we recommend updating your markup.</p>
+		</blockquote>
+
+		<div class="date-picker-dropdown-menu dropdown-menu show" style="position:static;">
+			<div class="date-picker-calendar">
+				<div class="date-picker-calendar-header">
+					<div class="date-picker-nav">
+						<div class="date-picker-nav-item input-date-picker-month">
+							<select class="form-control" disabled name="month">
+								<option value="0">January</option>
+								<option value="1">February</option>
+								<option value="2">March</option>
+								<option value="3">April</option>
+								<option value="4">May</option>
+								<option value="5">June</option>
+								<option value="6">July</option>
+								<option value="7">August</option>
+								<option value="8">September</option>
+								<option value="9">October</option>
+								<option value="10">November</option>
+								<option value="11">December</option>
+							</select>
+						</div>
+						<div class="date-picker-nav-item input-date-picker-year">
+							<select class="form-control" name="year">
+								<option value="1997">1997</option>
+								<option value="1998">1998</option>
+								<option value="1999">1999</option>
+								<option value="2000">2000</option>
+								<option value="2001">2001</option>
+								<option value="2002">2002</option>
+								<option value="2003">2003</option>
+								<option value="2004">2004</option>
+								<option value="2005">2005</option>
+								<option value="2006">2006</option>
+								<option value="2007">2007</option>
+								<option value="2008">2008</option>
+								<option value="2009">2009</option>
+								<option value="2010">2010</option>
+								<option value="2011">2011</option>
+								<option value="2012">2012</option>
+								<option value="2013">2013</option>
+								<option value="2014">2014</option>
+								<option value="2015">2015</option>
+								<option value="2016">2016</option>
+								<option value="2017">2017</option>
+								<option value="2018">2018</option>
+								<option value="2019">2019</option>
+								<option value="2020">2020</option>
+								<option value="2021">2021</option>
+								<option value="2022">2022</option>
+								<option value="2023">2023</option>
+							</select>
+						</div>
+
+						<div class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls">
+							<button aria-label="Select the previous month" class="btn nav-btn nav-btn-monospaced" disabled type="button">
+								<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-left"></use>
+								</svg>
+							</button>
+							<button aria-label="Select current date" class="btn nav-btn nav-btn-monospaced" type="button">
+								<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#simple-circle"></use>
+								</svg>
+							</button>
+							<button aria-label="Select the next month" class="btn nav-btn nav-btn-monospaced" type="button">
+								<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right"></use>
+								</svg>
+							</button>
+						</div>
+					</div>
+				</div>
+
+				<div class="date-picker-calendar-body">
+					<div class="date-picker-days-row date-picker-row">
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Mon</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Tues</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Wed</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Thu</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Fri</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Sat</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Sun</abbr></div>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">29</span></button>
+						<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">30</span></button>
+						<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">31</span></button>
+						<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button">3</button>
+						<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button">4</button>
+						<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button">5</button>
+						<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button">6</button>
+						<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button">7</button>
+						<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button">8</button>
+						<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button">9</button>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button">10</button>
+						<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button">11</button>
+						<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button">12</button>
+						<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item active" tabindex="-1" type="button">13</button>
+						<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button">14</button>
+						<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button">15</button>
+						<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button">16</button>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button">17</button>
+						<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button">18</button>
+						<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button">19</button>
+						<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button">20</button>
+						<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button">21</button>
+						<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button">22</button>
+						<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button">23</button>
+					</div>
+
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button">24</button>
+						<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button">25</button>
+						<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button">26</button>
+						<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button">27</button>
+						<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button">28</button>
+						<button aria-label="2019 03 01" class="date-picker-date date-picker-calendar-item next-month-date" type="button">1</button>
+						<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button">2</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
 		<h3>Date Picker</h3>
 
 		<div class="sheet">
@@ -101,63 +479,150 @@ section: Components
 
 							<div class="date-picker-calendar-body">
 								<div class="date-picker-days-row date-picker-row">
-									<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
-									<div class="date-picker-day date-picker-calendar-item"><abbr>M</abbr></div>
-									<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
-									<div class="date-picker-day date-picker-calendar-item"><abbr>W</abbr></div>
-									<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
-									<div class="date-picker-day date-picker-calendar-item"><abbr>F</abbr></div>
-									<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+									<div class="date-picker-col">
+										<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+									</div>
+
+									<div class="date-picker-col">
+										<div class="date-picker-day date-picker-calendar-item"><abbr>M</abbr></div>
+									</div>
+
+									<div class="date-picker-col">
+										<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
+									</div>
+
+									<div class="date-picker-col">
+										<div class="date-picker-day date-picker-calendar-item"><abbr>W</abbr></div>
+									</div>
+									<div class="date-picker-col">
+										<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
+									</div>
+									<div class="date-picker-col">
+										<div class="date-picker-day date-picker-calendar-item"><abbr>F</abbr></div>
+									</div>
+									<div class="date-picker-col">
+										<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+									</div>
 								</div>
 
 								<div class="date-picker-date-row date-picker-row">
-									<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button">27</button>
-									<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button">28</button>
-									<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button">29</button>
-									<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" type="button">30</button>
-									<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button">31</button>
-									<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button">1</button>
-									<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button">2</button>
+									<div class="date-picker-col">
+										<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button">27</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button">28</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button">29</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" type="button">30</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button">31</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button">1</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button">2</button>
+									</div>
 								</div>
 
 								<div class="date-picker-date-row date-picker-row">
-									<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button">3</button>
-									<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button">4</button>
-									<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button">5</button>
-									<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button">6</button>
-									<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button">7</button>
-									<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button">8</button>
-									<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button">9</button>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button">3</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button">4</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button">5</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button">6</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button">7</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button">8</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button">9</button>
+									</div>
 								</div>
 
 								<div class="date-picker-date-row date-picker-row">
-									<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button">10</button>
-									<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button">11</button>
-									<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button">12</button>
-									<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item active" tabindex="-1" type="button">13</button>
-									<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button">14</button>
-									<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button">15</button>
-									<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button">16</button>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button">10</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button">11</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button">12</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item active" tabindex="-1" type="button">13</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button">14</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button">15</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button">16</button>
+									</div>
 								</div>
 
 								<div class="date-picker-date-row date-picker-row">
-									<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button">17</button>
-									<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button">18</button>
-									<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button">19</button>
-									<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button">20</button>
-									<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button">21</button>
-									<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button">22</button>
-									<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button">23</button>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button">17</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button">18</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button">19</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button">20</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button">21</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button">22</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button">23</button>
+									</div>
 								</div>
 
 								<div class="date-picker-date-row date-picker-row">
-									<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button">24</button>
-									<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button">25</button>
-									<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button">26</button>
-									<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button">27</button>
-									<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button">28</button>
-									<button aria-label="2019 03 01" class="active date-picker-date date-picker-calendar-item next-month-date" type="button">1</button>
-									<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button">2</button>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button">24</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button">25</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button">26</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button">27</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button">28</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 03 01" class="active date-picker-date date-picker-calendar-item next-month-date" type="button">1</button>
+									</div>
+									<div class="date-picker-col">
+										<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button">2</button>
+									</div>
 								</div>
 							</div>
 

--- a/packages/clay-css/src/scss/atlas/variables/_date-picker.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_date-picker.scss
@@ -1,3 +1,13 @@
+// Date Picker Dropdown Menu
+
+$date-picker-dropdown-menu: () !default;
+$date-picker-dropdown-menu: map-deep-merge(
+	(
+		max-width: 368px,
+	),
+	$date-picker-dropdown-menu
+);
+
 // Date Picker Nav
 
 $date-picker-nav-btn: () !default;

--- a/packages/clay-css/src/scss/components/_date-picker.scss
+++ b/packages/clay-css/src/scss/components/_date-picker.scss
@@ -72,6 +72,49 @@
 	@include clay-row($date-picker-row);
 }
 
+.date-picker-col {
+	@include clay-css($date-picker-col);
+
+	&.c-selected {
+		$_c-selected: setter(map-get($date-picker-col, c-selected), ());
+
+		@include clay-css($_c-selected);
+
+		&:first-child {
+			$_c-selected-first-child: setter(
+				map-get($date-picker-col, c-selected-first-child),
+				()
+			);
+
+			@include clay-css($_c-selected-first-child);
+		}
+
+		&:last-child {
+			$_c-selected-last-child: setter(
+				map-get($date-picker-col, c-selected-last-child),
+				()
+			);
+
+			@include clay-css($_c-selected-last-child);
+		}
+	}
+
+	&.c-selected-start {
+		$_c-selected-start: setter(
+			map-get($date-picker-col, c-selected-start),
+			()
+		);
+
+		@include clay-css($_c-selected-start);
+	}
+
+	&.c-selected-end {
+		$_c-selected-end: setter(map-get($date-picker-col, c-selected-end), ());
+
+		@include clay-css($_c-selected-end);
+	}
+}
+
 .date-picker-days-row {
 	@include clay-row($date-picker-days-row);
 }

--- a/packages/clay-css/src/scss/variables/_date-picker.scss
+++ b/packages/clay-css/src/scss/variables/_date-picker.scss
@@ -60,10 +60,41 @@ $date-picker-row: map-deep-merge(
 	(
 		display: flex,
 		justify-content: space-between,
+		list-style: none,
 		margin-bottom: 0.5rem,
 		margin-top: 0.5rem,
+		padding: 0,
 	),
 	$date-picker-row
+);
+
+$date-picker-col: () !default;
+$date-picker-col: map-deep-merge(
+	(
+		padding-left: 0.5rem,
+		padding-right: 0.5rem,
+		c-selected: (
+			background-image: linear-gradient($primary-l3, $primary-l3),
+			background-repeat: no-repeat,
+		),
+		c-selected-first-child: (
+			border-bottom-left-radius: 100px,
+			border-top-left-radius: 100px,
+		),
+		c-selected-last-child: (
+			border-bottom-right-radius: 100px,
+			border-top-right-radius: 100px,
+		),
+		c-selected-start: (
+			background-position: right top,
+			background-size: 50% 100%,
+		),
+		c-selected-end: (
+			background-position: left top,
+			background-size: 50% 100%,
+		),
+	),
+	$date-picker-col
 );
 
 $date-picker-days-row: () !default;
@@ -141,7 +172,6 @@ $date-picker-calendar-item: map-deep-merge(
 		align-items: center,
 		bg: transparent,
 		border-width: 0,
-		cursor: $link-cursor,
 		disabled-cursor: $disabled-cursor,
 		display: inline-flex,
 		flex-shrink: 0,
@@ -149,8 +179,8 @@ $date-picker-calendar-item: map-deep-merge(
 		height: 2rem,
 		justify-content: center,
 		line-height: 1,
-		margin-left: 0.5rem,
-		margin-right: 0.5rem,
+		margin-left: 0,
+		margin-right: 0,
 		padding-bottom: 0,
 		padding-left: 0,
 		padding-right: 0,
@@ -169,6 +199,8 @@ $date-picker-date: map-deep-merge(
 	(
 		border-radius: 100px,
 		color: $gray-600,
+		cursor: $link-cursor,
+		position: relative,
 		hover-bg: $gray-200,
 		focus-box-shadow: $input-btn-focus-box-shadow,
 		focus-outline: 0,

--- a/packages/clay-date-picker/docs/markup-date-and-time-pickers.md
+++ b/packages/clay-date-picker/docs/markup-date-and-time-pickers.md
@@ -9,9 +9,20 @@ mainTabURL: 'docs/components/date-picker.html'
 <div class="nav-toc">
 
 -   [Example](#css-example)
--   [Field](#css-field)
 -   [Date Picker](#css-date-picker)
+    -   [Field](#css-date-picker-field)
+    -   [Date Range](#css-date-picker-date-range)
+    -   [Old Markup](#css-date-picker-old-markup)
+    -   [Browser Default](#css-browser-default-input-date)
 -   [Time Picker](#css-time-picker)
+    -   [12H](#css-time-picker-12h)
+    -   [12H With Time Zone](#css-time-picker-12h-with-time-zone)
+    -   [12H With Time Zone and Icon](#css-time-picker-12h-with-time-zone-and-icon)
+    -   [24H](#css-time-picker-24h)
+    -   [With Seconds and Clear](#css-time-picker-with-seconds-and-clear)
+    -   [Focus State](#css-time-picker-focus-state)
+    -   [Disabled State](#css-time-picker-disabled-state)
+    -   [Browser Default](#css-browser-default-input-time)
 
 </div>
 </div>
@@ -24,16 +35,47 @@ mainTabURL: 'docs/components/date-picker.html'
 
 The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`. `Footer`: You can add elements that complement the Date Picker like the Time Picker.
 
+<div class="clay-site-dropdown-menu-container sheet-example">
+	<div class="date-picker">
+		<div class="date-picker-dropdown-menu dropdown-menu">
+			<div class="date-picker-calendar">
+				<div class="date-picker-calendar-header">Date Picker Calendar Header</div>
+				<div class="date-picker-calendar-body">Date Picker Calendar Body</div>
+				<div class="date-picker-calendar-footer">Date Picker Calendar Footer</div>
+			</div>
+		</div>
+	</div>
+</div>
+
 ```html
-<div class="date-picker-calendar-header">...</div>
-<div class="date-picker-calendar-body">...</div>
-<div class="date-picker-calendar-footer">...</div>
+<div class="date-picker">
+	<div class="date-picker-dropdown-menu dropdown-menu">
+		<div class="date-picker-calendar-header">...</div>
+		<div class="date-picker-calendar-body">...</div>
+		<div class="date-picker-calendar-footer">...</div>
+	</div>
+</div>
 ```
 
-<div class="sheet-example">
+<div class="clay-site-dropdown-menu-container sheet-example">
 	<div class="date-picker">
-		<div class="clay-site-dropdown-menu-container date-picker-dropdown-menu">
-			<div class="dropdown-menu date-picker-calendar">
+		<div class="input-group">
+			<div class="input-group-item">
+				<input name="datePicker" type="hidden" value="">
+				<input class="form-control input-group-inset input-group-inset-after" placeholder="YYYY-MM-DD" type="text" value="">
+				<div class="input-group-inset-item input-group-inset-item-after">
+					<button class="btn btn-unstyled date-picker-dropdown-toggle" type="button">
+						<span class="c-inner" tabindex="-1">
+							<svg class="lexicon-icon lexicon-icon-calendar" focusable="false" role="presentation">
+								<use href="/images/icons/icons.svg#calendar" />
+							</svg>
+						</span>
+					</button>
+				</div>
+			</div>
+		</div>
+		<div class="date-picker-dropdown-menu dropdown-menu">
+			<div class="date-picker-calendar">
 				<div class="date-picker-calendar-header">
 					<div class="date-picker-nav">
 						<div class="date-picker-nav-item input-date-picker-month">
@@ -85,77 +127,167 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 						</div>
 						<div class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls">
 							<button aria-label="Select the previous month" class="btn nav-btn nav-btn-monospaced" disabled="" type="button">
-								<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
-									<use href="/images/icons/icons.svg#angle-left" />
-								</svg>
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+										<use href="/images/icons/icons.svg#angle-left" />
+									</svg>
+								</span>
 							</button>
 							<button aria-label="Select current date" class="btn nav-btn nav-btn-monospaced" type="button">
-								<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
-									<use href="/images/icons/icons.svg#simple-circle" />
-								</svg>
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+										<use href="/images/icons/icons.svg#simple-circle" />
+									</svg>
+								</span>
 							</button>
 							<button aria-label="Select the next month" class="btn nav-btn nav-btn-monospaced" type="button">
-								<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
-									<use href="/images/icons/icons.svg#angle-right" />
-								</svg>
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+										<use href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
 							</button>
 						</div>
 					</div>
 				</div>
 				<div class="date-picker-calendar-body">
 					<div class="date-picker-days-row date-picker-row">
-						<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>M</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>W</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>F</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>M</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>W</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>F</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button">27</button>
-						<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button">28</button>
-						<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button">29</button>
-						<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" type="button">30</button>
-						<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button">31</button>
-						<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button">1</button>
-						<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button">2</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button"><span class="c-inner" tabindex="-1">29</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">30</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">31</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button">3</button>
-						<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button">4</button>
-						<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button">5</button>
-						<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button">6</button>
-						<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button">7</button>
-						<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button">8</button>
-						<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button">9</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">3</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">4</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">5</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">6</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">7</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">8</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">9</span></button>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button">10</button>
-						<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button">11</button>
-						<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button">12</button>
-						<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item" tabindex="-1" type="button">13</button>
-						<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button">14</button>
-						<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button">15</button>
-						<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button">16</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">10</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">11</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">12</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item" tabindex="-1" type="button"><span class="c-inner" tabindex="-1">13</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">14</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">15</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">16</span></button>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button">17</button>
-						<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button">18</button>
-						<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button">19</button>
-						<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button">20</button>
-						<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button">21</button>
-						<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button">22</button>
-						<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button">23</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">17</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">18</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">19</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">20</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">21</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">22</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">23</span></button>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button">24</button>
-						<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button">25</button>
-						<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button">26</button>
-						<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button">27</button>
-						<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button">28</button>
-						<button aria-label="2019 03 01" class="date-picker-date date-picker-calendar-item next-month-date" type="button">1</button>
-						<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button">2</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">24</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">25</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">26</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 03 01" class="date-picker-date date-picker-calendar-item next-month-date" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+						</div>
 					</div>
 				</div>
 				<div class="date-picker-calendar-footer">
@@ -198,18 +330,20 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 					class="btn btn-unstyled date-picker-dropdown-toggle"
 					type="button"
 				>
-					<svg
-						class="lexicon-icon lexicon-icon-calendar"
-						focusable="false"
-						role="presentation"
-					>
-						<use href="/images/icons/icons.svg#calendar" />
-					</svg>
+					<span class="c-inner" tabindex="-1">
+						<svg
+							class="lexicon-icon lexicon-icon-calendar"
+							focusable="false"
+							role="presentation"
+						>
+							<use href="/images/icons/icons.svg#calendar" />
+						</svg>
+					</span>
 				</button>
 			</div>
 		</div>
 	</div>
-	<div class="date-picker-dropdown-menu dropdown-menu show">
+	<div class="date-picker-dropdown-menu dropdown-menu">
 		<div class="date-picker-calendar">
 			<div class="date-picker-calendar-header">
 				<div class="date-picker-nav">
@@ -233,7 +367,31 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 						<select class="form-control" name="year">
 							<option value="1997">1997</option>
 							<option value="1998">1998</option>
-							...
+							<option value="1999">1999</option>
+							<option value="2000">2000</option>
+							<option value="2001">2001</option>
+							<option value="2002">2002</option>
+							<option value="2003">2003</option>
+							<option value="2004">2004</option>
+							<option value="2005">2005</option>
+							<option value="2006">2006</option>
+							<option value="2007">2007</option>
+							<option value="2008">2008</option>
+							<option value="2009">2009</option>
+							<option value="2010">2010</option>
+							<option value="2011">2011</option>
+							<option value="2012">2012</option>
+							<option value="2013">2013</option>
+							<option value="2014">2014</option>
+							<option value="2015">2015</option>
+							<option value="2016">2016</option>
+							<option value="2017">2017</option>
+							<option value="2018">2018</option>
+							<option value="2019">2019</option>
+							<option value="2020">2020</option>
+							<option value="2021">2021</option>
+							<option value="2022">2022</option>
+							<option value="2023">2023</option>
 						</select>
 					</div>
 					<div
@@ -245,331 +403,421 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 							disabled=""
 							type="button"
 						>
-							<svg
-								class="lexicon-icon lexicon-icon-angle-left"
-								focusable="false"
-								role="presentation"
-							>
-								<use
-									href="/images/icons/icons.svg#angle-left"
-								/>
-							</svg>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-left"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										href="/images/icons/icons.svg#angle-left"
+									/>
+								</svg>
+							</span>
 						</button>
 						<button
 							aria-label="Select current date"
 							class="btn nav-btn nav-btn-monospaced"
 							type="button"
 						>
-							<svg
-								class="lexicon-icon lexicon-icon-simple-circle"
-								focusable="false"
-								role="presentation"
-							>
-								<use
-									href="/images/icons/icons.svg#simple-circle"
-								/>
-							</svg>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-simple-circle"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										href="/images/icons/icons.svg#simple-circle"
+									/>
+								</svg>
+							</span>
 						</button>
 						<button
 							aria-label="Select the next month"
 							class="btn nav-btn nav-btn-monospaced"
 							type="button"
 						>
-							<svg
-								class="lexicon-icon lexicon-icon-angle-right"
-								focusable="false"
-								role="presentation"
-							>
-								<use
-									href="/images/icons/icons.svg#angle-right"
-								/>
-							</svg>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										href="/images/icons/icons.svg#angle-right"
+									/>
+								</svg>
+							</span>
 						</button>
 					</div>
 				</div>
 			</div>
 			<div class="date-picker-calendar-body">
 				<div class="date-picker-days-row date-picker-row">
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>S</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>S</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>M</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>M</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>T</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>T</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>W</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>W</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>T</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>T</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>F</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>F</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>S</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>S</abbr>
+						</div>
 					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 01 27"
-						class="date-picker-date date-picker-calendar-item previous-month-date"
-						disabled=""
-						type="button"
-					>
-						27
-					</button>
-					<button
-						aria-label="2019 01 28"
-						class="date-picker-date date-picker-calendar-item previous-month-date"
-						disabled=""
-						type="button"
-					>
-						28
-					</button>
-					<button
-						aria-label="2019 01 29"
-						class="date-picker-date date-picker-calendar-item previous-month-date"
-						disabled=""
-						type="button"
-					>
-						29
-					</button>
-					<button
-						aria-label="2019 01 30"
-						class="date-picker-date date-picker-calendar-item previous-month-date"
-						type="button"
-					>
-						30
-					</button>
-					<button
-						aria-label="2019 01 31"
-						class="date-picker-date date-picker-calendar-item previous-month-date"
-						type="button"
-					>
-						31
-					</button>
-					<button
-						aria-label="2019 02 01"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						1
-					</button>
-					<button
-						aria-label="2019 02 02"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						2
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 27"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							disabled=""
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">27</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 28"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							disabled=""
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">28</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 29"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							disabled=""
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">29</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 30"
+							class="active date-picker-date date-picker-calendar-item previous-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">30</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 31"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">31</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 01"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">1</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 02"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">2</span>
+						</button>
+					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 02 03"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						3
-					</button>
-					<button
-						aria-label="2019 02 04"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						4
-					</button>
-					<button
-						aria-label="2019 02 05"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						5
-					</button>
-					<button
-						aria-label="2019 02 06"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						6
-					</button>
-					<button
-						aria-label="2019 02 07"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						7
-					</button>
-					<button
-						aria-label="2019 02 08"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						8
-					</button>
-					<button
-						aria-label="2019 02 09"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						9
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 03"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">3</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 04"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">4</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 05"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">5</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 06"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">6</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 07"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">7</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 08"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">8</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 09"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">9</span>
+						</button>
+					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 02 10"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						10
-					</button>
-					<button
-						aria-label="2019 02 11"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						11
-					</button>
-					<button
-						aria-label="2019 02 12"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						12
-					</button>
-					<button
-						aria-label="2019 02 13"
-						class="date-picker-date date-picker-calendar-item"
-						tabindex="-1"
-						type="button"
-					>
-						13
-					</button>
-					<button
-						aria-label="2019 02 14"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						14
-					</button>
-					<button
-						aria-label="2019 02 15"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						15
-					</button>
-					<button
-						aria-label="2019 02 16"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						16
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 10"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">10</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 11"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">11</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 12"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">12</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 13"
+							class="date-picker-date date-picker-calendar-item"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">13</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 14"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">14</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 15"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">15</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 16"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">16</span>
+						</button>
+					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 02 17"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						17
-					</button>
-					<button
-						aria-label="2019 02 18"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						18
-					</button>
-					<button
-						aria-label="2019 02 19"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						19
-					</button>
-					<button
-						aria-label="2019 02 20"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						20
-					</button>
-					<button
-						aria-label="2019 02 21"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						21
-					</button>
-					<button
-						aria-label="2019 02 22"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						22
-					</button>
-					<button
-						aria-label="2019 02 23"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						23
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 17"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">17</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 18"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">18</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 19"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">19</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 20"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">20</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 21"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">21</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 22"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">22</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 23"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">23</span>
+						</button>
+					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 02 24"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						24
-					</button>
-					<button
-						aria-label="2019 02 25"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						25
-					</button>
-					<button
-						aria-label="2019 02 26"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						26
-					</button>
-					<button
-						aria-label="2019 02 27"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						27
-					</button>
-					<button
-						aria-label="2019 02 28"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						28
-					</button>
-					<button
-						aria-label="2019 03 01"
-						class="date-picker-date date-picker-calendar-item next-month-date"
-						type="button"
-					>
-						1
-					</button>
-					<button
-						aria-label="2019 03 02"
-						class="date-picker-date date-picker-calendar-item next-month-date"
-						type="button"
-					>
-						2
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 24"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">24</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 25"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">25</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 26"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">26</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 27"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">27</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 28"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">28</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 03 01"
+							class="date-picker-date date-picker-calendar-item next-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">1</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 03 02"
+							class="date-picker-date date-picker-calendar-item next-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">2</span>
+						</button>
+					</div>
 				</div>
 			</div>
 			<div class="date-picker-calendar-footer">
@@ -605,58 +853,12 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 </div>
 ```
 
-## Field(#css-field)
-
-<div class="sheet-example">
-	<div class="input-group">
-		<div class="input-group-item">
-			<input name="datePicker" type="hidden" value="">
-			<input class="form-control input-group-inset input-group-inset-after" placeholder="YYYY-MM-DD" type="text" value="">
-			<div class="input-group-inset-item input-group-inset-item-after">
-				<button class="btn btn-unstyled date-picker-dropdown-toggle" type="button">
-					<svg class="lexicon-icon lexicon-icon-calendar" focusable="false" role="presentation">
-						<use href="/images/icons/icons.svg#calendar" />
-					</svg>
-				</button>
-			</div>
-		</div>
-	</div>
-</div>
-
-```html
-<div class="input-group">
-	<div class="input-group-item">
-		<input name="datePicker" type="hidden" value="" />
-		<input
-			class="form-control input-group-inset input-group-inset-after"
-			placeholder="YYYY-MM-DD"
-			type="text"
-			value=""
-		/>
-		<div class="input-group-inset-item input-group-inset-item-after">
-			<button
-				class="btn btn-unstyled date-picker-dropdown-toggle"
-				type="button"
-			>
-				<svg
-					class="lexicon-icon lexicon-icon-calendar"
-					focusable="false"
-					role="presentation"
-				>
-					<use href="/images/icons/icons.svg#calendar" />
-				</svg>
-			</button>
-		</div>
-	</div>
-</div>
-```
-
 ## Date Picker(#css-date-picker)
 
-<div class="sheet-example">
+<div class="clay-site-dropdown-menu-container sheet-example">
 	<div class="date-picker">
-		<div class="clay-site-dropdown-menu-container date-picker-dropdown-menu">
-			<div class="dropdown-menu date-picker-calendar">
+		<div class="date-picker-dropdown-menu dropdown-menu">
+			<div class="date-picker-calendar">
 				<div class="date-picker-calendar-header">
 					<div class="date-picker-nav">
 						<div class="date-picker-nav-item input-date-picker-month">
@@ -708,77 +910,167 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 						</div>
 						<div class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls">
 							<button aria-label="Select the previous month" class="btn nav-btn nav-btn-monospaced" disabled="" type="button">
-								<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
-									<use href="/images/icons/icons.svg#angle-left" />
-								</svg>
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+										<use href="/images/icons/icons.svg#angle-left" />
+									</svg>
+								</span>
 							</button>
 							<button aria-label="Select current date" class="btn nav-btn nav-btn-monospaced" type="button">
-								<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
-									<use href="/images/icons/icons.svg#simple-circle" />
-								</svg>
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+										<use href="/images/icons/icons.svg#simple-circle" />
+									</svg>
+								</span>
 							</button>
 							<button aria-label="Select the next month" class="btn nav-btn nav-btn-monospaced" type="button">
-								<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
-									<use href="/images/icons/icons.svg#angle-right" />
-								</svg>
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+										<use href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
 							</button>
 						</div>
 					</div>
 				</div>
 				<div class="date-picker-calendar-body">
 					<div class="date-picker-days-row date-picker-row">
-						<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>M</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>W</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>F</abbr></div>
-						<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>M</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>W</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>T</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>F</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>S</abbr></div>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button">27</button>
-						<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button">28</button>
-						<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button">29</button>
-						<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" type="button">30</button>
-						<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button">31</button>
-						<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button">1</button>
-						<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button">2</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled="" type="button"><span class="c-inner" tabindex="-1">29</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">30</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">31</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button">3</button>
-						<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button">4</button>
-						<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button">5</button>
-						<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button">6</button>
-						<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button">7</button>
-						<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button">8</button>
-						<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button">9</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">3</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">4</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">5</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">6</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">7</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">8</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">9</span></button>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button">10</button>
-						<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button">11</button>
-						<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button">12</button>
-						<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item" tabindex="-1" type="button">13</button>
-						<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button">14</button>
-						<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button">15</button>
-						<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button">16</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">10</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">11</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">12</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item" tabindex="-1" type="button"><span class="c-inner" tabindex="-1">13</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">14</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">15</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">16</span></button>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button">17</button>
-						<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button">18</button>
-						<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button">19</button>
-						<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button">20</button>
-						<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button">21</button>
-						<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button">22</button>
-						<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button">23</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">17</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">18</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">19</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">20</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">21</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">22</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">23</span></button>
+						</div>
 					</div>
 					<div class="date-picker-date-row date-picker-row">
-						<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button">24</button>
-						<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button">25</button>
-						<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button">26</button>
-						<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button">27</button>
-						<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button">28</button>
-						<button aria-label="2019 03 01" class="date-picker-date date-picker-calendar-item next-month-date" type="button">1</button>
-						<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button">2</button>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">24</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">25</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">26</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 03 01" class="date-picker-date date-picker-calendar-item next-month-date" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -788,32 +1080,7 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 
 ```html
 <div class="date-picker">
-	<div class="input-group">
-		<div class="input-group-item">
-			<input name="datePicker" type="hidden" value="" />
-			<input
-				class="form-control input-group-inset input-group-inset-after"
-				placeholder="YYYY-MM-DD"
-				type="text"
-				value=""
-			/>
-			<div class="input-group-inset-item input-group-inset-item-after">
-				<button
-					class="btn btn-unstyled date-picker-dropdown-toggle"
-					type="button"
-				>
-					<svg
-						class="lexicon-icon lexicon-icon-calendar"
-						focusable="false"
-						role="presentation"
-					>
-						<use href="/images/icons/icons.svg#calendar" />
-					</svg>
-				</button>
-			</div>
-		</div>
-	</div>
-	<div class="date-picker-dropdown-menu dropdown-menu show">
+	<div class="date-picker-dropdown-menu dropdown-menu">
 		<div class="date-picker-calendar">
 			<div class="date-picker-calendar-header">
 				<div class="date-picker-nav">
@@ -837,7 +1104,31 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 						<select class="form-control" name="year">
 							<option value="1997">1997</option>
 							<option value="1998">1998</option>
-							...
+							<option value="1999">1999</option>
+							<option value="2000">2000</option>
+							<option value="2001">2001</option>
+							<option value="2002">2002</option>
+							<option value="2003">2003</option>
+							<option value="2004">2004</option>
+							<option value="2005">2005</option>
+							<option value="2006">2006</option>
+							<option value="2007">2007</option>
+							<option value="2008">2008</option>
+							<option value="2009">2009</option>
+							<option value="2010">2010</option>
+							<option value="2011">2011</option>
+							<option value="2012">2012</option>
+							<option value="2013">2013</option>
+							<option value="2014">2014</option>
+							<option value="2015">2015</option>
+							<option value="2016">2016</option>
+							<option value="2017">2017</option>
+							<option value="2018">2018</option>
+							<option value="2019">2019</option>
+							<option value="2020">2020</option>
+							<option value="2021">2021</option>
+							<option value="2022">2022</option>
+							<option value="2023">2023</option>
 						</select>
 					</div>
 					<div
@@ -849,331 +1140,421 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 							disabled=""
 							type="button"
 						>
-							<svg
-								class="lexicon-icon lexicon-icon-angle-left"
-								focusable="false"
-								role="presentation"
-							>
-								<use
-									href="/images/icons/icons.svg#angle-left"
-								/>
-							</svg>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-left"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										href="/images/icons/icons.svg#angle-left"
+									/>
+								</svg>
+							</span>
 						</button>
 						<button
 							aria-label="Select current date"
 							class="btn nav-btn nav-btn-monospaced"
 							type="button"
 						>
-							<svg
-								class="lexicon-icon lexicon-icon-simple-circle"
-								focusable="false"
-								role="presentation"
-							>
-								<use
-									href="/images/icons/icons.svg#simple-circle"
-								/>
-							</svg>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-simple-circle"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										href="/images/icons/icons.svg#simple-circle"
+									/>
+								</svg>
+							</span>
 						</button>
 						<button
 							aria-label="Select the next month"
 							class="btn nav-btn nav-btn-monospaced"
 							type="button"
 						>
-							<svg
-								class="lexicon-icon lexicon-icon-angle-right"
-								focusable="false"
-								role="presentation"
-							>
-								<use
-									href="/images/icons/icons.svg#angle-right"
-								/>
-							</svg>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										href="/images/icons/icons.svg#angle-right"
+									/>
+								</svg>
+							</span>
 						</button>
 					</div>
 				</div>
 			</div>
 			<div class="date-picker-calendar-body">
 				<div class="date-picker-days-row date-picker-row">
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>S</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>S</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>M</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>M</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>T</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>T</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>W</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>W</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>T</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>T</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>F</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>F</abbr>
+						</div>
 					</div>
-					<div class="date-picker-day date-picker-calendar-item">
-						<abbr>S</abbr>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>S</abbr>
+						</div>
 					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 01 27"
-						class="date-picker-date date-picker-calendar-item previous-month-date"
-						disabled=""
-						type="button"
-					>
-						27
-					</button>
-					<button
-						aria-label="2019 01 28"
-						class="date-picker-date date-picker-calendar-item previous-month-date"
-						disabled=""
-						type="button"
-					>
-						28
-					</button>
-					<button
-						aria-label="2019 01 29"
-						class="date-picker-date date-picker-calendar-item previous-month-date"
-						disabled=""
-						type="button"
-					>
-						29
-					</button>
-					<button
-						aria-label="2019 01 30"
-						class="active date-picker-date date-picker-calendar-item previous-month-date"
-						type="button"
-					>
-						30
-					</button>
-					<button
-						aria-label="2019 01 31"
-						class="date-picker-date date-picker-calendar-item previous-month-date"
-						type="button"
-					>
-						31
-					</button>
-					<button
-						aria-label="2019 02 01"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						1
-					</button>
-					<button
-						aria-label="2019 02 02"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						2
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 27"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							disabled=""
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">27</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 28"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							disabled=""
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">28</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 29"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							disabled=""
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">29</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 30"
+							class="active date-picker-date date-picker-calendar-item previous-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">30</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 31"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">31</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 01"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">1</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 02"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">2</span>
+						</button>
+					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 02 03"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						3
-					</button>
-					<button
-						aria-label="2019 02 04"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						4
-					</button>
-					<button
-						aria-label="2019 02 05"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						5
-					</button>
-					<button
-						aria-label="2019 02 06"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						6
-					</button>
-					<button
-						aria-label="2019 02 07"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						7
-					</button>
-					<button
-						aria-label="2019 02 08"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						8
-					</button>
-					<button
-						aria-label="2019 02 09"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						9
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 03"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">3</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 04"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">4</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 05"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">5</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 06"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">6</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 07"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">7</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 08"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">8</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 09"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">9</span>
+						</button>
+					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 02 10"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						10
-					</button>
-					<button
-						aria-label="2019 02 11"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						11
-					</button>
-					<button
-						aria-label="2019 02 12"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						12
-					</button>
-					<button
-						aria-label="2019 02 13"
-						class="date-picker-date date-picker-calendar-item"
-						tabindex="-1"
-						type="button"
-					>
-						13
-					</button>
-					<button
-						aria-label="2019 02 14"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						14
-					</button>
-					<button
-						aria-label="2019 02 15"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						15
-					</button>
-					<button
-						aria-label="2019 02 16"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						16
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 10"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">10</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 11"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">11</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 12"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">12</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 13"
+							class="date-picker-date date-picker-calendar-item"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">13</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 14"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">14</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 15"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">15</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 16"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">16</span>
+						</button>
+					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 02 17"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						17
-					</button>
-					<button
-						aria-label="2019 02 18"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						18
-					</button>
-					<button
-						aria-label="2019 02 19"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						19
-					</button>
-					<button
-						aria-label="2019 02 20"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						20
-					</button>
-					<button
-						aria-label="2019 02 21"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						21
-					</button>
-					<button
-						aria-label="2019 02 22"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						22
-					</button>
-					<button
-						aria-label="2019 02 23"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						23
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 17"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">17</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 18"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">18</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 19"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">19</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 20"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">20</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 21"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">21</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 22"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">22</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 23"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">23</span>
+						</button>
+					</div>
 				</div>
 				<div class="date-picker-date-row date-picker-row">
-					<button
-						aria-label="2019 02 24"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						24
-					</button>
-					<button
-						aria-label="2019 02 25"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						25
-					</button>
-					<button
-						aria-label="2019 02 26"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						26
-					</button>
-					<button
-						aria-label="2019 02 27"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						27
-					</button>
-					<button
-						aria-label="2019 02 28"
-						class="date-picker-date date-picker-calendar-item"
-						type="button"
-					>
-						28
-					</button>
-					<button
-						aria-label="2019 03 01"
-						class="date-picker-date date-picker-calendar-item next-month-date"
-						type="button"
-					>
-						1
-					</button>
-					<button
-						aria-label="2019 03 02"
-						class="date-picker-date date-picker-calendar-item next-month-date"
-						type="button"
-					>
-						2
-					</button>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 24"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">24</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 25"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">25</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 26"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">26</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 27"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">27</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 28"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">28</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 03 01"
+							class="date-picker-date date-picker-calendar-item next-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">1</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 03 02"
+							class="date-picker-date date-picker-calendar-item next-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">2</span>
+						</button>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -1181,16 +1562,23 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 </div>
 ```
 
-## Time Picker(#css-time-picker)
+### Date Picker Field(#css-date-picker-field)
+
+Add the class `focus` to the `input-group-item` to show the focus border.
 
 <div class="sheet-example">
-	<div class="col-md-5">
-		<div class="input-group">
-			<div class="input-group-item">
-				<input class="form-control" name="timer" type="time" value="00:00">
-			</div>
-			<div class="input-group-item input-group-item-shrink">
-				<span class="input-group-text">(GMT+01:00)</span>
+	<div class="input-group">
+		<div class="input-group-item">
+			<input name="datePicker" type="hidden" value="">
+			<input class="form-control input-group-inset input-group-inset-after" placeholder="YYYY-MM-DD" type="text" value="">
+			<div class="input-group-inset-item input-group-inset-item-after">
+				<button class="btn btn-unstyled date-picker-dropdown-toggle" type="button">
+					<span class="c-inner" tabindex="-1">
+						<svg class="lexicon-icon lexicon-icon-calendar" focusable="false" role="presentation">
+							<use href="/images/icons/icons.svg#calendar" />
+						</svg>
+					</span>
+				</button>
 			</div>
 		</div>
 	</div>
@@ -1199,10 +1587,2290 @@ The DropDown content of the DatePicker consists of `Header`, `Body` and `Footer`
 ```html
 <div class="input-group">
 	<div class="input-group-item">
-		<input class="form-control" name="timer" type="time" value="00:00" />
+		<input name="datePicker" type="hidden" value="" />
+		<input
+			class="form-control input-group-inset input-group-inset-after"
+			placeholder="YYYY-MM-DD"
+			type="text"
+			value=""
+		/>
+		<div class="input-group-inset-item input-group-inset-item-after">
+			<button
+				class="btn btn-unstyled date-picker-dropdown-toggle"
+				type="button"
+			>
+				<span class="c-inner" tabindex="-1">
+					<svg
+						class="lexicon-icon lexicon-icon-calendar"
+						focusable="false"
+						role="presentation"
+					>
+						<use href="/images/icons/icons.svg#calendar" />
+					</svg>
+				</span>
+			</button>
+		</div>
 	</div>
-	<div class="input-group-item input-group-item-shrink">
-		<span class="input-group-text">(GMT+01:00)</span>
+</div>
+```
+
+### Date Picker Date Range(#css-date-picker-date-range)
+
+The class `c-selected` must be added to `date-picker-col` for all dates in the range.
+
+The modifier class `c-selected-start` must be added to `date-picker-col` for the first date in the range.
+
+The class `c-selected-end` must be added to `date-picker-col` for the last date in the range.
+
+<div class="clay-site-dropdown-menu-container sheet-example">
+	<div class="date-picker">
+		<div class="date-picker-dropdown-menu dropdown-menu">
+			<div class="date-picker-calendar">
+				<div class="date-picker-calendar-header">
+					<div class="date-picker-nav">
+						<div class="date-picker-nav-item input-date-picker-month">
+							<select class="form-control" disabled name="month">
+								<option value="0">January</option>
+								<option value="1">February</option>
+								<option value="2">March</option>
+								<option value="3">April</option>
+								<option value="4">May</option>
+								<option value="5">June</option>
+								<option value="6">July</option>
+								<option value="7">August</option>
+								<option value="8">September</option>
+								<option value="9">October</option>
+								<option value="10">November</option>
+								<option value="11">December</option>
+							</select>
+						</div>
+						<div class="date-picker-nav-item input-date-picker-year">
+							<select class="form-control" name="year">
+								<option value="1997">1997</option>
+								<option value="1998">1998</option>
+								<option value="1999">1999</option>
+								<option value="2000">2000</option>
+								<option value="2001">2001</option>
+								<option value="2002">2002</option>
+								<option value="2003">2003</option>
+								<option value="2004">2004</option>
+								<option value="2005">2005</option>
+								<option value="2006">2006</option>
+								<option value="2007">2007</option>
+								<option value="2008">2008</option>
+								<option value="2009">2009</option>
+								<option value="2010">2010</option>
+								<option value="2011">2011</option>
+								<option value="2012">2012</option>
+								<option value="2013">2013</option>
+								<option value="2014">2014</option>
+								<option value="2015">2015</option>
+								<option value="2016">2016</option>
+								<option value="2017">2017</option>
+								<option value="2018">2018</option>
+								<option value="2019">2019</option>
+								<option value="2020">2020</option>
+								<option value="2021">2021</option>
+								<option value="2022">2022</option>
+								<option value="2023">2023</option>
+							</select>
+						</div>
+						<div class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls">
+							<button aria-label="Select the previous month" class="btn nav-btn nav-btn-monospaced" disabled type="button">
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-left"></use>
+									</svg>
+								</span>
+							</button>
+							<button aria-label="Select current date" class="btn nav-btn nav-btn-monospaced" type="button">
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#simple-circle"></use>
+									</svg>
+								</span>
+							</button>
+							<button aria-label="Select the next month" class="btn nav-btn nav-btn-monospaced" type="button">
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right"></use>
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+				<div class="date-picker-calendar-body">
+					<div class="date-picker-days-row date-picker-row">
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Mon</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Tues</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Wed</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Thu</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Fri</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Sat</abbr></div>
+						</div>
+						<div class="date-picker-col">
+							<div class="date-picker-day date-picker-calendar-item"><abbr>Sun</abbr></div>
+						</div>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<div class="date-picker-col">
+							<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">29</span></button>
+						</div>
+						<div class="c-selected c-selected-start date-picker-col">
+							<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" tabindex="-1" type="button"><span class="c-inner" tabindex="-1">30</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">31</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+						</div>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">3</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">4</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">5</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">6</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">7</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">8</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">9</span></button>
+						</div>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">10</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">11</span></button>
+						</div>
+						<div class="c-selected date-picker-col">
+							<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">12</span></button>
+						</div>
+						<div class="c-selected c-selected-end date-picker-col">
+							<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item active" tabindex="-1" type="button"><span class="c-inner" tabindex="-1">13</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">14</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">15</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">16</span></button>
+						</div>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<div class="date-picker-col">
+							<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">17</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">18</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">19</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">20</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">21</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">22</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">23</span></button>
+						</div>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<div class="date-picker-col">
+							<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">24</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">25</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">26</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 03 01" class="date-picker-date date-picker-calendar-item next-month-date" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						</div>
+						<div class="date-picker-col">
+							<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="date-picker">
+	<div class="date-picker-dropdown-menu dropdown-menu">
+		<div class="date-picker-calendar">
+			<div class="date-picker-calendar-header">
+				<div class="date-picker-nav">
+					<div class="date-picker-nav-item input-date-picker-month">
+						<select class="form-control" disabled name="month">
+							<option value="0">January</option>
+							<option value="1">February</option>
+							<option value="2">March</option>
+							<option value="3">April</option>
+							<option value="4">May</option>
+							<option value="5">June</option>
+							<option value="6">July</option>
+							<option value="7">August</option>
+							<option value="8">September</option>
+							<option value="9">October</option>
+							<option value="10">November</option>
+							<option value="11">December</option>
+						</select>
+					</div>
+					<div class="date-picker-nav-item input-date-picker-year">
+						<select class="form-control" name="year">
+							<option value="1997">1997</option>
+							<option value="1998">1998</option>
+							<option value="1999">1999</option>
+							<option value="2000">2000</option>
+							<option value="2001">2001</option>
+							<option value="2002">2002</option>
+							<option value="2003">2003</option>
+							<option value="2004">2004</option>
+							<option value="2005">2005</option>
+							<option value="2006">2006</option>
+							<option value="2007">2007</option>
+							<option value="2008">2008</option>
+							<option value="2009">2009</option>
+							<option value="2010">2010</option>
+							<option value="2011">2011</option>
+							<option value="2012">2012</option>
+							<option value="2013">2013</option>
+							<option value="2014">2014</option>
+							<option value="2015">2015</option>
+							<option value="2016">2016</option>
+							<option value="2017">2017</option>
+							<option value="2018">2018</option>
+							<option value="2019">2019</option>
+							<option value="2020">2020</option>
+							<option value="2021">2021</option>
+							<option value="2022">2022</option>
+							<option value="2023">2023</option>
+						</select>
+					</div>
+					<div
+						class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+					>
+						<button
+							aria-label="Select the previous month"
+							class="btn nav-btn nav-btn-monospaced"
+							disabled
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-left"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-left"
+									></use>
+								</svg>
+							</span>
+						</button>
+						<button
+							aria-label="Select current date"
+							class="btn nav-btn nav-btn-monospaced"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-simple-circle"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#simple-circle"
+									></use>
+								</svg>
+							</span>
+						</button>
+						<button
+							aria-label="Select the next month"
+							class="btn nav-btn nav-btn-monospaced"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-right"
+									></use>
+								</svg>
+							</span>
+						</button>
+					</div>
+				</div>
+			</div>
+			<div class="date-picker-calendar-body">
+				<div class="date-picker-days-row date-picker-row">
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>Mon</abbr>
+						</div>
+					</div>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>Tues</abbr>
+						</div>
+					</div>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>Wed</abbr>
+						</div>
+					</div>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>Thu</abbr>
+						</div>
+					</div>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>Fri</abbr>
+						</div>
+					</div>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>Sat</abbr>
+						</div>
+					</div>
+					<div class="date-picker-col">
+						<div class="date-picker-day date-picker-calendar-item">
+							<abbr>Sun</abbr>
+						</div>
+					</div>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 27"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							disabled
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">27</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 28"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							disabled
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">28</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 01 29"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							disabled
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">29</span>
+						</button>
+					</div>
+					<div class="c-selected c-selected-start date-picker-col">
+						<button
+							aria-label="2019 01 30"
+							class="active date-picker-date date-picker-calendar-item previous-month-date"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">30</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 01 31"
+							class="date-picker-date date-picker-calendar-item previous-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">31</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 01"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">1</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 02"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">2</span>
+						</button>
+					</div>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 03"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">3</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 04"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">4</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 05"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">5</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 06"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">6</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 07"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">7</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 08"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">8</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 09"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">9</span>
+						</button>
+					</div>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 10"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">10</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 11"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">11</span>
+						</button>
+					</div>
+					<div class="c-selected date-picker-col">
+						<button
+							aria-label="2019 02 12"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">12</span>
+						</button>
+					</div>
+					<div class="c-selected c-selected-end date-picker-col">
+						<button
+							aria-label="2019 02 13"
+							class="date-picker-date date-picker-calendar-item active"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">13</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 14"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">14</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 15"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">15</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 16"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">16</span>
+						</button>
+					</div>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 17"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">17</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 18"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">18</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 19"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">19</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 20"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">20</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 21"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">21</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 22"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">22</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 23"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">23</span>
+						</button>
+					</div>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 24"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">24</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 25"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">25</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 26"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">26</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 27"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">27</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 02 28"
+							class="date-picker-date date-picker-calendar-item"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">28</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 03 01"
+							class="date-picker-date date-picker-calendar-item next-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">1</span>
+						</button>
+					</div>
+					<div class="date-picker-col">
+						<button
+							aria-label="2019 03 02"
+							class="date-picker-date date-picker-calendar-item next-month-date"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">2</span>
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+### Date Picker Old Markup(#css-date-picker-old-markup)
+
+<div class="clay-site-alert alert alert-warning">
+	In Clay CSS versions 3.24.1 and below, Date Picker days and dates weren't wrapped in an extra element <code>date-picker-col</code>. We added the wrapping element for highlighting a range of dates. See <a href="https://github.com/liferay/clay/issues/3986" rel="noreferrer noopener" target="_blank">#3986</a>. This old pattern is still supported, but we recommend updating your markup.
+</div>
+
+<div class="clay-site-dropdown-menu-container sheet-example">
+	<div class="date-picker">
+		<div class="date-picker-dropdown-menu dropdown-menu">
+			<div class="date-picker-calendar">
+				<div class="date-picker-calendar-header">
+					<div class="date-picker-nav">
+						<div class="date-picker-nav-item input-date-picker-month">
+							<select class="form-control" disabled name="month">
+								<option value="0">January</option>
+								<option value="1">February</option>
+								<option value="2">March</option>
+								<option value="3">April</option>
+								<option value="4">May</option>
+								<option value="5">June</option>
+								<option value="6">July</option>
+								<option value="7">August</option>
+								<option value="8">September</option>
+								<option value="9">October</option>
+								<option value="10">November</option>
+								<option value="11">December</option>
+							</select>
+						</div>
+						<div class="date-picker-nav-item input-date-picker-year">
+							<select class="form-control" name="year">
+								<option value="1997">1997</option>
+								<option value="1998">1998</option>
+								<option value="1999">1999</option>
+								<option value="2000">2000</option>
+								<option value="2001">2001</option>
+								<option value="2002">2002</option>
+								<option value="2003">2003</option>
+								<option value="2004">2004</option>
+								<option value="2005">2005</option>
+								<option value="2006">2006</option>
+								<option value="2007">2007</option>
+								<option value="2008">2008</option>
+								<option value="2009">2009</option>
+								<option value="2010">2010</option>
+								<option value="2011">2011</option>
+								<option value="2012">2012</option>
+								<option value="2013">2013</option>
+								<option value="2014">2014</option>
+								<option value="2015">2015</option>
+								<option value="2016">2016</option>
+								<option value="2017">2017</option>
+								<option value="2018">2018</option>
+								<option value="2019">2019</option>
+								<option value="2020">2020</option>
+								<option value="2021">2021</option>
+								<option value="2022">2022</option>
+								<option value="2023">2023</option>
+							</select>
+						</div>
+						<div class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls">
+							<button aria-label="Select the previous month" class="btn nav-btn nav-btn-monospaced" disabled type="button">
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-left"></use>
+									</svg>
+								</span>
+							</button>
+							<button aria-label="Select current date" class="btn nav-btn nav-btn-monospaced" type="button">
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-simple-circle" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#simple-circle"></use>
+									</svg>
+								</span>
+							</button>
+							<button aria-label="Select the next month" class="btn nav-btn nav-btn-monospaced" type="button">
+								<span class="c-inner" tabindex="-1">
+									<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right"></use>
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+				<div class="date-picker-calendar-body">
+					<div class="date-picker-days-row date-picker-row">
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Mon</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Tues</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Wed</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Thu</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Fri</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Sat</abbr></div>
+						<div class="date-picker-day date-picker-calendar-item"><abbr>Sun</abbr></div>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 01 27" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						<button aria-label="2019 01 28" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						<button aria-label="2019 01 29" class="date-picker-date date-picker-calendar-item previous-month-date" disabled type="button"><span class="c-inner" tabindex="-1">29</span></button>
+						<button aria-label="2019 01 30" class="active date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">30</span></button>
+						<button aria-label="2019 01 31" class="date-picker-date date-picker-calendar-item previous-month-date" type="button"><span class="c-inner" tabindex="-1">31</span></button>
+						<button aria-label="2019 02 01" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						<button aria-label="2019 02 02" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 02 03" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">3</span></button>
+						<button aria-label="2019 02 04" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">4</span></button>
+						<button aria-label="2019 02 05" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">5</span></button>
+						<button aria-label="2019 02 06" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">6</span></button>
+						<button aria-label="2019 02 07" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">7</span></button>
+						<button aria-label="2019 02 08" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">8</span></button>
+						<button aria-label="2019 02 09" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">9</span></button>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 02 10" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">10</span></button>
+						<button aria-label="2019 02 11" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">11</span></button>
+						<button aria-label="2019 02 12" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">12</span></button>
+						<button aria-label="2019 02 13" class="date-picker-date date-picker-calendar-item active" tabindex="-1" type="button"><span class="c-inner" tabindex="-1">13</span></button>
+						<button aria-label="2019 02 14" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">14</span></button>
+						<button aria-label="2019 02 15" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">15</span></button>
+						<button aria-label="2019 02 16" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">16</span></button>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 02 17" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">17</span></button>
+						<button aria-label="2019 02 18" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">18</span></button>
+						<button aria-label="2019 02 19" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">19</span></button>
+						<button aria-label="2019 02 20" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">20</span></button>
+						<button aria-label="2019 02 21" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">21</span></button>
+						<button aria-label="2019 02 22" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">22</span></button>
+						<button aria-label="2019 02 23" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">23</span></button>
+					</div>
+					<div class="date-picker-date-row date-picker-row">
+						<button aria-label="2019 02 24" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">24</span></button>
+						<button aria-label="2019 02 25" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">25</span></button>
+						<button aria-label="2019 02 26" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">26</span></button>
+						<button aria-label="2019 02 27" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">27</span></button>
+						<button aria-label="2019 02 28" class="date-picker-date date-picker-calendar-item" type="button"><span class="c-inner" tabindex="-1">28</span></button>
+						<button aria-label="2019 03 01" class="date-picker-date date-picker-calendar-item next-month-date" type="button"><span class="c-inner" tabindex="-1">1</span></button>
+						<button aria-label="2019 03 02" class="date-picker-date date-picker-calendar-item next-month-date" type="button"><span class="c-inner" tabindex="-1">2</span></button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="date-picker">
+	<div class="date-picker-dropdown-menu dropdown-menu">
+		<div class="date-picker-calendar">
+			<div class="date-picker-calendar-header">
+				<div class="date-picker-nav">
+					<div class="date-picker-nav-item input-date-picker-month">
+						<select class="form-control" disabled name="month">
+							<option value="0">January</option>
+							<option value="1">February</option>
+							<option value="2">March</option>
+							<option value="3">April</option>
+							<option value="4">May</option>
+							<option value="5">June</option>
+							<option value="6">July</option>
+							<option value="7">August</option>
+							<option value="8">September</option>
+							<option value="9">October</option>
+							<option value="10">November</option>
+							<option value="11">December</option>
+						</select>
+					</div>
+					<div class="date-picker-nav-item input-date-picker-year">
+						<select class="form-control" name="year">
+							<option value="1997">1997</option>
+							<option value="1998">1998</option>
+							<option value="1999">1999</option>
+							<option value="2000">2000</option>
+							<option value="2001">2001</option>
+							<option value="2002">2002</option>
+							<option value="2003">2003</option>
+							<option value="2004">2004</option>
+							<option value="2005">2005</option>
+							<option value="2006">2006</option>
+							<option value="2007">2007</option>
+							<option value="2008">2008</option>
+							<option value="2009">2009</option>
+							<option value="2010">2010</option>
+							<option value="2011">2011</option>
+							<option value="2012">2012</option>
+							<option value="2013">2013</option>
+							<option value="2014">2014</option>
+							<option value="2015">2015</option>
+							<option value="2016">2016</option>
+							<option value="2017">2017</option>
+							<option value="2018">2018</option>
+							<option value="2019">2019</option>
+							<option value="2020">2020</option>
+							<option value="2021">2021</option>
+							<option value="2022">2022</option>
+							<option value="2023">2023</option>
+						</select>
+					</div>
+					<div
+						class="date-picker-nav-item date-picker-nav-item-expand date-picker-nav-controls"
+					>
+						<button
+							aria-label="Select the previous month"
+							class="btn nav-btn nav-btn-monospaced"
+							disabled
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-left"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-left"
+									></use>
+								</svg>
+							</span>
+						</button>
+						<button
+							aria-label="Select current date"
+							class="btn nav-btn nav-btn-monospaced"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-simple-circle"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#simple-circle"
+									></use>
+								</svg>
+							</span>
+						</button>
+						<button
+							aria-label="Select the next month"
+							class="btn nav-btn nav-btn-monospaced"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-1">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-right"
+									></use>
+								</svg>
+							</span>
+						</button>
+					</div>
+				</div>
+			</div>
+			<div class="date-picker-calendar-body">
+				<div class="date-picker-days-row date-picker-row">
+					<div class="date-picker-day date-picker-calendar-item">
+						<abbr>Mon</abbr>
+					</div>
+					<div class="date-picker-day date-picker-calendar-item">
+						<abbr>Tues</abbr>
+					</div>
+					<div class="date-picker-day date-picker-calendar-item">
+						<abbr>Wed</abbr>
+					</div>
+					<div class="date-picker-day date-picker-calendar-item">
+						<abbr>Thu</abbr>
+					</div>
+					<div class="date-picker-day date-picker-calendar-item">
+						<abbr>Fri</abbr>
+					</div>
+					<div class="date-picker-day date-picker-calendar-item">
+						<abbr>Sat</abbr>
+					</div>
+					<div class="date-picker-day date-picker-calendar-item">
+						<abbr>Sun</abbr>
+					</div>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<button
+						aria-label="2019 01 27"
+						class="date-picker-date date-picker-calendar-item previous-month-date"
+						disabled
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">27</span>
+					</button>
+					<button
+						aria-label="2019 01 28"
+						class="date-picker-date date-picker-calendar-item previous-month-date"
+						disabled
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">28</span>
+					</button>
+					<button
+						aria-label="2019 01 29"
+						class="date-picker-date date-picker-calendar-item previous-month-date"
+						disabled
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">29</span>
+					</button>
+					<button
+						aria-label="2019 01 30"
+						class="active date-picker-date date-picker-calendar-item previous-month-date"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">30</span>
+					</button>
+					<button
+						aria-label="2019 01 31"
+						class="date-picker-date date-picker-calendar-item previous-month-date"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">31</span>
+					</button>
+					<button
+						aria-label="2019 02 01"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">1</span>
+					</button>
+					<button
+						aria-label="2019 02 02"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">2</span>
+					</button>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<button
+						aria-label="2019 02 03"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">3</span>
+					</button>
+					<button
+						aria-label="2019 02 04"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">4</span>
+					</button>
+					<button
+						aria-label="2019 02 05"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">5</span>
+					</button>
+					<button
+						aria-label="2019 02 06"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">6</span>
+					</button>
+					<button
+						aria-label="2019 02 07"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">7</span>
+					</button>
+					<button
+						aria-label="2019 02 08"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">8</span>
+					</button>
+					<button
+						aria-label="2019 02 09"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">9</span>
+					</button>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<button
+						aria-label="2019 02 10"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">10</span>
+					</button>
+					<button
+						aria-label="2019 02 11"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">11</span>
+					</button>
+					<button
+						aria-label="2019 02 12"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">12</span>
+					</button>
+					<button
+						aria-label="2019 02 13"
+						class="date-picker-date date-picker-calendar-item active"
+						tabindex="-1"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">13</span>
+					</button>
+					<button
+						aria-label="2019 02 14"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">14</span>
+					</button>
+					<button
+						aria-label="2019 02 15"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">15</span>
+					</button>
+					<button
+						aria-label="2019 02 16"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">16</span>
+					</button>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<button
+						aria-label="2019 02 17"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">17</span>
+					</button>
+					<button
+						aria-label="2019 02 18"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">18</span>
+					</button>
+					<button
+						aria-label="2019 02 19"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">19</span>
+					</button>
+					<button
+						aria-label="2019 02 20"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">20</span>
+					</button>
+					<button
+						aria-label="2019 02 21"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">21</span>
+					</button>
+					<button
+						aria-label="2019 02 22"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">22</span>
+					</button>
+					<button
+						aria-label="2019 02 23"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">23</span>
+					</button>
+				</div>
+				<div class="date-picker-date-row date-picker-row">
+					<button
+						aria-label="2019 02 24"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">24</span>
+					</button>
+					<button
+						aria-label="2019 02 25"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">25</span>
+					</button>
+					<button
+						aria-label="2019 02 26"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">26</span>
+					</button>
+					<button
+						aria-label="2019 02 27"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">27</span>
+					</button>
+					<button
+						aria-label="2019 02 28"
+						class="date-picker-date date-picker-calendar-item"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">28</span>
+					</button>
+					<button
+						aria-label="2019 03 01"
+						class="date-picker-date date-picker-calendar-item next-month-date"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">1</span>
+					</button>
+					<button
+						aria-label="2019 03 02"
+						class="date-picker-date date-picker-calendar-item next-month-date"
+						type="button"
+					>
+						<span class="c-inner" tabindex="-1">2</span>
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+### Browser Default Input Date(#css-browser-default-input-date)
+
+Check the <a href="https://caniuse.com/input-datetime" rel="noreferrer noopener" target="_blank">browser support</a> for `input[type="date"]` before deciding if it's a good fit for your application.
+
+<div class="sheet-example">
+	<div class="form-group">
+		<label for="defaultInputDate">Default Input Date</label>
+		<input class="form-control" id="defaultInputDate" name="defaultInputDate" type="date" value="1970-01-01" />
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<label for="defaultInputDate">Default Input Date</label>
+	<input
+		class="form-control"
+		id="defaultInputDate"
+		name="defaultInputDate"
+		type="date"
+		value="1970-01-01"
+	/>
+</div>
+```
+
+## Time Picker(#css-time-picker)
+
+<div class="clay-site-alert alert alert-warning">This requires external javascript to change values of nested inputs and increment/decrement buttons. We use <code>input type="text"</code> because it gives us better cross browser support for formatting numbers and text.</div>
+
+### Time Picker 12H(#css-time-picker-12h)
+
+<div class="sheet-example">
+	<div class="form-group">
+		<label for="timePicker12h">Time Picker (12H)</label>
+		<div class="clay-time">
+			<div class="input-group">
+				<div class="input-group-item input-group-item-shrink">
+					<div class="form-control">
+						<div class="clay-time-edit">
+							<input class="clay-time-hours form-control-inset" id="timePicker12h" maxlength="2" name="hours" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-minutes form-control-inset" maxlength="2" name="minutes" type="text" value="--">
+							<input class="clay-time-ampm form-control-inset" maxlength="2" name="ampm" type="text" value="PM">
+						</div>
+						<div class="clay-time-action-group">
+							<div class="clay-time-action-group-item">
+								<div class="btn-group-vertical clay-time-inner-spin" role="group">
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-inc" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-up"></use>
+										</svg>
+									</button>
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+										</svg>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<label for="timePicker12h">Time Picker (12H)</label>
+	<div class="clay-time">
+		<div class="input-group">
+			<div class="input-group-item input-group-item-shrink">
+				<div class="form-control">
+					<div class="clay-time-edit">
+						<input
+							class="clay-time-hours form-control-inset"
+							id="timePicker12h"
+							maxlength="2"
+							name="hours"
+							type="text"
+							value="--"
+						/>
+						<span class="clay-time-divider">:</span>
+						<input
+							class="clay-time-minutes form-control-inset"
+							maxlength="2"
+							name="minutes"
+							type="text"
+							value="--"
+						/>
+						<input
+							class="clay-time-ampm form-control-inset"
+							maxlength="2"
+							name="ampm"
+							type="text"
+							value="PM"
+						/>
+					</div>
+					<div class="clay-time-action-group">
+						<div class="clay-time-action-group-item">
+							<div
+								class="btn-group-vertical clay-time-inner-spin"
+								role="group"
+							>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-inc"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-up"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-up"
+										></use>
+									</svg>
+								</button>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										></use>
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+### Time Picker 12H With Time Zone(#css-time-picker-12h-with-time-zone)
+
+<div class="sheet-example">
+	<div class="form-group">
+		<label for="timePicker12hTimeZone">Time Picker (12H) with Time Zone</label>
+		<div class="clay-time">
+			<div class="input-group">
+				<div class="input-group-item input-group-item-shrink">
+					<div class="form-control">
+						<div class="clay-time-edit">
+							<input class="clay-time-hours form-control-inset" id="timePicker12hTimeZone" maxlength="2" name="hours" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-minutes form-control-inset" maxlength="2" name="minutes" type="text" value="--">
+							<input class="clay-time-ampm form-control-inset" maxlength="2" name="ampm" type="text" value="PM">
+						</div>
+						<div class="clay-time-action-group">
+							<div class="clay-time-action-group-item">
+								<div class="btn-group-vertical clay-time-inner-spin" role="group">
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-up"></use>
+										</svg>
+									</button>
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+										</svg>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="input-group-item input-group-item-shrink">
+					<span class="input-group-text">(GMT+01:00)</span>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+### Time Picker 12H With Time Zone and Icon(#css-time-picker-12h-with-time-zone-and-icon)
+
+<div class="sheet-example">
+	<div class="form-group">
+		<label for="timePicker12hTimeZoneIcon">Time Picker (12H) with Time Zone and Icon</label>
+		<div class="clay-time">
+			<div class="input-group">
+				<div class="input-group-item input-group-item-shrink">
+					<div class="input-group-text">
+						<svg class="lexicon-icon lexicon-icon-time" focusable="false" role="presentation">
+							<use xlink:href="/images/icons/icons.svg#time"></use>
+						</svg>
+					</div>
+				</div>
+				<div class="input-group-item input-group-item-shrink">
+					<div class="form-control">
+						<div class="clay-time-edit">
+							<input class="clay-time-hours form-control-inset" id="timePicker12hTimeZoneIcon" maxlength="2" name="hours" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-minutes form-control-inset" maxlength="2" name="minutes" type="text" value="--">
+							<input class="clay-time-ampm form-control-inset" maxlength="2" name="ampm" type="text" value="PM">
+						</div>
+						<div class="clay-time-action-group">
+							<div class="clay-time-action-group-item">
+								<div class="btn-group-vertical clay-time-inner-spin" role="group">
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-up"></use>
+										</svg>
+									</button>
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+										</svg>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="input-group-item input-group-item-shrink">
+					<span class="input-group-text">(GMT+01:00)</span>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<label for="timePicker12hTimeZoneIcon"
+		>Time Picker (12H) with Time Zone and Icon</label
+	>
+	<div class="clay-time">
+		<div class="input-group">
+			<div class="input-group-item input-group-item-shrink">
+				<div class="input-group-text">
+					<svg
+						class="lexicon-icon lexicon-icon-time"
+						focusable="false"
+						role="presentation"
+					>
+						<use xlink:href="/images/icons/icons.svg#time"></use>
+					</svg>
+				</div>
+			</div>
+			<div class="input-group-item input-group-item-shrink">
+				<div class="form-control">
+					<div class="clay-time-edit">
+						<input
+							class="clay-time-hours form-control-inset"
+							id="timePicker12hTimeZoneIcon"
+							maxlength="2"
+							name="hours"
+							type="text"
+							value="--"
+						/>
+						<span class="clay-time-divider">:</span>
+						<input
+							class="clay-time-minutes form-control-inset"
+							maxlength="2"
+							name="minutes"
+							type="text"
+							value="--"
+						/>
+						<input
+							class="clay-time-ampm form-control-inset"
+							maxlength="2"
+							name="ampm"
+							type="text"
+							value="PM"
+						/>
+					</div>
+					<div class="clay-time-action-group">
+						<div class="clay-time-action-group-item">
+							<div
+								class="btn-group-vertical clay-time-inner-spin"
+								role="group"
+							>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-up"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-up"
+										></use>
+									</svg>
+								</button>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										></use>
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="input-group-item input-group-item-shrink">
+				<span class="input-group-text">(GMT+01:00)</span>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+### Time Picker 24H(#css-time-picker-24h)
+
+<div class="sheet-example">
+	<div class="form-group">
+		<label for="timePicker24h">Time Picker (24H)</label>
+		<div class="clay-time">
+			<div class="input-group">
+				<div class="input-group-item input-group-item-shrink">
+					<div class="form-control">
+						<div class="clay-time-edit">
+							<input class="clay-time-hours form-control-inset" id="timePicker24h" maxlength="2" name="hours" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-minutes form-control-inset" maxlength="2" name="minutes" type="text" value="--">
+						</div>
+						<div class="clay-time-action-group">
+							<div class="clay-time-action-group-item">
+								<div class="btn-group-vertical clay-time-inner-spin" role="group">
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-up"></use>
+										</svg>
+									</button>
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+										</svg>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<label for="timePicker24h">Time Picker (24H)</label>
+	<div class="clay-time">
+		<div class="input-group">
+			<div class="input-group-item input-group-item-shrink">
+				<div class="form-control">
+					<div class="clay-time-edit">
+						<input
+							class="clay-time-hours form-control-inset"
+							id="timePicker24h"
+							maxlength="2"
+							name="hours"
+							type="text"
+							value="--"
+						/>
+						<span class="clay-time-divider">:</span>
+						<input
+							class="clay-time-minutes form-control-inset"
+							maxlength="2"
+							name="minutes"
+							type="text"
+							value="--"
+						/>
+					</div>
+					<div class="clay-time-action-group">
+						<div class="clay-time-action-group-item">
+							<div
+								class="btn-group-vertical clay-time-inner-spin"
+								role="group"
+							>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-up"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-up"
+										></use>
+									</svg>
+								</button>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										></use>
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+### Time Picker With Seconds and Clear(#css-time-picker-with-seconds-and-clear)
+
+<div class="sheet-example">
+	<div class="form-group">
+		<label for="timePicker12hSeconds">Time Picker (12H)</label>
+		<div class="clay-time">
+			<div class="input-group">
+				<div class="input-group-item input-group-item-shrink">
+					<div class="form-control">
+						<div class="clay-time-edit">
+							<input class="clay-time-hours form-control-inset" id="timePicker12hSeconds" maxlength="2" name="hours" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-minutes form-control-inset" maxlength="2" name="minutes" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-seconds form-control-inset" maxlength="2" name="seconds" type="text" value="--">
+							<input class="clay-time-ampm form-control-inset" maxlength="2" name="ampm" type="text" value="--">
+						</div>
+						<div class="clay-time-action-group">
+							<div class="clay-time-action-group-item">
+								<button class="btn clay-time-clear-btn" type="button">
+									<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle"></use>
+									</svg>
+								</button>
+							</div>
+							<div class="clay-time-action-group-item">
+								<div class="btn-group-vertical clay-time-inner-spin" role="group">
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-up"></use>
+										</svg>
+									</button>
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+										</svg>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="form-group">
+		<label for="timePicker24hSeconds">Time Picker (24H)</label>
+		<div class="clay-time">
+			<div class="input-group">
+				<div class="input-group-item input-group-item-shrink">
+					<div class="form-control">
+						<div class="clay-time-edit">
+							<input class="clay-time-hours form-control-inset" id="timePicker24hSeconds" maxlength="2" name="hours" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-minutes form-control-inset" maxlength="2" name="minutes" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-seconds form-control-inset" maxlength="2" name="seconds" type="text" value="--">
+						</div>
+						<div class="clay-time-action-group">
+							<div class="clay-time-action-group-item">
+								<button class="btn clay-time-clear-btn" type="button">
+									<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle"></use>
+									</svg>
+								</button>
+							</div>
+							<div class="clay-time-action-group-item">
+								<div class="btn-group-vertical clay-time-inner-spin" role="group">
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-up"></use>
+										</svg>
+									</button>
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+										</svg>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<label for="timePicker12hSeconds">Time Picker (12H)</label>
+	<div class="clay-time">
+		<div class="input-group">
+			<div class="input-group-item input-group-item-shrink">
+				<div class="form-control">
+					<div class="clay-time-edit">
+						<input
+							class="clay-time-hours form-control-inset"
+							id="timePicker12hSeconds"
+							maxlength="2"
+							name="hours"
+							type="text"
+							value="--"
+						/>
+						<span class="clay-time-divider">:</span>
+						<input
+							class="clay-time-minutes form-control-inset"
+							maxlength="2"
+							name="minutes"
+							type="text"
+							value="--"
+						/>
+						<span class="clay-time-divider">:</span>
+						<input
+							class="clay-time-seconds form-control-inset"
+							maxlength="2"
+							name="seconds"
+							type="text"
+							value="--"
+						/>
+						<input
+							class="clay-time-ampm form-control-inset"
+							maxlength="2"
+							name="ampm"
+							type="text"
+							value="--"
+						/>
+					</div>
+					<div class="clay-time-action-group">
+						<div class="clay-time-action-group-item">
+							<button
+								class="btn clay-time-clear-btn"
+								type="button"
+							>
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle"
+									></use>
+								</svg>
+							</button>
+						</div>
+						<div class="clay-time-action-group-item">
+							<div
+								class="btn-group-vertical clay-time-inner-spin"
+								role="group"
+							>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-up"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-up"
+										></use>
+									</svg>
+								</button>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										></use>
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="form-group">
+	<label for="timePicker24hSeconds">Time Picker (24H)</label>
+	<div class="clay-time">
+		<div class="input-group">
+			<div class="input-group-item input-group-item-shrink">
+				<div class="form-control">
+					<div class="clay-time-edit">
+						<input
+							class="clay-time-hours form-control-inset"
+							id="timePicker24hSeconds"
+							maxlength="2"
+							name="hours"
+							type="text"
+							value="--"
+						/>
+						<span class="clay-time-divider">:</span>
+						<input
+							class="clay-time-minutes form-control-inset"
+							maxlength="2"
+							name="minutes"
+							type="text"
+							value="--"
+						/>
+						<span class="clay-time-divider">:</span>
+						<input
+							class="clay-time-seconds form-control-inset"
+							maxlength="2"
+							name="seconds"
+							type="text"
+							value="--"
+						/>
+					</div>
+					<div class="clay-time-action-group">
+						<div class="clay-time-action-group-item">
+							<button
+								class="btn clay-time-clear-btn"
+								type="button"
+							>
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle"
+									></use>
+								</svg>
+							</button>
+						</div>
+						<div class="clay-time-action-group-item">
+							<div
+								class="btn-group-vertical clay-time-inner-spin"
+								role="group"
+							>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-inc"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-up"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-up"
+										></use>
+									</svg>
+								</button>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										></use>
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+### Time Picker Focus State(#css-time-picker-focus-state)
+
+Add the class `focus` to `form-control`.
+
+<div class="sheet-example">
+	<div class="form-group">
+		<label for="timePicker12hFocus">Time Picker (12H)</label>
+		<div class="clay-time">
+			<div class="input-group">
+				<div class="input-group-item input-group-item-shrink">
+					<div class="form-control focus">
+						<div class="clay-time-edit">
+							<input class="clay-time-hours form-control-inset" id="timePicker12hFocus" maxlength="2" name="hours" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-minutes form-control-inset" maxlength="2" name="minutes" type="text" value="--">
+							<input class="clay-time-ampm form-control-inset" maxlength="2" name="ampm" type="text" value="PM">
+						</div>
+						<div class="clay-time-action-group">
+							<div class="clay-time-action-group-item">
+								<div class="btn-group-vertical clay-time-inner-spin" role="group">
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-inc" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-up"></use>
+										</svg>
+									</button>
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+										</svg>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<label for="timePicker12hFocus">Time Picker (12H)</label>
+	<div class="clay-time">
+		<div class="input-group">
+			<div class="input-group-item input-group-item-shrink">
+				<div class="form-control focus">
+					<div class="clay-time-edit">
+						<input
+							class="clay-time-hours form-control-inset"
+							id="timePicker12hFocus"
+							maxlength="2"
+							name="hours"
+							type="text"
+							value="--"
+						/>
+						<span class="clay-time-divider">:</span>
+						<input
+							class="clay-time-minutes form-control-inset"
+							maxlength="2"
+							name="minutes"
+							type="text"
+							value="--"
+						/>
+						<input
+							class="clay-time-ampm form-control-inset"
+							maxlength="2"
+							name="ampm"
+							type="text"
+							value="PM"
+						/>
+					</div>
+					<div class="clay-time-action-group">
+						<div class="clay-time-action-group-item">
+							<div
+								class="btn-group-vertical clay-time-inner-spin"
+								role="group"
+							>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-inc"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-up"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-up"
+										></use>
+									</svg>
+								</button>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec"
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										></use>
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+### Time Picker Disabled State(#css-time-picker-disabled-state)
+
+Add the class `disabled` to `form-control` and the attribute `disabled` to all nested `input`s and `button`s. The `label` can also be styled in a disabled state with the class `disabled`.
+
+<div class="sheet-example">
+	<div class="form-group">
+		<label for="timePicker12hDisabled">Time Picker (12H)</label>
+		<div class="clay-time">
+			<div class="input-group">
+				<div class="input-group-item input-group-item-shrink">
+					<div class="form-control disabled">
+						<div class="clay-time-edit">
+							<input class="clay-time-hours form-control-inset" disabled id="timePicker12hDisabled" maxlength="2" name="hours" type="text" value="--">
+							<span class="clay-time-divider">:</span>
+							<input class="clay-time-minutes form-control-inset" disabled maxlength="2" name="minutes" type="text" value="--">
+							<input class="clay-time-ampm form-control-inset" disabled maxlength="2" name="ampm" type="text" value="PM">
+						</div>
+						<div class="clay-time-action-group">
+							<div class="clay-time-action-group-item">
+								<div class="btn-group-vertical clay-time-inner-spin" role="group">
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-inc" disabled type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-up" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-up"></use>
+										</svg>
+									</button>
+									<button class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec" disabled type="button">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-down"></use>
+										</svg>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<label for="timePicker12hDisabled">Time Picker (12H)</label>
+	<div class="clay-time">
+		<div class="input-group">
+			<div class="input-group-item input-group-item-shrink">
+				<div class="form-control disabled">
+					<div class="clay-time-edit">
+						<input
+							class="clay-time-hours form-control-inset"
+							disabled
+							id="timePicker12hDisabled"
+							maxlength="2"
+							name="hours"
+							type="text"
+							value="--"
+						/>
+						<span class="clay-time-divider">:</span>
+						<input
+							class="clay-time-minutes form-control-inset"
+							disabled
+							maxlength="2"
+							name="minutes"
+							type="text"
+							value="--"
+						/>
+						<input
+							class="clay-time-ampm form-control-inset"
+							disabled
+							maxlength="2"
+							name="ampm"
+							type="text"
+							value="PM"
+						/>
+					</div>
+					<div class="clay-time-action-group">
+						<div class="clay-time-action-group-item">
+							<div
+								class="btn-group-vertical clay-time-inner-spin"
+								role="group"
+							>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-inc"
+									disabled
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-up"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-up"
+										></use>
+									</svg>
+								</button>
+								<button
+									class="btn btn-secondary clay-time-inner-spin-btn clay-time-inner-spin-btn-dec"
+									disabled
+									type="button"
+								>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										></use>
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+```
+
+### Browser Default Input Time(#css-browser-default-input-time)
+
+Check the <a href="https://caniuse.com/input-datetime" rel="noreferrer noopener" target="_blank">browser support</a> for `input[type="time"]` before deciding if it's a good fit for your application.
+
+<div class="sheet-example">
+	<div class="form-group">
+		<div class="clay-time">
+			<label for="defaultTimeInput">Time</label>
+			<input class="form-control" id="defaultTimeInput" name="defaultTimeInput" type="time" value="14:00:00">
+		</div>
+	</div>
+	<div class="form-group">
+		<div class="clay-time">
+			<label for="inputGroupDefaultTimeInput">Time With Time Zone</label>
+			<div class="input-group">
+				<div class="input-group-item">
+					<input class="form-control" id="inputGroupDefaultTimeInput" name="timer" type="time" value="00:00">
+				</div>
+				<div class="input-group-item input-group-item-shrink">
+					<span class="input-group-text">(GMT+01:00)</span>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<label for="defaultTimeInput">Time</label>
+	<input
+		class="form-control"
+		id="defaultTimeInput"
+		name="defaultTimeInput"
+		type="time"
+		value="14:00:00"
+	/>
+</div>
+
+<div class="form-group">
+	<div class="input-group">
+		<div class="input-group-item">
+			<input
+				class="form-control"
+				name="timer"
+				type="time"
+				value="00:00"
+			/>
+		</div>
+		<div class="input-group-item input-group-item-shrink">
+			<span class="input-group-text">(GMT+01:00)</span>
+		</div>
 	</div>
 </div>
 ```

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -33,36 +33,38 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	);
 
 	return (
-		<button
-			aria-label={formatDate(
-				setDate(date, {
-					hours: 12,
-					milliseconds: 0,
-					minutes: 0,
-					seconds: 0,
-				}),
-				'yyyy MM dd'
-			)}
-			className={classNames}
-			disabled={outside}
-			onClick={() => onClick(date)}
-			onKeyDown={(event) => {
-				// When tabbing and selecting a DayNumber using
-				// SPACE key the active state it's not being removed.
-				// See https://github.com/liferay/clay/issues/3374 for more details.
-				if (event.key === Keys.Spacebar) {
-					event.preventDefault();
-				}
-			}}
-			onKeyUp={(event) => {
-				if (event.key === Keys.Spacebar) {
-					onClick(date);
-				}
-			}}
-			type="button"
-		>
-			{date.getDate()}
-		</button>
+		<div className="date-picker-col">
+			<button
+				aria-label={formatDate(
+					setDate(date, {
+						hours: 12,
+						milliseconds: 0,
+						minutes: 0,
+						seconds: 0,
+					}),
+					'yyyy MM dd'
+				)}
+				className={classNames}
+				disabled={outside}
+				onClick={() => onClick(date)}
+				onKeyDown={(event) => {
+					// When tabbing and selecting a DayNumber using
+					// SPACE key the active state it's not being removed.
+					// See https://github.com/liferay/clay/issues/3374 for more details.
+					if (event.key === Keys.Spacebar) {
+						event.preventDefault();
+					}
+				}}
+				onKeyUp={(event) => {
+					if (event.key === Keys.Spacebar) {
+						onClick(date);
+					}
+				}}
+				type="button"
+			>
+				{date.getDate()}
+			</button>
+		</div>
 	);
 };
 

--- a/packages/clay-date-picker/src/Weekday.tsx
+++ b/packages/clay-date-picker/src/Weekday.tsx
@@ -10,8 +10,10 @@ interface IProps {
 }
 
 const ClayDatePickerWeekday: React.FunctionComponent<IProps> = ({weekday}) => (
-	<div className="date-picker-calendar-item date-picker-day">
-		<abbr>{weekday}</abbr>
+	<div className="date-picker-col">
+		<div className="date-picker-calendar-item date-picker-day">
+			<abbr>{weekday}</abbr>
+		</div>
 	</div>
 );
 

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -202,324 +202,492 @@ exports[`BasicRendering renders by default 1`] = `
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -731,324 +899,492 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1290,324 +1626,492 @@ exports[`BasicRendering renders date picker with time 1`] = `
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
           <div
@@ -2096,324 +2600,492 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -203,323 +203,491 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 06 30"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 07 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 06 30"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 07 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 07 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 07 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 07 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 07 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 07 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 07 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 07 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 07 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 07 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 07 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 07 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 07 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 07 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 07 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 07 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 07 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 07 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 07 18"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 07 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 18"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 07 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 07 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 07 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 07 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 07 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 07 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 07 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 07 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 07 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 07 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 07 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 07 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 07 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 07 31"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 07 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 08 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 07 31"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 08 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 08 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 08 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 08 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
+                <button
+                  aria-label="2019 08 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -732,324 +900,492 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1262,324 +1598,492 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1807,324 +2311,492 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2018 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2018 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2018 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2018 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2018 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2018 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
-              <button
-                aria-label="2018 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
+                <button
+                  aria-label="2018 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2018 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2018 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2018 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2018 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2018 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2018 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
-              <button
-                aria-label="2018 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
+                <button
+                  aria-label="2018 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2018 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2018 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2018 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2018 04 18"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2018 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 18"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2018 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
-              <button
-                aria-label="2018 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
+                <button
+                  aria-label="2018 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2018 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2018 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2018 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2018 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2018 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2018 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
-              <button
-                aria-label="2018 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
+                <button
+                  aria-label="2018 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2018 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2018 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2018 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2018 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2018 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2018 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2018 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2018 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2018 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2018 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2018 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2018 05 05"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2018 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
+                <button
+                  aria-label="2018 05 05"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -2342,324 +3014,492 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -2872,324 +3712,492 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -203,324 +203,492 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 29"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 03 30"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 29"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 30"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -733,324 +901,492 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1263,324 +1599,492 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 30"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 30"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1793,324 +2297,492 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -2323,324 +2995,492 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 28"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 03 29"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 28"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 03 30"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 29"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 30"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -2853,384 +3693,580 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 26"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 03 27"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 26"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
-              <button
-                aria-label="2019 03 28"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 27"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 03 29"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 28"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 03 30"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 29"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 30"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 05 05"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 05 06"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 05"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
+                <button
+                  aria-label="2019 05 06"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -3443,324 +4479,492 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  W
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    W
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  F
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    F
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  S
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    S
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  M
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    M
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  T
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    T
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 03 27"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
-              <button
-                aria-label="2019 03 28"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 27"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 03 29"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 28"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 03 30"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 29"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 03 31"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 03 30"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                31
-              </button>
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 03 31"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  31
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -4108,324 +5312,492 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               class="date-picker-days-row date-picker-row"
             >
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  Пн
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    Пн
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  Вт
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    Вт
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  Ср
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    Ср
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  Чт
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    Чт
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  Пт
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    Пт
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  Сб
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    Сб
+                  </abbr>
+                </div>
               </div>
               <div
-                class="date-picker-calendar-item date-picker-day"
+                class="date-picker-col"
               >
-                <abbr>
-                  Вс
-                </abbr>
+                <div
+                  class="date-picker-calendar-item date-picker-day"
+                >
+                  <abbr>
+                    Вс
+                  </abbr>
+                </div>
               </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 01"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 04 02"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 01"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 04 03"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 02"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 04 04"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 03"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 04 05"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 04"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
-              <button
-                aria-label="2019 04 06"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 05"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                6
-              </button>
-              <button
-                aria-label="2019 04 07"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 06"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  6
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                7
-              </button>
+                <button
+                  aria-label="2019 04 07"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  7
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 08"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                8
-              </button>
-              <button
-                aria-label="2019 04 09"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 08"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  8
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                9
-              </button>
-              <button
-                aria-label="2019 04 10"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 09"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  9
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                10
-              </button>
-              <button
-                aria-label="2019 04 11"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 10"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  10
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                11
-              </button>
-              <button
-                aria-label="2019 04 12"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 11"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  11
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                12
-              </button>
-              <button
-                aria-label="2019 04 13"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 12"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  12
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                13
-              </button>
-              <button
-                aria-label="2019 04 14"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 13"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  13
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                14
-              </button>
+                <button
+                  aria-label="2019 04 14"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  14
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 15"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                15
-              </button>
-              <button
-                aria-label="2019 04 16"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 15"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  15
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                16
-              </button>
-              <button
-                aria-label="2019 04 17"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 16"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  16
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                17
-              </button>
-              <button
-                aria-label="2019 04 18"
-                class="date-picker-date date-picker-calendar-item active"
-                type="button"
+                <button
+                  aria-label="2019 04 17"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  17
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                18
-              </button>
-              <button
-                aria-label="2019 04 19"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 18"
+                  class="date-picker-date date-picker-calendar-item active"
+                  type="button"
+                >
+                  18
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                19
-              </button>
-              <button
-                aria-label="2019 04 20"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 19"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  19
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                20
-              </button>
-              <button
-                aria-label="2019 04 21"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 20"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  20
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                21
-              </button>
+                <button
+                  aria-label="2019 04 21"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  21
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 22"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                22
-              </button>
-              <button
-                aria-label="2019 04 23"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 22"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  22
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                23
-              </button>
-              <button
-                aria-label="2019 04 24"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 23"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  23
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                24
-              </button>
-              <button
-                aria-label="2019 04 25"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 24"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  24
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                25
-              </button>
-              <button
-                aria-label="2019 04 26"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 25"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  25
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                26
-              </button>
-              <button
-                aria-label="2019 04 27"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 26"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  26
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                27
-              </button>
-              <button
-                aria-label="2019 04 28"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 27"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  27
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                28
-              </button>
+                <button
+                  aria-label="2019 04 28"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  28
+                </button>
+              </div>
             </div>
             <div
               class="date-picker-date-row date-picker-row"
             >
-              <button
-                aria-label="2019 04 29"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+              <div
+                class="date-picker-col"
               >
-                29
-              </button>
-              <button
-                aria-label="2019 04 30"
-                class="date-picker-date date-picker-calendar-item"
-                type="button"
+                <button
+                  aria-label="2019 04 29"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  29
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                30
-              </button>
-              <button
-                aria-label="2019 05 01"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 04 30"
+                  class="date-picker-date date-picker-calendar-item"
+                  type="button"
+                >
+                  30
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                1
-              </button>
-              <button
-                aria-label="2019 05 02"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 01"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  1
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                2
-              </button>
-              <button
-                aria-label="2019 05 03"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 02"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  2
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                3
-              </button>
-              <button
-                aria-label="2019 05 04"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 03"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  3
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                4
-              </button>
-              <button
-                aria-label="2019 05 05"
-                class="date-picker-date date-picker-calendar-item disabled"
-                disabled=""
-                type="button"
+                <button
+                  aria-label="2019 05 04"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  4
+                </button>
+              </div>
+              <div
+                class="date-picker-col"
               >
-                5
-              </button>
+                <button
+                  aria-label="2019 05 05"
+                  class="date-picker-date date-picker-calendar-item disabled"
+                  disabled=""
+                  type="button"
+                >
+                  5
+                </button>
+              </div>
             </div>
           </div>
           <div


### PR DESCRIPTION
TODO: Still need to write documentation for this.

Had to wrap days and dates in `<div class="date-picker-col">` to achieve Lexicon's Date Range pattern. I tried to keep the markup as is, but it was too messy. Good news is the old markup will still work, just no styles for Date Range. We still need to implement the JS for this.

![date-range](https://user-images.githubusercontent.com/788266/111576937-ab002d80-876e-11eb-840d-d4615841827e.jpg)

fixes #3986