### PR TITLE
feat(@clayui/color-picker): Add the new DropDownContainerProps API

### DIFF
--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -72,6 +72,14 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	 * Flag for adding ColorPicker in disabled state
 	 */
 	disabled?: boolean;
+
+	/**
+	 * Props to add to the DropDown container.
+	 */
+	dropDownContainerProps?: React.ComponentProps<
+		typeof ClayDropDown.Menu
+	>['containerProps'];
+
 	/**
 	 * The label describing the collection of colors in the menu
 	 */
@@ -92,6 +100,8 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	 */
 	onValueChange?: (val: string) => void;
 
+	predefinedColors?: Array<string>;
+
 	/**
 	 * Determines if the hex input should render
 	 */
@@ -102,6 +112,8 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	 * This defaults to true
 	 */
 	showPalette?: boolean;
+
+	showPredefinedColorsWithCustom?: boolean;
 
 	/**
 	 * Flag to indicate if `input-group-sm` class should
@@ -128,23 +140,21 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	 * Value of the selected color hex
 	 */
 	value?: string;
-
-	showPredefinedColorsWithCustom?: boolean;
-	predefinedColors?: Array<string>;
 }
 
 const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	ariaLabels = DEFAULT_ARIA_LABELS,
 	colors,
 	disabled,
-	showPredefinedColorsWithCustom = false,
-	predefinedColors,
+	dropDownContainerProps,
 	label,
 	name,
 	onColorsChange,
 	onValueChange = () => {},
+	predefinedColors,
 	showHex = true,
 	showPalette = true,
+	showPredefinedColorsWithCustom = false,
 	small,
 	spritemap,
 	title,
@@ -234,6 +244,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 						active={active}
 						alignElementRef={triggerElementRef}
 						className="clay-color-dropdown-menu"
+						containerProps={dropDownContainerProps}
 						focusRefOnEsc={splotchRef}
 						onSetActive={setActive}
 						ref={dropdownContainerRef}

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal, Keys, observeRect} from '@clayui/shared';
+import {ClayPortal, IPortalBaseProps, Keys, observeRect} from '@clayui/shared';
 import classNames from 'classnames';
 import domAlign from 'dom-align';
 import React, {useEffect, useLayoutEffect, useRef} from 'react';
@@ -126,6 +126,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	closeOnClickOutside?: boolean;
 
 	/**
+	 * Props to add to the outer most container.
+	 */
+	containerProps?: IPortalBaseProps;
+
+	/**
 	 * Flag to indicate if menu is displaying a clay-icon on the left.
 	 */
 	hasLeftSymbols?: boolean;
@@ -174,6 +179,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 			children,
 			className,
 			closeOnClickOutside = true,
+			containerProps = {},
 			hasLeftSymbols,
 			hasRightSymbols,
 			height,
@@ -287,7 +293,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 		}, []);
 
 		return (
-			<ClayPortal subPortalRef={subPortalRef}>
+			<ClayPortal {...containerProps} subPortalRef={subPortalRef}>
 				<div ref={subPortalRef}>
 					<div
 						{...otherProps}

--- a/packages/clay-shared/src/Portal.tsx
+++ b/packages/clay-shared/src/Portal.tsx
@@ -26,23 +26,25 @@ const createDivElement = (className?: string, id?: string) => {
 	return element;
 };
 
-interface IProps {
-	children: React.ReactElement | Array<React.ReactElement>;
-
+export interface IBaseProps {
 	/**
 	 * Class to add to the root element
 	 */
 	className?: string;
 
 	/**
-	 * Ref of element to render portal into.
-	 */
-	containerRef?: React.RefObject<Element>;
-
-	/**
 	 * Id fof the root element
 	 */
 	id?: string;
+}
+
+interface IProps extends IBaseProps {
+	children: React.ReactElement | Array<React.ReactElement>;
+
+	/**
+	 * Ref of element to render portal into.
+	 */
+	containerRef?: React.RefObject<Element>;
 
 	/**
 	 * Ref of element to render nested portals into.

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -4,7 +4,7 @@
  */
 
 export const noop = () => {};
-export {ClayPortal} from './Portal';
+export {ClayPortal, IBaseProps as IPortalBaseProps} from './Portal';
 export {delegate} from './delegate';
 export {FocusScope} from './FocusScope';
 export {getEllipsisItems} from './getEllipsisItems';


### PR DESCRIPTION
Fixes #4028

Adding new APIs to add properties to get to `<ClayPortal />`, ideally, we wanted to get rid of having APIs with `*Props` as this may mean that we can go in mismatch the composition or our own foundations but this has become very common in our components.

I'm following the pattern here to maintain consistency but I have some ideas about this to avoid adding more APIs with `*Props` and creating a consistent pattern for all components without having to hurt our foundations. I will try to create a proposal for us to discuss.