### PR TITLE
feat(@clayui/css): Reboot `body` element should use clay-css mixin for generating properties

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -518,9 +518,6 @@ $cadmin-reset: map-merge(
 
 $cadmin-body-bg: $cadmin-white !default;
 $cadmin-body-color: $cadmin-gray-900 !default;
-$cadmin-body-moz-osx-font-smoothing: $cadmin-moz-osx-font-smoothing !default;
-$cadmin-body-webkit-font-smoothing: $cadmin-webkit-font-smoothing !default;
-$cadmin-body-text-align: inherit !default;
 
 // Button
 

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -26,22 +26,7 @@ main {
 }
 
 body {
-	// As a best practice, apply a default `background-color`
-
-	background-color: $body-bg;
-	color: $body-color;
-	font-family: $font-family-base;
-	font-size: $font-size-base;
-	font-weight: $font-weight-base;
-	-moz-osx-font-smoothing: $body-moz-osx-font-smoothing;
-	-webkit-font-smoothing: $body-webkit-font-smoothing;
-	line-height: $line-height-base;
-
-	// Remove the margin in all browsers
-
-	margin: 0;
-	-ms-overflow-style: scrollbar;
-	text-align: $body-text-align;
+	@include clay-css($c-body);
 
 	@include clay-scale-component {
 		font-size: $font-size-base-mobile;

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -379,6 +379,24 @@ $body-moz-osx-font-smoothing: $moz-osx-font-smoothing !default;
 $body-webkit-font-smoothing: $webkit-font-smoothing !default;
 $body-text-align: inherit !default;
 
+$c-body: () !default;
+$c-body: map-merge(
+	(
+		background-color: $body-bg,
+		color: $body-color,
+		font-family: $font-family-base,
+		font-size: $font-size-base,
+		-moz-osx-font-smoothing: $body-moz-osx-font-smoothing,
+		-webkit-font-smoothing: $body-webkit-font-smoothing,
+		font-weight: $font-weight-base,
+		line-height: $line-height-base,
+		margin: 0,
+		-ms-overflow-style: scrollbar,
+		text-align: $body-text-align,
+	),
+	$c-body
+);
+
 // Button
 
 $c-button-base: () !default;


### PR DESCRIPTION
fixes #4194