### PR TITLE
fix(@clayui/css): Global Functions update `setter` to accept more tha…

### DIFF
--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -58,20 +58,21 @@
 	@return $newMap;
 }
 
-/// A helper function for setting default values in variables inside mixins if no value is declared. If the value of a variable is `clay-unset`, `setter` returns a value of `null` which prevents Sass from outputting the declaration. If the value of a variable is `null`, `setter` returns the default, `$val`.
-/// @param {Any} $var - The Sass variable
-/// @param {Any} $val - The default value to return if `$var` is `null`
+/// A helper function for setting default values in variables inside mixins if no value is declared. If the value of a variable is `clay-unset`, `setter` returns a value of `null` which prevents Sass from outputting the CSS property. If all the values in the arglist `$vars...` is `null`, `setter` returns `null`.
+/// @param {Arglist} $vars - A list of comma-delimited variables (e.g., $var1, $var2, $var3).
 
-@function setter($var, $val: false) {
-	@if ($var == clay-unset) {
-		@return null;
+@function setter($vars...) {
+	@each $var in $vars {
+		@if ($var == clay-unset) {
+			@return null;
+		}
+
+		@if ($var != null) {
+			@return $var;
+		}
 	}
 
-	@if ($var != null) {
-		@return $var;
-	}
-
-	@return $val;
+	@return null;
 }
 
 /// A helper function that returns the opposite of a number, generally used for `null` values so Sass doesn't output a value `-null`. Returns `null` if `$num` is not a number.


### PR DESCRIPTION
…n 2 variables (e.g., `setter($var1, $var2, $var3, $var4, $var5)`)

fixes #4076

Instead of renaming the two parameters, it dawned on me that I could use an arglist. The `setter` function now accepts any number of variables and returns the first one that isn't `null`. The code below:

```
box-shadow: setter(
    map-get($map, active-focus-box-shadow),
    setter(
        map-get($active-focus, box-shadow),
        map-get($focus, box-shadow)
    )
),
```

can be changed to:

```
box-shadow: setter(
    map-get($map, active-focus-box-shadow),
    map-get($active-focus, box-shadow),
    map-get($focus, box-shadow)
),
```