### PR TITLE
feat: Add the `alignmentPosition` API to PaginationWithBasicItems and PaginationBarWithBasicItems component

### DIFF
--- a/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
+++ b/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
@@ -52,6 +52,14 @@ interface IProps extends React.ComponentProps<typeof PaginationBar> {
 	activePage?: number;
 
 	/**
+	 * Sets the default DropDown position of the component. The component
+	 * receives the Align constant values from the `@clayui/drop-down` package.
+	 */
+	alignmentPosition?: React.ComponentProps<
+		typeof ClayPaginationWithBasicItems
+	>['alignmentPosition'];
+
+	/**
 	 * Possible values of items per page.
 	 */
 	deltas?: Array<IDelta>;
@@ -121,6 +129,7 @@ const DEFAULT_LABELS = {
 export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> = ({
 	activeDelta,
 	activePage = 1,
+	alignmentPosition,
 	deltas = defaultDeltas,
 	disabledPages,
 	ellipsisBuffer,
@@ -170,6 +179,7 @@ export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> = 
 		<PaginationBar {...otherProps}>
 			{showDeltasDropDown && (
 				<PaginationBar.DropDown
+					alignmentPosition={alignmentPosition}
 					items={items}
 					trigger={
 						<ClayButton
@@ -199,6 +209,7 @@ export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> = 
 
 			<ClayPaginationWithBasicItems
 				activePage={activePage}
+				alignmentPosition={alignmentPosition}
 				disabledPages={disabledPages}
 				ellipsisBuffer={ellipsisBuffer}
 				hrefConstructor={hrefConstructor}

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -8,13 +8,17 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import React from 'react';
 
 export interface IPaginationEllipsisProps {
-	items?: Array<number>;
+	alignmentPosition?: React.ComponentProps<
+		typeof ClayDropDownWithItems
+	>['alignmentPosition'];
 	disabledPages?: Array<number>;
 	hrefConstructor?: (page?: number) => string;
+	items?: Array<number>;
 	onPageChange?: (page?: number) => void;
 }
 
 const ClayPaginationEllipsis: React.FunctionComponent<IPaginationEllipsisProps> = ({
+	alignmentPosition,
 	disabledPages = [],
 	hrefConstructor,
 	items = [],
@@ -29,6 +33,7 @@ const ClayPaginationEllipsis: React.FunctionComponent<IPaginationEllipsisProps> 
 
 	return (
 		<ClayDropDownWithItems
+			alignmentPosition={alignmentPosition}
 			className="page-item"
 			containerElement="li"
 			items={pages}

--- a/packages/clay-pagination/src/PaginationWithBasicItems.tsx
+++ b/packages/clay-pagination/src/PaginationWithBasicItems.tsx
@@ -7,6 +7,7 @@ import ClayIcon from '@clayui/icon';
 import {getEllipsisItems} from '@clayui/shared';
 import React from 'react';
 
+import type {IPaginationEllipsisProps} from './Ellipsis';
 import Pagination from './Pagination';
 
 const ELLIPSIS_BUFFER = 2;
@@ -16,6 +17,12 @@ interface IProps extends React.ComponentProps<typeof Pagination> {
 	 * The page that is currently active. The first page is `1`.
 	 */
 	activePage: number;
+
+	/**
+	 * Sets the default DropDown position of the component. The component
+	 * receives the Align constant values from the `@clayui/drop-down` package.
+	 */
+	alignmentPosition?: IPaginationEllipsisProps['alignmentPosition'];
 
 	/**
 	 * Labels for the aria attributes
@@ -62,6 +69,7 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 	(
 		{
 			activePage,
+			alignmentPosition,
 			ariaLabels = {
 				next: 'Next',
 				previous: 'Previous',
@@ -103,6 +111,7 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 							{
 								EllipsisComponent: Pagination.Ellipsis,
 								ellipsisProps: {
+									alignmentPosition,
 									disabledPages,
 									hrefConstructor,
 									onPageChange,

--- a/packages/clay-pagination/stories/index.tsx
+++ b/packages/clay-pagination/stories/index.tsx
@@ -91,4 +91,14 @@ storiesOf('Components|ClayPagination', module)
 				totalPages={totalPages}
 			/>
 		);
+	})
+	.add('ClayPaginationWithBasicItems w/ alignment DropDown position', () => {
+		const totalPages = number('Number of pages', 5);
+
+		return (
+			<PaginationWithState
+				alignmentPosition={4}
+				totalPages={totalPages}
+			/>
+		);
 	});


### PR DESCRIPTION
Fixes #4165

Well, this adds the API to control the position of DropDown within a Pagination component, essentially we should investigate the case of https://codesandbox.io/s/eloquent-darkness-g8lms where the `dom-align` might be getting lost but adding this API makes sense and unlocks this.