### PR TITLE
docs(clayui.com): ClayButton adds example of Base Button

### DIFF
--- a/packages/clay-button/docs/index.js
+++ b/packages/clay-button/docs/index.js
@@ -19,6 +19,9 @@ const ButtonDisplayTypesCode = `const Component = () => {
 			<ClayButton displayType="secondary">
 				Button Secondary
 			</ClayButton>
+			<ClayButton displayType={null}>
+				Base Button
+			</ClayButton>
 			<ClayButton displayType="link">
 				Button Link
 			</ClayButton>


### PR DESCRIPTION
![base-btn](https://user-images.githubusercontent.com/788266/111859191-483c9c80-88fc-11eb-889c-7aaddfb098b1.jpg)


fixes #3993