### PR TITLE
feat: Add the new ContainerProps API to Popover, TooltipProvider, Modal and DropDown

### DIFF
--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -55,7 +55,8 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement | HTMLLIElement> {
 	/**
 	 * Prop to pass DOM element attributes to <DropDown.Menu />.
 	 */
-	menuElementAttrs?: React.HTMLAttributes<HTMLDivElement>;
+	menuElementAttrs?: React.HTMLAttributes<HTMLDivElement> &
+		Pick<React.ComponentProps<typeof Menu>, 'containerProps'>;
 
 	menuHeight?: React.ComponentProps<typeof Menu>['height'];
 

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal} from '@clayui/shared';
+import {ClayPortal, IPortalBaseProps} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useEffect, useRef} from 'react';
 import warning from 'warning';
@@ -35,6 +35,11 @@ interface IProps
 	 * Container element to render modal into.
 	 */
 	containerElementRef?: React.RefObject<Element>;
+
+	/**
+	 * Props to add to the <ClayPortal/>.
+	 */
+	containerProps?: IPortalBaseProps;
 
 	/**
 	 * The size of element modal.
@@ -69,6 +74,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 	children,
 	className,
 	containerElementRef,
+	containerProps = {},
 	observer,
 	size,
 	spritemap,
@@ -92,6 +98,7 @@ const ClayModal: React.FunctionComponent<IProps> = ({
 
 	return (
 		<ClayPortal
+			{...containerProps}
 			containerRef={containerElementRef}
 			subPortalRef={modalElementRef}
 		>

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal, observeRect} from '@clayui/shared';
+import {ClayPortal, IPortalBaseProps, observeRect} from '@clayui/shared';
 import classNames from 'classnames';
 import domAlign from 'dom-align';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
@@ -45,6 +45,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	alignPosition?: typeof ALIGN_POSITIONS[number];
 
 	/**
+	 * Props to add to the <ClayPortal/>.
+	 */
+	containerProps?: IPortalBaseProps;
+
+	/**
 	 * Flag to indicate if container should not be scrollable
 	 */
 	disableScroll?: boolean;
@@ -78,6 +83,7 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 			alignPosition = 'bottom',
 			children,
 			className,
+			containerProps = {},
 			disableScroll = false,
 			header,
 			onShowChange,
@@ -188,7 +194,9 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 						},
 					})}
 
-					{show && <ClayPortal>{content}</ClayPortal>}
+					{show && (
+						<ClayPortal {...containerProps}>{content}</ClayPortal>
+					)}
 				</>
 			);
 		}

--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal, Keys, delegate} from '@clayui/shared';
+import {ClayPortal, IPortalBaseProps, Keys, delegate} from '@clayui/shared';
 import domAlign from 'dom-align';
 import React, {useCallback} from 'react';
 import warning from 'warning';
@@ -140,6 +140,11 @@ interface IPropsBase {
 	autoAlign?: boolean;
 
 	/**
+	 * Props to add to the <ClayPortal/>.
+	 */
+	containerProps?: IPortalBaseProps;
+
+	/**
 	 * Custom function for rendering the contents of the tooltip
 	 */
 	contentRenderer?: TContentRenderer;
@@ -171,6 +176,7 @@ const TooltipProvider: React.FunctionComponent<
 > = ({
 	autoAlign = true,
 	children,
+	containerProps = {},
 	contentRenderer = (props) => props.title,
 	delay = 600,
 	scope,
@@ -369,7 +375,7 @@ const TooltipProvider: React.FunctionComponent<
 	return (
 		<>
 			{show && (
-				<ClayPortal>
+				<ClayPortal {...containerProps}>
 					<ClayTooltip alignPosition={align} ref={tooltipRef} show>
 						{setAsHTML && typeof titleContent === 'string' ? (
 							<span


### PR DESCRIPTION
Fixes #4083

It just does the same thing that was done for ClayColorPicker, we are adding for all components that depend on `<ClayPortal />`.