### PR TITLE
fix(@clayui/autocomplete): fixes a potential XSS vulnerability in autocomplete by removing the use of `dangerouslySetInnerHTML`

### DIFF
--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -22,7 +22,7 @@ export interface IProps extends React.ComponentProps<typeof ClayDropDown.Item> {
 	value: string;
 }
 
-const optionsFuzzy = {post: '</strong>', pre: '<strong>'};
+const optionsFuzzy = {post: '|+', pre: '+|'};
 
 const ClayAutocompleteItem = React.forwardRef<HTMLLIElement, IProps>(
 	({innerRef, match = '', value, ...otherProps}: IProps, ref) => {
@@ -30,15 +30,21 @@ const ClayAutocompleteItem = React.forwardRef<HTMLLIElement, IProps>(
 
 		return (
 			<ClayDropDown.Item {...otherProps} innerRef={innerRef} ref={ref}>
-				{match && fuzzyMatch ? (
-					<div
-						dangerouslySetInnerHTML={{
-							__html: fuzzyMatch.rendered,
-						}}
-					/>
-				) : (
-					value
-				)}
+				{match && fuzzyMatch
+					? fuzzyMatch.rendered
+							.split('|')
+							.map((item, index) => {
+								const Text = item.includes('+')
+									? 'span'
+									: 'strong';
+								const value = item.replace(/\+/g, '');
+
+								return value ? (
+									<Text key={index}>{value}</Text>
+								) : null;
+							})
+							.filter(Boolean)
+					: value}
 			</ClayDropDown.Item>
 		);
 	}

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -520,17 +520,15 @@ exports[`Interactions Use custom function for filtering autocomplete results 1`]
       <button
         class="dropdown-item"
       >
-        <div>
-          <strong>
-            b
-          </strong>
-          <strong>
-            a
-          </strong>
-          <strong>
-            r
-          </strong>
-        </div>
+        <strong>
+          b
+        </strong>
+        <strong>
+          a
+        </strong>
+        <strong>
+          r
+        </strong>
       </button>
     </li>
   </ul>


### PR DESCRIPTION
Fixes #4169

Well to avoid XSS issues in Autocomplete because values can come from user input, I'm removing the use of `dangerouslySetInnerHTML` and "parsing" it to better handle the fuzzy output.