### PR TITLE
fix(@clayui/css): Reboot and Cadmin Reboot removes negative tabindex …

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_reboot.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_reboot.scss
@@ -183,10 +183,6 @@ html#{$cadmin-selector} {
 			}
 		}
 
-		[tabindex^='-'] {
-			outline: 0;
-		}
-
 		// Code
 
 		pre,

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -159,10 +159,6 @@ a {
 	}
 }
 
-[tabindex^='-'] {
-	outline: 0;
-}
-
 // Code
 
 pre,


### PR DESCRIPTION
…rule that removes default focus outline due to keyboard navigation accessibility issues. `tabindex="-1"` can still be focused programmatically.

fixes #4124

#3436 is no longer valid. Chrome doesn't show the focus outline for me anymore.