### PR TITLE
chore(release): prepare new clay release 3.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.33.0](https://github.com/liferay/clay/compare/v3.32.1...v3.33.0) (2021-08-11)
+
+### Bug Fixes
+
+-   **@clayui/css:** Cadmin Modal .modal.show should have display: block ([5876b9f](https://github.com/liferay/clay/commit/5876b9f)), closes [#4203](https://github.com/liferay/clay/issues/4203)
+-   **@clayui/css:** Cadmin removes unused variables `$cadmin-body-moz-osx-font-smoothing`, `$cadmin-body-webkit-font-smoothing`, `$cadmin-body-text-align`. We don't provide a CSS reset in Cadmin. ([c3af64e](https://github.com/liferay/clay/commit/c3af64e))
+-   **@clayui/css:** Forms .form-control-select with long text shouldn't break to new line and should have overflow ellipsis, similar behavior to select.form-control ([44804d8](https://github.com/liferay/clay/commit/44804d8)), closes [#4206](https://github.com/liferay/clay/issues/4206)
+-   **@clayui/css:** Forms remove Bootstrap's confusing way of setting an inset box-shadow on an input. This causes flickering on .btn.form-control-select on click. If you want a regular box-shadow and an inset box-shadow on an input define them both inside the \$input-box-shadow variable. Example below: ([83d56d1](https://github.com/liferay/clay/commit/83d56d1)), closes [#4206](https://github.com/liferay/clay/issues/4206)
+-   **@clayui/css:** Functions adds `_type-conversion-functions.scss` for converting colors of type string to type color. Sass doesn't provide a way to do this https://github.com/sass/sass/issues/3006. ([68be792](https://github.com/liferay/clay/commit/68be792)), closes [#4180](https://github.com/liferay/clay/issues/4180)
+-   **@clayui/css:** Global Functions `clay-get-fallback` convert color string to type color ([68fd699](https://github.com/liferay/clay/commit/68fd699))
+-   **@clayui/css:** Removes the use of `$theme-colors` Sass map to generate utility properties (e.g., `bg-primary`, `text-primary`, `list-group-item-primary`, `table-primary`) and allow configuring separately. The new way also supports CSS variables. Adds new maps: ([78fb2d2](https://github.com/liferay/clay/commit/78fb2d2))
+
+### Features
+
+-   **@clayui/css:** Reboot `body` element should use clay-css mixin for generating properties ([c0b456e](https://github.com/liferay/clay/commit/c0b456e)), closes [#4194](https://github.com/liferay/clay/issues/4194)
+-   **@clayui/pagination:** Add the `alignmentPosition` API to PaginationWithBasicItems component ([24ca87c](https://github.com/liferay/clay/commit/24ca87c))
+-   **@clayui/pagination-bar:** Add the `alignmentPosition` API to PaginationBarWithBasicItems component ([eca557f](https://github.com/liferay/clay/commit/eca557f))
+
 ## [3.32.1](https://github.com/liferay/clay/compare/v3.32.0...v3.32.1) (2021-07-30)
 
 ### Bug Fixes

--- a/clayui.com/CHANGELOG.md
+++ b/clayui.com/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.33.0](https://github.com/matuzalemsteles/clay/compare/v3.32.1...v3.33.0) (2021-08-11)
+
+**Note:** Version bump only for package clayui.com
+
 ## [3.32.1](https://github.com/matuzalemsteles/clay/compare/v3.32.0...v3.32.1) (2021-07-30)
 
 **Note:** Version bump only for package clayui.com

--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "clayui.com",
-	"version": "3.32.1",
+	"version": "3.33.0",
 	"license": "MIT",
 	"scripts": {
 		"copy:clay-css": "yarn copy:clay-css-js && yarn copy:clay-css-site-images && yarn copy:clay-css-images",
@@ -19,7 +19,7 @@
 		"@clayui/card": "^3.32.0",
 		"@clayui/charts": "^3.32.0",
 		"@clayui/color-picker": "^3.32.0",
-		"@clayui/css": "^3.32.1",
+		"@clayui/css": "^3.33.0",
 		"@clayui/data-provider": "^3.32.0",
 		"@clayui/date-picker": "^3.32.0",
 		"@clayui/drop-down": "^3.32.0",
@@ -34,8 +34,8 @@
 		"@clayui/multi-step-nav": "^3.32.0",
 		"@clayui/nav": "^3.32.0",
 		"@clayui/navigation-bar": "^3.32.0",
-		"@clayui/pagination": "^3.32.0",
-		"@clayui/pagination-bar": "^3.32.0",
+		"@clayui/pagination": "^3.33.0",
+		"@clayui/pagination-bar": "^3.33.0",
 		"@clayui/panel": "^3.32.0",
 		"@clayui/popover": "^3.32.0",
 		"@clayui/sticker": "^3.32.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"lerna": "3.4.0",
-	"version": "3.32.1",
+	"version": "3.33.0",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/packages/clay-css/CHANGELOG.md
+++ b/packages/clay-css/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.33.0](https://github.com/liferay/clay/tree/master/packages/clay-css/compare/v3.32.1...v3.33.0) (2021-08-11)
+
+
+### Bug Fixes
+
+* **@clayui/css:** Cadmin Modal .modal.show should have display: block ([5876b9f](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/5876b9f)), closes [#4203](https://github.com/liferay/clay/tree/master/packages/clay-css/issues/4203)
+* **@clayui/css:** Cadmin removes unused variables `$cadmin-body-moz-osx-font-smoothing`, `$cadmin-body-webkit-font-smoothing`, `$cadmin-body-text-align`. We don't provide a CSS reset in Cadmin. ([c3af64e](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/c3af64e))
+* **@clayui/css:** Forms .form-control-select with long text shouldn't break to new line and should have overflow ellipsis, similar behavior to select.form-control ([44804d8](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/44804d8)), closes [#4206](https://github.com/liferay/clay/tree/master/packages/clay-css/issues/4206)
+* **@clayui/css:** Forms remove Bootstrap's confusing way of setting an inset box-shadow on an input. This causes flickering on .btn.form-control-select on click. If you want a regular box-shadow and an inset box-shadow on an input define them both inside the $input-box-shadow variable. Example below: ([83d56d1](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/83d56d1)), closes [#4206](https://github.com/liferay/clay/tree/master/packages/clay-css/issues/4206)
+* **@clayui/css:** Functions adds `_type-conversion-functions.scss` for converting colors of type string to type color. Sass doesn't provide a way to do this https://github.com/sass/sass/issues/3006. ([68be792](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/68be792)), closes [#4180](https://github.com/liferay/clay/tree/master/packages/clay-css/issues/4180)
+* **@clayui/css:** Global Functions `clay-get-fallback` convert color string to type color ([68fd699](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/68fd699))
+* **@clayui/css:** Removes the use of `$theme-colors` Sass map to generate utility properties (e.g., `bg-primary`, `text-primary`, `list-group-item-primary`, `table-primary`) and allow configuring separately. The new way also supports CSS variables. Adds new maps: ([78fb2d2](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/78fb2d2))
+
+
+### Features
+
+* **@clayui/css:** Reboot `body` element should use clay-css mixin for generating properties ([c0b456e](https://github.com/liferay/clay/tree/master/packages/clay-css/commit/c0b456e)), closes [#4194](https://github.com/liferay/clay/tree/master/packages/clay-css/issues/4194)
+
+
+
+
+
 ## [3.32.1](https://github.com/liferay/clay/tree/master/packages/clay-css/compare/v3.32.0...v3.32.1) (2021-07-30)
 
 

--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/css",
-	"version": "3.32.1",
+	"version": "3.33.0",
 	"description": "Liferay's web implementation of the Lexicon Design Language",
 	"main": "index.js",
 	"files": [

--- a/packages/clay-css/src/content/form_elements.html
+++ b/packages/clay-css/src/content/form_elements.html
@@ -192,11 +192,33 @@ section: Components
 			<option>Sample 2</option>
 			<option>Sample 3</option>
 			<option>Sample 4</option>
+			<option>ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</option>
 		</select>
 	</div>
 	<div class="form-group">
 		<label>A Div Styled Like a Select Element</label>
-		<div class="form-control form-control-select">This is all show</div>
+		<div class="form-control form-control-select">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</div>
+	</div>
+	<div class="form-group">
+		<label>An Anchor Styled Like a Select Element</label>
+		<a class="form-control form-control-select" href="#1">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</a>
+	</div>
+	<div class="form-group">
+		<label>A Button Styled Like a Select Element</label>
+		<button class="form-control form-control-select" type="button">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</button>
+	</div>
+	<div class="form-group">
+		<label>A Div Styled Like an Sm Select Element</label>
+		<div class="form-control form-control-select form-control-sm">This is all show</div>
+	</div>
+	<div class="form-group">
+		<label>An Anchor Styled Like an Sm Select Element</label>
+		<a class="form-control form-control-select form-control-sm" href="#1">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</a>
+	</div>
+	<div class="form-group">
+		<!-- Mimicking markup seen in DXP -->
+		<label>A Button Styled Like an Sm Select Element</label>
+		<button class="btn btn-unstyled form-control form-control-select form-control-sm" type="button">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsualReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</button>
 	</div>
 	<div class="form-group">
 		<label for="selectElementWithSize5">Select Element with Size 5</label>

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.32.1
+ * Clay 3.33.0
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>

--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -49,8 +49,7 @@ $form-group-sm-item-label-spacer: 1.5625rem !default; // 25px
 $input-color: $gray-900 !default;
 $input-bg: $gray-200 !default;
 $input-border-color: $gray-300 !default;
-// Will need to be revisited if https://github.com/twbs/bootstrap/pull/24821 merge error is fixed
-$input-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
+$input-box-shadow: none !default;
 $input-placeholder-color: $gray-600 !default;
 $input-label-color: $gray-900 !default;
 

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -121,15 +121,7 @@ label {
 	&.focus {
 		background-color: $cadmin-input-focus-bg;
 		border-color: $cadmin-input-focus-border-color;
-
-		// Avoid using mixin so we can pass custom focus shadow properly
-
-		@if $cadmin-enable-shadows {
-			box-shadow: $cadmin-input-box-shadow, $cadmin-input-focus-box-shadow;
-		} @else {
-			box-shadow: $cadmin-input-focus-box-shadow;
-		}
-
+		box-shadow: $cadmin-input-focus-box-shadow;
 		color: $cadmin-input-focus-color;
 		outline: 0;
 
@@ -341,6 +333,18 @@ select.form-control {
 
 .form-control-select {
 	@include clay-css($cadmin-form-control-select);
+
+	&:hover {
+		$hover: setter(map-get($cadmin-form-control-select, hover), ());
+
+		@include clay-css($hover);
+	}
+
+	&:focus {
+		$focus: setter(map-get($cadmin-form-control-select, focus), ());
+
+		@include clay-css($focus);
+	}
 }
 
 select.form-control[size] {
@@ -604,11 +608,17 @@ textarea.form-control-lg,
 }
 
 %clay-select-form-control-sm {
-	height: $cadmin-input-height-sm;
+	@include clay-css(setter($cadmin-form-control-select-sm, ()));
 
 	@include clay-scale-component {
-		height: $cadmin-input-height-sm-mobile;
+		$mobile: setter(map-get($cadmin-form-control-select-sm, mobile), ());
+
+		@include clay-css($mobile);
 	}
+}
+
+.form-control-select.form-control-sm {
+	@extend %clay-select-form-control-sm !optional;
 }
 
 %clay-textarea-form-control-sm {

--- a/packages/clay-css/src/scss/cadmin/components/_modals.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_modals.scss
@@ -44,6 +44,8 @@
 
 .modal.show,
 &.modal.show {
+	display: block;
+
 	.modal-dialog {
 		transform: $cadmin-modal-show-transform;
 	}
@@ -315,13 +317,16 @@
 
 // Modal Close
 
-.modal .close {
-	&:first-child {
-		margin-left: -$cadmin-modal-close-spacer-x;
-	}
+&.modal,
+.modal {
+	.close {
+		&:first-child {
+			margin-left: -$cadmin-modal-close-spacer-x;
+		}
 
-	&:last-child {
-		margin-right: -$cadmin-modal-close-spacer-x;
+		&:last-child {
+			margin-right: -$cadmin-modal-close-spacer-x;
+		}
 	}
 }
 
@@ -349,6 +354,7 @@
 
 // Modal Full Screen
 
+&.modal-full-screen,
 .modal-full-screen {
 	bottom: $cadmin-modal-full-screen-spacer-y;
 	left: $cadmin-modal-full-screen-spacer-x;
@@ -412,30 +418,35 @@
 
 // Modal Height
 
+&.modal-height-sm,
 .modal-height-sm {
 	.modal-content {
 		height: $cadmin-modal-height-sm;
 	}
 }
 
+&.modal-height-md,
 .modal-height-md {
 	.modal-content {
 		height: $cadmin-modal-height-md;
 	}
 }
 
+&.modal-height-lg,
 .modal-height-lg {
 	.modal-content {
 		height: $cadmin-modal-height-lg;
 	}
 }
 
+&.modal-height-xl,
 .modal-height-xl {
 	.modal-content {
 		height: $cadmin-modal-height-xl;
 	}
 }
 
+&.modal-height-full,
 .modal-height-full {
 	.modal-dialog {
 		height: 100%;
@@ -489,6 +500,7 @@
 // Modal Variants
 
 @each $cadmin-color, $cadmin-value in $cadmin-modal-palette {
+	&.modal-#{$cadmin-color},
 	.modal-#{$cadmin-color} {
 		@include clay-modal-variant($cadmin-value);
 	}

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -12,7 +12,7 @@ $cadmin-input-border-width: $cadmin-input-border-top-width
 	$cadmin-input-border-left-width !default;
 
 $cadmin-input-border-radius: $cadmin-border-radius !default;
-$cadmin-input-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
+$cadmin-input-box-shadow: null !default;
 $cadmin-input-color: $cadmin-gray-900 !default;
 $cadmin-input-font-family: $cadmin-input-btn-font-family !default;
 $cadmin-input-font-size: $cadmin-input-btn-font-size !default;
@@ -607,10 +607,29 @@ $cadmin-form-control-select: map-deep-merge(
 			(
 				appearance: null,
 				cursor: null,
+				overflow: hidden,
+				text-overflow: ellipsis,
+				white-space: nowrap,
+				hover: (
+					color: inherit,
+					text-decoration: none,
+				),
 			)
 		)
 	),
 	$cadmin-form-control-select
+);
+
+$cadmin-form-control-select-sm: () !default;
+$cadmin-form-control-select-sm: map-deep-merge(
+	(
+		height: $cadmin-input-height-sm,
+		padding-right: 2em,
+		mobile: (
+			height: $cadmin-input-height-sm-mobile,
+		),
+	),
+	$cadmin-form-control-select-sm
 );
 
 // Select Size

--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -518,9 +518,6 @@ $cadmin-reset: map-merge(
 
 $cadmin-body-bg: $cadmin-white !default;
 $cadmin-body-color: $cadmin-gray-900 !default;
-$cadmin-body-moz-osx-font-smoothing: $cadmin-moz-osx-font-smoothing !default;
-$cadmin-body-webkit-font-smoothing: $cadmin-webkit-font-smoothing !default;
-$cadmin-body-text-align: inherit !default;
 
 // Button
 

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -121,15 +121,7 @@ label {
 	&.focus {
 		background-color: $input-focus-bg;
 		border-color: $input-focus-border-color;
-
-		// Avoid using mixin so we can pass custom focus shadow properly
-
-		@if $enable-shadows {
-			box-shadow: $input-box-shadow, $input-focus-box-shadow;
-		} @else {
-			box-shadow: $input-focus-box-shadow;
-		}
-
+		box-shadow: $input-focus-box-shadow;
 		color: $input-focus-color;
 		outline: 0;
 
@@ -337,6 +329,18 @@ select.form-control {
 
 .form-control-select {
 	@include clay-css($form-control-select);
+
+	&:hover {
+		$hover: setter(map-get($form-control-select, hover), ());
+
+		@include clay-css($hover);
+	}
+
+	&:focus {
+		$focus: setter(map-get($form-control-select, focus), ());
+
+		@include clay-css($focus);
+	}
 }
 
 select.form-control[size] {
@@ -600,11 +604,17 @@ textarea.form-control-lg,
 }
 
 %clay-select-form-control-sm {
-	height: $input-height-sm;
+	@include clay-css(setter($form-control-select-sm, ()));
 
 	@include clay-scale-component {
-		height: $input-height-sm-mobile;
+		$mobile: setter(map-get($form-control-select-sm, mobile));
+
+		@include clay-css($mobile);
 	}
+}
+
+.form-control-select.form-control-sm {
+	@extend %clay-select-form-control-sm !optional;
 }
 
 %clay-textarea-form-control-sm {

--- a/packages/clay-css/src/scss/components/_list-group.scss
+++ b/packages/clay-css/src/scss/components/_list-group.scss
@@ -409,21 +409,26 @@
 
 // List Group Item Variants
 
-@each $color, $value in $theme-colors {
+@each $color, $value in $list-group-item-theme-colors {
 	.list-group-item-#{$color} {
-		background-color: theme-color-level($color, -9);
-		color: theme-color-level($color, 6);
+		@include clay-css(setter($value, ()));
 
 		&.list-group-item-action {
-			@include hover-focus() {
-				background-color: darken(theme-color-level($color, -9), 5%);
-				color: theme-color-level($color, 6);
+			$active: setter(map-get($value, active), ());
+			$hover: setter(map-get($value, hover), ());
+
+			$focus: setter(map-get($value, focus), $hover);
+
+			&:hover {
+				@include clay-css($hover);
+			}
+
+			&:focus {
+				@include clay-css($focus);
 			}
 
 			&.active {
-				background-color: theme-color-level($color, 6);
-				border-color: theme-color-level($color, 6);
-				color: $white;
+				@include clay-css($active);
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -26,22 +26,7 @@ main {
 }
 
 body {
-	// As a best practice, apply a default `background-color`
-
-	background-color: $body-bg;
-	color: $body-color;
-	font-family: $font-family-base;
-	font-size: $font-size-base;
-	font-weight: $font-weight-base;
-	-moz-osx-font-smoothing: $body-moz-osx-font-smoothing;
-	-webkit-font-smoothing: $body-webkit-font-smoothing;
-	line-height: $line-height-base;
-
-	// Remove the margin in all browsers
-
-	margin: 0;
-	-ms-overflow-style: scrollbar;
-	text-align: $body-text-align;
+	@include clay-css($c-body);
 
 	@include clay-scale-component {
 		font-size: $font-size-base-mobile;

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -226,12 +226,41 @@ caption {
 
 // Table Row Backgrounds
 
-@each $color, $value in $theme-colors {
-	@include table-row-variant(
-		$color,
-		theme-color-level($color, $table-bg-level),
-		theme-color-level($color, $table-border-level)
-	);
+@each $color, $value in $table-row-theme-colors {
+	.table-#{$color} {
+		&,
+		> th,
+		> td {
+			@include clay-css(setter($value, ()));
+		}
+
+		$border-color: setter(map-get($value, border-color), ());
+
+		th,
+		td,
+		thead th,
+		tbody + tbody {
+			border-color: $border-color;
+		}
+	}
+
+	// Hover states for `.table-hover`
+	// Note: this is not available for cells or rows within `thead` or `tfoot`.
+
+	.table-hover {
+		$hover: setter(map-get($value, hover), ());
+
+		.table-#{$color} {
+			&:hover {
+				@include clay-css($hover);
+
+				> td,
+				> th {
+					background-color: map-get($hover, background-color);
+				}
+			}
+		}
+	}
 }
 
 // Table Active

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -24,36 +24,28 @@
 
 // Background
 
-@each $color, $value in $theme-colors {
+@each $color, $value in $bg-theme-colors {
+	$hover: setter(map-get($value, hover), ());
+
 	.bg-#{$color} {
-		background-color: $value !important;
+		@include clay-css(setter($value, ()));
 	}
 
 	a.bg-#{$color},
 	button.bg-#{$color} {
 		&:hover,
 		&:focus {
-			background-color: darken($value, 10%) !important;
+			@include clay-css($hover);
 		}
 	}
 }
 
 @if $enable-gradients {
-	@each $color, $value in $theme-colors {
+	@each $color, $value in $bg-gradient-theme-colors {
 		.bg-gradient-#{$color} {
-			background: $value
-				linear-gradient(180deg, mix($body-bg, $value, 15%), $value)
-				repeat-x !important;
+			@include clay-css(setter($value, ()));
 		}
 	}
-}
-
-.bg-white {
-	background-color: $white !important;
-}
-
-.bg-transparent {
-	background-color: transparent !important;
 }
 
 // Border
@@ -98,9 +90,9 @@
 	border-left: 0 !important;
 }
 
-@each $color, $value in $theme-colors {
+@each $color, $value in $border-theme-colors {
 	.border-#{$color} {
-		border-color: $value !important;
+		@include clay-css(setter($value, ()));
 	}
 }
 
@@ -722,20 +714,17 @@
 	color: $white !important;
 }
 
-@each $color, $value in $theme-colors {
+@each $color, $value in $text-theme-colors {
+	$hover: setter(map-get($value, hover));
+
 	.text-#{$color} {
-		color: $value !important;
+		@include clay-css(setter($value, ()));
 	}
 
-	@if $emphasized-link-hover-darken-percentage != 0 {
-		a.text-#{$color} {
-			&:hover,
-			&:focus {
-				color: darken(
-					$value,
-					$emphasized-link-hover-darken-percentage
-				) !important;
-			}
+	a.text-#{$color} {
+		&:hover,
+		&:focus {
+			@include clay-css($hover);
 		}
 	}
 }

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -3,12 +3,7 @@
 ////
 
 @import '_lx-icons-generated.scss';
-
-/// A function that returns an empty map of type `map`. In Sass, Empty maps and lists can be declared using `()` and Sass will assign its type as `list`. This function ensures its type will be `map`.
-
-@function map-new() {
-	@return map-remove((), 'key');
-}
+@import '_type-conversion-functions.scss';
 
 /// A function that returns a new map with all the keys and values including nested keys and values from both `$map1` and `$map2`. If both `$map1` and `$map2` have the same key, `$map2`’s value takes precedence.
 /// @param {Map, Null} $map1[()]
@@ -269,31 +264,29 @@
 			str-length($var) - 1
 		);
 
-		$units: (
-			'px': 1px,
-			'cm': 1cm,
-			'mm': 1mm,
-			'%': 1%,
-			'ch': 1ch,
-			'pc': 1pc,
-			'in': 1in,
-			'em': 1em,
-			'rem': 1rem,
-			'pt': 1pt,
-			'ex': 1ex,
-			'vw': 1vw,
-			'vh': 1vh,
-			'vmin': 1vmin,
-			'vmax': 1vmax,
-		);
+		$units: 'px'
+			'cm'
+			'mm'
+			'%'
+			'ch'
+			'pc'
+			'in'
+			'em'
+			'rem'
+			'pt'
+			'ex'
+			'vw'
+			'vh'
+			'vmin'
+			'vmax';
 
-		@each $unit in map-keys($units) {
+		@each $unit in $units {
 			@if (str-index($fallback-value, $unit)) {
 				@return to-number($fallback-value);
 			}
 		}
 
-		@return $fallback-value;
+		@return to-color($fallback-value);
 	}
 
 	@return $var;
@@ -645,92 +638,6 @@
 // * SPDX-License-Identifier: MIT
 // * SPDX-FileCopyrightText: © 2016 Hugo Giraudel <https://hugogiraudel.com/>
 // *
-
-/// Add `$unit` to `$value`
-/// @author Hugo Giraudel
-/// @link https://kittygiraudel.com/2014/01/15/casting-a-string-to-a-number-in-sass/
-/// @param {Number} $value - Value to add unit to
-/// @param {String} $unit - String representation of the unit
-///
-/// @return {Number} - `$value` expressed in `$unit`
-
-@function to-length($value, $unit) {
-	$units: (
-		'px': 1px,
-		'cm': 1cm,
-		'mm': 1mm,
-		'%': 1%,
-		'ch': 1ch,
-		'pc': 1pc,
-		'in': 1in,
-		'em': 1em,
-		'rem': 1rem,
-		'pt': 1pt,
-		'ex': 1ex,
-		'vw': 1vw,
-		'vh': 1vh,
-		'vmin': 1vmin,
-		'vmax': 1vmax,
-	);
-
-	@if not index(map-keys($units), $unit) {
-		$_: log('Invalid unit `#{$unit}`.');
-	}
-
-	@return $value * map-get($units, $unit);
-}
-
-/// Casts a string into a number
-/// @author Hugo Giraudel
-/// @link https://kittygiraudel.com/2014/01/15/casting-a-string-to-a-number-in-sass/
-/// @param {String | Number} $value - Value to be parsed
-/// @return {Number}
-
-@function to-number($value) {
-	@if type-of($value) == 'number' {
-		@return $value;
-	} @else if type-of($value) != 'string' {
-		$_: log('Value for `to-number` should be a number or a string.');
-	}
-
-	$digits: 0;
-	$result: 0;
-	$minus: str-slice($value, 1, 1) == '-';
-	$numbers: (
-		'0': 0,
-		'1': 1,
-		'2': 2,
-		'3': 3,
-		'4': 4,
-		'5': 5,
-		'6': 6,
-		'7': 7,
-		'8': 8,
-		'9': 9,
-	);
-
-	@for $i from if($minus, 2, 1) through str-length($value) {
-		$character: str-slice($value, $i, $i);
-
-		@if not(index(map-keys($numbers), $character) or $character == '.') {
-			@return to-length(
-				if($minus, -$result, $result),
-				str-slice($value, $i)
-			);
-		}
-
-		@if $character == '.' {
-			$digits: 1;
-		} @else if $digits == 0 {
-			$result: $result * 10 + map-get($numbers, $character);
-		} @else {
-			$digits: $digits * 10;
-			$result: $result + map-get($numbers, $character) / $digits;
-		}
-	}
-
-	@return if($minus, -$result, $result);
-}
 
 /// A function that fetches deeply nested values from a Sass map.
 /// @author Hugo Giraudel

--- a/packages/clay-css/src/scss/functions/_type-conversion-functions.scss
+++ b/packages/clay-css/src/scss/functions/_type-conversion-functions.scss
@@ -1,0 +1,608 @@
+/// A function that returns an empty map of type `map`. In Sass, Empty maps and lists can be declared using `()` and Sass will assign its type as `list`. This function ensures its type will be `map`.
+
+@function map-new() {
+	@return map-remove((), 'key');
+}
+
+// * REUSE-Snippet-Begin
+// * SPDX-License-Identifier: MIT
+// * SPDX-FileCopyrightText: © 2014 Kitty Giraudel <https://kittygiraudel.com/>
+// *
+
+/// Add `$unit` to `$value`
+/// @author Hugo Giraudel
+/// @link https://kittygiraudel.com/2014/01/15/casting-a-string-to-a-number-in-sass/
+/// @param {Number} $value - Value to add unit to
+/// @param {String} $unit - String representation of the unit
+///
+/// @return {Number} - `$value` expressed in `$unit`
+
+@function to-length($value, $unit) {
+	$units: (
+		'px': 1px,
+		'cm': 1cm,
+		'mm': 1mm,
+		'%': 1%,
+		'ch': 1ch,
+		'pc': 1pc,
+		'in': 1in,
+		'em': 1em,
+		'rem': 1rem,
+		'pt': 1pt,
+		'ex': 1ex,
+		'vw': 1vw,
+		'vh': 1vh,
+		'vmin': 1vmin,
+		'vmax': 1vmax,
+	);
+
+	@if not index(map-keys($units), $unit) {
+		$_: log('Invalid unit `#{$unit}`.');
+	}
+
+	@return $value * map-get($units, $unit);
+}
+
+/// Casts a string into a number
+/// @author Kitty Giraudel
+/// @link https://kittygiraudel.com/2014/01/15/casting-a-string-to-a-number-in-sass/
+/// @param {String | Number} $value - Value to be parsed
+/// @return {Number}
+
+@function to-number($value) {
+	@if type-of($value) == 'number' {
+		@return $value;
+	} @else if type-of($value) != 'string' {
+		$_: log('Value for `to-number` should be a number or a string.');
+	}
+
+	$digits: 0;
+	$result: 0;
+	$minus: str-slice($value, 1, 1) == '-';
+	$numbers: (
+		'0': 0,
+		'1': 1,
+		'2': 2,
+		'3': 3,
+		'4': 4,
+		'5': 5,
+		'6': 6,
+		'7': 7,
+		'8': 8,
+		'9': 9,
+	);
+
+	@for $i from if($minus, 2, 1) through str-length($value) {
+		$character: str-slice($value, $i, $i);
+
+		@if not(index(map-keys($numbers), $character) or $character == '.') {
+			@return to-length(
+				if($minus, -$result, $result),
+				str-slice($value, $i)
+			);
+		}
+
+		@if $character == '.' {
+			$digits: 1;
+		} @else if $digits == 0 {
+			$result: $result * 10 + map-get($numbers, $character);
+		} @else {
+			$digits: $digits * 10;
+			$result: $result + map-get($numbers, $character) / $digits;
+		}
+	}
+
+	@return if($minus, -$result, $result);
+}
+
+// * REUSE-Snippet-End
+
+// * REUSE-Snippet-Begin
+// * SPDX-License-Identifier: MIT
+// * SPDX-FileCopyrightText: © 2014 Kitty Giraudel <https://github.com/KittyGiraudel/SassyJSON>
+// *
+
+/// Logs an error at `$pointer` with `$string` message
+/// @author Kitty Giraudel
+/// @param {String} $string - error message
+/// @param {Number} $pointer - pointer position
+
+@function throw($string, $pointer) {
+	@error 'ERROR::#{$pointer}::#{$string}';
+}
+
+/// Parses a JSON encoded number to find the integer part
+/// @author Kitty Giraudel
+/// @param {String} $source - JSON complete source
+/// @param {Number} $pointer - current pointer
+/// @throw Unexpected token $token.
+/// @return {List} (new pointer, parsed number)
+/// @require {function} throw
+
+@function find-integer($source, $pointer) {
+	$source: to-lower-case($source);
+	$length: str-length($source);
+	$numbers: '0' '1' '2' '3' '4' '5' '6' '7' '8' '9';
+	$result: 0;
+
+	@while $pointer <= $length {
+		$token: str-slice($source, $pointer, $pointer);
+		$index: index($numbers, $token);
+
+		@if $token == '-' {
+			// do nothing
+		} @else if $index {
+			$result: $result * 10 + ($index - 1);
+		} @else {
+			@if index('e' '.' ' ' ',' ']' '}', $token) {
+				@return $pointer, $result;
+			}
+
+			@return throw('Unexpected token `' + $token + '`.', $pointer);
+		}
+
+		$pointer: $pointer + 1;
+	}
+
+	@return $pointer, $result;
+}
+
+/// Parses a JSON encoded number to find the digits
+/// @author Kitty Giraudel
+/// @param {String} $source - JSON complete source
+/// @param {Number} $pointer - current pointer
+/// @throw Unexpected token $token.
+/// @return {List} (new pointer, parsed number)
+/// @require {function} throw
+
+@function find-digits($source, $pointer) {
+	$source: to-lower-case($source);
+	$length: str-length($source);
+	$numbers: '0' '1' '2' '3' '4' '5' '6' '7' '8' '9';
+	$result: null;
+	$runs: 1;
+
+	@while $pointer <= $length {
+		$token: str-slice($source, $pointer, $pointer);
+		$index: index($numbers, $token);
+
+		@if $token == '.' {
+			// @continue;
+		} @else if $index and $index > 0 {
+			$runs: $runs * 10;
+			$result: if(
+				$result == null,
+				($index - 1),
+				$result * 10 + ($index - 1)
+			);
+		} @else {
+			@if index('e' '.' ' ' ',' ']' '}', $token) {
+				@return $pointer, if($result != null, $result / $runs, $result);
+			}
+
+			@return throw('Unexpected token `#{$token}`.', $pointer);
+		}
+
+		$pointer: $pointer + 1;
+	}
+
+	@return $pointer, if($result != null, $result / $runs, $result);
+}
+
+/// Parses a JSON encoded number to find the exponent part
+/// @author Kitty Giraudel
+/// @param {String} $source - JSON complete source
+/// @param {Number} $pointer - current pointer
+/// @throw Unexpected token $token.
+/// @return {List} - (new pointer, parsed number)
+/// @require {function} throw
+
+@function find-exponent($source, $pointer) {
+	$source: to-lower-case($source);
+	$length: str-length($source);
+	$numbers: '0' '1' '2' '3' '4' '5' '6' '7' '8' '9';
+	$result: null;
+	$minus: null;
+
+	@while $pointer <= $length {
+		$token: str-slice($source, $pointer, $pointer);
+		$index: index($numbers, $token);
+
+		@if $token == 'e' {
+			// @continue;
+		} @else if $token == '-' {
+			@if $minus != null {
+				@return throw('Unexpected token `-`.', $pointer);
+			}
+			$minus: true;
+		} @else if $token == '+' {
+			@if $minus != null {
+				@return throw('Unexpected token `+`.', $pointer);
+			}
+			$minus: false;
+		} @else if $index and $index > 0 {
+			$result: if(
+				$result == null,
+				($index - 1),
+				$result * 10 + ($index - 1)
+			);
+		} @else {
+			@if index(' ' ',' ']' '}', $token) == null {
+				@return throw('Unexpected token `' + $token + '`.', $pointer);
+			}
+
+			@return $pointer,
+				if($minus and $result != null, $result * -1, $result);
+		}
+
+		$pointer: $pointer + 1;
+	}
+
+	@return $pointer, if($minus and $result != null, $result * -1, $result);
+}
+
+/// Power function
+/// @author Kitty Giraudel
+/// @param {Number} $x - number
+/// @param {Number} $n - power
+/// @return {Number}
+
+@function pow($x, $n) {
+	@if $n == 0 {
+		@return 1;
+	}
+	$ret: 1;
+	@if $n >= 0 {
+		@for $i from 1 through $n {
+			$ret: $ret * $x;
+		}
+	} @else {
+		@for $i from $n to 0 {
+			$ret: $ret / $x;
+		}
+	}
+
+	@return $ret;
+}
+
+/// Parses a JSON encoded number
+/// @author Kitty Giraudel
+/// @param {String} $source - JSON complete source
+/// @param {Number} $pointer - current pointer
+/// @throw "Unexpected token $token."
+/// @throw "Unexpected end of stream."
+/// @return {List} (new pointer, parsed number)
+/// @require {function} throw
+/// @require {function} find-integer
+/// @require {function} find-digits
+/// @require {function} find-exponent
+/// @require {function} pow
+@function json-decode--number($source, $pointer) {
+	$pointer: $pointer - 1; // Move back pointer to begininng of number
+	$allowed: '-' '0' '1' '2' '3' '4' '5' '6' '7' '8' '9'; // Allowed characted to start with
+	$first: str-slice(
+		$source,
+		$pointer,
+		$pointer
+	); // First character of the number
+	$minus: $first == '-'; // Is it negative?
+
+	// Early check for errors
+	@if not index($allowed, $first) {
+		@return throw('Unexpected token `' + $first + '`.', $pointer);
+	}
+
+	// Find the integer part
+	$find-integer: find-integer($source, $pointer);
+	$pointer: nth($find-integer, 1);
+	$result: nth($find-integer, 2);
+	@if not $result {
+		// Error occured
+		@return $find-integer;
+	}
+
+	// Find digits
+	@if str-slice($source, $pointer, $pointer) == '.' {
+		$find-digits: find-digits($source, $pointer);
+		$pointer: nth($find-digits, 1);
+		$digits: nth($find-digits, 2);
+
+		@if $digits == null {
+			// Empty digits, throw error
+			@return throw('Unexpected end of stream.', $pointer);
+		} @else if $digits == false {
+			// Error occured, return it
+			@return $find-digits;
+		}
+
+		$result: $result + $digits;
+	}
+
+	// Find exponent
+	@if to-lower-case(str-slice($source, $pointer, $pointer)) == 'e' {
+		$find-exponent: find-exponent($source, $pointer);
+		$pointer: nth($find-exponent, 1);
+		$exponent: nth($find-exponent, 2);
+
+		@if $exponent == null {
+			// Empty exponent, throw error
+			@return throw('Unexpected end of stream.', $pointer);
+		} @else if $exponent == false {
+			// Error occured, return it
+			@return $find-exponent;
+		}
+
+		$result: $result * pow(10, $exponent);
+	}
+
+	@return ($pointer, if($minus, $result * -1, $result));
+}
+
+/// Convert an hexadecimal number to a decimal number
+/// @author Kitty Giraudel
+/// @param {String} $string - hexadecimal value
+/// @return {Number} - decimal number
+
+@function hex-to-dec($string) {
+	$hex: '0' '1' '2' '3' '4' '5' '6' '7' '8' '9' 'a' 'b' 'c' 'd' 'e' 'f';
+	$string: to-lower-case($string);
+	$length: str-length($string);
+
+	$dec: 0;
+	@for $i from 1 through $length {
+		$factor: 1 + (15 * ($length - $i));
+		$index: index($hex, str-slice($string, $i, $i));
+		$dec: $dec + $factor * ($index - 1);
+	}
+
+	@return $dec;
+}
+
+/// Cast a JSON encoded string into a hexadecimal color
+/// @author Kitty Giraudel
+/// @param {String} $string - JSON string
+/// @return {Color | String} - string or hex color depending on the match
+/// @require {function} hex-to-dec
+
+@function from-hex($string) {
+	$string-lower: to-lower-case($string);
+	$r: '';
+	$g: '';
+	$b: '';
+	$hex: '0' '1' '2' '3' '4' '5' '6' '7' '8' '9' 'a' 'b' 'c' 'd' 'e' 'f';
+	$length: str-length($string);
+	$max: if($length == 4, 1, 2);
+
+	// Check for length accuracy
+	@if $length != 4 and $length != 7 {
+		@return $string;
+	}
+
+	// Loop from the second character (omitting #)
+	@for $i from 2 through $length {
+		$c: str-slice($string-lower, $i, $i);
+
+		// If wrong character, return
+		@if index($hex, $c) == null {
+			@return $string;
+		}
+
+		@if str-length($r) < $max {
+			$r: $r + $c;
+		} @else if str-length($g) < $max {
+			$g: $g + $c;
+		} @else if str-length($b) < $max {
+			$b: $b + $c;
+		}
+	}
+
+	@if $length == 4 {
+		$r: $r + $r;
+		$g: $g + $g;
+		$b: $b + $b;
+	}
+
+	@return rgb(hex-to-dec($r), hex-to-dec($g), hex-to-dec($b));
+}
+
+/// Cast a stringified number / stringified percentage into number type
+/// @author Kitty Giraudel
+/// @param {String} $string - A string
+/// @return {Number} - unitless number or percentage
+/// @require {function} json-decode--number
+
+@function get-color-value($string) {
+	$first: str-slice($string, 1, 1);
+
+	// Pad <1 values with a leading 0
+	@if $first == '.' {
+		$string: '0' + $string;
+	}
+
+	$last: str-slice($string, -1, -1);
+
+	@return if(
+		$last == '%',
+		nth(json-decode--number(str-slice($string, 1, -2), 2), 2) * 1%,
+		nth(json-decode--number($string, 2), 2)
+	);
+}
+
+/// Cast a JSON encoded string into a hsl(a) color
+/// @author Kitty Giraudel
+/// @param {String} $string - JSON string
+/// @return {Color | String} - string or hsl(a) color, depending on the match
+/// @require {function} get-color-value
+
+@function from-hsl($string) {
+	$frags: ();
+	$string-lower: to-lower-case($string);
+	$is-alpha: str-slice($string-lower, 4, 4) == 'a';
+	$length: str-length($string);
+	$start: str-index($string, '(');
+
+	@for $i from $start through $length {
+		$token: str-slice($string-lower, $i, $i);
+		@if $token == ' ' or $token == '	' {
+			// @continue;
+		} @else if $token == '(' or $token == ',' {
+			$frags: append($frags, '');
+		} @else if $token == ')' {
+			@if length($frags) != if($is-alpha, 4, 3) {
+				@return $string;
+			} // Parsing error
+			$hue: get-color-value(nth($frags, 1));
+			$saturation: get-color-value(nth($frags, 2));
+			$lightness: get-color-value(nth($frags, 3));
+
+			@if not $hue or not $saturation or not $lightness {
+				@return $string;
+			}
+
+			@if $is-alpha {
+				@if length($frags) != 4 {
+					@return $string;
+				} // No alpha channel found
+				$alpha: get-color-value(nth($frags, 4));
+				@if not $alpha {
+					@return $string;
+				} // Error parsing alpha channel
+				@return hsla($hue, $saturation, $lightness, $alpha);
+			}
+
+			@return hsl($hue, $saturation, $lightness);
+		} @else {
+			$frags: set-nth(
+				$frags,
+				length($frags),
+				nth($frags, length($frags)) + $token
+			);
+		}
+	}
+
+	@return $string;
+}
+
+/// Cast a JSON encoded string into a rgb(a) color
+/// @author Kitty Giraudel
+/// @param {String} $string - JSON string
+/// @return {Color | String} - string or rgb(a) color depending on the match
+/// @require {function} get-color-value
+
+@function from-rgb($string) {
+	$string-lower: to-lower-case($string);
+	$frags: ();
+	$is-alpha: str-slice($string-lower, 4, 4) == 'a';
+	$start: str-index($string, '(');
+	$length: str-length($string);
+
+	@for $i from $start through $length {
+		$token: str-slice($string-lower, $i, $i);
+		@if $token == ' ' or $token == '	' {
+			// @continue;
+		} @else if $token == '(' or $token == ',' {
+			$frags: append($frags, '');
+		} @else if $token == ')' {
+			@if length($frags) != if($is-alpha, 4, 3) {
+				@return $string;
+			} // Parsing error
+			$red: get-color-value(nth($frags, 1));
+			$green: get-color-value(nth($frags, 2));
+			$blue: get-color-value(nth($frags, 3));
+
+			@if not $red or not $green or not $blue {
+				@return $string;
+			}
+
+			@if $is-alpha {
+				@if length($frags) != 4 {
+					@return $string;
+				} // No alpha channel found
+				$alpha: get-color-value(nth($frags, 4));
+				@if not $alpha {
+					@return $string;
+				} // Error parsing alpha channel
+				@return rgba($red, $green, $blue, $alpha);
+			}
+
+			@return rgb($red, $green, $blue);
+		} @else {
+			$frags: set-nth(
+				$frags,
+				length($frags),
+				nth($frags, length($frags)) + $token
+			);
+		}
+	}
+
+	@return $string;
+}
+
+/// A function that parses a string to see if it's a CSS color
+/// @author Kitty Giraudel
+/// @param {String} $string - JSON string
+/// @return {Color | String} - string or number, depending on the match
+/// @require {function} from-hex
+/// @require {function} from-rgb
+/// @require {function} from-hsl
+
+@function to-color($string) {
+	@if type-of($string) == 'color' {
+		@return $string;
+	}
+
+	$string-lower: to-lower-case($string);
+	$colors: transparent black silver gray white maroon red purple fuchsia green
+		lime olive yellow navy blue teal aqua aliceblue antiquewhite aqua
+		aquamarine azure beige bisque black blanchedalmond blue blueviolet brown
+		burlywood cadetblue chartreuse chocolate coral cornflowerblue cornsilk
+		crimson cyan darkblue darkcyan darkgoldenrod darkgray darkgreen darkgrey
+		darkkhaki darkmagenta darkolivegreen darkorange darkorchid darkred
+		darksalmon darkseagreen darkslateblue darkslategray darkslategrey
+		darkturquoise darkviolet deeppink deepskyblue dimgray dimgrey dodgerblue
+		firebrick floralwhite forestgreen fuchsia gainsboro ghostwhite gold
+		goldenrod gray green greenyellow grey honeydew hotpink indianred indigo
+		ivory khaki lavender lavenderblush lawngreen lemonchiffon lightblue
+		lightcoral lightcyan lightgoldenrodyellow lightgray lightgreen lightgrey
+		lightpink lightsalmon lightseagreen lightskyblue lightslategray
+		lightslategrey lightsteelblue lightyellow lime limegreen linen magenta
+		maroon mediumaquamarine mediumblue mediumorchid mediumpurple
+		mediumseagreen mediumslateblue mediumspringgreen mediumturquoise
+		mediumvioletred midnightblue mintcream mistyrose moccasin navajowhite
+		navy oldlace olive olivedrab orange orangered orchid palegoldenrod
+		palegreen paleturquoise palevioletred papayawhip peachpuff peru pink
+		plum powderblue purple red rosybrown royalblue saddlebrown salmon
+		sandybrown seagreen seashell sienna silver skyblue slateblue slategray
+		slategrey snow springgreen steelblue tan teal thistle tomato turquoise
+		violet wheat white whitesmoke yellow yellowgreen;
+	$keywords: ();
+
+	// Filling $keywords with stringified color keywords
+	@each $color in $colors {
+		$keywords: append($keywords, $color + '');
+	}
+
+	// Deal with inherit keyword
+	@if $string-lower == 'inherit' {
+		@return unquote($string);
+	}
+
+	@if index($keywords, $string-lower) {
+		// Deal with color keywords
+		@return nth($colors, index($keywords, $string-lower));
+	} @else if str-slice($string-lower, 1, 1) == '#' {
+		// Deal with hexadecimal triplets
+		@return from-hex($string);
+	} @else if str-slice($string-lower, 1, 3) == 'rgb' {
+		// Deal with rgb(a) colors
+		@return from-rgb($string);
+	} @else if str-slice($string-lower, 1, 3) == 'hsl' {
+		// Deal with hsl(a) colors
+		@return from-hsl($string);
+	} @else {
+		// Return string
+		@return $string;
+	}
+}
+
+// * REUSE-Snippet-End

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -596,10 +596,29 @@ $form-control-select: map-deep-merge(
 			(
 				appearance: null,
 				cursor: null,
+				overflow: hidden,
+				text-overflow: ellipsis,
+				white-space: nowrap,
+				hover: (
+					color: inherit,
+					text-decoration: none,
+				),
 			)
 		)
 	),
 	$form-control-select
+);
+
+$form-control-select-sm: () !default;
+$form-control-select-sm: map-deep-merge(
+	(
+		height: $input-height-sm,
+		padding-right: 2em,
+		mobile: (
+			height: $input-height-sm-mobile,
+		),
+	),
+	$form-control-select-sm
 );
 
 // Select Size

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -379,6 +379,24 @@ $body-moz-osx-font-smoothing: $moz-osx-font-smoothing !default;
 $body-webkit-font-smoothing: $webkit-font-smoothing !default;
 $body-text-align: inherit !default;
 
+$c-body: () !default;
+$c-body: map-merge(
+	(
+		background-color: $body-bg,
+		color: $body-color,
+		font-family: $font-family-base,
+		font-size: $font-size-base,
+		-moz-osx-font-smoothing: $body-moz-osx-font-smoothing,
+		-webkit-font-smoothing: $body-webkit-font-smoothing,
+		font-weight: $font-weight-base,
+		line-height: $line-height-base,
+		margin: 0,
+		-ms-overflow-style: scrollbar,
+		text-align: $body-text-align,
+	),
+	$c-body
+);
+
 // Button
 
 $c-button-base: () !default;

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -124,14 +124,14 @@ $dark-l2: lighten($dark, 32.94) !default;
 $theme-colors: () !default;
 $theme-colors: map-merge(
 	(
-		'primary': $primary,
-		'secondary': $secondary,
-		'success': $success,
-		'info': $info,
-		'warning': $warning,
-		'danger': $danger,
-		'light': $light,
-		'dark': $dark,
+		primary: $primary,
+		secondary: $secondary,
+		success: $success,
+		info: $info,
+		warning: $warning,
+		danger: $danger,
+		light: $light,
+		dark: $dark,
 	),
 	$theme-colors
 );
@@ -503,3 +503,213 @@ $input-btn-border-width: $border-width !default;
 
 $print-body-min-width: map-get($grid-breakpoints, 'lg') !default;
 $print-page-size: a3 !default;
+
+$bg-theme-colors: () !default;
+$bg-theme-colors: map-deep-merge(
+	(
+		primary: (
+			background-color: $primary !important,
+			hover: (
+				background-color: darken($primary, 10%) !important,
+			),
+		),
+		secondary: (
+			background-color: $secondary !important,
+			hover: (
+				background-color: darken($secondary, 10%) !important,
+			),
+		),
+		success: (
+			background-color: $success !important,
+			hover: (
+				background-color: darken($success, 10%) !important,
+			),
+		),
+		info: (
+			background-color: $info !important,
+			hover: (
+				background-color: darken($info, 10%) !important,
+			),
+		),
+		warning: (
+			background-color: $warning !important,
+			hover: (
+				background-color: darken($warning, 10%) !important,
+			),
+		),
+		danger: (
+			background-color: $danger !important,
+			hover: (
+				background-color: darken($danger, 10%) !important,
+			),
+		),
+		light: (
+			background-color: $light !important,
+			hover: (
+				background-color: darken($light, 10%) !important,
+			),
+		),
+		dark: (
+			background-color: $dark !important,
+			hover: (
+				background-color: darken($dark, 10%) !important,
+			),
+		),
+		white: (
+			background-color: $white !important,
+		),
+		transparent: (
+			background-color: transparent !important,
+		),
+	),
+	$bg-theme-colors
+);
+
+$bg-gradient-theme-colors: () !default;
+$bg-gradient-theme-colors: map-deep-merge(
+	(
+		primary: (
+			background: $primary
+				linear-gradient(180deg, mix($body-bg, $primary, 15%), $primary)
+				repeat-x !important,
+		),
+		secondary: (
+			background: $secondary
+				linear-gradient(
+					180deg,
+					mix($body-bg, $secondary, 15%),
+					$secondary
+				)
+				repeat-x !important,
+		),
+		success: (
+			background: $success
+				linear-gradient(180deg, mix($body-bg, $success, 15%), $success)
+				repeat-x !important,
+		),
+		info: (
+			background: $info
+				linear-gradient(180deg, mix($body-bg, $info, 15%), $info)
+				repeat-x !important,
+		),
+		warning: (
+			background: $warning
+				linear-gradient(180deg, mix($body-bg, $warning, 15%), $warning)
+				repeat-x !important,
+		),
+		danger: (
+			background: $danger
+				linear-gradient(180deg, mix($body-bg, $danger, 15%), $danger)
+				repeat-x !important,
+		),
+		light: (
+			background: $light
+				linear-gradient(180deg, mix($body-bg, $light, 15%), $light)
+				repeat-x !important,
+		),
+		dark: (
+			background: $dark
+				linear-gradient(180deg, mix($body-bg, $dark, 15%), $dark)
+				repeat-x !important,
+		),
+	),
+	$bg-gradient-theme-colors
+);
+
+$border-theme-colors: () !default;
+$border-theme-colors: map-deep-merge(
+	(
+		primary: (
+			border-color: $primary !important,
+		),
+		secondary: (
+			border-color: $secondary !important,
+		),
+		success: (
+			border-color: $success !important,
+		),
+		info: (
+			border-color: $info !important,
+		),
+		warning: (
+			border-color: $warning !important,
+		),
+		danger: (
+			border-color: $danger !important,
+		),
+		light: (
+			border-color: $light !important,
+		),
+		dark: (
+			border-color: $dark !important,
+		),
+	),
+	$border-theme-colors
+);
+
+$text-theme-colors: () !default;
+$text-theme-colors: map-deep-merge(
+	(
+		primary: (
+			color: $primary !important,
+			hover: (
+				color:
+					darken($primary, $emphasized-link-hover-darken-percentage)
+					!important,
+			),
+		),
+		secondary: (
+			color: $secondary !important,
+			hover: (
+				color:
+					darken($secondary, $emphasized-link-hover-darken-percentage)
+					!important,
+			),
+		),
+		success: (
+			color: $success !important,
+			hover: (
+				color:
+					darken($success, $emphasized-link-hover-darken-percentage)
+					!important,
+			),
+		),
+		info: (
+			color: $info !important,
+			hover: (
+				color: darken($info, $emphasized-link-hover-darken-percentage)
+					!important,
+			),
+		),
+		warning: (
+			color: $warning !important,
+			hover: (
+				color:
+					darken($warning, $emphasized-link-hover-darken-percentage)
+					!important,
+			),
+		),
+		danger: (
+			color: $danger !important,
+			hover: (
+				color: darken($danger, $emphasized-link-hover-darken-percentage)
+					!important,
+			),
+		),
+		light: (
+			color: $light !important,
+			hover: (
+				color: darken($light, $emphasized-link-hover-darken-percentage)
+					!important,
+			),
+		),
+		dark: (
+			color: $dark !important,
+			hover: (
+				color: darken($dark, $emphasized-link-hover-darken-percentage)
+					!important,
+			),
+		),
+	),
+	$text-theme-colors
+);

--- a/packages/clay-css/src/scss/variables/_list-group.scss
+++ b/packages/clay-css/src/scss/variables/_list-group.scss
@@ -162,6 +162,119 @@ $list-group-link-color: null !default;
 $list-group-link-hover-color: null !default;
 $list-group-link-active-color: $white !default;
 
+// List Group Item Variants
+
+$list-group-item-theme-colors: () !default;
+$list-group-item-theme-colors: map-deep-merge(
+	(
+		primary: (
+			background-color: theme-color-level(primary, -9),
+			color: theme-color-level(primary, 6),
+			hover: (
+				background-color: darken(theme-color-level(primary, -9), 5%),
+				color: theme-color-level(primary, 6),
+			),
+			active: (
+				background-color: theme-color-level(primary, 6),
+				border-color: theme-color-level(primary, 6),
+				color: $white,
+			),
+		),
+		secondary: (
+			background-color: theme-color-level(secondary, -9),
+			color: theme-color-level(secondary, 6),
+			hover: (
+				background-color: darken(theme-color-level(secondary, -9), 5%),
+				color: theme-color-level(secondary, 6),
+			),
+			active: (
+				background-color: theme-color-level(secondary, 6),
+				border-color: theme-color-level(secondary, 6),
+				color: $white,
+			),
+		),
+		success: (
+			background-color: theme-color-level(success, -9),
+			color: theme-color-level(success, 6),
+			hover: (
+				background-color: darken(theme-color-level(success, -9), 5%),
+				color: theme-color-level(success, 6),
+			),
+			active: (
+				background-color: theme-color-level(success, 6),
+				border-color: theme-color-level(success, 6),
+				color: $white,
+			),
+		),
+		info: (
+			background-color: theme-color-level(info, -9),
+			color: theme-color-level(info, 6),
+			hover: (
+				background-color: darken(theme-color-level(info, -9), 5%),
+				color: theme-color-level(info, 6),
+			),
+			active: (
+				background-color: theme-color-level(info, 6),
+				border-color: theme-color-level(info, 6),
+				color: $white,
+			),
+		),
+		warning: (
+			background-color: theme-color-level(warning, -9),
+			color: theme-color-level(warning, 6),
+			hover: (
+				background-color: darken(theme-color-level(warning, -9), 5%),
+				color: theme-color-level(warning, 6),
+			),
+			active: (
+				background-color: theme-color-level(warning, 6),
+				border-color: theme-color-level(warning, 6),
+				color: $white,
+			),
+		),
+		danger: (
+			background-color: theme-color-level(danger, -9),
+			color: theme-color-level(danger, 6),
+			hover: (
+				background-color: darken(theme-color-level(danger, -9), 5%),
+				color: theme-color-level(danger, 6),
+			),
+			active: (
+				background-color: theme-color-level(danger, 6),
+				border-color: theme-color-level(danger, 6),
+				color: $white,
+			),
+		),
+		light: (
+			background-color: theme-color-level(light, -9),
+			color: theme-color-level(light, 6),
+			hover: (
+				background-color: darken(theme-color-level(light, -9), 5%),
+				color: theme-color-level(light, 6),
+			),
+			active: (
+				background-color: theme-color-level(light, 6),
+				border-color: theme-color-level(light, 6),
+				color: $white,
+			),
+		),
+		dark: (
+			background-color: theme-color-level(dark, -9),
+			color: theme-color-level(dark, 6),
+			hover: (
+				background-color: darken(theme-color-level(dark, -9), 5%),
+				color: theme-color-level(dark, 6),
+			),
+			active: (
+				background-color: theme-color-level(dark, 6),
+				border-color: theme-color-level(dark, 6),
+				color: $white,
+			),
+		),
+	),
+	$list-group-item-theme-colors
+);
+
 // List Group Notification
 
 $list-group-notification-item-border-bottom-color: $list-group-border-color !default;

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -410,6 +410,79 @@ $table-valign-top-body-cell-padding-top: 1rem !default;
 
 $table-valign-bottom-body-cell-padding-bottom: 1rem !default;
 
+// Table Row Backgrounds
+
+$table-row-theme-colors: () !default;
+$table-row-theme-colors: map-deep-merge(
+	(
+		primary: (
+			background-color: theme-color-level(primary, $table-bg-level),
+			border-color: theme-color-level(primary, $table-border-level),
+			hover: (
+				background-color:
+					darken(theme-color-level(primary, $table-bg-level), 5%),
+			),
+		),
+		secondary: (
+			background-color: theme-color-level(secondary, $table-bg-level),
+			border-color: theme-color-level(secondary, $table-border-level),
+			hover: (
+				background-color:
+					darken(theme-color-level(secondary, $table-bg-level), 5%),
+			),
+		),
+		success: (
+			background-color: theme-color-level(success, $table-bg-level),
+			border-color: theme-color-level(success, $table-border-level),
+			hover: (
+				background-color:
+					darken(theme-color-level(success, $table-bg-level), 5%),
+			),
+		),
+		info: (
+			background-color: theme-color-level(info, $table-bg-level),
+			border-color: theme-color-level(info, $table-border-level),
+			hover: (
+				background-color:
+					darken(theme-color-level(info, $table-bg-level), 5%),
+			),
+		),
+		warning: (
+			background-color: theme-color-level(warning, $table-bg-level),
+			border-color: theme-color-level(warning, $table-border-level),
+			hover: (
+				background-color:
+					darken(theme-color-level(warning, $table-bg-level), 5%),
+			),
+		),
+		danger: (
+			background-color: theme-color-level(danger, $table-bg-level),
+			border-color: theme-color-level(danger, $table-border-level),
+			hover: (
+				background-color:
+					darken(theme-color-level(danger, $table-bg-level), 5%),
+			),
+		),
+		light: (
+			background-color: theme-color-level(light, $table-bg-level),
+			border-color: theme-color-level(light, $table-border-level),
+			hover: (
+				background-color:
+					darken(theme-color-level(light, $table-bg-level), 5%),
+			),
+		),
+		dark: (
+			background-color: theme-color-level(dark, $table-bg-level),
+			border-color: theme-color-level(dark, $table-border-level),
+			hover: (
+				background-color:
+					darken(theme-color-level(dark, $table-bg-level), 5%),
+			),
+		),
+	),
+	$table-row-theme-colors
+);
+
 // Table Draggable
 
 $table-drag: () !default;

--- a/packages/clay-pagination-bar/CHANGELOG.md
+++ b/packages/clay-pagination-bar/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.33.0](https://github.com/liferay/clay/compare/v3.32.1...v3.33.0) (2021-08-11)
+
+### Features
+
+-   **@clayui/pagination-bar:** Add the `alignmentPosition` API to PaginationBarWithBasicItems component ([eca557f](https://github.com/liferay/clay/commit/eca557f))
+
 # [3.32.0](https://github.com/liferay/clay/compare/v3.31.0...v3.32.0) (2021-07-28)
 
 ### Features

--- a/packages/clay-pagination-bar/package.json
+++ b/packages/clay-pagination-bar/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/pagination-bar",
-	"version": "3.32.0",
+	"version": "3.33.0",
 	"description": "ClayPaginationBar component",
 	"license": "BSD-3-Clause",
 	"repository": "https://github.com/liferay/clay",
@@ -29,7 +29,7 @@
 		"@clayui/button": "^3.32.0",
 		"@clayui/drop-down": "^3.32.0",
 		"@clayui/icon": "^3.32.0",
-		"@clayui/pagination": "^3.32.0",
+		"@clayui/pagination": "^3.33.0",
 		"@clayui/shared": "^3.32.0",
 		"classnames": "^2.2.6"
 	},

--- a/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
+++ b/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
@@ -52,6 +52,14 @@ interface IProps extends React.ComponentProps<typeof PaginationBar> {
 	activePage?: number;
 
 	/**
+	 * Sets the default DropDown position of the component. The component
+	 * receives the Align constant values from the `@clayui/drop-down` package.
+	 */
+	alignmentPosition?: React.ComponentProps<
+		typeof ClayPaginationWithBasicItems
+	>['alignmentPosition'];
+
+	/**
 	 * Possible values of items per page.
 	 */
 	deltas?: Array<IDelta>;
@@ -121,6 +129,7 @@ const DEFAULT_LABELS = {
 export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> = ({
 	activeDelta,
 	activePage = 1,
+	alignmentPosition,
 	deltas = defaultDeltas,
 	disabledPages,
 	ellipsisBuffer,
@@ -170,6 +179,7 @@ export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> = 
 		<PaginationBar {...otherProps}>
 			{showDeltasDropDown && (
 				<PaginationBar.DropDown
+					alignmentPosition={alignmentPosition}
 					items={items}
 					trigger={
 						<ClayButton
@@ -199,6 +209,7 @@ export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> = 
 
 			<ClayPaginationWithBasicItems
 				activePage={activePage}
+				alignmentPosition={alignmentPosition}
 				disabledPages={disabledPages}
 				ellipsisBuffer={ellipsisBuffer}
 				hrefConstructor={hrefConstructor}

--- a/packages/clay-pagination/CHANGELOG.md
+++ b/packages/clay-pagination/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.33.0](https://github.com/liferay/clay/compare/v3.32.1...v3.33.0) (2021-08-11)
+
+### Features
+
+-   **@clayui/pagination:** Add the `alignmentPosition` API to PaginationWithBasicItems component ([24ca87c](https://github.com/liferay/clay/commit/24ca87c))
+
 # [3.32.0](https://github.com/liferay/clay/compare/v3.31.0...v3.32.0) (2021-07-28)
 
 **Note:** Version bump only for package @clayui/pagination

--- a/packages/clay-pagination/package.json
+++ b/packages/clay-pagination/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/pagination",
-	"version": "3.32.0",
+	"version": "3.33.0",
 	"description": "ClayPagination component",
 	"license": "BSD-3-Clause",
 	"repository": "https://github.com/liferay/clay",

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -8,13 +8,17 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import React from 'react';
 
 export interface IPaginationEllipsisProps {
-	items?: Array<number>;
+	alignmentPosition?: React.ComponentProps<
+		typeof ClayDropDownWithItems
+	>['alignmentPosition'];
 	disabledPages?: Array<number>;
 	hrefConstructor?: (page?: number) => string;
+	items?: Array<number>;
 	onPageChange?: (page?: number) => void;
 }
 
 const ClayPaginationEllipsis: React.FunctionComponent<IPaginationEllipsisProps> = ({
+	alignmentPosition,
 	disabledPages = [],
 	hrefConstructor,
 	items = [],
@@ -29,6 +33,7 @@ const ClayPaginationEllipsis: React.FunctionComponent<IPaginationEllipsisProps> 
 
 	return (
 		<ClayDropDownWithItems
+			alignmentPosition={alignmentPosition}
 			className="page-item"
 			containerElement="li"
 			items={pages}

--- a/packages/clay-pagination/src/PaginationWithBasicItems.tsx
+++ b/packages/clay-pagination/src/PaginationWithBasicItems.tsx
@@ -7,6 +7,7 @@ import ClayIcon from '@clayui/icon';
 import {getEllipsisItems} from '@clayui/shared';
 import React from 'react';
 
+import type {IPaginationEllipsisProps} from './Ellipsis';
 import Pagination from './Pagination';
 
 const ELLIPSIS_BUFFER = 2;
@@ -16,6 +17,12 @@ interface IProps extends React.ComponentProps<typeof Pagination> {
 	 * The page that is currently active. The first page is `1`.
 	 */
 	activePage: number;
+
+	/**
+	 * Sets the default DropDown position of the component. The component
+	 * receives the Align constant values from the `@clayui/drop-down` package.
+	 */
+	alignmentPosition?: IPaginationEllipsisProps['alignmentPosition'];
 
 	/**
 	 * Labels for the aria attributes
@@ -62,6 +69,7 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 	(
 		{
 			activePage,
+			alignmentPosition,
 			ariaLabels = {
 				next: 'Next',
 				previous: 'Previous',
@@ -103,6 +111,7 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 							{
 								EllipsisComponent: Pagination.Ellipsis,
 								ellipsisProps: {
+									alignmentPosition,
 									disabledPages,
 									hrefConstructor,
 									onPageChange,

--- a/packages/clay-pagination/stories/index.tsx
+++ b/packages/clay-pagination/stories/index.tsx
@@ -91,4 +91,14 @@ storiesOf('Components|ClayPagination', module)
 				totalPages={totalPages}
 			/>
 		);
+	})
+	.add('ClayPaginationWithBasicItems w/ alignment DropDown position', () => {
+		const totalPages = number('Number of pages', 5);
+
+		return (
+			<PaginationWithState
+				alignmentPosition={4}
+				totalPages={totalPages}
+			/>
+		);
 	});

--- a/packages/demos/CHANGELOG.md
+++ b/packages/demos/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.33.0](https://github.com/matuzalemsteles/clay/compare/v3.32.1...v3.33.0) (2021-08-11)
+
+**Note:** Version bump only for package demos
+
 # [3.32.0](https://github.com/matuzalemsteles/clay/compare/v3.31.0...v3.32.0) (2021-07-28)
 
 **Note:** Version bump only for package demos

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -14,8 +14,8 @@
 		"@clayui/management-toolbar": "^3.32.0",
 		"@clayui/multi-select": "^3.32.0",
 		"@clayui/nav": "^3.32.0",
-		"@clayui/pagination": "^3.32.0",
-		"@clayui/pagination-bar": "^3.32.0",
+		"@clayui/pagination": "^3.33.0",
+		"@clayui/pagination-bar": "^3.33.0",
 		"@clayui/panel": "^3.32.0",
 		"classnames": "^2.2.6",
 		"react-dnd": "^10.0.2",
@@ -25,5 +25,5 @@
 	"devDependencies": {
 		"@types/recharts": "1.8.10"
 	},
-	"version": "3.32.0"
+	"version": "3.33.0"
 }


### PR DESCRIPTION
## [3.33.0](https://github.com/liferay/clay/compare/v3.32.1...v3.33.0) (2021-08-11)

### Bug Fixes

-   **@clayui/css:** Cadmin Modal .modal.show should have display: block ([5876b9f](https://github.com/liferay/clay/commit/5876b9f)), closes [#4203](https://github.com/liferay/clay/issues/4203)
-   **@clayui/css:** Cadmin removes unused variables `$cadmin-body-moz-osx-font-smoothing`, `$cadmin-body-webkit-font-smoothing`, `$cadmin-body-text-align`. We don't provide a CSS reset in Cadmin. ([c3af64e](https://github.com/liferay/clay/commit/c3af64e))
-   **@clayui/css:** Forms .form-control-select with long text shouldn't break to new line and should have overflow ellipsis, similar behavior to select.form-control ([44804d8](https://github.com/liferay/clay/commit/44804d8)), closes [#4206](https://github.com/liferay/clay/issues/4206)
-   **@clayui/css:** Forms remove Bootstrap's confusing way of setting an inset box-shadow on an input. This causes flickering on .btn.form-control-select on click. If you want a regular box-shadow and an inset box-shadow on an input define them both inside the \$input-box-shadow variable. Example below: ([83d56d1](https://github.com/liferay/clay/commit/83d56d1)), closes [#4206](https://github.com/liferay/clay/issues/4206)
-   **@clayui/css:** Functions adds `_type-conversion-functions.scss` for converting colors of type string to type color. Sass doesn't provide a way to do this https://github.com/sass/sass/issues/3006. ([68be792](https://github.com/liferay/clay/commit/68be792)), closes [#4180](https://github.com/liferay/clay/issues/4180)
-   **@clayui/css:** Global Functions `clay-get-fallback` convert color string to type color ([68fd699](https://github.com/liferay/clay/commit/68fd699))
-   **@clayui/css:** Removes the use of `$theme-colors` Sass map to generate utility properties (e.g., `bg-primary`, `text-primary`, `list-group-item-primary`, `table-primary`) and allow configuring separately. The new way also supports CSS variables. Adds new maps: ([78fb2d2](https://github.com/liferay/clay/commit/78fb2d2))

### Features

-   **@clayui/css:** Reboot `body` element should use clay-css mixin for generating properties ([c0b456e](https://github.com/liferay/clay/commit/c0b456e)), closes [#4194](https://github.com/liferay/clay/issues/4194)
-   **@clayui/pagination:** Add the `alignmentPosition` API to PaginationWithBasicItems component ([24ca87c](https://github.com/liferay/clay/commit/24ca87c))
-   **@clayui/pagination-bar:** Add the `alignmentPosition` API to PaginationBarWithBasicItems component ([eca557f](https://github.com/liferay/clay/commit/eca557f))
