### PR TITLE
feat(@clayui/tooltip): change the Provider to singleton and adds the listeners to the document.body

### DIFF
--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -206,7 +206,11 @@ const TooltipProvider: React.FunctionComponent<{
 				(window as any)[SYMBOL_TOOLTIP] = false;
 
 				document.body.removeEventListener('mouseout', handleHide, true);
-				document.body.removeEventListener('mouseover', handleShow, true);
+				document.body.removeEventListener(
+					'mouseover',
+					handleShow,
+					true
+				);
 			};
 		}
 	}, [handleHide]);

--- a/packages/clay-tooltip/stories/index.tsx
+++ b/packages/clay-tooltip/stories/index.tsx
@@ -44,45 +44,43 @@ storiesOf('Components|ClayTooltip', module)
 			<button title="Default">{'No Tooltip'}</button>
 
 			<ClayTooltipProvider>
-				<div>
-					<button title="Default">{'Default'}</button>
+				<button title="Default">{'Default'}</button>
 
-					{/* Note that the newline has to be a string within braces. */}
-					<button title={'Line1\nLine2'}>
-						{'With a line Break'}
-					</button>
+				{/* Note that the newline has to be a string within braces. */}
+				<button title={'Line1\nLine2'}>{'With a line Break'}</button>
 
-					<button data-tooltip-align="left" title="Left">
-						{'Left'}
-					</button>
+				<button data-tooltip-align="left" title="Left">
+					{'Left'}
+				</button>
 
-					<button data-tooltip-align="right" title="Right">
-						{'Right'}
-					</button>
+				<button data-tooltip-align="right" title="Right">
+					{'Right'}
+				</button>
 
-					<button data-tooltip-align="top" title="Top">
-						{'Top'}
-					</button>
+				<button data-tooltip-align="top" title="Top">
+					{'Top'}
+				</button>
+			</ClayTooltipProvider>
 
-					<button
-						data-tooltip-align="bottom"
-						data-tooltip-delay="0"
-						title="Bottom"
-					>
-						{'Custom Delay'}
-					</button>
+			<ClayTooltipProvider>
+				<button
+					data-tooltip-align="bottom"
+					data-tooltip-delay="0"
+					title="Bottom"
+				>
+					{'Custom Delay'}
+				</button>
 
-					<div
-						data-tooltip-align="bottom"
-						style={{
-							backgroundColor: '#F6F8FA',
-							border: '1px solid #D1D5DA',
-							padding: 8,
-						}}
-						title="I'm on the parent element"
-					>
-						<button>{'nested'}</button>
-					</div>
+				<div
+					data-tooltip-align="bottom"
+					style={{
+						backgroundColor: '#F6F8FA',
+						border: '1px solid #D1D5DA',
+						padding: 8,
+					}}
+					title="I'm on the parent element"
+				>
+					<button>{'nested'}</button>
 				</div>
 			</ClayTooltipProvider>
 		</div>


### PR DESCRIPTION
Fixes #4013

Well, the change here is quite simple, we stopped using the synthetic events of the React that were added in `children` to add events to `document.body` to cover the use cases with `React.Portal` and as a consequence to avoid conflicts with other providers on the same page which is quite common in DXP, making the Provider a singleton.