### PR TITLE
feat(@clayui/date-picker): Adds ClayDatePicker Range variation

### DIFF
--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -7,43 +7,84 @@ import {Keys} from '@clayui/shared';
 import classnames from 'classnames';
 import React from 'react';
 
-import {IDay, formatDate, setDate} from './Helpers';
+import {IDay, setDate} from './Helpers';
+import {TDaysSelected} from './types';
 
 interface IProps {
 	day: IDay;
-	daySelected: Date;
+	daysSelected: TDaysSelected;
 	disabled?: boolean;
-	onClick: (date: Date) => void;
+	range?: boolean;
+	onClick: (date: Date, range?: boolean) => void;
+}
+
+interface IInterval {
+	start: Date;
+	end: Date;
+}
+
+function isWithinInterval(dirtyDate: Date, dirtyInterval: IInterval) {
+	const interval = dirtyInterval || {};
+	const time = dirtyDate.getTime();
+	const startTime = interval.start.getTime();
+	const endTime = interval.end.getTime();
+
+	if (!(startTime <= endTime)) {
+		return false;
+	}
+
+	return time >= startTime && time <= endTime;
 }
 
 const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	day,
-	daySelected,
+	daysSelected,
 	disabled,
 	onClick,
+	range,
 }) => {
 	const {date, outside} = day;
+	const [startDate, endDate] = daysSelected;
+
+	const isSelectedToDate = date.toDateString() === endDate.toDateString();
+	const isSelectedFromDate = date.toDateString() === startDate.toDateString();
 
 	const classNames = classnames(
 		'date-picker-date date-picker-calendar-item',
 		{
-			active: date.toDateString() === daySelected.toDateString(),
+			active: isSelectedFromDate || (range && isSelectedToDate),
 			disabled: outside || disabled,
 		}
 	);
 
 	return (
-		<div className="date-picker-col">
+		<div
+			className={classnames(
+				'date-picker-col',
+				range && {
+					'c-selected':
+						!isSelectedFromDate &&
+						!isSelectedToDate &&
+						isWithinInterval(date, {
+							end: endDate,
+							start: startDate,
+						}),
+					'c-selected c-selected-end':
+						isSelectedToDate &&
+						!(isSelectedToDate && isSelectedFromDate),
+					'c-selected c-selected-start':
+						isSelectedFromDate &&
+						!(isSelectedToDate && isSelectedFromDate),
+				}
+			)}
+		>
 			<button
-				aria-label={formatDate(
-					setDate(date, {
-						hours: 12,
-						milliseconds: 0,
-						minutes: 0,
-						seconds: 0,
-					}),
-					'yyyy MM dd'
-				)}
+				aria-label={setDate(date, {
+					hours: 12,
+					milliseconds: 0,
+					minutes: 0,
+					seconds: 0,
+				}).toLocaleDateString()}
 				className={classNames}
 				disabled={outside}
 				onClick={() => onClick(date)}

--- a/packages/clay-date-picker/src/Helpers.ts
+++ b/packages/clay-date-picker/src/Helpers.ts
@@ -6,6 +6,8 @@
 import {default as formatDate} from 'date-fns/format';
 import {default as parseDate} from 'date-fns/parse';
 
+import {IYears, TDaysSelected} from './types';
+
 export {formatDate, parseDate};
 
 export interface IDay {
@@ -16,6 +18,36 @@ export interface IDay {
 export type WeekDays = Array<IDay>;
 
 export type Month = Array<WeekDays>;
+
+export const RANGE_SEPARATOR = ' - ';
+
+export function isDateRangeWithinYears(year: number, years: IYears) {
+	return year >= years.start && years.end >= year;
+}
+
+export function fromStringToRange(
+	value: string,
+	dateFormat: string,
+	referenceDate: Date
+): TDaysSelected {
+	const [fromDateString, toDateString] = value.split(RANGE_SEPARATOR);
+
+	return [
+		parseDate(fromDateString, dateFormat, referenceDate),
+		toDateString
+			? parseDate(toDateString, dateFormat, referenceDate)
+			: referenceDate,
+	];
+}
+
+export function fromRangeToString(range: TDaysSelected, dateFormat: string) {
+	const [startDate, endDate] = range;
+
+	return `${formatDate(startDate, dateFormat)}${RANGE_SEPARATOR}${formatDate(
+		endDate,
+		dateFormat
+	)}`;
+}
 
 /**
  * Clone a date object.

--- a/packages/clay-date-picker/src/InputDate.tsx
+++ b/packages/clay-date-picker/src/InputDate.tsx
@@ -6,16 +6,11 @@
 import {ClayInput} from '@clayui/form';
 import React from 'react';
 
-import {formatDate, isValid} from './Helpers';
-
 interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	ariaLabel?: string;
-	currentTime: string;
-	dateFormat: string;
 	disabled?: boolean;
 	inputName?: string;
 	placeholder?: string;
-	time: boolean;
 	useNative: boolean;
 	value: string;
 }
@@ -24,41 +19,23 @@ const ClayDatePickerInputDate = React.forwardRef<HTMLInputElement, IProps>(
 	(
 		{
 			ariaLabel,
-			currentTime,
-			dateFormat,
 			inputName = 'datePicker',
-			time = false,
 			useNative = false,
 			value = '',
 			...otherProps
 		},
 		ref
 	) => {
-		const isValidValue = (value: string | Date): string => {
-			if (value instanceof Date && isValid(value)) {
-				const date = formatDate(value, dateFormat);
-
-				return time ? `${date} ${currentTime}` : date;
-			}
-
-			return value as string;
-		};
-
-		const memoizedValue = React.useMemo(() => isValidValue(value), [
-			value,
-			currentTime,
-		]);
-
 		return (
 			<>
-				<input name={inputName} type="hidden" value={memoizedValue} />
+				<input name={inputName} type="hidden" value={value} />
 				<ClayInput
 					{...otherProps}
 					aria-label={ariaLabel}
 					insetAfter={!useNative}
 					ref={ref}
 					type={useNative ? 'date' : 'text'}
-					value={memoizedValue}
+					value={value}
 				/>
 			</>
 		);

--- a/packages/clay-date-picker/src/types.ts
+++ b/packages/clay-date-picker/src/types.ts
@@ -14,6 +14,7 @@ export enum FirstDayOfWeek {
 }
 
 export interface IAriaLabels {
+	buttonChooseDate: string;
 	buttonDot: string;
 	buttonNextMonth: string;
 	buttonPreviousMonth: string;
@@ -24,3 +25,5 @@ export interface IYears {
 	end: number;
 	start: number;
 }
+
+export type TDaysSelected = [Date, Date];

--- a/packages/clay-date-picker/stories/index.tsx
+++ b/packages/clay-date-picker/stories/index.tsx
@@ -15,12 +15,24 @@ const ClayDatePickerWithState = (props: {[key: string]: any}) => {
 	const [value, setValue] = React.useState<string | Date>('');
 
 	return (
-		<ClayDatePicker
-			{...props}
-			onValueChange={setValue}
-			spritemap={spritemap}
-			value={value as string}
-		/>
+		<>
+			<label>{'Date Picker'}</label>
+			<ClayDatePicker
+				{...props}
+				ariaLabels={{
+					buttonChooseDate: `Choose Date, selected date is ${
+						value.toLocaleString() ?? value
+					}`,
+					buttonDot: 'Go to today',
+					buttonNextMonth: 'Next month',
+					buttonPreviousMonth: 'Previous month',
+					input: value.toLocaleString(),
+				}}
+				onValueChange={setValue}
+				spritemap={spritemap}
+				value={value as string}
+			/>
+		</>
 	);
 };
 
@@ -133,5 +145,17 @@ storiesOf('Components|ClayDatePicker', module)
 			placeholder="YYYY-MM-DD"
 			spritemap={spritemap}
 			useNative
+		/>
+	))
+	.add('w/ date range', () => (
+		<ClayDatePickerWithState
+			dateFormat="yyyy/MM/dd"
+			placeholder="YYYY/MM/DD - YYYY/MM/DD"
+			range
+			spritemap={spritemap}
+			years={{
+				end: 2024,
+				start: 1997,
+			}}
 		/>
 	));


### PR DESCRIPTION
It came from the draft sent here: https://github.com/liferay/clay/pull/4008

# In resume:

Replace selectedDay state with selectedDays that contains a tuple with info about start and end dates. When not under `range` We are going to have a unique element on the tuple and it can be used as default value.

# Possible breaking changes(?)

onValueChange callback will not have two possible types as before(Date | string). Only strings will be accepted.

# Boy Scouting

Some a11y improvements like:

* Added an aria-label option for the button with the calendar symbol: buttonChooseDate
* Added an aria-label for each day on the calendar improving the message to screen reader from `2012 12 21` to `Thusday Dec 12 2012`
* Added aria-modal="true" and role="dialog" as https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html shows for the DatePicker dialog component :)