### PR TITLE
fix(@clayui/tooltip): Hide tooltip on `dragstart`

### DIFF
--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -58,6 +58,7 @@ const initialState: IState = {
 };
 
 const TRIGGER_HIDE_EVENTS = [
+	'dragstart',
 	'mouseout',
 	'mouseup',
 	'pointerup',


### PR DESCRIPTION
Fixes: https://github.com/liferay/clay/issues/4187

The root cause of the issue is that none of the existing hide events trigger when node is being dragged. Funnily enough, this includes `mouseout`; it makes sense as the node is all the time below the mouse. Once the drop happens, node is removed from DOM, leaving a dangling tooltip in portal.

To fix this, in this PR we are adding `dragstart` to list of events that trigger tooltip hide.

Before PR:
![before](https://user-images.githubusercontent.com/5435511/127361714-dc766483-0833-4dfd-a794-10c124d3d1a2.gif)

After PR:
![after](https://user-images.githubusercontent.com/5435511/127361704-55e2e682-d4b3-4451-ac61-87e94d870020.gif)

