### PR TITLE
fix(@clayui/css): Accessibility change request, overwrite 'outline: 0 !…

### DIFF
--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -2,6 +2,8 @@
 	@import url($font-import-url);
 }
 
+@import "components/_reboot.scss";
+
 @import "components/_grid";
 
 @import "components/_alerts";

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -1,0 +1,3 @@
+[tabindex="-1"]:focus:not(:focus-visible) {
+  box-shadow: $component-focus-box-shadow;
+}


### PR DESCRIPTION
…important;' with 'box-shadow: $component-focus-box-shadow;' in clay/packages/clay-css/src/scss/bootstrap/_reboot.scss on '[tabindex="-1"]:focus:not(:focus-visible)'

For more details please check: https://issues.liferay.com/browse/LPS-133314

fixes liferay#4124