### PR TITLE
feat(@clayui/modal): support custom opener for the modals

### DIFF
--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -43,6 +43,11 @@ interface IProps
 	observer: Observer;
 
 	/**
+	 * Element to render modal into.
+	 */
+	opener?: Element;
+
+	/**
 	 * Allows setting a custom z-index value, overriding the default one which is 1040, modal body z-index will be +10 of this value
 	 */
 	zIndex?: number;
@@ -64,6 +69,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 	children,
 	className,
 	observer,
+	opener = document.body,
 	size,
 	spritemap,
 	status,
@@ -72,6 +78,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 }: IProps) => {
 	const modalElementRef = useRef<HTMLDivElement | null>(null);
 	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
+	const openerRef = useRef< Element| null>(opener);
 
 	warning(observer !== undefined, warningMessage);
 
@@ -85,7 +92,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 		observer && observer.mutation ? observer.mutation : [false, false];
 
 	return (
-		<ClayPortal subPortalRef={modalElementRef}>
+		<ClayPortal containerRef={openerRef} subPortalRef={modalElementRef}>
 			<div
 				className={classNames('modal-backdrop fade', {
 					show,

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -32,6 +32,11 @@ interface IProps
 	center?: boolean;
 
 	/**
+	 * Container element to render modal into.
+	 */
+	containerElementRef?: React.RefObject<Element>;
+
+	/**
 	 * The size of element modal.
 	 */
 	size?: Size;
@@ -41,11 +46,6 @@ interface IProps
 	 * hook, adds observer from `useModal` hook here.
 	 */
 	observer: Observer;
-
-	/**
-	 * Element to render modal into.
-	 */
-	opener?: Element;
 
 	/**
 	 * Allows setting a custom z-index value, overriding the default one which is 1040, modal body z-index will be +10 of this value
@@ -68,8 +68,8 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 	center,
 	children,
 	className,
+	containerElementRef,
 	observer,
-	opener,
 	size,
 	spritemap,
 	status,
@@ -78,7 +78,6 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 }: IProps) => {
 	const modalElementRef = useRef<HTMLDivElement | null>(null);
 	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
-	const openerRef = useRef< Element| null>(opener ? opener : null);
 
 	warning(observer !== undefined, warningMessage);
 
@@ -92,7 +91,10 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 		observer && observer.mutation ? observer.mutation : [false, false];
 
 	return (
-		<ClayPortal containerRef={openerRef} subPortalRef={modalElementRef}>
+		<ClayPortal
+			containerRef={containerElementRef}
+			subPortalRef={modalElementRef}
+		>
 			<div
 				className={classNames('modal-backdrop fade', {
 					show,

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -69,7 +69,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 	children,
 	className,
 	observer,
-	opener = document.body,
+	opener,
 	size,
 	spritemap,
 	status,
@@ -78,7 +78,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 }: IProps) => {
 	const modalElementRef = useRef<HTMLDivElement | null>(null);
 	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
-	const openerRef = useRef< Element| null>(opener);
+	const openerRef = useRef< Element| null>(opener ? opener : null);
 
 	warning(observer !== undefined, warningMessage);
 

--- a/packages/clay-modal/src/__tests__/__snapshots__/modal.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/modal.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClayModal custom opener renders inside a container element 1`] = `
+<body
+  class="modal-open"
+>
+  <div>
+    <div
+      id="container"
+    >
+      container
+      <div>
+        <div
+          class="modal-backdrop fade"
+        />
+        <div
+          class="fade modal d-block"
+        >
+          <div
+            class="modal-dialog"
+            tabindex="-1"
+          >
+            <div
+              class="modal-content"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/clay-modal/src/__tests__/modal.tsx
+++ b/packages/clay-modal/src/__tests__/modal.tsx
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayModal, {useModal} from '..';
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+const spritemap = 'icons.svg';
+
+describe('ClayModal custom opener', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders inside a container element', () => {
+		const ModalWithState = () => {
+			const {observer} = useModal({onClose: () => {}});
+			const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+			return (
+				<>
+					<div id="container" ref={containerRef}>
+						{'container'}
+					</div>
+
+					<ClayModal
+						containerElementRef={containerRef}
+						observer={observer}
+						spritemap={spritemap}
+					/>
+				</>
+			);
+		};
+
+		render(<ModalWithState />);
+
+		expect(document.body).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
Fixes #4044 Extended ClayModal API to support custom opener window

Added a new prop called `opener` to `ClayModal` that would allow to render it in a different element than the default `document.body`. 
