### PR TITLE
fix(@clayui/css): Forms `form-group-sm div.form-control` should be 32px tall and grow to fix content inside, similar to a textarea element

### DIFF
--- a/packages/clay-css/src/content/form_group.html
+++ b/packages/clay-css/src/content/form_group.html
@@ -202,3 +202,19 @@ section: Components
 		</div>
 	</div>
 </div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Form Group Sm with div.form-control</h3>
+
+		<div class="form-group-sm">
+			<label>This is a fake input, just for show</label>
+			<div class="form-control"></div>
+		</div>
+
+		<div class="form-group-sm">
+			<label for="formGroupSmContentEditable">Content Editable</label>
+			<div class="form-control" contenteditable="true" id="formGroupSmContentEditable"></div>
+		</div>
+	</div>
+</div>

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -178,6 +178,12 @@ label {
 		width: 0;
 	}
 
+	// CKEditor markup work around
+
+	&[contenteditable] p {
+		margin-bottom: 0;
+	}
+
 	.label {
 		@include clay-label-size($cadmin-form-control-label-size);
 	}
@@ -726,6 +732,12 @@ textarea.form-control-sm,
 	.form-control,
 	.form-control-plaintext {
 		@extend %clay-form-control-sm;
+	}
+
+	div.form-control,
+	.form-control[contenteditable] {
+		height: auto;
+		min-height: $cadmin-input-height-sm;
 	}
 
 	select.form-control {

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -178,6 +178,12 @@ label {
 		width: 0;
 	}
 
+	// CKEditor markup work around
+
+	&[contenteditable] p {
+		margin-bottom: 0;
+	}
+
 	.label {
 		@include clay-label-size($form-control-label-size);
 	}
@@ -859,6 +865,12 @@ textarea.form-control-sm,
 	.form-control,
 	.form-control-plaintext {
 		@extend %clay-form-control-sm;
+	}
+
+	div.form-control,
+	.form-control[contenteditable] {
+		height: auto;
+		min-height: $input-height-sm;
 	}
 
 	select.form-control {


### PR DESCRIPTION
fixes #4164