### PR TITLE
fix(@clayui/css): Forms .form-control-select with long text shouldn't break to new line and should have overflow ellipsis, similar behavior to select.form-control

### DIFF
--- a/packages/clay-css/src/content/form_elements.html
+++ b/packages/clay-css/src/content/form_elements.html
@@ -192,11 +192,33 @@ section: Components
 			<option>Sample 2</option>
 			<option>Sample 3</option>
 			<option>Sample 4</option>
+			<option>ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</option>
 		</select>
 	</div>
 	<div class="form-group">
 		<label>A Div Styled Like a Select Element</label>
-		<div class="form-control form-control-select">This is all show</div>
+		<div class="form-control form-control-select">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</div>
+	</div>
+	<div class="form-group">
+		<label>An Anchor Styled Like a Select Element</label>
+		<a class="form-control form-control-select" href="#1">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</a>
+	</div>
+	<div class="form-group">
+		<label>A Button Styled Like a Select Element</label>
+		<button class="form-control form-control-select" type="button">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</button>
+	</div>
+	<div class="form-group">
+		<label>A Div Styled Like an Sm Select Element</label>
+		<div class="form-control form-control-select form-control-sm">This is all show</div>
+	</div>
+	<div class="form-group">
+		<label>An Anchor Styled Like an Sm Select Element</label>
+		<a class="form-control form-control-select form-control-sm" href="#1">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</a>
+	</div>
+	<div class="form-group">
+		<!-- Mimicking markup seen in DXP -->
+		<label>A Button Styled Like an Sm Select Element</label>
+		<button class="btn btn-unstyled form-control form-control-select form-control-sm" type="button">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</button>
 	</div>
 	<div class="form-group">
 		<label for="selectElementWithSize5">Select Element with Size 5</label>

--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -49,8 +49,7 @@ $form-group-sm-item-label-spacer: 1.5625rem !default; // 25px
 $input-color: $gray-900 !default;
 $input-bg: $gray-200 !default;
 $input-border-color: $gray-300 !default;
-// Will need to be revisited if https://github.com/twbs/bootstrap/pull/24821 merge error is fixed
-$input-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
+$input-box-shadow: none !default;
 $input-placeholder-color: $gray-600 !default;
 $input-label-color: $gray-900 !default;
 

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -341,6 +341,18 @@ select.form-control {
 
 .form-control-select {
 	@include clay-css($cadmin-form-control-select);
+
+	&:hover {
+		$hover: setter(map-get($cadmin-form-control-select, hover), ());
+
+		@include clay-css($hover);
+	}
+
+	&:focus {
+		$focus: setter(map-get($cadmin-form-control-select, focus), ());
+
+		@include clay-css($focus);
+	}
 }
 
 select.form-control[size] {
@@ -604,11 +616,17 @@ textarea.form-control-lg,
 }
 
 %clay-select-form-control-sm {
-	height: $cadmin-input-height-sm;
+	@include clay-css(setter($cadmin-form-control-select-sm, ()));
 
 	@include clay-scale-component {
-		height: $cadmin-input-height-sm-mobile;
+		$mobile: setter(map-get($cadmin-form-control-select-sm, mobile), ());
+
+		@include clay-css($mobile);
 	}
+}
+
+.form-control-select.form-control-sm {
+	@extend %clay-select-form-control-sm !optional;
 }
 
 %clay-textarea-form-control-sm {

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -121,15 +121,7 @@ label {
 	&.focus {
 		background-color: $cadmin-input-focus-bg;
 		border-color: $cadmin-input-focus-border-color;
-
-		// Avoid using mixin so we can pass custom focus shadow properly
-
-		@if $cadmin-enable-shadows {
-			box-shadow: $cadmin-input-box-shadow, $cadmin-input-focus-box-shadow;
-		} @else {
-			box-shadow: $cadmin-input-focus-box-shadow;
-		}
-
+		box-shadow: $cadmin-input-focus-box-shadow;
 		color: $cadmin-input-focus-color;
 		outline: 0;
 

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -12,7 +12,7 @@ $cadmin-input-border-width: $cadmin-input-border-top-width
 	$cadmin-input-border-left-width !default;
 
 $cadmin-input-border-radius: $cadmin-border-radius !default;
-$cadmin-input-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
+$cadmin-input-box-shadow: null !default;
 $cadmin-input-color: $cadmin-gray-900 !default;
 $cadmin-input-font-family: $cadmin-input-btn-font-family !default;
 $cadmin-input-font-size: $cadmin-input-btn-font-size !default;

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -607,10 +607,29 @@ $cadmin-form-control-select: map-deep-merge(
 			(
 				appearance: null,
 				cursor: null,
+				overflow: hidden,
+				text-overflow: ellipsis,
+				white-space: nowrap,
+				hover: (
+					color: inherit,
+					text-decoration: none,
+				),
 			)
 		)
 	),
 	$cadmin-form-control-select
+);
+
+$cadmin-form-control-select-sm: () !default;
+$cadmin-form-control-select-sm: map-deep-merge(
+	(
+		height: $cadmin-input-height-sm,
+		padding-right: 2em,
+		mobile: (
+			height: $cadmin-input-height-sm-mobile,
+		),
+	),
+	$cadmin-form-control-select-sm
 );
 
 // Select Size

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -337,6 +337,18 @@ select.form-control {
 
 .form-control-select {
 	@include clay-css($form-control-select);
+
+	&:hover {
+		$hover: setter(map-get($form-control-select, hover), ());
+
+		@include clay-css($hover);
+	}
+
+	&:focus {
+		$focus: setter(map-get($form-control-select, focus), ());
+
+		@include clay-css($focus);
+	}
 }
 
 select.form-control[size] {
@@ -600,11 +612,17 @@ textarea.form-control-lg,
 }
 
 %clay-select-form-control-sm {
-	height: $input-height-sm;
+	@include clay-css(setter($form-control-select-sm, ()));
 
 	@include clay-scale-component {
-		height: $input-height-sm-mobile;
+		$mobile: setter(map-get($form-control-select-sm, mobile));
+
+		@include clay-css($mobile);
 	}
+}
+
+.form-control-select.form-control-sm {
+	@extend %clay-select-form-control-sm !optional;
 }
 
 %clay-textarea-form-control-sm {

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -121,15 +121,7 @@ label {
 	&.focus {
 		background-color: $input-focus-bg;
 		border-color: $input-focus-border-color;
-
-		// Avoid using mixin so we can pass custom focus shadow properly
-
-		@if $enable-shadows {
-			box-shadow: $input-box-shadow, $input-focus-box-shadow;
-		} @else {
-			box-shadow: $input-focus-box-shadow;
-		}
-
+		box-shadow: $input-focus-box-shadow;
 		color: $input-focus-color;
 		outline: 0;
 

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -596,10 +596,29 @@ $form-control-select: map-deep-merge(
 			(
 				appearance: null,
 				cursor: null,
+				overflow: hidden,
+				text-overflow: ellipsis,
+				white-space: nowrap,
+				hover: (
+					color: inherit,
+					text-decoration: none,
+				),
 			)
 		)
 	),
 	$form-control-select
+);
+
+$form-control-select-sm: () !default;
+$form-control-select-sm: map-deep-merge(
+	(
+		height: $input-height-sm,
+		padding-right: 2em,
+		mobile: (
+			height: $input-height-sm-mobile,
+		),
+	),
+	$form-control-select-sm
 );
 
 // Select Size


### PR DESCRIPTION
.form-control-select.form-control-sm should have space on the right for the double-caret-l icon

![form-control-sel](https://user-images.githubusercontent.com/788266/128933011-64564061-bdaf-4a7d-a5ac-e9ef415af778.jpg)


fixes #4206