### PR TITLE
feat(@clayui/core): adds functionality for expandable nodes and nested nodes

### DIFF
--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -29,10 +29,12 @@
 		"@clayui/button": "^3.32.0",
 		"@clayui/drop-down": "^3.35.3",
 		"@clayui/icon": "^3.32.0",
+		"@clayui/layout": "^3.32.0",
 		"@clayui/modal": "^3.35.3",
 		"@clayui/provider": "^3.35.3",
-		"@clayui/layout": "^3.32.0",
-		"classnames": "^2.2.6"
+		"@clayui/shared": "^3.35.3",
+		"classnames": "^2.2.6",
+		"react-transition-group": "^4.4.1"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -15,7 +15,10 @@ export interface ICollectionProps<T> {
 }
 
 function getKey(index: number, key?: React.Key | null, parentKey?: React.Key) {
-	if (key != null) {
+	if (
+		key != null &&
+		(!String(key).startsWith('.') || String(key).startsWith('.$'))
+	) {
 		return key;
 	}
 
@@ -26,7 +29,7 @@ export function Collection<T extends Record<any, any>>({
 	children,
 	items,
 }: ICollectionProps<T>) {
-	const {parentKey} = useItem();
+	const {key: parentKey} = useItem();
 
 	return (
 		<>
@@ -43,7 +46,7 @@ export function Collection<T extends Record<any, any>>({
 						return (
 							<ItemContextProvider
 								key={key}
-								value={{...item, key, parentKey: key}}
+								value={{...item, key}}
 							>
 								{child}
 							</ItemContextProvider>
@@ -57,10 +60,7 @@ export function Collection<T extends Record<any, any>>({
 						const key = getKey(index, child.key, parentKey);
 
 						return (
-							<ItemContextProvider
-								key={key}
-								value={{key, parentKey: key}}
-							>
+							<ItemContextProvider key={key} value={{key}}>
 								{child}
 							</ItemContextProvider>
 						);

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -5,13 +5,15 @@
 
 import React from 'react';
 
+import {useTreeViewContext} from './context';
 import {ItemContextProvider, useItem} from './useItem';
 
 export type ChildrenFunction<T> = (item: T) => React.ReactElement;
 
 export interface ICollectionProps<T> {
 	children: React.ReactNode | ChildrenFunction<T>;
-	items?: Array<T>;
+	items?: Array<T> | Record<string, T>;
+	rootItem?: string;
 }
 
 function getKey(index: number, key?: React.Key | null, parentKey?: React.Key) {
@@ -27,14 +29,27 @@ function getKey(index: number, key?: React.Key | null, parentKey?: React.Key) {
 
 export function Collection<T extends Record<any, any>>({
 	children,
-	items,
+	items: compoundItems,
+	rootItem,
 }: ICollectionProps<T>) {
 	const {key: parentKey} = useItem();
+	const {items: rootItems} = useTreeViewContext();
+
+	const items =
+		typeof compoundItems === 'object' &&
+		!Array.isArray(compoundItems) &&
+		rootItem
+			? [compoundItems[rootItem]]
+			: (compoundItems as Array<T>);
 
 	return (
 		<>
 			{typeof children === 'function' && items
 				? items.map((item, index) => {
+						if (typeof item === 'string') {
+							item = (rootItems as Record<string, T>)[item];
+						}
+
 						const child = children(item);
 
 						const key = getKey(

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+import {ItemContextProvider, useItem} from './useItem';
+
+export type ChildrenFunction<T> = (item: T) => React.ReactElement;
+
+export interface ICollectionProps<T> {
+	children: React.ReactNode | ChildrenFunction<T>;
+	items?: Array<T>;
+}
+
+function getKey(index: number, key?: React.Key | null, parentKey?: React.Key) {
+	if (key != null) {
+		return key;
+	}
+
+	return parentKey ? `${parentKey}.${index}` : `$.${index}`;
+}
+
+export function Collection<T extends Record<any, any>>({
+	children,
+	items,
+}: ICollectionProps<T>) {
+	const {parentKey} = useItem();
+
+	return (
+		<>
+			{typeof children === 'function' && items
+				? items.map((item, index) => {
+						const child = children(item);
+
+						const key = getKey(
+							index,
+							item.id ?? child.key,
+							parentKey
+						);
+
+						return (
+							<ItemContextProvider
+								key={key}
+								value={{...item, key, parentKey: key}}
+							>
+								{child}
+							</ItemContextProvider>
+						);
+				  })
+				: React.Children.toArray(children).map((child, index) => {
+						if (!React.isValidElement(child)) {
+							return null;
+						}
+
+						const key = getKey(index, child.key, parentKey);
+
+						return (
+							<ItemContextProvider
+								key={key}
+								value={{key, parentKey: key}}
+							>
+								{child}
+							</ItemContextProvider>
+						);
+				  })}
+		</>
+	);
+}

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -5,15 +5,13 @@
 
 import React from 'react';
 
-import {useTreeViewContext} from './context';
 import {ItemContextProvider, useItem} from './useItem';
 
 export type ChildrenFunction<T> = (item: T) => React.ReactElement;
 
 export interface ICollectionProps<T> {
 	children: React.ReactNode | ChildrenFunction<T>;
-	items?: Array<T> | Record<string, T>;
-	rootItem?: string;
+	items?: Array<T>;
 }
 
 function getKey(index: number, key?: React.Key | null, parentKey?: React.Key) {
@@ -29,27 +27,14 @@ function getKey(index: number, key?: React.Key | null, parentKey?: React.Key) {
 
 export function Collection<T extends Record<any, any>>({
 	children,
-	items: compoundItems,
-	rootItem,
+	items,
 }: ICollectionProps<T>) {
 	const {key: parentKey} = useItem();
-	const {items: rootItems} = useTreeViewContext();
-
-	const items =
-		typeof compoundItems === 'object' &&
-		!Array.isArray(compoundItems) &&
-		rootItem
-			? [compoundItems[rootItem]]
-			: (compoundItems as Array<T>);
 
 	return (
 		<>
 			{typeof children === 'function' && items
 				? items.map((item, index) => {
-						if (typeof item === 'string') {
-							item = (rootItems as Record<string, T>)[item];
-						}
-
 						const child = children(item);
 
 						const key = getKey(

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -40,6 +40,7 @@ export function TreeView<T>({
 	nestedKey,
 	onExpandedChange,
 	onSelectionChange,
+	rootItem,
 	selectedKeys,
 	showExpanderOnHover = true,
 	...otherProps
@@ -57,6 +58,7 @@ export function TreeView<T>({
 				? (children as ChildrenFunction<Object>)
 				: undefined,
 		expanderIcons,
+		items,
 		nestedKey,
 		showExpanderOnHover,
 		...state,
@@ -72,7 +74,9 @@ export function TreeView<T>({
 			role="tree"
 		>
 			<TreeViewContext.Provider value={context}>
-				<Collection<T> items={items}>{children}</Collection>
+				<Collection<T> items={items} rootItem={rootItem}>
+					{children}
+				</Collection>
 			</TreeViewContext.Provider>
 		</ul>
 	);

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -6,21 +6,18 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import {ChildrenFunction, Collection, ICollectionProps} from './Collection';
 import {TreeViewGroup} from './TreeViewGroup';
 import {TreeViewItem, TreeViewItemStack} from './TreeViewItem';
 import {TreeViewContext} from './context';
-import {ItemContextProvider} from './useItem';
 import {IExpandable, IMultipleSelection, useTree} from './useTree';
 
-type ChildrenFunction<T> = (item: T) => React.ReactElement;
-
 interface ITreeViewProps<T>
-	extends React.HTMLAttributes<HTMLUListElement>,
+	extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'>,
 		IMultipleSelection,
-		IExpandable {
-	children: React.ReactNode | ChildrenFunction<T>;
+		IExpandable,
+		ICollectionProps<T> {
 	displayType?: 'light' | 'dark';
-	items?: Array<T>;
 	nestedKey?: string;
 	showExpanderOnHover?: boolean;
 }
@@ -33,7 +30,7 @@ export function TreeView<T>(
 	ItemStack: typeof TreeViewItemStack;
 };
 
-export function TreeView<T extends Record<any, any>>({
+export function TreeView<T>({
 	children,
 	className,
 	displayType = 'light',
@@ -69,21 +66,12 @@ export function TreeView<T extends Record<any, any>>({
 			role="tree"
 		>
 			<TreeViewContext.Provider value={context}>
-				{typeof children === 'function' && items
-					? items.map((item, index) => (
-							<ItemContextProvider
-								key={item.id ?? index}
-								value={item}
-							>
-								{children(item)}
-							</ItemContextProvider>
-					  ))
-					: children}
+				<Collection<T> items={items}>{children}</Collection>
 			</TreeViewContext.Provider>
 		</ul>
 	);
 }
 
-TreeView.Item = TreeViewItem;
 TreeView.Group = TreeViewGroup;
+TreeView.Item = TreeViewItem;
 TreeView.ItemStack = TreeViewItemStack;

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -10,12 +10,11 @@ import {ChildrenFunction, Collection, ICollectionProps} from './Collection';
 import {TreeViewGroup} from './TreeViewGroup';
 import {TreeViewItem, TreeViewItemStack} from './TreeViewItem';
 import {Icons, TreeViewContext} from './context';
-import {IExpandable, IMultipleSelection, useTree} from './useTree';
+import {ITreeProps, useTree} from './useTree';
 
 interface ITreeViewProps<T>
 	extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'>,
-		IMultipleSelection,
-		IExpandable,
+		ITreeProps,
 		ICollectionProps<T> {
 	displayType?: 'light' | 'dark';
 	expanderIcons?: Icons;
@@ -40,6 +39,8 @@ export function TreeView<T>({
 	items,
 	nestedKey,
 	onExpandedChange,
+	onSelectionChange,
+	selectedKeys,
 	showExpanderOnHover = true,
 	...otherProps
 }: ITreeViewProps<T>) {
@@ -55,6 +56,8 @@ export function TreeView<T>({
 				: undefined,
 		expanderIcons,
 		nestedKey,
+		onSelectionChange,
+		selectedKeys,
 		showExpanderOnHover,
 		...state,
 	};

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import {ChildrenFunction, Collection, ICollectionProps} from './Collection';
 import {TreeViewGroup} from './TreeViewGroup';
 import {TreeViewItem, TreeViewItemStack} from './TreeViewItem';
-import {TreeViewContext} from './context';
+import {Icons, TreeViewContext} from './context';
 import {IExpandable, IMultipleSelection, useTree} from './useTree';
 
 interface ITreeViewProps<T>
@@ -18,6 +18,7 @@ interface ITreeViewProps<T>
 		IExpandable,
 		ICollectionProps<T> {
 	displayType?: 'light' | 'dark';
+	expanderIcons?: Icons;
 	nestedKey?: string;
 	showExpanderOnHover?: boolean;
 }
@@ -35,6 +36,7 @@ export function TreeView<T>({
 	className,
 	displayType = 'light',
 	expandedKeys,
+	expanderIcons,
 	items,
 	nestedKey,
 	onExpandedChange,
@@ -51,6 +53,7 @@ export function TreeView<T>({
 			typeof children === 'function'
 				? (children as ChildrenFunction<Object>)
 				: undefined,
+		expanderIcons,
 		nestedKey,
 		showExpanderOnHover,
 		...state,

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -40,7 +40,6 @@ export function TreeView<T>({
 	nestedKey,
 	onExpandedChange,
 	onSelectionChange,
-	rootItem,
 	selectedKeys,
 	showExpanderOnHover = true,
 	...otherProps
@@ -58,7 +57,6 @@ export function TreeView<T>({
 				? (children as ChildrenFunction<Object>)
 				: undefined,
 		expanderIcons,
-		items,
 		nestedKey,
 		showExpanderOnHover,
 		...state,
@@ -74,9 +72,7 @@ export function TreeView<T>({
 			role="tree"
 		>
 			<TreeViewContext.Provider value={context}>
-				<Collection<T> items={items} rootItem={rootItem}>
-					{children}
-				</Collection>
+				<Collection<T> items={items}>{children}</Collection>
 			</TreeViewContext.Provider>
 		</ul>
 	);

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -47,6 +47,8 @@ export function TreeView<T>({
 	const state = useTree({
 		expandedKeys,
 		onExpandedChange,
+		onSelectionChange,
+		selectedKeys,
 	});
 
 	const context = {
@@ -56,8 +58,6 @@ export function TreeView<T>({
 				: undefined,
 		expanderIcons,
 		nestedKey,
-		onSelectionChange,
-		selectedKeys,
 		showExpanderOnHover,
 		...state,
 	};

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -7,18 +7,12 @@ import {setElementFullHeight} from '@clayui/shared';
 import React from 'react';
 import {CSSTransition} from 'react-transition-group';
 
+import {Collection, ICollectionProps} from './Collection';
 import {useTreeViewContext} from './context';
-import {ItemContextProvider, useItem} from './useItem';
-
-type ChildrenFunction<T> = (item: T) => React.ReactElement;
-
-type TreeViewItemProps<T> = {
-	children: React.ReactNode | ChildrenFunction<T>;
-	items?: Array<T>;
-};
+import {useItem} from './useItem';
 
 export function TreeViewGroup<T>(
-	props: TreeViewItemProps<T>
+	props: ICollectionProps<T>
 ): JSX.Element & {
 	displayName: string;
 };
@@ -26,7 +20,7 @@ export function TreeViewGroup<T>(
 export function TreeViewGroup<T extends Record<any, any>>({
 	children,
 	items,
-}: TreeViewItemProps<T>) {
+}: ICollectionProps<T>) {
 	const {expandedKeys} = useTreeViewContext();
 
 	const item = useItem();
@@ -41,8 +35,8 @@ export function TreeViewGroup<T extends Record<any, any>>({
 				exit: 'show',
 				exitActive: 'collapsing',
 			}}
-			id={item.id}
-			in={expandedKeys!.has(item.id)}
+			id={item.key}
+			in={expandedKeys!.has(item.key)}
 			onEnter={(el: HTMLElement) =>
 				el.setAttribute('style', 'height: 0px')
 			}
@@ -54,16 +48,7 @@ export function TreeViewGroup<T extends Record<any, any>>({
 		>
 			<div>
 				<ul className="treeview-group" role="group">
-					{typeof children === 'function' && items
-						? items.map((item, index) => (
-								<ItemContextProvider
-									key={item.id ?? index}
-									value={item}
-								>
-									{children(item)}
-								</ItemContextProvider>
-						  ))
-						: children}
+					<Collection<T> items={items}>{children}</Collection>
 				</ul>
 			</div>
 		</CSSTransition>

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -29,7 +29,7 @@ export function TreeViewGroup<T extends Record<any, any>>({
 	return (
 		<CSSTransition
 			className={classNames('collapse', {
-				show: expandedKeys!.has(item.key),
+				show: expandedKeys.has(item.key),
 			})}
 			classNames={{
 				enter: 'collapsing',
@@ -39,7 +39,7 @@ export function TreeViewGroup<T extends Record<any, any>>({
 				exitActive: 'collapsing',
 			}}
 			id={item.key}
-			in={expandedKeys!.has(item.key)}
+			in={expandedKeys.has(item.key)}
 			onEnter={(el: HTMLElement) =>
 				el.setAttribute('style', 'height: 0px')
 			}

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -4,6 +4,7 @@
  */
 
 import {setElementFullHeight} from '@clayui/shared';
+import classNames from 'classnames';
 import React from 'react';
 import {CSSTransition} from 'react-transition-group';
 
@@ -27,7 +28,9 @@ export function TreeViewGroup<T extends Record<any, any>>({
 
 	return (
 		<CSSTransition
-			className="collapse"
+			className={classNames('collapse', {
+				show: expandedKeys!.has(item.key),
+			})}
 			classNames={{
 				enter: 'collapsing',
 				enterActive: 'show',

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -44,12 +44,12 @@ export function TreeViewItem({children}: TreeViewItemProps) {
 			<li className="treeview-item" role="none">
 				<div
 					aria-expanded={
-						group ? expandedKeys!.has(item.key) : undefined
+						group ? expandedKeys.has(item.key) : undefined
 					}
 					className={classNames('treeview-link', {
-						collapsed: group && !expandedKeys!.has(item.key),
+						collapsed: group && expandedKeys.has(item.key),
 					})}
-					onClick={() => group && toggle!(item.key)}
+					onClick={() => group && toggle(item.key)}
 					role="treeitem"
 					style={{paddingLeft: `${spacing}px`}}
 					tabIndex={0}
@@ -89,7 +89,12 @@ export function TreeViewItemStack({
 	children,
 	expandable = true,
 }: TreeViewItemStackProps) {
-	const {expandedKeys, expanderIcons, toggle} = useTreeViewContext();
+	const {
+		expandedKeys,
+		expanderIcons,
+		selection,
+		toggle,
+	} = useTreeViewContext();
 
 	const item = useItem();
 
@@ -100,14 +105,14 @@ export function TreeViewItemStack({
 			{expandable && (
 				<Layout.ContentCol>
 					<Button
-						aria-controls={item.key}
-						aria-expanded={expandedKeys!.has(item.key)}
+						aria-controls={`${item.key}`}
+						aria-expanded={expandedKeys.has(item.key)}
 						className={classNames('component-expander', {
-							collapsed: !expandedKeys!.has(item.key),
+							collapsed: expandedKeys.has(item.key),
 						})}
 						displayType={null}
 						monospaced
-						onClick={() => toggle!(item.key)}
+						onClick={() => toggle(item.key)}
 					>
 						<span className="c-inner" tabIndex={-2}>
 							{expanderIcons?.close ? (
@@ -143,6 +148,14 @@ export function TreeViewItemStack({
 					// @ts-ignore
 				} else if (child?.type.displayName === 'ClayIcon') {
 					content = <div className="component-icon">{child}</div>;
+
+					// @ts-ignore
+				} else if (child?.type.displayName === 'ClayCheckbox') {
+					content = React.cloneElement(child as React.ReactElement, {
+						checked: selection.selectedKeys.has(item.key),
+						indeterminate: selection.isIntermediate(item.key),
+						onChange: () => selection.toggleSelection(item.key),
+					});
 				}
 
 				return (

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -6,7 +6,11 @@
 import Button from '@clayui/button';
 import Icon from '@clayui/icon';
 import Layout from '@clayui/layout';
+import classNames from 'classnames';
 import React, {useContext} from 'react';
+
+import {useTreeViewContext} from './context';
+import {useItem} from './useItem';
 
 type TreeViewItemProps = {
 	children: React.ReactNode;
@@ -16,6 +20,14 @@ const SpacingContext = React.createContext(0);
 
 export function TreeViewItem({children}: TreeViewItemProps) {
 	const spacing = useContext(SpacingContext);
+	const {
+		childrenRoot,
+		expandedKeys,
+		nestedKey,
+		toggle,
+	} = useTreeViewContext();
+
+	const item = useItem();
 
 	const [left, right] = React.Children.toArray(children);
 
@@ -23,13 +35,19 @@ export function TreeViewItem({children}: TreeViewItemProps) {
 		// @ts-ignore
 		right?.type?.displayName === 'ClayTreeViewGroup' ? right : null;
 
+	if (!group && nestedKey && item[nestedKey] && childrenRoot) {
+		return childrenRoot(item);
+	}
+
 	return (
 		<SpacingContext.Provider value={spacing + 24}>
 			<li className="treeview-item" role="none">
 				<div
-					aria-expanded="true"
-					className="treeview-link"
-					data-toggle="collapse"
+					aria-expanded={expandedKeys!.has(item.id)}
+					className={classNames('treeview-link', {
+						collapsed: !expandedKeys!.has(item.id),
+					})}
+					onClick={() => toggle!(item.id)}
 					role="treeitem"
 					style={{paddingLeft: `${spacing}px`}}
 					tabIndex={0}
@@ -69,6 +87,10 @@ export function TreeViewItemStack({
 	children,
 	expandable = true,
 }: TreeViewItemStackProps) {
+	const {expandedKeys, toggle} = useTreeViewContext();
+
+	const item = useItem();
+
 	const childrenArray = React.Children.toArray(children);
 
 	return (
@@ -76,11 +98,14 @@ export function TreeViewItemStack({
 			{expandable && (
 				<Layout.ContentCol>
 					<Button
-						aria-expanded="true"
-						className="component-expander"
-						data-toggle="collapse"
+						aria-controls={item.id}
+						aria-expanded={expandedKeys!.has(item.id)}
+						className={classNames('component-expander', {
+							collapsed: !expandedKeys!.has(item.id),
+						})}
 						displayType={null}
 						monospaced
+						onClick={() => toggle!(item.id)}
 					>
 						<span className="c-inner" tabIndex={-2}>
 							<Icon symbol="angle-down" />

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -43,11 +43,13 @@ export function TreeViewItem({children}: TreeViewItemProps) {
 		<SpacingContext.Provider value={spacing + 24}>
 			<li className="treeview-item" role="none">
 				<div
-					aria-expanded={expandedKeys!.has(item.id)}
+					aria-expanded={
+						group ? expandedKeys!.has(item.key) : undefined
+					}
 					className={classNames('treeview-link', {
-						collapsed: !expandedKeys!.has(item.id),
+						collapsed: group && !expandedKeys!.has(item.key),
 					})}
-					onClick={() => toggle!(item.id)}
+					onClick={() => group && toggle!(item.key)}
 					role="treeitem"
 					style={{paddingLeft: `${spacing}px`}}
 					tabIndex={0}
@@ -87,7 +89,7 @@ export function TreeViewItemStack({
 	children,
 	expandable = true,
 }: TreeViewItemStackProps) {
-	const {expandedKeys, toggle} = useTreeViewContext();
+	const {expandedKeys, expanderIcons, toggle} = useTreeViewContext();
 
 	const item = useItem();
 
@@ -98,14 +100,14 @@ export function TreeViewItemStack({
 			{expandable && (
 				<Layout.ContentCol>
 					<Button
-						aria-controls={item.id}
-						aria-expanded={expandedKeys!.has(item.id)}
+						aria-controls={item.key}
+						aria-expanded={expandedKeys!.has(item.key)}
 						className={classNames('component-expander', {
-							collapsed: !expandedKeys!.has(item.id),
+							collapsed: !expandedKeys!.has(item.key),
 						})}
 						displayType={null}
 						monospaced
-						onClick={() => toggle!(item.id)}
+						onClick={() => toggle!(item.key)}
 					>
 						<span className="c-inner" tabIndex={-2}>
 							<Icon symbol="angle-down" />
@@ -120,6 +122,10 @@ export function TreeViewItemStack({
 
 			{React.Children.map(children, (child, index) => {
 				let content = child;
+
+				if (!content) {
+					return null;
+				}
 
 				if (typeof child === 'string') {
 					content = <div className="component-text">{child}</div>;

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -110,11 +110,21 @@ export function TreeViewItemStack({
 						onClick={() => toggle!(item.key)}
 					>
 						<span className="c-inner" tabIndex={-2}>
-							<Icon symbol="angle-down" />
-							<Icon
-								className="component-expanded-d-none"
-								symbol="angle-right"
-							/>
+							{expanderIcons?.close ? (
+								expanderIcons.close
+							) : (
+								<Icon symbol="angle-down" />
+							)}
+							{expanderIcons?.open ? (
+								React.cloneElement(expanderIcons.open, {
+									className: 'component-expanded-d-none',
+								})
+							) : (
+								<Icon
+									className="component-expanded-d-none"
+									symbol="angle-right"
+								/>
+							)}
 						</span>
 					</Button>
 				</Layout.ContentCol>

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -155,6 +155,22 @@ export function TreeViewItemStack({
 						checked: selection.selectedKeys.has(item.key),
 						indeterminate: selection.isIntermediate(item.key),
 						onChange: () => selection.toggleSelection(item.key),
+						onClick: (
+							event: React.MouseEvent<
+								HTMLInputElement,
+								MouseEvent
+							>
+						) => {
+							event.stopPropagation();
+
+							const {
+								onClick,
+							} = (child as React.ReactElement).props;
+
+							if (onClick) {
+								onClick(event);
+							}
+						},
 					});
 				}
 

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -5,6 +5,7 @@
 
 import React, {useContext} from 'react';
 
+import type {ICollectionProps} from './Collection';
 import type {ITreeState} from './useTree';
 
 export type Icons = {
@@ -16,6 +17,7 @@ export interface ITreeViewContext extends ITreeState {
 	childrenRoot?: (item: Object) => React.ReactElement;
 	expanderIcons?: Icons;
 	nestedKey?: string;
+	items?: ICollectionProps<unknown>['items'];
 	showExpanderOnHover?: boolean;
 }
 

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -5,6 +5,11 @@
 
 import React, {Key, useContext} from 'react';
 
+export type Icons = {
+	open: React.ReactElement;
+	close: React.ReactElement;
+};
+
 export interface ITreeViewContext {
 	childrenRoot?: (item: Object) => React.ReactElement;
 	expandedKeys?: Set<Key>;

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -5,7 +5,6 @@
 
 import React, {useContext} from 'react';
 
-import type {ICollectionProps} from './Collection';
 import type {ITreeState} from './useTree';
 
 export type Icons = {
@@ -17,7 +16,6 @@ export interface ITreeViewContext extends ITreeState {
 	childrenRoot?: (item: Object) => React.ReactElement;
 	expanderIcons?: Icons;
 	nestedKey?: string;
-	items?: ICollectionProps<unknown>['items'];
 	showExpanderOnHover?: boolean;
 }
 

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {useContext} from 'react';
+import React, {Key, useContext} from 'react';
 
 export interface ITreeViewContext {
 	childrenRoot?: (item: Object) => React.ReactElement;
-	expandedKeys?: Set<string>;
+	expandedKeys?: Set<Key>;
+	expanderIcons?: Icons;
 	nestedKey?: string;
 	showExpanderOnHover?: boolean;
-	toggle?: (key: string) => void;
+	toggle?: (key: Key) => void;
 }
 
 export const TreeViewContext = React.createContext<ITreeViewContext>({});

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -6,7 +6,11 @@
 import React, {useContext} from 'react';
 
 export interface ITreeViewContext {
+	childrenRoot?: (item: Object) => React.ReactElement;
+	expandedKeys?: Set<string>;
+	nestedKey?: string;
 	showExpanderOnHover?: boolean;
+	toggle?: (key: string) => void;
 }
 
 export const TreeViewContext = React.createContext<ITreeViewContext>({});

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -3,23 +3,25 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {Key, useContext} from 'react';
+import React, {useContext} from 'react';
+
+import type {ITreeState} from './useTree';
 
 export type Icons = {
 	open: React.ReactElement;
 	close: React.ReactElement;
 };
 
-export interface ITreeViewContext {
+export interface ITreeViewContext extends ITreeState {
 	childrenRoot?: (item: Object) => React.ReactElement;
-	expandedKeys?: Set<Key>;
 	expanderIcons?: Icons;
 	nestedKey?: string;
 	showExpanderOnHover?: boolean;
-	toggle?: (key: Key) => void;
 }
 
-export const TreeViewContext = React.createContext<ITreeViewContext>({});
+export const TreeViewContext = React.createContext<ITreeViewContext>(
+	{} as ITreeViewContext
+);
 
 export function useTreeViewContext(): ITreeViewContext {
 	return useContext(TreeViewContext);

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -29,11 +29,10 @@ export function ItemContextProvider({children, value}: Props) {
 
 	const keyRef = useRef(getKey(value.key));
 
-	useEffect(() => selection.createLayoutItemLazy(keyRef.current, parentKey), [
-		selection.createLayoutItemLazy,
-		keyRef,
-		parentKey,
-	]);
+	useEffect(
+		() => selection.createPartialLayoutItem(keyRef.current, parentKey),
+		[selection.createPartialLayoutItem, keyRef, parentKey]
+	);
 
 	const props = {
 		...value,

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -14,25 +14,16 @@ type Props = {
 
 const ItemContext = React.createContext<Value>({});
 
-// From https://gist.github.com/gordonbrander/2230317
-function getUUID() {
-	const array = window.crypto.getRandomValues(new Uint32Array(8));
-
-	let output = '';
-
-	for (let i = 0; i < array.length; i++) {
-		output += (i < 2 || i > 5 ? '' : '-') + array[i].toString(16).slice(-4);
-	}
-
-	return output;
+function getKey(key: React.Key) {
+	return `${key}`.replace('.$', '');
 }
 
-export function ItemContextProvider({children, value}: Props) {
-	const idRef = useRef(value.id ?? getUUID());
+export function ItemContextProvider({children, value = {}}: Props) {
+	const keyRef = useRef(getKey(value.key));
 
 	const props = {
 		...value,
-		id: idRef.current,
+		key: keyRef.current,
 	};
 
 	return (

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React, {useContext, useRef} from 'react';
+
+type Value = Record<string, any>;
+
+type Props = {
+	children: React.ReactNode;
+	value: Value;
+};
+
+const ItemContext = React.createContext<Value>({});
+
+// From https://gist.github.com/gordonbrander/2230317
+function getUUID() {
+	const array = window.crypto.getRandomValues(new Uint32Array(8));
+
+	let output = '';
+
+	for (let i = 0; i < array.length; i++) {
+		output += (i < 2 || i > 5 ? '' : '-') + array[i].toString(16).slice(-4);
+	}
+
+	return output;
+}
+
+export function ItemContextProvider({children, value}: Props) {
+	const idRef = useRef(value.id ?? getUUID());
+
+	const props = {
+		...value,
+		id: idRef.current,
+	};
+
+	return (
+		<ItemContext.Provider value={props}>{children}</ItemContext.Provider>
+	);
+}
+
+export function useItem() {
+	return useContext(ItemContext);
+}

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -29,8 +29,8 @@ export function ItemContextProvider({children, value}: Props) {
 
 	const keyRef = useRef(getKey(value.key));
 
-	useEffect(() => selection.mount(keyRef.current, parentKey), [
-		selection.mount,
+	useEffect(() => selection.createLayoutItemLazy(keyRef.current, parentKey), [
+		selection.createLayoutItemLazy,
 		keyRef,
 		parentKey,
 	]);

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -3,23 +3,37 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {useContext, useRef} from 'react';
+import React, {useContext, useEffect, useRef} from 'react';
 
-type Value = Record<string, any>;
+import {useTreeViewContext} from './context';
+
+type Value = {
+	[propName: string]: any;
+	key: React.Key;
+};
 
 type Props = {
 	children: React.ReactNode;
 	value: Value;
 };
 
-const ItemContext = React.createContext<Value>({});
+const ItemContext = React.createContext<Value>({} as Value);
 
 function getKey(key: React.Key) {
 	return `${key}`.replace('.$', '');
 }
 
-export function ItemContextProvider({children, value = {}}: Props) {
+export function ItemContextProvider({children, value}: Props) {
+	const {selection} = useTreeViewContext();
+	const {key: parentKey} = useItem();
+
 	const keyRef = useRef(getKey(value.key));
+
+	useEffect(() => selection.mount(keyRef.current, parentKey), [
+		selection.mount,
+		keyRef,
+		parentKey,
+	]);
 
 	const props = {
 		...value,

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -19,8 +19,8 @@ export interface IMultipleSelection {
 }
 
 export interface IMultipleSelectionState {
+	createLayoutItemLazy: (key: Key, parentKey?: Key) => () => void;
 	isIntermediate: (key: Key) => boolean;
-	mount: (key: Key, parentKey?: Key) => () => void;
 	selectedKeys: Set<Key>;
 	toggleSelection: (key: Key) => void;
 }
@@ -136,7 +136,7 @@ export function useMultipleSelection(
 	// stream. This means it is reactive to rendering, if any component of the
 	// structure is removed it will update the layout without going traverse
 	// the structure.
-	const mount = useCallback(
+	const createLayoutItemLazy = useCallback(
 		(key: Key, parentKey?: Key) => {
 			const keyMap = layoutKeys.current.get(key);
 
@@ -214,8 +214,8 @@ export function useMultipleSelection(
 	};
 
 	return {
+		createLayoutItemLazy,
 		isIntermediate,
-		mount,
 		selectedKeys,
 		toggleSelection,
 	};

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -19,7 +19,7 @@ export interface IMultipleSelection {
 }
 
 export interface IMultipleSelectionState {
-	createLayoutItemLazy: (key: Key, parentKey?: Key) => () => void;
+	createPartialLayoutItem: (key: Key, parentKey?: Key) => () => void;
 	isIntermediate: (key: Key) => boolean;
 	selectedKeys: Set<Key>;
 	toggleSelection: (key: Key) => void;
@@ -136,7 +136,7 @@ export function useMultipleSelection(
 	// stream. This means it is reactive to rendering, if any component of the
 	// structure is removed it will update the layout without going traverse
 	// the structure.
-	const createLayoutItemLazy = useCallback(
+	const createPartialLayoutItem = useCallback(
 		(key: Key, parentKey?: Key) => {
 			const keyMap = layoutKeys.current.get(key);
 
@@ -214,7 +214,7 @@ export function useMultipleSelection(
 	};
 
 	return {
-		createLayoutItemLazy,
+		createPartialLayoutItem,
 		isIntermediate,
 		selectedKeys,
 		toggleSelection,

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -1,0 +1,216 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useInternalState} from '@clayui/shared';
+import {Key, useCallback, useRef} from 'react';
+
+export interface IMultipleSelection {
+	/**
+	 * Handler that is called when the selection changes.
+	 */
+	onSelectionChange?: (keys: Set<Key>) => void;
+
+	/**
+	 * The currently selected keys in the collection.
+	 */
+	selectedKeys?: Set<Key>;
+}
+
+export interface IMultipleSelectionState {
+	isIntermediate: (key: Key) => boolean;
+	mount: (key: Key, parentKey?: Key) => () => void;
+	selectedKeys: Set<Key>;
+	toggleSelection: (key: Key) => void;
+}
+
+export interface IMultipleSelectionProps extends IMultipleSelection {}
+
+type LayoutInfo = {
+	children: Set<Key>;
+	intermediate: boolean;
+	parentKey?: Key;
+};
+
+export function useMultipleSelection(
+	props: IMultipleSelectionProps
+): IMultipleSelectionState {
+	const layoutKeys = useRef(new Map<Key, LayoutInfo>());
+
+	const [selectedKeys, setSelectionKeys] = useInternalState<Set<Key>>({
+		initialValue: new Set(),
+		onChange: props.onSelectionChange,
+		value: props.selectedKeys,
+	});
+
+	const toggleParentSelection = (keyMap: LayoutInfo, selecteds: Set<Key>) => {
+		if (!keyMap.parentKey) {
+			return;
+		}
+
+		const parentKeyMap = layoutKeys.current.get(
+			keyMap.parentKey
+		) as LayoutInfo;
+
+		// Instead of doing the whole operation again below, we know that the
+		// element below already has intermediate status and we don't need to
+		// check everything again.
+		if (keyMap.intermediate) {
+			parentKeyMap.intermediate = true;
+			selecteds.delete(keyMap.parentKey);
+		} else {
+			const children = [...parentKeyMap.children];
+
+			// Instead of using every to check if all elements are selected, we
+			// look for any not selected, which means we don't have all the
+			// elements selected and we don't always need to go through the
+			// entire array.
+			const unselected = children.some((key) => !selecteds.has(key));
+
+			if (unselected) {
+				// An element can only be intermediate when there is at least
+				// one element selected in its tree. We don't need to sweep
+				// the tree because we have the recursive effect.
+				if (children.some((key) => selecteds.has(key))) {
+					parentKeyMap.intermediate = true;
+				} else {
+					parentKeyMap.intermediate = false;
+				}
+
+				selecteds.delete(keyMap.parentKey);
+			} else {
+				parentKeyMap.intermediate = false;
+				selecteds.add(keyMap.parentKey);
+			}
+		}
+
+		toggleParentSelection(parentKeyMap, selecteds);
+	};
+
+	const toggleChildrenSelection = (
+		keyMap: LayoutInfo,
+		selecteds: Set<Key>
+	) => {
+		if (!keyMap.children.size) {
+			return;
+		}
+
+		keyMap.children.forEach((key) => {
+			if (selecteds.has(key)) {
+				selecteds.delete(key);
+			} else {
+				selecteds.add(key);
+			}
+
+			const childrenKeyMap = layoutKeys.current.get(key) as LayoutInfo;
+
+			toggleChildrenSelection(childrenKeyMap, selecteds);
+		});
+	};
+
+	const toggleSelection = (key: Key) => {
+		const keyMap = layoutKeys.current.get(key) as LayoutInfo;
+		const selecteds = new Set(selectedKeys);
+
+		if (selecteds.has(key)) {
+			selecteds.delete(key);
+		} else {
+			selecteds.add(key);
+		}
+
+		toggleChildrenSelection(keyMap, selecteds);
+		toggleParentSelection(keyMap, selecteds);
+
+		setSelectionKeys(selecteds);
+	};
+
+	// The Mount will start building the tree in a flat structure using the
+	// component's rendering stream to avoid traversing the tree in a separate
+	// stream. This means it is reactive to rendering, if any component of the
+	// structure is removed it will update the layout without going traverse
+	// the structure.
+	const mount = useCallback(
+		(key: Key, parentKey?: Key) => {
+			const keyMap = layoutKeys.current.get(key);
+
+			if (!keyMap) {
+				layoutKeys.current.set(key, {
+					children: new Set(),
+					intermediate: false,
+					parentKey,
+				});
+			} else if (keyMap.parentKey !== parentKey) {
+				layoutKeys.current.set(key, {
+					...keyMap,
+					parentKey,
+				});
+			}
+
+			if (parentKey) {
+				const keyMap = layoutKeys.current.get(parentKey);
+
+				if (keyMap) {
+					layoutKeys.current.set(parentKey, {
+						...keyMap,
+						children: new Set([...keyMap.children, key]),
+					});
+				} else {
+					// Pre-initializes the parent layout, as this is linked to
+					// React rendering, the mount is used inside `useEffect`
+					// this causes callbacks from the last rendering to be
+					// called first than parents, starting from the bottom up.
+					//
+					// We just add an initial value then update the parentKey
+					// when the corresponding one is called.
+					layoutKeys.current.set(parentKey, {
+						children: new Set([key]),
+						intermediate: false,
+						parentKey: undefined,
+					});
+				}
+			}
+
+			return function unmount() {
+				layoutKeys.current.delete(key);
+
+				if (parentKey && layoutKeys.current.has(parentKey)) {
+					const keyMap = layoutKeys.current.get(
+						parentKey
+					) as LayoutInfo;
+
+					const children = new Set(keyMap.children);
+
+					children.delete(key);
+
+					layoutKeys.current.set(parentKey, {
+						...keyMap,
+						children,
+					});
+				}
+			};
+		},
+		[layoutKeys]
+	);
+
+	const isIntermediate = (key: Key) => {
+		if (selectedKeys.has(key)) {
+			return false;
+		}
+
+		const keyMap = layoutKeys.current.get(key);
+
+		if (!keyMap) {
+			return false;
+		}
+
+		return keyMap.intermediate;
+	};
+
+	return {
+		isIntermediate,
+		mount,
+		selectedKeys,
+		toggleSelection,
+	};
+}

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -90,22 +90,23 @@ export function useMultipleSelection(
 
 	const toggleChildrenSelection = (
 		keyMap: LayoutInfo,
-		selecteds: Set<Key>
+		selecteds: Set<Key>,
+		select: boolean
 	) => {
 		if (!keyMap.children.size) {
 			return;
 		}
 
 		keyMap.children.forEach((key) => {
-			if (selecteds.has(key)) {
-				selecteds.delete(key);
-			} else {
+			if (select) {
 				selecteds.add(key);
+			} else {
+				selecteds.delete(key);
 			}
 
 			const childrenKeyMap = layoutKeys.current.get(key) as LayoutInfo;
 
-			toggleChildrenSelection(childrenKeyMap, selecteds);
+			toggleChildrenSelection(childrenKeyMap, selecteds, select);
 		});
 	};
 
@@ -113,13 +114,18 @@ export function useMultipleSelection(
 		const keyMap = layoutKeys.current.get(key) as LayoutInfo;
 		const selecteds = new Set(selectedKeys);
 
+		// Resets the intermediate state because the element will be selected
+		// or otherwise the state must be false because it will be unchecking
+		// all its children.
+		keyMap.intermediate = false;
+
 		if (selecteds.has(key)) {
 			selecteds.delete(key);
 		} else {
 			selecteds.add(key);
 		}
 
-		toggleChildrenSelection(keyMap, selecteds);
+		toggleChildrenSelection(keyMap, selecteds, selecteds.has(key));
 		toggleParentSelection(keyMap, selecteds);
 
 		setSelectionKeys(selecteds);

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {useInternalState} from '@clayui/shared';
+
 export interface IExpandable {
 	/**
 	 * The currently expanded keys in the collection.
@@ -25,4 +27,31 @@ export interface IMultipleSelection {
 	 * Handler that is called when the selection changes.
 	 */
 	onSelectionChange?: (keys: Set<string>) => void;
+}
+
+interface ITreeProps extends IExpandable, IMultipleSelection {}
+
+export function useTree(props: ITreeProps) {
+	const [expandedKeys, setExpandedKeys] = useInternalState<Set<string>>({
+		initialValue: new Set(),
+		onChange: props.onExpandedChange,
+		value: props.expandedKeys,
+	});
+
+	const toggle = (key: string) => {
+		const expanded = new Set(expandedKeys);
+
+		if (expanded.has(key)) {
+			expanded.delete(key);
+		} else {
+			expanded.add(key);
+		}
+
+		setExpandedKeys(expanded);
+	};
+
+	return {
+		expandedKeys,
+		toggle,
+	};
 }

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -4,41 +4,42 @@
  */
 
 import {useInternalState} from '@clayui/shared';
+import type {Key} from 'react';
 
 export interface IExpandable {
 	/**
 	 * The currently expanded keys in the collection.
 	 */
-	expandedKeys?: Set<string>;
+	expandedKeys?: Set<Key>;
 
 	/**
 	 * Handler that is called when items are expanded or collapsed.
 	 */
-	onExpandedChange?: (keys: Set<string>) => void;
+	onExpandedChange?: (keys: Set<Key>) => void;
 }
 
 export interface IMultipleSelection {
 	/**
 	 * The currently selected keys in the collection.
 	 */
-	selectedKeys?: Set<string>;
+	selectedKeys?: Set<Key>;
 
 	/**
 	 * Handler that is called when the selection changes.
 	 */
-	onSelectionChange?: (keys: Set<string>) => void;
+	onSelectionChange?: (keys: Set<Key>) => void;
 }
 
 interface ITreeProps extends IExpandable, IMultipleSelection {}
 
 export function useTree(props: ITreeProps) {
-	const [expandedKeys, setExpandedKeys] = useInternalState<Set<string>>({
+	const [expandedKeys, setExpandedKeys] = useInternalState<Set<Key>>({
 		initialValue: new Set(),
 		onChange: props.onExpandedChange,
 		value: props.expandedKeys,
 	});
 
-	const toggle = (key: string) => {
+	const toggle = (key: Key) => {
 		const expanded = new Set(expandedKeys);
 
 		if (expanded.has(key)) {

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -6,6 +6,12 @@
 import {useInternalState} from '@clayui/shared';
 import type {Key} from 'react';
 
+import {
+	IMultipleSelection,
+	IMultipleSelectionState,
+	useMultipleSelection,
+} from './useMultipleSelection';
+
 export interface IExpandable {
 	/**
 	 * The currently expanded keys in the collection.
@@ -18,25 +24,24 @@ export interface IExpandable {
 	onExpandedChange?: (keys: Set<Key>) => void;
 }
 
-export interface IMultipleSelection {
-	/**
-	 * The currently selected keys in the collection.
-	 */
-	selectedKeys?: Set<Key>;
+export interface ITreeProps extends IExpandable, IMultipleSelection {}
 
-	/**
-	 * Handler that is called when the selection changes.
-	 */
-	onSelectionChange?: (keys: Set<Key>) => void;
+export interface ITreeState {
+	expandedKeys: Set<Key>;
+	selection: IMultipleSelectionState;
+	toggle: (key: Key) => void;
 }
 
-interface ITreeProps extends IExpandable, IMultipleSelection {}
-
-export function useTree(props: ITreeProps) {
+export function useTree(props: ITreeProps): ITreeState {
 	const [expandedKeys, setExpandedKeys] = useInternalState<Set<Key>>({
 		initialValue: new Set(),
 		onChange: props.onExpandedChange,
 		value: props.expandedKeys,
+	});
+
+	const selection = useMultipleSelection({
+		onSelectionChange: props.onSelectionChange,
+		selectedKeys: props.selectedKeys,
 	});
 
 	const toggle = (key: Key) => {
@@ -53,6 +58,7 @@ export function useTree(props: ITreeProps) {
 
 	return {
 		expandedKeys,
+		selection,
 		toggle,
 	};
 }

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -11,7 +11,7 @@ import Icon from '@clayui/icon';
 import {Provider} from '@clayui/provider';
 import Sticker from '@clayui/sticker';
 import {storiesOf} from '@storybook/react';
-import React from 'react';
+import React, {useState} from 'react';
 
 import {TreeView} from '../src/tree-view';
 
@@ -237,7 +237,7 @@ storiesOf('Components|ClayTreeView', module)
 						{'Juan Hidalgo'}
 					</TreeView.ItemStack>
 					<TreeView.Group>
-						<TreeView.Item>
+						<TreeView.Item key="Victor Valle">
 							<TreeView.ItemStack>
 								<Sticker
 									displayType="primary"
@@ -249,7 +249,7 @@ storiesOf('Components|ClayTreeView', module)
 								{'Victor Valle'}
 							</TreeView.ItemStack>
 							<TreeView.Group>
-								<TreeView.Item>
+								<TreeView.Item key="susana-vázquez">
 									<Sticker
 										displayType="primary"
 										shape="user-icon"
@@ -259,7 +259,7 @@ storiesOf('Components|ClayTreeView', module)
 									</Sticker>
 									{'Susana Vázquez'}
 								</TreeView.Item>
-								<TreeView.Item>
+								<TreeView.Item key="myriam-manso">
 									<Sticker
 										displayType="primary"
 										shape="user-icon"
@@ -271,7 +271,7 @@ storiesOf('Components|ClayTreeView', module)
 								</TreeView.Item>
 							</TreeView.Group>
 						</TreeView.Item>
-						<TreeView.Item>
+						<TreeView.Item key="emily-young">
 							<Sticker
 								displayType="primary"
 								shape="user-icon"
@@ -285,4 +285,125 @@ storiesOf('Components|ClayTreeView', module)
 				</TreeView.Item>
 			</TreeView>
 		</Provider>
-	));
+	))
+	.add('page elements', () => {
+		const TYPES_TO_SYMBOLS = {
+			container: 'container',
+			editable: 'text',
+			'fragment-image': 'picture',
+			'fragment-text': 'h1',
+			paragraph: 'paragraph',
+			row: 'table',
+		} as Record<string, string>;
+
+		const items = [
+			{
+				children: [
+					{
+						children: [
+							{
+								children: [
+									{
+										children: [
+											{
+												children: [
+													{
+														id: 11,
+														name: 'element-text',
+														type: 'editable',
+													},
+												],
+												name: 'Heading',
+												type: 'fragment-text',
+											},
+											{
+												children: [
+													{
+														id: 10,
+														name: 'element-text',
+														type: 'editable',
+													},
+												],
+												name: 'Paragraph',
+												type: 'paragraph',
+											},
+										],
+										id: 5,
+										name: 'Module',
+									},
+									{
+										children: [
+											{
+												children: [
+													{
+														id: 9,
+														name: 'image-squere',
+														type: 'editable',
+													},
+												],
+												id: 6,
+												name: 'Image',
+												type: 'fragment-image',
+											},
+										],
+										id: 4,
+										name: 'Module',
+									},
+								],
+								id: 3,
+								name: 'Grid',
+								type: 'row',
+							},
+						],
+						id: 2,
+						name: 'Container',
+						type: 'container',
+					},
+				],
+				id: 1,
+				name: 'Container',
+				type: 'container',
+			},
+		];
+
+		const [expandedKeys, setExpandedKeys] = useState<Set<React.Key>>(
+			new Set(['1'])
+		);
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView
+					expandedKeys={expandedKeys}
+					expanderIcons={{
+						close: <Icon symbol="hr" />,
+						open: <Icon symbol="plus" />,
+					}}
+					items={items}
+					nestedKey="children"
+					onExpandedChange={(keys) => setExpandedKeys(keys)}
+					showExpanderOnHover={false}
+				>
+					{(item) => (
+						<TreeView.Item>
+							<TreeView.ItemStack>
+								{item.type && (
+									<Icon
+										symbol={TYPES_TO_SYMBOLS[item.type]}
+									/>
+								)}
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{({name, type}) => (
+									<TreeView.Item>
+										<Icon symbol={TYPES_TO_SYMBOLS[type]} />
+										{name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	});

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -15,6 +15,13 @@ import React from 'react';
 
 import {TreeView} from '../src/tree-view';
 
+interface IItem {
+	children?: Array<IItem>;
+	name: string;
+	status?: string;
+	type?: string;
+}
+
 storiesOf('Components|ClayTreeView', module)
 	.add('light', () => (
 		<Provider spritemap={spritemap} theme="cadmin">
@@ -86,6 +93,135 @@ storiesOf('Components|ClayTreeView', module)
 			</TreeView>
 		</Provider>
 	))
+	.add('nested', () => {
+		const TYPES_TO_SYMBOLS = {
+			document: 'document-text',
+			pdf: 'document-pdf',
+			success: 'check-circle-full',
+			warning: 'warning-full',
+		} as Record<string, string>;
+
+		const TYPES_TO_COLORS = {
+			document: 'text-primary',
+			pdf: 'text-danger',
+			success: 'text-success',
+			warning: 'text-warning',
+		} as Record<string, string>;
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView
+					items={[
+						{
+							children: [
+								{
+									children: [
+										{
+											children: [{name: 'Research 1'}],
+											name: 'Research',
+										},
+										{
+											children: [{name: 'News 1'}],
+											name: 'News',
+										},
+									],
+									name: 'Blogs',
+								},
+								{
+									children: [
+										{
+											children: [
+												{
+													name: 'Instructions.pdf',
+													status: 'success',
+													type: 'pdf',
+												},
+											],
+											name: 'PDF',
+										},
+										{
+											children: [
+												{
+													name:
+														'Treeview review.docx',
+													status: 'success',
+													type: 'document',
+												},
+												{
+													name:
+														'Heuristics Evaluation.docx',
+													status: 'success',
+													type: 'document',
+												},
+											],
+											name: 'Word',
+										},
+									],
+									name: 'Documents and Media',
+								},
+							],
+							name: 'Liferay Drive',
+							type: 'cloud',
+						},
+						{
+							children: [
+								{name: 'Blogs'},
+								{name: 'Documents and Media'},
+							],
+							name: 'Repositories',
+							type: 'repository',
+						},
+						{
+							children: [{name: 'PDF'}, {name: 'Word'}],
+							name: 'Documents and Media',
+							status: 'warning',
+						},
+					]}
+					nestedKey="children"
+				>
+					{(item: IItem) => (
+						<TreeView.Item>
+							<TreeView.ItemStack>
+								<Icon symbol={item.type ?? 'folder'} />
+								{item.name}
+								{item.status && (
+									<Icon
+										className={TYPES_TO_COLORS[item.status]}
+										symbol={TYPES_TO_SYMBOLS[item.status]}
+									/>
+								)}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{({name, status, type}: IItem) => (
+									<TreeView.Item>
+										{type && (
+											<Icon
+												className={
+													TYPES_TO_COLORS[type]
+												}
+												symbol={TYPES_TO_SYMBOLS[type]}
+											/>
+										)}
+										{name}
+										{status && (
+											<Icon
+												className={
+													TYPES_TO_COLORS[status]
+												}
+												symbol={
+													TYPES_TO_SYMBOLS[status]
+												}
+											/>
+										)}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
 	.add('sticker', () => (
 		<Provider spritemap={spritemap} theme="cadmin">
 			<TreeView showExpanderOnHover={false}>

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -23,15 +23,6 @@ interface IItem {
 	type?: string;
 }
 
-const TYPES_TO_SYMBOLS = {
-	container: 'container',
-	editable: 'text',
-	'fragment-image': 'picture',
-	'fragment-text': 'h1',
-	paragraph: 'paragraph',
-	row: 'table',
-} as Record<string, string>;
-
 const ITEMS_DRIVE = [
 	{
 		children: [
@@ -291,6 +282,15 @@ storiesOf('Components|ClayTreeView', module)
 		</Provider>
 	))
 	.add('page elements', () => {
+		const TYPES_TO_SYMBOLS = {
+			container: 'container',
+			editable: 'text',
+			'fragment-image': 'picture',
+			'fragment-text': 'h1',
+			paragraph: 'paragraph',
+			row: 'table',
+		} as Record<string, string>;
+
 		const items = [
 			{
 				children: [
@@ -442,56 +442,4 @@ storiesOf('Components|ClayTreeView', module)
 				</TreeView>
 			</Provider>
 		);
-	})
-	.add('flat items', () => (
-		<Provider spritemap={spritemap} theme="cadmin">
-			<TreeView
-				items={{
-					ab7146d1: {
-						children: ['p659d51e', 'q8a7c550'],
-						id: 'ab7146d1',
-						name: 'Grid',
-						type: 'row',
-					},
-					fd5768d1: {
-						children: ['ab7146d1'],
-						id: 'fd5768d1',
-						name: 'Container',
-						type: 'container',
-					},
-					p659d51e: {
-						id: 'p659d51e',
-						name: 'Module',
-					},
-					q8a7c550: {
-						id: 'q8a7c550',
-						name: 'Module',
-					},
-				}}
-				nestedKey="children"
-				rootItem="fd5768d1"
-				showExpanderOnHover={false}
-			>
-				{(item) => (
-					<TreeView.Item>
-						<TreeView.ItemStack>
-							{item.type && (
-								<Icon symbol={TYPES_TO_SYMBOLS[item.type]} />
-							)}
-							{item.name}
-						</TreeView.ItemStack>
-						<TreeView.Group items={item.children}>
-							{(item: any) => (
-								<TreeView.Item>
-									<Icon
-										symbol={TYPES_TO_SYMBOLS[item.type]}
-									/>
-									{item.name}
-								</TreeView.Item>
-							)}
-						</TreeView.Group>
-					</TreeView.Item>
-				)}
-			</TreeView>
-		</Provider>
-	));
+	});

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -23,6 +23,15 @@ interface IItem {
 	type?: string;
 }
 
+const TYPES_TO_SYMBOLS = {
+	container: 'container',
+	editable: 'text',
+	'fragment-image': 'picture',
+	'fragment-text': 'h1',
+	paragraph: 'paragraph',
+	row: 'table',
+} as Record<string, string>;
+
 const ITEMS_DRIVE = [
 	{
 		children: [
@@ -282,15 +291,6 @@ storiesOf('Components|ClayTreeView', module)
 		</Provider>
 	))
 	.add('page elements', () => {
-		const TYPES_TO_SYMBOLS = {
-			container: 'container',
-			editable: 'text',
-			'fragment-image': 'picture',
-			'fragment-text': 'h1',
-			paragraph: 'paragraph',
-			row: 'table',
-		} as Record<string, string>;
-
 		const items = [
 			{
 				children: [
@@ -442,4 +442,56 @@ storiesOf('Components|ClayTreeView', module)
 				</TreeView>
 			</Provider>
 		);
-	});
+	})
+	.add('flat items', () => (
+		<Provider spritemap={spritemap} theme="cadmin">
+			<TreeView
+				items={{
+					ab7146d1: {
+						children: ['p659d51e', 'q8a7c550'],
+						id: 'ab7146d1',
+						name: 'Grid',
+						type: 'row',
+					},
+					fd5768d1: {
+						children: ['ab7146d1'],
+						id: 'fd5768d1',
+						name: 'Container',
+						type: 'container',
+					},
+					p659d51e: {
+						id: 'p659d51e',
+						name: 'Module',
+					},
+					q8a7c550: {
+						id: 'q8a7c550',
+						name: 'Module',
+					},
+				}}
+				nestedKey="children"
+				rootItem="fd5768d1"
+				showExpanderOnHover={false}
+			>
+				{(item) => (
+					<TreeView.Item>
+						<TreeView.ItemStack>
+							{item.type && (
+								<Icon symbol={TYPES_TO_SYMBOLS[item.type]} />
+							)}
+							{item.name}
+						</TreeView.ItemStack>
+						<TreeView.Group items={item.children}>
+							{(item: any) => (
+								<TreeView.Item>
+									<Icon
+										symbol={TYPES_TO_SYMBOLS[item.type]}
+									/>
+									{item.name}
+								</TreeView.Item>
+							)}
+						</TreeView.Group>
+					</TreeView.Item>
+				)}
+			</TreeView>
+		</Provider>
+	));

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -7,6 +7,7 @@ import '@clayui/css/lib/css/atlas.css';
 
 import '@clayui/css/src/scss/cadmin.scss';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import {ClayCheckbox as Checkbox} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {Provider} from '@clayui/provider';
 import Sticker from '@clayui/sticker';
@@ -21,6 +22,68 @@ interface IItem {
 	status?: string;
 	type?: string;
 }
+
+const ITEMS_DRIVE = [
+	{
+		children: [
+			{
+				children: [
+					{
+						children: [{name: 'Research 1'}],
+						name: 'Research',
+					},
+					{
+						children: [{name: 'News 1'}],
+						name: 'News',
+					},
+				],
+				name: 'Blogs',
+			},
+			{
+				children: [
+					{
+						children: [
+							{
+								name: 'Instructions.pdf',
+								status: 'success',
+								type: 'pdf',
+							},
+						],
+						name: 'PDF',
+					},
+					{
+						children: [
+							{
+								name: 'Treeview review.docx',
+								status: 'success',
+								type: 'document',
+							},
+							{
+								name: 'Heuristics Evaluation.docx',
+								status: 'success',
+								type: 'document',
+							},
+						],
+						name: 'Word',
+					},
+				],
+				name: 'Documents and Media',
+			},
+		],
+		name: 'Liferay Drive',
+		type: 'cloud',
+	},
+	{
+		children: [{name: 'Blogs'}, {name: 'Documents and Media'}],
+		name: 'Repositories',
+		type: 'repository',
+	},
+	{
+		children: [{name: 'PDF'}, {name: 'Word'}],
+		name: 'Documents and Media',
+		status: 'warning',
+	},
+];
 
 storiesOf('Components|ClayTreeView', module)
 	.add('light', () => (
@@ -110,75 +173,7 @@ storiesOf('Components|ClayTreeView', module)
 
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
-				<TreeView
-					items={[
-						{
-							children: [
-								{
-									children: [
-										{
-											children: [{name: 'Research 1'}],
-											name: 'Research',
-										},
-										{
-											children: [{name: 'News 1'}],
-											name: 'News',
-										},
-									],
-									name: 'Blogs',
-								},
-								{
-									children: [
-										{
-											children: [
-												{
-													name: 'Instructions.pdf',
-													status: 'success',
-													type: 'pdf',
-												},
-											],
-											name: 'PDF',
-										},
-										{
-											children: [
-												{
-													name:
-														'Treeview review.docx',
-													status: 'success',
-													type: 'document',
-												},
-												{
-													name:
-														'Heuristics Evaluation.docx',
-													status: 'success',
-													type: 'document',
-												},
-											],
-											name: 'Word',
-										},
-									],
-									name: 'Documents and Media',
-								},
-							],
-							name: 'Liferay Drive',
-							type: 'cloud',
-						},
-						{
-							children: [
-								{name: 'Blogs'},
-								{name: 'Documents and Media'},
-							],
-							name: 'Repositories',
-							type: 'repository',
-						},
-						{
-							children: [{name: 'PDF'}, {name: 'Word'}],
-							name: 'Documents and Media',
-							status: 'warning',
-						},
-					]}
-					nestedKey="children"
-				>
+				<TreeView items={ITEMS_DRIVE} nestedKey="children">
 					{(item: IItem) => (
 						<TreeView.Item>
 							<TreeView.ItemStack>
@@ -398,6 +393,47 @@ storiesOf('Components|ClayTreeView', module)
 									<TreeView.Item>
 										<Icon symbol={TYPES_TO_SYMBOLS[type]} />
 										{name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
+	.add('selection', () => {
+		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
+			new Set()
+		);
+
+		// Just to avoid TypeScript error with required props
+		const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
+
+		OptionalCheckbox.displayName = 'ClayCheckbox';
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView
+					items={ITEMS_DRIVE}
+					nestedKey="children"
+					onSelectionChange={(keys) => setSelectionChange(keys)}
+					selectedKeys={selectedKeys}
+					showExpanderOnHover={false}
+				>
+					{(item) => (
+						<TreeView.Item>
+							<TreeView.ItemStack>
+								<OptionalCheckbox />
+								<Icon symbol="folder" />
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item>
+										<OptionalCheckbox />
+										<Icon symbol="folder" />
+										{item.name}
 									</TreeView.Item>
 								)}
 							</TreeView.Group>


### PR DESCRIPTION
Fixes #4210

This functionality is written under PR #4218. Still putting it as a draft because it's not done, I still need to tweak the code and clean up some parts.

As I mentioned in PR, it is possible to make expandable without necessarily having to render props, but that would need a restricted API, as we commonly use in high-level.

Why not use `maps` actually people can use them if they want, but the component won't have visibility of items that are rendered just from the markup but we can't do much without the control we can have with render props, neither would we be able to do nested rendering automatically or apply virtualization strategies, perhaps even a scroll-based "load more", commonly known as an infinite scroll.

```jsx
<TreeView>
      {ITEMS.map(item, () => (
        <TreeView.Item>
          {item.name}
          <TreeView.Group>
            {item.children.map(item, () => (
              <TreeView.Item>{item.name}</TreeView.Item>
            ))}
          </TreeView.Group>
        </TreeView.Item>
      ))}
</TreeView>
```

For an example of usage, see the storybook with the case of `nested`. As I mentioned in the previous PR, we can do this in different ways but the purpose here is also to find a middle ground so that we don't need to create a low-level `TreeView` without the features and a high-level with the features and an API restrict as we do for the other components.