### PR TITLE
chore(release): publish v3.25.4 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.25.4](https://github.com/liferay/clay/compare/v3.25.3...v3.25.4) (2021-04-07)
+
+### Bug Fixes
+
+-   **@clayui/date-picker:** Date Navigation Controls are wrong color. This adds clay css classes but also leaves btn-monospaced and btn-sm just incase. ([850286e](https://github.com/liferay/clay/commit/850286e))
+-   **@clayui/date-picker:** disable focus control using the arrow keys ([d21dd7d](https://github.com/liferay/clay/commit/d21dd7d))
+-   **@clayui/date-picker:** Removes `btn-sm` and `btn-monospaced` from Date Navigation controls. They're not needed. ([e70ad3c](https://github.com/liferay/clay/commit/e70ad3c))
+
 ## [3.25.3](https://github.com/liferay/clay/compare/v3.25.2...v3.25.3) (2021-03-24)
 
 ### Bug Fixes

--- a/clayui.com/CHANGELOG.md
+++ b/clayui.com/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.25.4](https://github.com/ambrinchaudhary/clay/compare/v3.25.3...v3.25.4) (2021-04-07)
+
+**Note:** Version bump only for package clayui.com
+
 ## [3.25.3](https://github.com/ambrinchaudhary/clay/compare/v3.25.2...v3.25.3) (2021-03-24)
 
 **Note:** Version bump only for package clayui.com

--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "clayui.com",
-	"version": "3.25.3",
+	"version": "3.25.4",
 	"license": "MIT",
 	"scripts": {
 		"copy:clay-css": "yarn copy:clay-css-js && yarn copy:clay-css-site-images && yarn copy:clay-css-images",
@@ -21,7 +21,7 @@
 		"@clayui/color-picker": "^3.25.1",
 		"@clayui/css": "^3.25.3",
 		"@clayui/data-provider": "^3.3.10",
-		"@clayui/date-picker": "^3.25.1",
+		"@clayui/date-picker": "^3.25.4",
 		"@clayui/drop-down": "^3.25.1",
 		"@clayui/form": "^3.14.4",
 		"@clayui/icon": "^3.1.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"lerna": "3.4.0",
-	"version": "3.25.3",
+	"version": "3.25.4",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/packages/clay-date-picker/CHANGELOG.md
+++ b/packages/clay-date-picker/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.25.4](https://github.com/liferay/clay/compare/v3.25.3...v3.25.4) (2021-04-07)
+
+### Bug Fixes
+
+-   **@clayui/date-picker:** Date Navigation Controls are wrong color. This adds clay css classes but also leaves btn-monospaced and btn-sm just incase. ([850286e](https://github.com/liferay/clay/commit/850286e))
+-   **@clayui/date-picker:** disable focus control using the arrow keys ([d21dd7d](https://github.com/liferay/clay/commit/d21dd7d))
+-   **@clayui/date-picker:** Removes `btn-sm` and `btn-monospaced` from Date Navigation controls. They're not needed. ([e70ad3c](https://github.com/liferay/clay/commit/e70ad3c))
+
 ## [3.25.1](https://github.com/liferay/clay/compare/v3.25.0...v3.25.1) (2021-03-05)
 
 **Note:** Version bump only for package @clayui/date-picker

--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/date-picker",
-	"version": "3.25.1",
+	"version": "3.25.4",
 	"description": "ClayDatePicker component",
 	"license": "BSD-3-Clause",
 	"repository": "https://github.com/liferay/clay",

--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -126,31 +126,28 @@ const ClayDatePickerDateNavigation: React.FunctionComponent<IProps> = ({
 				<div className="date-picker-nav-controls date-picker-nav-item date-picker-nav-item-expand">
 					<Button
 						aria-label={ariaLabels.buttonPreviousMonth}
+						className="nav-btn nav-btn-monospaced"
 						disabled={disabled}
-						displayType="unstyled"
-						monospaced
+						displayType={null}
 						onClick={handlePreviousMonthClicked}
-						small
 					>
 						<Icon spritemap={spritemap} symbol="angle-left" />
 					</Button>
 					<Button
 						aria-label={ariaLabels.buttonDot}
+						className="nav-btn nav-btn-monospaced"
 						disabled={disabled}
-						displayType="unstyled"
-						monospaced
+						displayType={null}
 						onClick={onDotClicked}
-						small
 					>
 						<Icon spritemap={spritemap} symbol="simple-circle" />
 					</Button>
 					<Button
 						aria-label={ariaLabels.buttonNextMonth}
+						className="nav-btn nav-btn-monospaced"
 						disabled={disabled}
-						displayType="unstyled"
-						monospaced
+						displayType={null}
 						onClick={handleNextMonthClicked}
-						small
 					>
 						<Icon spritemap={spritemap} symbol="angle-right" />
 					</Button>

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -152,7 +152,7 @@ exports[`BasicRendering renders by default 1`] = `
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -166,7 +166,7 @@ exports[`BasicRendering renders by default 1`] = `
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -180,7 +180,7 @@ exports[`BasicRendering renders by default 1`] = `
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -681,7 +681,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -695,7 +695,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -709,7 +709,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1240,7 +1240,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1254,7 +1254,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1268,7 +1268,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2046,7 +2046,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2060,7 +2060,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2074,7 +2074,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -153,7 +153,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -167,7 +167,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -181,7 +181,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -682,7 +682,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -696,7 +696,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -710,7 +710,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1212,7 +1212,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1226,7 +1226,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1240,7 +1240,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1757,7 +1757,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1771,7 +1771,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1785,7 +1785,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2292,7 +2292,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2306,7 +2306,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2320,7 +2320,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2822,7 +2822,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2836,7 +2836,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2850,7 +2850,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -153,7 +153,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -167,7 +167,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -181,7 +181,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -683,7 +683,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -697,7 +697,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -711,7 +711,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1213,7 +1213,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1227,7 +1227,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1241,7 +1241,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1743,7 +1743,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1757,7 +1757,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -1771,7 +1771,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2273,7 +2273,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2287,7 +2287,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2301,7 +2301,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2803,7 +2803,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2817,7 +2817,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -2831,7 +2831,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -3393,7 +3393,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -3407,7 +3407,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -3421,7 +3421,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -4058,7 +4058,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               >
                 <button
                   aria-label="Select the previous month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -4072,7 +4072,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 </button>
                 <button
                   aria-label="Select current date"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg
@@ -4086,7 +4086,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 </button>
                 <button
                   aria-label="Select the next month"
-                  class="btn btn-monospaced btn-sm btn-unstyled"
+                  class="nav-btn nav-btn-monospaced btn"
                   type="button"
                 >
                   <svg

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -372,7 +372,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		}, [handleFocus]);
 
 		return (
-			<FocusScope arrowKeysLeftRight>
+			<FocusScope>
 				<div className="date-picker">
 					<ClayInput.Group id={id} ref={triggerElementRef}>
 						<ClayInput.GroupItem>


### PR DESCRIPTION
## [3.25.4](https://github.com/liferay/clay/compare/v3.25.3...v3.25.4) (2021-04-07)

### Bug Fixes

-   **@clayui/date-picker:** Date Navigation Controls are wrong color. This adds clay css classes but also leaves btn-monospaced and btn-sm just incase. ([850286e](https://github.com/liferay/clay/commit/850286e))
-   **@clayui/date-picker:** disable focus control using the arrow keys ([d21dd7d](https://github.com/liferay/clay/commit/d21dd7d))
-   **@clayui/date-picker:** Removes `btn-sm` and `btn-monospaced` from Date Navigation controls. They're not needed. ([e70ad3c](https://github.com/liferay/clay/commit/e70ad3c))