### PR TITLE
fix(@clayui/date-picker): disable focus control using the arrow keys

### DIFF
--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -372,7 +372,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		}, [handleFocus]);
 
 		return (
-			<FocusScope arrowKeysLeftRight>
+			<FocusScope>
 				<div className="date-picker">
 					<ClayInput.Group id={id} ref={triggerElementRef}>
 						<ClayInput.GroupItem>


### PR DESCRIPTION
Fixes #3981

We are disabling focus control using the arrow keys because it causes inappropriate behavior in the Date Picker, when there is input instead of going through the strings it will jump to the next element. We have no way of identifying whether the user skips to the next element or continues to go through the input string.

The best case for this would be to deal with a better focus control only within the Date Picker, disregarding the input.

This change still allows focus control but only using `tab` and `shift + tab`.