### PR TITLE
feat(@clayui/panel): adds the small API to Panel.Group

### DIFF
--- a/packages/clay-panel/src/Group.tsx
+++ b/packages/clay-panel/src/Group.tsx
@@ -30,6 +30,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * This class generally should be used inside card, sheet, or a type of padded container.
 	 */
 	flush?: boolean;
+
+	/**
+	 * Flag to enable the small variation for panels within a group of panels.
+	 */
+	small?: boolean;
 }
 
 const ClayPanelGroup: React.FunctionComponent<IProps> = ({
@@ -39,6 +44,7 @@ const ClayPanelGroup: React.FunctionComponent<IProps> = ({
 	fluidFirst,
 	fluidLast,
 	flush,
+	small,
 	...otherProps
 }: IProps) => {
 	return (
@@ -50,6 +56,7 @@ const ClayPanelGroup: React.FunctionComponent<IProps> = ({
 				'panel-group-fluid-first': fluidFirst,
 				'panel-group-fluid-last': fluidLast,
 				'panel-group-flush': flush,
+				'panel-group-sm': small,
 			})}
 			role="tablist"
 		>

--- a/packages/clay-panel/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-panel/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,95 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ClayPanel renders 1`] = `
-<div
-  className="panel"
-  role="tablist"
->
+<div>
   <div
-    className="panel-header"
-  >
-    <span
-      className="panel-title"
-    >
-      Display Title
-    </span>
-  </div>
-  <div
-    className="panel-header"
-  >
-    Header!
-  </div>
-  <div
-    className="panel-body"
-  >
-    Body!
-  </div>
-  <div
-    className="panel-footer"
-  >
-    Footer!
-  </div>
-</div>
-`;
-
-exports[`ClayPanel renders with custom displayTitle 1`] = `
-<div
-  className="panel panel-secondary"
-  role="tablist"
->
-  <button
-    aria-expanded={false}
-    className="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
-    onClick={[Function]}
-    role="tab"
-    type="button"
-  >
-    <div>
-      <h3>
-        Custom Panel Title
-      </h3>
-    </div>
-    <span
-      className="collapse-icon-closed"
-    >
-      <svg
-        className="lexicon-icon lexicon-icon-angle-right"
-        role="presentation"
-      >
-        <use
-          xlinkHref="/foo/bar#angle-right"
-        />
-      </svg>
-    </span>
-    <span
-      className="collapse-icon-open"
-    >
-      <svg
-        className="lexicon-icon lexicon-icon-angle-down"
-        role="presentation"
-      >
-        <use
-          xlinkHref="/foo/bar#angle-down"
-        />
-      </svg>
-    </span>
-  </button>
-  <div
-    className="panel-collapse collapse"
-    role="tabpanel"
+    class="panel"
+    role="tablist"
   >
     <div
-      className="panel-header"
+      class="panel-header"
+    >
+      <span
+        class="panel-title"
+      >
+        Display Title
+      </span>
+    </div>
+    <div
+      class="panel-header"
     >
       Header!
     </div>
     <div
-      className="panel-body"
+      class="panel-body"
     >
       Body!
     </div>
     <div
-      className="panel-footer"
+      class="panel-footer"
     >
       Footer!
     </div>
@@ -97,131 +34,200 @@ exports[`ClayPanel renders with custom displayTitle 1`] = `
 </div>
 `;
 
-exports[`ClayPanel renders with different displayType 1`] = `
-<div
-  className="panel panel-secondary"
-  role="tablist"
->
+exports[`ClayPanel renders with custom displayTitle 1`] = `
+<div>
   <div
-    className="panel-header"
-  >
-    <span
-      className="panel-title"
-    >
-      Display Title
-    </span>
-  </div>
-  <div
-    className="panel-header"
-  >
-    Header!
-  </div>
-  <div
-    className="panel-body"
-  >
-    Body!
-  </div>
-  <div
-    className="panel-footer"
-  >
-    Footer!
-  </div>
-</div>
-`;
-
-exports[`ClayPanel renders with multiple panels 1`] = `
-<div
-  aria-orientation="vertical"
-  className="panel-group"
-  role="tablist"
->
-  <div
-    className="panel"
-    role="tablist"
-  >
-    <div
-      className="panel-header"
-    >
-      <span
-        className="panel-title"
-      >
-        Display Title
-      </span>
-    </div>
-    <div
-      className="panel-body"
-    >
-      Body!
-    </div>
-  </div>
-  <div
-    className="panel"
-    role="tablist"
-  >
-    <div
-      className="panel-header"
-    >
-      <span
-        className="panel-title"
-      >
-        Display Title
-      </span>
-    </div>
-    <div
-      className="panel-body"
-    >
-      Body!
-    </div>
-  </div>
-  <div
-    className="panel"
+    class="panel panel-secondary"
     role="tablist"
   >
     <button
-      aria-expanded={false}
-      className="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
-      onClick={[Function]}
+      aria-expanded="false"
+      class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
       role="tab"
       type="button"
     >
+      <div>
+        <h3>
+          Custom Panel Title
+        </h3>
+      </div>
       <span
-        className="panel-title"
-      >
-        Display Title
-      </span>
-      <span
-        className="collapse-icon-closed"
+        class="collapse-icon-closed"
       >
         <svg
-          className="lexicon-icon lexicon-icon-angle-right"
+          class="lexicon-icon lexicon-icon-angle-right"
           role="presentation"
         >
           <use
-            xlinkHref="/foo/bar#angle-right"
+            xlink:href="/foo/bar#angle-right"
           />
         </svg>
       </span>
       <span
-        className="collapse-icon-open"
+        class="collapse-icon-open"
       >
         <svg
-          className="lexicon-icon lexicon-icon-angle-down"
+          class="lexicon-icon lexicon-icon-angle-down"
           role="presentation"
         >
           <use
-            xlinkHref="/foo/bar#angle-down"
+            xlink:href="/foo/bar#angle-down"
           />
         </svg>
       </span>
     </button>
     <div
-      className="panel-collapse collapse"
+      class="panel-collapse collapse"
       role="tabpanel"
     >
       <div
-        className="panel-body"
+        class="panel-header"
+      >
+        Header!
+      </div>
+      <div
+        class="panel-body"
       >
         Body!
+      </div>
+      <div
+        class="panel-footer"
+      >
+        Footer!
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayPanel renders with different displayType 1`] = `
+<div>
+  <div
+    class="panel panel-secondary"
+    role="tablist"
+  >
+    <div
+      class="panel-header"
+    >
+      <span
+        class="panel-title"
+      >
+        Display Title
+      </span>
+    </div>
+    <div
+      class="panel-header"
+    >
+      Header!
+    </div>
+    <div
+      class="panel-body"
+    >
+      Body!
+    </div>
+    <div
+      class="panel-footer"
+    >
+      Footer!
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayPanel renders with multiple panels 1`] = `
+<div>
+  <div
+    aria-orientation="vertical"
+    class="panel-group"
+    role="tablist"
+  >
+    <div
+      class="panel"
+      role="tablist"
+    >
+      <div
+        class="panel-header"
+      >
+        <span
+          class="panel-title"
+        >
+          Display Title
+        </span>
+      </div>
+      <div
+        class="panel-body"
+      >
+        Body!
+      </div>
+    </div>
+    <div
+      class="panel"
+      role="tablist"
+    >
+      <div
+        class="panel-header"
+      >
+        <span
+          class="panel-title"
+        >
+          Display Title
+        </span>
+      </div>
+      <div
+        class="panel-body"
+      >
+        Body!
+      </div>
+    </div>
+    <div
+      class="panel"
+      role="tablist"
+    >
+      <button
+        aria-expanded="false"
+        class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
+        role="tab"
+        type="button"
+      >
+        <span
+          class="panel-title"
+        >
+          Display Title
+        </span>
+        <span
+          class="collapse-icon-closed"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-angle-right"
+            role="presentation"
+          >
+            <use
+              xlink:href="/foo/bar#angle-right"
+            />
+          </svg>
+        </span>
+        <span
+          class="collapse-icon-open"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-angle-down"
+            role="presentation"
+          >
+            <use
+              xlink:href="/foo/bar#angle-down"
+            />
+          </svg>
+        </span>
+      </button>
+      <div
+        class="panel-collapse collapse"
+        role="tabpanel"
+      >
+        <div
+          class="panel-body"
+        >
+          Body!
+        </div>
       </div>
     </div>
   </div>
@@ -229,60 +235,61 @@ exports[`ClayPanel renders with multiple panels 1`] = `
 `;
 
 exports[`ClayPanel renders without displayTitle 1`] = `
-<div
-  className="panel panel-secondary"
-  role="tablist"
->
-  <button
-    aria-expanded={false}
-    className="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
-    onClick={[Function]}
-    role="tab"
-    type="button"
-  >
-    <span
-      className="collapse-icon-closed"
-    >
-      <svg
-        className="lexicon-icon lexicon-icon-angle-right"
-        role="presentation"
-      >
-        <use
-          xlinkHref="/foo/bar#angle-right"
-        />
-      </svg>
-    </span>
-    <span
-      className="collapse-icon-open"
-    >
-      <svg
-        className="lexicon-icon lexicon-icon-angle-down"
-        role="presentation"
-      >
-        <use
-          xlinkHref="/foo/bar#angle-down"
-        />
-      </svg>
-    </span>
-  </button>
+<div>
   <div
-    className="panel-collapse collapse"
-    role="tabpanel"
+    class="panel panel-secondary"
+    role="tablist"
   >
-    <div
-      className="panel-header"
+    <button
+      aria-expanded="false"
+      class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
+      role="tab"
+      type="button"
     >
-      Header!
-    </div>
+      <span
+        class="collapse-icon-closed"
+      >
+        <svg
+          class="lexicon-icon lexicon-icon-angle-right"
+          role="presentation"
+        >
+          <use
+            xlink:href="/foo/bar#angle-right"
+          />
+        </svg>
+      </span>
+      <span
+        class="collapse-icon-open"
+      >
+        <svg
+          class="lexicon-icon lexicon-icon-angle-down"
+          role="presentation"
+        >
+          <use
+            xlink:href="/foo/bar#angle-down"
+          />
+        </svg>
+      </span>
+    </button>
     <div
-      className="panel-body"
+      class="panel-collapse collapse"
+      role="tabpanel"
     >
-      Body!
-    </div>
-    <div
-      className="panel-footer"
-    >
-      Footer!
+      <div
+        class="panel-header"
+      >
+        Header!
+      </div>
+      <div
+        class="panel-body"
+      >
+        Body!
+      </div>
+      <div
+        class="panel-footer"
+      >
+        Footer!
+      </div>
     </div>
   </div>
 </div>

--- a/packages/clay-panel/src/__tests__/index.tsx
+++ b/packages/clay-panel/src/__tests__/index.tsx
@@ -6,11 +6,12 @@
 import ClayPanel from '..';
 import {act, cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
 
 describe('ClayPanel', () => {
+	afterEach(cleanup);
+
 	it('renders', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayPanel displayTitle="Display Title" spritemap="/foo/bar">
 				<ClayPanel.Header>{'Header!'}</ClayPanel.Header>
 				<ClayPanel.Body>{'Body!'}</ClayPanel.Body>
@@ -18,11 +19,11 @@ describe('ClayPanel', () => {
 			</ClayPanel>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with different displayType', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayPanel
 				displayTitle="Display Title"
 				displayType="secondary"
@@ -34,11 +35,11 @@ describe('ClayPanel', () => {
 			</ClayPanel>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with multiple panels', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayPanel.Group>
 				<ClayPanel displayTitle="Display Title" spritemap="/foo/bar">
 					<ClayPanel.Body>{'Body!'}</ClayPanel.Body>
@@ -58,11 +59,35 @@ describe('ClayPanel', () => {
 			</ClayPanel.Group>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders with multiple small panels', () => {
+		const {container} = render(
+			<ClayPanel.Group small>
+				<ClayPanel displayTitle="Display Title" spritemap="/foo/bar">
+					<ClayPanel.Body>{'Body!'}</ClayPanel.Body>
+				</ClayPanel>
+
+				<ClayPanel displayTitle="Display Title" spritemap="/foo/bar">
+					<ClayPanel.Body>{'Body!'}</ClayPanel.Body>
+				</ClayPanel>
+
+				<ClayPanel
+					collapsable
+					displayTitle="Display Title"
+					spritemap="/foo/bar"
+				>
+					<ClayPanel.Body>{'Body!'}</ClayPanel.Body>
+				</ClayPanel>
+			</ClayPanel.Group>
+		);
+
+		expect(container.querySelector('.panel-group-sm')).toBeTruthy();
 	});
 
 	it('renders with custom displayTitle', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayPanel
 				collapsable
 				displayTitle={
@@ -80,11 +105,11 @@ describe('ClayPanel', () => {
 			</ClayPanel>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders without displayTitle', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayPanel
 				collapsable
 				displayType="secondary"
@@ -97,7 +122,7 @@ describe('ClayPanel', () => {
 			</ClayPanel>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 });
 

--- a/packages/clay-panel/stories/index.tsx
+++ b/packages/clay-panel/stories/index.tsx
@@ -158,4 +158,21 @@ storiesOf('Components|ClayPanel', module)
 			<ClayPanel.Body>{'Body!'}</ClayPanel.Body>
 			<ClayPanel.Footer>{'Footer!'}</ClayPanel.Footer>
 		</ClayPanel>
+	))
+	.add('w/ small', () => (
+		<ClayPanel.Group small>
+			{['One', 'Two', 'Three'].map((item) => (
+				<ClayPanel
+					collapsable
+					displayTitle={item}
+					key={item}
+					showCollapseIcon={boolean('Show Collapse Icon', true)}
+					spritemap={spritemap}
+				>
+					<ClayPanel.Body>
+						{`Here is some content inside for number ${item}`}
+					</ClayPanel.Body>
+				</ClayPanel>
+			))}
+		</ClayPanel.Group>
 	));


### PR DESCRIPTION
Fixes #4025

Just by adding the new `small` API to` <ClayPanel.Group />` which renders small panels within the group, I also removed the use of `react-test-renderer` in favor of using only `testing-library`, I went through a few tests and we still use it a lot, I will create another issue later to track it and remove the use of `react-test-renderer` from our test suite.