### PR TITLE
feat(@clayui/list): Add `forwardRef` to ClayList components

### DIFF
--- a/packages/clay-list/src/Header.tsx
+++ b/packages/clay-list/src/Header.tsx
@@ -6,18 +6,20 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayListHeader: React.FunctionComponent<React.HTMLAttributes<
-	HTMLLIElement
->> = ({children, className, ...otherProps}) => {
+const ClayListHeader = React.forwardRef<
+	HTMLLIElement,
+	React.HTMLAttributes<HTMLLIElement>
+>(({children, className, ...otherProps}, ref) => {
 	return (
 		<li
 			{...otherProps}
 			className={classNames('list-group-header', className)}
+			ref={ref}
 		>
 			<p className="list-group-header-title">{children}</p>
 		</li>
 	);
-};
+});
 
 ClayListHeader.displayName = 'ClayListHeader';
 

--- a/packages/clay-list/src/ItemText.tsx
+++ b/packages/clay-list/src/ItemText.tsx
@@ -12,23 +12,19 @@ interface IProps extends React.HTMLAttributes<HTMLParagraphElement> {
 	 */
 	subtext?: boolean;
 }
-const ClayListItemText: React.FunctionComponent<IProps> = ({
-	children,
-	className,
-	subtext,
-	...otherProps
-}: IProps) => {
-	return (
+const ClayListItemText = React.forwardRef<HTMLParagraphElement, IProps>(
+	({children, className, subtext, ...otherProps}: IProps, ref) => (
 		<p
 			{...otherProps}
 			className={classNames(className, {
 				'list-group-subtext': subtext,
 				'list-group-text': !subtext,
 			})}
+			ref={ref}
 		>
 			{children}
 		</p>
-	);
-};
+	)
+);
 
 export default ClayListItemText;

--- a/packages/clay-list/src/ItemText.tsx
+++ b/packages/clay-list/src/ItemText.tsx
@@ -27,4 +27,6 @@ const ClayListItemText = React.forwardRef<HTMLParagraphElement, IProps>(
 	)
 );
 
+ClayListItemText.displayName = 'ClayListItemText';
+
 export default ClayListItemText;

--- a/packages/clay-list/src/ItemTitle.tsx
+++ b/packages/clay-list/src/ItemTitle.tsx
@@ -31,4 +31,6 @@ const ClayListItemTitle = React.forwardRef<
 	);
 });
 
+ClayListItemTitle.displayName = 'ClayListItemTitle';
+
 export default ClayListItemTitle;

--- a/packages/clay-list/src/ItemTitle.tsx
+++ b/packages/clay-list/src/ItemTitle.tsx
@@ -7,9 +7,10 @@ import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayListItemTitle: React.FunctionComponent<React.BaseHTMLAttributes<
-	HTMLAnchorElement
->> = ({children, className, href, ...otherProps}) => {
+const ClayListItemTitle = React.forwardRef<
+	HTMLDivElement,
+	React.BaseHTMLAttributes<HTMLAnchorElement>
+>(({children, className, href, ...otherProps}, ref) => {
 	const TagName = href ? 'div' : 'p';
 
 	const content = href ? (
@@ -21,10 +22,13 @@ const ClayListItemTitle: React.FunctionComponent<React.BaseHTMLAttributes<
 	);
 
 	return (
-		<TagName className={classNames('list-group-title', className)}>
+		<TagName
+			className={classNames('list-group-title', className)}
+			ref={ref}
+		>
 			{content}
 		</TagName>
 	);
-};
+});
 
 export default ClayListItemTitle;

--- a/packages/clay-list/src/QuickActionMenu.tsx
+++ b/packages/clay-list/src/QuickActionMenu.tsx
@@ -23,6 +23,8 @@ const ClayListQuickActionMenu = React.forwardRef<
 	);
 });
 
+ClayListQuickActionMenu.displayName = 'ClayListQuickActionMenu';
+
 export default Object.assign(ClayListQuickActionMenu, {
 	Item: QuickActionMenuItem,
 });

--- a/packages/clay-list/src/QuickActionMenu.tsx
+++ b/packages/clay-list/src/QuickActionMenu.tsx
@@ -8,21 +8,21 @@ import React from 'react';
 
 import QuickActionMenuItem from './QuickActionMenuItem';
 
-const ClayListQuickActionMenu: React.FunctionComponent<
+const ClayListQuickActionMenu = React.forwardRef<
+	HTMLDivElement,
 	React.HTMLAttributes<HTMLDivElement>
-> & {
-	Item: typeof QuickActionMenuItem;
-} = ({children, className, ...otherProps}) => {
+>(({children, className, ...otherProps}, ref) => {
 	return (
 		<div
 			{...otherProps}
 			className={classNames('quick-action-menu', className)}
+			ref={ref}
 		>
 			{children}
 		</div>
 	);
-};
+});
 
-ClayListQuickActionMenu.Item = QuickActionMenuItem;
-
-export default ClayListQuickActionMenu;
+export default Object.assign(ClayListQuickActionMenu, {
+	Item: QuickActionMenuItem,
+});

--- a/packages/clay-list/src/QuickActionMenuItem.tsx
+++ b/packages/clay-list/src/QuickActionMenuItem.tsx
@@ -48,4 +48,6 @@ const ClayListQuickActionMenuItem = React.forwardRef<
 	);
 });
 
+ClayListQuickActionMenuItem.displayName = 'ClayListQuickActionMenuItem';
+
 export default ClayListQuickActionMenuItem;

--- a/packages/clay-list/src/QuickActionMenuItem.tsx
+++ b/packages/clay-list/src/QuickActionMenuItem.tsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 interface IItemProps
-	extends React.HTMLAttributes<HTMLAnchorElement | HTMLSpanElement> {
+	extends React.HTMLAttributes<HTMLAnchorElement | HTMLButtonElement> {
 	/**
 	 * Value of path the item should link to.
 	 */
@@ -26,13 +26,10 @@ interface IItemProps
 	symbol: string;
 }
 
-const ClayListQuickActionMenuItem: React.FunctionComponent<IItemProps> = ({
-	className,
-	href,
-	spritemap,
-	symbol,
-	...otherProps
-}: IItemProps) => {
+const ClayListQuickActionMenuItem = React.forwardRef<
+	HTMLAnchorElement & HTMLButtonElement,
+	IItemProps
+>(({className, href, spritemap, symbol, ...otherProps}: IItemProps, ref) => {
 	const ElementTag = href ? ClayLink : 'button';
 
 	return (
@@ -43,11 +40,12 @@ const ClayListQuickActionMenuItem: React.FunctionComponent<IItemProps> = ({
 				className
 			)}
 			href={href}
+			ref={ref}
 			role="button"
 		>
 			<ClayIcon spritemap={spritemap} symbol={symbol} />
 		</ElementTag>
 	);
-};
+});
 
 export default ClayListQuickActionMenuItem;


### PR DESCRIPTION
Fixes #4149

Well, I went ahead and also added `forwardRef` to the other ClayList components, we only had a few, so it might be good practice to add to the others.

@bryceosterhaus I added it to the `ClayList.ItemTitle` component but I'm not sure if that solves your problem, from what I understand from the `next/link` it will pass the `href` to the `children`, in this case we have a `div` that wraps `children` of `ClayList.ItemTitle` or if it is a Link.