### PR TITLE
feat(@clayui/tooltip): update logic to handle scoping and a global listener

### DIFF
--- a/packages/clay-shared/src/delegate.ts
+++ b/packages/clay-shared/src/delegate.ts
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+function isDisabled(node: Element & {disabled?: boolean}) {
+	return !!(node.disabled || node.closest('[disabled]'));
+}
+
+function delegate(
+	element: HTMLElement,
+	eventName: keyof GlobalEventHandlersEventMap,
+	selector: string,
+	callback: (e: any) => void
+) {
+	const eventHandler = (event: {
+		delegateTarget?: Element;
+		defaultPrevented?: boolean;
+		target?: HTMLElement;
+	}) => {
+		const {defaultPrevented, target} = event;
+
+		if (target) {
+			if (
+				defaultPrevented ||
+				(eventName === 'click' && isDisabled(target))
+			) {
+				return;
+			}
+
+			const delegateTarget = target.closest(selector);
+
+			if (delegateTarget) {
+				event.delegateTarget = delegateTarget;
+
+				callback(event);
+			}
+		}
+	};
+
+	element.addEventListener(eventName, eventHandler as any);
+
+	return {
+		dispose() {
+			element.removeEventListener(eventName, eventHandler as any);
+		},
+	};
+}
+
+export {delegate};
+export default delegate;

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -5,6 +5,7 @@
 
 export const noop = () => {};
 export {ClayPortal} from './Portal';
+export {delegate} from './delegate';
 export {FocusScope} from './FocusScope';
 export {getEllipsisItems} from './getEllipsisItems';
 export {Keys} from './Keys';

--- a/packages/clay-tooltip/stories/index.tsx
+++ b/packages/clay-tooltip/stories/index.tsx
@@ -7,6 +7,7 @@ import '@clayui/css/lib/css/atlas.css';
 import {select} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 
 import ClayTooltip, {ClayTooltipProvider} from '../src';
 
@@ -72,6 +73,13 @@ storiesOf('Components|ClayTooltip', module)
 						{'Custom Delay'}
 					</button>
 
+					<button
+						data-title="Using data-title"
+						data-tooltip-delay="0"
+					>
+						{'data-title'}
+					</button>
+
 					<div
 						data-tooltip-align="bottom"
 						style={{
@@ -87,6 +95,36 @@ storiesOf('Components|ClayTooltip', module)
 			</ClayTooltipProvider>
 		</div>
 	))
+	.add('ClayTooltipProvider as global w/ scope', () => {
+		return (
+			<div>
+				<ClayTooltipProvider scope=".my-custom-tooltip-scope,.some-other-scope" />
+
+				<div>
+					<button title="browser">{'Browser Default'}</button>
+
+					<div className="my-custom-tooltip-scope">
+						<button title="Clay Style">{'Clay Style'}</button>
+
+						<button
+							data-title-set-as-html
+							title={ReactDOMServer.renderToString(
+								<span style={{color: 'red'}}>
+									{'Custom Styles'}
+								</span>
+							)}
+						>
+							{'Custom Styles'}
+						</button>
+					</div>
+
+					<div className="some-other-scope">
+						<button title="test">{'test'}</button>
+					</div>
+				</div>
+			</div>
+		);
+	})
 	.add('ClayTooltipProvider w/ custom JSX', () => {
 		const ItalicsComponent = (props: any) => <i>{props.title}</i>;
 


### PR DESCRIPTION
back at it with more tooltip adventures.... [Previous convo on DXP changes here](https://github.com/liferay-frontend/liferay-portal/pull/1016)

Okay, so I went with a solution that allowed our provider to be used as a singleton plus the ability to scope it within a specific set of selectors. By making these changes here we could re-write our tooltip-support-web file to be really simple...

```js
import {ClayTooltipProvider} from '@clayui/tooltip';
import {render} from '@liferay/frontend-js-react-web';

const SELECTOR_TRIGGER = `
	.lfr-portal-tooltip,
	.manage-collaborators-dialog .lexicon-icon[data-title]:not(.lfr-portal-tooltip),
	.manage-collaborators-dialog .lexicon-icon[title]:not(.lfr-portal-tooltip),
	.manage-collaborators-dialog [data-restore-title],
	.management-bar [data-title]:not(.lfr-portal-tooltip),
	.management-bar [title]:not(.lfr-portal-tooltip),
	.management-bar [data-restore-title],
	.preview-toolbar-container [data-title]:not(.lfr-portal-tooltip),
	.preview-toolbar-container [title]:not(.lfr-portal-tooltip),
	.preview-tooltbar-containter [data-restore-title],
	.progress-container[data-title],
	.redirect-entries [data-title]:not(.lfr-portal-tooltip),
	.source-editor__fixed-text__help[data-title],
	.upper-tbar [data-title]:not(.lfr-portal-tooltip),
	.upper-tbar [title]:not(.lfr-portal-tooltip),
	.upper-tbar [data-restore-title],
	.lfr-tooltip-scope [title]:not(iframe,[title=""]),
	.lfr-tooltip-scope [data-title]:not([data-title=""]),
	.lfr-tooltip-scope [data-restore-title]:not([data-restore-title=""])
`;

const DEFAULT_TOOLTIP_CONTAINER_ID = 'tooltipContainer';

const getDefaultTooltipContainer = () => {
	let container = document.getElementById(DEFAULT_TOOLTIP_CONTAINER_ID);

	if (!container) {
		container = document.createElement('div');
		container.id = DEFAULT_TOOLTIP_CONTAINER_ID;
		document.body.appendChild(container);
	}

	return container;
};

export default () => {
	render(
		ClayTooltipProvider,
		{scope: SELECTOR_TRIGGER},
		getDefaultTooltipContainer()
	);
};

```

We can think add in our custom React portal to DXP which provides the same class scope, and we should be able to cover all of our use cases.

Any thoughts or concerns?