### PR TITLE
refactor(@clayui/shared): don't coerce `contentEditable`

### DIFF
--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -43,7 +43,8 @@ export function isFocusable({
 
 	if (
 		(tabIndex != null && tabIndex >= minTabIndex) ||
-		!!contentEditable === true
+		contentEditable === true ||
+		contentEditable === 'true'
 	) {
 		return true;
 	}


### PR DESCRIPTION
Not sure whether this would actually cause a bug, so labeling this as a refactor commit.

`contentEditable` can be a string (eg. `'true'`)or a bool (or `undefined`), so we probably shouldn't coerce it (eg. `!!'false'` is `true`). Instead, explicitly check against `true` and `'true'`.

Originally started looking at this because the `!!` in [this PR](https://github.com/liferay/clay/pull/3942) looked a bit off.

    
