### PR TITLE
fix(@clayui/layout): ContentCol should use autofit-col-end instead of autofit-col-float-end

### DIFF
--- a/packages/clay-layout/src/Content.tsx
+++ b/packages/clay-layout/src/Content.tsx
@@ -132,7 +132,7 @@ const ContentCol = React.forwardRef<HTMLElement, IContentColProps>(
 				'autofit-col-expand': expand,
 				'autofit-col-gutters': gutters,
 				'autofit-col-shrink': shrink,
-				[`autofit-col-float-${float}`]: float,
+				[`autofit-col-${float}`]: float,
 			})}
 			ref={ref}
 		>


### PR DESCRIPTION
Found this while using the Layout components, I think this should be `autofit-col-end` instead of `autofit-col-float-end`