### PR TITLE
fix(@clayui/css): Management Bar Search Bar button should be 32px x 32px and icon size 16px

### DIFF
--- a/packages/clay-css/src/content/management-bar.html
+++ b/packages/clay-css/src/content/management-bar.html
@@ -59,12 +59,12 @@ section: Components
 								<div class="input-group-item">
 									<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
 									<span class="input-group-inset-item input-group-inset-item-after">
-										<button class="btn btn-unstyled" type="submit">
+										<button class="btn btn-monospaced btn-unstyled" type="submit">
 											<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
 											</svg>
 										</button>
-										<button class="btn btn-unstyled d-none" type="button">
+										<button class="btn btn-monospaced btn-unstyled d-none" type="button">
 											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 											</svg>
@@ -184,12 +184,12 @@ section: Components
 						<div class="input-group-item">
 							<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
 							<span class="input-group-inset-item input-group-inset-item-after">
-								<button class="btn btn-unstyled" type="submit">
+								<button class="btn btn-monospaced btn-unstyled" type="submit">
 									<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
 									</svg>
 								</button>
-								<button class="btn btn-unstyled d-none" type="button">
+								<button class="btn btn-monospaced btn-unstyled d-none" type="button">
 									<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 									</svg>
@@ -530,12 +530,12 @@ section: Components
 								<div class="input-group-item">
 									<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
 									<span class="input-group-inset-item input-group-inset-item-after">
-										<button class="btn btn-unstyled" type="submit">
+										<button class="btn btn-monospaced btn-unstyled" type="submit">
 											<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
 											</svg>
 										</button>
-										<button class="btn btn-unstyled d-none" type="button">
+										<button class="btn btn-monospaced btn-unstyled d-none" type="button">
 											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 											</svg>
@@ -633,12 +633,12 @@ section: Components
 								<div class="input-group-item">
 									<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
 									<span class="input-group-inset-item input-group-inset-item-after">
-										<button class="btn btn-unstyled" type="submit">
+										<button class="btn btn-monospaced btn-unstyled" type="submit">
 											<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
 											</svg>
 										</button>
-										<button class="btn btn-unstyled d-none" type="button">
+										<button class="btn btn-monospaced btn-unstyled d-none" type="button">
 											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 											</svg>
@@ -675,12 +675,12 @@ section: Components
 							<div class="input-group-item">
 								<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
 								<span class="input-group-inset-item input-group-inset-item-after">
-									<button class="btn btn-unstyled" type="submit">
+									<button class="btn btn-monospaced btn-unstyled" type="submit">
 										<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
 										</svg>
 									</button>
-									<button class="btn btn-unstyled d-none" type="button">
+									<button class="btn btn-monospaced btn-unstyled d-none" type="button">
 										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 										</svg>
@@ -743,12 +743,12 @@ section: Components
 								<div class="input-group-item">
 									<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
 									<span class="input-group-inset-item input-group-inset-item-after">
-										<button class="btn btn-unstyled" type="submit">
+										<button class="btn btn-monospaced btn-unstyled" type="submit">
 											<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
 											</svg>
 										</button>
-										<button class="btn btn-unstyled d-none" type="button">
+										<button class="btn btn-monospaced btn-unstyled d-none" type="button">
 											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 											</svg>
@@ -868,12 +868,12 @@ section: Components
 								<div class="input-group-item">
 									<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
 									<span class="input-group-inset-item input-group-inset-item-after">
-										<button class="btn btn-unstyled" type="submit">
+										<button class="btn btn-monospaced btn-unstyled" type="submit">
 											<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
 											</svg>
 										</button>
-										<button class="btn btn-unstyled d-none" type="button">
+										<button class="btn btn-monospaced btn-unstyled d-none" type="button">
 											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 											</svg>

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -294,20 +294,26 @@
 			padding-right: $input-group-addon-padding-x-lg;
 			padding-top: $input-group-addon-padding-y-lg;
 		}
-	}
 
-	> .input-group-inset-item {
-		> .btn {
-			@include clay-button-size($input-group-lg-inset-item-btn);
-		}
+		> .input-group-inset-item {
+			> .btn {
+				@include clay-button-size($input-group-lg-inset-item-btn);
+			}
 
-		> .form-file {
-			height: 75%;
-
-			.btn {
-				@include clay-button-size(
-					$input-group-lg-inset-item-form-file-btn
+			> .btn-monospaced {
+				@include clay-button-variant(
+					$input-group-lg-inset-item-btn-monospaced
 				);
+			}
+
+			> .form-file {
+				height: 75%;
+
+				.btn {
+					@include clay-button-size(
+						$input-group-lg-inset-item-form-file-btn
+					);
+				}
 			}
 		}
 	}
@@ -372,20 +378,26 @@
 			padding-right: $input-group-addon-padding-x-sm;
 			padding-top: $input-group-addon-padding-y-sm;
 		}
-	}
 
-	> .input-group-inset-item {
-		> .btn {
-			@include clay-button-size($input-group-sm-inset-item-btn);
-		}
+		> .input-group-inset-item {
+			> .btn {
+				@include clay-button-size($input-group-sm-inset-item-btn);
+			}
 
-		> .form-file {
-			height: 75%;
-
-			.btn {
-				@include clay-button-size(
-					$input-group-sm-inset-item-form-file-btn
+			> .btn-monospaced {
+				@include clay-button-variant(
+					$input-group-sm-inset-item-btn-monospaced
 				);
+			}
+
+			> .form-file {
+				height: 75%;
+
+				.btn {
+					@include clay-button-size(
+						$input-group-sm-inset-item-form-file-btn
+					);
+				}
 			}
 		}
 	}
@@ -510,6 +522,12 @@
 					}
 				}
 			}
+		}
+
+		.btn-monospaced {
+			@include clay-button-variant(
+				$input-group-inset-item-btn-monospaced
+			);
 		}
 
 		.form-file {

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -668,11 +668,13 @@ $input-group-inset-item-padding-right: 5px !default;
 $input-group-inset-item-btn: () !default;
 $input-group-inset-item-btn: map-deep-merge(
 	(
-		display: block,
+		align-items: center,
+		display: flex,
 		height: 75%,
+		justify-content: center,
 		line-height: 1,
-		margin-left: 0.125rem,
-		margin-right: 0.125rem,
+		margin-left: 0.1875rem,
+		margin-right: 0.1875rem,
 		padding-bottom: 0,
 		padding-left: 0.5rem,
 		padding-right: 0.5rem,
@@ -683,8 +685,22 @@ $input-group-inset-item-btn: map-deep-merge(
 			height: 100%,
 			justify-content: center,
 		),
+		lexicon-icon: (
+			margin-top: 0,
+		),
 	),
 	$input-group-inset-item-btn
+);
+
+$input-group-inset-item-btn-monospaced: () !default;
+$input-group-inset-item-btn-monospaced: map-deep-merge(
+	(
+		font-size: 1rem,
+		height: 2rem,
+		padding: 0,
+		width: 2rem,
+	),
+	$input-group-inset-item-btn-monospaced
 );
 
 $input-group-inset-form-file-btn: () !default;
@@ -735,6 +751,8 @@ $input-group-lg-item-btn-monospaced: map-deep-merge(
 );
 
 $input-group-lg-inset-item-btn: () !default;
+
+$input-group-lg-inset-item-btn-monospaced: () !default;
 
 $input-group-lg-inset-item-form-file-btn: () !default;
 $input-group-lg-inset-item-form-file-btn: map-deep-merge(
@@ -797,6 +815,17 @@ $input-group-sm-inset-item-btn: map-deep-merge(
 		padding-top: 0,
 	),
 	$input-group-sm-inset-item-btn
+);
+
+$input-group-sm-inset-item-btn-monospaced: () !default;
+$input-group-sm-inset-item-btn-monospaced: map-deep-merge(
+	(
+		height: 1.5rem,
+		margin-left: 0.25rem,
+		margin-right: 0.25rem,
+		width: 1.5rem,
+	),
+	$input-group-sm-inset-item-btn-monospaced
 );
 
 $input-group-sm-inset-item-form-file-btn: () !default;

--- a/packages/clay-management-toolbar/docs/markup-management-toolbar.md
+++ b/packages/clay-management-toolbar/docs/markup-management-toolbar.md
@@ -84,12 +84,12 @@ mainTabURL: 'docs/components/management-toolbar.html'
                                 <input class="form-control input-group-inset input-group-inset-after"
                                     placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-unstyled" type="submit">
+                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-unstyled d-none" type="button">
+                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -240,12 +240,12 @@ mainTabURL: 'docs/components/management-toolbar.html'
                                 <input class="form-control input-group-inset input-group-inset-after"
                                     placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-unstyled" type="submit">
+                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-unstyled d-none" type="button">
+                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -401,12 +401,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                                 <input class="form-control input-group-inset input-group-inset-after"
                                     placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-unstyled" type="submit">
+                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-unstyled d-none" type="button">
+                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -587,7 +587,10 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 							<span
 								class="input-group-inset-item input-group-inset-item-after"
 							>
-								<button class="btn btn-unstyled" type="submit">
+								<button
+									class="btn btn-monospaced btn-unstyled"
+									type="submit"
+								>
 									<svg
 										class="lexicon-icon lexicon-icon-search"
 										focusable="false"
@@ -599,7 +602,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 									</svg>
 								</button>
 								<button
-									class="btn btn-unstyled d-none"
+									class="btn btn-monospaced btn-unstyled d-none"
 									type="button"
 								>
 									<svg
@@ -794,12 +797,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                             <div class="input-group-item">
                                 <input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-unstyled" type="submit">
+                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-unstyled d-none" type="button">
+                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -978,7 +981,10 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 							<span
 								class="input-group-inset-item input-group-inset-item-after"
 							>
-								<button class="btn btn-unstyled" type="submit">
+								<button
+									class="btn btn-monospaced btn-unstyled"
+									type="submit"
+								>
 									<svg
 										class="lexicon-icon lexicon-icon-search"
 										focusable="false"
@@ -990,7 +996,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 									</svg>
 								</button>
 								<button
-									class="btn btn-unstyled d-none"
+									class="btn btn-monospaced btn-unstyled d-none"
 									type="button"
 								>
 									<svg
@@ -1142,12 +1148,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                             <input class="form-control input-group-inset input-group-inset-after"
                                 placeholder="Search for..." type="text">
                             <span class="input-group-inset-item input-group-inset-item-after">
-                                <button class="btn btn-unstyled" type="submit">
+                                <button class="btn btn-monospaced btn-unstyled" type="submit">
                                     <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                         <use href="/images/icons/icons.svg#search"></use>
                                     </svg>
                                 </button>
-                                <button class="btn btn-unstyled d-none" type="button">
+                                <button class="btn btn-monospaced btn-unstyled d-none" type="button">
                                     <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                         <use href="/images/icons/icons.svg#times"></use>
                                     </svg>
@@ -1176,7 +1182,10 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 						<span
 							class="input-group-inset-item input-group-inset-item-after"
 						>
-							<button class="btn btn-unstyled" type="submit">
+							<button
+								class="btn btn-monospaced btn-unstyled"
+								type="submit"
+							>
 								<svg
 									class="lexicon-icon lexicon-icon-search"
 									focusable="false"
@@ -1188,7 +1197,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 								</svg>
 							</button>
 							<button
-								class="btn btn-unstyled d-none"
+								class="btn btn-monospaced btn-unstyled d-none"
 								type="button"
 							>
 								<svg
@@ -1223,12 +1232,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                                 <input class="form-control input-group-inset input-group-inset-after"
                                     placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-unstyled" type="submit">
+                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-unstyled d-none" type="button">
+                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -1270,7 +1279,10 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 							<span
 								class="input-group-inset-item input-group-inset-item-after"
 							>
-								<button class="btn btn-unstyled" type="submit">
+								<button
+									class="btn btn-monospaced btn-unstyled"
+									type="submit"
+								>
 									<svg
 										class="lexicon-icon lexicon-icon-search"
 										focusable="false"
@@ -1282,7 +1294,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 									</svg>
 								</button>
 								<button
-									class="btn btn-unstyled d-none"
+									class="btn btn-monospaced btn-unstyled d-none"
 									type="button"
 								>
 									<svg
@@ -1437,9 +1449,9 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                             </span>
                             <span class="label-item label-item-after">
                                 <button class="btn close" aria-label="close" type="button">
-                                    <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+                                    <svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
                                         <title>times</title>
-                                        <use href="/images/icons/icons.svg#times"></use>
+                                        <use href="/images/icons/icons.svg#times-small"></use>
                                     </svg>
                                 </button>
                             </span>
@@ -1454,9 +1466,9 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                             </span>
                             <span class="label-item label-item-after">
                                 <button class="btn close" aria-label="close" type="button">
-                                    <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+                                    <svg class="lexicon-icon lexicon-icon-times-small" focusable="false" role="presentation">
                                         <title>times</title>
-                                        <use href="/images/icons/icons.svg#times"></use>
+                                        <use href="/images/icons/icons.svg#times-small"></use>
                                     </svg>
                                 </button>
                             </span>
@@ -1510,13 +1522,13 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 								type="button"
 							>
 								<svg
-									class="lexicon-icon lexicon-icon-times"
+									class="lexicon-icon lexicon-icon-times-small"
 									focusable="false"
 									role="presentation"
 								>
 									<title>times</title>
 									<use
-										href="/images/icons/icons.svg#times"
+										href="/images/icons/icons.svg#times-small"
 									></use>
 								</svg>
 							</button>
@@ -1541,13 +1553,13 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 								type="button"
 							>
 								<svg
-									class="lexicon-icon lexicon-icon-times"
+									class="lexicon-icon lexicon-icon-times-small"
 									focusable="false"
 									role="presentation"
 								>
 									<title>times</title>
 									<use
-										href="/images/icons/icons.svg#times"
+										href="/images/icons/icons.svg#times-small"
 									></use>
 								</svg>
 							</button>
@@ -1612,12 +1624,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                                 <input class="form-control input-group-inset input-group-inset-after"
                                     placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-unstyled" type="submit">
+                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-unstyled d-none" type="button">
+                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -1740,7 +1752,10 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 							<span
 								class="input-group-inset-item input-group-inset-item-after"
 							>
-								<button class="btn btn-unstyled" type="submit">
+								<button
+									class="btn btn-monospaced btn-unstyled"
+									type="submit"
+								>
 									<svg
 										class="lexicon-icon lexicon-icon-search"
 										focusable="false"
@@ -1752,7 +1767,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 									</svg>
 								</button>
 								<button
-									class="btn btn-unstyled d-none"
+									class="btn btn-monospaced btn-unstyled d-none"
 									type="button"
 								>
 									<svg


### PR DESCRIPTION
fix(@clayui/css): Input Groups add `btn-monospaced` support for buttons inside `input-group-inset-item`

fix(@clayui/css): Input Group adds Sass maps `$input-group-inset-item-btn-monospaced`, `$input-group-lg-inset-item-btn-monospaced`, `$input-group-sm-inset-item-btn-monospaced`
    
fixes #4049

![mgmt-bar](https://user-images.githubusercontent.com/788266/117732601-0665ff00-b1a5-11eb-841e-643459ea6cfa.jpg)
