### PR TITLE
fix(@clayui/date-picker): DatePickerDayNumber use the classes `previous-month-date` and `next-month-date` to style day outside the month instead of `disabled`

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_date-picker.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_date-picker.scss
@@ -65,7 +65,9 @@ $date-picker-previous-month-date: map-deep-merge(
 		color: $gray-500,
 		opacity: null,
 		focus-opacity: null,
-		active-opacity: null,
+		active: (
+			background-color: $primary-l2,
+		),
 	),
 	$date-picker-previous-month-date
 );
@@ -76,7 +78,9 @@ $date-picker-next-month-date: map-deep-merge(
 		color: $gray-500,
 		opacity: null,
 		focus-opacity: null,
-		active-opacity: null,
+		active: (
+			background-color: $primary-l2,
+		),
 	),
 	$date-picker-next-month-date
 );

--- a/packages/clay-css/src/scss/variables/_date-picker.scss
+++ b/packages/clay-css/src/scss/variables/_date-picker.scss
@@ -218,7 +218,10 @@ $date-picker-previous-month-date: map-deep-merge(
 	(
 		opacity: 0.65,
 		focus-opacity: 1,
-		active-opacity: 1,
+		active: (
+			background-color: $primary-l1,
+			color: $primary-l3,
+		),
 	),
 	$date-picker-previous-month-date
 );
@@ -228,7 +231,10 @@ $date-picker-next-month-date: map-deep-merge(
 	(
 		opacity: 0.65,
 		focus-opacity: 1,
-		active-opacity: 1,
+		active: (
+			background-color: $primary-l1,
+			color: $primary-l3,
+		),
 	),
 	$date-picker-next-month-date
 );

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -24,7 +24,7 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 	onClick,
 	range,
 }) => {
-	const {date, outside} = day;
+	const {date, nextMonth, previousMonth} = day;
 	const [startDate, endDate] = daysSelected;
 
 	const hasEndDateSelected = date.toDateString() === endDate.toDateString();
@@ -35,7 +35,9 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 		'date-picker-date date-picker-calendar-item',
 		{
 			active: hasStartDateSelected || (range && hasEndDateSelected),
-			disabled: outside || disabled,
+			disabled,
+			'next-month-date': nextMonth,
+			'previous-month-date': previousMonth,
 		}
 	);
 
@@ -62,7 +64,7 @@ const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
 					seconds: 0,
 				}).toDateString()}
 				className={classNames}
-				disabled={outside}
+				disabled={disabled}
 				onClick={() => onClick(date)}
 				onKeyDown={(event) => {
 					// When tabbing and selecting a DayNumber using

--- a/packages/clay-date-picker/src/Helpers.ts
+++ b/packages/clay-date-picker/src/Helpers.ts
@@ -10,7 +10,8 @@ export {formatDate, parseDate};
 
 export interface IDay {
 	date: Date;
-	outside?: boolean;
+	nextMonth?: boolean;
+	previousMonth?: boolean;
 }
 
 export type WeekDays = Array<IDay>;

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -107,7 +107,8 @@ function getDaysInMonth(d: Date) {
  *   [
  *     {
  *       date: Sun Dec 30 2018 12:00:00 GMT-0300...
- *       outside: true
+ *       nextMonth: false
+ *       previousMonth: true
  * 	   },
  *     ...
  *   ]
@@ -145,7 +146,7 @@ function getWeekArray(d: Date, firstDayOfWeek = 0): Month {
 	for (let i = 7 - firstWeek.length; i > 0; i -= 1) {
 		const outsideDate = clone(firstWeek[0].date);
 		outsideDate.setDate(firstWeek[0].date.getDate() - 1);
-		firstWeek.unshift({date: outsideDate, outside: true});
+		firstWeek.unshift({date: outsideDate, previousMonth: true});
 	}
 
 	// push days until the end of the last week
@@ -153,7 +154,7 @@ function getWeekArray(d: Date, firstDayOfWeek = 0): Month {
 	for (let i = lastWeek.length; i < 7; i += 1) {
 		const outsideDate = clone(lastWeek[lastWeek.length - 1].date);
 		outsideDate.setDate(lastWeek[lastWeek.length - 1].date.getDate() + 1);
-		lastWeek.push({date: outsideDate, outside: true});
+		lastWeek.push({date: outsideDate, nextMonth: true});
 	}
 
 	return weekArray;

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -326,7 +326,7 @@ describe('IncrementalInteractions', () => {
 		expect(dayNumber.classList).toContain('active');
 	});
 
-	it('clicking on the days number disabled not should change the date and the input value', () => {
+	it('clicking on the days number previous-month or next-month should change the date and the input value', () => {
 		const {getByLabelText, getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
@@ -343,10 +343,10 @@ describe('IncrementalInteractions', () => {
 
 		fireEvent.click(dayNumber);
 
-		expect(input.value).not.toBe('2019-05-01');
+		expect(input.value).toBe('2019-05-01');
 		expect(yearSelect.value).toBe('2019');
 		expect(monthSelect.value).toBe('3');
-		expect(dayNumber.classList).not.toContain('active');
+		expect(dayNumber.classList).toContain('active');
 	});
 
 	describe('TimePicker', () => {

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -290,8 +290,7 @@ exports[`BasicRendering renders by default 1`] = `
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -648,8 +647,7 @@ exports[`BasicRendering renders by default 1`] = `
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -660,8 +658,7 @@ exports[`BasicRendering renders by default 1`] = `
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -672,8 +669,7 @@ exports[`BasicRendering renders by default 1`] = `
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -684,8 +680,7 @@ exports[`BasicRendering renders by default 1`] = `
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -990,8 +985,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -1348,8 +1342,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -1360,8 +1353,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -1372,8 +1364,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -1384,8 +1375,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -1720,8 +1710,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -2078,8 +2067,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -2090,8 +2078,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -2102,8 +2089,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -2114,8 +2100,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -2697,8 +2682,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -3055,8 +3039,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -3067,8 +3050,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -3079,8 +3061,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -3091,8 +3072,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -291,8 +291,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               >
                 <button
                   aria-label="Sun Jun 30 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   30
@@ -660,8 +659,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               >
                 <button
                   aria-label="Thu Aug 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -672,8 +670,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               >
                 <button
                   aria-label="Fri Aug 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -684,8 +681,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               >
                 <button
                   aria-label="Sat Aug 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -991,8 +987,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -1349,8 +1344,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -1361,8 +1355,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -1373,8 +1366,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -1385,8 +1377,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -1692,8 +1683,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -2050,8 +2040,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -2062,8 +2051,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -2074,8 +2062,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -2086,8 +2073,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -2754,8 +2740,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               >
                 <button
                   aria-label="Tue May 01 2018"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -2766,8 +2751,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               >
                 <button
                   aria-label="Wed May 02 2018"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -2778,8 +2762,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               >
                 <button
                   aria-label="Thu May 03 2018"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -2790,8 +2773,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               >
                 <button
                   aria-label="Fri May 04 2018"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -2802,8 +2784,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               >
                 <button
                   aria-label="Sat May 05 2018"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   5
@@ -3114,8 +3095,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -3472,8 +3452,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -3484,8 +3463,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -3496,8 +3474,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -3508,8 +3485,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -3815,8 +3791,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -4173,8 +4148,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -4185,8 +4159,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -4197,8 +4170,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -4209,8 +4181,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -291,8 +291,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Fri Mar 29 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   29
@@ -303,8 +302,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sat Mar 30 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   30
@@ -315,8 +313,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -673,8 +670,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -685,8 +681,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -992,8 +987,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -1350,8 +1344,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -1362,8 +1355,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -1374,8 +1366,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -1386,8 +1377,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -1693,8 +1683,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sat Mar 30 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   30
@@ -1705,8 +1694,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -2063,8 +2051,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -2075,8 +2062,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -2087,8 +2073,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -2394,8 +2379,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -2752,8 +2736,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -2764,8 +2747,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -2776,8 +2758,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -2788,8 +2769,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -3095,8 +3075,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Mar 28 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   28
@@ -3107,8 +3086,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Fri Mar 29 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   29
@@ -3119,8 +3097,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sat Mar 30 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   30
@@ -3131,8 +3108,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -3489,8 +3465,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -3796,8 +3771,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Tue Mar 26 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   26
@@ -3808,8 +3782,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Wed Mar 27 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   27
@@ -3820,8 +3793,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Mar 28 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   28
@@ -3832,8 +3804,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Fri Mar 29 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   29
@@ -3844,8 +3815,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sat Mar 30 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   30
@@ -3856,8 +3826,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -4218,8 +4187,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -4230,8 +4198,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -4242,8 +4209,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -4254,8 +4220,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -4266,8 +4231,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sun May 05 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   5
@@ -4278,8 +4242,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Mon May 06 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   6
@@ -4585,8 +4548,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Wed Mar 27 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   27
@@ -4597,8 +4559,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Thu Mar 28 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   28
@@ -4609,8 +4570,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Fri Mar 29 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   29
@@ -4621,8 +4581,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sat Mar 30 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   30
@@ -4633,8 +4592,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               >
                 <button
                   aria-label="Sun Mar 31 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item previous-month-date"
                   type="button"
                 >
                   31
@@ -5767,8 +5725,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               >
                 <button
                   aria-label="Wed May 01 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   1
@@ -5779,8 +5736,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               >
                 <button
                   aria-label="Thu May 02 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   2
@@ -5791,8 +5747,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               >
                 <button
                   aria-label="Fri May 03 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   3
@@ -5803,8 +5758,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               >
                 <button
                   aria-label="Sat May 04 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   4
@@ -5815,8 +5769,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               >
                 <button
                   aria-label="Sun May 05 2019"
-                  class="date-picker-date date-picker-calendar-item disabled"
-                  disabled=""
+                  class="date-picker-date date-picker-calendar-item next-month-date"
                   type="button"
                 >
                   5


### PR DESCRIPTION
fixes #4036