### PR TITLE
chore(release): publish v3.25.3 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.25.3](https://github.com/liferay/clay/compare/v3.25.2...v3.25.3) (2021-03-24)
+
+### Bug Fixes
+
+-   **@clayui/css:** Atlas Menubar (Vertical Navigation) link active state should be more visible ([5a94cfd](https://github.com/liferay/clay/commit/5a94cfd))
+-   **@clayui/css:** Menubar toggler with c-inner cuts off caret icon ([1932782](https://github.com/liferay/clay/commit/1932782))
+-   **@clayui/css:** Mixins `clay-link` adds option to style `&.show, &[aria-expanded='true']` separately from `active-class` so we can style panel toggles ([8a1a148](https://github.com/liferay/clay/commit/8a1a148))
+-   **@clayui/multi-select:** Use `btn-outline-secondary btn-outline-borderless` instead of `btn-unstyled` for Clear All Button ([3d71cf0](https://github.com/liferay/clay/commit/3d71cf0))
+
 ## [3.25.2](https://github.com/liferay/clay/compare/v3.25.1...v3.25.2) (2021-03-10)
 
 ### Bug Fixes

--- a/clayui.com/CHANGELOG.md
+++ b/clayui.com/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.25.3](https://github.com/ambrinchaudhary/clay/compare/v3.25.2...v3.25.3) (2021-03-24)
+
+**Note:** Version bump only for package clayui.com
+
 ## [3.25.2](https://github.com/ambrinchaudhary/clay/compare/v3.25.1...v3.25.2) (2021-03-10)
 
 **Note:** Version bump only for package clayui.com

--- a/clayui.com/content/docs/css/content/menubar.md
+++ b/clayui.com/content/docs/css/content/menubar.md
@@ -1,0 +1,1232 @@
+---
+title: 'Menubar (Vertical Navigation)'
+description: 'An alternative navigation pattern that displays navigation items vertically.'
+order: 5
+---
+
+<div class="clay-site-alert alert alert-info">Check the <a href="https://liferay.design/lexicon" rel="noopener noreferrer" target="_blank">Lexicon</a> <a href="https://liferay.design/lexicon/core-components/navigation/vertical-nav/" rel="noopener noreferrer" target="_blank">Vertical Navigation Pattern</a> for a more in-depth look at the motivations and proper usage of this component.</div>
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Menubar Vertical Expand Md](#css-menubar-vertical-expand-md)
+    -   [Menubar Transparent](#css-menubar-vertical-expand-md-transparent)
+    -   [Menubar Decorated](#css-menubar-vertical-expand-md-decorated)
+-   [Menubar Vertical Expand Lg](#css-menubar-vertical-expand-lg)
+
+</div>
+</div>
+
+## Menubar Vertical Expand Md(#css-menubar-vertical-expand-md)
+
+A pattern for collapsing vertical navigations, collapses at 767px. For vertical navigations that don't collapse use <a href="../../../docs/components/nav/markup.html#css-nav-stacked">Nav Stacked</a>, <a href="../../../docs/components/nav/markup.html#css-nav-nested">Nav Nested</a>, or <a href="../../../docs/components/nav/markup.html#css-nav-nested-margins">Nav Nested Margins</a>.
+
+### Menubar Transparent(#css-menubar-vertical-expand-md-transparent)
+
+<nav class="menubar menubar-transparent menubar-vertical-expand-md">
+	<a aria-controls="menubarVerticalMdCollapse01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" href="#menubarVerticalMdCollapse01" role="button">
+		<span class="c-inner" tabindex="-1">
+			Details
+			<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+			</svg>
+		</span>
+	</a>
+	<div class="collapse menubar-collapse" id="menubarVerticalMdCollapse01">
+		<ul class="nav nav-nested-margins">
+			<li class="nav-item">
+				<a aria-controls="menubarVerticalMdNestedCollapse01" aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse01" role="button">
+					<span class="c-inner" tabindex="-1">
+						Basic Information
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse show" id="menubarVerticalMdNestedCollapse01">
+					<ul class="nav nav-stacked">
+						<li class="nav-item"><a class="active nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+						<li class="nav-item">
+							<a aria-controls="menubarVerticalMdNestedCollapse02" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse02" role="button">
+								<span class="c-inner" tabindex="-1">
+									Documents and Media
+									<span class="collapse-icon-closed">
+										<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#caret-right" />
+										</svg>
+									</span>
+									<span class="collapse-icon-open">
+										<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+										</svg>
+									</span>
+								</span>
+							</a>
+							<div class="collapse" id="menubarVerticalMdNestedCollapse02">
+								<ul class="nav nav-stacked">
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Documents and Media</span></a></li>
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
+								</ul>
+							</div>
+						</li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a aria-controls="menubarVerticalMdNestedCollapse03" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse03" role="button">
+					<span class="c-inner" tabindex="-1">
+						SEO
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalMdNestedCollapse03">
+					<ul class="nav nav-stacked">
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Sitemap</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Robots</span></a></li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a aria-controls="menubarVerticalMdNestedCollapse04" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse04" role="button">
+					<span class="c-inner" tabindex="-1">
+						Advanced
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalMdNestedCollapse04">
+					<ul class="nav nav-stacked">
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Default User Associations</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Staging</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Analytics</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Maps</span></a></li>
+					</ul>
+				</div>
+			</li>
+		</ul>
+	</div>
+</nav>
+
+```html
+<nav class="menubar menubar-transparent menubar-vertical-expand-md">
+	<a
+		aria-controls="menubarVerticalMdCollapse01"
+		aria-expanded="false"
+		class="menubar-toggler"
+		data-toggle="collapse"
+		href="#menubarVerticalMdCollapse01"
+		role="button"
+	>
+		<span class="c-inner" tabindex="-1">
+			Details
+			<svg
+				class="lexicon-icon lexicon-icon-caret-bottom"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+			</svg>
+		</span>
+	</a>
+	<div class="collapse menubar-collapse" id="menubarVerticalMdCollapse01">
+		<ul class="nav nav-nested-margins">
+			<li class="nav-item">
+				<a
+					aria-controls="menubarVerticalMdNestedCollapse01"
+					aria-expanded="true"
+					class="collapse-icon nav-link"
+					data-toggle="collapse"
+					href="#menubarVerticalMdNestedCollapse01"
+					role="button"
+				>
+					<span class="c-inner" tabindex="-1">
+						Basic Information
+						<span class="collapse-icon-closed">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-right"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-right"
+								/>
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-bottom"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-bottom"
+								/>
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div
+					class="collapse show"
+					id="menubarVerticalMdNestedCollapse01"
+				>
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="active nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Details</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Categorization</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a
+								aria-controls="menubarVerticalMdNestedCollapse02"
+								aria-expanded="false"
+								class="collapsed collapse-icon nav-link"
+								data-toggle="collapse"
+								href="#menubarVerticalMdNestedCollapse02"
+								role="button"
+							>
+								<span class="c-inner" tabindex="-1">
+									Documents and Media
+									<span class="collapse-icon-closed">
+										<svg
+											class="lexicon-icon lexicon-icon-caret-right"
+											focusable="false"
+											role="presentation"
+										>
+											<use
+												xlink:href="/images/icons/icons.svg#caret-right"
+											/>
+										</svg>
+									</span>
+									<span class="collapse-icon-open">
+										<svg
+											class="lexicon-icon lexicon-icon-caret-bottom"
+											focusable="false"
+											role="presentation"
+										>
+											<use
+												xlink:href="/images/icons/icons.svg#caret-bottom"
+											/>
+										</svg>
+									</span>
+								</span>
+							</a>
+							<div
+								class="collapse"
+								id="menubarVerticalMdNestedCollapse02"
+							>
+								<ul class="nav nav-stacked">
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Details</span
+											></a
+										>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Categorization</span
+											></a
+										>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Documents and Media</span
+											></a
+										>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Site Template</span
+											></a
+										>
+									</li>
+								</ul>
+							</div>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Site Template</span
+								></a
+							>
+						</li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a
+					aria-controls="menubarVerticalMdNestedCollapse03"
+					aria-expanded="false"
+					class="collapsed collapse-icon nav-link"
+					data-toggle="collapse"
+					href="#menubarVerticalMdNestedCollapse03"
+					role="button"
+				>
+					<span class="c-inner" tabindex="-1">
+						SEO
+						<span class="collapse-icon-closed">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-right"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-right"
+								/>
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-bottom"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-bottom"
+								/>
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalMdNestedCollapse03">
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Sitemap</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Robots</span
+								></a
+							>
+						</li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a
+					aria-controls="menubarVerticalMdNestedCollapse04"
+					aria-expanded="false"
+					class="collapsed collapse-icon nav-link"
+					data-toggle="collapse"
+					href="#menubarVerticalMdNestedCollapse04"
+					role="button"
+				>
+					<span class="c-inner" tabindex="-1">
+						Advanced
+						<span class="collapse-icon-closed">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-right"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-right"
+								/>
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-bottom"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-bottom"
+								/>
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalMdNestedCollapse04">
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Default User Associations</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Staging</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Analytics</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Maps</span
+								></a
+							>
+						</li>
+					</ul>
+				</div>
+			</li>
+		</ul>
+	</div>
+</nav>
+```
+
+### Menubar Decorated(#css-menubar-vertical-expand-md-decorated)
+
+<div class="clay-site-alert alert alert-warning">This variation uses `nav-nested` instead of `nav-nested-margins`.</div>
+
+<nav class="menubar menubar-decorated menubar-transparent menubar-vertical-expand-md">
+	<a aria-controls="menubarVerticalMdDecoratedCollapse01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" href="#menubarVerticalMdDecoratedCollapse01" role="button">
+		<span class="c-inner" tabindex="-1">
+			Details
+			<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+			</svg>
+		</span>
+	</a>
+	<div class="collapse menubar-collapse" id="menubarVerticalMdDecoratedCollapse01">
+		<ul class="nav nav-nested">
+			<li class="nav-item">
+				<a aria-controls="menubarVerticalMdDecoratedNestedCollapse01" aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdDecoratedNestedCollapse01" role="button">
+					<span class="c-inner" tabindex="-1">
+						Basic Information
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse show" id="menubarVerticalMdDecoratedNestedCollapse01">
+					<ul class="nav nav-stacked">
+						<li class="nav-item"><a class="active nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+						<li class="nav-item">
+							<a aria-controls="menubarVerticalMdDecoratedNestedCollapse02" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdDecoratedNestedCollapse02" role="button">
+								<span class="c-inner" tabindex="-1">
+									Documents and Media
+									<span class="collapse-icon-closed">
+										<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#caret-right" />
+										</svg>
+									</span>
+									<span class="collapse-icon-open">
+										<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+										</svg>
+									</span>
+								</span>
+							</a>
+							<div class="collapse" id="menubarVerticalMdDecoratedNestedCollapse02">
+								<ul class="nav nav-stacked">
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Documents and Media</span></a></li>
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
+								</ul>
+							</div>
+						</li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a aria-controls="menubarVerticalMdDecoratedNestedCollapse03" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdDecoratedNestedCollapse03" role="button">
+					<span class="c-inner" tabindex="-1">
+						SEO
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalMdDecoratedNestedCollapse03">
+					<ul class="nav nav-stacked">
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Sitemap</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Robots</span></a></li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a aria-controls="menubarVerticalMdDecoratedNestedCollapse04" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdDecoratedNestedCollapse04" role="button">
+					<span class="c-inner" tabindex="-1">
+						Advanced
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalMdDecoratedNestedCollapse04">
+					<ul class="nav nav-stacked">
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Default User Associations</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Staging</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Analytics</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Maps</span></a></li>
+					</ul>
+				</div>
+			</li>
+		</ul>
+	</div>
+</nav>
+
+```html
+<nav
+	class="menubar menubar-decorated menubar-transparent menubar-vertical-expand-md"
+>
+	<a
+		aria-controls="menubarVerticalMdDecoratedCollapse01"
+		aria-expanded="false"
+		class="menubar-toggler"
+		data-toggle="collapse"
+		href="#menubarVerticalMdDecoratedCollapse01"
+		role="button"
+	>
+		<span class="c-inner" tabindex="-1">
+			Details
+			<svg
+				class="lexicon-icon lexicon-icon-caret-bottom"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+			</svg>
+		</span>
+	</a>
+	<div
+		class="collapse menubar-collapse"
+		id="menubarVerticalMdDecoratedCollapse01"
+	>
+		<ul class="nav nav-nested">
+			<li class="nav-item">
+				<a
+					aria-controls="menubarVerticalMdDecoratedNestedCollapse01"
+					aria-expanded="true"
+					class="collapse-icon nav-link"
+					data-toggle="collapse"
+					href="#menubarVerticalMdDecoratedNestedCollapse01"
+					role="button"
+				>
+					<span class="c-inner" tabindex="-1">
+						Basic Information
+						<span class="collapse-icon-closed">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-right"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-right"
+								/>
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-bottom"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-bottom"
+								/>
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div
+					class="collapse show"
+					id="menubarVerticalMdDecoratedNestedCollapse01"
+				>
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="active nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Details</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Categorization</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a
+								aria-controls="menubarVerticalMdDecoratedNestedCollapse02"
+								aria-expanded="false"
+								class="collapsed collapse-icon nav-link"
+								data-toggle="collapse"
+								href="#menubarVerticalMdDecoratedNestedCollapse02"
+								role="button"
+							>
+								<span class="c-inner" tabindex="-1">
+									Documents and Media
+									<span class="collapse-icon-closed">
+										<svg
+											class="lexicon-icon lexicon-icon-caret-right"
+											focusable="false"
+											role="presentation"
+										>
+											<use
+												xlink:href="/images/icons/icons.svg#caret-right"
+											/>
+										</svg>
+									</span>
+									<span class="collapse-icon-open">
+										<svg
+											class="lexicon-icon lexicon-icon-caret-bottom"
+											focusable="false"
+											role="presentation"
+										>
+											<use
+												xlink:href="/images/icons/icons.svg#caret-bottom"
+											/>
+										</svg>
+									</span>
+								</span>
+							</a>
+							<div
+								class="collapse"
+								id="menubarVerticalMdDecoratedNestedCollapse02"
+							>
+								<ul class="nav nav-stacked">
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Details</span
+											></a
+										>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Categorization</span
+											></a
+										>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Documents and Media</span
+											></a
+										>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Site Template</span
+											></a
+										>
+									</li>
+								</ul>
+							</div>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Site Template</span
+								></a
+							>
+						</li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a
+					aria-controls="menubarVerticalMdDecoratedNestedCollapse03"
+					aria-expanded="false"
+					class="collapsed collapse-icon nav-link"
+					data-toggle="collapse"
+					href="#menubarVerticalMdDecoratedNestedCollapse03"
+					role="button"
+				>
+					<span class="c-inner" tabindex="-1">
+						SEO
+						<span class="collapse-icon-closed">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-right"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-right"
+								/>
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-bottom"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-bottom"
+								/>
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div
+					class="collapse"
+					id="menubarVerticalMdDecoratedNestedCollapse03"
+				>
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Sitemap</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Robots</span
+								></a
+							>
+						</li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a
+					aria-controls="menubarVerticalMdDecoratedNestedCollapse04"
+					aria-expanded="false"
+					class="collapsed collapse-icon nav-link"
+					data-toggle="collapse"
+					href="#menubarVerticalMdDecoratedNestedCollapse04"
+					role="button"
+				>
+					<span class="c-inner" tabindex="-1">
+						Advanced
+						<span class="collapse-icon-closed">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-right"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-right"
+								/>
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-bottom"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-bottom"
+								/>
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div
+					class="collapse"
+					id="menubarVerticalMdDecoratedNestedCollapse04"
+				>
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Default User Associations</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Staging</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Analytics</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Maps</span
+								></a
+							>
+						</li>
+					</ul>
+				</div>
+			</li>
+		</ul>
+	</div>
+</nav>
+```
+
+## Menubar Vertical Expand Lg(#css-menubar-vertical-expand-lg)
+
+<nav class="menubar menubar-transparent menubar-vertical-expand-lg">
+	<a aria-controls="menubarVerticalLgCollapse01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" href="#menubarVerticalLgCollapse01" role="button">
+		<span class="c-inner" tabindex="-1">
+			Details
+			<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+				<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+			</svg>
+		</span>
+	</a>
+	<div class="collapse menubar-collapse" id="menubarVerticalLgCollapse01">
+		<ul class="nav nav-nested-margins">
+			<li class="nav-item">
+				<a aria-controls="menubarVerticalLgNestedCollapse01" aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse01" role="button">
+					<span class="c-inner" tabindex="-1">
+						Basic Information
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse show" id="menubarVerticalLgNestedCollapse01">
+					<ul class="nav nav-stacked">
+						<li class="nav-item"><a class="active nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+						<li class="nav-item">
+							<a aria-controls="menubarVerticalLgNestedCollapse02" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse02" role="button">
+								<span class="c-inner" tabindex="-1">
+									Documents and Media
+									<span class="collapse-icon-closed">
+										<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#caret-right" />
+										</svg>
+									</span>
+									<span class="collapse-icon-open">
+										<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+										</svg>
+									</span>
+								</span>
+							</a>
+							<div class="collapse" id="menubarVerticalLgNestedCollapse02">
+								<ul class="nav nav-stacked">
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Documents and Media</span></a></li>
+									<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
+								</ul>
+							</div>
+						</li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a aria-controls="menubarVerticalLgNestedCollapse03" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse03" role="button">
+					<span class="c-inner" tabindex="-1">
+						SEO
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalLgNestedCollapse03">
+					<ul class="nav nav-stacked">
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Sitemap</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Robots</span></a></li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a aria-controls="menubarVerticalLgNestedCollapse04" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse04" role="button">
+					<span class="c-inner" tabindex="-1">
+						Advanced
+						<span class="collapse-icon-closed">
+							<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-right" />
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalLgNestedCollapse04">
+					<ul class="nav nav-stacked">
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Default User Associations</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Staging</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Analytics</span></a></li>
+						<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Maps</span></a></li>
+					</ul>
+				</div>
+			</li>
+		</ul>
+	</div>
+</nav>
+
+```html
+<nav class="menubar menubar-transparent menubar-vertical-expand-lg">
+	<a
+		aria-controls="menubarVerticalLgCollapse01"
+		aria-expanded="false"
+		class="menubar-toggler"
+		data-toggle="collapse"
+		href="#menubarVerticalLgCollapse01"
+		role="button"
+	>
+		<span class="c-inner" tabindex="-1">
+			Details
+			<svg
+				class="lexicon-icon lexicon-icon-caret-bottom"
+				focusable="false"
+				role="presentation"
+			>
+				<use xlink:href="/images/icons/icons.svg#caret-bottom" />
+			</svg>
+		</span>
+	</a>
+	<div class="collapse menubar-collapse" id="menubarVerticalLgCollapse01">
+		<ul class="nav nav-nested-margins">
+			<li class="nav-item">
+				<a
+					aria-controls="menubarVerticalLgNestedCollapse01"
+					aria-expanded="true"
+					class="collapse-icon nav-link"
+					data-toggle="collapse"
+					href="#menubarVerticalLgNestedCollapse01"
+					role="button"
+				>
+					<span class="c-inner" tabindex="-1">
+						Basic Information
+						<span class="collapse-icon-closed">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-right"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-right"
+								/>
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-bottom"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-bottom"
+								/>
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div
+					class="collapse show"
+					id="menubarVerticalLgNestedCollapse01"
+				>
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="active nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Details</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Categorization</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a
+								aria-controls="menubarVerticalLgNestedCollapse02"
+								aria-expanded="false"
+								class="collapsed collapse-icon nav-link"
+								data-toggle="collapse"
+								href="#menubarVerticalLgNestedCollapse02"
+								role="button"
+							>
+								<span class="c-inner" tabindex="-1">
+									Documents and Media
+									<span class="collapse-icon-closed">
+										<svg
+											class="lexicon-icon lexicon-icon-caret-right"
+											focusable="false"
+											role="presentation"
+										>
+											<use
+												xlink:href="/images/icons/icons.svg#caret-right"
+											/>
+										</svg>
+									</span>
+									<span class="collapse-icon-open">
+										<svg
+											class="lexicon-icon lexicon-icon-caret-bottom"
+											focusable="false"
+											role="presentation"
+										>
+											<use
+												xlink:href="/images/icons/icons.svg#caret-bottom"
+											/>
+										</svg>
+									</span>
+								</span>
+							</a>
+							<div
+								class="collapse"
+								id="menubarVerticalLgNestedCollapse02"
+							>
+								<ul class="nav nav-stacked">
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Details</span
+											></a
+										>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Categorization</span
+											></a
+										>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Documents and Media</span
+											></a
+										>
+									</li>
+									<li class="nav-item">
+										<a class="nav-link" href="#1"
+											><span class="c-inner" tabindex="-1"
+												>Site Template</span
+											></a
+										>
+									</li>
+								</ul>
+							</div>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Site Template</span
+								></a
+							>
+						</li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a
+					aria-controls="menubarVerticalLgNestedCollapse03"
+					aria-expanded="false"
+					class="collapsed collapse-icon nav-link"
+					data-toggle="collapse"
+					href="#menubarVerticalLgNestedCollapse03"
+					role="button"
+				>
+					<span class="c-inner" tabindex="-1">
+						SEO
+						<span class="collapse-icon-closed">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-right"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-right"
+								/>
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-bottom"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-bottom"
+								/>
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalLgNestedCollapse03">
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Sitemap</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Robots</span
+								></a
+							>
+						</li>
+					</ul>
+				</div>
+			</li>
+			<li class="nav-item">
+				<a
+					aria-controls="menubarVerticalLgNestedCollapse04"
+					aria-expanded="false"
+					class="collapsed collapse-icon nav-link"
+					data-toggle="collapse"
+					href="#menubarVerticalLgNestedCollapse04"
+					role="button"
+				>
+					<span class="c-inner" tabindex="-1">
+						Advanced
+						<span class="collapse-icon-closed">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-right"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-right"
+								/>
+							</svg>
+						</span>
+						<span class="collapse-icon-open">
+							<svg
+								class="lexicon-icon lexicon-icon-caret-bottom"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#caret-bottom"
+								/>
+							</svg>
+						</span>
+					</span>
+				</a>
+				<div class="collapse" id="menubarVerticalLgNestedCollapse04">
+					<ul class="nav nav-stacked">
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Default User Associations</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Staging</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Analytics</span
+								></a
+							>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" href="#1"
+								><span class="c-inner" tabindex="-1"
+									>Maps</span
+								></a
+							>
+						</li>
+					</ul>
+				</div>
+			</li>
+		</ul>
+	</div>
+</nav>
+```

--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "clayui.com",
-	"version": "3.25.2",
+	"version": "3.25.3",
 	"license": "MIT",
 	"scripts": {
 		"copy:clay-css": "yarn copy:clay-css-js && yarn copy:clay-css-site-images && yarn copy:clay-css-images",
@@ -19,7 +19,7 @@
 		"@clayui/card": "^3.25.1",
 		"@clayui/charts": "^3.25.1",
 		"@clayui/color-picker": "^3.25.1",
-		"@clayui/css": "^3.25.2",
+		"@clayui/css": "^3.25.3",
 		"@clayui/data-provider": "^3.3.10",
 		"@clayui/date-picker": "^3.25.1",
 		"@clayui/drop-down": "^3.25.1",
@@ -30,7 +30,7 @@
 		"@clayui/link": "^3.2.0",
 		"@clayui/list": "^3.25.1",
 		"@clayui/modal": "^3.8.5",
-		"@clayui/multi-select": "^3.25.1",
+		"@clayui/multi-select": "^3.25.3",
 		"@clayui/multi-step-nav": "^3.25.1",
 		"@clayui/nav": "^3.4.5",
 		"@clayui/navigation-bar": "^3.3.5",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"lerna": "3.4.0",
-	"version": "3.25.2",
+	"version": "3.25.3",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/packages/clay-button/docs/index.js
+++ b/packages/clay-button/docs/index.js
@@ -19,6 +19,9 @@ const ButtonDisplayTypesCode = `const Component = () => {
 			<ClayButton displayType="secondary">
 				Button Secondary
 			</ClayButton>
+			<ClayButton displayType={null}>
+				Base Button
+			</ClayButton>
 			<ClayButton displayType="link">
 				Button Link
 			</ClayButton>

--- a/packages/clay-css/CHANGELOG.md
+++ b/packages/clay-css/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.25.3](https://github.com/liferay/clay/tree/master/packages/clay-css/compare/v3.25.2...v3.25.3) (2021-03-24)
+
+
+### Bug Fixes
+
+* **@clayui/css:** Atlas Menubar (Vertical Navigation) link active state should be more visible ([5a94cfd](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/5a94cfd))
+* **@clayui/css:** Menubar toggler with c-inner cuts off caret icon ([1932782](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/1932782))
+* **@clayui/css:** Mixins `clay-link` adds option to style `&.show, &[aria-expanded='true']` separately from `active-class` so we can style panel toggles ([8a1a148](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/8a1a148))
+
+
+
+
+
 ## [3.25.2](https://github.com/liferay/clay/tree/master/packages/clay-css/compare/v3.25.1...v3.25.2) (2021-03-10)
 
 

--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/css",
-	"version": "3.25.2",
+	"version": "3.25.3",
 	"description": "Liferay's web implementation of the Lexicon Design Language",
 	"main": "index.js",
 	"files": [

--- a/packages/clay-css/src/content/menu-bar-vertical-decorated.html
+++ b/packages/clay-css/src/content/menu-bar-vertical-decorated.html
@@ -15,99 +15,109 @@ section: Components
 	<div class="col-md-6">
 		<nav class="menubar menubar-decorated menubar-transparent menubar-vertical-expand-md">
 			<a aria-controls="menubarVerticalMdCollapse01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" href="#menubarVerticalMdCollapse01" role="button">
-				Details
-				<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-				</svg>
+				<span class="c-inner" tabindex="-1">
+					Details
+					<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+					</svg>
+				</span>
 			</a>
 			<div class="collapse menubar-collapse" id="menubarVerticalMdCollapse01">
 				<ul class="nav nav-nested">
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalMdNestedCollapse01" aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse01" role="button">
-							Basic Information
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Basic Information
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse show" id="menubarVerticalMdNestedCollapse01">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="active nav-link" href="#1">Details</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
+								<li class="nav-item"><a class="active nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
 								<li class="nav-item">
 									<a aria-controls="menubarVerticalMdNestedCollapse02" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse02" role="button">
-										Documents and Media
-										<span class="collapse-icon-closed">
-											<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-											</svg>
-										</span>
-										<span class="collapse-icon-open">
-											<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-											</svg>
+										<span class="c-inner" tabindex="-1">
+											Documents and Media
+											<span class="collapse-icon-closed">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+											<span class="collapse-icon-open">
+												<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+												</svg>
+											</span>
 										</span>
 									</a>
 									<div class="collapse" id="menubarVerticalMdNestedCollapse02">
 										<ul class="nav nav-stacked">
-											<li class="nav-item"><a class="nav-link" href="#1">Details</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Documents and Media</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Documents and Media</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 										</ul>
 									</div>
 								</li>
-								<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalMdNestedCollapse03" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse03" role="button">
-							SEO
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								SEO
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse" id="menubarVerticalMdNestedCollapse03">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Sitemap</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Robots</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Sitemap</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Robots</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalMdNestedCollapse04" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse04" role="button">
-							Advanced
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Advanced
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse" id="menubarVerticalMdNestedCollapse04">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Default User Associations</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Staging</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Analytics</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Maps</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Default User Associations</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Staging</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Analytics</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Maps</span></a></li>
 							</ul>
 						</div>
 					</li>
@@ -126,99 +136,109 @@ section: Components
 	<div class="col-md-6">
 		<nav class="menubar menubar-decorated menubar-transparent menubar-vertical-expand-md">
 			<button aria-controls="menubarVerticalMdCollapseButton01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" data-target="#menubarVerticalMdCollapseButton01" role="button">
-				Details
-				<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-				</svg>
+				<span class="c-inner" tabindex="-1">
+					Details
+					<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+					</svg>
+				<span class="c-inner" tabindex="-1">
 			</button>
 			<div class="collapse menubar-collapse" id="menubarVerticalMdCollapseButton01">
 				<ul class="nav nav-nested">
 					<li class="nav-item">
 						<button aria-controls="menubarVerticalMdNestedCollapseButton01" aria-expanded="true" class="btn btn-unstyled collapse-icon nav-link" data-toggle="collapse" data-target="#menubarVerticalMdNestedCollapseButton01" type="button">
-							Basic Information
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Basic Information
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</button>
 						<div class="collapse show" id="menubarVerticalMdNestedCollapseButton01">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="active nav-link" href="#1">Details</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
+								<li class="nav-item"><a class="active nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
 								<li class="nav-item">
 									<button aria-controls="menubarVerticalMdNestedCollapseButton02" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#menubarVerticalMdNestedCollapseButton02" type="button">
-										Documents and Media
-										<span class="collapse-icon-closed">
-											<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-											</svg>
-										</span>
-										<span class="collapse-icon-open">
-											<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-											</svg>
+										<span class="c-inner" tabindex="-1">
+											Documents and Media
+											<span class="collapse-icon-closed">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+											<span class="collapse-icon-open">
+												<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+												</svg>
+											</span>
 										</span>
 									</button>
 									<div class="collapse" id="menubarVerticalMdNestedCollapseButton02">
 										<ul class="nav nav-stacked">
-											<li class="nav-item"><a class="nav-link" href="#1">Details</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Documents and Media</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Documents and Media</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 										</ul>
 									</div>
 								</li>
-								<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<button aria-controls="menubarVerticalMdNestedCollapseButton03" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#menubarVerticalMdNestedCollapseButton03" type="button">
-							SEO
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								SEO
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</button>
 						<div class="collapse" id="menubarVerticalMdNestedCollapseButton03">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Sitemap</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Robots</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Sitemap</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Robots</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<button aria-controls="menubarVerticalMdNestedCollapseButton04" aria-expanded="false" class="btn btn-unstyled collapsed collapse-icon nav-link" data-toggle="collapse" data-target="#menubarVerticalMdNestedCollapseButton04" type="button">
-							Advanced
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Advanced
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</button>
 						<div class="collapse" id="menubarVerticalMdNestedCollapseButton04">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Default User Associations</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Staging</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Analytics</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Maps</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Default User Associations</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Staging</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Analytics</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Maps</span></a></li>
 							</ul>
 						</div>
 					</li>
@@ -241,99 +261,109 @@ section: Components
 	<div class="col-lg-6">
 		<nav class="menubar menubar-decorated menubar-transparent menubar-vertical-expand-lg">
 			<a aria-controls="menubarVerticalLgCollapse01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" href="#menubarVerticalLgCollapse01" role="button">
-				Details
-				<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-				</svg>
+				<span class="c-inner" tabindex="-1">
+					Details
+					<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+					</svg>
+				</span>
 			</a>
 			<div class="collapse menubar-collapse" id="menubarVerticalLgCollapse01">
 				<ul class="nav nav-nested">
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalLgNestedCollapse01" aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse01" role="button">
-							Basic Information
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Basic Information
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse show" id="menubarVerticalLgNestedCollapse01">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="active nav-link" href="#1">Details</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
+								<li class="nav-item"><a class="active nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
 								<li class="nav-item">
 									<a aria-controls="menubarVerticalLgNestedCollapse02" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse02" role="button">
-										Documents and Media
-										<span class="collapse-icon-closed">
-											<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-											</svg>
-										</span>
-										<span class="collapse-icon-open">
-											<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-											</svg>
+										<span class="c-inner" tabindex="-1">
+											Documents and Media
+											<span class="collapse-icon-closed">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+											<span class="collapse-icon-open">
+												<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+												</svg>
+											</span>
 										</span>
 									</a>
 									<div class="collapse" id="menubarVerticalLgNestedCollapse02">
 										<ul class="nav nav-stacked">
-											<li class="nav-item"><a class="nav-link" href="#1">Details</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Documents and Media</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Documents and Media</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 										</ul>
 									</div>
 								</li>
-								<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalLgNestedCollapse03" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse03" role="button">
-							SEO
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								SEO
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse" id="menubarVerticalLgNestedCollapse03">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Sitemap</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Robots</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Sitemap</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Robots</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalLgNestedCollapse04" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse04" role="button">
-							Advanced
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Advanced
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse" id="menubarVerticalLgNestedCollapse04">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Default User Associations</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Staging</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Analytics</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Maps</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Default User Associations</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Staging</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Analytics</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Maps</span></a></li>
 							</ul>
 						</div>
 					</li>

--- a/packages/clay-css/src/content/menu_bar_vertical.html
+++ b/packages/clay-css/src/content/menu_bar_vertical.html
@@ -15,99 +15,109 @@ section: Components
 	<div class="col-md-6">
 		<nav class="menubar menubar-transparent menubar-vertical-expand-md">
 			<a aria-controls="menubarVerticalMdCollapse01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" href="#menubarVerticalMdCollapse01" role="button">
-				Details
-				<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-				</svg>
+				<span class="c-inner" tabindex="-1">
+					Details
+					<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+					</svg>
+				</span>
 			</a>
 			<div class="collapse menubar-collapse" id="menubarVerticalMdCollapse01">
-				<ul class="nav nav-nested">
+				<ul class="nav nav-nested-margins">
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalMdNestedCollapse01" aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse01" role="button">
-							Basic Information
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Basic Information
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse show" id="menubarVerticalMdNestedCollapse01">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="active nav-link" href="#1">Details</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
+								<li class="nav-item"><a class="active nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
 								<li class="nav-item">
 									<a aria-controls="menubarVerticalMdNestedCollapse02" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse02" role="button">
-										Documents and Media
-										<span class="collapse-icon-closed">
-											<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-											</svg>
-										</span>
-										<span class="collapse-icon-open">
-											<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-											</svg>
+										<span class="c-inner" tabindex="-1">
+											Documents and Media
+											<span class="collapse-icon-closed">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+											<span class="collapse-icon-open">
+												<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+												</svg>
+											</span>
 										</span>
 									</a>
 									<div class="collapse" id="menubarVerticalMdNestedCollapse02">
 										<ul class="nav nav-stacked">
-											<li class="nav-item"><a class="nav-link" href="#1">Details</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Documents and Media</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Documents and Media</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 										</ul>
 									</div>
 								</li>
-								<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalMdNestedCollapse03" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse03" role="button">
-							SEO
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								SEO
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse" id="menubarVerticalMdNestedCollapse03">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Sitemap</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Robots</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Sitemap</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Robots</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalMdNestedCollapse04" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalMdNestedCollapse04" role="button">
-							Advanced
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Advanced
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse" id="menubarVerticalMdNestedCollapse04">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Default User Associations</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Staging</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Analytics</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Maps</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Default User Associations</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Staging</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Analytics</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Maps</span></a></li>
 							</ul>
 						</div>
 					</li>
@@ -132,7 +142,7 @@ section: Components
 				</svg>
 			</button>
 			<div class="collapse menubar-collapse" id="menubarVerticalMdCollapseButton01">
-				<ul class="nav nav-nested">
+				<ul class="nav nav-nested-margins">
 					<li class="nav-item">
 						<button aria-controls="menubarVerticalMdNestedCollapseButton01" aria-expanded="true" class="btn btn-unstyled collapse-icon nav-link" data-toggle="collapse" data-target="#menubarVerticalMdNestedCollapseButton01" type="button">
 							Basic Information
@@ -241,99 +251,109 @@ section: Components
 	<div class="col-lg-6">
 		<nav class="menubar menubar-transparent menubar-vertical-expand-lg">
 			<a aria-controls="menubarVerticalLgCollapse01" aria-expanded="false" class="menubar-toggler" data-toggle="collapse" href="#menubarVerticalLgCollapse01" role="button">
-				Details
-				<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-					<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-				</svg>
+				<span class="c-inner" tabindex="-1">
+					Details
+					<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+					</svg>
+				</span>
 			</a>
 			<div class="collapse menubar-collapse" id="menubarVerticalLgCollapse01">
-				<ul class="nav nav-nested">
+				<ul class="nav nav-nested-margins">
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalLgNestedCollapse01" aria-expanded="true" class="collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse01" role="button">
-							Basic Information
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Basic Information
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse show" id="menubarVerticalLgNestedCollapse01">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="active nav-link" href="#1">Details</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
+								<li class="nav-item"><a class="active nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
 								<li class="nav-item">
 									<a aria-controls="menubarVerticalLgNestedCollapse02" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse02" role="button">
-										Documents and Media
-										<span class="collapse-icon-closed">
-											<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-											</svg>
-										</span>
-										<span class="collapse-icon-open">
-											<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-											</svg>
+										<span class="c-inner" tabindex="-1">
+											Documents and Media
+											<span class="collapse-icon-closed">
+												<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+												</svg>
+											</span>
+											<span class="collapse-icon-open">
+												<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+												</svg>
+											</span>
 										</span>
 									</a>
 									<div class="collapse" id="menubarVerticalLgNestedCollapse02">
 										<ul class="nav nav-stacked">
-											<li class="nav-item"><a class="nav-link" href="#1">Details</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Categorization</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Documents and Media</a></li>
-											<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Details</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Categorization</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Documents and Media</span></a></li>
+											<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 										</ul>
 									</div>
 								</li>
-								<li class="nav-item"><a class="nav-link" href="#1">Site Template</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Site Template</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalLgNestedCollapse03" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse03" role="button">
-							SEO
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								SEO
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse" id="menubarVerticalLgNestedCollapse03">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Sitemap</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Robots</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Sitemap</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Robots</span></a></li>
 							</ul>
 						</div>
 					</li>
 					<li class="nav-item">
 						<a aria-controls="menubarVerticalLgNestedCollapse04" aria-expanded="false" class="collapsed collapse-icon nav-link" data-toggle="collapse" href="#menubarVerticalLgNestedCollapse04" role="button">
-							Advanced
-							<span class="collapse-icon-closed">
-								<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
-								</svg>
-							</span>
-							<span class="collapse-icon-open">
-								<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
-									<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
-								</svg>
+							<span class="c-inner" tabindex="-1">
+								Advanced
+								<span class="collapse-icon-closed">
+									<svg class="lexicon-icon lexicon-icon-caret-right" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-right" />
+									</svg>
+								</span>
+								<span class="collapse-icon-open">
+									<svg class="lexicon-icon lexicon-icon-caret-bottom" focusable="false" role="presentation">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-bottom" />
+									</svg>
+								</span>
 							</span>
 						</a>
 						<div class="collapse" id="menubarVerticalLgNestedCollapse04">
 							<ul class="nav nav-stacked">
-								<li class="nav-item"><a class="nav-link" href="#1">Default User Associations</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Staging</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Analytics</a></li>
-								<li class="nav-item"><a class="nav-link" href="#1">Maps</a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Default User Associations</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Staging</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Analytics</span></a></li>
+								<li class="nav-item"><a class="nav-link" href="#1"><span class="c-inner" tabindex="-1">Maps</span></a></li>
 							</ul>
 						</div>
 					</li>

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.25.2
+ * Clay 3.25.3
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>

--- a/packages/clay-css/src/scss/atlas/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_menubar.scss
@@ -15,7 +15,16 @@ $menubar-vertical-transparent-md: map-deep-merge(
 			focus-color: $gray-900,
 			focus-box-shadow: map-get($dropdown-item-base, focus-box-shadow),
 			focus-outline: map-get($dropdown-item-base, focus-outline),
+			active-class: (
+				background-color: $primary-l3,
+				color: $primary,
+			),
 			disabled-box-shadow: none,
+			show: (
+				background-color: $c-unset,
+				color: $gray-900,
+				font-weight: $font-weight-semi-bold,
+			),
 		),
 		link-mobile: (
 			transition: none,
@@ -53,7 +62,16 @@ $menubar-vertical-transparent-lg: map-deep-merge(
 			focus-color: $gray-900,
 			focus-box-shadow: map-get($dropdown-item-base, focus-box-shadow),
 			focus-outline: map-get($dropdown-item-base, focus-outline),
+			active-class: (
+				background-color: $primary-l3,
+				color: $primary,
+			),
 			disabled-box-shadow: none,
+			show: (
+				background-color: $c-unset,
+				color: $gray-900,
+				font-weight: $font-weight-semi-bold,
+			),
 		),
 		link-mobile: (
 			transition: none,

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -268,6 +268,9 @@
 		)
 	);
 
+	$show: setter(map-get($map, show), ());
+	$show: map-merge($active-class, $show);
+
 	$btn-focus: setter(map-get($map, btn-focus), ());
 	$btn-focus: map-merge(
 		$btn-focus,
@@ -351,11 +354,14 @@
 			@include clay-css($active);
 		}
 
-		&[aria-expanded='true'],
-		&.show,
-		.show > &,
 		&.active {
 			@include clay-css($active-class);
+		}
+
+		&[aria-expanded='true'],
+		&.show,
+		.show > & {
+			@include clay-css($show);
 		}
 
 		&:disabled,

--- a/packages/clay-css/src/scss/mixins/_menubar.scss
+++ b/packages/clay-css/src/scss/mixins/_menubar.scss
@@ -103,6 +103,16 @@
 	); // -1px
 	$collapse-z-index-mobile: map-get($map, collapse-z-index-mobile);
 
+	$nav-nested-margins-item: setter(
+		map-get($map, nav-nested-margins-item),
+		()
+	);
+
+	$nav-nested-margins-item-mobile: setter(
+		map-get($map, nav-nested-margins-item-mobile),
+		()
+	);
+
 	// .menubar-toggler
 
 	$toggler-border-color-mobile: setter(
@@ -213,6 +223,16 @@
 
 				.lexicon-icon {
 					margin-top: 0;
+				}
+			}
+		}
+
+		.nav-nested-margins {
+			> li .nav > li {
+				@include clay-css($nav-nested-margins-item);
+
+				@include media-breakpoint-down($breakpoint-down) {
+					@include clay-css($nav-nested-margins-item-mobile);
 				}
 			}
 		}
@@ -441,6 +461,16 @@
 		$dropdown-box-shadow
 	);
 
+	$nav-nested-margins-item: setter(
+		map-get($map, nav-nested-margins-item),
+		()
+	);
+
+	$nav-nested-margins-item-mobile: setter(
+		map-get($map, nav-nested-margins-item-mobile),
+		()
+	);
+
 	// .menubar-toggler
 
 	// `$toggler-border-color-mobile` is deprecated use `$toggler-mobile` instead
@@ -495,6 +525,16 @@
 	.menubar-toggler {
 		@include media-breakpoint-down($breakpoint-down) {
 			@include clay-button-variant($toggler-mobile);
+		}
+	}
+
+	.nav-nested-margins {
+		> li .nav > li {
+			@include clay-css($nav-nested-margins-item);
+
+			@include media-breakpoint-down($breakpoint-down) {
+				@include clay-css($nav-nested-margins-item-mobile);
+			}
 		}
 	}
 

--- a/packages/clay-css/src/scss/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/variables/_menubar.scss
@@ -14,6 +14,12 @@ $menubar-vertical-expand-md: map-deep-merge(
 			),
 		collapse-z-index-mobile:
 			$zindex-menubar-vertical-expand-md-collapse-mobile,
+		nav-nested-margins-item-mobile: (
+			margin-left: 0,
+		),
+		toggler-c-inner: (
+			max-width: none,
+		),
 	),
 	$menubar-vertical-expand-md
 );
@@ -93,6 +99,12 @@ $menubar-vertical-expand-lg: map-deep-merge(
 			),
 		collapse-z-index-mobile:
 			$zindex-menubar-vertical-expand-lg-collapse-mobile,
+		nav-nested-margins-item-mobile: (
+			margin-left: 0,
+		),
+		toggler-c-inner: (
+			max-width: none,
+		),
 	),
 	$menubar-vertical-expand-lg
 );

--- a/packages/clay-multi-select/CHANGELOG.md
+++ b/packages/clay-multi-select/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.25.3](https://github.com/liferay/clay/compare/v3.25.2...v3.25.3) (2021-03-24)
+
+### Bug Fixes
+
+-   **@clayui/multi-select:** Use `btn-outline-secondary btn-outline-borderless` instead of `btn-unstyled` for Clear All Button ([3d71cf0](https://github.com/liferay/clay/commit/3d71cf0))
+
 ## [3.25.1](https://github.com/liferay/clay/compare/v3.25.0...v3.25.1) (2021-03-05)
 
 ### Bug Fixes

--- a/packages/clay-multi-select/package.json
+++ b/packages/clay-multi-select/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/multi-select",
-	"version": "3.25.1",
+	"version": "3.25.3",
 	"description": "ClayMultiSelect component",
 	"license": "BSD-3-Clause",
 	"repository": "https://github.com/liferay/clay",

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -121,7 +121,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -370,7 +370,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -489,7 +489,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -528,7 +528,7 @@ exports[`Interactions add non-sequential text should filter the items when it is
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -595,7 +595,7 @@ exports[`Interactions adding text doesn not filter the items with a custom funct
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -678,7 +678,7 @@ exports[`Interactions adding text filters the items 1`] = `
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -747,7 +747,7 @@ exports[`Interactions adding text filters the items with a custom function 1`] =
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >
@@ -816,7 +816,7 @@ exports[`Interactions adding upper or lower case text should filter the items wh
         class="input-group-item input-group-item-shrink"
       >
         <button
-          class="component-action btn btn-monospaced btn-unstyled"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
         >

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -361,8 +361,9 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 						(inputValue || items.length > 0) && (
 							<ClayInput.GroupItem shrink>
 								<ClayButtonWithIcon
+									borderless
 									className="component-action"
-									displayType="unstyled"
+									displayType="secondary"
 									onClick={() => {
 										onClearAllButtonClick();
 
@@ -370,6 +371,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 											inputRef.current.focus();
 										}
 									}}
+									outline
 									spritemap={spritemap}
 									symbol="times-circle"
 									title={clearAllTitle}

--- a/packages/demos/CHANGELOG.md
+++ b/packages/demos/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.25.3](https://github.com/ambrinchaudhary/clay/compare/v3.25.2...v3.25.3) (2021-03-24)
+
+**Note:** Version bump only for package demos
+
 ## [3.25.1](https://github.com/ambrinchaudhary/clay/compare/v3.25.0...v3.25.1) (2021-03-05)
 
 **Note:** Version bump only for package demos

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -12,7 +12,7 @@
 		"@clayui/layout": "^3.3.0",
 		"@clayui/list": "^3.25.1",
 		"@clayui/management-toolbar": "^3.3.0",
-		"@clayui/multi-select": "^3.25.1",
+		"@clayui/multi-select": "^3.25.3",
 		"@clayui/nav": "^3.4.5",
 		"@clayui/pagination": "^3.25.1",
 		"@clayui/pagination-bar": "^3.25.1",
@@ -25,5 +25,5 @@
 	"devDependencies": {
 		"@types/recharts": "1.8.10"
 	},
-	"version": "3.25.1"
+	"version": "3.25.3"
 }


### PR DESCRIPTION
## [3.25.3](https://github.com/liferay/clay/compare/v3.25.2...v3.25.3) (2021-03-24)

### Bug Fixes

-   **@clayui/css:** Atlas Menubar (Vertical Navigation) link active state should be more visible ([5a94cfd](https://github.com/liferay/clay/commit/5a94cfd))
-   **@clayui/css:** Menubar toggler with c-inner cuts off caret icon ([1932782](https://github.com/liferay/clay/commit/1932782))
-   **@clayui/css:** Mixins `clay-link` adds option to style `&.show, &[aria-expanded='true']` separately from `active-class` so we can style panel toggles ([8a1a148](https://github.com/liferay/clay/commit/8a1a148))
-   **@clayui/multi-select:** Use `btn-outline-secondary btn-outline-borderless` instead of `btn-unstyled` for Clear All Button ([3d71cf0](https://github.com/liferay/clay/commit/3d71cf0))

