### PR TITLE
docs(clayui.com): updates the `order by` icons in the Management Toolbar documentation

### DIFF
--- a/packages/clay-management-toolbar/docs/index.js
+++ b/packages/clay-management-toolbar/docs/index.js
@@ -229,13 +229,13 @@ const ManagementToolbarCode = `const Component = () => {
 
 					<ClayManagementToolbar.Item>
 						<ClayButton
-							className="nav-link nav-link-monospaced order-arrow-down-active"
+							className="nav-link nav-link-monospaced"
 							displayType="unstyled"
 							onClick={() => {}}
 						>
 							<ClayIcon
 								spritemap={spritemap}
-								symbol="order-arrow"
+								symbol="order-list-up"
 							/>
 						</ClayButton>
 					</ClayManagementToolbar.Item>

--- a/packages/clay-management-toolbar/docs/markup-management-toolbar.md
+++ b/packages/clay-management-toolbar/docs/markup-management-toolbar.md
@@ -69,9 +69,9 @@ mainTabURL: 'docs/components/management-toolbar.html'
                     </ul>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced order-arrow-down-active" href="#1" role="button">
-                        <svg class="lexicon-icon lexicon-icon-order-arrow" focusable="false" role="presentation">
-                            <use href="/images/icons/icons.svg#order-arrow"></use>
+                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                        <svg class="lexicon-icon lexicon-icon-order-list-up" focusable="false" role="presentation">
+                            <use href="/images/icons/icons.svg#order-list-up"></use>
                         </svg>
                     </a>
                 </li>
@@ -225,9 +225,9 @@ mainTabURL: 'docs/components/management-toolbar.html'
                     </ul>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced order-arrow-down-active" href="#1" role="button">
-                        <svg class="lexicon-icon lexicon-icon-order-arrow" focusable="false" role="presentation">
-                            <use href="/images/icons/icons.svg#order-arrow"></use>
+                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                        <svg class="lexicon-icon lexicon-icon-order-list-up" focusable="false" role="presentation">
+                            <use href="/images/icons/icons.svg#order-list-up"></use>
                         </svg>
                     </a>
                 </li>
@@ -386,9 +386,9 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </ul>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced order-arrow-down-active" href="#1" role="button">
-                        <svg class="lexicon-icon lexicon-icon-order-arrow" focusable="false" role="presentation">
-                            <use href="/images/icons/icons.svg#order-arrow"></use>
+                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                        <svg class="lexicon-icon lexicon-icon-order-list-up" focusable="false" role="presentation">
+                            <use href="/images/icons/icons.svg#order-list-up"></use>
                         </svg>
                     </a>
                 </li>
@@ -561,17 +561,13 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 				</ul>
 			</li>
 			<li class="nav-item">
-				<a
-					class="nav-link nav-link-monospaced order-arrow-down-active"
-					href="#1"
-					role="button"
-				>
+				<a class="nav-link nav-link-monospaced" href="#1" role="button">
 					<svg
-						class="lexicon-icon lexicon-icon-order-arrow"
+						class="lexicon-icon lexicon-icon-order-list-up"
 						focusable="false"
 						role="presentation"
 					>
-						<use href="/images/icons/icons.svg#order-arrow"></use>
+						<use href="/images/icons/icons.svg#order-list-up"></use>
 					</svg>
 				</a>
 			</li>
@@ -784,9 +780,9 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </ul>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced order-arrow-down-active" href="#1" role="button">
-                        <svg class="lexicon-icon lexicon-icon-order-arrow" focusable="false" role="presentation">
-                            <use href="/images/icons/icons.svg#order-arrow"></use>
+                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                        <svg class="lexicon-icon lexicon-icon-order-list-up" focusable="false" role="presentation">
+                            <use href="/images/icons/icons.svg#order-list-up"></use>
                         </svg>
                     </a>
                 </li>
@@ -956,17 +952,13 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 				</ul>
 			</li>
 			<li class="nav-item">
-				<a
-					class="nav-link nav-link-monospaced order-arrow-down-active"
-					href="#1"
-					role="button"
-				>
+				<a class="nav-link nav-link-monospaced" href="#1" role="button">
 					<svg
-						class="lexicon-icon lexicon-icon-order-arrow"
+						class="lexicon-icon lexicon-icon-order-list-up"
 						focusable="false"
 						role="presentation"
 					>
-						<use href="/images/icons/icons.svg#order-arrow"></use>
+						<use href="/images/icons/icons.svg#order-list-up"></use>
 					</svg>
 				</a>
 			</li>
@@ -1605,9 +1597,9 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </button>
                 </li>
                 <li class="nav-item">
-                    <button class="btn btn-unstyled nav-btn nav-btn-monospaced order-arrow-down-active" type="button">
-                    <svg class="lexicon-icon lexicon-icon-order-arrow" focusable="false" role="presentation">
-                        <use href="/images/icons/icons.svg#order-arrow"></use>
+                    <button class="btn btn-unstyled nav-btn nav-btn-monospaced" type="button">
+                    <svg class="lexicon-icon lexicon-icon-order-list-up" focusable="false" role="presentation">
+                        <use href="/images/icons/icons.svg#order-list-up"></use>
                     </svg>
                     </button>
                 </li>
@@ -1720,15 +1712,15 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 			</li>
 			<li class="nav-item">
 				<button
-					class="btn btn-unstyled nav-btn nav-btn-monospaced order-arrow-down-active"
+					class="btn btn-unstyled nav-btn nav-btn-monospaced"
 					type="button"
 				>
 					<svg
-						class="lexicon-icon lexicon-icon-order-arrow"
+						class="lexicon-icon lexicon-icon-order-list-up"
 						focusable="false"
 						role="presentation"
 					>
-						<use href="/images/icons/icons.svg#order-arrow"></use>
+						<use href="/images/icons/icons.svg#order-list-up"></use>
 					</svg>
 				</button>
 			</li>

--- a/packages/clay-management-toolbar/stories/index.tsx
+++ b/packages/clay-management-toolbar/stories/index.tsx
@@ -88,13 +88,13 @@ storiesOf('Components|ClayManagementToolbar', module).add(
 						<ClayManagementToolbar.Item>
 							<ClayButton
 								aria-label="Order items"
-								className="nav-link nav-link-monospaced order-arrow-down-active"
+								className="nav-link nav-link-monospaced"
 								displayType="link"
 								onClick={() => {}}
 							>
 								<ClayIcon
 									spritemap={spritemap}
-									symbol="order-arrow"
+									symbol="order-list-up"
 								/>
 							</ClayButton>
 						</ClayManagementToolbar.Item>

--- a/packages/demos/stories/ListPage.tsx
+++ b/packages/demos/stories/ListPage.tsx
@@ -12,7 +12,6 @@ import {ClayListWithItems} from '@clayui/list';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import {sub} from '@clayui/shared';
-import classNames from 'classnames';
 import React from 'react';
 
 export default () => {
@@ -183,19 +182,17 @@ export default () => {
 
 							<ClayManagementToolbar.Item>
 								<ClayButton
-									className={classNames(
-										'nav-link nav-link-monospaced',
-										{
-											'order-arrow-down-active': !sortAsc,
-											'order-arrow-up-active': sortAsc,
-										}
-									)}
+									className="nav-link nav-link-monospaced"
 									displayType="unstyled"
 									onClick={() => setSortAsc(!sortAsc)}
 								>
 									<ClayIcon
 										spritemap={spritemap}
-										symbol="order-arrow"
+										symbol={
+											sortAsc
+												? 'order-list-up'
+												: 'order-list-down'
+										}
 									/>
 								</ClayButton>
 							</ClayManagementToolbar.Item>


### PR DESCRIPTION
Fixes #4023

This just updates our examples to use the new icons in Storybook and clayui.com. @pat270 since we have new icons to represent the asc or desc sort, I got rid of `order-arrow-down-active` in the examples, let me know if it still becomes necessary.