### PR TITLE
fix(@clayui/list): fix error when building types

### DIFF
--- a/packages/clay-list/src/QuickActionMenuItem.tsx
+++ b/packages/clay-list/src/QuickActionMenuItem.tsx
@@ -8,7 +8,7 @@ import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
 
-interface IItemProps
+export interface IItemProps
 	extends React.HTMLAttributes<HTMLAnchorElement | HTMLButtonElement> {
 	/**
 	 * Value of path the item should link to.


### PR DESCRIPTION

When building types, this error appears: "Default export of the module has or is using private name 'IItemProps'." Probably a regression of #4157 or because we are exporting the types in another way with `forwardRef`, strange thing is that CI didn't catch that, I'll check later if we're checking the types.