### PR TITLE
chore(release): prepare new clay release 3.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.32.1](https://github.com/liferay/clay/compare/v3.32.0...v3.32.1) (2021-07-30)
+
+### Bug Fixes
+
+-   **@clayui/css:** Cadmin Treeview scope `component-action`, `component-expander`, `component-icon`, `component-text` so styles don't bleed into other components ([1ce70bd](https://github.com/liferay/clay/commit/1ce70bd)), closes [#4198](https://github.com/liferay/clay/issues/4198)
+
 # [3.32.0](https://github.com/liferay/clay/compare/v3.31.0...v3.32.0) (2021-07-28)
 
 ### Bug Fixes

--- a/clayui.com/CHANGELOG.md
+++ b/clayui.com/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.32.1](https://github.com/matuzalemsteles/clay/compare/v3.32.0...v3.32.1) (2021-07-30)
+
+**Note:** Version bump only for package clayui.com
+
 # [3.32.0](https://github.com/matuzalemsteles/clay/compare/v3.31.0...v3.32.0) (2021-07-28)
 
 ### Bug Fixes

--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "clayui.com",
-	"version": "3.32.0",
+	"version": "3.32.1",
 	"license": "MIT",
 	"scripts": {
 		"copy:clay-css": "yarn copy:clay-css-js && yarn copy:clay-css-site-images && yarn copy:clay-css-images",
@@ -19,7 +19,7 @@
 		"@clayui/card": "^3.32.0",
 		"@clayui/charts": "^3.32.0",
 		"@clayui/color-picker": "^3.32.0",
-		"@clayui/css": "^3.32.0",
+		"@clayui/css": "^3.32.1",
 		"@clayui/data-provider": "^3.32.0",
 		"@clayui/date-picker": "^3.32.0",
 		"@clayui/drop-down": "^3.32.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"lerna": "3.4.0",
-	"version": "3.32.0",
+	"version": "3.32.1",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/packages/clay-css/CHANGELOG.md
+++ b/packages/clay-css/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.32.1](https://github.com/liferay/clay/tree/master/packages/clay-css/compare/v3.32.0...v3.32.1) (2021-07-30)
+
+
+### Bug Fixes
+
+* **@clayui/css:** Cadmin Treeview scope `component-action`, `component-expander`, `component-icon`, `component-text` so styles don't bleed into other components ([1ce70bd](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/1ce70bd)), closes [#4198](https://github.com/liferay/clay/tree/master/packages/clay-css/issues/4198)
+
+
+
+
+
 # [3.32.0](https://github.com/liferay/clay/tree/master/packages/clay-css/compare/v3.31.0...v3.32.0) (2021-07-28)
 
 

--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/css",
-	"version": "3.32.0",
+	"version": "3.32.1",
 	"description": "Liferay's web implementation of the Lexicon Design Language",
 	"main": "index.js",
 	"files": [

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.32.0
+ * Clay 3.32.1
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>

--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -19,6 +19,46 @@
 		@include clay-css($custom-control);
 	}
 
+	.component-expander {
+		$component-expander: setter(
+			map-get($cadmin-treeview, component-expander),
+			()
+		);
+
+		@include clay-button-variant($component-expander);
+
+		.lexicon-icon:not(.component-expanded-d-none) {
+			display: none;
+		}
+	}
+
+	.component-action {
+		$component-action: setter(
+			map-get($cadmin-treeview, component-action),
+			()
+		);
+
+		@include clay-button-variant($component-action);
+	}
+
+	.component-icon {
+		$component-icon: setter(map-get($cadmin-treeview, component-icon), ());
+
+		@include clay-css($component-icon);
+
+		.lexicon-icon {
+			$lexicon-icon: setter(map-get($component-icon, lexicon-icon), ());
+
+			@include clay-css($lexicon-icon);
+		}
+	}
+
+	.component-text {
+		$component-text: setter(map-get($cadmin-treeview, component-text), ());
+
+		@include clay-css($component-text);
+	}
+
 	&.show-component-expander-on-hover {
 		@include clay-css($cadmin-treeview-show-component-expander-on-hover);
 
@@ -129,43 +169,6 @@
 			}
 		}
 	}
-}
-
-.component-expander {
-	$component-expander: setter(
-		map-get($cadmin-treeview, component-expander),
-		()
-	);
-
-	@include clay-button-variant($component-expander);
-
-	.lexicon-icon:not(.component-expanded-d-none) {
-		display: none;
-	}
-}
-
-.component-action {
-	$component-action: setter(map-get($cadmin-treeview, component-action), ());
-
-	@include clay-button-variant($component-action);
-}
-
-.component-icon {
-	$component-icon: setter(map-get($cadmin-treeview, component-icon), ());
-
-	@include clay-css($component-icon);
-
-	.lexicon-icon {
-		$lexicon-icon: setter(map-get($component-icon, lexicon-icon), ());
-
-		@include clay-css($lexicon-icon);
-	}
-}
-
-.component-text {
-	$component-text: setter(map-get($cadmin-treeview, component-text), ());
-
-	@include clay-css($component-text);
 }
 
 .treeview-nested-margins {


### PR DESCRIPTION
## [3.32.1](https://github.com/liferay/clay/compare/v3.32.0...v3.32.1) (2021-07-30)

### Bug Fixes

-   **@clayui/css:** Cadmin Treeview scope `component-action`, `component-expander`, `component-icon`, `component-text` so styles don't bleed into other components ([1ce70bd](https://github.com/liferay/clay/commit/1ce70bd)), closes [#4198](https://github.com/liferay/clay/issues/4198)