### PR TITLE
feat(@clayui/drop-down): add the new contextual type to create a cascading menu

### DIFF
--- a/packages/clay-drop-down/README.mdx
+++ b/packages/clay-drop-down/README.mdx
@@ -17,6 +17,7 @@ import {
 -   [Composing](#composing)
     -   [Using dropdown without a trigger](#using-dropdown-without-a-trigger)
 -   [DropDownWithItems](#dropdownwithitems)
+    -   [Cascading Menu](#cascading-menu)
 -   [DropDownWithDrilldown](#dropdownwithdrilldown)
 -   [Caveats](#caveats)
 
@@ -94,6 +95,32 @@ const Menu = ({children, hasLeftSymbols, hasRightSymbols}) => {
 Allows you to create a simple DropDown, through its API you are able to create a Menu with groups of checkboxes and radios, links, buttons, search, caption, etc.
 
 <DropDownWithItems />
+
+### Cascading Menu
+
+`DropDownWithItems` allows the possibility to create a contextual menu, the nature of the API allows the creation of more cascade menus but the **Lexicon specification recommends using only one level** and using `DropDownWithDrilldown` component.
+
+To render a cascading menu it is necessary to set the `type` of the item to `contextual` and add to the `items` object that follows the same API as the other items.
+
+```js
+const items = [
+	{label: 'Folder'},
+	{type: 'divider'},
+	{
+		items: [
+			{label: 'Basic Document'},
+			{label: 'Contract'},
+			{label: 'Marketing Banner'},
+			{label: 'Spreadsheet'},
+			{label: 'Presentation'},
+		],
+		label: 'Document',
+		type: 'contextual',
+	},
+	{label: 'Shortcut'},
+	{label: 'Repository'},
+];
+```
 
 ## DropDownWithDrilldown
 

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -123,10 +123,10 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 
 	const handleFocus = (event: FocusEvent) => {
 		if (
-			menuElementRef.current &&
-			!menuElementRef.current.contains(event.target as Node) &&
-			triggerElementRef.current &&
-			!triggerElementRef.current.contains(event.target as Node)
+			!menuElementRef.current?.parentElement?.contains(
+				event.target as Node
+			) &&
+			!triggerElementRef.current?.contains(event.target as Node)
 		) {
 			onActiveChange(false);
 		}

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -215,11 +215,13 @@ const Contextual: React.FunctionComponent<
 	return (
 		<ClayDropDown.Item
 			{...otherProps}
-			onClick={() => {
-				setVisible(true);
+			onClick={(event) => {
+				if (event.currentTarget === event.target) {
+					setVisible(true);
 
-				clearTimeout(timeoutHandleRef.current);
-				timeoutHandleRef.current = null;
+					clearTimeout(timeoutHandleRef.current);
+					timeoutHandleRef.current = null;
+				}
 			}}
 			onMouseEnter={() => {
 				if (!visible) {

--- a/packages/clay-drop-down/stories/index.tsx
+++ b/packages/clay-drop-down/stories/index.tsx
@@ -462,4 +462,29 @@ storiesOf('Components|ClayDropDown', module)
 				</ClayButton>
 			</>
 		);
+	})
+	.add('w/ cascading menu', () => {
+		return (
+			<ClayDropDownWithItems
+				items={[
+					{label: 'Folder'},
+					{type: 'divider'},
+					{
+						items: [
+							{label: 'Basic Document'},
+							{label: 'Contract'},
+							{label: 'Marketing Banner'},
+							{label: 'Spreadsheet'},
+							{label: 'Presentation'},
+						],
+						label: 'Document',
+						type: 'contextual',
+					},
+					{label: 'Shortcut'},
+					{label: 'Repository'},
+				]}
+				spritemap={spritemap}
+				trigger={<ClayButton>{'Cascading Menu'}</ClayButton>}
+			/>
+		);
 	});

--- a/packages/clay-shared/src/MouseSafeArea.tsx
+++ b/packages/clay-shared/src/MouseSafeArea.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 
+import {ClayPortal} from './Portal';
 import {useMousePosition} from './useMousePosition';
 
 type Props = {
@@ -14,23 +15,29 @@ type Props = {
 export const MouseSafeArea = ({parentRef}: Props) => {
 	const [mouseX, mouseY] = useMousePosition();
 
-	const {height: h = 0, width: w = 0, x = 0, y = 0} =
+	const {height: h = 0, top = 0, width: w = 0, x = 0, y = 0} =
 		parentRef.current?.getBoundingClientRect() || {};
 
-	const positions = {h, mouseX, mouseY, w, x, y};
+	const {offsetWidth: ownerW = 0} =
+		parentRef.current?.ownerDocument.body || {};
+
+	const positions = {h, mouseX, mouseY, ownerW, w, x, y};
 
 	return (
-		<div
-			style={{
-				clipPath: getClipPath(positions),
-				height: h,
-				left: getLeft(positions),
-				position: 'absolute',
-				right: getRight(positions),
-				top: 0,
-				width: getWidth(positions),
-			}}
-		/>
+		<ClayPortal>
+			<div
+				style={{
+					clipPath: getClipPath(positions),
+					height: h,
+					left: getLeft(positions),
+					position: 'absolute',
+					right: getRight(positions),
+					top,
+					width: getWidth(positions),
+					zIndex: 1010,
+				}}
+			/>
+		</ClayPortal>
 	);
 };
 
@@ -38,16 +45,19 @@ interface IPositions {
 	h: number;
 	mouseX: number;
 	mouseY: number;
+	ownerW: number;
 	w: number;
 	x: number;
 	y: number;
 }
 
 const getLeft = ({mouseX, x}: IPositions) =>
-	mouseX > x ? undefined : `${-Math.max(x - mouseX, 10)}px`;
+	mouseX > x ? undefined : `${x - Math.max(x - mouseX, 10)}px`;
 
-const getRight = ({mouseX, w, x}: IPositions) =>
-	mouseX > x ? `${-Math.max(mouseX - (x + w), 10)}px` : undefined;
+const getRight = ({mouseX, ownerW, w, x}: IPositions) =>
+	mouseX > x
+		? `${ownerW - (x + w) - Math.max(mouseX - (x + w), 10)}px`
+		: undefined;
 
 const getWidth = ({mouseX, w, x}: IPositions) =>
 	`${Math.max(mouseX > x ? mouseX - (x + w) : x - mouseX, 10)}px`;

--- a/packages/clay-shared/src/MouseSafeArea.tsx
+++ b/packages/clay-shared/src/MouseSafeArea.tsx
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+import {useMousePosition} from './useMousePosition';
+
+type Props = {
+	parentRef: React.RefObject<HTMLDivElement>;
+};
+
+export const MouseSafeArea = ({parentRef}: Props) => {
+	const [mouseX, mouseY] = useMousePosition();
+
+	const {height: h = 0, width: w = 0, x = 0, y = 0} =
+		parentRef.current?.getBoundingClientRect() || {};
+
+	const positions = {h, mouseX, mouseY, w, x, y};
+
+	return (
+		<div
+			style={{
+				clipPath: getClipPath(positions),
+				height: h,
+				left: getLeft(positions),
+				position: 'absolute',
+				right: getRight(positions),
+				top: 0,
+				width: getWidth(positions),
+			}}
+		/>
+	);
+};
+
+interface IPositions {
+	h: number;
+	mouseX: number;
+	mouseY: number;
+	w: number;
+	x: number;
+	y: number;
+}
+
+const getLeft = ({mouseX, x}: IPositions) =>
+	mouseX > x ? undefined : `${-Math.max(x - mouseX, 10)}px`;
+
+const getRight = ({mouseX, w, x}: IPositions) =>
+	mouseX > x ? `${-Math.max(mouseX - (x + w), 10)}px` : undefined;
+
+const getWidth = ({mouseX, w, x}: IPositions) =>
+	`${Math.max(mouseX > x ? mouseX - (x + w) : x - mouseX, 10)}px`;
+
+const getClipPath = ({h, mouseX, mouseY, x, y}: IPositions) =>
+	mouseX > x
+		? `polygon(0% 0%, 0% 100%, 100% ${(100 * (mouseY - y)) / h}%)`
+		: `polygon(100% 0%, 0% ${(100 * (mouseY - y)) / h}%, 100% 100%)`;

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -16,4 +16,6 @@ export {useDebounce} from './useDebounce';
 export {useFocusManagement, FOCUSABLE_ELEMENTS} from './useFocusManagement';
 export {setElementFullHeight} from './setElementFullHeight';
 export {useInternalState} from './useInternalState';
+export {useMousePosition} from './useMousePosition';
+export {MouseSafeArea} from './MouseSafeArea';
 export type {TInternalStateOnChange} from './useInternalState';

--- a/packages/clay-shared/src/useMousePosition.ts
+++ b/packages/clay-shared/src/useMousePosition.ts
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useEffect, useState} from 'react';
+
+type MousePosition = [number, number];
+
+function throttle<T>(callback: Function, limit: number) {
+	var waiting = false;
+
+	return (...args: Array<T>) => {
+		if (!waiting) {
+			callback(...args);
+			waiting = true;
+
+			setTimeout(() => {
+				waiting = false;
+			}, limit);
+		}
+	};
+}
+
+/**
+ * Hook to get the current mouse position
+ */
+export const useMousePosition = () => {
+	const [mousePosition, setMousePosition] = useState<MousePosition>([0, 0]);
+
+	useEffect(() => {
+		const handleMousePosition = throttle(
+			(event: MouseEvent) =>
+				setMousePosition([event.clientX, event.clientY]),
+			150
+		);
+
+		window.addEventListener('mousemove', handleMousePosition);
+
+		return () =>
+			window.removeEventListener('mousemove', handleMousePosition);
+	}, []);
+
+	return mousePosition;
+};

--- a/packages/clay-shared/src/useMousePosition.ts
+++ b/packages/clay-shared/src/useMousePosition.ts
@@ -32,7 +32,7 @@ export const useMousePosition = () => {
 		const handleMousePosition = throttle(
 			(event: MouseEvent) =>
 				setMousePosition([event.clientX, event.clientY]),
-			150
+			200
 		);
 
 		window.addEventListener('mousemove', handleMousePosition);


### PR DESCRIPTION
Fixes #4097 

Well add this just as a draft just missing to understand how the visibility of the cascading menu will work, it is still not very clear if when hovering the mouse outside the cascading menu it should disappear, looking at the Figma prototype it looks like this but I'm not sure about that.

- [Spec](https://docs.google.com/document/d/1gnFu8Fwb_JEl1Lat_THfzXN9vkCJ7Q4f6zM82ioj1Wo/edit?usp=sharing)

I thought that just adding a level would be easier but in fact, our API allows you to add another level, so implementing it in a recursive way is more natural for our implementation. this is because we only want one level. To create a cascading menu is the same as creating a `group` but just change the type to `contextual` (I'm not sure about that name yet, suggestion is welcome), this allows you to switch between a group or create one menu.

```js
const items = [
	{label: 'Folder'},
	{type: 'divider'},
	{
		items: [
			{label: 'Basic Document'},
			{label: 'Contract'},
			{label: 'Marketing Banner'},
			{label: 'Spreadsheet'},
			{label: 'Presentation'},
		],
		label: 'Document',
		type: 'contextual',
	},
	{label: 'Shortcut'},
	{label: 'Repository'},
];
```

### Contextual Menu

Well, I followed a pattern that is common for contextual menus, where we build a safe area that allows the user to navigate to the menu without the menu closing, this video shows this aria well. Some examples like https://css-tricks.com/menus-with-dynamic-hit-areas/

- [Demo](https://deploy-preview-4102--next-storybook-clayui.netlify.app/?path=/story/components-claydropdown--w-cascading-menu)

https://user-images.githubusercontent.com/13750819/119883129-8f9b6680-bf05-11eb-9849-c36ec2874947.mp4

@drakonux could you confirm what the visibility behavior would be?