### PR TITLE
docs(@clayui/list): Fixes error when generating `List.ItemField` API table

### DIFF
--- a/packages/clay-list/docs/api-list.mdx
+++ b/packages/clay-list/docs/api-list.mdx
@@ -37,7 +37,7 @@ mainTabURL: 'docs/components/list.html'
 
 ## List.ItemField
 
-<div>[APITable "clay-list/src/ItemField.tsx"]</div>
+<div>[APITable "clay-layout/src/Content.tsx#ClayContentCol"]</div>
 
 ## List.ItemText
 


### PR DESCRIPTION
Fixes #4163

Well, we removed this component in favor of using `ClayLayout.ContentCol` directly because it had the same markup and `ItemField` was built well before ClayLayout, so the file was removed and so it doesn't generate the table, I point to the `ContentCol` component because we still keep the `ItemField` for compatibility.