### PR TITLE
fix(@clayui/css): Mixins `clay-label-size` and `clay-label-variant` convert to use new (easier to remember) Sass map keys. The old keys will still work and win over new keys.

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_labels.scss
@@ -21,7 +21,9 @@ $label-link-hover-text-decoration: underline !default;
 $label-close: () !default;
 $label-close: map-deep-merge(
 	(
-		disabled-color: inherit,
+		disabled: (
+			color: inherit,
+		),
 	),
 	$label-close
 );
@@ -32,13 +34,24 @@ $label-lg: () !default;
 $label-lg: map-deep-merge(
 	(
 		font-size: 0.75rem,
-		height: 1.5rem,
-		padding-x: 0.5rem,
-		padding-y: 0.3125rem,
-		item-spacer-y: -0.0625rem,
-		lexicon-icon-height: 1em,
-		lexicon-icon-width: 1em,
-		sticker-size: 0.875rem,
+		min-height: 1.5rem,
+		padding-bottom: 0.3125rem,
+		padding-left: 0.5rem,
+		padding-right: 0.5rem,
+		padding-top: 0.3125rem,
+		label-item: (
+			margin-bottom: -0.0625rem,
+			margin-top: -0.0625rem,
+		),
+		lexicon-icon: (
+			height: 1em,
+			width: 1em,
+		),
+		sticker: (
+			height: 0.875rem,
+			line-height: 0.875rem,
+			width: 0.875rem,
+		),
 	),
 	$label-lg
 );
@@ -50,8 +63,12 @@ $label-base: map-deep-merge(
 	(
 		outline: 0,
 		transition: box-shadow 0.15s ease-in-out,
-		focus-box-shadow: $btn-focus-box-shadow,
-		disabled-box-shadow: none,
+		focus: (
+			box-shadow: $btn-focus-box-shadow,
+		),
+		disabled: (
+			box-shadow: none,
+		),
 	),
 	$label-base
 );
@@ -77,8 +94,10 @@ $label-primary: map-deep-merge(
 	(
 		border-color: $label-primary-border-color,
 		color: $label-primary-color,
-		hover-border-color: $label-primary-hover-border-color,
-		hover-color: $label-primary-hover-color,
+		hover: (
+			border-color: $label-primary-hover-border-color,
+			color: $label-primary-hover-color,
+		),
 	),
 	$label-primary
 );
@@ -104,8 +123,10 @@ $label-secondary: map-deep-merge(
 	(
 		border-color: $label-secondary-border-color,
 		color: $label-secondary-color,
-		hover-border-color: $label-secondary-hover-border-color,
-		hover-color: $label-secondary-hover-color,
+		hover: (
+			border-color: $label-secondary-hover-border-color,
+			color: $label-secondary-hover-color,
+		),
 	),
 	$label-secondary
 );
@@ -131,8 +152,10 @@ $label-success: map-deep-merge(
 	(
 		border-color: $label-success-border-color,
 		color: $label-success-color,
-		hover-border-color: $label-success-hover-border-color,
-		hover-color: $label-success-hover-color,
+		hover: (
+			border-color: $label-success-hover-border-color,
+			color: $label-success-hover-color,
+		),
 	),
 	$label-success
 );
@@ -158,8 +181,10 @@ $label-info: map-deep-merge(
 	(
 		border-color: $label-info-border-color,
 		color: $label-info-color,
-		hover-border-color: $label-info-hover-border-color,
-		hover-color: $label-info-hover-color,
+		hover: (
+			border-color: $label-info-hover-border-color,
+			color: $label-info-hover-color,
+		),
 	),
 	$label-info
 );
@@ -185,8 +210,10 @@ $label-warning: map-deep-merge(
 	(
 		border-color: $label-warning-border-color,
 		color: $label-warning-color,
-		hover-border-color: $label-warning-hover-border-color,
-		hover-color: $label-warning-hover-color,
+		hover: (
+			border-color: $label-warning-hover-border-color,
+			color: $label-warning-hover-color,
+		),
 	),
 	$label-warning
 );
@@ -212,8 +239,10 @@ $label-danger: map-deep-merge(
 	(
 		border-color: $label-danger-border-color,
 		color: $label-danger-color,
-		hover-border-color: $label-danger-hover-border-color,
-		hover-color: $label-danger-hover-color,
+		hover: (
+			border-color: $label-danger-hover-border-color,
+			color: $label-danger-hover-color,
+		),
 	),
 	$label-danger
 );
@@ -241,11 +270,13 @@ $label-light-hover-border-color: $label-light-border-color !default;
 $label-light: () !default;
 $label-light: map-deep-merge(
 	(
-		bg: $label-light-bg,
+		background-color: $label-light-bg,
 		border-color: $label-light-border-color,
 		color: $label-light-color,
-		hover-border-color: $label-light-hover-border-color,
-		hover-color: $label-light-hover-color,
+		hover: (
+			border-color: $label-light-hover-border-color,
+			color: $label-light-hover-color,
+		),
 	),
 	$label-light
 );
@@ -271,8 +302,10 @@ $label-dark: map-deep-merge(
 	(
 		border-color: $label-dark-border-color,
 		color: $label-dark-color,
-		hover-border-color: $label-dark-hover-border-color,
-		hover-color: $label-dark-hover-color,
+		hover: (
+			border-color: $label-dark-hover-border-color,
+			color: $label-dark-hover-color,
+		),
 	),
 	$label-dark
 );
@@ -288,11 +321,15 @@ $label-inverse-primary: map-deep-merge(
 			border-color: null,
 			color: $white,
 		),
-		link-hover: (
-			color: null,
+		link: (
+			hover: (
+				color: null,
+			),
 		),
 		close: (
-			hover-color: null,
+			hover: (
+				color: null,
+			),
 		),
 	),
 	$label-inverse-primary
@@ -307,11 +344,15 @@ $label-inverse-secondary: map-deep-merge(
 			border-color: null,
 			color: $white,
 		),
-		link-hover: (
-			color: null,
+		link: (
+			hover: (
+				color: null,
+			),
 		),
 		close: (
-			hover-color: null,
+			hover: (
+				color: null,
+			),
 		),
 	),
 	$label-inverse-secondary
@@ -326,11 +367,15 @@ $label-inverse-success: map-deep-merge(
 			border-color: null,
 			color: $white,
 		),
-		link-hover: (
-			color: null,
+		link: (
+			hover: (
+				color: null,
+			),
 		),
 		close: (
-			hover-color: null,
+			hover: (
+				color: null,
+			),
 		),
 	),
 	$label-inverse-success
@@ -345,11 +390,15 @@ $label-inverse-info: map-deep-merge(
 			border-color: null,
 			color: $white,
 		),
-		link-hover: (
-			color: null,
+		link: (
+			hover: (
+				color: null,
+			),
 		),
 		close: (
-			hover-color: null,
+			hover: (
+				color: null,
+			),
 		),
 	),
 	$label-inverse-info
@@ -364,11 +413,15 @@ $label-inverse-warning: map-deep-merge(
 			border-color: null,
 			color: $white,
 		),
-		link-hover: (
-			color: null,
+		link: (
+			hover: (
+				color: null,
+			),
 		),
 		close: (
-			hover-color: null,
+			hover: (
+				color: null,
+			),
 		),
 	),
 	$label-inverse-warning
@@ -383,11 +436,15 @@ $label-inverse-danger: map-deep-merge(
 			border-color: null,
 			color: $white,
 		),
-		link-hover: (
-			color: null,
+		link: (
+			hover: (
+				color: null,
+			),
 		),
 		close: (
-			hover-color: null,
+			hover: (
+				color: null,
+			),
 		),
 	),
 	$label-inverse-danger
@@ -402,11 +459,15 @@ $label-inverse-light: map-deep-merge(
 			border-color: null,
 			color: $dark,
 		),
-		link-hover: (
-			color: null,
+		link: (
+			hover: (
+				color: null,
+			),
 		),
 		close: (
-			hover-color: null,
+			hover: (
+				color: null,
+			),
 		),
 	),
 	$label-inverse-light
@@ -421,11 +482,15 @@ $label-inverse-dark: map-deep-merge(
 			border-color: null,
 			color: $white,
 		),
-		link-hover: (
-			color: null,
+		link: (
+			hover: (
+				color: null,
+			),
 		),
 		close: (
-			hover-color: null,
+			hover: (
+				color: null,
+			),
 		),
 	),
 	$label-inverse-dark

--- a/packages/clay-css/src/scss/cadmin/variables/_labels.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_labels.scss
@@ -71,14 +71,26 @@ $cadmin-label-lg: () !default;
 $cadmin-label-lg: map-deep-merge(
 	(
 		font-size: 12px,
-		height: 24px,
-		padding-x: 8px,
-		padding-y: 5px,
+		height: auto,
+		min-height: 24px,
+		padding-bottom: 5px,
+		padding-left: 8px,
+		padding-right: 8px,
+		padding-top: 5px,
 		text-transform: none,
-		item-spacer-y: -1px,
-		lexicon-icon-height: 1em,
-		lexicon-icon-width: 1em,
-		sticker-size: 14px,
+		label-item: (
+			margin-bottom: -1px,
+			margin-top: -1px,
+		),
+		lexicon-icon: (
+			height: 1em,
+			width: 1em,
+		),
+		sticker: (
+			height: 14px,
+			line-height: 14px,
+			width: 14px,
+		),
 	),
 	$cadmin-label-lg
 );
@@ -90,8 +102,12 @@ $cadmin-label-base: map-deep-merge(
 	(
 		outline: 0,
 		transition: box-shadow 0.15s ease-in-out,
-		focus-box-shadow: $cadmin-btn-focus-box-shadow,
-		disabled-box-shadow: none,
+		focus: (
+			box-shadow: $cadmin-btn-focus-box-shadow,
+		),
+		disabled: (
+			box-shadow: none,
+		),
 	),
 	$cadmin-label-base
 );
@@ -131,8 +147,12 @@ $cadmin-label-primary-link-hover-color: $cadmin-label-primary-hover-color !defau
 $cadmin-label-primary-close: () !default;
 $cadmin-label-primary-close: map-deep-merge(
 	(
-		hover-color: $cadmin-label-primary-hover-color,
-		focus-color: $cadmin-label-primary-hover-color,
+		hover: (
+			color: $cadmin-label-primary-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-primary-hover-color,
+		),
 	),
 	$cadmin-label-primary-close
 );
@@ -140,15 +160,23 @@ $cadmin-label-primary-close: map-deep-merge(
 $cadmin-label-primary: () !default;
 $cadmin-label-primary: map-deep-merge(
 	(
-		bg: $cadmin-label-primary-bg,
+		background-color: $cadmin-label-primary-bg,
 		border-color: $cadmin-label-primary-border-color,
 		color: $cadmin-label-primary-color,
-		hover-bg: $cadmin-label-primary-hover-bg,
-		hover-border-color: $cadmin-label-primary-hover-border-color,
-		hover-color: $cadmin-label-primary-hover-color,
-		focus-color: $cadmin-label-primary-hover-color,
-		link-color: $cadmin-label-primary-link-color,
-		link-hover-color: $cadmin-label-primary-link-hover-color,
+		hover: (
+			background-color: $cadmin-label-primary-hover-bg,
+			border-color: $cadmin-label-primary-hover-border-color,
+			color: $cadmin-label-primary-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-primary-hover-color,
+		),
+		link: (
+			color: $cadmin-label-primary-link-color,
+			hover: (
+				color: $cadmin-label-primary-link-hover-color,
+			),
+		),
 		close: $cadmin-label-primary-close,
 	),
 	$cadmin-label-primary
@@ -189,8 +217,12 @@ $cadmin-label-secondary-link-hover-color: $cadmin-label-secondary-hover-color !d
 $cadmin-label-secondary-close: () !default;
 $cadmin-label-secondary-close: map-deep-merge(
 	(
-		hover-color: $cadmin-label-secondary-hover-color,
-		focus-color: $cadmin-label-secondary-hover-color,
+		hover: (
+			color: $cadmin-label-secondary-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-secondary-hover-color,
+		),
 	),
 	$cadmin-label-secondary-close
 );
@@ -198,15 +230,23 @@ $cadmin-label-secondary-close: map-deep-merge(
 $cadmin-label-secondary: () !default;
 $cadmin-label-secondary: map-deep-merge(
 	(
-		bg: $cadmin-label-secondary-bg,
+		background-color: $cadmin-label-secondary-bg,
 		border-color: $cadmin-label-secondary-border-color,
 		color: $cadmin-label-secondary-color,
-		hover-bg: $cadmin-label-secondary-hover-bg,
-		hover-border-color: $cadmin-label-secondary-hover-border-color,
-		hover-color: $cadmin-label-secondary-hover-color,
-		focus-color: $cadmin-label-secondary-hover-color,
-		link-color: $cadmin-label-secondary-link-color,
-		link-hover-color: $cadmin-label-secondary-link-hover-color,
+		hover: (
+			background-color: $cadmin-label-secondary-hover-bg,
+			border-color: $cadmin-label-secondary-hover-border-color,
+			color: $cadmin-label-secondary-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-secondary-hover-color,
+		),
+		link: (
+			color: $cadmin-label-secondary-link-color,
+			hover: (
+				color: $cadmin-label-secondary-link-hover-color,
+			),
+		),
 		close: $cadmin-label-secondary-close,
 	),
 	$cadmin-label-secondary
@@ -247,8 +287,12 @@ $cadmin-label-success-link-hover-color: $cadmin-label-success-hover-color !defau
 $cadmin-label-success-close: () !default;
 $cadmin-label-success-close: map-deep-merge(
 	(
-		hover-color: $cadmin-label-success-hover-color,
-		focus-color: $cadmin-label-success-hover-color,
+		hover: (
+			color: $cadmin-label-success-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-success-hover-color,
+		),
 	),
 	$cadmin-label-success-close
 );
@@ -256,15 +300,23 @@ $cadmin-label-success-close: map-deep-merge(
 $cadmin-label-success: () !default;
 $cadmin-label-success: map-deep-merge(
 	(
-		bg: $cadmin-label-success-bg,
+		background-color: $cadmin-label-success-bg,
 		border-color: $cadmin-label-success-border-color,
 		color: $cadmin-label-success-color,
-		hover-bg: $cadmin-label-success-hover-bg,
-		hover-border-color: $cadmin-label-success-hover-border-color,
-		hover-color: $cadmin-label-success-hover-color,
-		focus-color: $cadmin-label-success-hover-color,
-		link-color: $cadmin-label-success-link-color,
-		link-hover-color: $cadmin-label-success-link-hover-color,
+		hover: (
+			background-color: $cadmin-label-success-hover-bg,
+			border-color: $cadmin-label-success-hover-border-color,
+			color: $cadmin-label-success-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-success-hover-color,
+		),
+		link: (
+			color: $cadmin-label-success-link-color,
+			hover: (
+				color: $cadmin-label-success-link-hover-color,
+			),
+		),
 		close: $cadmin-label-success-close,
 	),
 	$cadmin-label-success
@@ -305,8 +357,12 @@ $cadmin-label-info-link-hover-color: $cadmin-label-info-hover-color !default;
 $cadmin-label-info-close: () !default;
 $cadmin-label-info-close: map-deep-merge(
 	(
-		hover-color: $cadmin-label-info-hover-color,
-		focus-color: $cadmin-label-info-hover-color,
+		hover: (
+			color: $cadmin-label-info-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-info-hover-color,
+		),
 	),
 	$cadmin-label-info-close
 );
@@ -314,15 +370,23 @@ $cadmin-label-info-close: map-deep-merge(
 $cadmin-label-info: () !default;
 $cadmin-label-info: map-deep-merge(
 	(
-		bg: $cadmin-label-info-bg,
+		background-color: $cadmin-label-info-bg,
 		border-color: $cadmin-label-info-border-color,
 		color: $cadmin-label-info-color,
-		hover-bg: $cadmin-label-info-hover-bg,
-		hover-border-color: $cadmin-label-info-hover-border-color,
-		hover-color: $cadmin-label-info-hover-color,
-		focus-color: $cadmin-label-info-hover-color,
-		link-color: $cadmin-label-info-link-color,
-		link-hover-color: $cadmin-label-info-link-hover-color,
+		hover: (
+			background-color: $cadmin-label-info-hover-bg,
+			border-color: $cadmin-label-info-hover-border-color,
+			color: $cadmin-label-info-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-info-hover-color,
+		),
+		link: (
+			color: $cadmin-label-info-link-color,
+			hover: (
+				color: $cadmin-label-info-link-hover-color,
+			),
+		),
 		close: $cadmin-label-info-close,
 	),
 	$cadmin-label-info
@@ -363,8 +427,12 @@ $cadmin-label-warning-link-hover-color: $cadmin-label-warning-hover-color !defau
 $cadmin-label-warning-close: () !default;
 $cadmin-label-warning-close: map-deep-merge(
 	(
-		hover-color: $cadmin-label-warning-hover-color,
-		focus-color: $cadmin-label-warning-hover-color,
+		hover: (
+			color: $cadmin-label-warning-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-warning-hover-color,
+		),
 	),
 	$cadmin-label-warning-close
 );
@@ -372,15 +440,23 @@ $cadmin-label-warning-close: map-deep-merge(
 $cadmin-label-warning: () !default;
 $cadmin-label-warning: map-deep-merge(
 	(
-		bg: $cadmin-label-warning-bg,
+		background-color: $cadmin-label-warning-bg,
 		border-color: $cadmin-label-warning-border-color,
 		color: $cadmin-label-warning-color,
-		hover-bg: $cadmin-label-warning-hover-bg,
-		hover-border-color: $cadmin-label-warning-hover-border-color,
-		hover-color: $cadmin-label-warning-hover-color,
-		focus-color: $cadmin-label-warning-hover-color,
-		link-color: $cadmin-label-warning-link-color,
-		link-hover-color: $cadmin-label-warning-link-hover-color,
+		hover: (
+			background-color: $cadmin-label-warning-hover-bg,
+			border-color: $cadmin-label-warning-hover-border-color,
+			color: $cadmin-label-warning-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-warning-hover-color,
+		),
+		link: (
+			color: $cadmin-label-warning-link-color,
+			hover: (
+				color: $cadmin-label-warning-link-hover-color,
+			),
+		),
 		close: $cadmin-label-warning-close,
 	),
 	$cadmin-label-warning
@@ -421,8 +497,12 @@ $cadmin-label-danger-link-hover-color: $cadmin-label-danger-hover-color !default
 $cadmin-label-danger-close: () !default;
 $cadmin-label-danger-close: map-deep-merge(
 	(
-		hover-color: $cadmin-label-danger-hover-color,
-		focus-color: $cadmin-label-danger-hover-color,
+		hover: (
+			color: $cadmin-label-danger-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-danger-hover-color,
+		),
 	),
 	$cadmin-label-danger-close
 );
@@ -430,15 +510,23 @@ $cadmin-label-danger-close: map-deep-merge(
 $cadmin-label-danger: () !default;
 $cadmin-label-danger: map-deep-merge(
 	(
-		bg: $cadmin-label-danger-bg,
+		background-color: $cadmin-label-danger-bg,
 		border-color: $cadmin-label-danger-border-color,
 		color: $cadmin-label-danger-color,
-		hover-bg: $cadmin-label-danger-hover-bg,
-		hover-border-color: $cadmin-label-danger-hover-border-color,
-		hover-color: $cadmin-label-danger-hover-color,
-		focus-color: $cadmin-label-danger-hover-color,
-		link-color: $cadmin-label-danger-link-color,
-		link-hover-color: $cadmin-label-danger-link-hover-color,
+		hover: (
+			background-color: $cadmin-label-danger-hover-bg,
+			border-color: $cadmin-label-danger-hover-border-color,
+			color: $cadmin-label-danger-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-danger-hover-color,
+		),
+		link: (
+			color: $cadmin-label-danger-link-color,
+			hover: (
+				color: $cadmin-label-danger-link-hover-color,
+			),
+		),
 		close: $cadmin-label-danger-close,
 	),
 	$cadmin-label-danger
@@ -479,8 +567,12 @@ $cadmin-label-light-link-hover-color: $cadmin-label-light-hover-color !default;
 $cadmin-label-light-close: () !default;
 $cadmin-label-light-close: map-deep-merge(
 	(
-		hover-color: $cadmin-label-light-hover-color,
-		focus-color: $cadmin-label-light-hover-color,
+		hover: (
+			color: $cadmin-label-light-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-light-hover-color,
+		),
 	),
 	$cadmin-label-light-close
 );
@@ -488,15 +580,23 @@ $cadmin-label-light-close: map-deep-merge(
 $cadmin-label-light: () !default;
 $cadmin-label-light: map-deep-merge(
 	(
-		bg: $cadmin-label-light-bg,
+		background-color: $cadmin-label-light-bg,
 		border-color: $cadmin-label-light-border-color,
 		color: $cadmin-label-light-color,
-		hover-bg: $cadmin-label-light-hover-bg,
-		hover-border-color: $cadmin-label-light-hover-border-color,
-		hover-color: $cadmin-label-light-hover-color,
-		focus-color: $cadmin-label-light-hover-color,
-		link-color: $cadmin-label-light-link-color,
-		link-hover-color: $cadmin-label-light-link-hover-color,
+		hover: (
+			background-color: $cadmin-label-light-hover-bg,
+			border-color: $cadmin-label-light-hover-border-color,
+			color: $cadmin-label-light-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-light-hover-color,
+		),
+		link: (
+			color: $cadmin-label-light-link-color,
+			hover: (
+				color: $cadmin-label-light-link-hover-color,
+			),
+		),
 		close: $cadmin-label-light-close,
 	),
 	$cadmin-label-light
@@ -537,8 +637,12 @@ $cadmin-label-dark-link-hover-color: $cadmin-label-dark-hover-color !default;
 $cadmin-label-dark-close: () !default;
 $cadmin-label-dark-close: map-deep-merge(
 	(
-		hover-color: $cadmin-label-dark-hover-color,
-		focus-color: $cadmin-label-dark-hover-color,
+		hover: (
+			color: $cadmin-label-dark-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-dark-hover-color,
+		),
 	),
 	$cadmin-label-dark-close
 );
@@ -546,15 +650,23 @@ $cadmin-label-dark-close: map-deep-merge(
 $cadmin-label-dark: () !default;
 $cadmin-label-dark: map-deep-merge(
 	(
-		bg: $cadmin-label-dark-bg,
+		background-color: $cadmin-label-dark-bg,
 		border-color: $cadmin-label-dark-border-color,
 		color: $cadmin-label-dark-color,
-		hover-bg: $cadmin-label-dark-hover-bg,
-		hover-border-color: $cadmin-label-dark-hover-border-color,
-		hover-color: $cadmin-label-dark-hover-color,
-		focus-color: $cadmin-label-dark-hover-color,
-		link-color: $cadmin-label-dark-link-color,
-		link-hover-color: $cadmin-label-dark-link-hover-color,
+		hover: (
+			background-color: $cadmin-label-dark-hover-bg,
+			border-color: $cadmin-label-dark-hover-border-color,
+			color: $cadmin-label-dark-hover-color,
+		),
+		focus: (
+			color: $cadmin-label-dark-hover-color,
+		),
+		link: (
+			color: $cadmin-label-dark-link-color,
+			hover: (
+				color: $cadmin-label-dark-link-hover-color,
+			),
+		),
 		close: $cadmin-label-dark-close,
 	),
 	$cadmin-label-dark

--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -28,42 +28,135 @@
 /// c-inner: {Map | Null}, // Pass parameters to `clay-css` mixin
 
 @mixin clay-label-size($map) {
-	$border-width: setter(
-		map-get($map, border-width),
-		if(
-			variable-exists(label-border-width),
-			$label-border-width,
-			$cadmin-label-border-width
+	$enabled: setter(map-get($map, enabled), true);
+
+	$base: setter($map, ());
+	$base: map-merge(
+		$base,
+		(
+			border-width:
+				setter(
+					map-get($base, border-width),
+					if(
+						variable-exists(label-border-width),
+						$label-border-width,
+						$cadmin-label-border-width
+					)
+				),
+			padding-bottom:
+				setter(map-get($map, padding-y), map-get($base, padding-bottom)),
+			padding-left:
+				setter(map-get($map, padding-x), map-get($base, padding-left)),
+			padding-right:
+				setter(map-get($map, padding-x), map-get($base, padding-right)),
+			padding-top:
+				setter(map-get($map, padding-y), map-get($base, padding-top)),
 		)
 	);
-	$font-size: map-get($map, font-size);
-	$height: map-get($map, height);
-	$line-height: map-get($map, line-height);
-	$margin-bottom: map-get($map, margin-bottom);
-	$margin-left: map-get($map, margin-left);
-	$margin-right: map-get($map, margin-right);
-	$margin-top: map-get($map, margin-top);
-	$padding-x: map-get($map, padding-x);
-	$padding-y: map-get($map, padding-y);
-	$text-transform: map-get($map, text-transform);
 
-	$item-spacer-x: map-get($map, item-spacer-x);
-	$item-spacer-y: map-get($map, item-spacer-y);
-
-	$lexicon-icon-height: setter(
-		map-get($map, lexicon-icon-height),
-		map-get($map, lexicon-icon-width)
+	$label-item: setter(map-get($map, label-item), ());
+	$label-item: map-merge(
+		$label-item,
+		(
+			margin-bottom:
+				setter(
+					map-get($map, item-spacer-y),
+					map-get($label-item, margin-bottom)
+				),
+			margin-top:
+				setter(
+					map-get($map, item-spacer-y),
+					map-get($label-item, margin-top)
+				),
+		)
 	);
-	$lexicon-icon-margin-top: map-get($map, lexicon-icon-margin-top);
-	$lexicon-icon-width: map-get($map, lexicon-icon-width);
 
-	$sticker-border-radius: map-get($map, sticker-border-radius);
-	$sticker-size: map-get($map, sticker-size);
+	$label-item-before: setter(map-get($map, label-item-before), ());
+	$label-item-before: map-merge(
+		$label-item-before,
+		(
+			margin-right:
+				setter(
+					map-get($map, item-spacer-x),
+					map-get($label-item-before, margin-right)
+				),
+		)
+	);
+
+	$label-item-after: setter(map-get($map, label-item-after), ());
+	$label-item-after: map-merge(
+		$label-item-after,
+		(
+			margin-left:
+				setter(
+					map-get($map, item-spacer-x),
+					map-get($label-item-after, margin-left)
+				),
+		)
+	);
+
+	$lexicon-icon: setter(map-get($map, lexicon-icon), ());
+	$lexicon-icon: map-merge(
+		$lexicon-icon,
+		(
+			height:
+				setter(
+					map-get($map, lexicon-icon-height),
+					setter(
+						map-get($lexicon-icon, height),
+						map-get($lexicon-icon, width)
+					)
+				),
+			margin-top:
+				setter(
+					map-get($map, lexicon-icon-margin-top),
+					map-get($lexicon-icon, margin-top)
+				),
+			width:
+				setter(
+					map-get($map, lexicon-icon-width),
+					map-get($lexicon-icon, width)
+				),
+		)
+	);
+
+	$sticker: setter(map-get($map, sticker), ());
+	$sticker: map-merge(
+		$sticker,
+		(
+			border-radius:
+				setter(
+					map-get($map, sticker-border-radius),
+					map-get($sticker, border-radius)
+				),
+			height:
+				setter(map-get($map, sticker-size), map-get($sticker, height)),
+			line-height:
+				setter(
+					map-get($map, sticker-size),
+					map-get($sticker, line-height)
+				),
+			width: setter(map-get($map, sticker-size), map-get($sticker, width)),
+		)
+	);
+
+	$sticker-overlay: setter(map-get($map, sticker-overlay), ());
+	$sticker-overlay: map-merge(
+		$sticker-overlay,
+		(
+			border-radius:
+				setter(
+					map-get($sticker-overlay, border-radius),
+					map-get($sticker, border-radius)
+				),
+		)
+	);
 
 	$close: setter(map-get($map, close), ());
 
 	$c-inner: setter(map-get($map, c-inner), ());
 	$c-inner: map-deep-merge(
+		$c-inner,
 		(
 			enabled:
 				setter(
@@ -74,82 +167,78 @@
 					),
 					true
 				),
-			margin-bottom: math-sign($padding-y),
-			margin-left: math-sign($padding-x),
-			margin-right: math-sign($padding-x),
-			margin-top: math-sign($padding-y),
-		),
-		$c-inner
+			margin-bottom:
+				setter(
+					map-get($c-inner, margin-bottom),
+					math-sign(map-get($base, padding-bottom))
+				),
+			margin-left:
+				setter(
+					map-get($c-inner, margin-left),
+					math-sign(map-get($base, padding-left))
+				),
+			margin-right:
+				setter(
+					map-get($c-inner, margin-right),
+					math-sign(map-get($base, padding-right))
+				),
+			margin-top:
+				setter(
+					map-get($c-inner, margin-top),
+					math-sign(map-get($base, padding-top))
+				),
+		)
 	);
 
-	border-width: $border-width;
-	font-size: $font-size;
-	height: auto;
-	line-height: $line-height;
-	margin-bottom: $margin-bottom;
-	margin-left: $margin-left;
-	margin-right: $margin-right;
-	margin-top: $margin-top;
-	min-height: $height;
-	padding-bottom: $padding-y;
-	padding-left: $padding-x;
-	padding-right: $padding-x;
-	padding-top: $padding-y;
-	text-transform: $text-transform;
+	@if ($enabled) {
+		@include clay-css($base);
 
-	// Inline Item in Labels are deprecated in v2.0.0-rc.11 use .label-item
-	// pattern instead
-	.inline-item {
-		a,
-		.btn-unstyled,
+		// Inline Item in Labels are deprecated in v2.0.0-rc.11 use .label-item
+		// pattern instead
+		.inline-item {
+			a,
+			.btn-unstyled,
+			.close {
+				margin-top: map-get($lexicon-icon, margin-top);
+			}
+
+			.lexicon-icon {
+				@include clay-css($lexicon-icon);
+			}
+		}
+
+		.label-item {
+			@include clay-css($label-item);
+
+			.lexicon-icon {
+				@include clay-css($lexicon-icon);
+			}
+		}
+
+		.label-item-before {
+			@include clay-css($label-item-before);
+		}
+
+		.label-item-after {
+			@include clay-css($label-item-after);
+		}
+
 		.close {
-			margin-top: $lexicon-icon-margin-top;
+			@include clay-close($close);
 		}
 
-		.lexicon-icon {
-			height: $lexicon-icon-height;
-			margin-top: $lexicon-icon-margin-top;
-			width: $lexicon-icon-width;
+		.sticker {
+			@include clay-css($sticker);
 		}
-	}
 
-	.label-item {
-		margin-bottom: $item-spacer-y;
-		margin-top: $item-spacer-y;
-
-		.lexicon-icon {
-			height: $lexicon-icon-height;
-			margin-top: $lexicon-icon-margin-top;
-			width: $lexicon-icon-width;
+		.sticker-overlay {
+			@include clay-css($sticker-overlay);
 		}
-	}
 
-	.label-item-before {
-		margin-right: $item-spacer-x;
-	}
-
-	.label-item-after {
-		margin-left: $item-spacer-x;
-	}
-
-	.close {
-		@include clay-close($close);
-	}
-
-	.sticker {
-		border-radius: $sticker-border-radius;
-		height: $sticker-size;
-		line-height: $sticker-size;
-		width: $sticker-size;
-	}
-
-	.sticker-overlay {
-		border-radius: $sticker-border-radius;
-	}
-
-	@if (map-get($c-inner, enabled)) {
-		> .c-inner {
-			@include clay-css($c-inner);
+		@if (map-get($c-inner, enabled)) {
+			> .c-inner {
+				@include clay-css($c-inner);
+			}
 		}
 	}
 }
@@ -190,73 +279,145 @@
 /// close: {Map | Null}, // Pass parameters to `clay-close` mixin
 
 @mixin clay-label-variant($map) {
-	$map: map-merge(
+	$enabled: setter(map-get($map, enabled), true);
+
+	$base: setter($map, ());
+	$base: map-merge(
+		$base,
 		(
-			background-color: map-get($map, bg),
-			border-color: map-get($map, border-color),
-			color: map-get($map, color),
-			outline: map-get($map, outline),
-			text-decoration: map-get($map, text-decoration),
-			transition: map-get($map, transition),
-		),
-		$map
+			background-color:
+				setter(map-get($map, bg), map-get($base, background-color)),
+		)
 	);
 
-	$hover: map-deep-merge(
+	$hover: setter(map-get($map, hover), ());
+	$hover: map-merge(
+		$hover,
 		(
-			background-color: map-get($map, hover-bg),
-			border-color: map-get($map, hover-border-color),
-			color: map-get($map, hover-color),
-			text-decoration: map-get($map, hover-text-decoration),
-		),
-		map-get($map, hover)
+			background-color:
+				setter(
+					map-get($map, hover-bg),
+					map-get($hover, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, hover-border-color),
+					map-get($hover, border-color)
+				),
+			color: setter(map-get($map, hover-color), map-get($hover, color)),
+			text-decoration:
+				setter(
+					map-get($map, hover-text-decoration),
+					map-get($hover, text-decoration)
+				),
+		)
 	);
 
-	$focus: map-deep-merge(
+	$focus: setter(map-get($map, focus), ());
+	$focus: map-merge(
+		$focus,
 		(
-			background-color: map-get($map, focus-bg),
-			border-color: map-get($map, focus-border-color),
-			box-shadow: map-get($map, focus-box-shadow),
-			color: map-get($map, focus-color),
-			outline: map-get($map, focus-outline),
-			text-decoration: map-get($map, focus-text-decoration),
-		),
-		map-get($map, focus)
+			background-color:
+				setter(
+					map-get($map, focus-bg),
+					map-get($focus, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, focus-border-color),
+					map-get($focus, border-color)
+				),
+			box-shadow:
+				setter(
+					map-get($map, focus-box-shadow),
+					map-get($focus, box-shadow)
+				),
+			color: setter(map-get($map, focus-color), map-get($focus, color)),
+			outline:
+				setter(map-get($map, focus-outline), map-get($focus, outline)),
+			text-decoration:
+				setter(
+					map-get($map, focus-text-decoration),
+					map-get($focus, text-decoration)
+				),
+		)
 	);
 
-	$disabled: map-deep-merge(
+	$disabled: setter(map-get($map, disabled), ());
+	$disabled: map-merge(
+		$disabled,
 		(
-			background-color: map-get($map, disabled-bg),
-			border-color: map-get($map, disabled-border-color),
-			box-shadow: map-get($map, disabled-box-shadow),
-			color: map-get($map, disabled-color),
-		),
-		map-get($map, disabled)
+			background-color:
+				setter(
+					map-get($map, disabled-bg),
+					map-get($disabled, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, disabled-border-color),
+					map-get($disabled, border-color)
+				),
+			box-shadow:
+				setter(
+					map-get($map, disabled-box-shadow),
+					map-get($disabled, box-shadow)
+				),
+			color:
+				setter(map-get($map, disabled-color), map-get($disabled, color)),
+		)
+	);
+
+	$link: setter(map-get($map, link), ());
+
+	$link-hover: setter(map-get($link, hover), ());
+	$link-hover: map-merge(
+		$link-hover,
+		(
+			color:
+				setter(
+					map-get($map, link-hover-color),
+					map-get($link-hover, color)
+				),
+			text-decoration:
+				setter(
+					map-get($map, link-hover-text-decoration),
+					map-get($link-hover, text-decoration)
+				),
+		)
 	);
 
 	$link: map-deep-merge(
+		$link,
 		(
-			color: map-get($map, link-color),
-			text-decoration: map-get($map, link-text-decoration),
-		),
-		map-get($map, link)
-	);
-
-	$link-hover: map-deep-merge(
-		(
-			color: map-get($map, link-hover-color),
-			text-decoration: map-get($map, link-hover-text-decoration),
-		),
-		map-get($map, link-hover)
+			color: setter(map-get($map, link-color), map-get($link, color)),
+			text-decoration:
+				setter(
+					map-get($map, link-text-decoration),
+					map-get($link, text-decoration)
+				),
+			hover: $link-hover,
+		)
 	);
 
 	$close: setter(map-get($map, close), ());
 
-	@include clay-css($map);
+	@if ($enabled) {
+		@include clay-css($base);
 
-	@at-root {
-		a#{&},
-		button#{&} {
+		@at-root {
+			a#{&},
+			button#{&} {
+				&:hover {
+					@include clay-css($hover);
+				}
+
+				&:focus {
+					@include clay-css($focus);
+				}
+			}
+		}
+
+		&[tabindex] {
 			&:hover {
 				@include clay-css($hover);
 			}
@@ -265,34 +426,24 @@
 				@include clay-css($focus);
 			}
 		}
-	}
 
-	&[tabindex] {
-		&:hover {
-			@include clay-css($hover);
+		&:disabled,
+		&.disabled {
+			@include clay-css($disabled);
 		}
 
-		&:focus {
-			@include clay-css($focus);
+		a,
+		.btn-unstyled {
+			@include clay-css($link);
+
+			&:hover,
+			&:focus {
+				@include clay-css($link-hover);
+			}
 		}
-	}
 
-	&:disabled,
-	&.disabled {
-		@include clay-css($disabled);
-	}
-
-	a,
-	.btn-unstyled {
-		@include clay-css($link);
-
-		&:hover,
-		&:focus {
-			@include clay-css($link-hover);
+		.close {
+			@include clay-close($close);
 		}
-	}
-
-	.close {
-		@include clay-close($close);
 	}
 }

--- a/packages/clay-css/src/scss/variables/_labels.scss
+++ b/packages/clay-css/src/scss/variables/_labels.scss
@@ -54,10 +54,16 @@ $label-close: map-deep-merge(
 		margin-top: -2px,
 		opacity: 1,
 		width: auto,
-		hover-color: inherit,
-		hover-opacity: 1,
-		focus-opacity: 1,
-		disabled-opacity: $btn-disabled-opacity,
+		hover: (
+			color: inherit,
+			opacity: 1,
+		),
+		focus: (
+			opacity: 1,
+		),
+		disabled: (
+			opacity: $btn-disabled-opacity,
+		),
 	),
 	$label-close
 );
@@ -68,8 +74,11 @@ $label-lg: () !default;
 $label-lg: map-deep-merge(
 	(
 		font-size: 0.875rem,
-		padding-x: 1rem,
-		padding-y: 0.375rem,
+		height: auto,
+		padding-bottom: 0.375rem,
+		padding-left: 1rem,
+		padding-right: 1rem,
+		padding-top: 0.375rem,
 		text-transform: none,
 	),
 	$label-lg
@@ -114,8 +123,12 @@ $label-primary-link-hover-color: $label-primary-hover-color !default;
 $label-primary-close: () !default;
 $label-primary-close: map-deep-merge(
 	(
-		hover-color: $label-primary-hover-color,
-		focus-color: $label-primary-hover-color,
+		hover: (
+			color: $label-primary-hover-color,
+		),
+		focus: (
+			color: $label-primary-hover-color,
+		),
 	),
 	$label-primary-close
 );
@@ -123,15 +136,23 @@ $label-primary-close: map-deep-merge(
 $label-primary: () !default;
 $label-primary: map-deep-merge(
 	(
-		bg: $label-primary-bg,
+		background-color: $label-primary-bg,
 		border-color: $label-primary-border-color,
 		color: $label-primary-color,
-		hover-bg: $label-primary-hover-bg,
-		hover-border-color: $label-primary-hover-border-color,
-		hover-color: $label-primary-hover-color,
-		focus-color: $label-primary-hover-color,
-		link-color: $label-primary-link-color,
-		link-hover-color: $label-primary-link-hover-color,
+		hover: (
+			background-color: $label-primary-hover-bg,
+			border-color: $label-primary-hover-border-color,
+			color: $label-primary-hover-color,
+		),
+		focus: (
+			color: $label-primary-hover-color,
+		),
+		link: (
+			color: $label-primary-link-color,
+			hover: (
+				color: $label-primary-link-hover-color,
+			),
+		),
 		close: $label-primary-close,
 	),
 	$label-primary
@@ -172,8 +193,12 @@ $label-secondary-link-hover-color: $label-secondary-hover-color !default;
 $label-secondary-close: () !default;
 $label-secondary-close: map-deep-merge(
 	(
-		hover-color: $label-secondary-hover-color,
-		focus-color: $label-secondary-hover-color,
+		hover: (
+			color: $label-secondary-hover-color,
+		),
+		focus: (
+			color: $label-secondary-hover-color,
+		),
 	),
 	$label-secondary-close
 );
@@ -181,15 +206,23 @@ $label-secondary-close: map-deep-merge(
 $label-secondary: () !default;
 $label-secondary: map-deep-merge(
 	(
-		bg: $label-secondary-bg,
+		background-color: $label-secondary-bg,
 		border-color: $label-secondary-border-color,
 		color: $label-secondary-color,
-		hover-bg: $label-secondary-hover-bg,
-		hover-border-color: $label-secondary-hover-border-color,
-		hover-color: $label-secondary-hover-color,
-		focus-color: $label-secondary-hover-color,
-		link-color: $label-secondary-link-color,
-		link-hover-color: $label-secondary-link-hover-color,
+		hover: (
+			background-color: $label-secondary-hover-bg,
+			border-color: $label-secondary-hover-border-color,
+			color: $label-secondary-hover-color,
+		),
+		focus: (
+			color: $label-secondary-hover-color,
+		),
+		link: (
+			color: $label-secondary-link-color,
+			hover: (
+				color: $label-secondary-link-hover-color,
+			),
+		),
 		close: $label-secondary-close,
 	),
 	$label-secondary
@@ -230,8 +263,12 @@ $label-success-link-hover-color: $label-success-hover-color !default;
 $label-success-close: () !default;
 $label-success-close: map-deep-merge(
 	(
-		hover-color: $label-success-hover-color,
-		focus-color: $label-success-hover-color,
+		hover: (
+			color: $label-success-hover-color,
+		),
+		focus: (
+			color: $label-success-hover-color,
+		),
 	),
 	$label-success-close
 );
@@ -239,15 +276,23 @@ $label-success-close: map-deep-merge(
 $label-success: () !default;
 $label-success: map-deep-merge(
 	(
-		bg: $label-success-bg,
+		background-color: $label-success-bg,
 		border-color: $label-success-border-color,
 		color: $label-success-color,
-		hover-bg: $label-success-hover-bg,
-		hover-border-color: $label-success-hover-border-color,
-		hover-color: $label-success-hover-color,
-		focus-color: $label-success-hover-color,
-		link-color: $label-success-link-color,
-		link-hover-color: $label-success-link-hover-color,
+		hover: (
+			background-color: $label-success-hover-bg,
+			border-color: $label-success-hover-border-color,
+			color: $label-success-hover-color,
+		),
+		focus: (
+			color: $label-success-hover-color,
+		),
+		link: (
+			color: $label-success-link-color,
+			hover: (
+				color: $label-success-link-hover-color,
+			),
+		),
 		close: $label-success-close,
 	),
 	$label-success
@@ -288,8 +333,12 @@ $label-info-link-hover-color: $label-info-hover-color !default;
 $label-info-close: () !default;
 $label-info-close: map-deep-merge(
 	(
-		hover-color: $label-info-hover-color,
-		focus-color: $label-info-hover-color,
+		hover: (
+			color: $label-info-hover-color,
+		),
+		focus: (
+			color: $label-info-hover-color,
+		),
 	),
 	$label-info-close
 );
@@ -297,15 +346,23 @@ $label-info-close: map-deep-merge(
 $label-info: () !default;
 $label-info: map-deep-merge(
 	(
-		bg: $label-info-bg,
+		background-color: $label-info-bg,
 		border-color: $label-info-border-color,
 		color: $label-info-color,
-		hover-bg: $label-info-hover-bg,
-		hover-border-color: $label-info-hover-border-color,
-		hover-color: $label-info-hover-color,
-		focus-color: $label-info-hover-color,
-		link-color: $label-info-link-color,
-		link-hover-color: $label-info-link-hover-color,
+		hover: (
+			background-color: $label-info-hover-bg,
+			border-color: $label-info-hover-border-color,
+			color: $label-info-hover-color,
+		),
+		focus: (
+			color: $label-info-hover-color,
+		),
+		link: (
+			color: $label-info-link-color,
+			hover: (
+				color: $label-info-link-hover-color,
+			),
+		),
 		close: $label-info-close,
 	),
 	$label-info
@@ -346,8 +403,12 @@ $label-warning-link-hover-color: $label-warning-hover-color !default;
 $label-warning-close: () !default;
 $label-warning-close: map-deep-merge(
 	(
-		hover-color: $label-warning-hover-color,
-		focus-color: $label-warning-hover-color,
+		hover: (
+			color: $label-warning-hover-color,
+		),
+		focus: (
+			color: $label-warning-hover-color,
+		),
 	),
 	$label-warning-close
 );
@@ -355,15 +416,23 @@ $label-warning-close: map-deep-merge(
 $label-warning: () !default;
 $label-warning: map-deep-merge(
 	(
-		bg: $label-warning-bg,
+		background-color: $label-warning-bg,
 		border-color: $label-warning-border-color,
 		color: $label-warning-color,
-		hover-bg: $label-warning-hover-bg,
-		hover-border-color: $label-warning-hover-border-color,
-		hover-color: $label-warning-hover-color,
-		focus-color: $label-warning-hover-color,
-		link-color: $label-warning-link-color,
-		link-hover-color: $label-warning-link-hover-color,
+		hover: (
+			background-color: $label-warning-hover-bg,
+			border-color: $label-warning-hover-border-color,
+			color: $label-warning-hover-color,
+		),
+		focus: (
+			color: $label-warning-hover-color,
+		),
+		link: (
+			color: $label-warning-link-color,
+			hover: (
+				color: $label-warning-link-hover-color,
+			),
+		),
 		close: $label-warning-close,
 	),
 	$label-warning
@@ -404,8 +473,12 @@ $label-danger-link-hover-color: $label-danger-hover-color !default;
 $label-danger-close: () !default;
 $label-danger-close: map-deep-merge(
 	(
-		hover-color: $label-danger-hover-color,
-		focus-color: $label-danger-hover-color,
+		hover: (
+			color: $label-danger-hover-color,
+		),
+		focus: (
+			color: $label-danger-hover-color,
+		),
 	),
 	$label-danger-close
 );
@@ -413,15 +486,23 @@ $label-danger-close: map-deep-merge(
 $label-danger: () !default;
 $label-danger: map-deep-merge(
 	(
-		bg: $label-danger-bg,
+		background-color: $label-danger-bg,
 		border-color: $label-danger-border-color,
 		color: $label-danger-color,
-		hover-bg: $label-danger-hover-bg,
-		hover-border-color: $label-danger-hover-border-color,
-		hover-color: $label-danger-hover-color,
-		focus-color: $label-danger-hover-color,
-		link-color: $label-danger-link-color,
-		link-hover-color: $label-danger-link-hover-color,
+		hover: (
+			background-color: $label-danger-hover-bg,
+			border-color: $label-danger-hover-border-color,
+			color: $label-danger-hover-color,
+		),
+		focus: (
+			color: $label-danger-hover-color,
+		),
+		link: (
+			color: $label-danger-link-color,
+			hover: (
+				color: $label-danger-link-hover-color,
+			),
+		),
 		close: $label-danger-close,
 	),
 	$label-danger
@@ -462,8 +543,12 @@ $label-light-link-hover-color: $label-light-hover-color !default;
 $label-light-close: () !default;
 $label-light-close: map-deep-merge(
 	(
-		hover-color: $label-light-hover-color,
-		focus-color: $label-light-hover-color,
+		hover: (
+			color: $label-light-hover-color,
+		),
+		focus: (
+			color: $label-light-hover-color,
+		),
 	),
 	$label-light-close
 );
@@ -471,15 +556,23 @@ $label-light-close: map-deep-merge(
 $label-light: () !default;
 $label-light: map-deep-merge(
 	(
-		bg: $label-light-bg,
+		background-color: $label-light-bg,
 		border-color: $label-light-border-color,
 		color: $label-light-color,
-		hover-bg: $label-light-hover-bg,
-		hover-border-color: $label-light-hover-border-color,
-		hover-color: $label-light-hover-color,
-		focus-color: $label-light-hover-color,
-		link-color: $label-light-link-color,
-		link-hover-color: $label-light-link-hover-color,
+		hover: (
+			background-color: $label-light-hover-bg,
+			border-color: $label-light-hover-border-color,
+			color: $label-light-hover-color,
+		),
+		focus: (
+			color: $label-light-hover-color,
+		),
+		link: (
+			color: $label-light-link-color,
+			hover: (
+				color: $label-light-link-hover-color,
+			),
+		),
 		close: $label-light-close,
 	),
 	$label-light
@@ -520,8 +613,12 @@ $label-dark-link-hover-color: $label-dark-hover-color !default;
 $label-dark-close: () !default;
 $label-dark-close: map-deep-merge(
 	(
-		hover-color: $label-dark-hover-color,
-		focus-color: $label-dark-hover-color,
+		hover: (
+			color: $label-dark-hover-color,
+		),
+		focus: (
+			color: $label-dark-hover-color,
+		),
 	),
 	$label-dark-close
 );
@@ -529,15 +626,23 @@ $label-dark-close: map-deep-merge(
 $label-dark: () !default;
 $label-dark: map-deep-merge(
 	(
-		bg: $label-dark-bg,
+		background-color: $label-dark-bg,
 		border-color: $label-dark-border-color,
 		color: $label-dark-color,
-		hover-bg: $label-dark-hover-bg,
-		hover-border-color: $label-dark-hover-border-color,
-		hover-color: $label-dark-hover-color,
-		focus-color: $label-dark-hover-color,
-		link-color: $label-dark-link-color,
-		link-hover-color: $label-dark-link-hover-color,
+		hover: (
+			background-color: $label-dark-hover-bg,
+			border-color: $label-dark-hover-border-color,
+			color: $label-dark-hover-color,
+		),
+		focus: (
+			color: $label-dark-hover-color,
+		),
+		link: (
+			color: $label-dark-link-color,
+			hover: (
+				color: $label-dark-link-hover-color,
+			),
+		),
 		close: $label-dark-close,
 	),
 	$label-dark
@@ -556,11 +661,15 @@ $label-inverse-primary: map-deep-merge(
 			border-color: darken($primary, 10%),
 			color: color-yiq(darken($primary, 10%)),
 		),
-		link-hover: (
-			color: darken(color-yiq(darken($primary, 10%)), 10%),
+		link: (
+			hover: (
+				color: darken(color-yiq(darken($primary, 10%)), 10%),
+			),
 		),
 		close: (
-			hover-color: darken(color-yiq(darken($primary, 10%)), 10%),
+			hover: (
+				color: darken(color-yiq(darken($primary, 10%)), 10%),
+			),
 		),
 	),
 	$label-inverse-primary
@@ -577,11 +686,15 @@ $label-inverse-secondary: map-deep-merge(
 			border-color: darken($secondary, 10%),
 			color: color-yiq(darken($secondary, 10%)),
 		),
-		link-hover: (
-			color: darken(color-yiq(darken($secondary, 10%)), 10%),
+		link: (
+			hover: (
+				color: darken(color-yiq(darken($secondary, 10%)), 10%),
+			),
 		),
 		close: (
-			hover-color: darken(color-yiq(darken($secondary, 10%)), 10%),
+			hover: (
+				color: darken(color-yiq(darken($secondary, 10%)), 10%),
+			),
 		),
 	),
 	$label-inverse-secondary
@@ -598,11 +711,15 @@ $label-inverse-success: map-deep-merge(
 			border-color: darken($success, 10%),
 			color: color-yiq(darken($success, 10%)),
 		),
-		link-hover: (
-			color: darken(color-yiq(darken($success, 10%)), 10%),
+		link: (
+			hover: (
+				color: darken(color-yiq(darken($success, 10%)), 10%),
+			),
 		),
 		close: (
-			hover-color: darken(color-yiq(darken($success, 10%)), 10%),
+			hover: (
+				color: darken(color-yiq(darken($success, 10%)), 10%),
+			),
 		),
 	),
 	$label-inverse-success
@@ -619,11 +736,15 @@ $label-inverse-info: map-deep-merge(
 			border-color: darken($info, 10%),
 			color: color-yiq(darken($info, 10%)),
 		),
-		link-hover: (
-			color: darken(color-yiq(darken($info, 10%)), 10%),
+		link: (
+			hover: (
+				color: darken(color-yiq(darken($info, 10%)), 10%),
+			),
 		),
 		close: (
-			hover-color: darken(color-yiq(darken($info, 10%)), 10%),
+			hover: (
+				color: darken(color-yiq(darken($info, 10%)), 10%),
+			),
 		),
 	),
 	$label-inverse-info
@@ -640,11 +761,15 @@ $label-inverse-warning: map-deep-merge(
 			border-color: darken($warning, 10%),
 			color: color-yiq(darken($warning, 10%)),
 		),
-		link-hover: (
-			color: lighten(color-yiq(darken($warning, 10%)), 20%),
+		link: (
+			hover: (
+				color: lighten(color-yiq(darken($warning, 10%)), 20%),
+			),
 		),
 		close: (
-			hover-color: lighten(color-yiq(darken($warning, 10%)), 20%),
+			hover: (
+				color: lighten(color-yiq(darken($warning, 10%)), 20%),
+			),
 		),
 	),
 	$label-inverse-warning
@@ -661,11 +786,15 @@ $label-inverse-danger: map-deep-merge(
 			border-color: darken($danger, 10%),
 			color: color-yiq(darken($danger, 10%)),
 		),
-		link-hover: (
-			color: darken(color-yiq(darken($danger, 10%)), 10%),
+		link: (
+			hover: (
+				color: darken(color-yiq(darken($danger, 10%)), 10%),
+			),
 		),
 		close: (
-			hover-color: darken(color-yiq(darken($danger, 10%)), 10%),
+			hover: (
+				color: darken(color-yiq(darken($danger, 10%)), 10%),
+			),
 		),
 	),
 	$label-inverse-danger
@@ -682,11 +811,15 @@ $label-inverse-light: map-deep-merge(
 			border-color: darken($light, 10%),
 			color: color-yiq(darken($light, 10%)),
 		),
-		link-hover: (
-			color: lighten(color-yiq(darken($light, 10%)), 10%),
+		link: (
+			hover: (
+				color: lighten(color-yiq(darken($light, 10%)), 10%),
+			),
 		),
 		close: (
-			hover-color: lighten(color-yiq(darken($light, 10%)), 10%),
+			hover: (
+				color: lighten(color-yiq(darken($light, 10%)), 10%),
+			),
 		),
 	),
 	$label-inverse-light
@@ -703,11 +836,15 @@ $label-inverse-dark: map-deep-merge(
 			border-color: darken($dark, 10%),
 			color: color-yiq(darken($dark, 10%)),
 		),
-		link-hover: (
-			color: darken(color-yiq(darken($dark, 10%)), 10%),
+		link: (
+			hover: (
+				color: darken(color-yiq(darken($dark, 10%)), 10%),
+			),
 		),
 		close: (
-			hover-color: darken(color-yiq(darken($dark, 10%)), 10%),
+			hover: (
+				color: darken(color-yiq(darken($dark, 10%)), 10%),
+			),
 		),
 	),
 	$label-inverse-dark


### PR DESCRIPTION
fixes #4069