### PR TITLE
fix(@clayui/css): Mixins Card convert to use new (easier to remember)…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_cards.scss
@@ -27,7 +27,9 @@ $card-title: map-deep-merge(
 $card-title-link: () !default;
 $card-title-link: map-deep-merge(
 	(
-		hover-color: map-get($card-title, color),
+		hover: (
+			color: map-get($card-title, color),
+		),
 	),
 	$card-title-link
 );
@@ -45,7 +47,9 @@ $card-subtitle: map-deep-merge(
 $card-subtitle-link: () !default;
 $card-subtitle-link: map-deep-merge(
 	(
-		hover-color: $gray-600,
+		hover: (
+			color: $gray-600,
+		),
 	),
 	$card-subtitle-link
 );
@@ -57,8 +61,10 @@ $card-link: map-deep-merge(
 	(
 		color: $gray-600,
 		font-size: 0.875rem,
-		hover-color: $gray-600,
-		hover-text-decoration: underline,
+		hover: (
+			color: $gray-600,
+			text-decoration: underline,
+		),
 	),
 	$card-link
 );
@@ -73,10 +79,17 @@ $form-check-card-checked-box-shadow: 0 0 0 2px
 $card-interactive: () !default;
 $card-interactive: map-deep-merge(
 	(
-		hover-bg: #f7f8f9,
-		focus-border-color: null,
-		focus-box-shadow: 0 0 0 2px #FFF#{','} 0 0 0 4px #719aff,
-		active-bg: #f1f2f5,
+		hover: (
+			background-color: #f7f8f9,
+		),
+		focus: (
+			border-color: null,
+			box-shadow: #{0 0 0 2px #fff,
+			0 0 0 4px #719aff},
+		),
+		active: (
+			background-color: #f1f2f5,
+		),
 	),
 	$card-interactive
 );
@@ -86,10 +99,14 @@ $card-interactive: map-deep-merge(
 $card-interactive-secondary: () !default;
 $card-interactive-secondary: map-deep-merge(
 	(
-		hover-border-color: transparent,
-		hover-box-shadow: 0 0 0 2px #719aff,
-		focus-border-color: transparent,
-		focus-box-shadow: 0 0 0 2px #719aff,
+		hover: (
+			border-color: transparent,
+			box-shadow: 0 0 0 2px #719aff,
+		),
+		focus: (
+			border-color: transparent,
+			box-shadow: 0 0 0 2px #719aff,
+		),
 	),
 	$card-interactive-secondary
 );
@@ -99,8 +116,12 @@ $card-interactive-secondary: map-deep-merge(
 $card-type-asset: () !default;
 $card-type-asset: map-deep-merge(
 	(
-		aspect-ratio-border-color: $gray-300,
-		card-body-padding-top: 0.75rem,
+		aspect-ratio: (
+			border-color: $gray-300,
+		),
+		card-body: (
+			padding-top: 0.75rem,
+		),
 	),
 	$card-type-asset
 );
@@ -108,7 +129,9 @@ $card-type-asset: map-deep-merge(
 $image-card: () !default;
 $image-card: map-deep-merge(
 	(
-		aspect-ratio-checkered-fg: $gray-300,
+		aspect-ratio: (
+			checkered-foreground-color: $gray-300,
+		),
 	),
 	$image-card
 );
@@ -116,7 +139,9 @@ $image-card: map-deep-merge(
 $file-card: () !default;
 $file-card: map-deep-merge(
 	(
-		asset-icon-color: $gray-400,
+		asset-icon: (
+			color: $gray-400,
+		),
 	),
 	$file-card
 );
@@ -136,7 +161,7 @@ $card-type-template-after-highlight: map-deep-merge(
 $card-type-template-aspect-ratio: () !default;
 $card-type-template-aspect-ratio: map-deep-merge(
 	(
-		bg-image: none,
+		background-image: none,
 	),
 	$card-type-template-aspect-ratio
 );

--- a/packages/clay-css/src/scss/mixins/_cards.scss
+++ b/packages/clay-css/src/scss/mixins/_cards.scss
@@ -36,57 +36,36 @@
 @mixin clay-card-section-variant($map) {
 	$enabled: setter(map-get($map, enabled), true);
 
-	$bg: map-get($map, bg);
-	$border-color: map-get($map, border-color);
-	$border-radius: map-get($map, border-radius);
-	$border-style: map-get($map, border-style);
-	$border-width: map-get($map, border-width);
-	$display: map-get($map, display);
-	$flex-basis: map-get($map, flex-basis);
-	$flex-direction: map-get($map, flex-direction);
-	$flex-grow: map-get($map, flex-grow);
-	$flex-shrink: map-get($map, flex-shrink);
-	$flex-wrap: map-get($map, flex-wrap);
-	$margin-bottom: map-get($map, margin-bottom);
-	$margin-left: map-get($map, margin-left);
-	$margin-right: map-get($map, margin-right);
-	$margin-top: map-get($map, margin-top);
-	$padding-bottom: map-get($map, padding-bottom);
-	$padding-left: map-get($map, padding-left);
-	$padding-right: map-get($map, padding-right);
-	$padding-top: map-get($map, padding-top);
-	$text-align: map-get($map, text-align);
-	$width: map-get($map, width);
+	$base: map-merge(
+		$map,
+		(
+			background-color:
+				setter(map-get($map, bg), map-get($map, background-color)),
+		)
+	);
 
-	$autofit-col-padding-left: map-get($map, autofit-col-padding-left);
-	$autofit-col-padding-right: map-get($map, autofit-col-padding-right);
+	$autofit-col: setter(map-get($map, autofit-col), ());
+	$autofit-col: map-merge(
+		$autofit-col,
+		(
+			padding-left:
+				setter(
+					map-get($map, autofit-col-padding-left),
+					map-get($autofit-col, padding-left)
+				),
+			padding-right:
+				setter(
+					map-get($map, autofit-col-padding-right),
+					map-get($autofit-col, padding-right)
+				),
+		)
+	);
 
 	@if ($enabled) {
-		background-color: $bg;
-		border-color: $border-color;
-		border-radius: $border-radius;
-		border-style: $border-style;
-		border-width: $border-width;
-		display: $display;
-		flex-basis: $flex-basis;
-		flex-direction: $flex-direction;
-		flex-grow: $flex-grow;
-		flex-shrink: $flex-shrink;
-		flex-wrap: $flex-wrap;
-		margin-bottom: $margin-bottom;
-		margin-left: $margin-left;
-		margin-right: $margin-right;
-		margin-top: $margin-top;
-		padding-bottom: $padding-bottom;
-		padding-left: $padding-left;
-		padding-right: $padding-right;
-		padding-top: $padding-top;
-		text-align: $text-align;
-		width: $width;
+		@include clay-css($base);
 
 		.autofit-col {
-			padding-left: $autofit-col-padding-left;
-			padding-right: $autofit-col-padding-right;
+			@include clay-css($autofit-col);
 		}
 	}
 }
@@ -159,54 +138,144 @@
 @mixin clay-card-variant($map) {
 	$enabled: setter(map-get($map, enabled), true);
 
-	$bg: map-get($map, bg);
-	$border-color: map-get($map, border-color);
-	$border-style: map-get($map, border-style);
-	$border-width: map-get($map, border-width);
-	$box-shadow: map-get($map, box-shadow);
-	$cursor: map-get($map, cursor);
-	$color: map-get($map, color);
-	$display: map-get($map, display);
-	$flex-basis: map-get($map, flex-basis);
-	$flex-direction: map-get($map, flex-direction);
-	$flex-grow: map-get($map, flex-grow);
-	$flex-shrink: map-get($map, flex-shrink);
-	$margin-bottom: map-get($map, margin-bottom);
-	$min-width: map-get($map, min-width);
-	$outline: map-get($map, outline);
-	$position: map-get($map, position);
-	$text-decoration: map-get($map, text-decoration);
-	$transition: map-get($map, transition);
-	$width: map-get($map, width);
-	$word-wrap: map-get($map, word-wrap);
+	$base: map-merge(
+		$map,
+		(
+			background-color:
+				setter(map-get($map, bg), map-get($map, background-color)),
+		)
+	);
 
-	$hover-bg: map-get($map, hover-bg);
-	$hover-border-color: map-get($map, hover-border-color);
-	$hover-box-shadow: map-get($map, hover-box-shadow);
-	$hover-color: map-get($map, hover-color);
-	$hover-text-decoration: map-get($map, hover-text-decoration);
-	$hover-card-title: setter(map-get($map, hover-card-title), ());
-	$hover-card-subtitle: setter(map-get($map, hover-card-subtitle), ());
-	$hover-card-text: setter(map-get($map, hover-card-text), ());
-	$hover-card-link: setter(map-get($map, hover-card-link), ());
+	$hover: setter(map-get($map, hover), ());
+	$hover: map-merge(
+		$hover,
+		(
+			background-color:
+				setter(
+					map-get($map, hover-bg),
+					map-get($hover, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, hover-border-color),
+					map-get($hover, border-color)
+				),
+			box-shadow:
+				setter(
+					map-get($map, hover-box-shadow),
+					map-get($hover, box-shadow)
+				),
+			color: setter(map-get($map, hover-color), map-get($hover, color)),
+			text-decoration:
+				setter(
+					map-get($map, hover-text-decoration),
+					map-get($hover, text-decoration)
+				),
+		)
+	);
 
-	$focus-bg: map-get($map, focus-bg);
-	$focus-border-color: map-get($map, focus-border-color);
-	$focus-box-shadow: map-get($map, focus-box-shadow);
-	$focus-color: map-get($map, focus-color);
-	$focus-text-decoration: map-get($map, focus-text-decoration);
-	$focus-card-title: setter(map-get($map, focus-card-title), ());
-	$focus-card-subtitle: setter(map-get($map, focus-card-subtitle), ());
-	$focus-card-text: setter(map-get($map, focus-card-text), ());
-	$focus-card-link: setter(map-get($map, focus-card-link), ());
+	$old-hover-card-title: setter(map-get($map, hover-card-title), ());
+	$hover-card-title: setter(map-get($hover, card-title), ());
+	$hover-card-title: map-merge($hover-card-title, $old-hover-card-title);
 
-	$active-bg: map-get($map, active-bg);
-	$active-border-color: map-get($map, active-border-color);
-	$active-color: map-get($map, active-color);
-	$active-card-title: setter(map-get($map, active-card-title), ());
-	$active-card-subtitle: setter(map-get($map, active-card-subtitle), ());
-	$active-card-text: setter(map-get($map, active-card-text), ());
-	$active-card-link: setter(map-get($map, active-card-link), ());
+	$old-hover-card-subtitle: setter(map-get($map, hover-card-subtitle), ());
+	$hover-card-subtitle: setter(map-get($hover, card-subtitle), ());
+	$hover-card-subtitle: map-merge(
+		$hover-card-subtitle,
+		$old-hover-card-subtitle
+	);
+
+	$old-hover-card-text: setter(map-get($map, hover-card-text), ());
+	$hover-card-text: setter(map-get($hover, card-text), ());
+	$hover-card-text: map-merge($hover-card-text, $old-hover-card-text);
+
+	$old-hover-card-link: setter(map-get($map, hover-card-link), ());
+	$hover-card-link: setter(map-get($hover, card-link), ());
+	$hover-card-link: map-merge($hover-card-link, $old-hover-card-link);
+
+	$focus: setter(map-get($map, focus), ());
+	$focus: map-merge(
+		$focus,
+		(
+			background-color:
+				setter(
+					map-get($map, focus-bg),
+					map-get($focus, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, focus-border-color),
+					map-get($focus, border-color)
+				),
+			box-shadow:
+				setter(
+					map-get($map, focus-box-shadow),
+					map-get($focus, box-shadow)
+				),
+			color: setter(map-get($map, focus-color), map-get($focus, color)),
+			text-decoration:
+				setter(
+					map-get($map, focus-text-decoration),
+					map-get($focus, text-decoration)
+				),
+		)
+	);
+
+	$old-focus-card-title: setter(map-get($map, focus-card-title), ());
+	$focus-card-title: setter(map-get($focus, card-title), ());
+	$focus-card-title: map-merge($focus-card-title, $old-focus-card-title);
+
+	$old-focus-card-subtitle: setter(map-get($map, focus-card-subtitle), ());
+	$focus-card-subtitle: setter(map-get($focus, card-subtitle), ());
+	$focus-card-subtitle: map-merge(
+		$focus-card-subtitle,
+		$old-focus-card-subtitle
+	);
+
+	$old-focus-card-text: setter(map-get($map, focus-card-text), ());
+	$focus-card-text: setter(map-get($focus, card-text), ());
+	$focus-card-text: map-merge($focus-card-text, $old-focus-card-text);
+
+	$old-focus-card-link: setter(map-get($map, focus-card-link), ());
+	$focus-card-link: setter(map-get($focus, card-link), ());
+	$focus-card-link: map-merge($focus-card-link, $old-focus-card-link);
+
+	$active: setter(map-get($map, active), ());
+	$active: map-merge(
+		$active,
+		(
+			background-color:
+				setter(
+					map-get($map, active-bg),
+					map-get($active, background-color)
+				),
+			border-color:
+				setter(
+					map-get($map, active-border-color),
+					map-get($active, border-color)
+				),
+			color: setter(map-get($map, active-color), map-get($active, color)),
+		)
+	);
+
+	$old-active-card-title: setter(map-get($map, active-card-title), ());
+	$active-card-title: setter(map-get($active, card-title), ());
+	$active-card-title: map-merge($active-card-title, $old-active-card-title);
+
+	$old-active-card-subtitle: setter(map-get($map, active-card-subtitle), ());
+	$active-card-subtitle: setter(map-get($active, card-subtitle), ());
+	$active-card-subtitle: map-merge(
+		$active-card-subtitle,
+		$old-active-card-subtitle
+	);
+
+	$old-active-card-text: setter(map-get($map, active-card-text), ());
+	$active-card-text: setter(map-get($active, card-text), ());
+	$active-card-text: map-merge($active-card-text, $old-active-card-text);
+
+	$old-active-card-link: setter(map-get($map, active-card-link), ());
+	$active-card-link: setter(map-get($active, card-link), ());
+	$active-card-link: map-merge($active-card-link, $old-active-card-link);
 
 	$after-highlight: setter(map-get($map, after-highlight), ());
 
@@ -235,33 +304,10 @@
 	@if ($enabled) {
 		&.card,
 		.card {
-			background-color: $bg;
-			border-color: $border-color;
-			border-style: $border-style;
-			border-width: $border-width;
-			box-shadow: $box-shadow;
-			cursor: $cursor;
-			color: $color;
-			display: $display;
-			flex-basis: $flex-basis;
-			flex-direction: $flex-direction;
-			flex-grow: $flex-grow;
-			flex-shrink: $flex-shrink;
-			margin-bottom: $margin-bottom;
-			min-width: $min-width;
-			outline: $outline;
-			position: $position;
-			text-decoration: $text-decoration;
-			transition: $transition;
-			width: $width;
-			word-wrap: $word-wrap;
+			@include clay-css($base);
 
 			&:hover {
-				background-color: $hover-bg;
-				border-color: $hover-border-color;
-				box-shadow: $hover-box-shadow;
-				color: $hover-color;
-				text-decoration: $hover-text-decoration;
+				@include clay-css($hover);
 
 				.card-title {
 					@include clay-link($hover-card-title);
@@ -281,11 +327,7 @@
 			}
 
 			&:focus {
-				background-color: $focus-bg;
-				border-color: $focus-border-color;
-				box-shadow: $focus-box-shadow;
-				color: $focus-color;
-				text-decoration: $focus-text-decoration;
+				@include clay-css($focus);
 
 				.card-title {
 					@include clay-link($focus-card-title);
@@ -306,9 +348,7 @@
 
 			&:active,
 			&.active {
-				background-color: $active-bg;
-				border-color: $active-border-color;
-				color: $active-color;
+				@include clay-css($active);
 
 				.card-title {
 					@include clay-link($active-card-title);
@@ -407,91 +447,192 @@
 @mixin clay-card-type-asset($map) {
 	$enabled: setter(map-get($map, enabled), true);
 
-	$aspect-ratio-border-color: setter(
-		map-get($map, aspect-ratio-border-color),
-		if(
-			variable-exists(card-border-color),
-			$card-border-color,
-			$cadmin-card-border-color
+	$aspect-ratio: setter(map-get($map, aspect-ratio), ());
+	$aspect-ratio: map-merge(
+		$aspect-ratio,
+		(
+			border-color:
+				setter(
+					map-get($map, aspect-ratio-border-color),
+					map-get($aspect-ratio, border-color),
+					if(
+						variable-exists(card-border-color),
+						$card-border-color,
+						$cadmin-card-border-color
+					)
+				),
+			border-style:
+				setter(
+					map-get($map, aspect-ratio-border-style),
+					map-get($aspect-ratio, border-style),
+					solid
+				),
+			border-width:
+				setter(
+					map-get($map, aspect-ratio-border-bottom-width),
+					map-get($map, aspect-ratio-border-width),
+					map-get($aspect-ratio, border-width),
+					0 0 0.0625rem 0
+				),
+			horizontal:
+				setter(
+					map-get($map, aspect-ratio-horizontal),
+					map-get($aspect-ratio, horizontal),
+					16
+				),
+			vertical:
+				setter(
+					map-get($map, aspect-ratio-vertical),
+					map-get($aspect-ratio, vertical),
+					9
+				),
 		)
 	);
-	$aspect-ratio-border-style: setter(
-		map-get($map, aspect-ratio-border-style),
-		solid
+
+	$aspect-ratio-horizontal: map-get($aspect-ratio, horizontal);
+	$aspect-ratio-vertical: map-get($aspect-ratio, vertical);
+
+	$card-body: setter(map-get($map, card-body), ());
+	$card-body: map-merge(
+		$card-body,
+		(
+			padding-bottom:
+				setter(
+					map-get($map, card-body-padding-bottom),
+					map-get($card-body, padding-bottom)
+				),
+			padding-left:
+				setter(
+					map-get($map, card-body-padding-left),
+					map-get($card-body, padding-left)
+				),
+			padding-right:
+				setter(
+					map-get($map, card-body-padding-right),
+					map-get($card-body, padding-right)
+				),
+			padding-top:
+				setter(
+					map-get($map, card-body-padding-top),
+					map-get($card-body, padding-top)
+				),
+		)
 	);
 
-	// The Sass map key name `aspect-ratio-border-bottom-width` is deprecated as of v2.5.1 use `aspect-ratio-border-width` instead
-	$aspect-ratio-border-bottom-width: setter(
-		map-get($map, aspect-ratio-border-bottom-width),
-		0 0 0.0625rem 0
-	); // 0 0 1px 0
-
-	$aspect-ratio-border-width: map-get($map, aspect-ratio-border-width);
-	$aspect-ratio-horizontal: setter(
-		map-get($map, aspect-ratio-horizontal),
-		16
-	);
-	$aspect-ratio-vertical: setter(map-get($map, aspect-ratio-vertical), 9);
-
-	$card-body-padding-bottom: map-get($map, card-body-padding-bottom);
-	$card-body-padding-left: map-get($map, card-body-padding-left);
-	$card-body-padding-right: map-get($map, card-body-padding-right);
-	$card-body-padding-top: map-get($map, card-body-padding-top);
-	$card-row-align-items: setter(
-		map-get($map, card-row-align-items),
-		flex-start
+	$card-row: setter(map-get($map, card-row), ());
+	$card-row: map-merge(
+		$card-row,
+		(
+			align-items:
+				setter(
+					map-get($map, card-row-align-items),
+					map-get($card-row, align-items),
+					flex-start
+				),
+		)
 	);
 
-	$checkbox-cursor: setter(
-		map-get($map, checkbox-cursor),
-		if(variable-exists(link-cursor), $link-cursor, $cadmin-link-cursor)
+	$checkbox: setter(map-get($map, checkbox), ());
+	$checkbox: map-merge(
+		$checkbox,
+		(
+			cursor:
+				setter(
+					map-get($map, checkbox-cursor),
+					map-get($checkbox, cursor),
+					if(
+						variable-exists(link-cursor),
+						$link-cursor,
+						$cadmin-link-cursor
+					)
+				),
+		)
 	);
 
-	$asset-icon-color: map-get($map, asset-icon-color);
-	$asset-icon-width: setter(map-get($map, asset-icon-width), 22.225%);
-	$asset-icon-sticker-border-radius: setter(
-		map-get($map, asset-icon-sticker-border-radius),
-		50%
-	);
-	$asset-icon-sticker-font-size: setter(
-		map-get($map, asset-icon-sticker-font-size),
-		2vw
+	$card-type-asset-icon: setter(map-get($map, card-type-asset-icon), ());
+	$card-type-asset-icon: map-merge(
+		$card-type-asset-icon,
+		(
+			color:
+				setter(
+					map-get($map, asset-icon-color),
+					map-get($card-type-asset-icon, color)
+				),
+			width:
+				setter(
+					map-get($map, asset-icon-width),
+					map-get($card-type-asset-icon, width),
+					22.225%
+				),
+		)
 	);
 
-	$dropdown-action-offset-bottom: map-get(
-		$map,
-		dropdown-action-offset-bottom
+	$card-type-asset-icon-sticker: setter(
+		map-get($card-type-asset-icon, sticker),
+		()
 	);
-	$dropdown-action-offset-left: map-get($map, dropdown-action-offset-left);
-	$dropdown-action-offset-right: setter(
-		map-get($map, dropdown-action-offset-right),
-		-0.5rem
-	); // -8px
-	$dropdown-action-offset-top: setter(
-		map-get($map, dropdown-action-offset-top),
-		-0.1875rem
-	); // -3px
+	$card-type-asset-icon-sticker: map-merge(
+		$card-type-asset-icon-sticker,
+		(
+			border-radius:
+				setter(
+					map-get($map, asset-icon-sticker-border-radius),
+					map-get($card-type-asset-icon-sticker, border-radius),
+					50%
+				),
+			font-size:
+				setter(
+					map-get($map, asset-icon-sticker-font-size),
+					map-get($card-type-asset-icon-sticker, font-size),
+					2vw
+				),
+		)
+	);
+
+	$dropdown-action: setter(map-get($map, dropdown-action), ());
+	$dropdown-action: map-merge(
+		$dropdown-action,
+		(
+			margin-bottom:
+				setter(
+					map-get($map, dropdown-action-offset-bottom),
+					map-get($dropdown-action, margin-bottom)
+				),
+			margin-left:
+				setter(
+					map-get($map, dropdown-action-offset-left),
+					map-get($dropdown-action, margin-left)
+				),
+			margin-right:
+				setter(
+					map-get($map, dropdown-action-offset-right),
+					map-get($dropdown-action, margin-right),
+					-0.5rem
+				),
+			margin-top:
+				setter(
+					map-get($map, dropdown-action-offset-top),
+					map-get($dropdown-action, margin-top),
+					-0.1875rem
+				),
+		)
+	);
 
 	@if ($enabled) {
 		.aspect-ratio {
-			border-color: $aspect-ratio-border-color;
-			border-style: $aspect-ratio-border-style;
-			border-width: $aspect-ratio-border-width;
+			@include clay-css($aspect-ratio);
 
-			@if not $aspect-ratio-border-width {
-				// `$aspect-ratio-border-bottom-width is deprecated as of v2.5.1 use `$aspect-ratio-border-width` instead
-				border-width: $aspect-ratio-border-bottom-width;
+			@if ($aspect-ratio-horizontal and $aspect-ratio-vertical) {
+				@include clay-aspect-ratio(
+					$aspect-ratio-horizontal,
+					$aspect-ratio-vertical
+				);
 			}
-
-			@include clay-aspect-ratio(
-				$aspect-ratio-horizontal,
-				$aspect-ratio-vertical
-			);
 
 			.custom-control label,
 			.form-check-label {
 				bottom: 0;
-				cursor: $checkbox-cursor;
+				cursor: map-get($checkbox, cursor);
 				left: 0;
 				position: absolute;
 				right: 0;
@@ -500,19 +641,15 @@
 		}
 
 		.card-body {
-			padding-bottom: $card-body-padding-bottom;
-			padding-left: $card-body-padding-left;
-			padding-right: $card-body-padding-right;
-			padding-top: $card-body-padding-top;
+			@include clay-css($card-body);
 		}
 
 		.card-row {
-			align-items: $card-row-align-items;
+			@include clay-css($card-row);
 		}
 
 		.card-type-asset-icon {
-			color: $asset-icon-color;
-			width: $asset-icon-width;
+			@include clay-css($card-type-asset-icon);
 
 			.inline-item {
 				bottom: 0;
@@ -528,24 +665,18 @@
 			}
 
 			> .sticker {
-				@include border-radius($asset-icon-sticker-border-radius);
-
-				display: block;
-				font-size: $asset-icon-sticker-font-size;
-				padding-bottom: 100%;
-				width: 100%;
+				@include clay-css($card-type-asset-icon-sticker);
 			}
 
 			.sticker-overlay {
-				@include border-radius($asset-icon-sticker-border-radius);
+				@include border-radius(
+					map-get($card-type-asset-icon-sticker, border-radius)
+				);
 			}
 		}
 
 		.dropdown-action {
-			margin-bottom: $dropdown-action-offset-bottom;
-			margin-left: $dropdown-action-offset-left;
-			margin-right: $dropdown-action-offset-right;
-			margin-top: $dropdown-action-offset-top;
+			@include clay-css($dropdown-action);
 		}
 	}
 }
@@ -570,27 +701,80 @@
 @mixin clay-card-type-asset-variant($map) {
 	$enabled: setter(map-get($map, enabled), true);
 
-	$aspect-ratio-bg: map-get($map, aspect-ratio-bg);
-	$aspect-ratio-checkered-fg: map-get($map, aspect-ratio-checkered-fg);
-	$aspect-ratio-checkered-bg: map-get($map, aspect-ratio-checkered-bg);
+	$base: setter($map, ());
 
-	$asset-icon-color: map-get($map, asset-icon-color);
-	$asset-icon-max-width: map-get($map, asset-icon-max-width);
-	$asset-icon-min-width: map-get($map, asset-icon-min-width);
-	$asset-icon-width: map-get($map, asset-icon-width);
-
-	$asset-icon-lexicon-icon-height: map-get(
-		$map,
-		asset-icon-lexicon-icon-height
+	$aspect-ratio: setter(map-get($map, aspect-ratio), ());
+	$aspect-ratio: map-merge(
+		$aspect-ratio,
+		(
+			background-color:
+				setter(
+					map-get($map, aspect-ratio-bg),
+					map-get($map, aspect-ratio-checkered-bg),
+					map-get($aspect-ratio, background-color)
+				),
+			checkered-foreground-color:
+				setter(
+					map-get($map, aspect-ratio-checkered-fg),
+					map-get($aspect-ratio, checkered-foreground-color)
+				),
+		)
 	);
-	$asset-icon-lexicon-icon-width: map-get(
-		$map,
-		asset-icon-lexicon-icon-width
+
+	$aspect-ratio-checkered-fg: map-get(
+		$aspect-ratio,
+		checkered-foreground-color
+	);
+
+	$asset-icon: setter(map-get($map, asset-icon), ());
+	$asset-icon: map-merge(
+		$asset-icon,
+		(
+			color:
+				setter(
+					map-get($map, asset-icon-color),
+					map-get($asset-icon, color)
+				),
+			max-width:
+				setter(
+					map-get($map, asset-icon-max-width),
+					map-get($asset-icon, max-width)
+				),
+			min-width:
+				setter(
+					map-get($map, asset-icon-min-width),
+					map-get($asset-icon, min-width)
+				),
+			width:
+				setter(
+					map-get($map, asset-icon-width),
+					map-get($asset-icon, width)
+				),
+		)
+	);
+
+	$asset-icon-lexicon-icon: setter(map-get($asset-icon, lexicon-icon), ());
+	$asset-icon-lexicon-icon: map-merge(
+		$asset-icon-lexicon-icon,
+		(
+			height:
+				setter(
+					map-get($map, asset-icon-lexicon-icon-height),
+					map-get($asset-icon-lexicon-icon, height)
+				),
+			width:
+				setter(
+					map-get($map, asset-icon-lexicon-icon-width),
+					map-get($asset-icon-lexicon-icon, width)
+				),
+		)
 	);
 
 	@if ($enabled) {
+		@include clay-css($base);
+
 		.aspect-ratio {
-			background-color: $aspect-ratio-bg;
+			@include clay-css($aspect-ratio);
 
 			@if ($aspect-ratio-checkered-fg) {
 				@include clay-bg-checkered($aspect-ratio-checkered-fg);
@@ -598,14 +782,10 @@
 		}
 
 		.card-type-asset-icon {
-			color: $asset-icon-color;
-			max-width: $asset-icon-max-width;
-			min-width: $asset-icon-min-width;
-			width: $asset-icon-width;
+			@include clay-css($asset-icon);
 
 			.lexicon-icon {
-				height: $asset-icon-lexicon-icon-height;
-				width: $asset-icon-lexicon-icon-width;
+				@include clay-css($asset-icon-lexicon-icon);
 			}
 		}
 	}
@@ -633,50 +813,99 @@
 @mixin clay-card-type-directory($map) {
 	$enabled: setter(map-get($map, enabled), true);
 
-	$card-body-padding-bottom: map-get($map, card-body-padding-bottom);
-	$card-body-padding-left: map-get($map, card-body-padding-left);
-	$card-body-padding-right: map-get($map, card-body-padding-right);
-	$card-body-padding-top: map-get($map, card-body-padding-top);
+	$base: setter($map, ());
 
-	$sticker-font-size: map-get($map, sticker-font-size);
-	$sticker-line-height: map-get($map, sticker-line-height);
+	$card-body: setter(map-get($map, card-body), ());
+	$card-body: map-merge(
+		$card-body,
+		(
+			padding-bottom:
+				setter(
+					map-get($map, card-body-padding-bottom),
+					map-get($card-body, padding-bottom)
+				),
+			padding-left:
+				setter(
+					map-get($map, card-body-padding-left),
+					map-get($card-body, padding-left)
+				),
+			padding-right:
+				setter(
+					map-get($map, card-body-padding-right),
+					map-get($card-body, padding-right)
+				),
+			padding-top:
+				setter(
+					map-get($map, card-body-padding-top),
+					map-get($card-body, padding-top)
+				),
+		)
+	);
+
+	$sticker: setter(map-get($map, sticker), ());
+	$sticker: map-merge(
+		$sticker,
+		(
+			font-size:
+				setter(
+					map-get($map, sticker-font-size),
+					map-get($sticker, font-size)
+				),
+			height:
+				setter(map-get($map, sticker-size), map-get($sticker, height)),
+			line-height:
+				setter(
+					map-get($map, sticker-line-height),
+					map-get($map, sticker-size),
+					map-get($sticker, line-height)
+				),
+			width: setter(map-get($map, sticker-size), map-get($sticker, width)),
+		)
+	);
+
 	$sticker-size: map-get($map, sticker-size);
 
-	$dropdown-action-offset-bottom: map-get(
-		$map,
-		dropdown-action-offset-bottom
+	$dropdown-action: setter(map-get($map, dropdown-action), ());
+	$dropdown-action: map-merge(
+		$dropdown-action,
+		(
+			margin-bottom:
+				setter(
+					map-get($map, dropdown-action-offset-bottom),
+					map-get($dropdown-action, margin-bottom)
+				),
+			margin-left:
+				setter(
+					map-get($map, dropdown-action-offset-left),
+					map-get($dropdown-action, margin-left)
+				),
+			margin-right:
+				setter(
+					map-get($map, dropdown-action-offset-right),
+					map-get($dropdown-action, margin-right),
+					-0.5rem
+				),
+			margin-top:
+				setter(
+					map-get($map, dropdown-action-offset-top),
+					map-get($dropdown-action, margin-top)
+				),
+		)
 	);
-	$dropdown-action-offset-left: map-get($map, dropdown-action-offset-left);
-	$dropdown-action-offset-right: setter(
-		map-get($map, dropdown-action-offset-right),
-		-0.5rem
-	); // -8px
-	$dropdown-action-offset-top: map-get($map, dropdown-action-offset-top);
 
 	@if ($enabled) {
+		@include clay-css($base);
+
 		.card-body {
-			padding-bottom: $card-body-padding-bottom;
-			padding-left: $card-body-padding-left;
-			padding-right: $card-body-padding-right;
-			padding-top: $card-body-padding-top;
+			@include clay-css($card-body);
 		}
 
 		.dropdown-action {
-			margin-bottom: $dropdown-action-offset-bottom;
-			margin-left: $dropdown-action-offset-left;
-			margin-right: $dropdown-action-offset-right;
-			margin-top: $dropdown-action-offset-top;
+			@include clay-css($dropdown-action);
 		}
 
 		.sticker {
-			font-size: $sticker-font-size;
-			height: $sticker-size;
-			line-height: if(
-				$sticker-line-height,
-				$sticker-line-height,
-				$sticker-size
-			);
-			width: $sticker-size;
+			@include clay-css($sticker);
 		}
 	}
 }

--- a/packages/clay-css/src/scss/variables/_cards.scss
+++ b/packages/clay-css/src/scss/variables/_cards.scss
@@ -153,7 +153,9 @@ $card-subtitle-link: () !default;
 $card-subtitle-link: map-deep-merge(
 	(
 		color: map-get($card-subtitle, color),
-		hover-color: darken($gray-600, 15%),
+		hover: (
+			color: darken($gray-600, 15%),
+		),
 	),
 	$card-subtitle-link
 );
@@ -164,8 +166,8 @@ $card-link: () !default;
 $card-link: map-deep-merge(
 	(
 		color: $link-color,
-		hover-color: $link-hover-color,
 		hover: (
+			color: $link-hover-color,
 			text-decoration: none,
 		),
 	),
@@ -215,9 +217,15 @@ $card-interactive-after-highlight: map-deep-merge(
 		position: absolute,
 		right: -$card-border-width,
 		transition: height 0.15s ease-out,
-		hover-height: 4px,
-		focus-height: 4px,
-		active-height: 4px,
+		hover: (
+			height: 4px,
+		),
+		focus: (
+			height: 4px,
+		),
+		active: (
+			height: 4px,
+		),
 	),
 	$card-interactive-after-highlight
 );
@@ -236,11 +244,17 @@ $card-interactive: map-deep-merge(
 		cursor: $link-cursor,
 		outline: 0,
 		transition: $btn-transition,
-		hover-bg: $gray-100,
-		hover-text-decoration: none,
-		focus-border-color: lighten($component-active-bg, 25%),
-		focus-box-shadow: $input-btn-focus-box-shadow,
-		active-bg: $gray-200,
+		hover: (
+			background-color: $gray-100,
+			text-decoration: none,
+		),
+		focus: (
+			border-color: lighten($component-active-bg, 25%),
+			box-shadow: $input-btn-focus-box-shadow,
+		),
+		active: (
+			background-color: $gray-200,
+		),
 		after-highlight: $card-interactive-after-highlight,
 		card-body: $card-interactive-card-body,
 	),
@@ -252,9 +266,15 @@ $card-interactive: map-deep-merge(
 $card-interactive-primary-after-highlight: () !default;
 $card-interactive-primary-after-highlight: map-deep-merge(
 	(
-		hover-bg: $component-active-bg,
-		focus-bg: $component-active-bg,
-		active-bg: $component-active-bg,
+		hover: (
+			background-color: $component-active-bg,
+		),
+		focus: (
+			background-color: $component-active-bg,
+		),
+		active: (
+			background-color: $component-active-bg,
+		),
 	),
 	$card-interactive-primary-after-highlight
 );
@@ -262,8 +282,12 @@ $card-interactive-primary-after-highlight: map-deep-merge(
 $card-interactive-primary: () !default;
 $card-interactive-primary: map-deep-merge(
 	(
-		focus-bg: $gray-100,
-		active-bg: $gray-200,
+		focus: (
+			background-color: $gray-100,
+		),
+		active: (
+			background-color: $gray-200,
+		),
 		after-highlight: $card-interactive-primary-after-highlight,
 	),
 	$card-interactive-primary
@@ -275,11 +299,15 @@ $card-interactive-secondary: () !default;
 $card-interactive-secondary: map-deep-merge(
 	(
 		color: $gray-900,
-		hover-color: $gray-900,
-		hover-bg: $white,
-		hover-border-color: lighten($component-active-bg, 25%),
-		hover-box-shadow: $input-btn-focus-box-shadow,
-		active-bg: $white,
+		hover: (
+			background-color: $white,
+			border-color: lighten($component-active-bg, 25%),
+			box-shadow: $input-btn-focus-box-shadow,
+			color: $gray-900,
+		),
+		active: (
+			background-color: $white,
+		),
 	),
 	$card-interactive-secondary
 );
@@ -287,6 +315,18 @@ $card-interactive-secondary: map-deep-merge(
 // Card Type Asset
 
 $card-type-asset: () !default;
+$card-type-asset: map-deep-merge(
+	(
+		card-type-asset-icon: (
+			sticker: (
+				display: block,
+				padding-bottom: 100%,
+				width: 100%,
+			),
+		),
+	),
+	$card-type-asset
+);
 
 // Image Card
 
@@ -297,7 +337,9 @@ $image-card: () !default;
 $file-card: () !default;
 $file-card: map-deep-merge(
 	(
-		asset-icon-color: $gray-600,
+		asset-icon: (
+			color: $gray-600,
+		),
 	),
 	$file-card
 );
@@ -308,8 +350,8 @@ $product-card: () !default;
 $product-card: map-deep-merge(
 	(
 		aspect-ratio: (
-			bg: $white,
-			bg-image: linear-gradient(0deg, #ebebeb, #ebebeb),
+			background-color: $white,
+			background-image: linear-gradient(0deg, #ebebeb, #ebebeb),
 		),
 		card-body: (
 			text-align: center,
@@ -333,11 +375,15 @@ $product-card: map-deep-merge(
 $user-card: () !default;
 $user-card: map-deep-merge(
 	(
-		asset-icon-max-width: 80px,
-		asset-icon-min-width: 48px,
-		asset-icon-width: 30%,
-		asset-icon-lexicon-icon-height: auto,
-		asset-icon-lexicon-icon-width: 50%,
+		asset-icon: (
+			max-width: 80px,
+			min-width: 48px,
+			width: 30%,
+			lexicon-icon: (
+				height: auto,
+				width: 50%,
+			),
+		),
 	),
 	$user-card
 );
@@ -409,7 +455,9 @@ $card-page-item-user: map-deep-merge(
 $card-type-directory: () !default;
 $card-type-directory: map-deep-merge(
 	(
-		sticker-font-size: 1.125rem,
+		sticker: (
+			font-size: 1.125rem,
+		),
 	),
 	$card-type-directory
 );
@@ -418,7 +466,7 @@ $card-type-directory: map-deep-merge(
 
 $card-page-item-directory: () !default;
 $card-page-item-directory: map-deep-merge(
-	($card-page-item-asset),
+	$card-page-item-asset,
 	$card-page-item-directory
 );
 
@@ -434,8 +482,10 @@ $card-type-template-aspect-ratio: map-deep-merge(
 		horizontal: 16,
 		text-align: center,
 		vertical: 9,
-		lexicon-icon-height: auto,
-		lexicon-icon-width: 28%,
+		lexicon-icon: (
+			height: auto,
+			width: 28%,
+		),
 	),
 	$card-type-template-aspect-ratio
 );
@@ -469,7 +519,9 @@ $card-type-template: () !default;
 $card-type-template: map-deep-merge(
 	(
 		color: $gray-900,
-		hover-color: $gray-900,
+		hover: (
+			color: $gray-900,
+		),
 		after-highlight: $card-type-template-after-highlight,
 		aspect-ratio: $card-type-template-aspect-ratio,
 		aspect-ratio-item: $card-type-template-aspect-ratio-item,
@@ -514,8 +566,10 @@ $template-card-horizontal-card-row: map-deep-merge(
 		margin-left: -4px,
 		margin-right: -4px,
 		width: auto,
-		autofit-col-padding-left: 4px,
-		autofit-col-padding-right: 4px,
+		autofit-col: (
+			padding-left: 4px,
+			padding-right: 4px,
+		),
 	),
 	$template-card-horizontal-card-row
 );
@@ -533,7 +587,9 @@ $template-card-horizontal: () !default;
 $template-card-horizontal: map-deep-merge(
 	(
 		color: $gray-600,
-		hover-color: $gray-600,
+		hover: (
+			color: $gray-600,
+		),
 		sticker: $template-card-horizontal-sticker,
 		card-row: $template-card-horizontal-card-row,
 		card-title: $template-card-horizontal-card-title,


### PR DESCRIPTION
… Sass map keys. The old keys will still work and win over new keys.

- clay-card-section-variant
- clay-card-variant
- clay-card-type-asset
- clay-card-type-asset-variant
- clay-card-type-directory

fix(@clayui/css): Card convert variables that use Card Mixins to use new Sass map keys

fixes #4088