### PR TITLE
fix(@clayui/css): Accessibility change request, replace 'outline: 0 !important;' 

### DIFF
--- a/packages/clay-css/src/scss/bootstrap/_reboot.scss
+++ b/packages/clay-css/src/scss/bootstrap/_reboot.scss
@@ -64,7 +64,7 @@ body {
 // See https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
 // and https://developer.paciellogroup.com/blog/2018/03/focus-visible-and-backwards-compatibility/
 [tabindex="-1"]:focus:not(:focus-visible) {
-  outline: 0 !important;
+  box-shadow: $component-focus-box-shadow;
 }
 
 


### PR DESCRIPTION
fix(@clayui/css): Accessibility change request, replace 'outline: 0 !important;' with 'box-shadow: $component-focus-box-shadow;' in clay/packages/clay-css/src/scss/bootstrap/_reboot.scss on '[tabindex="-1"]:focus:not(:focus-visible)'

For more details, please check: https://issues.liferay.com/browse/LPS-133314
fixes #4124 

To update the Clay version we will use: https://issues.liferay.com/browse/LPS-134019 

fixes #4124 

/cc @pat270 