### PR TITLE
 feat(@clayui/drop-down): Allow the menu to be toggled

### DIFF
--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {TInternalStateOnChange, useInternalState} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -11,6 +12,11 @@ import ClayDropDownMenu from './Menu';
 import Drilldown from './drilldown';
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Flag to indicate if the menu should be initially active (open).
+	 */
+	active?: boolean;
+
 	/**
 	 * Default position of menu element. Values come from `./Menu`.
 	 */
@@ -54,6 +60,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	offsetFn?: React.ComponentProps<typeof ClayDropDown>['offsetFn'];
 
 	/**
+	 * Callback the will be invoked when the active prop is changed.
+	 */
+	onActiveChange?: TInternalStateOnChange<boolean>;
+
+	/**
 	 * Path to spritemap
 	 */
 	spritemap?: string;
@@ -70,6 +81,7 @@ interface IHistory {
 }
 
 export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
+	active,
 	alignmentPosition,
 	className,
 	containerElement,
@@ -79,19 +91,23 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	menuWidth,
 	menus,
 	offsetFn,
+	onActiveChange,
 	spritemap,
 	trigger,
 }: IProps) => {
-	const [active, setActive] = React.useState(false);
 	const [activeMenu, setActiveMenu] = React.useState(initialActiveMenu);
 	const [direction, setDirection] = React.useState<'prev' | 'next'>();
 	const [history, setHistory] = React.useState<Array<IHistory>>([]);
+	const [internalActive, setInternalActive] = useInternalState({
+		onChange: onActiveChange,
+		value: active,
+	});
 
 	const menuIds = Object.keys(menus);
 
 	return (
 		<ClayDropDown
-			active={active}
+			active={internalActive}
 			alignmentPosition={alignmentPosition}
 			className={className}
 			containerElement={containerElement}
@@ -103,7 +119,7 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 			menuHeight={menuHeight}
 			menuWidth={menuWidth}
 			offsetFn={offsetFn}
-			onActiveChange={setActive}
+			onActiveChange={setInternalActive}
 			trigger={trigger}
 		>
 			<Drilldown.Inner>

--- a/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
@@ -134,4 +134,52 @@ describe('ClayDropDownWithDrilldown', () => {
 			document.querySelectorAll('.drilldown-item')[0].classList
 		).toContain('drilldown-current');
 	});
+
+	it('renders with the menu initially active', () => {
+		render(
+			<ClayDropDownWithDrilldown
+				active
+				initialActiveMenu="x0a3"
+				menus={{
+					x0a3: [
+						{href: '#', title: 'Hash Link'},
+						{child: 'x0a4', title: 'Subnav'},
+					],
+					x0a4: [{href: '#', title: '2nd hash link'}],
+				}}
+				spritemap="#"
+				trigger={<button data-testid="trigger" />}
+			/>
+		);
+
+		expect(document.body).toMatchSnapshot();
+	});
+
+	it('the menu can be toggled by clicking in an item', () => {
+		const onActiveChange = jest.fn();
+
+		const {getByTestId} = render(
+			<ClayDropDownWithDrilldown
+				initialActiveMenu="x0a3"
+				menus={{
+					x0a3: [
+						{onClick: onActiveChange, title: 'Toggle'},
+						{child: 'x0a4', title: 'Subnav'},
+					],
+					x0a4: [{href: '#', title: '2nd hash link'}],
+				}}
+				onActiveChange={onActiveChange}
+				spritemap="#"
+				trigger={<button data-testid="trigger" />}
+			/>
+		);
+
+		fireEvent.click(getByTestId('menu-item-Toggle'));
+		fireEvent.click(getByTestId('menu-item-Toggle'));
+		fireEvent.click(getByTestId('menu-item-Toggle'));
+
+		expect(onActiveChange).toHaveBeenCalledTimes(3);
+
+		expect(document.body).toMatchSnapshot();
+	});
 });

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -355,3 +355,195 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
   </div>
 </body>
 `;
+
+exports[`ClayDropDownWithDrilldown renders with the menu initially active 1`] = `
+<body>
+  <div>
+    <div
+      class="dropdown"
+    >
+      <button
+        class="dropdown-toggle"
+        data-testid="trigger"
+        style=""
+      />
+    </div>
+  </div>
+  <div>
+    <div>
+      <div
+        class="dropdown-menu drilldown dropdown-menu-indicator-end show"
+        style="left: -999px; top: -995px;"
+      >
+        <div
+          class="drilldown-inner"
+        >
+          <div
+            class="drilldown-item drilldown-current"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <a
+                  class="dropdown-item"
+                  data-testid="menu-item-Hash Link"
+                  href="#"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Hash Link
+                  </span>
+                </a>
+              </li>
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-Subnav"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Subnav
+                  </span>
+                  <span
+                    class="dropdown-item-indicator-end"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-right"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="##angle-right"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="drilldown-item"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <a
+                  class="dropdown-item"
+                  data-testid="menu-item-2nd hash link"
+                  href="#"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    2nd hash link
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an item 1`] = `
+<body>
+  <div>
+    <div
+      class="dropdown"
+    >
+      <button
+        class="dropdown-toggle"
+        data-testid="trigger"
+        style=""
+      />
+    </div>
+  </div>
+  <div>
+    <div>
+      <div
+        class="dropdown-menu drilldown dropdown-menu-indicator-end"
+        style="left: -999px; top: -995px;"
+      >
+        <div
+          class="drilldown-inner"
+        >
+          <div
+            class="drilldown-item drilldown-current"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-Toggle"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Toggle
+                  </span>
+                </button>
+              </li>
+              <li>
+                <button
+                  class="dropdown-item btn btn-unstyled"
+                  data-testid="menu-item-Subnav"
+                  type="button"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    Subnav
+                  </span>
+                  <span
+                    class="dropdown-item-indicator-end"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-right"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="##angle-right"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="drilldown-item"
+          >
+            <ul
+              class="inline-scroller"
+            >
+              <li>
+                <a
+                  class="dropdown-item"
+                  data-testid="menu-item-2nd hash link"
+                  href="#"
+                >
+                  <span
+                    class="dropdown-item-indicator-text-end"
+                  >
+                    2nd hash link
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/clay-drop-down/stories/index.tsx
+++ b/packages/clay-drop-down/stories/index.tsx
@@ -301,6 +301,41 @@ storiesOf('Components|ClayDropDown', module)
 			trigger={<ClayButton>{'Click Me'}</ClayButton>}
 		/>
 	))
+	.add('ClayDropDownWithDrillDown/active', () => {
+		const [active, setActive] = React.useState(true);
+
+		const onActiveChange = () => {
+			setActive(!active);
+		};
+
+		return (
+			<ClayDropDownWithDrilldown
+				active={active}
+				initialActiveMenu="x0a3"
+				menus={{
+					x0a3: [
+						{href: '#', title: 'Hash Link'},
+						{onClick: () => alert('test'), title: 'Alert!'},
+						{
+							onClick: () => {
+								onActiveChange();
+							},
+							title: 'Toggle menu',
+						},
+						{child: 'x0a4', title: 'Subnav'},
+					],
+					x0a4: [
+						{href: '#', title: '2nd hash link'},
+						{child: 'x0a5', title: 'Subnav'},
+					],
+					x0a5: [{title: 'The'}, {title: 'End'}],
+				}}
+				onActiveChange={onActiveChange}
+				spritemap={spritemap}
+				trigger={<ClayButton>{'Click Me'}</ClayButton>}
+			/>
+		);
+	})
 	.add('ClayDropDownWithItems', () => {
 		const [value, setValue] = React.useState('');
 


### PR DESCRIPTION
Two new props have been added to `ClayDropDownWithDrillDown`:
`active` and `onActiveChange`. Setting `active` to `true` will make the
menu initially `active` (open), and `onActiveChange` will allow the menu
to be toggled.

Fixes #4103
