### PR TITLE
docs: Adds RFC process and documentation template

### DIFF
--- a/docs/0000-proposal-template.md
+++ b/docs/0000-proposal-template.md
@@ -1,0 +1,43 @@
+# Feature name
+
+-   Start Date: (fill me in with today's date, YYYY-MM-DD)
+-   Authors: [Author 1](https://github.com/claydev), [Author 2](https://github.com/claydev)
+-   RFC PR: (leave this empty)
+-   Clay Issue: (leave this empty)
+-   Status: **Awaiting implementation**
+
+_During the review process, add the following fields as needed:_
+
+-   Implementation: [liferay/clay#NNNNN](https://github.com/liferay/clay/NNNNN) or available in version 3.x.x or available under feature flag.
+
+## Introduction
+
+A short description of what the feature is.
+
+## Motivation
+
+Describe the problems this proposal seeks to solve. What use cases does it support? Motivate why this new change would help developers.
+
+It focuses on explaining the motivation so that if this RFC is not accepted, the motivation can be used to develop alternative solutions.
+
+## Proposed solution
+
+Describe your solution to the problem. Take examples and describe how they work. Show how your solution adds value and is better than current alternative solutions: it's cleaner, more flexible...
+
+## Detailed design
+
+Describe the solution design in enough detail for someone familiar with Clay to understand and for someone familiar with the implementation to be able to implement it. If a new API is involved, show the full API and its documentation comments detailing what it does.
+
+## Alternatives considered
+
+Describe alternative approaches to addressing the same problem, and why you chose this approach instead.
+
+## Adoption strategy
+
+If we implement this proposal, how will existing Clay developers adopt it? Is this a significant change? Can we write a codemod? Should we coordinate with other projects?
+
+## How we teach this
+
+What names and terminology work best for these concepts and why? How is this idea best presented?
+
+When this proposal is accepted would it mean that Clay's documentation should be reorganized or changed?

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+# Clay internal documents
+
+It consists of short documents that explain how flows, tools, how processes work on the Clay project.
+
+Documents are not necessarily technical but any document that helps to understand certain motivations or that centralizes information that has a benefit for the entire team.
+
+There are two types of documents, repository infrastructure documents, release cycles or explanations of internal tools, and [RFCs documents](#rfcs) that are used to discuss and centralize "substantial" changes in Clay that reflect on components or documentation that are sourced to users.
+
+## Docs
+
+-   [Developing components](developing_components.md)
+-   [How are clayui.com pages created](creating_pages.md)
+-   [Clay CSS Version History](clay_css_version_history.md)
+
+## RFCs
+
+Clay evolves rapidly and undergoes constant changes as the DXP platform evolves and takes new forms, new components are implemented over time or are evolved to add new behaviors, conversations get lost in various PRs and issues.
+
+However, some of these changes and agreements need to be documented or pin so that we can take them into account before adding new behaviors or helping with decision making, they are easy to find and they are objective and enlightening.
+
+The "RFC" (request for comments) process is intended to provide a consistent and controlled path for new features to enter the project.
+
+### When to follow this process
+
+You should consider using this process when you intend to make "substantial" changes to Clay or its documentation. Some examples that have benefited from an RFC are:
+
+-   A new feature that creates a new API surface area that can be common across all components.
+-   The removal of features that already shipped as part of the release channel.
+-   The introduction of a new organization of documents or significant changes.
+
+The RFC process is a great opportunity to draw more attention to your proposal. Even if the proposals appear to be "obvious" they can be improved significantly, since the team can discuss together with other people and they can give their opinion.
+
+The RFC process can also be helpful to encourage discussions about a proposed feature as it is being designed, and incorporate important constraints into the design while it's easier to change, before the design has been fully implemented.
+
+### What is the process
+
+To add a new feature or make a major change to Clay components or change direction, an RFC must first be submitted and that it first merged as a markdown file. Once merged, the RFC is awaiting implementation.
+
+-   Fork this repository
+-   Copy `0000-proposal-template.md` for `proposals/0000-my-feature.md` (`my-feature` is descriptive)
+-   Fill out the RFC
+-   Submit a pull request. Like a pull request, the RFC will receive design feedback from the core team or key stakeholders.
+-   The RFC must build consensus as it receives feedback.
+-   The team will decide if the RFC makes sense and will benefit from being included in Clay.
+-   An RFC can naturally generate long discussions and long feedback loops that reflect in the final changes to the proposal.
+-   An RFC can be closed if no consensus is created between the author, people who commented on the RP, and the team.
+
+### The RFC life-cycle
+
+Once an RFC enters status awaiting implementation, authors can implement it and send the PR to Clay.
+
+An RFC can be a proposal from other developers that do not involve the core team, if the author doesn't have time to work on the proposal when the RFC is merged this does not mean the team will implement it right away when it is merged but it does mean that the team agreed with that in principle and will set a priority so that it can be implemented.

--- a/docs/proposals/0001-component-offerings.md
+++ b/docs/proposals/0001-component-offerings.md
@@ -1,0 +1,142 @@
+# Component offerings: Low-level and High-level components
+
+-   Start Date: 2019-30-05
+-   Authors: [Bryce Osterhaus](https://github.com/bryceosterhaus)
+-   RFC PR: (leave this empty)
+-   Clay Issue: (leave this empty)
+-   Status: **Implemented**
+
+## Introduction
+
+A principle for how components are developed and delivered for each package determines what the flexibility, low-level, or high-level levels of a component are and for what purpose they are written.
+
+## Motivation
+
+The primary issue we are facing right now is determining how "high-level" the component should be. For example, should we create a single component with many props, or should we create many components to be composed together.
+
+This boils down to two main goals:
+
+-   Provide enough flexibility and low-level components for teams to quickly build and deliver applications without being blocked by us
+-   Provide quality high level components that allow teams to quickly build applications with the best possible interactions (UX) that are consistent, performant, accessible and extensible without the need of repeating themselves over and over again. These high-level components are composed of low-level components
+
+```jsx
+<Card>
+	<Card.Title onClick={handleTitleClick}>
+		<Icon symbol="check" />
+		{'Hello World'}
+	</Card.Title>
+	<Card.Body onClick={handleBodyClick}>
+		<Card.Description>{'Some cool descriptors'}</Card.Description>
+	</Card.Body>
+</Card>
+```
+
+vs
+
+```jsx
+<Card
+	iconTitleLeftSymbol="check"
+	onTitleClick={handleTitleClick}
+	onBodyClick={handleBodyClick}
+	description="foo bar baz"
+	title="hello world"
+/>
+```
+
+## Proposed solution
+
+The decision going forward is to create 2 sets of components:
+
+-   Low-level composable components such as `<ClayCard.Header/>`, `<ClayCard.Footer/>`.
+-   Simple high-level components that cover basic lexicon uses.
+
+### What does this look like?
+
+#### Composable
+
+```jsx
+<DropDown>
+	<DropDown.Search
+		onChange={() => {}}
+		placeholder="Search"
+		spritemap={spritemap}
+		value={''}
+	/>
+	<DropDown.ItemList>
+		{items.map((item, i) => (
+			<DropDown.Item href={item.href} key={i}>
+				{item.label}
+			</DropDown.Item>
+		))}
+	</DropDown.ItemList>
+</DropDown>
+```
+
+Composing gives the user more control over the layout and interactions. Our "sell" here for the low-level components are for cases where users need to create other behaviors or customize their components in more detail.
+
+#### High-level
+
+```jsx
+<DropDownWithPagination
+	delta={delta}
+	header="Favorites"
+	items={items} // Array of objects with `label` and `href`
+	message={'Showing {0} of {1} Structures'}
+	title="Folder"
+/>
+```
+
+Compare if this component was composed of low-level components:
+
+```jsx
+<DropDown>
+	<DropDown.Header header="Folder" />
+	<DropDown.ItemList>
+		<DropDown.Group header="Favorites">
+			{items.slice(0, page * delta).map((item, i) => (
+				<DropDown.Item href={item.href} key={i}>
+					{item.label}
+				</DropDown.Item>
+			))}
+		</DropDown.Group>
+	</DropDown.ItemList>
+	<DropDown.Caption>
+		{`Showing ${page * delta} of ${items.length} structures`}
+	</DropDown.Caption>
+	<DropDown.Action onClick={() => setPage(page + 1)}>
+		{'Show More'}
+	</DropDown.Action>
+</DropDown>
+```
+
+You'll notice that the high-level component handles much of the interactions internally. It will handle the click of the `show more`, paginate, and update language as necessary. In fact, even this high-level component will be made from the smaller low-level building blocks.
+
+Finally, both the high-level and low-level components will be exported from each package. The low-level component will be exported as default, but the high-level ones will be exported by name. The high-level components should be descriptive in name, following the pattern of `{ComponentName}{Variant}`.
+
+For example:
+
+```js
+export {ClayDropDownWithPagination};
+
+export default ClayDropDown;
+```
+
+The purpose of this would be to expose descriptive high-level components as well as the basic building blocks of the component as the default export.
+
+## Consequences
+
+### Benefits
+
+-   Gives users high-level components to import and use right away.
+-   Gives users low-level components to build more complex interactions.
+-   Gives maintainers leverage by encouraging users to build their own custom components built on our building blocks rather than baking it into one of our high-level versions.
+-   Increased consistency for high-level components usage
+-   Reduced support costs (less versions of the same thing)
+
+### Drawbacks
+
+-   More lines of code to maintain.
+-   Increased API surface area, with corresponding requirement to maintain backwards compatibility.
+-   Risk of exposing implementation details as low-level API.
+-   Possible lock-in scenarios when using high-level components. Teams might need to move from a high-level component to a composition scenario in case they need to add something not already covered.
+-   Increased uncertainty... what approach should a developer use and when?


### PR DESCRIPTION
Well initially we've already made an attempt to document our decisions with the [ADR](https://github.com/joelparkerhenderson/architecture-decision-record) model (#2017) and then moved to the Wiki (#2818) because we don't use it as much or because we don't see more value, but this has changed as Clay has evolved and more and more we need to make more decisions from Clay's future, API decisions... which are reflected in developers, a lot of these decisions are focused on specific issues of a component or a PR that adds a new API that we can ignore in certain moments the impact this has on the experience of using the components and harm consistency, over time this is very easy to be distorted even if someone is from the beginning.

The RFC idea may be similar to the idea of [ADRs](https://github.com/joelparkerhenderson/architecture-decision-record) but it comes closer to the idea of documenting proposals, decisions that have substantial to Clay, not necessarily just architecturally related but also closer to what other projects use, to help in decision making and help the principles of the project.

- React
- Vue
- Gastby
- Swift
- Rust
- NPM
- Ember
- ....

One of the views I have on the things I added in the "Clay strategy and solid foundation" document will be reflected in RFCs generated to discuss, such as #4112.

Leave your thoughts and worries behind.