### PR TITLE
refactor(@clayui/shared): sort expressions

### DIFF
--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -53,16 +53,16 @@ export function isFocusable({
 	}
 
 	if (tagName === 'input') {
-		return type !== 'hidden' && type !== 'file';
+		return type !== 'file' && type !== 'hidden';
 	}
 
 	return (
 		tagName === 'button' ||
-		tagName === 'textarea' ||
+		tagName === 'embed' ||
+		tagName === 'iframe' ||
 		tagName === 'object' ||
 		tagName === 'select' ||
-		tagName === 'iframe' ||
-		tagName === 'embed'
+		tagName === 'textarea'
 	);
 }
 


### PR DESCRIPTION
Seeing as The Liferay Way™ is to sort sortable things, I'm sorting the expressions in these statements. Sometimes there are logical reasons for not sorting in order (eg. wanting to short-circuit) or performance reasons (eg. putting the cheapest checks first), but in this case, the comparisons all just string equality checks which can be considered to have essentially zero cost.

Noticed while reading [#3942](https://github.com/liferay/clay/pull/3942).

There is one other sortable thing in that PR that I didn't touch, and that is `FOCUSABLE_ELEMENTS`, because there is just a tiny little chance that it might have some subtle performance ramification depending on how the browser matches the selector, so I'd rather not risk changing it.

![this-is-the-way](https://user-images.githubusercontent.com/7074/116230235-ad837900-a757-11eb-94fe-4fc342216deb.gif)
