### PR TITLE
feat(@clayui/css): Adds Cadmin Treeview

### DIFF
--- a/clayui.com/content/docs/components/markup-treeview.md
+++ b/clayui.com/content/docs/components/markup-treeview.md
@@ -1,0 +1,7751 @@
+---
+title: 'Treeview'
+description: 'A tree view is a component-based on nodes that are shown in a hierarchical structure.'
+lexiconDefinition: 'https://liferay.design/lexicon/core-components/tree-view/'
+---
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Treeview](#css-treeview)
+    -   [Group](#css-treeview-group)
+    -   [Item](#css-treeview-item)
+    -   [Link](#css-treeview-link)
+    -   [Component Expander](#css-treeview-component-expander)
+    -   [Component Action](#css-treeview-component-action)
+-   [Variations](#css-variations)
+    -   [Expander on Hover](#css-treeview-expander-on-hover)
+    -   [Light](#css-treeview-light)
+    -   [Dark](#css-treeview-dark)
+
+</div>
+</div>
+
+<div class="clay-site-alert alert alert-warning">This component is a Cadmin only component.</div>
+
+The component must be wrapped in:
+
+```html{expanded}
+<div class="cadmin">
+	...
+</div>
+```
+
+## Treeview(#css-treeview)
+
+The treeview provides a way to display information in a hierarchical structure by using collapsible items (nodes). You can navigate between these items using either your mouse device or keyboard. The most common example of a treeview is a folder structure for file systems, but it can be used for showing any hierarchical relationships.
+
+<div class="clay-site-alert alert alert-info">
+	See <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/treeview-2a.html" rel="noreferrer noopener" target="_blank">https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/treeview-2a.html</a> for accessibility patterns.
+</div>
+
+<div class="clay-site-alert alert alert-warning">
+	Treeview Link indentation must be provided by javascript through inline styles, use the styles `padding-left: 24px;` on `.treeview-link` and `margin-left: -24px` on `.treeview-link > .c-inner`. Increase the indentation for each level by increasing or decreasing `padding-left` or `margin-left` by 24px.
+</div>
+
+<div class="cadmin">
+	<ul class="treeview treeview-light treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewCollapse01" aria-expanded="true" class="treeview-link" data-target="#treeviewCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button aria-controls="treeviewCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse show" id="treeviewCollapse01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div aria-controls="treeviewCollapse02" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col">
+										<button aria-controls="treeviewCollapse02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse02" data-toggle="collapse" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#angle-down" />
+												</svg>
+												<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#angle-right" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<span class="component-icon">
+											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#folder" />
+											</svg>
+										</span>
+									</span>
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span class="text-truncate-inline" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+										</span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+						<div class="collapse" id="treeviewCollapse02">
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<span class="autofit-row">
+												<span class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Details"><span class="text-truncate">Details</span></span></span>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<span class="autofit-row">
+												<span class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<span class="autofit-row">
+												<span class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<span class="autofit-row">
+												<span class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewCollapse03" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1">
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button aria-controls="treeviewCollapse03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse03" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Repositories"><span class="text-truncate">Repositories</span></span>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse" id="treeviewCollapse03">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Site Map"><span class="text-truncate">Sitemap</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Robots"><span class="text-truncate">Robots</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewCollapse04" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse04" data-toggle="collapse" role="treeitem" tabindex="-1">
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button aria-controls="treeviewCollapse04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse04" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse" id="treeviewCollapse04">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Staging"><span class="text-truncate">Staging</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Maps"><span class="text-truncate">Maps</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+
+```html
+<div class="cadmin">
+	<ul class="treeview treeview-light treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewCollapse01"
+				aria-expanded="true"
+				class="treeview-link"
+				data-target="#treeviewCollapse01"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="0"
+			>
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button
+								aria-controls="treeviewCollapse01"
+								aria-expanded="true"
+								class="btn btn-monospaced component-expander"
+								data-target="#treeviewCollapse01"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									title="Liferay Drive"
+									><span class="text-truncate"
+										>Liferay Drive</span
+									></span
+								>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse show" id="treeviewCollapse01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							aria-controls="treeviewCollapse02"
+							aria-expanded="false"
+							class="collapsed treeview-link"
+							data-target="#treeviewCollapse02"
+							data-toggle="collapse"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span class="autofit-col">
+										<button
+											aria-controls="treeviewCollapse02"
+											aria-expanded="false"
+											class="btn btn-monospaced component-expander"
+											data-target="#treeviewCollapse02"
+											data-toggle="collapse"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-angle-down"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#angle-down"
+													/>
+												</svg>
+												<svg
+													class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#angle-right"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<span class="component-icon">
+											<svg
+												class="lexicon-icon lexicon-icon-folder"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#folder"
+												/>
+											</svg>
+										</span>
+									</span>
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text">
+											<span
+												class="text-truncate-inline"
+												title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
+												><span class="text-truncate"
+													>Liferay Drive
+													(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
+												></span
+											>
+										</span>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+						<div class="collapse" id="treeviewCollapse02">
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<span
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<span class="autofit-row">
+												<span
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Details"
+															><span
+																class="text-truncate"
+																>Details</span
+															></span
+														></span
+													>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<span
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<span class="autofit-row">
+												<span
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Categorization"
+															><span
+																class="text-truncate"
+																>Categorization</span
+															></span
+														></span
+													>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<span
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<span class="autofit-row">
+												<span
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Documents and Media"
+															><span
+																class="text-truncate"
+																>Documents and
+																Media</span
+															></span
+														></span
+													>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<span
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<span class="autofit-row">
+												<span
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Site Template"
+															><span
+																class="text-truncate"
+																>Site
+																Template</span
+															></span
+														></span
+													>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewCollapse03"
+				aria-expanded="false"
+				class="collapsed treeview-link"
+				data-target="#treeviewCollapse03"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="-1"
+			>
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button
+								aria-controls="treeviewCollapse03"
+								aria-expanded="false"
+								class="btn btn-monospaced component-expander"
+								data-target="#treeviewCollapse03"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									title="Repositories"
+									><span class="text-truncate"
+										>Repositories</span
+									></span
+								>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse" id="treeviewCollapse03">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Site Map"
+												><span class="text-truncate"
+													>Sitemap</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Robots"
+												><span class="text-truncate"
+													>Robots</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewCollapse04"
+				aria-expanded="false"
+				class="collapsed treeview-link"
+				data-target="#treeviewCollapse04"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="-1"
+			>
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button
+								aria-controls="treeviewCollapse04"
+								aria-expanded="false"
+								class="btn btn-monospaced component-expander"
+								data-target="#treeviewCollapse04"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									title="Documents and Media"
+									><span class="text-truncate"
+										>Documents and Media</span
+									></span
+								>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse" id="treeviewCollapse04">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Default User Associations"
+												><span class="text-truncate"
+													>Default User
+													Associations</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Staging"
+												><span class="text-truncate"
+													>Staging</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Analytics"
+												><span class="text-truncate"
+													>Analytics</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Maps"
+												><span class="text-truncate"
+													>Maps</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+```
+
+### Treeview Group(#css-treeview-group)
+
+The class `treeview-group` must be applied to all nested `ul` elements inside `treeview`. This class helps provide the proper spacing for nested `treeview-link`s.
+
+```html
+<div class="cadmin">
+	<ul class="treeview treeview-light treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewExpanderCollapse01"
+				aria-expanded="false"
+				class="treeview-link"
+				data-target="#treeviewExpanderCollapse01"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="0"
+			>
+				...
+			</div>
+			<div class="collapse" id="treeviewExpanderCollapse01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+								><span class="component-text"
+									>Tree Item</span
+								></span
+							>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+```
+
+### Treeview Item(#css-treeview-item)
+
+The class `treeview-item` must be applied to all `li` elements. This class helps provide the proper spacing for nested `treeview-link`s.
+
+```html
+<div class="cadmin">
+	<ul class="treeview treeview-light treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewExpanderCollapse01"
+				aria-expanded="false"
+				class="treeview-link"
+				data-target="#treeviewExpanderCollapse01"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="0"
+			>
+				...
+			</div>
+		</li>
+	</ul>
+</div>
+```
+
+### Treeview Link(#css-treeview-link)
+
+This is the container for all nodes inside `treeview`. If there are auxiliary controls inside the `treeview-link` (e.g., `a` or `button`) it is recommended to use a `div` element with the `tabindex` attribute.
+
+```html
+<div class="cadmin">
+	<ul class="treeview treeview-light treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewExpanderCollapse01"
+				aria-expanded="false"
+				class="treeview-link"
+				data-target="#treeviewExpanderCollapse01"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="0"
+			>
+				...
+			</div>
+		</li>
+	</ul>
+</div>
+```
+
+### Component Expander(#css-treeview-component-expander)
+
+The expander is used to expand or collapse the nodes and serves as an indicator for those states. The class `component-expander` marks the button as the toggle. The class `component-expanded-d-none` on `lexicon-icon` hides the icon when tree node is expanded.
+
+<div class="cadmin">
+	<ul class="treeview treeview-light treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewExpanderCollapse01" aria-expanded="false" class="treeview-link" data-target="#treeviewExpanderCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button aria-controls="treeviewExpanderCollapse01" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewExpanderCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+							</span>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse" id="treeviewExpanderCollapse01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Tree Item</span></span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+
+```html
+<button
+	aria-controls="treeviewExpanderCollapse01"
+	aria-expanded="false"
+	class="btn btn-monospaced component-expander"
+	data-target="#treeviewExpanderCollapse01"
+	data-toggle="collapse"
+	tabindex="-1"
+	type="button"
+>
+	<span class="c-inner" tabindex="-2">
+		<svg
+			class="lexicon-icon lexicon-icon-angle-down"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#angle-down" />
+		</svg>
+		<svg
+			class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#angle-right" />
+		</svg>
+	</span>
+</button>
+```
+
+### Component Action(#css-treeview-component-action)
+
+The action button(s) are used to supply additional features to a tree node, such as removal or a dropdown. The buttons must have the class `component-action`. They are displayed when hovering or focusing a tree node.
+
+<div class="cadmin">
+	<ul class="treeview treeview-light treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewActionButtonCollapse01" aria-expanded="true" class="treeview-link" data-target="#treeviewActionButtonCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button aria-controls="treeviewActionButtonCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewActionButtonCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse show" id="treeviewActionButtonCollapse01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Tree Item</span></span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+
+```html
+<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+	<span class="c-inner" tabindex="-2">
+		<svg
+			class="lexicon-icon lexicon-icon-ellipsis-v"
+			focusable="false"
+			role="presentation"
+		>
+			<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+		</svg>
+	</span>
+</button>
+```
+
+## Variations(#css-variations)
+
+### Show Component Expander on Hover(#css-treeview-expander-on-hover)
+
+The class `show-component-expander-on-hover` displays the `component-expander` when the mouse hovers over the `treeview` component.
+
+<div class="cadmin">
+	<ul class="show-component-expander-on-hover treeview treeview-nested treeview-light" role="tree">
+		<li class="treeview-item" role="none">
+			<div aria-controls="showComponentExpanderCollapse01" aria-expanded="true" class="treeview-link" data-target="#showComponentExpanderCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button aria-controls="showComponentExpanderCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander show" data-target="#showComponentExpanderCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse show" id="showComponentExpanderCollapse01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div aria-controls="showComponentExpanderCollapse02" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col">
+										<button aria-controls="showComponentExpanderCollapse02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse02" data-toggle="collapse" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#angle-down" />
+												</svg>
+												<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#angle-right" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<span class="component-icon">
+											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#folder" />
+											</svg>
+										</span>
+									</span>
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+										</span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#info-circle" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+						<div class="collapse" id="showComponentExpanderCollapse02">
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<span class="autofit-row">
+												<span class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" data-toggle="tooltip" title="Details">Details</span></span></span>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<span class="autofit-row">
+												<span class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<span class="autofit-row">
+												<span class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<span class="autofit-row">
+												<span class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div aria-controls="showComponentExpanderCollapse03" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1">
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button aria-controls="showComponentExpanderCollapse03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse03" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" data-toggle="tooltip" title="Repositories"><span class="text-truncate">Repositories</span></span>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse" id="showComponentExpanderCollapse03">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Robots"><span class="text-truncate">Robots</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div aria-controls="showComponentExpanderCollapse04" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse04" data-toggle="collapse" role="treeitem" tabindex="-1">
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button aria-controls="showComponentExpanderCollapse04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse04" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse" id="showComponentExpanderCollapse04">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Staging"><span class="text-truncate">Staging</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<span class="autofit-row">
+									<span class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Maps"><span class="text-truncate">Maps</span></span></span>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+
+```html
+<div class="cadmin">
+	<ul
+		class="show-component-expander-on-hover treeview treeview-nested treeview-light"
+		role="tree"
+	>
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="showComponentExpanderCollapse01"
+				aria-expanded="true"
+				class="treeview-link"
+				data-target="#showComponentExpanderCollapse01"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="0"
+			>
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button
+								aria-controls="showComponentExpanderCollapse01"
+								aria-expanded="true"
+								class="btn btn-monospaced component-expander show"
+								data-target="#showComponentExpanderCollapse01"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									data-toggle="tooltip"
+									title="Liferay Drive"
+									><span class="text-truncate"
+										>Liferay Drive</span
+									></span
+								>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse show" id="showComponentExpanderCollapse01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							aria-controls="showComponentExpanderCollapse02"
+							aria-expanded="false"
+							class="collapsed treeview-link"
+							data-target="#showComponentExpanderCollapse02"
+							data-toggle="collapse"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span class="autofit-col">
+										<button
+											aria-controls="showComponentExpanderCollapse02"
+											aria-expanded="false"
+											class="btn btn-monospaced component-expander"
+											data-target="#showComponentExpanderCollapse02"
+											data-toggle="collapse"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-angle-down"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#angle-down"
+													/>
+												</svg>
+												<svg
+													class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#angle-right"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<span class="component-icon">
+											<svg
+												class="lexicon-icon lexicon-icon-folder"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#folder"
+												/>
+											</svg>
+										</span>
+									</span>
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text">
+											<span
+												class="text-truncate-inline"
+												data-toggle="tooltip"
+												title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
+												><span class="text-truncate"
+													>Liferay Drive
+													(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
+												></span
+											>
+										</span>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-info-circle"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#info-circle"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+						<div
+							class="collapse"
+							id="showComponentExpanderCollapse02"
+						>
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<span
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<span class="autofit-row">
+												<span
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															><span
+																class="text-truncate"
+																data-toggle="tooltip"
+																title="Details"
+																>Details</span
+															></span
+														></span
+													>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<span
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<span class="autofit-row">
+												<span
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															data-toggle="tooltip"
+															title="Categorization"
+															><span
+																class="text-truncate"
+																>Categorization</span
+															></span
+														></span
+													>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<span
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<span class="autofit-row">
+												<span
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															data-toggle="tooltip"
+															title="Documents and Media"
+															><span
+																class="text-truncate"
+																>Documents and
+																Media</span
+															></span
+														></span
+													>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<span
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<span class="autofit-row">
+												<span
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															data-toggle="tooltip"
+															title="Site Template"
+															><span
+																class="text-truncate"
+																>Site
+																Template</span
+															></span
+														></span
+													>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+												<span class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</span>
+											</span>
+										</span>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="showComponentExpanderCollapse03"
+				aria-expanded="false"
+				class="collapsed treeview-link"
+				data-target="#showComponentExpanderCollapse03"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="-1"
+			>
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button
+								aria-controls="showComponentExpanderCollapse03"
+								aria-expanded="false"
+								class="btn btn-monospaced component-expander"
+								data-target="#showComponentExpanderCollapse03"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									data-toggle="tooltip"
+									title="Repositories"
+									><span class="text-truncate"
+										>Repositories</span
+									></span
+								>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse" id="showComponentExpanderCollapse03">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												data-toggle="tooltip"
+												title="Sitemap"
+												><span class="text-truncate"
+													>Sitemap</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												data-toggle="tooltip"
+												title="Robots"
+												><span class="text-truncate"
+													>Robots</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="showComponentExpanderCollapse04"
+				aria-expanded="false"
+				class="collapsed treeview-link"
+				data-target="#showComponentExpanderCollapse04"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="-1"
+			>
+				<span class="c-inner" tabindex="-2">
+					<span class="autofit-row">
+						<span class="autofit-col">
+							<button
+								aria-controls="showComponentExpanderCollapse04"
+								aria-expanded="false"
+								class="btn btn-monospaced component-expander"
+								data-target="#showComponentExpanderCollapse04"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<span class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</span>
+						</span>
+						<span class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									data-toggle="tooltip"
+									title="Documents and Media"
+									><span class="text-truncate"
+										>Documents and Media</span
+									></span
+								>
+							</span>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+						<span class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</span>
+					</span>
+				</span>
+			</div>
+			<div class="collapse" id="showComponentExpanderCollapse04">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												data-toggle="tooltip"
+												title="Default User Associations"
+												><span class="text-truncate"
+													>Default User
+													Associations</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												data-toggle="tooltip"
+												title="Staging"
+												><span class="text-truncate"
+													>Staging</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												data-toggle="tooltip"
+												title="Analytics"
+												><span class="text-truncate"
+													>Analytics</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<span
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<span class="autofit-row">
+									<span
+										class="autofit-col autofit-col-expand"
+									>
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												data-toggle="tooltip"
+												title="Maps"
+												><span class="text-truncate"
+													>Maps</span
+												></span
+											></span
+										>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+									<span class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</span>
+								</span>
+							</span>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+```
+
+### Treeview Light(#css-treeview-light)
+
+A `treeview` variation for light colored backgrounds.
+
+<div class="cadmin">
+	<ul class="treeview treeview-nested treeview-light" role="tree">
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewLightCollapseCheckbox01" aria-expanded="true" class="treeview-link" data-target="#treeviewLightCollapseCheckbox01" data-toggle="collapse" role="treeitem" tabindex="0">
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button aria-controls="treeviewLightCollapseCheckbox01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox01" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input class="custom-control-input" tabindex="-1" type="checkbox" />
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse show" id="treeviewLightCollapseCheckbox01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div aria-controls="treeviewLightCollapseCheckbox02" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewLightCollapseCheckbox02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<button aria-controls="treeviewLightCollapseCheckbox02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox02" data-toggle="collapse" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#angle-down" />
+												</svg>
+												<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#angle-right" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col">
+										<div class="component-icon">
+											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#folder" />
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span class="text-truncate-inline" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+										</span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="collapse" id="treeviewLightCollapseCheckbox02">
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div class="custom-control custom-checkbox">
+														<label>
+															<input class="custom-control-input" tabindex="-1" type="checkbox" />
+															<span class="custom-control-label"></span>
+														</label>
+													</div>
+												</div>
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" title="Details">Details</span></span></span>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div class="custom-control custom-checkbox">
+														<label>
+															<input class="custom-control-input" tabindex="-1" type="checkbox" />
+															<span class="custom-control-label"></span>
+														</label>
+													</div>
+												</div>
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div class="custom-control custom-checkbox">
+														<label>
+															<input class="custom-control-input" tabindex="-1" type="checkbox" />
+															<span class="custom-control-label"></span>
+														</label>
+													</div>
+												</div>
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div class="custom-control custom-checkbox">
+														<label>
+															<input class="custom-control-input" tabindex="-1" type="checkbox" />
+															<span class="custom-control-label"></span>
+														</label>
+													</div>
+												</div>
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewLightCollapseCheckbox03" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewLightCollapseCheckbox03" data-toggle="collapse" role="treeitem" tabindex="-1">
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button aria-controls="treeviewLightCollapseCheckbox03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox03" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input class="custom-control-input" tabindex="-1" type="checkbox" />
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Repositories"><span class="text-truncate">Repositories</span></span>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse" id="treeviewLightCollapseCheckbox03">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Robots"><span class="text-truncate">Robots</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewLightCollapseCheckbox04" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewLightCollapseCheckbox04" data-toggle="collapse" role="treeitem" tabindex="-1">
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button aria-controls="treeviewLightCollapseCheckbox04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox04" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input class="custom-control-input" tabindex="-1" type="checkbox" />
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse" id="treeviewLightCollapseCheckbox04">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Staging"><span class="text-truncate">Staging</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Maps"><span class="text-truncate">Maps</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+
+```html
+<div class="cadmin">
+	<ul class="treeview treeview-nested treeview-light" role="tree">
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewLightCollapseCheckbox01"
+				aria-expanded="true"
+				class="treeview-link"
+				data-target="#treeviewLightCollapseCheckbox01"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="0"
+			>
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button
+								aria-controls="treeviewLightCollapseCheckbox01"
+								aria-expanded="true"
+								class="btn btn-monospaced component-expander"
+								data-target="#treeviewLightCollapseCheckbox01"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input
+										class="custom-control-input"
+										tabindex="-1"
+										type="checkbox"
+									/>
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									title="Liferay Drive"
+									><span class="text-truncate"
+										>Liferay Drive</span
+									></span
+								>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse show" id="treeviewLightCollapseCheckbox01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							aria-controls="treeviewLightCollapseCheckbox02"
+							aria-expanded="false"
+							class="collapsed treeview-link"
+							data-target="#treeviewLightCollapseCheckbox02"
+							data-toggle="collapse"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<button
+											aria-controls="treeviewLightCollapseCheckbox02"
+											aria-expanded="false"
+											class="btn btn-monospaced component-expander"
+											data-target="#treeviewLightCollapseCheckbox02"
+											data-toggle="collapse"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-angle-down"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#angle-down"
+													/>
+												</svg>
+												<svg
+													class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#angle-right"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col">
+										<div class="component-icon">
+											<svg
+												class="lexicon-icon lexicon-icon-folder"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#folder"
+												/>
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span
+												class="text-truncate-inline"
+												title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
+												><span class="text-truncate"
+													>Liferay Drive
+													(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
+												></span
+											>
+										</span>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div
+							class="collapse"
+							id="treeviewLightCollapseCheckbox02"
+						>
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<div
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div
+														class="custom-control custom-checkbox"
+													>
+														<label>
+															<input
+																class="custom-control-input"
+																tabindex="-1"
+																type="checkbox"
+															/>
+															<span
+																class="custom-control-label"
+															></span>
+														</label>
+													</div>
+												</div>
+												<div
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															><span
+																class="text-truncate"
+																title="Details"
+																>Details</span
+															></span
+														></span
+													>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<div
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div
+														class="custom-control custom-checkbox"
+													>
+														<label>
+															<input
+																class="custom-control-input"
+																tabindex="-1"
+																type="checkbox"
+															/>
+															<span
+																class="custom-control-label"
+															></span>
+														</label>
+													</div>
+												</div>
+												<div
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Categorization"
+															><span
+																class="text-truncate"
+																>Categorization</span
+															></span
+														></span
+													>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<div
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div
+														class="custom-control custom-checkbox"
+													>
+														<label>
+															<input
+																class="custom-control-input"
+																tabindex="-1"
+																type="checkbox"
+															/>
+															<span
+																class="custom-control-label"
+															></span>
+														</label>
+													</div>
+												</div>
+												<div
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Documents and Media"
+															><span
+																class="text-truncate"
+																>Documents and
+																Media</span
+															></span
+														></span
+													>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<div
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div
+														class="custom-control custom-checkbox"
+													>
+														<label>
+															<input
+																class="custom-control-input"
+																tabindex="-1"
+																type="checkbox"
+															/>
+															<span
+																class="custom-control-label"
+															></span>
+														</label>
+													</div>
+												</div>
+												<div
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Site Template"
+															><span
+																class="text-truncate"
+																>Site
+																Template</span
+															></span
+														></span
+													>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewLightCollapseCheckbox03"
+				aria-expanded="false"
+				class="collapsed treeview-link"
+				data-target="#treeviewLightCollapseCheckbox03"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="-1"
+			>
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button
+								aria-controls="treeviewLightCollapseCheckbox03"
+								aria-expanded="false"
+								class="btn btn-monospaced component-expander"
+								data-target="#treeviewLightCollapseCheckbox03"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input
+										class="custom-control-input"
+										tabindex="-1"
+										type="checkbox"
+									/>
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									title="Repositories"
+									><span class="text-truncate"
+										>Repositories</span
+									></span
+								>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse" id="treeviewLightCollapseCheckbox03">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Sitemap"
+												><span class="text-truncate"
+													>Sitemap</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Robots"
+												><span class="text-truncate"
+													>Robots</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewLightCollapseCheckbox04"
+				aria-expanded="false"
+				class="collapsed treeview-link"
+				data-target="#treeviewLightCollapseCheckbox04"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="-1"
+			>
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button
+								aria-controls="treeviewLightCollapseCheckbox04"
+								aria-expanded="false"
+								class="btn btn-monospaced component-expander"
+								data-target="#treeviewLightCollapseCheckbox04"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input
+										class="custom-control-input"
+										tabindex="-1"
+										type="checkbox"
+									/>
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									title="Documents and Media"
+									><span class="text-truncate"
+										>Documents and Media</span
+									></span
+								>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse" id="treeviewLightCollapseCheckbox04">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Default User Associations"
+												><span class="text-truncate"
+													>Default User
+													Associations</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Staging"
+												><span class="text-truncate"
+													>Staging</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Analytics"
+												><span class="text-truncate"
+													>Analytics</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Maps"
+												><span class="text-truncate"
+													>Maps</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+```
+
+### Treeview Dark(#css-treeview-dark)
+
+A `treeview` variation for dark colored backgrounds.
+
+<div class="bg-dark cadmin">
+	<ul class="treeview treeview-dark treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewDarkCollapseCheckbox01" aria-expanded="true" class="treeview-link" data-target="#treeviewDarkCollapseCheckbox01" data-toggle="collapse" role="treeitem" tabindex="0">
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button aria-controls="treeviewDarkCollapseCheckbox01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewDarkCollapseCheckbox01" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input class="custom-control-input" tabindex="-1" type="checkbox" />
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse show" id="treeviewDarkCollapseCheckbox01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div aria-controls="treeviewDarkCollapseCheckbox02" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewDarkCollapseCheckbox02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<button aria-controls="treeviewDarkCollapseCheckbox02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewDarkCollapseCheckbox02" data-toggle="collapse" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#angle-down" />
+												</svg>
+												<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#angle-right" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col">
+										<div class="component-icon">
+											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#folder" />
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span class="text-truncate-inline" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+										</span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="collapse" id="treeviewDarkCollapseCheckbox02">
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div class="custom-control custom-checkbox">
+														<label>
+															<input class="custom-control-input" tabindex="-1" type="checkbox" />
+															<span class="custom-control-label"></span>
+														</label>
+													</div>
+												</div>
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" title="Details">Details</span></span></span>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div class="custom-control custom-checkbox">
+														<label>
+															<input class="custom-control-input" tabindex="-1" type="checkbox" />
+															<span class="custom-control-label"></span>
+														</label>
+													</div>
+												</div>
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div class="custom-control custom-checkbox">
+														<label>
+															<input class="custom-control-input" tabindex="-1" type="checkbox" />
+															<span class="custom-control-label"></span>
+														</label>
+													</div>
+												</div>
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div class="custom-control custom-checkbox">
+														<label>
+															<input class="custom-control-input" tabindex="-1" type="checkbox" />
+															<span class="custom-control-label"></span>
+														</label>
+													</div>
+												</div>
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text"><span class="text-truncate-inline" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewDarkCollapseCheckbox03" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewDarkCollapseCheckbox03" data-toggle="collapse" role="treeitem" tabindex="-1">
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button aria-controls="treeviewDarkCollapseCheckbox03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewDarkCollapseCheckbox03" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input class="custom-control-input" tabindex="-1" type="checkbox" />
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Repositories"><span class="text-truncate">Repositories</span></span>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse" id="treeviewDarkCollapseCheckbox03">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Robots"><span class="text-truncate">Robots</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div aria-controls="treeviewDarkCollapseCheckbox04" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewDarkCollapseCheckbox04" data-toggle="collapse" role="treeitem" tabindex="-1">
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button aria-controls="treeviewDarkCollapseCheckbox04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewDarkCollapseCheckbox04" data-toggle="collapse" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-down" />
+									</svg>
+									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#angle-right" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input class="custom-control-input" tabindex="-1" type="checkbox" />
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#folder" />
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+								<span class="c-inner" tabindex="-2">
+									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse" id="treeviewDarkCollapseCheckbox04">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Staging"><span class="text-truncate">Staging</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="custom-control custom-checkbox">
+											<label>
+												<input class="custom-control-input" tabindex="-1" type="checkbox" />
+												<span class="custom-control-label"></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"><span class="text-truncate-inline" title="Maps"><span class="text-truncate">Maps</span></span></span>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+
+```html
+<div class="bg-dark cadmin">
+	<ul class="treeview treeview-dark treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewDarkCollapseCheckbox01"
+				aria-expanded="true"
+				class="treeview-link"
+				data-target="#treeviewDarkCollapseCheckbox01"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="0"
+			>
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button
+								aria-controls="treeviewDarkCollapseCheckbox01"
+								aria-expanded="true"
+								class="btn btn-monospaced component-expander"
+								data-target="#treeviewDarkCollapseCheckbox01"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input
+										class="custom-control-input"
+										tabindex="-1"
+										type="checkbox"
+									/>
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									title="Liferay Drive"
+									><span class="text-truncate"
+										>Liferay Drive</span
+									></span
+								>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse show" id="treeviewDarkCollapseCheckbox01">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							aria-controls="treeviewDarkCollapseCheckbox02"
+							aria-expanded="false"
+							class="collapsed treeview-link"
+							data-target="#treeviewDarkCollapseCheckbox02"
+							data-toggle="collapse"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<button
+											aria-controls="treeviewDarkCollapseCheckbox02"
+											aria-expanded="false"
+											class="btn btn-monospaced component-expander"
+											data-target="#treeviewDarkCollapseCheckbox02"
+											data-toggle="collapse"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-angle-down"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#angle-down"
+													/>
+												</svg>
+												<svg
+													class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#angle-right"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col">
+										<div class="component-icon">
+											<svg
+												class="lexicon-icon lexicon-icon-folder"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#folder"
+												/>
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span
+												class="text-truncate-inline"
+												title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
+												><span class="text-truncate"
+													>Liferay Drive
+													(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
+												></span
+											>
+										</span>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div
+							class="collapse"
+							id="treeviewDarkCollapseCheckbox02"
+						>
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<div
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div
+														class="custom-control custom-checkbox"
+													>
+														<label>
+															<input
+																class="custom-control-input"
+																tabindex="-1"
+																type="checkbox"
+															/>
+															<span
+																class="custom-control-label"
+															></span>
+														</label>
+													</div>
+												</div>
+												<div
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															><span
+																class="text-truncate"
+																title="Details"
+																>Details</span
+															></span
+														></span
+													>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<div
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div
+														class="custom-control custom-checkbox"
+													>
+														<label>
+															<input
+																class="custom-control-input"
+																tabindex="-1"
+																type="checkbox"
+															/>
+															<span
+																class="custom-control-label"
+															></span>
+														</label>
+													</div>
+												</div>
+												<div
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Categorization"
+															><span
+																class="text-truncate"
+																>Categorization</span
+															></span
+														></span
+													>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<div
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div
+														class="custom-control custom-checkbox"
+													>
+														<label>
+															<input
+																class="custom-control-input"
+																tabindex="-1"
+																type="checkbox"
+															/>
+															<span
+																class="custom-control-label"
+															></span>
+														</label>
+													</div>
+												</div>
+												<div
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Documents and Media"
+															><span
+																class="text-truncate"
+																>Documents and
+																Media</span
+															></span
+														></span
+													>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+								<li class="treeview-item" role="none">
+									<div
+										class="treeview-link"
+										role="treeitem"
+										tabindex="-1"
+										style="padding-left:48px;"
+									>
+										<div
+											class="c-inner"
+											tabindex="-2"
+											style="margin-left:-48px;"
+										>
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div
+														class="custom-control custom-checkbox"
+													>
+														<label>
+															<input
+																class="custom-control-input"
+																tabindex="-1"
+																type="checkbox"
+															/>
+															<span
+																class="custom-control-label"
+															></span>
+														</label>
+													</div>
+												</div>
+												<div
+													class="autofit-col autofit-col-expand"
+												>
+													<span class="component-text"
+														><span
+															class="text-truncate-inline"
+															title="Site Template"
+															><span
+																class="text-truncate"
+																>Site
+																Template</span
+															></span
+														></span
+													>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-times-circle-full"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#times-circle-full"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+												<div class="autofit-col">
+													<button
+														class="btn btn-monospaced component-action"
+														tabindex="-1"
+														type="button"
+													>
+														<span
+															class="c-inner"
+															tabindex="-2"
+														>
+															<svg
+																class="lexicon-icon lexicon-icon-ellipsis-v"
+																focusable="false"
+																role="presentation"
+															>
+																<use
+																	xlink:href="/images/icons/icons.svg#ellipsis-v"
+																/>
+															</svg>
+														</span>
+													</button>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewDarkCollapseCheckbox03"
+				aria-expanded="false"
+				class="collapsed treeview-link"
+				data-target="#treeviewDarkCollapseCheckbox03"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="-1"
+			>
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button
+								aria-controls="treeviewDarkCollapseCheckbox03"
+								aria-expanded="false"
+								class="btn btn-monospaced component-expander"
+								data-target="#treeviewDarkCollapseCheckbox03"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input
+										class="custom-control-input"
+										tabindex="-1"
+										type="checkbox"
+									/>
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									title="Repositories"
+									><span class="text-truncate"
+										>Repositories</span
+									></span
+								>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse" id="treeviewDarkCollapseCheckbox03">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Sitemap"
+												><span class="text-truncate"
+													>Sitemap</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Robots"
+												><span class="text-truncate"
+													>Robots</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewDarkCollapseCheckbox04"
+				aria-expanded="false"
+				class="collapsed treeview-link"
+				data-target="#treeviewDarkCollapseCheckbox04"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="-1"
+			>
+				<div class="c-inner" tabindex="-2">
+					<div class="autofit-row">
+						<div class="autofit-col">
+							<button
+								aria-controls="treeviewDarkCollapseCheckbox04"
+								aria-expanded="false"
+								class="btn btn-monospaced component-expander"
+								data-target="#treeviewDarkCollapseCheckbox04"
+								data-toggle="collapse"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-angle-down"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-down"
+										/>
+									</svg>
+									<svg
+										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#angle-right"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<div class="custom-control custom-checkbox">
+								<label>
+									<input
+										class="custom-control-input"
+										tabindex="-1"
+										type="checkbox"
+									/>
+									<span class="custom-control-label"></span>
+								</label>
+							</div>
+						</div>
+						<div class="autofit-col">
+							<div class="component-icon">
+								<svg
+									class="lexicon-icon lexicon-icon-folder"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#folder"
+									/>
+								</svg>
+							</div>
+						</div>
+						<div class="autofit-col autofit-col-expand">
+							<span class="component-text">
+								<span
+									class="text-truncate-inline"
+									title="Documents and Media"
+									><span class="text-truncate"
+										>Documents and Media</span
+									></span
+								>
+							</span>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-times-circle-full"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#times-circle-full"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+						<div class="autofit-col">
+							<button
+								class="btn btn-monospaced component-action"
+								tabindex="-1"
+								type="button"
+							>
+								<span class="c-inner" tabindex="-2">
+									<svg
+										class="lexicon-icon lexicon-icon-ellipsis-v"
+										focusable="false"
+										role="presentation"
+									>
+										<use
+											xlink:href="/images/icons/icons.svg#ellipsis-v"
+										/>
+									</svg>
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="collapse" id="treeviewDarkCollapseCheckbox04">
+				<ul class="treeview-group" role="group">
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Default User Associations"
+												><span class="text-truncate"
+													>Default User
+													Associations</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Staging"
+												><span class="text-truncate"
+													>Staging</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Analytics"
+												><span class="text-truncate"
+													>Analytics</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div
+							class="treeview-link"
+							role="treeitem"
+							tabindex="-1"
+							style="padding-left:24px;"
+						>
+							<div
+								class="c-inner"
+								tabindex="-2"
+								style="margin-left:-24px;"
+							>
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div
+											class="custom-control custom-checkbox"
+										>
+											<label>
+												<input
+													class="custom-control-input"
+													tabindex="-1"
+													type="checkbox"
+												/>
+												<span
+													class="custom-control-label"
+												></span>
+											</label>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text"
+											><span
+												class="text-truncate-inline"
+												title="Maps"
+												><span class="text-truncate"
+													>Maps</span
+												></span
+											></span
+										>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-times-circle-full"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#times-circle-full"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+									<div class="autofit-col">
+										<button
+											class="btn btn-monospaced component-action"
+											tabindex="-1"
+											type="button"
+										>
+											<span class="c-inner" tabindex="-2">
+												<svg
+													class="lexicon-icon lexicon-icon-ellipsis-v"
+													focusable="false"
+													role="presentation"
+												>
+													<use
+														xlink:href="/images/icons/icons.svg#ellipsis-v"
+													/>
+												</svg>
+											</span>
+										</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+```

--- a/clayui.com/plugins/gatsby-plugin-clay-css-tasks/gatsby-node.js
+++ b/clayui.com/plugins/gatsby-plugin-clay-css-tasks/gatsby-node.js
@@ -140,6 +140,11 @@ const generateCSSFiles = (pluginOptions) => {
 		outFile: path.join(cssDir, 'base.css'),
 	});
 
+	const cadmin = compileSass({
+		file: path.join(scssDir, 'cadmin.scss'),
+		outFile: path.join(cssDir, 'cadmin.css'),
+	});
+
 	const colors = compileSass({
 		file: path.join(clayuiSrcDir, 'colors.scss'),
 		includePaths: [scssDir],
@@ -159,6 +164,8 @@ const generateCSSFiles = (pluginOptions) => {
 	fs.writeFileSync(path.join(cssDir, 'base.css'), base.css.toString());
 
 	fs.writeFileSync(path.join(cssDir, 'base.css.map'), base.map.toString());
+
+	fs.writeFileSync(path.join(cssDir, 'cadmin.css'), cadmin.css.toString());
 
 	fs.writeFileSync(path.join(cssDir, 'colors.css'), colors.css.toString());
 
@@ -186,7 +193,7 @@ exports.onPostBootstrap = ({reporter}, pluginOptions) => {
 	generateCSSFiles(pluginOptions);
 
 	reporter.info(
-		`Compiling 'atlas.css', 'colors.css', 'base.css' and 'colors-base.css' finished!`
+		`Compiling 'atlas.css', 'colors.css', 'base.css', 'cadmin.css' and 'colors-base.css' finished!`
 	);
 };
 
@@ -208,7 +215,7 @@ exports.onCreateDevServer = ({reporter}, pluginOptions) => {
 			generateCSSFiles(pluginOptions);
 
 			reporter.info(
-				`Compiling 'atlas.css', 'colors.css', 'base.css' and 'colors-base.css' finished!`
+				`Compiling 'atlas.css', 'colors.css', 'base.css', 'cadmin.css' and 'colors-base.css' finished!`
 			);
 		}
 	}

--- a/clayui.com/src/html.js
+++ b/clayui.com/src/html.js
@@ -23,6 +23,11 @@ export default (props) => {
 				/>
 				<link href="/css/atlas.css" id="clayCSSFile" rel="stylesheet" />
 				<link
+					href="/css/cadmin.css"
+					id="clayCadminFile"
+					rel="stylesheet"
+				/>
+				<link
 					href="/css/colors.css"
 					id="clayuiCSSFile"
 					rel="stylesheet"

--- a/packages/clay-css/src/content/cadmin_treeview.html
+++ b/packages/clay-css/src/content/cadmin_treeview.html
@@ -1,0 +1,2266 @@
+---
+title: Treeview
+section: Clay Admin (Cadmin)
+---
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Treeview</h3>
+
+		<div class="alert alert-warning">This component is a Cadmin only component. It must be wrapped in ```<div class="cadmin"></div>```. We should provide an option to omit this class.</div>
+
+		<div class="alert alert-info">
+			See <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/treeview-2a.html" rel="noreferrer noopener" target="_blank">https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-2/treeview-2a.html</a> for accessibility.
+		</div>
+	</div>
+
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Treeview with Checkboxes</h3>
+	</div>
+
+	<div class="col-md-4">
+		<div class="cadmin">
+			<ul class="treeview treeview-nested treeview-light" role="tree">
+				<li class="treeview-item" role="none">
+					<div aria-controls="treeviewCollapseCheckbox01" aria-expanded="true" class="treeview-link show" data-target="#treeviewCollapseCheckbox01" data-toggle="collapse" role="treeitem" tabindex="0">
+						<div class="c-inner" tabindex="-2">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<button aria-controls="treeviewCollapseCheckbox01" aria-expanded="true" class="btn btn-monospaced component-expander show" data-target="#treeviewCollapseCheckbox01" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
+									</div>
+								</div>
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+									</span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="collapse show" id="treeviewCollapseCheckbox01">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div aria-controls="treeviewCollapseCheckbox02" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapseCheckbox02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<button aria-controls="treeviewCollapseCheckbox02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapseCheckbox02" data-toggle="collapse" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+														</svg>
+														<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
+												</div>
+											</div>
+											<div class="autofit-col">
+												<div class="component-icon">
+													<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text">
+													<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+												</span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#info-circle" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+								<div class="collapse" id="treeviewCollapseCheckbox02">
+									<ul class="treeview-group" role="group">
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+												<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+													<div class="autofit-row">
+														<div class="autofit-col">
+															<div class="custom-control custom-checkbox">
+																<label>
+																	<input class="custom-control-input" tabindex="-1" type="checkbox" />
+																	<span class="custom-control-label"></span>
+																</label>
+															</div>
+														</div>
+														<div class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" data-toggle="tooltip" title="Details">Details</span></span></span>
+														</div>
+														<div class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</div>
+														<div class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</div>
+													</div>
+												</div>
+											</div>
+										</li>
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+												<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+													<div class="autofit-row">
+														<div class="autofit-col">
+															<div class="custom-control custom-checkbox">
+																<label>
+																	<input class="custom-control-input" tabindex="-1" type="checkbox" />
+																	<span class="custom-control-label"></span>
+																</label>
+															</div>
+														</div>
+														<div class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+														</div>
+														<div class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</div>
+														<div class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</div>
+													</div>
+												</div>
+											</div>
+										</li>
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+												<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+													<div class="autofit-row">
+														<div class="autofit-col">
+															<div class="custom-control custom-checkbox">
+																<label>
+																	<input class="custom-control-input" tabindex="-1" type="checkbox" />
+																	<span class="custom-control-label"></span>
+																</label>
+															</div>
+														</div>
+														<div class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+														</div>
+														<div class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</div>
+														<div class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</div>
+													</div>
+												</div>
+											</div>
+										</li>
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+												<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+													<div class="autofit-row">
+														<div class="autofit-col">
+															<div class="custom-control custom-checkbox">
+																<label>
+																	<input class="custom-control-input" tabindex="-1" type="checkbox" />
+																	<span class="custom-control-label"></span>
+																</label>
+															</div>
+														</div>
+														<div class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+														</div>
+														<div class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</div>
+														<div class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</div>
+													</div>
+												</div>
+											</div>
+										</li>
+									</ul>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div aria-controls="treeviewCollapseCheckbox03" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapseCheckbox03" data-toggle="collapse" role="treeitem" tabindex="-1">
+						<div class="c-inner" tabindex="-2">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<button aria-controls="treeviewCollapseCheckbox03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapseCheckbox03" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
+									</div>
+								</div>
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Repositories"><span class="text-truncate">Repositories</span></span>
+									</span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="collapse" id="treeviewCollapseCheckbox03">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
+												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
+												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Robots"><span class="text-truncate">Robots</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div aria-controls="treeviewCollapseCheckbox04" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapseCheckbox04" data-toggle="collapse" role="treeitem" tabindex="-1">
+						<div class="c-inner" tabindex="-2">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<button aria-controls="treeviewCollapseCheckbox04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapseCheckbox04" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
+									</div>
+								</div>
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+									</span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="collapse" id="treeviewCollapseCheckbox04">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
+												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
+												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Staging"><span class="text-truncate">Staging</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
+												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
+												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Maps"><span class="text-truncate">Maps</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Show Component Expander on Hover</h3>
+
+		<blockquote class="blockquote">
+			<p>The class `show-component-expander-on-hover` displays the `component-expander` when the mouse hovers over the `treeview` component.</p>
+		</blockquote>
+	</div>
+
+	<div class="col-md-4">
+		<div class="cadmin">
+			<ul class="show-component-expander-on-hover treeview treeview-nested treeview-light" role="tree">
+				<li class="treeview-item" role="none">
+					<div aria-controls="showComponentExpanderCollapse01" aria-expanded="true" class="treeview-link show" data-target="#showComponentExpanderCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+						<span class="c-inner" tabindex="-2">
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button aria-controls="showComponentExpanderCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander show" data-target="#showComponentExpanderCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+					<div class="collapse show" id="showComponentExpanderCollapse01">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div aria-controls="showComponentExpanderCollapse02" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<span class="autofit-row">
+											<span class="autofit-col">
+												<button aria-controls="showComponentExpanderCollapse02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse02" data-toggle="collapse" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+														</svg>
+														<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<span class="component-icon">
+													<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
+											</span>
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text">
+													<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+												</span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#info-circle" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+								<div class="collapse" id="showComponentExpanderCollapse02">
+									<ul class="treeview-group" role="group">
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+												<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+													<span class="autofit-row">
+														<span class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" data-toggle="tooltip" title="Details">Details</span></span></span>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+													</span>
+												</span>
+											</div>
+										</li>
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+												<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+													<span class="autofit-row">
+														<span class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+													</span>
+												</span>
+											</div>
+										</li>
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+												<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+													<span class="autofit-row">
+														<span class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+													</span>
+												</span>
+											</div>
+										</li>
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+												<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+													<span class="autofit-row">
+														<span class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+													</span>
+												</span>
+											</div>
+										</li>
+									</ul>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div aria-controls="showComponentExpanderCollapse03" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1">
+						<span class="c-inner" tabindex="-2">
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button aria-controls="showComponentExpanderCollapse03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse03" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Repositories"><span class="text-truncate">Repositories</span></span>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+					<div class="collapse" id="showComponentExpanderCollapse03">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Robots"><span class="text-truncate">Robots</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div aria-controls="showComponentExpanderCollapse04" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse04" data-toggle="collapse" role="treeitem" tabindex="-1">
+						<span class="c-inner" tabindex="-2">
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button aria-controls="showComponentExpanderCollapse04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse04" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+					<div class="collapse" id="showComponentExpanderCollapse04">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Staging"><span class="text-truncate">Staging</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Maps"><span class="text-truncate">Maps</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+
+	</div>
+
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Treeview Dark</h3>
+	</div>
+
+	<div class="col-md-4">
+		<div class="bg-dark">
+			<div class="cadmin">
+				<ul class="treeview treeview-dark treeview-nested" role="tree">
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="0">
+							<div class="c-inner" tabindex="-2">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="component-icon">
+											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+										</span>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div aria-controls="treeviewDarkCollapse01" aria-expanded="false" class="treeview-link" data-target="#treeviewDarkCollapse01" data-toggle="collapse" role="treeitem" tabindex="-1">
+							<div class="c-inner" tabindex="-2">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="btn btn-monospaced component-expander">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col">
+										<div class="component-icon">
+											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span class="text-truncate-inline" data-toggle="tooltip" title="Blogs"><span class="text-truncate">Blogs</span></span>
+										</span>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="collapse" id="treeviewDarkCollapse01">
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+											<div class="autofit-row">
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text">
+														<span class="text-truncate-inline" data-toggle="tooltip" title="Blog Post 1"><span class="text-truncate">Blog Post 1</span></span>
+													</span>
+												</div>
+											</div>
+										</div>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div aria-controls="treeviewDarkCollapse02" aria-expanded="false" class="treeview-link" data-target="#treeviewDarkCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1">
+							<div class="c-inner" tabindex="-2">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="btn btn-monospaced component-expander">
+											<span class="c-inner" tabindex="-2">
+												<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+												</svg>
+												<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+												</svg>
+											</span>
+										</div>
+									</div>
+									<div class="autofit-col">
+										<div class="component-icon">
+											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+										</span>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="collapse" id="treeviewDarkCollapse02">
+							<ul class="treeview-group" role="group">
+								<li class="treeview-item" role="none">
+									<div aria-controls="treeviewDarkCollapse03" aria-expanded="false" class="treeview-link" data-target="#treeviewDarkCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+										<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+											<div class="autofit-row">
+												<div class="autofit-col">
+													<div class="btn btn-monospaced component-expander">
+														<span class="c-inner" tabindex="-2">
+															<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+																<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+															</svg>
+															<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+																<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+															</svg>
+														</span>
+													</div>
+												</div>
+												<div class="autofit-col">
+													<div class="component-icon">
+														<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+														</svg>
+													</div>
+												</div>
+												<div class="autofit-col autofit-col-expand">
+													<span class="component-text">
+														<span class="text-truncate-inline" data-toggle="tooltip" title="Images"><span class="text-truncate">Images</span></span>
+													</span>
+												</div>
+											</div>
+										</div>
+									</div>
+									<div class="collapse" id="treeviewDarkCollapse03">
+										<ul class="treeview-group" role="group">
+											<li class="treeview-item" role="none">
+												<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+													<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+														<div class="autofit-row">
+															<div class="autofit-col">
+																<div class="component-icon">
+																	<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+																	</svg>
+																</div>
+															</div>
+															<div class="autofit-col autofit-col-expand">
+																<span class="component-text">
+																	<span class="text-truncate-inline" data-toggle="tooltip" title="Portraits"><span class="text-truncate">Portraits</span></span>
+																</span>
+															</div>
+														</div>
+													</div>
+												</div>
+											</li>
+										</ul>
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1">
+							<div class="c-inner" tabindex="-2">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="component-icon">
+											<svg class="lexicon-icon lexicon-icon-repository" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#repository" />
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span class="text-truncate-inline" data-toggle="tooltip" title="Repositories"><span class="text-truncate">Repositories</span></span>
+										</span>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+					<li class="treeview-item" role="none">
+						<div class="treeview-link" role="treeitem" tabindex="-1">
+							<div class="c-inner" tabindex="-2">
+								<div class="autofit-row">
+									<div class="autofit-col">
+										<div class="component-icon">
+											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+											</svg>
+										</div>
+									</div>
+									<div class="autofit-col autofit-col-expand">
+										<span class="component-text">
+											<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+										</span>
+									</div>
+								</div>
+							</div>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Treeview with Buttons and Links</h3>
+
+		<div class="alert alert-warning">
+			This should only be used if there are no auxiliary controls inside the button or link, such as `a` or `button`.
+		</div>
+	</div>
+
+	<div class="col-md-4">
+		<div class="cadmin">
+			<ul class="treeview treeview-light treeview-nested" role="tree">
+				<li class="treeview-item" role="none">
+					<button class="treeview-link" role="treeitem" tabindex="0" type="button">
+						<div class="c-inner" tabindex="-2">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-cloud" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#cloud" />
+										</svg>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+									</span>
+								</div>
+							</div>
+						</div>
+					</button>
+				</li>
+				<li class="treeview-item" role="none">
+					<button aria-controls="treeviewButtonsAndLinksCollapse01" aria-expanded="false" class="treeview-link" data-target="#treeviewButtonsAndLinksCollapse01" data-toggle="collapse" role="treeitem" tabindex="-1" type="button">
+						<div class="c-inner" tabindex="-2">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="btn btn-monospaced component-expander">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+										</svg>
+										<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+										</svg>
+									</div>
+								</div>
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Blogs"><span class="text-truncate">Blogs</span></span>
+									</span>
+								</div>
+							</div>
+						</div>
+					</button>
+					<div class="collapse" id="treeviewButtonsAndLinksCollapse01">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<button class="treeview-link" role="treeitem" tabindex="-1" type="button" style="padding-left:24px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<div class="autofit-row">
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text">
+													<span class="text-truncate-inline" data-toggle="tooltip" title="Blog Post 1"><span class="text-truncate">Blog Post 1</span></span>
+												</span>
+											</div>
+										</div>
+									</div>
+								</button>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<button aria-controls="treeviewButtonsAndLinksCollapse02" aria-expanded="false" class="treeview-link" data-target="#treeviewButtonsAndLinksCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1" type="button">
+						<div class="c-inner" tabindex="-2">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="btn btn-monospaced component-expander">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</div>
+								</div>
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+									</span>
+								</div>
+							</div>
+						</div>
+					</button>
+					<div class="collapse" id="treeviewButtonsAndLinksCollapse02">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<a aria-controls="treeviewButtonsAndLinksCollapse03" aria-expanded="false" class="treeview-link" href="#treeviewButtonsAndLinksCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="btn btn-monospaced component-expander">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+														</svg>
+														<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+														</svg>
+													</span>
+												</div>
+											</div>
+											<div class="autofit-col">
+												<div class="component-icon">
+													<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text">
+													<span class="text-truncate-inline" data-toggle="tooltip" title="Images"><span class="text-truncate">Images</span></span>
+												</span>
+											</div>
+										</div>
+									</div>
+								</a>
+								<div class="collapse" id="treeviewButtonsAndLinksCollapse03">
+									<ul class="treeview-group" role="group">
+										<li class="treeview-item" role="none">
+											<a class="treeview-link" href="#1" role="treeitem" tabindex="-1" style="padding-left:48px;">
+												<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+													<div class="autofit-row">
+														<div class="autofit-col">
+															<div class="component-icon">
+																<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+																</svg>
+															</div>
+														</div>
+														<div class="autofit-col autofit-col-expand">
+															<span class="component-text">
+																<span class="text-truncate-inline" data-toggle="tooltip" title="Portraits"><span class="text-truncate">Portraits</span></span>
+															</span>
+														</div>
+													</div>
+												</div>
+											</a>
+										</li>
+									</ul>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<a class="treeview-link" href="#1" role="treeitem" tabindex="-1">
+						<div class="c-inner" tabindex="-2">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-repository" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#repository" />
+										</svg>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Repositories"><span class="text-truncate">Repositories</span></span>
+									</span>
+								</div>
+							</div>
+						</div>
+					</a>
+				</li>
+				<li class="treeview-item" role="none">
+					<button class="treeview-link" role="treeitem" tabindex="-1" type="button">
+						<div class="c-inner" tabindex="-2">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+									</span>
+								</div>
+							</div>
+						</div>
+					</button>
+				</li>
+			</ul>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Treeview Nested Margins</h3>
+
+		<div class="cadmin">
+			<ul class="treeview treeview-nested-margins treeview-light" role="tree">
+				<li class="treeview-item" role="none">
+					<div aria-controls="treeviewCollapse01" aria-expanded="true" class="treeview-link show" data-target="#treeviewCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+						<span class="c-inner" tabindex="-2">
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button aria-controls="treeviewCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander show" data-target="#treeviewCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+					<div class="collapse show" id="treeviewCollapse01">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div aria-controls="treeviewCollapse02" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1">
+									<span class="c-inner" tabindex="-2">
+										<span class="autofit-row">
+											<span class="autofit-col">
+												<button aria-controls="treeviewCollapse02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse02" data-toggle="collapse" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+														</svg>
+														<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<span class="component-icon">
+													<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+													</svg>
+												</span>
+											</span>
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text">
+													<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+												</span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#info-circle" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+								<div class="collapse" id="treeviewCollapse02">
+									<ul class="treeview-group" role="group">
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1">
+												<span class="c-inner" tabindex="-2">
+													<span class="autofit-row">
+														<span class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" data-toggle="tooltip" title="Details">Details</span></span></span>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+													</span>
+												</span>
+											</div>
+										</li>
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1">
+												<span class="c-inner" tabindex="-2">
+													<span class="autofit-row">
+														<span class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+													</span>
+												</span>
+											</div>
+										</li>
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1">
+												<span class="c-inner" tabindex="-2">
+													<span class="autofit-row">
+														<span class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+													</span>
+												</span>
+											</div>
+										</li>
+										<li class="treeview-item" role="none">
+											<div class="treeview-link" role="treeitem" tabindex="-1">
+												<span class="c-inner" tabindex="-2">
+													<span class="autofit-row">
+														<span class="autofit-col autofit-col-expand">
+															<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+														<span class="autofit-col">
+															<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+																<span class="c-inner" tabindex="-2">
+																	<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+																		<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+																	</svg>
+																</span>
+															</button>
+														</span>
+													</span>
+												</span>
+											</div>
+										</li>
+									</ul>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div aria-controls="treeviewCollapse03" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1">
+						<span class="c-inner" tabindex="-2">
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button aria-controls="treeviewCollapse03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse03" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Repositories"><span class="text-truncate">Repositories</span></span>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+					<div class="collapse" id="treeviewCollapse03">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1">
+									<span class="c-inner" tabindex="-2">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1">
+									<span class="c-inner" tabindex="-2">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Robots"><span class="text-truncate">Robots</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div aria-controls="treeviewCollapse04" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse04" data-toggle="collapse" role="treeitem" tabindex="-1">
+						<span class="c-inner" tabindex="-2">
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button aria-controls="treeviewCollapse04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse04" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+					<div class="collapse" id="treeviewCollapse04">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1">
+									<span class="c-inner" tabindex="-2">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1">
+									<span class="c-inner" tabindex="-2">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Staging"><span class="text-truncate">Staging</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1">
+									<span class="c-inner" tabindex="-2">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1">
+									<span class="c-inner" tabindex="-2">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Maps"><span class="text-truncate">Maps</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+
+	</div>
+</div>
+
+<script>
+$('.treeview-link button').add('.treeview-link a').add('.treeview .custom-control').on('click', function(event) {
+	event.stopPropagation();
+});
+
+$('.treeview .btn[data-toggle="collapse"]').on('click', function(event) {
+	var target = $(this).attr('data-target');
+
+	$(target).collapse('toggle');
+});
+
+$(document).on('show.bs.collapse', function(event) {
+	var id = $(event.target).attr('id');
+	var target = $('[data-target="#' + id + '"]').length === 0 ? $('[href="#' + id + '"]') : $('[data-target="#' + id + '"]');
+
+	target.addClass('show');
+});
+
+$(document).on('hide.bs.collapse', function(event) {
+	var id = $(event.target).attr('id');
+	var target = $('[data-target="#' + id + '"]').length === 0 ? $('[href="#' + id + '"]') : $('[data-target="#' + id + '"]');
+
+	target.removeClass('show');
+});
+
+$('.treeview [role="treeitem"]').on('focus', function(event) {
+	var $this = $(this);
+
+	$this.addClass('focus');
+
+	$this.on('focusout', function(event) {
+		var containsRelatedTarget = event.currentTarget.contains(event.relatedTarget);
+		var focusOriginalLink = event.currentTarget === event.relatedTarget;
+
+		if (!containsRelatedTarget || focusOriginalLink) {
+			$this.removeClass('focus');
+			$this.find('[tabindex="0"]').first().attr('tabindex', -1);
+			$this.find('[tabindex="0"]').first().attr('tabindex', -1);
+
+			$this.off('focusout');
+		}
+	});
+});
+
+$('.treeview [role="treeitem"]').on('keydown', function(event) {
+	var $this = $(this);
+
+	event.stopPropagation();
+
+	if (event.keyCode === 13) { // enter
+		event.preventDefault();
+
+		$this.find('[tabindex="-1"]').first().focus();
+		$this.find('[tabindex="-1"]').attr('tabindex', 0);
+
+		$($this.attr('data-target')).collapse('toggle');
+	}
+
+	var tree = $this.closest('[role="tree"]');
+	var treeitems = tree.find('[role="treeitem"]');
+
+	var currentIndex = treeitems.index($(this));
+	var prevIndex = currentIndex - 1;
+	var nextIndex = currentIndex + 1;
+
+	if(event.keyCode === 38) { // up
+		event.preventDefault();
+
+		while(
+			$(treeitems.get(currentIndex)).hasClass('focus')
+			&& prevIndex > -1
+		) {
+			if ($(treeitems.get(prevIndex)).is(':visible')) {
+
+				$(treeitems.get(currentIndex)).blur();
+				$(treeitems.get(currentIndex)).removeClass('focus');
+				$(treeitems.get(currentIndex)).attr('tabindex', -1);
+
+				$(treeitems.get(prevIndex)).focus();
+				$(treeitems.get(prevIndex)).addClass('focus');
+				$(treeitems.get(prevIndex)).attr('tabindex', 0);
+			}
+
+			prevIndex--;
+		}
+	}
+
+	if (event.keyCode === 40) { // down
+		event.preventDefault();
+
+		while(
+			$(treeitems.get(currentIndex)).hasClass('focus')
+			&& nextIndex < treeitems.length
+		) {
+			if ($(treeitems.get(nextIndex)).is(':visible')) {
+
+				$(treeitems.get(currentIndex)).blur();
+				$(treeitems.get(currentIndex)).removeClass('focus');
+				$(treeitems.get(currentIndex)).attr('tabindex', -1);
+
+				$(treeitems.get(nextIndex)).focus();
+				$(treeitems.get(nextIndex)).addClass('focus');
+				$(treeitems.get(nextIndex)).attr('tabindex', 0);
+			}
+
+			nextIndex++;
+		}
+	}
+});
+
+$(function () {
+	$('[data-toggle="tooltip"]').tooltip();
+});
+</script>

--- a/packages/clay-css/src/scss/cadmin.scss
+++ b/packages/clay-css/src/scss/cadmin.scss
@@ -76,6 +76,7 @@ html#{$cadmin-selector} {
 		@import 'cadmin/components/_tbar';
 		@import 'cadmin/components/_toggle-switch';
 		@import 'cadmin/components/_tooltip';
+		@import 'cadmin/components/_treeview';
 
 		@import 'cadmin/components/_utilities';
 		@import 'cadmin/components/_utilities-functional-important';

--- a/packages/clay-css/src/scss/cadmin/_variables.scss
+++ b/packages/clay-css/src/scss/cadmin/_variables.scss
@@ -53,6 +53,7 @@
 @import 'variables/_tbar';
 @import 'variables/_toggle-switch';
 @import 'variables/_tooltip';
+@import 'variables/_treeview';
 @import 'variables/_type';
 
 @import 'variables/_utilities';

--- a/packages/clay-css/src/scss/cadmin/components/_links.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_links.scss
@@ -65,3 +65,20 @@ button.link-outline {
 .component-action {
 	@include clay-link($cadmin-component-action);
 }
+
+.component-text {
+	@include clay-css($cadmin-component-text);
+}
+
+.component-icon {
+	@include clay-css($cadmin-component-icon);
+
+	.lexicon-icon {
+		$lexicon-icon: setter(
+			map-get($cadmin-component-icon, lexicon-icon),
+			()
+		);
+
+		@include clay-css($lexicon-icon);
+	}
+}

--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -1,0 +1,421 @@
+.treeview {
+	@include clay-css($cadmin-treeview);
+
+	.btn {
+		$btn: setter(map-get($cadmin-treeview, btn), ());
+
+		@include clay-button-variant($btn);
+	}
+
+	.btn-monospaced {
+		$btn-monospaced: setter(map-get($cadmin-treeview, btn-monospaced), ());
+
+		@include clay-button-variant($btn-monospaced);
+	}
+
+	.custom-control {
+		$custom-control: setter(map-get($cadmin-treeview, custom-control), ());
+
+		@include clay-css($custom-control);
+	}
+
+	&.show-component-expander-on-hover {
+		@include clay-css($cadmin-treeview-show-component-expander-on-hover);
+
+		&:hover,
+		&.hover {
+			$hover: setter(
+				map-get(
+					$cadmin-treeview-show-component-expander-on-hover,
+					hover
+				),
+				()
+			);
+
+			@include clay-css($hover);
+
+			.component-expander {
+				$component-expander: setter(
+					map-get($hover, component-expander),
+					()
+				);
+
+				@include clay-css($component-expander);
+			}
+		}
+
+		.treeview-link {
+			$treeview-link: setter(
+				map-get(
+					$cadmin-treeview-show-component-expander-on-hover,
+					treeview-link
+				),
+				()
+			);
+
+			@include clay-css($treeview-link);
+
+			&:focus,
+			&.focus {
+				$focus: setter(map-get($treeview-link, focus), ());
+
+				@include clay-css($focus);
+
+				.component-expander {
+					$component-expander: setter(
+						map-get($focus, component-expander)
+					);
+
+					@include clay-css($component-expander);
+				}
+			}
+		}
+
+		.component-expander {
+			$component-expander: setter(
+				map-get(
+					$cadmin-treeview-show-component-expander-on-hover,
+					component-expander
+				),
+				()
+			);
+
+			@include clay-css($component-expander);
+		}
+	}
+}
+
+.treeview-group {
+	$group: setter(map-get($cadmin-treeview, group), ());
+
+	@include clay-css($group);
+}
+
+.treeview-item {
+	$item: setter(map-get($cadmin-treeview, item), ());
+
+	@include clay-css($item);
+
+	&:last-child {
+		$last-child: setter(map-get($item, last-child), ());
+
+		@include clay-css($last-child);
+	}
+}
+
+.treeview-link {
+	$link: setter(map-get($cadmin-treeview, link), ());
+
+	@include clay-link($link);
+
+	&.hover,
+	&:hover,
+	&.focus,
+	&:focus {
+		.component-action {
+			display: block;
+		}
+	}
+
+	&.show,
+	&[aria-expanded='true'] {
+		.component-expander {
+			.component-expanded-d-none {
+				display: none;
+			}
+
+			.lexicon-icon:not(.component-expanded-d-none) {
+				display: inline-block;
+			}
+		}
+	}
+}
+
+.component-expander {
+	$component-expander: setter(
+		map-get($cadmin-treeview, component-expander),
+		()
+	);
+
+	@include clay-button-variant($component-expander);
+
+	.lexicon-icon:not(.component-expanded-d-none) {
+		display: none;
+	}
+}
+
+.component-action {
+	$component-action: setter(map-get($cadmin-treeview, component-action), ());
+
+	@include clay-button-variant($component-action);
+}
+
+.component-icon {
+	$component-icon: setter(map-get($cadmin-treeview, component-icon), ());
+
+	@include clay-css($component-icon);
+
+	.lexicon-icon {
+		$lexicon-icon: setter(map-get($component-icon, lexicon-icon), ());
+
+		@include clay-css($lexicon-icon);
+	}
+}
+
+.component-text {
+	$component-text: setter(map-get($cadmin-treeview, component-text), ());
+
+	@include clay-css($component-text);
+}
+
+.treeview-nested-margins {
+	.treeview-group .treeview-item {
+		margin-left: 24px;
+	}
+}
+
+.treeview-nested {
+	padding-bottom: 4px;
+	padding-top: 4px;
+
+	> .treeview-item > .treeview-link {
+		padding-left: 0;
+
+		> .c-inner {
+			margin-left: 0;
+		}
+	}
+
+	.treeview-group {
+		> .treeview-item > .treeview-link {
+			padding-left: 24px;
+
+			> .c-inner {
+				margin-left: -24px;
+			}
+		}
+	}
+
+	.treeview-group .treeview-group > .treeview-item > .treeview-link {
+		padding-left: 48px;
+
+		> .c-inner {
+			margin-left: -48px;
+		}
+	}
+
+	.treeview-group
+		.treeview-group
+		.treeview-group
+		> .treeview-item
+		> .treeview-link {
+		padding-left: 72px;
+
+		> .c-inner {
+			margin-left: -72px;
+		}
+	}
+
+	.treeview-group
+		.treeview-group
+		.treeview-group
+		.treeview-group
+		> .treeview-item
+		> .treeview-link {
+		padding-left: 96px;
+
+		> .c-inner {
+			margin-left: -96px;
+		}
+	}
+}
+
+// Treeview Variants
+
+.treeview-light {
+	@include clay-css($cadmin-treeview-light);
+
+	.btn {
+		$btn: setter(map-get($cadmin-treeview-light, btn), ());
+
+		@include clay-button-variant($btn);
+	}
+
+	.btn-monospaced {
+		$btn-monospaced: setter(
+			map-get($cadmin-treeview-light, btn-monospaced),
+			()
+		);
+
+		@include clay-button-variant($btn-monospaced);
+	}
+
+	.component-expander {
+		$component-expander: setter(
+			map-get($cadmin-treeview-light, component-expander),
+			()
+		);
+
+		@include clay-button-variant($component-expander);
+
+		&.btn-secondary {
+			$btn-secondary: setter(
+				map-get($component-expander, btn-secondary),
+				()
+			);
+
+			@include clay-button-variant($btn-secondary);
+		}
+	}
+
+	.custom-control {
+		$custom-control: setter(
+			map-get($cadmin-treeview-light, custom-control),
+			()
+		);
+
+		@include clay-css($custom-control);
+	}
+
+	.treeview-group {
+		$group: setter(map-get($cadmin-treeview-light, group), ());
+
+		@include clay-css($group);
+	}
+
+	.treeview-item {
+		$item: setter(map-get($cadmin-treeview-light, item), ());
+
+		@include clay-css($item);
+
+		&:last-child {
+			$last-child: setter(map-get($item, last-child), ());
+
+			@include clay-css($last-child);
+		}
+	}
+
+	.treeview-link {
+		$link: setter(map-get($cadmin-treeview-light, link), ());
+
+		@include clay-link($link);
+	}
+
+	.component-action {
+		$component-action: setter(
+			map-get($cadmin-treeview-light, component-action),
+			()
+		);
+
+		@include clay-button-variant($component-action);
+	}
+
+	.component-icon {
+		$component: setter(map-get($cadmin-treeview-light, component), ());
+
+		@include clay-css($component);
+	}
+
+	.component-text {
+		$component: setter(map-get($cadmin-treeview-light, component), ());
+
+		@include clay-css($component);
+	}
+}
+
+.treeview-dark {
+	@include clay-css($cadmin-treeview-dark);
+
+	.btn {
+		$btn: setter(map-get($cadmin-treeview-dark, btn), ());
+
+		@include clay-button-variant($btn);
+	}
+
+	.btn-monospaced {
+		$btn-monospaced: setter(
+			map-get($cadmin-treeview-dark, btn-monospaced),
+			()
+		);
+
+		@include clay-button-variant($btn-monospaced);
+	}
+
+	.component-expander {
+		$component-expander: setter(
+			map-get($cadmin-treeview-dark, component-expander),
+			()
+		);
+
+		@include clay-button-variant($component-expander);
+
+		&.btn-secondary {
+			$btn-secondary: setter(
+				map-get($component-expander, btn-secondary),
+				()
+			);
+
+			@include clay-button-variant($btn-secondary);
+		}
+	}
+
+	.custom-control {
+		$custom-control: setter(
+			map-get($cadmin-treeview-dark, custom-control),
+			()
+		);
+
+		@include clay-css($custom-control);
+	}
+
+	.treeview-group {
+		$group: setter(map-get($cadmin-treeview-dark, group), ());
+
+		@include clay-css($group);
+	}
+
+	.treeview-item {
+		$item: setter(map-get($cadmin-treeview-dark, item), ());
+
+		@include clay-css($item);
+
+		&:last-child {
+			$last-child: setter(map-get($item, last-child), ());
+
+			@include clay-css($last-child);
+		}
+	}
+
+	.treeview-link {
+		$link: setter(map-get($cadmin-treeview-dark, link), ());
+
+		@include clay-link($link);
+	}
+
+	.component-action {
+		$component-action: setter(
+			map-get($cadmin-treeview-dark, component-action),
+			()
+		);
+
+		@include clay-button-variant($component-action);
+	}
+
+	.component-icon {
+		$component-icon: setter(
+			map-get($cadmin-treeview-dark, component-icon),
+			()
+		);
+
+		@include clay-css($component-icon);
+	}
+
+	.component-text {
+		$component-text: setter(
+			map-get($cadmin-treeview-dark, component-text),
+			()
+		);
+
+		@include clay-css($component-text);
+	}
+}

--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -86,13 +86,13 @@
 }
 
 .treeview-group {
-	$group: setter(map-get($cadmin-treeview, group), ());
+	$group: setter(map-get($cadmin-treeview, treeview-group), ());
 
 	@include clay-css($group);
 }
 
 .treeview-item {
-	$item: setter(map-get($cadmin-treeview, item), ());
+	$item: setter(map-get($cadmin-treeview, treeview-item), ());
 
 	@include clay-css($item);
 
@@ -169,63 +169,20 @@
 }
 
 .treeview-nested-margins {
-	.treeview-group .treeview-item {
-		margin-left: 24px;
-	}
-}
-
-.treeview-nested {
-	padding-bottom: 4px;
-	padding-top: 4px;
-
-	> .treeview-item > .treeview-link {
-		padding-left: 0;
-
-		> .c-inner {
-			margin-left: 0;
-		}
-	}
+	@include clay-css($cadmin-treeview-nested-margins);
 
 	.treeview-group {
-		> .treeview-item > .treeview-link {
-			padding-left: 24px;
+		$group: setter(
+			map-get($cadmin-treeview-nested-margins, treeview-group),
+			()
+		);
 
-			> .c-inner {
-				margin-left: -24px;
-			}
-		}
-	}
+		@include clay-css($group);
 
-	.treeview-group .treeview-group > .treeview-item > .treeview-link {
-		padding-left: 48px;
+		.treeview-item {
+			$item: setter(map-get($group, treeview-item), ());
 
-		> .c-inner {
-			margin-left: -48px;
-		}
-	}
-
-	.treeview-group
-		.treeview-group
-		.treeview-group
-		> .treeview-item
-		> .treeview-link {
-		padding-left: 72px;
-
-		> .c-inner {
-			margin-left: -72px;
-		}
-	}
-
-	.treeview-group
-		.treeview-group
-		.treeview-group
-		.treeview-group
-		> .treeview-item
-		> .treeview-link {
-		padding-left: 96px;
-
-		> .c-inner {
-			margin-left: -96px;
+			@include clay-css($item);
 		}
 	}
 }
@@ -278,13 +235,13 @@
 	}
 
 	.treeview-group {
-		$group: setter(map-get($cadmin-treeview-light, group), ());
+		$group: setter(map-get($cadmin-treeview-light, treeview-group), ());
 
 		@include clay-css($group);
 	}
 
 	.treeview-item {
-		$item: setter(map-get($cadmin-treeview-light, item), ());
+		$item: setter(map-get($cadmin-treeview-light, treeview-item), ());
 
 		@include clay-css($item);
 
@@ -369,13 +326,13 @@
 	}
 
 	.treeview-group {
-		$group: setter(map-get($cadmin-treeview-dark, group), ());
+		$group: setter(map-get($cadmin-treeview-dark, treeview-group), ());
 
 		@include clay-css($group);
 	}
 
 	.treeview-item {
-		$item: setter(map-get($cadmin-treeview-dark, item), ());
+		$item: setter(map-get($cadmin-treeview-dark, treeview-item), ());
 
 		@include clay-css($item);
 

--- a/packages/clay-css/src/scss/cadmin/variables/_links.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_links.scss
@@ -332,3 +332,20 @@ $cadmin-component-action: map-deep-merge(
 	),
 	$cadmin-component-action
 );
+
+$cadmin-component-text: () !default;
+
+$cadmin-component-icon: () !default;
+$cadmin-component-icon: map-deep-merge(
+	(
+		align-items: center,
+		display: inline-flex,
+		height: 32px,
+		justify-content: center,
+		width: 32px,
+		lexicon-icon: (
+			margin-top: 0,
+		),
+	),
+	$cadmin-component-icon
+);

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -1,0 +1,177 @@
+$cadmin-treeview: () !default;
+$cadmin-treeview: map-merge(
+	(
+		display: block,
+		font-size: 14px,
+		list-style: none,
+		margin-bottom: 0,
+		padding-left: 0,
+		btn-monospaced: (
+			font-size: 14px,
+			height: 24px,
+			width: 24px,
+			focus: (
+				box-shadow: $cadmin-component-focus-inset-box-shadow,
+			),
+		),
+		custom-control: (
+			margin-left: 4px,
+			margin-right: 4px,
+			margin-top: 1.5px,
+		),
+		group: (
+			display: block,
+			list-style: none,
+			margin-bottom: 0,
+			padding-left: 0,
+		),
+		item: (
+			padding-bottom: 2px,
+			padding-top: 2px,
+			word-wrap: break-word,
+			last-child: (
+				padding-bottom: 0,
+			),
+		),
+		link: (
+			cursor: pointer,
+			display: block,
+			min-width: 100%,
+			padding: 0,
+			position: relative,
+			user-select: none,
+			hover: (
+				text-decoration: none,
+			),
+			focus: (
+				box-shadow: $cadmin-component-focus-inset-box-shadow,
+				outline: 0,
+			),
+		),
+		component-action: (
+			display: none,
+			margin-left: 2px,
+			margin-right: 2px,
+			hover: (
+				background-color: transparent,
+				color: $cadmin-secondary,
+			),
+			focus: (
+				color: $cadmin-secondary,
+			),
+			active: (
+				background-color: transparent,
+			),
+		),
+		component-icon: (
+			display: inline,
+			height: auto,
+			margin-left: 4px,
+			margin-right: 4px,
+			width: auto,
+		),
+		component-text: (
+			padding-bottom: 1.5px,
+			padding-left: 4px,
+			padding-top: 1.5px,
+			user-select: auto,
+		),
+	),
+	$cadmin-treeview
+);
+
+$cadmin-treeview-show-component-expander-on-hover: () !default;
+$cadmin-treeview-show-component-expander-on-hover: map-deep-merge(
+	(
+		hover: (
+			component-expander: (
+				opacity: 1,
+				transition: opacity ease-in-out 600ms,
+			),
+		),
+		component-expander: (
+			opacity: 0,
+			transition: opacity ease-in-out 450ms,
+		),
+		treeview-link: (
+			focus: (
+				component-expander: (
+					opacity: 1,
+					transition: none,
+				),
+			),
+		),
+	),
+	$cadmin-treeview-show-component-expander-on-hover
+);
+
+// Variants
+
+$cadmin-treeview-light: () !default;
+$cadmin-treeview-light: map-deep-merge(
+	(
+		component-expander: (
+			color: $cadmin-secondary,
+			hover: (
+				color: $cadmin-primary,
+			),
+			btn-secondary: (
+				background-color: $cadmin-white,
+			),
+		),
+		link: (
+			color: $cadmin-gray-600,
+			hover: (
+				background-color: $cadmin-gray-100,
+				color: $cadmin-gray-900,
+			),
+			active: (
+				background-color: $cadmin-gray-200,
+				color: $cadmin-gray-900,
+			),
+			active-class: (
+				background-color: $cadmin-gray-200,
+				color: $cadmin-gray-900,
+			),
+			show: (
+				background-color: null,
+				color: null,
+			),
+		),
+	),
+	$cadmin-treeview-light
+);
+
+$cadmin-treeview-dark: () !default;
+$cadmin-treeview-dark: map-deep-merge(
+	(
+		component-expander: (
+			color: $cadmin-secondary-l1,
+			hover: (
+				color: $cadmin-primary-l1,
+			),
+		),
+		link: (
+			color: $cadmin-secondary-l1,
+			hover: (
+				background-color: rgba($cadmin-white, 0.04),
+			),
+			active-class: (
+				background-color: rgba($cadmin-white, 0.06),
+				color: $cadmin-white,
+			),
+			disabled: (
+				background-color: transparent,
+				color: rgba($cadmin-secondary-l1, 0.04),
+			),
+			show: (
+				background-color: null,
+				color: null,
+			),
+		),
+		component-action: (
+			color: $cadmin-secondary-l1,
+		),
+	),
+	$cadmin-treeview-dark
+);

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -1,11 +1,12 @@
 $cadmin-treeview: () !default;
 $cadmin-treeview: map-merge(
 	(
-		display: block,
+		display: flex,
+		flex-direction: column,
 		font-size: 14px,
 		list-style: none,
 		margin-bottom: 0,
-		padding-left: 0,
+		padding: 2px 0,
 		btn-monospaced: (
 			font-size: 14px,
 			height: 24px,
@@ -19,23 +20,21 @@ $cadmin-treeview: map-merge(
 			margin-right: 4px,
 			margin-top: 1.5px,
 		),
-		group: (
-			display: block,
+		treeview-group: (
+			display: flex,
+			flex-direction: column,
 			list-style: none,
 			margin-bottom: 0,
 			padding-left: 0,
 		),
-		item: (
-			padding-bottom: 2px,
-			padding-top: 2px,
+		treeview-item: (
 			word-wrap: break-word,
-			last-child: (
-				padding-bottom: 0,
-			),
 		),
 		link: (
 			cursor: pointer,
 			display: block,
+			margin-bottom: 2px,
+			margin-top: 2px,
 			min-width: 100%,
 			padding: 0,
 			position: relative,
@@ -78,6 +77,18 @@ $cadmin-treeview: map-merge(
 		),
 	),
 	$cadmin-treeview
+);
+
+$cadmin-treeview-nested-margins: () !default;
+$cadmin-treeview-nested-margins: map-deep-merge(
+	(
+		treeview-group: (
+			treeview-item: (
+				margin-left: 24px,
+			),
+		),
+	),
+	$cadmin-treeview-nested-margins
 );
 
 $cadmin-treeview-show-component-expander-on-hover: () !default;


### PR DESCRIPTION
I'm not 100% happy with this implementation. The markup is huge since I'm trying to cover all use cases. I tried to pare it down, but couldn't find a good solution for icon placement and working with all the different combinations of html elements (`a`, `button`). If the markup causes laggy rendering issues in the React component, I was thinking about adding a version with lighter markup for specific cases. 🤷 

Also we need the Cadmin pr to get merged in Portal before we can use this component. I can focus on getting that merged next. We can break things now.

![treeview](https://user-images.githubusercontent.com/788266/122304259-ca1b7200-ceb9-11eb-9eff-7b8091cf47b2.jpg)

fixes #4111