### PR TITLE
feat(@clayui/date-picker): Adds ClayDatePicker Range variation

### DIFF
--- a/packages/clay-date-picker/README.mdx
+++ b/packages/clay-date-picker/README.mdx
@@ -6,27 +6,31 @@ packageNpm: '@clayui/date-picker'
 ---
 
 import {
-	DatePickerWithState,
-	DatePickerWithTime,
 	DatePickerCustomFooter,
 	DatePickerLocale,
+	DatePickerWithRange,
+	DatePickerWithState,
+	DatePickerWithTime,
 } from '$packages/clay-date-picker/docs/index';
 
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
 -   [Time](#time)
+-   [Range](#range)
 -   [Internationalization](#internationalization)
 -   [Custom Footer](#custom-footer)
+-   [Programatically Expand Dropdown](#programatically-expand-dropdown)
+-   [Note about Moment.js](#note-about-moment.js)
 
 </div>
 </div>
 
 Date Picker is created following the principles of <a href="https://liferay.design/lexicon/core-components/forms/picker-date-time/">Lexicon</a>, Internationalization and Extension Points by default is integrated with Time Picker that offers the minimum of features to set a time.
 
-By default Date Picker does not handle input masking, letting you take control so you can take care of internationalization. Date Picker will update the Calendar only when the value entered in the input is a valid date, respecting the [`dateFormat`](#api-dateFormat) API.
+By default Date Picker does not handle input masking, letting you take control so you can take care of internationalization. Date Picker will update the Calendar only when the value entered in the input is a valid date, respecting the [`dateFormat`](date-picker/api.html#api-dateFormat) API.
 
-For mobile viewing mode, Lexicon encourages you to use the native Date Picker, they are many robust and more accessible in the mobile view, Clay offers the [`useNative`](#api-useNative) API to replace the Date Picker view mode with the native and continue to get the features of the component.
+For mobile viewing mode, Lexicon encourages you to use the native Date Picker, they are many robust and more accessible in the mobile view, Clay offers the [`useNative`](date-picker/api.html#api-useNative) API to replace the Date Picker view mode with the native and continue to get the features of the component.
 
 <div class="clay-site-alert alert alert-warning">
 	<strong class="lead">Warning</strong>
@@ -34,12 +38,12 @@ For mobile viewing mode, Lexicon encourages you to use the native Date Picker, t
 	must be used on mobile devices.
 </div>
 
-The component is treated as controlled, use the [`onValueChange`](#api-onValueChange) and [`value`](#api-value) APIs to control the flow of information.
+The component is treated as controlled, use the [`onValueChange`](date-picker/api.html#api-onValueChange) and [`value`](date-picker/api.html#api-value) APIs to control the flow of information.
 
 <div class="clay-site-alert alert alert-warning">
 	<strong class="lead">Warning</strong>
 	You can set a range of years using the API <code class="language-text">
-		<a href="#api-years">years</a>
+		<a href="date-picker/api.html#api-years">years</a>
 	</code>, which can be displayed in the Date Picker, if the user enters a year
 	that is not within the range will be treated as an invalid date.
 </div>
@@ -48,20 +52,35 @@ The component is treated as controlled, use the [`onValueChange`](#api-onValueCh
 
 ## Time
 
-The ClayTimePicker by default is already implemented in the Date Picker, you can enable it using the [`time`](#api-time) API. To provide a context for the timezone user, use the [`timezone`](#api-timezone) API for this.
+The ClayTimePicker by default is already implemented in the Date Picker, you can enable it using the [`time`](date-picker/api.html#api-time) API. To provide a context for the timezone user, use the [`timezone`](date-picker/api.html#api-timezone) API for this.
 
 <DatePickerWithTime />
 
+## Range
+
+Range is used to allowing the user to select a date range using a single calendar. The user can interact in the single `input` to select the start and end dates using the `-` separator, the separator is fixed.
+
+When a range is selected using the `input` or the calendar, the [`onValueChange`](date-picker/api.html#api-onValueChange) callback is called with the value in `string` type, respecting the format of the [`dateFormat`](date-picker/api.html#api-dateFormat) for both dates together with the separator.
+
+<div class="clay-site-alert alert alert-warning">
+	<strong class="lead">Warning</strong>
+	The <code class="language-text">time</code> is not supported when the <code class="language-text">
+		range
+	</code> is enabled.
+</div>
+
+<DatePickerWithRange />
+
 ## Internationalization
 
-To set internationalization of the component, you need to configure the props according to the language. Date Picker offers low level APIs to configure [`firstDayOfWeek`](#api-firstDayOfWeek), [`weekdaysShort`](#api-weekdaysShort), [`months`](#api-months), [`timezone`](#api-timezone) and [`dateFormat`](#api-dateFormat), you can follow the example below to set up a Date Picker for Russian.
+To set internationalization of the component, you need to configure the props according to the language. Date Picker offers low level APIs to configure [`firstDayOfWeek`](date-picker/api.html#api-firstDayOfWeek), [`weekdaysShort`](date-picker/api.html#api-weekdaysShort), [`months`](date-picker/api.html#api-months), [`timezone`](date-picker/api.html#api-timezone) and [`dateFormat`](date-picker/api.html#api-dateFormat), you can follow the example below to set up a Date Picker for Russian.
 
 <DatePickerLocale />
 
--   [`firstDayOfWeek`](#api-firstDayOfWeek) by default the value by default the value is 0 (Sunday) and its values ​​are the days of the week, 1 (Monday), 2 (Tuesday), 3 (Wednesday), 4 (Thursday), 5 (Friday), 6 (Saturday).
--   [`dateFormat`](#api-dateFormat) and `timeFormat` is defined according to the **formatting rules of [date-fns](https://date-fns.org/v2.14.0/docs/format)** which is an implementation of the [unicode technical standards](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table).
--   [`months`](#api-months) is an `Array<string>` with available months **starting January to December**.
--   [`weekdaysShort`](#api-weekdaysShort) is an `Array<string>` with the **names of the days of the week in short form**, starting from **Sunday to Saturday**.
+-   [`firstDayOfWeek`](date-picker/api.html#api-firstDayOfWeek) by default the value by default the value is 0 (Sunday) and its values are the days of the week, 1 (Monday), 2 (Tuesday), 3 (Wednesday), 4 (Thursday), 5 (Friday), 6 (Saturday).
+-   [`dateFormat`](date-picker/api.html#api-dateFormat) and `timeFormat` is defined according to the **formatting rules of [date-fns](https://date-fns.org/v2.14.0/docs/format)** which is an implementation of the [unicode technical standards](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table).
+-   [`months`](date-picker/api.html#api-months) is an `Array<string>` with available months **starting January to December**.
+-   [`weekdaysShort`](date-picker/api.html#api-weekdaysShort) is an `Array<string>` with the **names of the days of the week in short form**, starting from **Sunday to Saturday**.
 
 <div class="clay-site-alert alert alert-warning">
 	<strong class="lead">Warning</strong>
@@ -76,7 +95,7 @@ To set internationalization of the component, you need to configure the props ac
 
 ## Custom Footer
 
-To customize the Date Picker content footer you can use the [`footerElement`](#api-footerElement) API, its type is a Function that should return an element ([Read more about renders props](https://reactjs.org/docs/render-props.html)), this personalization point is treated as an extension point in the <a href="https://liferay.design/lexicon/">Lexicon</a> language.
+To customize the Date Picker content footer you can use the [`footerElement`](date-picker/api.html#api-footerElement) API, its type is a Function that should return an element ([Read more about renders props](https://reactjs.org/docs/render-props.html)), this personalization point is treated as an extension point in the <a href="https://liferay.design/lexicon/">Lexicon</a> language.
 
 <DatePickerCustomFooter />
 

--- a/packages/clay-date-picker/docs/index.js
+++ b/packages/clay-date-picker/docs/index.js
@@ -162,9 +162,45 @@ render(<Component />)`;
 	);
 };
 
+const DatePickerWithRangeCode = `import ClayDatePicker from '@clayui/date-picker';
+`;
+
+const DatePickerWithRange = () => {
+	const scope = {ClayDatePicker};
+	const code = `const Component = () => {
+	const [value, setValue] = useState(null);
+
+	return (
+		<ClayDatePicker
+			onValueChange={setValue}
+			placeholder="YYYY-MM-DD - YYYY-MM-DD"
+			range
+			spritemap={spritemap}
+			value={value}
+			years={{
+				end: 2024,
+				start: 1997,
+			}}
+		/>
+	);
+}
+
+render(<Component />)`;
+
+	return (
+		<Editor
+			code={code}
+			disabled
+			imports={DatePickerWithRangeCode}
+			scope={scope}
+		/>
+	);
+};
+
 export {
-	DatePickerLocale,
-	DatePickerWithTime,
 	DatePickerCustomFooter,
+	DatePickerLocale,
+	DatePickerWithRange,
 	DatePickerWithState,
+	DatePickerWithTime,
 };

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -45,7 +45,8 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	const [startDate, endDate] = daysSelected;
 
 	const hasEndDateSelected = date.toDateString() === endDate.toDateString();
-	const hasStartDateSelected = date.toDateString() === startDate.toDateString();
+	const hasStartDateSelected =
+		date.toDateString() === startDate.toDateString();
 
 	const classNames = classnames(
 		'date-picker-date date-picker-calendar-item',

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -84,7 +84,7 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 					milliseconds: 0,
 					minutes: 0,
 					seconds: 0,
-				}).toLocaleDateString()}
+				}).toDateString()}
 				className={classNames}
 				disabled={outside}
 				onClick={() => onClick(date)}

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -7,43 +7,84 @@ import {Keys} from '@clayui/shared';
 import classnames from 'classnames';
 import React from 'react';
 
-import {IDay, formatDate, setDate} from './Helpers';
+import {IDay, setDate} from './Helpers';
+import {TDaysSelected} from './types';
 
 interface IProps {
 	day: IDay;
-	daySelected: Date;
+	daysSelected: TDaysSelected;
 	disabled?: boolean;
-	onClick: (date: Date) => void;
+	range?: boolean;
+	onClick: (date: Date, range?: boolean) => void;
+}
+
+interface IInterval {
+	start: Date;
+	end: Date;
+}
+
+function isWithinInterval(dirtyDate: Date, dirtyInterval: IInterval) {
+	const interval = dirtyInterval || {};
+	const time = dirtyDate.getTime();
+	const startTime = interval.start.getTime();
+	const endTime = interval.end.getTime();
+
+	if (!(startTime <= endTime)) {
+		return false;
+	}
+
+	return time >= startTime && time <= endTime;
 }
 
 const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	day,
-	daySelected,
+	daysSelected,
 	disabled,
 	onClick,
+	range,
 }) => {
 	const {date, outside} = day;
+	const [startDate, endDate] = daysSelected;
+
+	const isSelectedToDate = date.toDateString() === endDate.toDateString();
+	const isSelectedFromDate = date.toDateString() === startDate.toDateString();
 
 	const classNames = classnames(
 		'date-picker-date date-picker-calendar-item',
 		{
-			active: date.toDateString() === daySelected.toDateString(),
+			active: isSelectedFromDate || (range && isSelectedToDate),
 			disabled: outside || disabled,
 		}
 	);
 
 	return (
-		<div className="date-picker-col">
+		<div
+			className={classnames(
+				'date-picker-col',
+				range && {
+					'c-selected':
+						!isSelectedFromDate &&
+						!isSelectedToDate &&
+						isWithinInterval(date, {
+							end: endDate,
+							start: startDate,
+						}),
+					'c-selected c-selected-end':
+						isSelectedToDate &&
+						!(isSelectedToDate && isSelectedFromDate),
+					'c-selected c-selected-start':
+						isSelectedFromDate &&
+						!(isSelectedToDate && isSelectedFromDate),
+				}
+			)}
+		>
 			<button
-				aria-label={formatDate(
-					setDate(date, {
-						hours: 12,
-						milliseconds: 0,
-						minutes: 0,
-						seconds: 0,
-					}),
-					'yyyy MM dd'
-				)}
+				aria-label={setDate(date, {
+					hours: 12,
+					milliseconds: 0,
+					minutes: 0,
+					seconds: 0,
+				}).toLocaleDateString()}
 				className={classNames}
 				disabled={outside}
 				onClick={() => onClick(date)}

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -8,14 +8,13 @@ import classnames from 'classnames';
 import React from 'react';
 
 import {IDay, setDate} from './Helpers';
-import {TDaysSelected} from './types';
 
 interface IProps {
 	day: IDay;
-	daysSelected: TDaysSelected;
+	daysSelected: readonly [Date, Date];
 	disabled?: boolean;
 	range?: boolean;
-	onClick: (date: Date, range?: boolean) => void;
+	onClick: (date: Date) => void;
 }
 
 interface IInterval {
@@ -23,13 +22,12 @@ interface IInterval {
 	end: Date;
 }
 
-function isWithinInterval(dirtyDate: Date, dirtyInterval: IInterval) {
-	const interval = dirtyInterval || {};
+function isWithinInterval(dirtyDate: Date, interval: IInterval) {
 	const time = dirtyDate.getTime();
 	const startTime = interval.start.getTime();
 	const endTime = interval.end.getTime();
 
-	if (!(startTime <= endTime)) {
+	if (startTime > endTime) {
 		return false;
 	}
 
@@ -46,13 +44,13 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	const {date, outside} = day;
 	const [startDate, endDate] = daysSelected;
 
-	const isSelectedToDate = date.toDateString() === endDate.toDateString();
-	const isSelectedFromDate = date.toDateString() === startDate.toDateString();
+	const hasEndDateSelected = date.toDateString() === endDate.toDateString();
+	const hasStartDateSelected = date.toDateString() === startDate.toDateString();
 
 	const classNames = classnames(
 		'date-picker-date date-picker-calendar-item',
 		{
-			active: isSelectedFromDate || (range && isSelectedToDate),
+			active: hasStartDateSelected || (range && hasEndDateSelected),
 			disabled: outside || disabled,
 		}
 	);
@@ -63,18 +61,16 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 				'date-picker-col',
 				range && {
 					'c-selected':
-						!isSelectedFromDate &&
-						!isSelectedToDate &&
+						!hasStartDateSelected &&
+						!hasEndDateSelected &&
 						isWithinInterval(date, {
 							end: endDate,
 							start: startDate,
 						}),
 					'c-selected c-selected-end':
-						isSelectedToDate &&
-						!(isSelectedToDate && isSelectedFromDate),
+						hasEndDateSelected && !hasStartDateSelected,
 					'c-selected c-selected-start':
-						isSelectedFromDate &&
-						!(isSelectedToDate && isSelectedFromDate),
+						hasStartDateSelected && !hasEndDateSelected,
 				}
 			)}
 		>

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -17,23 +17,6 @@ interface IProps {
 	onClick: (date: Date) => void;
 }
 
-interface IInterval {
-	start: Date;
-	end: Date;
-}
-
-function isWithinInterval(dirtyDate: Date, interval: IInterval) {
-	const time = dirtyDate.getTime();
-	const startTime = interval.start.getTime();
-	const endTime = interval.end.getTime();
-
-	if (startTime > endTime) {
-		return false;
-	}
-
-	return time >= startTime && time <= endTime;
-}
-
 const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	day,
 	daysSelected,
@@ -64,10 +47,7 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 					'c-selected':
 						!hasStartDateSelected &&
 						!hasEndDateSelected &&
-						isWithinInterval(date, {
-							end: endDate,
-							start: startDate,
-						}),
+						isWithinInterval(date, daysSelected),
 					'c-selected c-selected-end':
 						hasEndDateSelected && !hasStartDateSelected,
 					'c-selected c-selected-start':
@@ -105,5 +85,19 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 		</div>
 	);
 };
+
+function isWithinInterval(date: Date, interval: readonly [Date, Date]) {
+	const [start, end] = interval;
+
+	const time = date.getTime();
+	const startTime = start.getTime();
+	const endTime = end.getTime();
+
+	if (startTime > endTime) {
+		return false;
+	}
+
+	return time >= startTime && time <= endTime;
+}
 
 export default ClayDatePickerDayNumber;

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -45,12 +45,11 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 				'date-picker-col',
 				range && {
 					'c-selected':
-						!hasStartDateSelected &&
-						!hasEndDateSelected &&
+						startDate.toDateString() !== endDate.toDateString() &&
 						isWithinInterval(date, daysSelected),
-					'c-selected c-selected-end':
+					'c-selected-end':
 						hasEndDateSelected && !hasStartDateSelected,
-					'c-selected c-selected-start':
+					'c-selected-start':
 						hasStartDateSelected && !hasEndDateSelected,
 				}
 			)}

--- a/packages/clay-date-picker/src/Helpers.ts
+++ b/packages/clay-date-picker/src/Helpers.ts
@@ -6,6 +6,8 @@
 import {default as formatDate} from 'date-fns/format';
 import {default as parseDate} from 'date-fns/parse';
 
+import {IYears, TDaysSelected} from './types';
+
 export {formatDate, parseDate};
 
 export interface IDay {
@@ -16,6 +18,36 @@ export interface IDay {
 export type WeekDays = Array<IDay>;
 
 export type Month = Array<WeekDays>;
+
+export const RANGE_SEPARATOR = ' - ';
+
+export function isDateRangeWithinYears(year: number, years: IYears) {
+	return year >= years.start && years.end >= year;
+}
+
+export function fromStringToRange(
+	value: string,
+	dateFormat: string,
+	referenceDate: Date
+): TDaysSelected {
+	const [fromDateString, toDateString] = value.split(RANGE_SEPARATOR);
+
+	return [
+		parseDate(fromDateString, dateFormat, referenceDate),
+		toDateString
+			? parseDate(toDateString, dateFormat, referenceDate)
+			: referenceDate,
+	];
+}
+
+export function fromRangeToString(range: TDaysSelected, dateFormat: string) {
+	const [startDate, endDate] = range;
+
+	return `${formatDate(startDate, dateFormat)}${RANGE_SEPARATOR}${formatDate(
+		endDate,
+		dateFormat
+	)}`;
+}
 
 /**
  * Clone a date object.

--- a/packages/clay-date-picker/src/Helpers.ts
+++ b/packages/clay-date-picker/src/Helpers.ts
@@ -6,8 +6,6 @@
 import {default as formatDate} from 'date-fns/format';
 import {default as parseDate} from 'date-fns/parse';
 
-import {IYears, TDaysSelected} from './types';
-
 export {formatDate, parseDate};
 
 export interface IDay {
@@ -19,114 +17,11 @@ export type WeekDays = Array<IDay>;
 
 export type Month = Array<WeekDays>;
 
-export const RANGE_SEPARATOR = ' - ';
-
-export function isDateRangeWithinYears(year: number, years: IYears) {
-	return year >= years.start && years.end >= year;
-}
-
-export function fromStringToRange(
-	value: string,
-	dateFormat: string,
-	referenceDate: Date
-): TDaysSelected {
-	const [fromDateString, toDateString] = value.split(RANGE_SEPARATOR);
-
-	return [
-		parseDate(fromDateString, dateFormat, referenceDate),
-		toDateString
-			? parseDate(toDateString, dateFormat, referenceDate)
-			: referenceDate,
-	];
-}
-
-export function fromRangeToString(range: TDaysSelected, dateFormat: string) {
-	const [startDate, endDate] = range;
-
-	return `${formatDate(startDate, dateFormat)}${RANGE_SEPARATOR}${formatDate(
-		endDate,
-		dateFormat
-	)}`;
-}
-
 /**
  * Clone a date object.
  */
 export function clone(date: number | Date) {
 	return new Date(date instanceof Date ? date.getTime() : date);
-}
-
-export function getDaysInMonth(d: Date) {
-	const firstDayOfMonth = new Date(d.getFullYear(), d.getMonth(), 1, 12);
-
-	firstDayOfMonth.setMonth(firstDayOfMonth.getMonth() + 1);
-	firstDayOfMonth.setDate(firstDayOfMonth.getDate() - 1);
-
-	return firstDayOfMonth.getDate();
-}
-
-/**
- * Utility function to generate a table two days of the month.
- * Based on (This implementation does not have the fixation of
- * 6 weeks) https://github.com/gpbl/react-day-picker/blob/master/src/Helpers.js#L55
- *
- * @example
- * getWeekArray(new Date(), 0);
- *
- * [
- *   [
- *     {
- *       date: Sun Dec 30 2018 12:00:00 GMT-0300...
- *       outside: true
- * 	   },
- *     ...
- *   ]
- *   ...
- * ]
- *
- * The `outside` property references when a day
- * does not belong to the current month.
- */
-export function getWeekArray(d: Date, firstDayOfWeek = 0): Month {
-	const daysInMonth = getDaysInMonth(d);
-	const dayArray: Array<IDay> = [];
-
-	let week: WeekDays = [];
-	const weekArray: Month = [];
-
-	for (let i = 1; i <= daysInMonth; i += 1) {
-		const genDay = new Date(d.getFullYear(), d.getMonth(), i, 12);
-		dayArray.push({date: genDay});
-	}
-
-	dayArray.forEach((day) => {
-		if (week.length > 0 && day.date.getDay() === firstDayOfWeek) {
-			weekArray.push(week);
-			week = [];
-		}
-		week.push(day);
-		if (dayArray.indexOf(day) === dayArray.length - 1) {
-			weekArray.push(week);
-		}
-	});
-
-	// unshift days from start of the first week
-	const firstWeek = weekArray[0];
-	for (let i = 7 - firstWeek.length; i > 0; i -= 1) {
-		const outsideDate = clone(firstWeek[0].date);
-		outsideDate.setDate(firstWeek[0].date.getDate() - 1);
-		firstWeek.unshift({date: outsideDate, outside: true});
-	}
-
-	// push days until the end of the last week
-	const lastWeek = weekArray[weekArray.length - 1];
-	for (let i = lastWeek.length; i < 7; i += 1) {
-		const outsideDate = clone(lastWeek[lastWeek.length - 1].date);
-		outsideDate.setDate(lastWeek[lastWeek.length - 1].date.getDate() + 1);
-		lastWeek.push({date: outsideDate, outside: true});
-	}
-
-	return weekArray;
 }
 
 export function range({end, start}: {end: number; start: number}) {

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -9,6 +9,31 @@ import {IDay, Month, WeekDays, clone, formatDate, setDate} from './Helpers';
 import {FirstDayOfWeek} from './types';
 
 /**
+ * Handles selected days and stabilize date time when set to avoid problems
+ * when the range is used to check intervals.
+ */
+export const useDaysSelected = (initialMonth: Date) => {
+	const [daysSelected, set] = useState(() => {
+		const date = normalizeTime(initialMonth);
+
+		return [date, date] as const;
+	});
+
+	const setDaysSelected = useCallback(([start, end]: [Date, Date]) => {
+		// Preserves the reference of dates
+		if (start === end) {
+			const date = normalizeTime(start);
+
+			set([date, date]);
+		} else {
+			set([normalizeTime(start), normalizeTime(end)]);
+		}
+	}, []);
+
+	return [daysSelected, setDaysSelected] as const;
+};
+
+/**
  * Generates the table of days of the month.
  */
 export const useWeeks = (
@@ -57,6 +82,9 @@ export const useCurrentTime = (format: string) => {
 		(hours: number | string, minutes: number | string) => void
 	];
 };
+
+const normalizeTime = (date: Date) =>
+	setDate(date, {hours: 12, milliseconds: 0, minutes: 0, seconds: 0});
 
 function getDaysInMonth(d: Date) {
 	const firstDayOfMonth = new Date(d.getFullYear(), d.getMonth(), 1, 12);

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -3,10 +3,60 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React from 'react';
+import {useCallback, useState} from 'react';
 
 import {IDay, Month, WeekDays, clone, formatDate, setDate} from './Helpers';
 import {FirstDayOfWeek} from './types';
+
+/**
+ * Generates the table of days of the month.
+ */
+export const useWeeks = (
+	currentMonth: Date,
+	firstDayOfWeek: FirstDayOfWeek
+) => {
+	const [weeks, set] = useState<Month>(() =>
+		getWeekArray(currentMonth, firstDayOfWeek)
+	);
+
+	const setWeeks = useCallback(
+		(value: Date) => set(getWeekArray(value, firstDayOfWeek)),
+		[firstDayOfWeek]
+	);
+
+	return [weeks, setWeeks] as [Month, (value: Date) => void];
+};
+
+/**
+ * Sets the current time
+ */
+export const useCurrentTime = (format: string) => {
+	const [currentTime, set] = useState<string>(() =>
+		formatDate(setDate(new Date(), {hours: 0, minutes: 0}), format)
+	);
+
+	const setCurrentTime = useCallback(
+		(hours: number | string, minutes: number | string) => {
+			const date = setDate(new Date(), {hours, minutes});
+
+			if (typeof hours !== 'string') {
+				hours = formatDate(date, 'HH');
+			}
+
+			if (typeof minutes !== 'string') {
+				minutes = formatDate(date, 'mm');
+			}
+
+			set(`${hours}:${minutes}`);
+		},
+		[]
+	);
+
+	return [currentTime, setCurrentTime] as [
+		string,
+		(hours: number | string, minutes: number | string) => void
+	];
+};
 
 function getDaysInMonth(d: Date) {
 	const firstDayOfMonth = new Date(d.getFullYear(), d.getMonth(), 1, 12);
@@ -80,51 +130,3 @@ function getWeekArray(d: Date, firstDayOfWeek = 0): Month {
 
 	return weekArray;
 }
-
-/**
- * Generates the table of days of the month.
- */
-const useWeeks = (currentMonth: Date, firstDayOfWeek: FirstDayOfWeek) => {
-	const [weeks, set] = React.useState<Month>(() =>
-		getWeekArray(currentMonth, firstDayOfWeek)
-	);
-
-	function setWeeks(value: Date) {
-		set(getWeekArray(value, firstDayOfWeek));
-	}
-
-	return [weeks, setWeeks] as [Month, (value: Date) => void];
-};
-
-/**
- * Sets the current time
- */
-const useCurrentTime = (format: string) => {
-	const [currentTime, set] = React.useState<string>(() =>
-		formatDate(setDate(new Date(), {hours: 0, minutes: 0}), format)
-	);
-
-	function setCurrentTime(
-		hours: number | string,
-		minutes: number | string
-	): void {
-		const date = setDate(new Date(), {hours, minutes});
-
-		if (typeof hours !== 'string') {
-			hours = formatDate(date, 'HH');
-		}
-
-		if (typeof minutes !== 'string') {
-			minutes = formatDate(date, 'mm');
-		}
-
-		set(`${hours}:${minutes}`);
-	}
-
-	return [currentTime, setCurrentTime] as [
-		string,
-		(hours: number | string, minutes: number | string) => void
-	];
-};
-
-export {useCurrentTime, useWeeks};

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -39,7 +39,7 @@ function getDaysInMonth(d: Date) {
  * The `outside` property references when a day
  * does not belong to the current month.
  */
- function getWeekArray(d: Date, firstDayOfWeek = 0): Month {
+function getWeekArray(d: Date, firstDayOfWeek = 0): Month {
 	const daysInMonth = getDaysInMonth(d);
 	const dayArray: Array<IDay> = [];
 

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -5,8 +5,81 @@
 
 import React from 'react';
 
-import {Month, formatDate, getWeekArray, setDate} from './Helpers';
+import {IDay, Month, WeekDays, clone, formatDate, setDate} from './Helpers';
 import {FirstDayOfWeek} from './types';
+
+function getDaysInMonth(d: Date) {
+	const firstDayOfMonth = new Date(d.getFullYear(), d.getMonth(), 1, 12);
+
+	firstDayOfMonth.setMonth(firstDayOfMonth.getMonth() + 1);
+	firstDayOfMonth.setDate(firstDayOfMonth.getDate() - 1);
+
+	return firstDayOfMonth.getDate();
+}
+
+/**
+ * Utility function to generate a table two days of the month.
+ * Based on (This implementation does not have the fixation of
+ * 6 weeks) https://github.com/gpbl/react-day-picker/blob/master/src/Helpers.js#L55
+ *
+ * @example
+ * getWeekArray(new Date(), 0);
+ *
+ * [
+ *   [
+ *     {
+ *       date: Sun Dec 30 2018 12:00:00 GMT-0300...
+ *       outside: true
+ * 	   },
+ *     ...
+ *   ]
+ *   ...
+ * ]
+ *
+ * The `outside` property references when a day
+ * does not belong to the current month.
+ */
+ function getWeekArray(d: Date, firstDayOfWeek = 0): Month {
+	const daysInMonth = getDaysInMonth(d);
+	const dayArray: Array<IDay> = [];
+
+	let week: WeekDays = [];
+	const weekArray: Month = [];
+
+	for (let i = 1; i <= daysInMonth; i += 1) {
+		const genDay = new Date(d.getFullYear(), d.getMonth(), i, 12);
+		dayArray.push({date: genDay});
+	}
+
+	dayArray.forEach((day) => {
+		if (week.length > 0 && day.date.getDay() === firstDayOfWeek) {
+			weekArray.push(week);
+			week = [];
+		}
+		week.push(day);
+		if (dayArray.indexOf(day) === dayArray.length - 1) {
+			weekArray.push(week);
+		}
+	});
+
+	// unshift days from start of the first week
+	const firstWeek = weekArray[0];
+	for (let i = 7 - firstWeek.length; i > 0; i -= 1) {
+		const outsideDate = clone(firstWeek[0].date);
+		outsideDate.setDate(firstWeek[0].date.getDate() - 1);
+		firstWeek.unshift({date: outsideDate, outside: true});
+	}
+
+	// push days until the end of the last week
+	const lastWeek = weekArray[weekArray.length - 1];
+	for (let i = lastWeek.length; i < 7; i += 1) {
+		const outsideDate = clone(lastWeek[lastWeek.length - 1].date);
+		outsideDate.setDate(lastWeek[lastWeek.length - 1].date.getDate() + 1);
+		lastWeek.push({date: outsideDate, outside: true});
+	}
+
+	return weekArray;
+}
 
 /**
  * Generates the table of days of the month.

--- a/packages/clay-date-picker/src/InputDate.tsx
+++ b/packages/clay-date-picker/src/InputDate.tsx
@@ -6,16 +6,11 @@
 import {ClayInput} from '@clayui/form';
 import React from 'react';
 
-import {formatDate, isValid} from './Helpers';
-
 interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	ariaLabel?: string;
-	currentTime: string;
-	dateFormat: string;
 	disabled?: boolean;
 	inputName?: string;
 	placeholder?: string;
-	time: boolean;
 	useNative: boolean;
 	value: string;
 }
@@ -24,41 +19,23 @@ const ClayDatePickerInputDate = React.forwardRef<HTMLInputElement, IProps>(
 	(
 		{
 			ariaLabel,
-			currentTime,
-			dateFormat,
 			inputName = 'datePicker',
-			time = false,
 			useNative = false,
 			value = '',
 			...otherProps
 		},
 		ref
 	) => {
-		const isValidValue = (value: string | Date): string => {
-			if (value instanceof Date && isValid(value)) {
-				const date = formatDate(value, dateFormat);
-
-				return time ? `${date} ${currentTime}` : date;
-			}
-
-			return value as string;
-		};
-
-		const memoizedValue = React.useMemo(() => isValidValue(value), [
-			value,
-			currentTime,
-		]);
-
 		return (
 			<>
-				<input name={inputName} type="hidden" value={memoizedValue} />
+				<input name={inputName} type="hidden" value={value} />
 				<ClayInput
 					{...otherProps}
 					aria-label={ariaLabel}
 					insetAfter={!useNative}
 					ref={ref}
 					type={useNative ? 'date' : 'text'}
-					value={memoizedValue}
+					value={value}
 				/>
 			</>
 		);

--- a/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
+++ b/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
@@ -27,6 +27,23 @@ describe('BasicRendering', () => {
 		expect(document.body).toMatchSnapshot();
 	});
 
+	it('renders the date picker with the selected day using the initialMonth', () => {
+		const {getByLabelText} = render(
+			<ClayDatePicker
+				initialMonth={new Date(2019, 3, 18)}
+				onValueChange={() => {}}
+				placeholder="YYYY-MM-DD"
+				spritemap={spritemap}
+				value={''}
+				years={{end: 2019, start: 2019}}
+			/>
+		);
+
+		const daySelected = getByLabelText('Thu Apr 18 2019');
+
+		expect(daySelected.classList).toContain('active');
+	});
+
 	it('renders date picker with dropdown open', () => {
 		render(
 			<ClayDatePicker

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -56,7 +56,7 @@ describe('IncrementalInteractions', () => {
 		);
 
 		const input: any = getByLabelText(ariaLabels.input);
-		const dayNumber = getByLabelText('2019 04 10');
+		const dayNumber = getByLabelText(new Date('2019 04 10').toDateString());
 		const monthSelect: any = getByTestId('month-select');
 		const yearSelect: any = getByTestId('year-select');
 
@@ -192,7 +192,7 @@ describe('IncrementalInteractions', () => {
 
 		fireEvent.click(backArrowButtonEl);
 
-		const days = queryAllByLabelText('2019 03', {exact: false});
+		const days = queryAllByLabelText('Mar', {exact: false});
 
 		expect(yearSelect.value).toBe('2019');
 		expect(monthSelect.value).toBe('2');
@@ -218,7 +218,7 @@ describe('IncrementalInteractions', () => {
 
 		expect(input.value).toBe(formatDate(currentDate, 'yyyy-MM-dd'));
 
-		const dayNumber = getByLabelText(formatDate(currentDate, 'yyyy MM dd'));
+		const dayNumber = getByLabelText(currentDate.toDateString());
 		expect(dayNumber.classList).toContain('active');
 	});
 
@@ -238,7 +238,7 @@ describe('IncrementalInteractions', () => {
 
 		fireEvent.click(nextArrowButtonEl);
 
-		const days = queryAllByLabelText('2019 05', {exact: false});
+		const days = queryAllByLabelText('May', {exact: false});
 
 		expect(yearSelect.value).toBe('2019');
 		expect(monthSelect.value).toBe('4');
@@ -268,7 +268,7 @@ describe('IncrementalInteractions', () => {
 
 		const monthSelect: any = getByTestId('month-select');
 		const yearSelect: any = getByTestId('year-select');
-		const days = queryAllByLabelText('2018 12', {exact: false});
+		const days = queryAllByLabelText('Dec', {exact: false});
 
 		expect(yearSelect.value).toBe('2018');
 		expect(monthSelect.value).toBe('11');
@@ -296,7 +296,7 @@ describe('IncrementalInteractions', () => {
 
 		const monthSelect: any = getByTestId('month-select');
 		const yearSelect: any = getByTestId('year-select');
-		const days = queryAllByLabelText('2020 01', {exact: false});
+		const days = queryAllByLabelText('Jan', {exact: false});
 
 		expect(yearSelect.value).toBe('2020');
 		expect(monthSelect.value).toBe('0');
@@ -314,7 +314,7 @@ describe('IncrementalInteractions', () => {
 		);
 
 		const input: any = getByLabelText(ariaLabels.input);
-		const dayNumber = getByLabelText('2019 04 28');
+		const dayNumber = getByLabelText(new Date('2019 04 28').toDateString());
 		const monthSelect: any = getByTestId('month-select');
 		const yearSelect: any = getByTestId('year-select');
 
@@ -337,7 +337,7 @@ describe('IncrementalInteractions', () => {
 		);
 
 		const input: any = getByLabelText(ariaLabels.input);
-		const dayNumber = getByLabelText('2019 05 01');
+		const dayNumber = getByLabelText(new Date('2019 05 01').toDateString());
 		const monthSelect: any = getByTestId('month-select');
 		const yearSelect: any = getByTestId('year-select');
 
@@ -381,7 +381,11 @@ describe('IncrementalInteractions', () => {
 			);
 
 			const input: any = getByLabelText(ariaLabels.input);
-			const dayNumber = getByLabelText('2019 04 24');
+
+			const dayNumber = getByLabelText(
+				new Date('2019 04 24').toDateString()
+			);
+
 			const hoursEl = getByTestId('hours') as HTMLInputElement;
 
 			fireEvent.click(dayNumber);

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -420,4 +420,89 @@ describe('IncrementalInteractions', () => {
 			expect(minutesEl.value).toBe('20');
 		});
 	});
+
+	describe('Range', () => {
+		it('clicking on the previous day the start date changes the start date to the selected date', () => {
+			const {getByLabelText} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					initialExpanded
+					placeholder="YYYY-MM-DD"
+					range
+					spritemap={spritemap}
+				/>
+			);
+
+			const dayNumber = getByLabelText(
+				new Date('2019 04 10').toDateString()
+			);
+			const endDate = getByLabelText(
+				new Date('2019 04 18').toDateString()
+			);
+
+			fireEvent.click(dayNumber);
+
+			expect(dayNumber.classList).toContain('active');
+			expect(endDate.classList).toContain('active');
+		});
+
+		it('clicking on the day later the start date sets the end date for the selected date', () => {
+			const {getByLabelText} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					initialExpanded
+					placeholder="YYYY-MM-DD"
+					range
+					spritemap={spritemap}
+				/>
+			);
+
+			const dayNumber = getByLabelText(
+				new Date('2019 04 25').toDateString()
+			);
+			const startDate = getByLabelText(
+				new Date('2019 04 18').toDateString()
+			);
+
+			fireEvent.click(dayNumber);
+
+			expect(startDate.classList).toContain('active');
+			expect(dayNumber.classList).toContain('active');
+		});
+
+		it.each(['2019 04 23', '2019 04 10', '2019 04 30'])(
+			'clicking on any day (%s) sets the start and end date for the selected day when the range is already defined',
+			(date) => {
+				const {getByLabelText} = render(
+					<DatePickerWithState
+						ariaLabels={ariaLabels}
+						initialExpanded
+						placeholder="YYYY-MM-DD"
+						range
+						spritemap={spritemap}
+					/>
+				);
+
+				const endDate = getByLabelText(
+					new Date('2019 04 25').toDateString()
+				);
+				const startDate = getByLabelText(
+					new Date('2019 04 18').toDateString()
+				);
+
+				fireEvent.click(endDate);
+
+				expect(startDate.classList).toContain('active');
+				expect(endDate.classList).toContain('active');
+
+				const dayNumber = getByLabelText(new Date(date).toDateString());
+
+				fireEvent.click(dayNumber);
+
+				expect(dayNumber.classList).toContain('active');
+				expect(startDate.classList).not.toContain('active');
+				expect(endDate.classList).not.toContain('active');
+			}
+		);
+	});
 });

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 const spritemap = 'icons.svg';
 
 const ariaLabels = {
+	buttonChooseDate: 'Choose your desired date',
 	buttonDot: 'Select current date',
 	buttonNextMonth: 'Select the next month',
 	buttonPreviousMonth: 'Select the previous month',

--- a/packages/clay-date-picker/src/__tests__/Internationalization.tsx
+++ b/packages/clay-date-picker/src/__tests__/Internationalization.tsx
@@ -12,6 +12,7 @@ import {FirstDayOfWeek} from '../types';
 const spritemap = 'icons.svg';
 
 const ariaLabels = {
+	buttonChooseDate: 'Choose your desired date',
 	buttonDot: 'Select current date',
 	buttonNextMonth: 'Select the next month',
 	buttonPreviousMonth: 'Select the previous month',

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -302,7 +302,7 @@ exports[`BasicRendering renders by default 1`] = `
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -497,7 +497,7 @@ exports[`BasicRendering renders by default 1`] = `
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -1002,7 +1002,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -1197,7 +1197,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -1732,7 +1732,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -1927,7 +1927,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -2709,7 +2709,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -2904,7 +2904,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -28,6 +28,7 @@ exports[`BasicRendering renders by default 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -54,7 +55,9 @@ exports[`BasicRendering renders by default 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -286,7 +289,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -298,8 +301,8 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -309,7 +312,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -320,7 +323,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -331,7 +334,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -342,7 +345,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -353,7 +356,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -368,7 +371,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -379,7 +382,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -390,7 +393,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -401,7 +404,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -412,7 +415,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -423,7 +426,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -434,7 +437,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -449,7 +452,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -460,7 +463,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -471,7 +474,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -482,7 +485,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -493,8 +496,8 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -504,7 +507,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -515,7 +518,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -530,7 +533,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -541,7 +544,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -552,7 +555,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -563,7 +566,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -574,7 +577,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -585,7 +588,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -596,7 +599,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -611,7 +614,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -622,7 +625,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -633,7 +636,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -644,7 +647,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -656,7 +659,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -668,7 +671,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -680,7 +683,7 @@ exports[`BasicRendering renders by default 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -725,6 +728,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -751,7 +755,9 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -983,7 +989,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -995,8 +1001,8 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -1006,7 +1012,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1017,7 +1023,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1028,7 +1034,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1039,7 +1045,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1050,7 +1056,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1065,7 +1071,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1076,7 +1082,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1087,7 +1093,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1098,7 +1104,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1109,7 +1115,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1120,7 +1126,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1131,7 +1137,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1146,7 +1152,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1157,7 +1163,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1168,7 +1174,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1179,7 +1185,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1190,8 +1196,8 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -1201,7 +1207,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1212,7 +1218,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1227,7 +1233,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1238,7 +1244,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1249,7 +1255,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1260,7 +1266,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1271,7 +1277,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1282,7 +1288,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1293,7 +1299,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1308,7 +1314,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1319,7 +1325,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1330,7 +1336,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1341,7 +1347,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1353,7 +1359,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1365,7 +1371,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1377,7 +1383,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1452,6 +1458,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -1478,7 +1485,9 @@ exports[`BasicRendering renders date picker with time 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -1710,7 +1719,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1722,8 +1731,8 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -1733,7 +1742,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1744,7 +1753,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1755,7 +1764,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1766,7 +1775,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1777,7 +1786,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1792,7 +1801,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1803,7 +1812,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1814,7 +1823,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1825,7 +1834,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1836,7 +1845,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1847,7 +1856,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1858,7 +1867,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1873,7 +1882,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1884,7 +1893,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1895,7 +1904,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1906,7 +1915,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1917,8 +1926,8 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -1928,7 +1937,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1939,7 +1948,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1954,7 +1963,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1965,7 +1974,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1976,7 +1985,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1987,7 +1996,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1998,7 +2007,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2009,7 +2018,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2020,7 +2029,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2035,7 +2044,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2046,7 +2055,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2057,7 +2066,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2068,7 +2077,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2080,7 +2089,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2092,7 +2101,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2104,7 +2113,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2291,6 +2300,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -2317,7 +2327,9 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -2684,7 +2696,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2696,8 +2708,8 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -2707,7 +2719,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2718,7 +2730,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2729,7 +2741,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2740,7 +2752,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2751,7 +2763,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2766,7 +2778,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2777,7 +2789,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2788,7 +2800,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2799,7 +2811,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2810,7 +2822,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2821,7 +2833,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2832,7 +2844,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2847,7 +2859,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2858,7 +2870,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2869,7 +2881,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2880,7 +2892,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2891,8 +2903,8 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -2902,7 +2914,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2913,7 +2925,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2928,7 +2940,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2939,7 +2951,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2950,7 +2962,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2961,7 +2973,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2972,7 +2984,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2983,7 +2995,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2994,7 +3006,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3009,7 +3021,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3020,7 +3032,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3031,7 +3043,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3042,7 +3054,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3054,7 +3066,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3066,7 +3078,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3078,7 +3090,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -1003,7 +1003,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -1198,7 +1198,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -1704,7 +1704,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -1899,7 +1899,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -3126,7 +3126,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -3321,7 +3321,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -3553,6 +3553,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -3579,7 +3580,9 @@ exports[`IncrementalInteractions date entered in the input element should reflec
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -3811,7 +3814,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3823,7 +3826,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
+                  aria-label="Mon Apr 01 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3834,7 +3837,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3845,7 +3848,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3856,7 +3859,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3867,7 +3870,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3878,7 +3881,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3893,7 +3896,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3904,7 +3907,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3915,7 +3918,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3926,7 +3929,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
@@ -3937,7 +3940,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3948,7 +3951,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3959,7 +3962,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3974,7 +3977,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3985,7 +3988,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3996,7 +3999,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4007,7 +4010,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4018,7 +4021,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
+                  aria-label="Thu Apr 18 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4029,7 +4032,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4040,7 +4043,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4055,7 +4058,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4066,7 +4069,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4077,7 +4080,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4088,7 +4091,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4099,7 +4102,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4110,7 +4113,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4121,7 +4124,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4136,7 +4139,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4147,7 +4150,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4158,7 +4161,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4169,7 +4172,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4181,7 +4184,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4193,7 +4196,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4205,7 +4208,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -29,6 +29,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -55,7 +56,9 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -287,7 +290,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 06 30"
+                  aria-label="Sun Jun 30 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -299,7 +302,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 01"
+                  aria-label="Mon Jul 01 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -310,7 +313,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 02"
+                  aria-label="Tue Jul 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -321,7 +324,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 03"
+                  aria-label="Wed Jul 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -332,7 +335,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 04"
+                  aria-label="Thu Jul 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -343,7 +346,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 05"
+                  aria-label="Fri Jul 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -354,7 +357,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 06"
+                  aria-label="Sat Jul 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -369,7 +372,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 07"
+                  aria-label="Sun Jul 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -380,7 +383,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 08"
+                  aria-label="Mon Jul 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -391,7 +394,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 09"
+                  aria-label="Tue Jul 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -402,7 +405,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 10"
+                  aria-label="Wed Jul 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -413,7 +416,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 11"
+                  aria-label="Thu Jul 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -424,7 +427,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 12"
+                  aria-label="Fri Jul 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -435,7 +438,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 13"
+                  aria-label="Sat Jul 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -450,7 +453,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 14"
+                  aria-label="Sun Jul 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -461,7 +464,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 15"
+                  aria-label="Mon Jul 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -472,7 +475,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 16"
+                  aria-label="Tue Jul 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -483,7 +486,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 17"
+                  aria-label="Wed Jul 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -494,7 +497,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 18"
+                  aria-label="Thu Jul 18 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -505,7 +508,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 19"
+                  aria-label="Fri Jul 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -516,7 +519,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 20"
+                  aria-label="Sat Jul 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -531,7 +534,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 21"
+                  aria-label="Sun Jul 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -542,7 +545,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 22"
+                  aria-label="Mon Jul 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -553,7 +556,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 23"
+                  aria-label="Tue Jul 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -564,7 +567,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 24"
+                  aria-label="Wed Jul 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -575,7 +578,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 25"
+                  aria-label="Thu Jul 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -586,7 +589,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 26"
+                  aria-label="Fri Jul 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -597,7 +600,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 27"
+                  aria-label="Sat Jul 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -612,7 +615,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 28"
+                  aria-label="Sun Jul 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -623,7 +626,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 29"
+                  aria-label="Mon Jul 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -634,7 +637,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 30"
+                  aria-label="Tue Jul 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -645,7 +648,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 07 31"
+                  aria-label="Wed Jul 31 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -656,7 +659,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 08 01"
+                  aria-label="Thu Aug 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -668,7 +671,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 08 02"
+                  aria-label="Fri Aug 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -680,7 +683,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 08 03"
+                  aria-label="Sat Aug 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -726,6 +729,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -752,7 +756,9 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -984,7 +990,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -996,8 +1002,8 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -1007,7 +1013,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1018,7 +1024,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1029,7 +1035,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1040,7 +1046,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1051,7 +1057,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1066,7 +1072,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1077,7 +1083,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1088,7 +1094,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1099,7 +1105,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1110,7 +1116,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1121,7 +1127,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1132,7 +1138,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1147,7 +1153,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1158,7 +1164,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1169,7 +1175,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1180,7 +1186,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1191,8 +1197,8 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -1202,7 +1208,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1213,7 +1219,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1228,7 +1234,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1239,7 +1245,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1250,7 +1256,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1261,7 +1267,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1272,7 +1278,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1283,7 +1289,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1294,7 +1300,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1309,7 +1315,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1320,7 +1326,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1331,7 +1337,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1342,7 +1348,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1354,7 +1360,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1366,7 +1372,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1378,7 +1384,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1424,6 +1430,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -1450,7 +1457,9 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -1682,7 +1691,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1694,8 +1703,8 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -1705,7 +1714,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1716,7 +1725,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1727,7 +1736,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1738,7 +1747,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1749,7 +1758,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1764,7 +1773,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1775,7 +1784,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1786,7 +1795,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1797,7 +1806,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1808,7 +1817,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1819,7 +1828,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1830,7 +1839,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1845,7 +1854,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1856,7 +1865,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1867,7 +1876,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1878,7 +1887,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1889,8 +1898,8 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -1900,7 +1909,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1911,7 +1920,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1926,7 +1935,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1937,7 +1946,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1948,7 +1957,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1959,7 +1968,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1970,7 +1979,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1981,7 +1990,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1992,7 +2001,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2007,7 +2016,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2018,7 +2027,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2029,7 +2038,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2040,7 +2049,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2052,7 +2061,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2064,7 +2073,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2076,7 +2085,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2122,6 +2131,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -2148,7 +2158,9 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -2395,7 +2407,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 01"
+                  aria-label="Sun Apr 01 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2406,7 +2418,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 02"
+                  aria-label="Mon Apr 02 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2417,7 +2429,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 03"
+                  aria-label="Tue Apr 03 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2428,7 +2440,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 04"
+                  aria-label="Wed Apr 04 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2439,7 +2451,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 05"
+                  aria-label="Thu Apr 05 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2450,7 +2462,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 06"
+                  aria-label="Fri Apr 06 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2461,7 +2473,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 07"
+                  aria-label="Sat Apr 07 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2476,7 +2488,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 08"
+                  aria-label="Sun Apr 08 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2487,7 +2499,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 09"
+                  aria-label="Mon Apr 09 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2498,7 +2510,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 10"
+                  aria-label="Tue Apr 10 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2509,7 +2521,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 11"
+                  aria-label="Wed Apr 11 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2520,7 +2532,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 12"
+                  aria-label="Thu Apr 12 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2531,7 +2543,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 13"
+                  aria-label="Fri Apr 13 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2542,7 +2554,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 14"
+                  aria-label="Sat Apr 14 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2557,7 +2569,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 15"
+                  aria-label="Sun Apr 15 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2568,7 +2580,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 16"
+                  aria-label="Mon Apr 16 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2579,7 +2591,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 17"
+                  aria-label="Tue Apr 17 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2590,7 +2602,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 18"
+                  aria-label="Wed Apr 18 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2601,7 +2613,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 19"
+                  aria-label="Thu Apr 19 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2612,7 +2624,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 20"
+                  aria-label="Fri Apr 20 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2623,7 +2635,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 21"
+                  aria-label="Sat Apr 21 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2638,7 +2650,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 22"
+                  aria-label="Sun Apr 22 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2649,7 +2661,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 23"
+                  aria-label="Mon Apr 23 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2660,7 +2672,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 24"
+                  aria-label="Tue Apr 24 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2671,7 +2683,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 25"
+                  aria-label="Wed Apr 25 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2682,7 +2694,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 26"
+                  aria-label="Thu Apr 26 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2693,7 +2705,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 27"
+                  aria-label="Fri Apr 27 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2704,7 +2716,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 28"
+                  aria-label="Sat Apr 28 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2719,7 +2731,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 29"
+                  aria-label="Sun Apr 29 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2730,7 +2742,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 04 30"
+                  aria-label="Mon Apr 30 2018"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2741,7 +2753,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 05 01"
+                  aria-label="Tue May 01 2018"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2753,7 +2765,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 05 02"
+                  aria-label="Wed May 02 2018"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2765,7 +2777,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 05 03"
+                  aria-label="Thu May 03 2018"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2777,7 +2789,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 05 04"
+                  aria-label="Fri May 04 2018"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2789,7 +2801,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2018 05 05"
+                  aria-label="Sat May 05 2018"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2835,6 +2847,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -2866,7 +2879,9 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -3098,7 +3113,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3110,8 +3125,8 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -3121,7 +3136,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3132,7 +3147,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3143,7 +3158,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3154,7 +3169,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3165,7 +3180,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3180,7 +3195,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3191,7 +3206,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3202,7 +3217,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3213,7 +3228,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3224,7 +3239,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3235,7 +3250,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3246,7 +3261,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3261,7 +3276,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3272,7 +3287,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3283,7 +3298,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3294,7 +3309,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3305,8 +3320,8 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -3316,7 +3331,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3327,7 +3342,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3342,7 +3357,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3353,7 +3368,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3364,7 +3379,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3375,7 +3390,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3386,7 +3401,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3397,7 +3412,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3408,7 +3423,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3423,7 +3438,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3434,7 +3449,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3445,7 +3460,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3456,7 +3471,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3468,7 +3483,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3480,7 +3495,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3492,7 +3507,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -327,7 +327,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -522,7 +522,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -1004,7 +1004,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -1199,7 +1199,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -1717,7 +1717,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -1912,7 +1912,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -2406,7 +2406,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -2601,7 +2601,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -3143,7 +3143,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -3342,7 +3342,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -3868,7 +3868,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -4067,7 +4067,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -4645,7 +4645,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -4844,7 +4844,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18
@@ -5421,7 +5421,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               >
                 <button
                   aria-label="Mon Apr 01 2019"
-                  class="date-picker-date date-picker-calendar-item active"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   1
@@ -5616,7 +5616,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               >
                 <button
                   aria-label="Thu Apr 18 2019"
-                  class="date-picker-date date-picker-calendar-item"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   18

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -29,6 +29,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -55,7 +56,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -287,7 +290,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 29"
+                  aria-label="Fri Mar 29 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -299,7 +302,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 30"
+                  aria-label="Sat Mar 30 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -311,7 +314,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -323,8 +326,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -334,7 +337,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -345,7 +348,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -356,7 +359,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -371,7 +374,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -382,7 +385,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -393,7 +396,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -404,7 +407,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -415,7 +418,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -426,7 +429,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -437,7 +440,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -452,7 +455,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -463,7 +466,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -474,7 +477,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -485,7 +488,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -496,7 +499,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -507,7 +510,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -518,8 +521,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -533,7 +536,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -544,7 +547,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -555,7 +558,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -566,7 +569,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -577,7 +580,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -588,7 +591,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -599,7 +602,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -614,7 +617,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -625,7 +628,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -636,7 +639,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -647,7 +650,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -658,7 +661,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -669,7 +672,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -681,7 +684,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -727,6 +730,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -753,7 +757,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -985,7 +991,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -997,8 +1003,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -1008,7 +1014,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1019,7 +1025,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1030,7 +1036,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1041,7 +1047,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1052,7 +1058,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1067,7 +1073,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1078,7 +1084,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1089,7 +1095,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1100,7 +1106,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1111,7 +1117,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1122,7 +1128,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1133,7 +1139,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1148,7 +1154,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1159,7 +1165,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1170,7 +1176,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1181,7 +1187,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1192,8 +1198,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -1203,7 +1209,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1214,7 +1220,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1229,7 +1235,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1240,7 +1246,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1251,7 +1257,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1262,7 +1268,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1273,7 +1279,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1284,7 +1290,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1295,7 +1301,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1310,7 +1316,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1321,7 +1327,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1332,7 +1338,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1343,7 +1349,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1355,7 +1361,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1367,7 +1373,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1379,7 +1385,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1425,6 +1431,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -1451,7 +1458,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -1683,7 +1692,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 30"
+                  aria-label="Sat Mar 30 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1695,7 +1704,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -1707,8 +1716,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -1718,7 +1727,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1729,7 +1738,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1740,7 +1749,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1751,7 +1760,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1766,7 +1775,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1777,7 +1786,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1788,7 +1797,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1799,7 +1808,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1810,7 +1819,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1821,7 +1830,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1832,7 +1841,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1847,7 +1856,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1858,7 +1867,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1869,7 +1878,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1880,7 +1889,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1891,7 +1900,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1902,8 +1911,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -1913,7 +1922,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1928,7 +1937,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1939,7 +1948,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1950,7 +1959,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1961,7 +1970,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1972,7 +1981,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1983,7 +1992,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -1994,7 +2003,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2009,7 +2018,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2020,7 +2029,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2031,7 +2040,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2042,7 +2051,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2053,7 +2062,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2065,7 +2074,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2077,7 +2086,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2123,6 +2132,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -2149,7 +2159,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -2381,7 +2393,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2393,8 +2405,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -2404,7 +2416,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2415,7 +2427,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2426,7 +2438,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2437,7 +2449,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2448,7 +2460,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2463,7 +2475,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2474,7 +2486,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2485,7 +2497,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2496,7 +2508,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2507,7 +2519,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2518,7 +2530,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2529,7 +2541,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2544,7 +2556,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2555,7 +2567,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2566,7 +2578,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2577,7 +2589,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2588,8 +2600,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -2599,7 +2611,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2610,7 +2622,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2625,7 +2637,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2636,7 +2648,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2647,7 +2659,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2658,7 +2670,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2669,7 +2681,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2680,7 +2692,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2691,7 +2703,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2706,7 +2718,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2717,7 +2729,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2728,7 +2740,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -2739,7 +2751,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2751,7 +2763,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2763,7 +2775,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2775,7 +2787,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -2821,6 +2833,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -2847,7 +2860,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -3079,7 +3094,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 28"
+                  aria-label="Thu Mar 28 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3091,7 +3106,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 29"
+                  aria-label="Fri Mar 29 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3103,7 +3118,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 30"
+                  aria-label="Sat Mar 30 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3115,7 +3130,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3127,8 +3142,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -3138,7 +3153,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3149,7 +3164,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3164,7 +3179,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3175,7 +3190,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3186,7 +3201,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3197,7 +3212,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3208,7 +3223,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3219,7 +3234,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3230,7 +3245,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3245,7 +3260,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3256,7 +3271,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3267,7 +3282,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3278,7 +3293,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3289,7 +3304,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3300,7 +3315,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3311,7 +3326,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3326,8 +3341,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -3337,7 +3352,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3348,7 +3363,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3359,7 +3374,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3370,7 +3385,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3381,7 +3396,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3392,7 +3407,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3407,7 +3422,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3418,7 +3433,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3429,7 +3444,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3440,7 +3455,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3451,7 +3466,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3462,7 +3477,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3473,7 +3488,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3519,6 +3534,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -3545,7 +3561,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -3777,7 +3795,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 26"
+                  aria-label="Tue Mar 26 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3789,7 +3807,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 27"
+                  aria-label="Wed Mar 27 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3801,7 +3819,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 28"
+                  aria-label="Thu Mar 28 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3813,7 +3831,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 29"
+                  aria-label="Fri Mar 29 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3825,7 +3843,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 30"
+                  aria-label="Sat Mar 30 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3837,7 +3855,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -3849,8 +3867,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -3864,7 +3882,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3875,7 +3893,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3886,7 +3904,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3897,7 +3915,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3908,7 +3926,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3919,7 +3937,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3930,7 +3948,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3945,7 +3963,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3956,7 +3974,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3967,7 +3985,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3978,7 +3996,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -3989,7 +4007,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4000,7 +4018,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4011,7 +4029,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4026,7 +4044,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4037,7 +4055,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4048,8 +4066,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -4059,7 +4077,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4070,7 +4088,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4081,7 +4099,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4092,7 +4110,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4107,7 +4125,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4118,7 +4136,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4129,7 +4147,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4140,7 +4158,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4151,7 +4169,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4162,7 +4180,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4173,7 +4191,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4188,7 +4206,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4199,7 +4217,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4211,7 +4229,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4223,7 +4241,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4235,7 +4253,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4247,7 +4265,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 05"
+                  aria-label="Sun May 05 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4259,7 +4277,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 06"
+                  aria-label="Mon May 06 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4305,6 +4323,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -4331,7 +4350,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -4563,7 +4584,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 27"
+                  aria-label="Wed Mar 27 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4575,7 +4596,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 28"
+                  aria-label="Thu Mar 28 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4587,7 +4608,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 29"
+                  aria-label="Fri Mar 29 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4599,7 +4620,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 30"
+                  aria-label="Sat Mar 30 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4611,7 +4632,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 03 31"
+                  aria-label="Sun Mar 31 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -4623,8 +4644,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -4634,7 +4655,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4649,7 +4670,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4660,7 +4681,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4671,7 +4692,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4682,7 +4703,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4693,7 +4714,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4704,7 +4725,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4715,7 +4736,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4730,7 +4751,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4741,7 +4762,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4752,7 +4773,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4763,7 +4784,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4774,7 +4795,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4785,7 +4806,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4796,7 +4817,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4811,7 +4832,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4822,8 +4843,8 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -4833,7 +4854,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4844,7 +4865,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4855,7 +4876,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4866,7 +4887,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4877,7 +4898,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4892,7 +4913,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4903,7 +4924,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4914,7 +4935,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4925,7 +4946,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4936,7 +4957,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4947,7 +4968,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -4958,7 +4979,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5003,6 +5024,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
               type="button"
@@ -5029,7 +5051,9 @@ exports[`Internationalization renders the date picker in russian 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-modal="true"
           class="date-picker-calendar"
+          role="dialog"
         >
           <div
             class="date-picker-calendar-header"
@@ -5396,8 +5420,8 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 01"
-                  class="date-picker-date date-picker-calendar-item"
+                  aria-label="Mon Apr 01 2019"
+                  class="date-picker-date date-picker-calendar-item active"
                   type="button"
                 >
                   1
@@ -5407,7 +5431,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 02"
+                  aria-label="Tue Apr 02 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5418,7 +5442,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 03"
+                  aria-label="Wed Apr 03 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5429,7 +5453,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 04"
+                  aria-label="Thu Apr 04 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5440,7 +5464,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 05"
+                  aria-label="Fri Apr 05 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5451,7 +5475,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 06"
+                  aria-label="Sat Apr 06 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5462,7 +5486,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 07"
+                  aria-label="Sun Apr 07 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5477,7 +5501,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 08"
+                  aria-label="Mon Apr 08 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5488,7 +5512,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 09"
+                  aria-label="Tue Apr 09 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5499,7 +5523,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 10"
+                  aria-label="Wed Apr 10 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5510,7 +5534,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 11"
+                  aria-label="Thu Apr 11 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5521,7 +5545,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 12"
+                  aria-label="Fri Apr 12 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5532,7 +5556,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 13"
+                  aria-label="Sat Apr 13 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5543,7 +5567,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 14"
+                  aria-label="Sun Apr 14 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5558,7 +5582,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 15"
+                  aria-label="Mon Apr 15 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5569,7 +5593,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 16"
+                  aria-label="Tue Apr 16 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5580,7 +5604,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 17"
+                  aria-label="Wed Apr 17 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5591,8 +5615,8 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 18"
-                  class="date-picker-date date-picker-calendar-item active"
+                  aria-label="Thu Apr 18 2019"
+                  class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
                   18
@@ -5602,7 +5626,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 19"
+                  aria-label="Fri Apr 19 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5613,7 +5637,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 20"
+                  aria-label="Sat Apr 20 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5624,7 +5648,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 21"
+                  aria-label="Sun Apr 21 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5639,7 +5663,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 22"
+                  aria-label="Mon Apr 22 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5650,7 +5674,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 23"
+                  aria-label="Tue Apr 23 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5661,7 +5685,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 24"
+                  aria-label="Wed Apr 24 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5672,7 +5696,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 25"
+                  aria-label="Thu Apr 25 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5683,7 +5707,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 26"
+                  aria-label="Fri Apr 26 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5694,7 +5718,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 27"
+                  aria-label="Sat Apr 27 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5705,7 +5729,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 28"
+                  aria-label="Sun Apr 28 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5720,7 +5744,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 29"
+                  aria-label="Mon Apr 29 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5731,7 +5755,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 04 30"
+                  aria-label="Tue Apr 30 2019"
                   class="date-picker-date date-picker-calendar-item"
                   type="button"
                 >
@@ -5742,7 +5766,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 01"
+                  aria-label="Wed May 01 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -5754,7 +5778,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 02"
+                  aria-label="Thu May 02 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -5766,7 +5790,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 03"
+                  aria-label="Fri May 03 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -5778,7 +5802,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 04"
+                  aria-label="Sat May 04 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"
@@ -5790,7 +5814,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 class="date-picker-col"
               >
                 <button
-                  aria-label="2019 05 05"
+                  aria-label="Sun May 05 2019"
                   class="date-picker-date date-picker-calendar-item disabled"
                   disabled=""
                   type="button"

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -408,15 +408,17 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 
 			changeMonth(NEW_DATE);
 
-			setDaysSelected([NEW_DATE, endDate]);
+			const newDaysSelected: [Date, Date] =
+				range && endDate < NEW_DATE
+					? [endDate, NEW_DATE]
+					: [NEW_DATE, endDate];
+
+			setDaysSelected(newDaysSelected);
 
 			let dateFormatted;
 
 			if (range) {
-				dateFormatted = fromRangeToString(
-					[NEW_DATE, endDate],
-					dateFormat
-				);
+				dateFormatted = fromRangeToString(newDaysSelected, dateFormat);
 			} else if (time) {
 				dateFormatted = formatDate(
 					parseDate(currentTime, TIME_FORMAT, NEW_DATE),

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -318,14 +318,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				daysSelectedToString = formatDate(date, dateFormat);
 
 				if (time) {
-					daysSelectedToString = formatDate(
-						parseDate(
-							`${daysSelectedToString} ${currentTime}`,
-							`${dateFormat} ${TIME_FORMAT}`,
-							date
-						),
-						`${dateFormat} ${TIME_FORMAT}`
-					);
+					daysSelectedToString = `${daysSelectedToString} ${currentTime}`;
 				}
 			}
 
@@ -363,7 +356,10 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				setDaysSelected([startDate, endDate]);
 
 				if (time) {
-					setCurrentTime(startDate.getHours(), startDate.getMinutes());
+					setCurrentTime(
+						startDate.getHours(),
+						startDate.getMinutes()
+					);
 				}
 			}
 
@@ -405,21 +401,17 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			hours: number | string,
 			minutes: number | string
 		) => {
-			const format = `${dateFormat} ${TIME_FORMAT}`;
 			const [day] = daysSelected;
 
-			const dateParsed = parseDate(value, format, NEW_DATE);
-			const newDate = isValid(dateParsed)
-				? dateParsed
-				: new Date(day.getTime());
-
-			newDate.setHours(Number(hours));
-			newDate.setMinutes(Number(minutes));
-
-			if (isValid(dateParsed)) {
-				onValueChange(formatDate(newDate, format), 'time');
-			}
-
+			onValueChange(
+				typeof hours === 'string' && typeof minutes === 'string'
+					? `${formatDate(day, dateFormat)} ${hours}:${minutes}`
+					: formatDate(
+							setDate(day, {hours, minutes}),
+							`${dateFormat} ${TIME_FORMAT}`
+					  ),
+				'time'
+			);
 			setCurrentTime(hours, minutes);
 		};
 

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -235,13 +235,11 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		 * in the cases where We have a date range and when `range` property
 		 * is disabled we will just use the first element of the tuple(startDate)
 		 */
-		const [daysSelected, setDaysSelected] = React.useState(
-			() =>
-				[
-					setDate(initialMonth, DEFAULT_DATE_TIME),
-					setDate(initialMonth, DEFAULT_DATE_TIME),
-				] as const
-		);
+		const [daysSelected, setDaysSelected] = React.useState(() => {
+			const date = setDate(initialMonth, DEFAULT_DATE_TIME);
+
+			return [date, date] as const;
+		});
 
 		/**
 		 * Indicates the time selected by the user.
@@ -303,7 +301,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			let daysSelectedToString;
 
 			if (range) {
-				if (date === endDate) {
+				if (startDate !== endDate) {
 					newDaysSelected = [date, date];
 				} else if (date < startDate) {
 					newDaysSelected = [date, endDate];

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -403,15 +403,18 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		) => {
 			const [day] = daysSelected;
 
-			onValueChange(
-				typeof hours === 'string' && typeof minutes === 'string'
-					? `${formatDate(day, dateFormat)} ${hours}:${minutes}`
-					: formatDate(
-							setDate(day, {hours, minutes}),
-							`${dateFormat} ${TIME_FORMAT}`
-					  ),
-				'time'
-			);
+			if (value) {
+				onValueChange(
+					typeof hours === 'string' && typeof minutes === 'string'
+						? `${formatDate(day, dateFormat)} ${hours}:${minutes}`
+						: formatDate(
+								setDate(day, {hours, minutes}),
+								`${dateFormat} ${TIME_FORMAT}`
+						  ),
+					'time'
+				);
+			}
+
 			setCurrentTime(hours, minutes);
 		};
 

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -150,21 +150,19 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	onExpandedChange?: TInternalStateOnChange<boolean>;
 }
 
-const NEW_DATE = new Date();
-
-const TIME_FORMAT = 'HH:mm';
+const DEFAULT_DATE_TIME = {
+	hours: 12,
+	milliseconds: 0,
+	minutes: 0,
+	seconds: 0,
+};
 
 /**
  * Normalize date for always set noon to avoid time zone issues
  */
-const normalizeDate = (date: Date) =>
-	setDate(date, {
-		date: 1,
-		hours: 12,
-		milliseconds: 0,
-		minutes: 0,
-		seconds: 0,
-	});
+const NEW_DATE = setDate(new Date(), DEFAULT_DATE_TIME);
+
+const TIME_FORMAT = 'HH:mm';
 
 /**
  * ClayDatePicker component.
@@ -227,7 +225,9 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		 * Indicates the current month rendered on the screen.
 		 */
 		const [currentMonth, setCurrentMonth] = React.useState(() =>
-			normalizeDate(initialMonth)
+			// Normalize the date to always set noon to avoid time zone problems
+			// and to the 1st of the month.
+			setDate(initialMonth, {date: 1, ...DEFAULT_DATE_TIME})
 		);
 
 		/**
@@ -238,8 +238,8 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		const [daysSelected, setDaysSelected] = React.useState(
 			() =>
 				[
-					normalizeDate(initialMonth),
-					normalizeDate(initialMonth),
+					setDate(initialMonth, DEFAULT_DATE_TIME),
+					setDate(initialMonth, DEFAULT_DATE_TIME),
 				] as const
 		);
 
@@ -278,7 +278,10 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		 * content and takes care of updating the weeks.
 		 */
 		const changeMonth = (date: Date) => {
-			const dateNormalized = normalizeDate(date);
+			const dateNormalized = setDate(date, {
+				date: 1,
+				...DEFAULT_DATE_TIME,
+			});
 
 			setCurrentMonth(dateNormalized);
 			onNavigation(dateNormalized);

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -25,40 +25,6 @@ import Weekday from './Weekday';
 import WeekdayHeader from './WeekdayHeader';
 import {FirstDayOfWeek, IAriaLabels, IYears} from './types';
 
-export {FirstDayOfWeek};
-
-function isYearWithinYears(year: number, years: IYears) {
-	return years.start <= year && year <= years.end;
-}
-
-export const RANGE_SEPARATOR = ' - ';
-
-function fromStringToRange(
-	value: string,
-	dateFormat: string,
-	referenceDate: Date
-): readonly [Date, Date] {
-	const [fromDateString, toDateString] = value.split(RANGE_SEPARATOR);
-
-	const fromDate = parseDate(fromDateString, dateFormat, referenceDate);
-
-	return [
-		fromDate,
-		toDateString
-			? parseDate(toDateString, dateFormat, referenceDate)
-			: fromDate,
-	];
-}
-
-function fromRangeToString(range: [Date, Date], dateFormat: string) {
-	const [startDate, endDate] = range;
-
-	return `${formatDate(startDate, dateFormat)}${RANGE_SEPARATOR}${formatDate(
-		endDate,
-		dateFormat
-	)}`;
-}
-
 interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	/**
 	 * Labels for the aria attributes
@@ -599,6 +565,39 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 	}
 );
 
+const RANGE_SEPARATOR = ' - ';
+
+function isYearWithinYears(year: number, years: IYears) {
+	return years.start <= year && year <= years.end;
+}
+
+function fromStringToRange(
+	value: string,
+	dateFormat: string,
+	referenceDate: Date
+): readonly [Date, Date] {
+	const [fromDateString, toDateString] = value.split(RANGE_SEPARATOR);
+
+	const fromDate = parseDate(fromDateString, dateFormat, referenceDate);
+
+	return [
+		fromDate,
+		toDateString
+			? parseDate(toDateString, dateFormat, referenceDate)
+			: fromDate,
+	];
+}
+
+function fromRangeToString(range: [Date, Date], dateFormat: string) {
+	const [startDate, endDate] = range;
+
+	return `${formatDate(startDate, dateFormat)}${RANGE_SEPARATOR}${formatDate(
+		endDate,
+		dateFormat
+	)}`;
+}
+
 ClayDatePicker.displayName = 'ClayDatePicker';
 
+export {FirstDayOfWeek};
 export default ClayDatePicker;

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -405,9 +405,17 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				);
 			}
 
-			const time = parseDate(currentTime, TIME_FORMAT, DATE_NOW);
+			if (time) {
+				const time = parseDate(currentTime, TIME_FORMAT, DATE_NOW);
 
-			onValueChange(formatDate(time, `${dateFormat} ${TIME_FORMAT}`));
+				return onValueChange(
+					formatDate(time, `${dateFormat} ${TIME_FORMAT}`)
+				);
+			}
+
+			const dateFormatted = formatDate(DATE_NOW, dateFormat);
+
+			return onValueChange(dateFormatted);
 		};
 
 		const handleTimeChange = (
@@ -425,7 +433,9 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			newDate.setHours(Number(hours));
 			newDate.setMinutes(Number(minutes));
 
-			onValueChange(formatDate(newDate, format), 'time');
+			if (isValid(dateParsed)) {
+				onValueChange(formatDate(newDate, format), 'time');
+			}
 
 			setCurrentTime(hours, minutes);
 		};

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -313,6 +313,12 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 					newDaysSelected,
 					dateFormat
 				);
+
+				const [newStartDate, newEndDate] = newDaysSelected;
+
+				if (newStartDate.getMonth() !== newEndDate.getMonth()) {
+					changeMonth(startDate);
+				}
 			} else {
 				newDaysSelected = [date, date];
 

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -343,27 +343,27 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 
 			const format = time ? `${dateFormat} ${TIME_FORMAT}` : dateFormat;
 
-			const [fromDate, toDate] = fromStringToRange(
+			const [startDate, endDate] = fromStringToRange(
 				value,
 				format,
 				NEW_DATE
 			);
 
-			const yearFrom = fromDate.getFullYear();
-			const yearTo = toDate.getFullYear();
+			const yearFrom = startDate.getFullYear();
+			const yearTo = endDate.getFullYear();
 
 			if (
-				isValid(fromDate) &&
-				isValid(toDate) &&
+				isValid(startDate) &&
+				isValid(endDate) &&
 				isYearWithinYears(yearFrom, years) &&
 				isYearWithinYears(yearTo, years)
 			) {
-				changeMonth(fromDate);
+				changeMonth(startDate);
 
-				setDaysSelected([fromDate, toDate]);
+				setDaysSelected([startDate, endDate]);
 
 				if (time) {
-					setCurrentTime(fromDate.getHours(), fromDate.getMinutes());
+					setCurrentTime(startDate.getHours(), startDate.getMinutes());
 				}
 			}
 
@@ -384,8 +384,6 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 					? [endDate, NEW_DATE]
 					: [NEW_DATE, endDate];
 
-			setDaysSelected(newDaysSelected);
-
 			let dateFormatted;
 
 			if (range) {
@@ -399,6 +397,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				dateFormatted = formatDate(NEW_DATE, dateFormat);
 			}
 
+			setDaysSelected(newDaysSelected);
 			onValueChange(dateFormatted);
 		};
 
@@ -576,15 +575,15 @@ function fromStringToRange(
 	dateFormat: string,
 	referenceDate: Date
 ): readonly [Date, Date] {
-	const [fromDateString, toDateString] = value.split(RANGE_SEPARATOR);
+	const [startDateString, endDateString] = value.split(RANGE_SEPARATOR);
 
-	const fromDate = parseDate(fromDateString, dateFormat, referenceDate);
+	const startDate = parseDate(startDateString, dateFormat, referenceDate);
 
 	return [
-		fromDate,
-		toDateString
-			? parseDate(toDateString, dateFormat, referenceDate)
-			: fromDate,
+		startDate,
+		endDateString
+			? parseDate(endDateString, dateFormat, referenceDate)
+			: startDate,
 	];
 }
 

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -18,7 +18,7 @@ import DateNavigation from './DateNavigation';
 import DayNumber from './DayNumber';
 import DaysTable from './DaysTable';
 import {formatDate, isValid, parseDate, setDate} from './Helpers';
-import {useCurrentTime, useWeeks} from './Hooks';
+import {useCurrentTime, useDaysSelected, useWeeks} from './Hooks';
 import InputDate from './InputDate';
 import TimePicker from './TimePicker';
 import Weekday from './Weekday';
@@ -157,10 +157,7 @@ const DEFAULT_DATE_TIME = {
 	seconds: 0,
 };
 
-/**
- * Normalize date for always set noon to avoid time zone issues
- */
-const NEW_DATE = setDate(new Date(), DEFAULT_DATE_TIME);
+const NEW_DATE = new Date();
 
 const TIME_FORMAT = 'HH:mm';
 
@@ -235,11 +232,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		 * in the cases where We have a date range and when `range` property
 		 * is disabled we will just use the first element of the tuple(startDate)
 		 */
-		const [daysSelected, setDaysSelected] = React.useState(() => {
-			const date = setDate(initialMonth, DEFAULT_DATE_TIME);
-
-			return [date, date] as const;
-		});
+		const [daysSelected, setDaysSelected] = useDaysSelected(initialMonth);
 
 		/**
 		 * Indicates the time selected by the user.

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -334,8 +334,13 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			let daysSelectedToString;
 
 			if (range) {
-				newDaysSelected =
-					date < startDate ? [date, endDate] : [startDate, date];
+				if (date === endDate) {
+					newDaysSelected = [date, date];
+				} else if (date < startDate) {
+					newDaysSelected = [date, endDate];
+				} else {
+					newDaysSelected = [startDate, date];
+				}
 
 				daysSelectedToString = fromRangeToString(
 					newDaysSelected,

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -40,11 +40,13 @@ function fromStringToRange(
 ): readonly [Date, Date] {
 	const [fromDateString, toDateString] = value.split(RANGE_SEPARATOR);
 
+	const fromDate = parseDate(fromDateString, dateFormat, referenceDate);
+
 	return [
-		parseDate(fromDateString, dateFormat, referenceDate),
+		fromDate,
 		toDateString
 			? parseDate(toDateString, dateFormat, referenceDate)
-			: referenceDate,
+			: fromDate,
 	];
 }
 

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -50,7 +50,7 @@ function fromStringToRange(
 	];
 }
 
-function fromRangeToString(range: readonly [Date, Date], dateFormat: string) {
+function fromRangeToString(range: [Date, Date], dateFormat: string) {
 	const [startDate, endDate] = range;
 
 	return `${formatDate(startDate, dateFormat)}${RANGE_SEPARATOR}${formatDate(
@@ -325,61 +325,41 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		};
 
 		/**
-		 * Holds the logic for how to behave when clicking on a date,
-		 * on the DatePicker using date ranges
-		 */
-		const handleDateRangeClicked = (date: Date) => {
-			const [startDate, endDate] = daysSelected;
-
-			if (date < startDate) {
-				setDaysSelected([date, endDate]);
-
-				onValueChange(
-					fromRangeToString(daysSelected, dateFormat),
-					'click'
-				);
-
-				return;
-			}
-
-			setDaysSelected([startDate, date]);
-
-			onValueChange(
-				fromRangeToString([startDate, date], dateFormat),
-				'click'
-			);
-		};
-
-		/**
 		 * Handles the click on element of the day
 		 */
 		const handleDayClicked = (date: Date) => {
+			const [startDate, endDate] = daysSelected;
+
+			let newDaysSelected: [Date, Date];
+			let daysSelectedToString;
+
 			if (range) {
-				handleDateRangeClicked(date);
+				newDaysSelected =
+					date < startDate ? [date, endDate] : [startDate, date];
 
-				return;
-			}
-
-			setDaysSelected([date, date]);
-
-			const dateFormatted = formatDate(date, dateFormat);
-
-			if (time) {
-				const dateString = formatDate(
-					parseDate(
-						`${dateFormatted} ${currentTime}`,
-						`${dateFormat} ${TIME_FORMAT}`,
-						date
-					),
-					`${dateFormat} ${TIME_FORMAT}`
+				daysSelectedToString = fromRangeToString(
+					newDaysSelected,
+					dateFormat
 				);
+			} else {
+				newDaysSelected = [date, date];
 
-				onValueChange(dateString, 'click');
+				daysSelectedToString = formatDate(date, dateFormat);
 
-				return;
+				if (time) {
+					daysSelectedToString = formatDate(
+						parseDate(
+							`${daysSelectedToString} ${currentTime}`,
+							`${dateFormat} ${TIME_FORMAT}`,
+							date
+						),
+						`${dateFormat} ${TIME_FORMAT}`
+					);
+				}
 			}
 
-			onValueChange(dateFormatted, 'click');
+			setDaysSelected(newDaysSelected);
+			onValueChange(daysSelectedToString, 'click');
 		};
 
 		/**

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -161,9 +161,9 @@ const normalizeDate = (date: Date) =>
 	setDate(date, {
 		date: 1,
 		hours: 12,
-		milliseconds: 1,
-		minutes: 1,
-		seconds: 1,
+		milliseconds: 0,
+		minutes: 0,
+		seconds: 0,
 	});
 
 /**

--- a/packages/clay-date-picker/src/types.ts
+++ b/packages/clay-date-picker/src/types.ts
@@ -14,6 +14,7 @@ export enum FirstDayOfWeek {
 }
 
 export interface IAriaLabels {
+	buttonChooseDate: string;
 	buttonDot: string;
 	buttonNextMonth: string;
 	buttonPreviousMonth: string;
@@ -24,3 +25,5 @@ export interface IYears {
 	end: number;
 	start: number;
 }
+
+export type TDaysSelected = [Date, Date];

--- a/packages/clay-date-picker/src/types.ts
+++ b/packages/clay-date-picker/src/types.ts
@@ -25,5 +25,3 @@ export interface IYears {
 	end: number;
 	start: number;
 }
-
-export type TDaysSelected = [Date, Date];

--- a/packages/clay-date-picker/stories/index.tsx
+++ b/packages/clay-date-picker/stories/index.tsx
@@ -15,12 +15,24 @@ const ClayDatePickerWithState = (props: {[key: string]: any}) => {
 	const [value, setValue] = React.useState<string | Date>('');
 
 	return (
-		<ClayDatePicker
-			{...props}
-			onValueChange={setValue}
-			spritemap={spritemap}
-			value={value as string}
-		/>
+		<>
+			<label>{'Date Picker'}</label>
+			<ClayDatePicker
+				{...props}
+				ariaLabels={{
+					buttonChooseDate: `Choose Date, selected date is ${
+						value.toLocaleString() ?? value
+					}`,
+					buttonDot: 'Go to today',
+					buttonNextMonth: 'Next month',
+					buttonPreviousMonth: 'Previous month',
+					input: value.toLocaleString(),
+				}}
+				onValueChange={setValue}
+				spritemap={spritemap}
+				value={value as string}
+			/>
+		</>
 	);
 };
 
@@ -133,5 +145,17 @@ storiesOf('Components|ClayDatePicker', module)
 			placeholder="YYYY-MM-DD"
 			spritemap={spritemap}
 			useNative
+		/>
+	))
+	.add('w/ date range', () => (
+		<ClayDatePickerWithState
+			dateFormat="yyyy/MM/dd"
+			placeholder="YYYY/MM/DD - YYYY/MM/DD"
+			range
+			spritemap={spritemap}
+			years={{
+				end: 2024,
+				start: 1997,
+			}}
 		/>
 	));


### PR DESCRIPTION
I'm just adding a few more commits to correct some things, for context see the original PR: #4012

We still have some problems that we need to fix:

- We have a CSS bug where the `active` state of the date is disabled it does not appear, maybe we should just show color of the `active` with less opacity instead of removing it? cc @pat270 @drakonux 
- ~~The experience for changing the start range when an end date is already selected seems a little confusing https://github.com/liferay/clay/pull/4012#issuecomment-822558650~~

Despite having some small details to fix I think that both do not prevent this PR from entering the master.