### PR TITLE
fix(@clayui/color-picker): fix error of "hidden" input add extra margin

### DIFF
--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -5,12 +5,6 @@ exports[`Interactions opens custom color picker drop down when clicked 1`] = `
   <div
     class="clay-color-picker"
   >
-    <input
-      name="colorPicker2"
-      style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
-      type="text"
-      value="#008000"
-    />
     <label>
       Custom Colors
     </label>
@@ -21,6 +15,13 @@ exports[`Interactions opens custom color picker drop down when clicked 1`] = `
       <div
         class="input-group-item input-group-item-shrink input-group-prepend"
       >
+        <input
+          name="colorPicker2"
+          style="height: 0px; position: absolute; visibility: hidden; width: 0px;"
+          tabindex="-1"
+          type="text"
+          value="#008000"
+        />
         <div
           class="input-group-text"
         >
@@ -61,12 +62,6 @@ exports[`Rendering default 1`] = `
     <div
       class="clay-color-picker"
     >
-      <input
-        name="colorPicker1"
-        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
-        type="text"
-        value="#FFF"
-      />
       <label>
         Default
       </label>
@@ -77,6 +72,13 @@ exports[`Rendering default 1`] = `
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
         >
+          <input
+            name="colorPicker1"
+            style="height: 0px; position: absolute; visibility: hidden; width: 0px;"
+            tabindex="-1"
+            type="text"
+            value="#FFF"
+          />
           <div
             class="input-group-text"
           >
@@ -438,12 +440,6 @@ exports[`Rendering disabled palette 1`] = `
     <div
       class="clay-color-picker"
     >
-      <input
-        name="colorPicker1"
-        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
-        type="text"
-        value="#FFF"
-      />
       <label>
         Default
       </label>
@@ -454,6 +450,13 @@ exports[`Rendering disabled palette 1`] = `
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
         >
+          <input
+            name="colorPicker1"
+            style="height: 0px; position: absolute; visibility: hidden; width: 0px;"
+            tabindex="-1"
+            type="text"
+            value="#FFF"
+          />
           <div
             class="input-group-text"
           >
@@ -815,12 +818,6 @@ exports[`Rendering disabled state 1`] = `
     <div
       class="clay-color-picker"
     >
-      <input
-        name="colorPicker1"
-        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
-        type="text"
-        value="#FFF"
-      />
       <label>
         Default
       </label>
@@ -831,6 +828,13 @@ exports[`Rendering disabled state 1`] = `
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
         >
+          <input
+            name="colorPicker1"
+            style="height: 0px; position: absolute; visibility: hidden; width: 0px;"
+            tabindex="-1"
+            type="text"
+            value="#FFF"
+          />
           <div
             class="input-group-text"
           >
@@ -1194,12 +1198,6 @@ exports[`Rendering renders w/ var() 1`] = `
     <div
       class="clay-color-picker"
     >
-      <input
-        name="colorPicker1"
-        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
-        type="text"
-        value="var(--blue)"
-      />
       <label>
         Default
       </label>
@@ -1210,6 +1208,13 @@ exports[`Rendering renders w/ var() 1`] = `
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
         >
+          <input
+            name="colorPicker1"
+            style="height: 0px; position: absolute; visibility: hidden; width: 0px;"
+            tabindex="-1"
+            type="text"
+            value="var(--blue)"
+          />
           <div
             class="input-group-text"
           >
@@ -1578,12 +1583,6 @@ exports[`Rendering renders with a hash for the value 1`] = `
     <div
       class="clay-color-picker"
     >
-      <input
-        name="colorPicker1"
-        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
-        type="text"
-        value="#FFF"
-      />
       <label>
         Default
       </label>
@@ -1594,6 +1593,13 @@ exports[`Rendering renders with a hash for the value 1`] = `
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
         >
+          <input
+            name="colorPicker1"
+            style="height: 0px; position: absolute; visibility: hidden; width: 0px;"
+            tabindex="-1"
+            type="text"
+            value="#FFF"
+          />
           <div
             class="input-group-text"
           >
@@ -1955,12 +1961,6 @@ exports[`Rendering renders with a named color for the value 1`] = `
     <div
       class="clay-color-picker"
     >
-      <input
-        name="colorPicker1"
-        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
-        type="text"
-        value="red"
-      />
       <label>
         Default
       </label>
@@ -1971,6 +1971,13 @@ exports[`Rendering renders with a named color for the value 1`] = `
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
         >
+          <input
+            name="colorPicker1"
+            style="height: 0px; position: absolute; visibility: hidden; width: 0px;"
+            tabindex="-1"
+            type="text"
+            value="red"
+          />
           <div
             class="input-group-text"
           >
@@ -2340,12 +2347,6 @@ exports[`Rendering small color-picker 1`] = `
     <div
       class="clay-color-picker"
     >
-      <input
-        name="colorPicker1"
-        style="height: 0px; margin: 0px; padding: 0px; visibility: hidden; width: 0px;"
-        type="text"
-        value="#FFF"
-      />
       <label>
         Small
       </label>
@@ -2356,6 +2357,13 @@ exports[`Rendering small color-picker 1`] = `
         <div
           class="input-group-item input-group-item-shrink input-group-prepend"
         >
+          <input
+            name="colorPicker1"
+            style="height: 0px; position: absolute; visibility: hidden; width: 0px;"
+            tabindex="-1"
+            type="text"
+            value="#FFF"
+          />
           <div
             class="input-group-text"
           >

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -197,25 +197,6 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	return (
 		<FocusScope arrowKeysUpDown={false}>
 			<div className="clay-color-picker">
-				{name && (
-					<input
-						name={name}
-						onChange={(e) =>
-							useNative ? onValueChange(e.target.value) : null
-						}
-						ref={valueInputRef}
-						style={{
-							height: 0,
-							margin: 0,
-							padding: 0,
-							visibility: 'hidden',
-							width: 0,
-						}}
-						type={useNative ? 'color' : 'text'}
-						value={value ? `${isHex ? '#' : ''}${value}` : ''}
-					/>
-				)}
-
 				{title && <label>{title}</label>}
 
 				<ClayInput.Group
@@ -224,6 +205,29 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 					small={small}
 				>
 					<ClayInput.GroupItem prepend={showHex} shrink>
+						{name && (
+							<input
+								name={name}
+								onChange={(e) =>
+									useNative
+										? onValueChange(e.target.value)
+										: null
+								}
+								ref={valueInputRef}
+								style={{
+									height: 0,
+									position: 'absolute',
+									visibility: 'hidden',
+									width: 0,
+								}}
+								tabIndex={-1}
+								type={useNative ? 'color' : 'text'}
+								value={
+									value ? `${isHex ? '#' : ''}${value}` : ''
+								}
+							/>
+						)}
+
 						<ClayInput.GroupText>
 							<Splotch
 								aria-label={ariaLabels.selectColor}

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -54,7 +54,11 @@ export function isFocusable({
 	}
 
 	if (tagName === 'input') {
-		return type !== 'file' && type !== 'hidden';
+		return (
+			type !== 'file' &&
+			type !== 'hidden' &&
+			(tabIndex != null ? tabIndex >= minTabIndex : true)
+		);
 	}
 
 	return (


### PR DESCRIPTION
Fixes #4173

Hey @pat270 I realized that we can't add a `type=hidden` because we use this `input` as support for the native state, we need it for when I click on `Splotch` to open the native input, so I had to go with the first solution of adding the `position: absolute;`. This is related to this PR #3596

This PR also fixes an error on `FocusScope`, when you press `Tab + Shift` you get stuck on `input` which is not visible, so I added the behavior to ignore focus when `tabIndex` of `input` is smaller than the minimum and if not, keep the default behavior of ignoring only with type hidden and file.