### PR TITLE
docs(clayui.com): Dropdown Menu adds example of menuElementAttrs to f…

### DIFF
--- a/packages/clay-drop-down/docs/index.js
+++ b/packages/clay-drop-down/docs/index.js
@@ -21,6 +21,13 @@ const dropDownCode = `const Component = () => {
 			trigger={<button className="btn btn-primary">Click here!</button>}
 			active={active}
 			onActiveChange={setActive}
+			menuElementAttrs={{
+				className: 'my-custom-dropdown-menu',
+				containerProps: {
+					className: 'dropdown-menu-react-portal-div',
+					id: 'dropdownMenuReactPortalDiv',
+				},
+			}}
 		>
 			<ClayDropDown.Help>{'Can I help you?'}</ClayDropDown.Help>
 			<ClayDropDown.ItemList>


### PR DESCRIPTION
…irst example

I realized this is under the API sections of the docs, but I always forget to check there and have a hard time remembering the syntax. If this is overkill, feel free to close it.

fixes #4105