### PR TITLE
feat(@clayui/popover): add observeRect to align the popover on the scroll

### DIFF
--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -3,12 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal, Keys} from '@clayui/shared';
+import {ClayPortal, Keys, observeRect} from '@clayui/shared';
 import classNames from 'classnames';
 import domAlign from 'dom-align';
 import React, {useEffect, useLayoutEffect, useRef} from 'react';
-
-import observeRect from './observeRect';
 
 export const Align = {
 	BottomCenter: 4,

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal} from '@clayui/shared';
+import {ClayPortal, observeRect} from '@clayui/shared';
 import classNames from 'classnames';
 import domAlign from 'dom-align';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 export const ALIGN_POSITIONS = [
 	'top',
@@ -100,12 +100,9 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 		const show = externalShow ? externalShow : internalShow;
 		const setShow = onShowChange ? onShowChange : internalSetShow;
 
-		useEffect(() => {
+		const align = useCallback(() => {
 			if (
-				trigger &&
-				ref &&
 				(ref as React.RefObject<HTMLElement>).current &&
-				triggerRef &&
 				triggerRef.current
 			) {
 				const points = ALIGNMENTS_MAP[alignPosition] as [
@@ -121,7 +118,19 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 					}
 				);
 			}
-		}, [show]);
+		}, [alignPosition, triggerRef, ref]);
+
+		useEffect(() => {
+			if (trigger) {
+				align();
+			}
+		}, [align, show]);
+
+		useEffect(() => {
+			if (trigger && triggerRef.current) {
+				return observeRect(triggerRef.current, align);
+			}
+		}, [align]);
 
 		useEffect(() => {
 			if (!disableScroll && popoverScrollerRef.current && show) {

--- a/packages/clay-popover/stories/index.tsx
+++ b/packages/clay-popover/stories/index.tsx
@@ -6,6 +6,7 @@
 import '@clayui/css/lib/css/atlas.css';
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import ClayModal, {useModal} from '@clayui/modal';
 import {boolean, select} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
@@ -100,6 +101,83 @@ storiesOf('Components|ClayPopover', module)
 				caffeine. White roast seasonal, mocha trifecta, dripper caffeine
 				spoon acerbic to go macchiato strong.`}
 				</ClayPopover>
+			</>
+		);
+	})
+	.add('popover w/ recalculate position', () => {
+		const [visible, setVisible] = React.useState(false);
+		const {observer, onClose} = useModal({
+			onClose: () => setVisible(false),
+		});
+
+		return (
+			<>
+				{visible && (
+					<ClayModal
+						observer={observer}
+						size="lg"
+						spritemap={spritemap}
+						status="info"
+					>
+						<ClayModal.Header>{'Title'}</ClayModal.Header>
+						<ClayModal.Body scrollable>
+							<ClayPopover
+								header="Popover"
+								trigger={
+									<ClayButtonWithIcon
+										aria-label="Information button"
+										displayType="secondary"
+										spritemap={spritemap}
+										symbol="info-circle-open"
+									/>
+								}
+							>
+								{`Viennese flavour cup eu, percolator froth ristretto mazagran
+							caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+							spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+							caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+							spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+							caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+							spoon acerbic to go macchiato strong. Viennese flavour cup eu, percolator froth ristretto mazagran
+							caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+							spoon acerbic to go macchiato strong.`}
+							</ClayPopover>
+							<br />
+							<img
+								alt="cat"
+								src="https://cataas.com/cat/says/it will have"
+							/>
+							<img
+								alt="cat"
+								src="https://cataas.com/cat/says/a scroll"
+							/>
+						</ClayModal.Body>
+						<ClayModal.Footer
+							first={
+								<ClayButton.Group spaced>
+									<ClayButton displayType="secondary">
+										{'Secondary'}
+									</ClayButton>
+									<ClayButton displayType="secondary">
+										{'Secondary'}
+									</ClayButton>
+								</ClayButton.Group>
+							}
+							last={
+								<ClayButton onClick={onClose}>
+									{'Primary'}
+								</ClayButton>
+							}
+						/>
+					</ClayModal>
+				)}
+
+				<ClayButton
+					displayType="primary"
+					onClick={() => setVisible(true)}
+				>
+					{'Open modal'}
+				</ClayButton>
 			</>
 		);
 	});

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -10,6 +10,7 @@ export {getEllipsisItems} from './getEllipsisItems';
 export {Keys} from './Keys';
 export {LinkOrButton} from './LinkOrButton';
 export {sub} from './sub';
+export {observeRect} from './observeRect';
 export {useDebounce} from './useDebounce';
 export {useFocusManagement, FOCUSABLE_ELEMENTS} from './useFocusManagement';
 export {setElementFullHeight} from './setElementFullHeight';

--- a/packages/clay-shared/src/observeRect.ts
+++ b/packages/clay-shared/src/observeRect.ts
@@ -35,13 +35,13 @@ const run = (node: Element, state: IRectState) => {
 	rafId = window.requestAnimationFrame(() => run(node, state));
 };
 
-export default function observeRect(
+export const observeRect = (
 	node: Element,
 	callback: (rect?: DOMRect) => void
-) {
+) => {
 	run(node, {callback, hasRectChanged: false, rect: undefined});
 
 	return () => {
 		cancelAnimationFrame(rafId);
 	};
-}
+};


### PR DESCRIPTION
Fixes #4035

Nothing much different from what was done for `DropDown.Menu`, we just call the alignment method with each change in the `trigger`. The change is that I moved the `observeRect` utility to `shared` to allow reuse in DropDown and Popover.