### PR TITLE
feat(@clayui/drop-down): Make it possible to render dividers

### DIFF
--- a/packages/clay-drop-down/README.mdx
+++ b/packages/clay-drop-down/README.mdx
@@ -118,6 +118,20 @@ const menus = {
 };
 ```
 
+If you want to add separators between your menu items, it's possible to do so, by
+using an item that has this shape `{type: 'divider'}`.
+
+```js{expanded}
+const menus = {
+	of23: [
+		{title: 'First', child: 'of09'},
+		{type: 'divider'},
+		{title: 'Second'},
+	],
+	of09: [{title: 'Three'}],
+};
+```
+
 ## Caveats
 
 One caveat with the drop down menu is that it is rendered inside of a [React Portal](https://reactjs.org/docs/portals.html) and is rendered directly to the `body` element. This means if you are using the `menuWidth` prop set to `auto`, it will not respect the size of the node parent of the drop down, since the menu is rendered directly to the body.

--- a/packages/clay-drop-down/docs/index.js
+++ b/packages/clay-drop-down/docs/index.js
@@ -179,14 +179,16 @@ const dropDownWithDrilldownCode = `const Component = () => {
 			menus={{
 				x0a3: [
 					{href: '#', title: 'Hash Link'},
+					{type: 'divider'},
 					{onClick: () => alert('test'), title: 'Alert!'},
+					{type: 'divider'},
 					{child: 'x0a4', title: 'Subnav'},
 				],
 				x0a4: [
 					{href: '#', title: '2nd hash link'},
 					{child: 'x0a5', title: 'Subnav'},
 				],
-				x0a5: [{title: 'The'}, {title: 'End'}],
+				x0a5: [{title: 'The'}, {type: 'divider'}, {title: 'End'}],
 			}}
 			spritemap={spritemap}
 			trigger={<ClayButton>{'Click Me'}</ClayButton>}

--- a/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
@@ -47,7 +47,7 @@ describe('ClayDropDownWithDrilldown', () => {
 
 		fireEvent.click(getByTestId('trigger'));
 
-		expect(document).toMatchSnapshot();
+		expect(document.body).toMatchSnapshot();
 	});
 
 	it('renders dividers', () => {
@@ -76,7 +76,7 @@ describe('ClayDropDownWithDrilldown', () => {
 
 		fireEvent.click(getByTestId('trigger'));
 
-		expect(document).toMatchSnapshot();
+		expect(document.body).toMatchSnapshot();
 	});
 
 	it('navigates forwards when clicking through menus', () => {

--- a/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
@@ -50,6 +50,35 @@ describe('ClayDropDownWithDrilldown', () => {
 		expect(document).toMatchSnapshot();
 	});
 
+	it('renders dividers', () => {
+		const {getByTestId} = render(
+			<ClayDropDownWithDrilldown
+				initialActiveMenu="x0a3"
+				menus={{
+					x0a3: [
+						{href: '#', title: 'Hash Link'},
+						{type: 'divider'},
+						{onClick: () => alert('test'), title: 'Alert!'},
+						{type: 'divider'},
+						{child: 'x0a4', title: 'Subnav'},
+					],
+					x0a4: [
+						{href: '#', title: '2nd hash link'},
+						{type: 'divider'},
+						{child: 'x0a5', title: 'Subnav'},
+					],
+					x0a5: [{title: 'The'}, {type: 'divider'}, {title: 'End'}],
+				}}
+				spritemap="#"
+				trigger={<button data-testid="trigger" />}
+			/>
+		);
+
+		fireEvent.click(getByTestId('trigger'));
+
+		expect(document).toMatchSnapshot();
+	});
+
 	it('navigates forwards when clicking through menus', () => {
 		const {getByTestId} = render(
 			<ClayDropDownWithDrilldown

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -1,47 +1,357 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ClayDropDownWithDrilldown renders 1`] = `
-Document {
-  "location": Location {
-    "assign": [Function],
-    "hash": "",
-    "host": "localhost",
-    "hostname": "localhost",
-    "href": "http://localhost/",
-    "origin": "http://localhost",
-    "pathname": "/",
-    "port": "",
-    "protocol": "http:",
-    "reload": [Function],
-    "replace": [Function],
-    "search": "",
-    "toString": [Function],
-  },
-  Symbol(SameObject caches): Object {
-    "styleSheets": StyleSheetList {},
-  },
-}
+<body>
+  <div>
+    <div
+      class="dropdown"
+    >
+      <button
+        class="dropdown-toggle"
+        data-testid="trigger"
+        style=""
+      />
+    </div>
+  </div>
+  <div>
+    <div>
+      <div
+        class="dropdown-menu drilldown dropdown-menu-indicator-end show"
+        style="left: -999px; top: -995px;"
+      >
+        <div
+          class="drilldown-inner"
+        >
+          <div
+            class="drilldown-item drilldown-current"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <a
+                  class="dropdown-item"
+                  data-testid="menu-item-Hash Link"
+                  href="#"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Hash Link
+                  </span>
+                </a>
+              </li>
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-Alert!"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Alert!
+                  </span>
+                </button>
+              </li>
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-Subnav"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Subnav
+                  </span>
+                  <span
+                    class="dropdown-item-indicator-end"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-right"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="##angle-right"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="drilldown-item"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <a
+                  class="dropdown-item"
+                  data-testid="menu-item-2nd hash link"
+                  href="#"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    2nd hash link
+                  </span>
+                </a>
+              </li>
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-Subnav"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Subnav
+                  </span>
+                  <span
+                    class="dropdown-item-indicator-end"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-right"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="##angle-right"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="drilldown-item"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-The"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    The
+                  </span>
+                </button>
+              </li>
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-End"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    End
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
 `;
 
 exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
-Document {
-  "location": Location {
-    "assign": [Function],
-    "hash": "",
-    "host": "localhost",
-    "hostname": "localhost",
-    "href": "http://localhost/",
-    "origin": "http://localhost",
-    "pathname": "/",
-    "port": "",
-    "protocol": "http:",
-    "reload": [Function],
-    "replace": [Function],
-    "search": "",
-    "toString": [Function],
-  },
-  Symbol(SameObject caches): Object {
-    "styleSheets": StyleSheetList {},
-  },
-}
+<body>
+  <div>
+    <div
+      class="dropdown"
+    >
+      <button
+        class="dropdown-toggle"
+        data-testid="trigger"
+        style=""
+      />
+    </div>
+  </div>
+  <div>
+    <div>
+      <div
+        class="dropdown-menu drilldown dropdown-menu-indicator-end show"
+        style="left: -999px; top: -995px;"
+      >
+        <div
+          class="drilldown-inner"
+        >
+          <div
+            class="drilldown-item drilldown-current"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <a
+                  class="dropdown-item"
+                  data-testid="menu-item-Hash Link"
+                  href="#"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Hash Link
+                  </span>
+                </a>
+              </li>
+              <li
+                aria-hidden="true"
+                class="dropdown-divider"
+                role="presentation"
+              />
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-Alert!"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Alert!
+                  </span>
+                </button>
+              </li>
+              <li
+                aria-hidden="true"
+                class="dropdown-divider"
+                role="presentation"
+              />
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-Subnav"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Subnav
+                  </span>
+                  <span
+                    class="dropdown-item-indicator-end"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-right"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="##angle-right"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="drilldown-item"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <a
+                  class="dropdown-item"
+                  data-testid="menu-item-2nd hash link"
+                  href="#"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    2nd hash link
+                  </span>
+                </a>
+              </li>
+              <li
+                aria-hidden="true"
+                class="dropdown-divider"
+                role="presentation"
+              />
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-Subnav"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Subnav
+                  </span>
+                  <span
+                    class="dropdown-item-indicator-end"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-right"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="##angle-right"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="drilldown-item"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-The"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    The
+                  </span>
+                </button>
+              </li>
+              <li
+                aria-hidden="true"
+                class="dropdown-divider"
+                role="presentation"
+              />
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-End"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    End
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
 `;

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -22,3 +22,26 @@ Document {
   },
 }
 `;
+
+exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
+Document {
+  "location": Location {
+    "assign": [Function],
+    "hash": "",
+    "host": "localhost",
+    "hostname": "localhost",
+    "href": "http://localhost/",
+    "origin": "http://localhost",
+    "pathname": "/",
+    "port": "",
+    "protocol": "http:",
+    "reload": [Function],
+    "replace": [Function],
+    "search": "",
+    "toString": [Function],
+  },
+  Symbol(SameObject caches): Object {
+    "styleSheets": StyleSheetList {},
+  },
+}
+`;

--- a/packages/clay-drop-down/src/drilldown/Menu.tsx
+++ b/packages/clay-drop-down/src/drilldown/Menu.tsx
@@ -10,11 +10,16 @@ import classNames from 'classnames';
 import React from 'react';
 import {CSSTransition} from 'react-transition-group';
 
+import Divider from '../Divider';
+
+type TType = 'divider';
+
 export interface IItem extends React.ComponentProps<typeof LinkOrButton> {
 	child?: string;
-	title: string;
+	title?: string;
 	href?: string;
 	symbol?: string;
+	type?: TType;
 }
 
 export interface IProps {
@@ -88,55 +93,59 @@ const DrilldownMenu: React.FunctionComponent<IProps> = ({
 									onClick,
 									symbol,
 									title,
+									type,
 									...other
 								},
 								j
-							) => (
-								<li key={`${j}-${title}`}>
-									<LinkOrButton
-										{...other}
-										buttonDisplayType="unstyled"
-										className={classNames(
-											'dropdown-item',
-											className
-										)}
-										data-testid={`menu-item-${title}`}
-										onClick={(
-											event: React.SyntheticEvent
-										) => {
-											if (onClick) {
-												onClick(event);
-											}
+							) =>
+								type === 'divider' ? (
+									<Divider key={`${j}-divider`} />
+								) : (
+									<li key={`${j}-${title}`}>
+										<LinkOrButton
+											{...other}
+											buttonDisplayType="unstyled"
+											className={classNames(
+												'dropdown-item',
+												className
+											)}
+											data-testid={`menu-item-${title}`}
+											onClick={(
+												event: React.SyntheticEvent
+											) => {
+												if (onClick) {
+													onClick(event);
+												}
 
-											if (title && child) {
-												onForward(title, child);
-											}
-										}}
-									>
-										{symbol && (
-											<span className="dropdown-item-indicator-start">
-												<ClayIcon
-													spritemap={spritemap}
-													symbol={symbol}
-												/>
+												if (title && child) {
+													onForward(title, child);
+												}
+											}}
+										>
+											{symbol && (
+												<span className="dropdown-item-indicator-start">
+													<ClayIcon
+														spritemap={spritemap}
+														symbol={symbol}
+													/>
+												</span>
+											)}
+
+											<span className="dropdown-item-indicator-text-end">
+												{title}
 											</span>
-										)}
 
-										<span className="dropdown-item-indicator-text-end">
-											{title}
-										</span>
-
-										{child && (
-											<span className="dropdown-item-indicator-end">
-												<ClayIcon
-													spritemap={spritemap}
-													symbol="angle-right"
-												/>
-											</span>
-										)}
-									</LinkOrButton>
-								</li>
-							)
+											{child && (
+												<span className="dropdown-item-indicator-end">
+													<ClayIcon
+														spritemap={spritemap}
+														symbol="angle-right"
+													/>
+												</span>
+											)}
+										</LinkOrButton>
+									</li>
+								)
 						)}
 					</ul>
 				)}

--- a/packages/clay-drop-down/stories/index.tsx
+++ b/packages/clay-drop-down/stories/index.tsx
@@ -285,14 +285,17 @@ storiesOf('Components|ClayDropDown', module)
 			menus={{
 				x0a3: [
 					{href: '#', title: 'Hash Link'},
+					{type: 'divider'},
 					{onClick: () => alert('test'), title: 'Alert!'},
+					{type: 'divider'},
 					{child: 'x0a4', title: 'Subnav'},
 				],
 				x0a4: [
 					{href: '#', title: '2nd hash link'},
+					{type: 'divider'},
 					{child: 'x0a5', title: 'Subnav'},
 				],
-				x0a5: [{title: 'The'}, {title: 'End'}],
+				x0a5: [{title: 'The'}, {type: 'divider'}, {title: 'End'}],
 			}}
 			spritemap={spritemap}
 			trigger={<ClayButton>{'Click Me'}</ClayButton>}


### PR DESCRIPTION
In this change, we're adding the possibility to render dividers
in the `ClayDropDownWithDrilldown` component. The change is rather
straightforward: if a menu item with the `type: 'divider'` is passed
in the `menus` prop, it will be rendered as a `<Divider />`.

Fixes #4089