### PR TITLE
fix(@clayui/dropdown): Pass useCssRight to domAlign

### DIFF
--- a/custom-types/dom-align/index.d.ts
+++ b/custom-types/dom-align/index.d.ts
@@ -16,6 +16,7 @@ interface IConfigOptional {
 	offset?: readonly [number, number];
 	targetOffset?: readonly [string, string];
 	overflow?: {adjustX: boolean; adjustY: boolean};
+	useCssRight?: boolean
 }
 
 declare function doAlign(

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -6,7 +6,7 @@
 import {ClayPortal, IPortalBaseProps, Keys, observeRect} from '@clayui/shared';
 import classNames from 'classnames';
 import domAlign from 'dom-align';
-import React, {useEffect, useLayoutEffect, useRef} from 'react';
+import React, {useEffect, useLayoutEffect, useMemo, useRef} from 'react';
 
 export const Align = {
 	BottomCenter: 4,
@@ -200,6 +200,12 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 	) => {
 		const subPortalRef = useRef<HTMLDivElement | null>(null);
 
+		const rtl = useMemo(() => {
+			return (
+				document.querySelector('html')?.getAttribute('dir') === 'rtl'
+			);
+		}, []);
+
 		useEffect(() => {
 			if (closeOnClickOutside) {
 				const handleClick = (event: MouseEvent) => {
@@ -272,6 +278,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 								adjustY: autoBestAlign,
 							},
 							points,
+							useCssRight: rtl,
 						}
 					);
 				}


### PR DESCRIPTION
Fixes https://github.com/liferay/clay/issues/4238

Couldn't tested it in DXP since I'm not able to use local Clay in portal, but it should work.