### PR TITLE
fix(@clayui/css): Wrap *-theme-colors map keys in single quotes. Key …

### DIFF
--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -124,14 +124,14 @@ $dark-l2: lighten($dark, 32.94) !default;
 $theme-colors: () !default;
 $theme-colors: map-merge(
 	(
-		primary: $primary,
-		secondary: $secondary,
-		success: $success,
-		info: $info,
-		warning: $warning,
-		danger: $danger,
-		light: $light,
-		dark: $dark,
+		'primary': $primary,
+		'secondary': $secondary,
+		'success': $success,
+		'info': $info,
+		'warning': $warning,
+		'danger': $danger,
+		'light': $light,
+		'dark': $dark,
 	),
 	$theme-colors
 );

--- a/packages/clay-css/src/scss/variables/_list-group.scss
+++ b/packages/clay-css/src/scss/variables/_list-group.scss
@@ -167,7 +167,7 @@ $list-group-link-active-color: $white !default;
 $list-group-item-theme-colors: () !default;
 $list-group-item-theme-colors: map-deep-merge(
 	(
-		primary: (
+		'primary': (
 			background-color: theme-color-level(primary, -9),
 			color: theme-color-level(primary, 6),
 			hover: (
@@ -180,7 +180,7 @@ $list-group-item-theme-colors: map-deep-merge(
 				color: $white,
 			),
 		),
-		secondary: (
+		'secondary': (
 			background-color: theme-color-level(secondary, -9),
 			color: theme-color-level(secondary, 6),
 			hover: (
@@ -193,7 +193,7 @@ $list-group-item-theme-colors: map-deep-merge(
 				color: $white,
 			),
 		),
-		success: (
+		'success': (
 			background-color: theme-color-level(success, -9),
 			color: theme-color-level(success, 6),
 			hover: (
@@ -206,7 +206,7 @@ $list-group-item-theme-colors: map-deep-merge(
 				color: $white,
 			),
 		),
-		info: (
+		'info': (
 			background-color: theme-color-level(info, -9),
 			color: theme-color-level(info, 6),
 			hover: (
@@ -219,7 +219,7 @@ $list-group-item-theme-colors: map-deep-merge(
 				color: $white,
 			),
 		),
-		warning: (
+		'warning': (
 			background-color: theme-color-level(warning, -9),
 			color: theme-color-level(warning, 6),
 			hover: (
@@ -232,7 +232,7 @@ $list-group-item-theme-colors: map-deep-merge(
 				color: $white,
 			),
 		),
-		danger: (
+		'danger': (
 			background-color: theme-color-level(danger, -9),
 			color: theme-color-level(danger, 6),
 			hover: (
@@ -245,7 +245,7 @@ $list-group-item-theme-colors: map-deep-merge(
 				color: $white,
 			),
 		),
-		light: (
+		'light': (
 			background-color: theme-color-level(light, -9),
 			color: theme-color-level(light, 6),
 			hover: (
@@ -258,7 +258,7 @@ $list-group-item-theme-colors: map-deep-merge(
 				color: $white,
 			),
 		),
-		dark: (
+		'dark': (
 			background-color: theme-color-level(dark, -9),
 			color: theme-color-level(dark, 6),
 			hover: (

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -415,7 +415,7 @@ $table-valign-bottom-body-cell-padding-bottom: 1rem !default;
 $table-row-theme-colors: () !default;
 $table-row-theme-colors: map-deep-merge(
 	(
-		primary: (
+		'primary': (
 			background-color: theme-color-level(primary, $table-bg-level),
 			border-color: theme-color-level(primary, $table-border-level),
 			hover: (
@@ -423,7 +423,7 @@ $table-row-theme-colors: map-deep-merge(
 					darken(theme-color-level(primary, $table-bg-level), 5%),
 			),
 		),
-		secondary: (
+		'secondary': (
 			background-color: theme-color-level(secondary, $table-bg-level),
 			border-color: theme-color-level(secondary, $table-border-level),
 			hover: (
@@ -431,7 +431,7 @@ $table-row-theme-colors: map-deep-merge(
 					darken(theme-color-level(secondary, $table-bg-level), 5%),
 			),
 		),
-		success: (
+		'success': (
 			background-color: theme-color-level(success, $table-bg-level),
 			border-color: theme-color-level(success, $table-border-level),
 			hover: (
@@ -439,7 +439,7 @@ $table-row-theme-colors: map-deep-merge(
 					darken(theme-color-level(success, $table-bg-level), 5%),
 			),
 		),
-		info: (
+		'info': (
 			background-color: theme-color-level(info, $table-bg-level),
 			border-color: theme-color-level(info, $table-border-level),
 			hover: (
@@ -447,7 +447,7 @@ $table-row-theme-colors: map-deep-merge(
 					darken(theme-color-level(info, $table-bg-level), 5%),
 			),
 		),
-		warning: (
+		'warning': (
 			background-color: theme-color-level(warning, $table-bg-level),
 			border-color: theme-color-level(warning, $table-border-level),
 			hover: (
@@ -455,7 +455,7 @@ $table-row-theme-colors: map-deep-merge(
 					darken(theme-color-level(warning, $table-bg-level), 5%),
 			),
 		),
-		danger: (
+		'danger': (
 			background-color: theme-color-level(danger, $table-bg-level),
 			border-color: theme-color-level(danger, $table-border-level),
 			hover: (
@@ -463,7 +463,7 @@ $table-row-theme-colors: map-deep-merge(
 					darken(theme-color-level(danger, $table-bg-level), 5%),
 			),
 		),
-		light: (
+		'light': (
 			background-color: theme-color-level(light, $table-bg-level),
 			border-color: theme-color-level(light, $table-border-level),
 			hover: (
@@ -471,7 +471,7 @@ $table-row-theme-colors: map-deep-merge(
 					darken(theme-color-level(light, $table-bg-level), 5%),
 			),
 		),
-		dark: (
+		'dark': (
 			background-color: theme-color-level(dark, $table-bg-level),
 			border-color: theme-color-level(dark, $table-border-level),
 			hover: (

--- a/packages/clay-css/src/scss/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/variables/_utilities.scss
@@ -131,58 +131,58 @@ $page-header-bg: $gray-200 !default;
 $bg-theme-colors: () !default;
 $bg-theme-colors: map-deep-merge(
 	(
-		primary: (
+		'primary': (
 			background-color: $primary !important,
 			hover: (
 				background-color: darken($primary, 10%) !important,
 			),
 		),
-		secondary: (
+		'secondary': (
 			background-color: $secondary !important,
 			hover: (
 				background-color: darken($secondary, 10%) !important,
 			),
 		),
-		success: (
+		'success': (
 			background-color: $success !important,
 			hover: (
 				background-color: darken($success, 10%) !important,
 			),
 		),
-		info: (
+		'info': (
 			background-color: $info !important,
 			hover: (
 				background-color: darken($info, 10%) !important,
 			),
 		),
-		warning: (
+		'warning': (
 			background-color: $warning !important,
 			hover: (
 				background-color: darken($warning, 10%) !important,
 			),
 		),
-		danger: (
+		'danger': (
 			background-color: $danger !important,
 			hover: (
 				background-color: darken($danger, 10%) !important,
 			),
 		),
-		light: (
+		'light': (
 			background-color: $light !important,
 			hover: (
 				background-color: darken($light, 10%) !important,
 			),
 		),
-		dark: (
+		'dark': (
 			background-color: $dark !important,
 			hover: (
 				background-color: darken($dark, 10%) !important,
 			),
 		),
-		white: (
+		'white': (
 			background-color: $white !important,
 		),
-		transparent: (
+		'transparent': (
 			background-color: transparent !important,
 		),
 	),
@@ -192,7 +192,7 @@ $bg-theme-colors: map-deep-merge(
 $bg-gradient-theme-colors: () !default;
 $bg-gradient-theme-colors: map-deep-merge(
 	(
-		primary: (
+		'primary': (
 			background: $primary
 				linear-gradient(
 					180deg,
@@ -201,7 +201,7 @@ $bg-gradient-theme-colors: map-deep-merge(
 				)
 				repeat-x !important,
 		),
-		secondary: (
+		'secondary': (
 			background: $secondary
 				linear-gradient(
 					180deg,
@@ -210,7 +210,7 @@ $bg-gradient-theme-colors: map-deep-merge(
 				)
 				repeat-x !important,
 		),
-		success: (
+		'success': (
 			background: $success
 				linear-gradient(
 					180deg,
@@ -219,7 +219,7 @@ $bg-gradient-theme-colors: map-deep-merge(
 				)
 				repeat-x !important,
 		),
-		info: (
+		'info': (
 			background: $info
 				linear-gradient(
 					180deg,
@@ -228,7 +228,7 @@ $bg-gradient-theme-colors: map-deep-merge(
 				)
 				repeat-x !important,
 		),
-		warning: (
+		'warning': (
 			background: $warning
 				linear-gradient(
 					180deg,
@@ -237,7 +237,7 @@ $bg-gradient-theme-colors: map-deep-merge(
 				)
 				repeat-x !important,
 		),
-		danger: (
+		'danger': (
 			background: $danger
 				linear-gradient(
 					180deg,
@@ -246,7 +246,7 @@ $bg-gradient-theme-colors: map-deep-merge(
 				)
 				repeat-x !important,
 		),
-		light: (
+		'light': (
 			background: $light
 				linear-gradient(
 					180deg,
@@ -255,7 +255,7 @@ $bg-gradient-theme-colors: map-deep-merge(
 				)
 				repeat-x !important,
 		),
-		dark: (
+		'dark': (
 			background: $dark
 				linear-gradient(
 					180deg,
@@ -273,31 +273,31 @@ $bg-gradient-theme-colors: map-deep-merge(
 $border-theme-colors: () !default;
 $border-theme-colors: map-deep-merge(
 	(
-		primary: (
+		'primary': (
 			border-color: $primary !important,
 		),
-		secondary: (
+		'secondary': (
 			border-color: $secondary !important,
 		),
-		success: (
+		'success': (
 			border-color: $success !important,
 		),
-		info: (
+		'info': (
 			border-color: $info !important,
 		),
-		warning: (
+		'warning': (
 			border-color: $warning !important,
 		),
-		danger: (
+		'danger': (
 			border-color: $danger !important,
 		),
-		light: (
+		'light': (
 			border-color: $light !important,
 		),
-		dark: (
+		'dark': (
 			border-color: $dark !important,
 		),
-		white: (
+		'white': (
 			border-color: $white !important,
 		),
 	),
@@ -322,7 +322,7 @@ $positions: static, relative, absolute, fixed, sticky !default;
 $text-theme-colors: () !default;
 $text-theme-colors: map-deep-merge(
 	(
-		primary: (
+		'primary': (
 			color: $primary !important,
 			hover: (
 				color:
@@ -330,7 +330,7 @@ $text-theme-colors: map-deep-merge(
 					!important,
 			),
 		),
-		secondary: (
+		'secondary': (
 			color: $secondary !important,
 			hover: (
 				color:
@@ -338,7 +338,7 @@ $text-theme-colors: map-deep-merge(
 					!important,
 			),
 		),
-		success: (
+		'success': (
 			color: $success !important,
 			hover: (
 				color:
@@ -346,14 +346,14 @@ $text-theme-colors: map-deep-merge(
 					!important,
 			),
 		),
-		info: (
+		'info': (
 			color: $info !important,
 			hover: (
 				color: darken($info, $emphasized-link-hover-darken-percentage)
 					!important,
 			),
 		),
-		warning: (
+		'warning': (
 			color: $warning !important,
 			hover: (
 				color:
@@ -361,37 +361,37 @@ $text-theme-colors: map-deep-merge(
 					!important,
 			),
 		),
-		danger: (
+		'danger': (
 			color: $danger !important,
 			hover: (
 				color: darken($danger, $emphasized-link-hover-darken-percentage)
 					!important,
 			),
 		),
-		light: (
+		'light': (
 			color: $light !important,
 			hover: (
 				color: darken($light, $emphasized-link-hover-darken-percentage)
 					!important,
 			),
 		),
-		dark: (
+		'dark': (
 			color: $dark !important,
 			hover: (
 				color: darken($dark, $emphasized-link-hover-darken-percentage)
 					!important,
 			),
 		),
-		body: (
+		'body': (
 			color: $body-color !important,
 		),
-		muted: (
+		'muted': (
 			color: $text-muted !important,
 		),
-		black-50: (
+		'black-50': (
 			color: rgba($black, 0.5) !important,
 		),
-		white-50: (
+		'white-50': (
 			color: rgba($white, 0.5) !important,
 		),
 	),


### PR DESCRIPTION
…names that match CSS colors makes Sass throw this warning without quotes:

> WARNING: You probably don't mean to use the color value white in interpolation here.
It may end up represented as white, which will likely produce invalid CSS.
Always quote color names when using them as strings or map keys (for example, "white").
If you really want to use the color value here, use '"" + $color'.

fixes #4219