### PR TITLE
feat: Adds RTL OOTB support to methods using dom-align

### DIFF
--- a/custom-types/dom-align/index.d.ts
+++ b/custom-types/dom-align/index.d.ts
@@ -4,27 +4,25 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-interface IConfig {
-	points: readonly [string, string];
-	offset: readonly [number, number];
-	targetOffset: readonly [string, string];
-	overflow: {adjustX: boolean; adjustY: boolean};
-}
-
-interface IConfigOptional {
-	points?: readonly [string, string];
-	offset?: readonly [number, number];
-	targetOffset?: readonly [string, string];
-	overflow?: {adjustX: boolean; adjustY: boolean};
-	useCssRight?: boolean
-}
-
-declare function doAlign(
-	sourceNode: HTMLElement,
-	targetNode: HTMLElement,
-	config?: IConfigOptional
-): IConfig;
-
 declare module 'dom-align' {
-	export = doAlign;
+	export interface IConfig {
+		points: readonly [string, string];
+		offset: readonly [number, number];
+		targetOffset: readonly [string, string];
+		overflow: {adjustX: boolean; adjustY: boolean};
+	}
+
+	export interface IConfigOptional {
+		points?: readonly [string, string];
+		offset?: readonly [number, number];
+		targetOffset?: readonly [string, string];
+		overflow?: {adjustX: boolean; adjustY: boolean};
+		useCssRight?: boolean
+	}
+
+	export default function doAlign(
+		sourceNode: HTMLElement,
+		targetNode: HTMLElement,
+		config?: IConfigOptional
+	): IConfig;
 }

--- a/custom-types/dom-align/index.d.ts
+++ b/custom-types/dom-align/index.d.ts
@@ -16,6 +16,7 @@ interface IConfigOptional {
 	offset?: readonly [number, number];
 	targetOffset?: readonly [string, string];
 	overflow?: {adjustX: boolean; adjustY: boolean};
+	useCssRight?: boolean
 }
 
 declare function doAlign(

--- a/packages/clay-drop-down/package.json
+++ b/packages/clay-drop-down/package.json
@@ -32,7 +32,6 @@
 		"@clayui/link": "^3.32.0",
 		"@clayui/shared": "^3.32.0",
 		"classnames": "^2.2.6",
-		"dom-align": "^1.10.2",
 		"react-transition-group": "^4.4.1",
 		"warning": "^4.0.3"
 	},

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -3,10 +3,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal, IPortalBaseProps, Keys, observeRect} from '@clayui/shared';
+import {
+	ClayPortal,
+	IPortalBaseProps,
+	Keys,
+	doAlign,
+	observeRect,
+} from '@clayui/shared';
 import classNames from 'classnames';
-import domAlign from 'dom-align';
-import React, {useEffect, useLayoutEffect, useMemo, useRef} from 'react';
+import React, {useEffect, useLayoutEffect, useRef} from 'react';
 
 export const Align = {
 	BottomCenter: 4,
@@ -200,12 +205,6 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 	) => {
 		const subPortalRef = useRef<HTMLDivElement | null>(null);
 
-		const rtl = useMemo(() => {
-			return (
-				document.querySelector('html')?.getAttribute('dir') === 'rtl'
-			);
-		}, []);
-
 		useEffect(() => {
 			if (closeOnClickOutside) {
 				const handleClick = (event: MouseEvent) => {
@@ -268,19 +267,17 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 				}
 
 				if ((ref as React.RefObject<HTMLElement>).current) {
-					domAlign(
-						(ref as React.RefObject<HTMLElement>).current!,
-						alignElementRef.current,
-						{
-							offset: offsetFn(points),
-							overflow: {
-								adjustX: autoBestAlign,
-								adjustY: autoBestAlign,
-							},
-							points,
-							useCssRight: rtl,
-						}
-					);
+					doAlign({
+						offset: offsetFn(points),
+						overflow: {
+							adjustX: autoBestAlign,
+							adjustY: autoBestAlign,
+						},
+						points,
+						sourceElement: (ref as React.RefObject<HTMLElement>)
+							.current!,
+						targetElement: alignElementRef.current,
+					});
 				}
 			}
 		};

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -6,7 +6,7 @@
 import {ClayPortal, IPortalBaseProps, Keys, observeRect} from '@clayui/shared';
 import classNames from 'classnames';
 import domAlign from 'dom-align';
-import React, {useEffect, useLayoutEffect, useRef} from 'react';
+import React, {useEffect, useLayoutEffect, useMemo, useRef} from 'react';
 
 export const Align = {
 	BottomCenter: 4,
@@ -200,6 +200,12 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 	) => {
 		const subPortalRef = useRef<HTMLDivElement | null>(null);
 
+		const rtl = useMemo(() => {
+			return (
+				document.querySelector('html')?.getAttribute('dir') === 'rtl'
+			);
+		}, []);
+
 		useEffect(() => {
 			if (closeOnClickOutside) {
 				const handleClick = (event: MouseEvent) => {
@@ -272,6 +278,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 								adjustY: autoBestAlign,
 							},
 							points,
+							useCssRight: rtl,
 						}
 					);
 				}

--- a/packages/clay-popover/package.json
+++ b/packages/clay-popover/package.json
@@ -27,8 +27,7 @@
 	],
 	"dependencies": {
 		"@clayui/shared": "^3.32.0",
-		"classnames": "^2.2.6",
-		"dom-align": "^1.10.2"
+		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal, IPortalBaseProps, observeRect} from '@clayui/shared';
+import {
+	ClayPortal,
+	IPortalBaseProps,
+	doAlign,
+	observeRect,
+} from '@clayui/shared';
 import classNames from 'classnames';
-import domAlign from 'dom-align';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 export const ALIGN_POSITIONS = [
@@ -116,13 +120,12 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 					string
 				];
 
-				domAlign(
-					(ref as React.RefObject<HTMLElement>).current!,
-					triggerRef.current as HTMLElement,
-					{
-						points,
-					}
-				);
+				doAlign({
+					points,
+					sourceElement: (ref as React.RefObject<HTMLElement>)
+						.current!,
+					targetElement: triggerRef.current as HTMLElement,
+				});
 			}
 		}, [alignPosition, triggerRef, ref]);
 

--- a/packages/clay-shared/package.json
+++ b/packages/clay-shared/package.json
@@ -28,7 +28,8 @@
 	"dependencies": {
 		"@clayui/button": "^3.32.0",
 		"@clayui/link": "^3.32.0",
-		"classnames": "^2.2.6"
+		"classnames": "^2.2.6",
+		"dom-align": "^1.10.2"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-shared/src/doAlign.ts
+++ b/packages/clay-shared/src/doAlign.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import domAlign, {IConfigOptional} from 'dom-align';
+
+type AlignProps<T, K> = Omit<IConfigOptional, 'useCssRight'> & {
+	sourceElement: K;
+	targetElement: T;
+};
+
+function isRtl<T extends HTMLElement>(element: T) {
+	return window.getComputedStyle(element).direction === 'rtl';
+}
+
+export function doAlign<T extends HTMLElement, K extends HTMLElement>({
+	sourceElement,
+	targetElement,
+	...config
+}: AlignProps<T, K>) {
+	return domAlign(sourceElement, targetElement, {
+		...config,
+		useCssRight: isRtl(sourceElement),
+	});
+}

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -6,6 +6,7 @@
 export const noop = () => {};
 export {ClayPortal} from './Portal';
 export {delegate} from './delegate';
+export {doAlign} from './doAlign';
 export {FocusScope} from './FocusScope';
 export {getEllipsisItems} from './getEllipsisItems';
 export {Keys} from './Keys';

--- a/packages/clay-tooltip/package.json
+++ b/packages/clay-tooltip/package.json
@@ -28,7 +28,6 @@
 	"dependencies": {
 		"@clayui/shared": "^3.32.0",
 		"classnames": "^2.2.6",
-		"dom-align": "^1.10.2",
 		"warning": "^4.0.3"
 	},
 	"peerDependencies": {

--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -3,8 +3,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {ClayPortal, IPortalBaseProps, Keys, delegate} from '@clayui/shared';
-import domAlign from 'dom-align';
+import {
+	ClayPortal,
+	IPortalBaseProps,
+	Keys,
+	delegate,
+	doAlign,
+} from '@clayui/shared';
 import React, {useCallback} from 'react';
 import warning from 'warning';
 
@@ -330,17 +335,16 @@ const TooltipProvider: React.FunctionComponent<
 		) {
 			const points = ALIGNMENTS_MAP[align || 'top'] as [string, string];
 
-			const newAlignmentString = domAlign(
-				(tooltipRef as React.RefObject<HTMLDivElement>).current!,
-				titleNodeRef.current,
-				{
-					overflow: {
-						adjustX: autoAlign,
-						adjustY: autoAlign,
-					},
-					points,
-				}
-			).points.join('') as keyof typeof ALIGNMENTS_INVERSE_MAP;
+			const newAlignmentString = doAlign({
+				overflow: {
+					adjustX: autoAlign,
+					adjustY: autoAlign,
+				},
+				points,
+				sourceElement: (tooltipRef as React.RefObject<HTMLDivElement>)
+					.current!,
+				targetElement: titleNodeRef.current,
+			}).points.join('') as keyof typeof ALIGNMENTS_INVERSE_MAP;
 
 			const pointsString = points.join('');
 


### PR DESCRIPTION
Fixes #4238

From #4239, I added some changes to this PR of the @carloslancha, moved the method to our `@clayui/shared` package to be able to use it in other components that also use `dom-align`, I also went with @jbalsas' advice to get the element direction, since there may be the use case that we have different directions on the same page in some scenarios, seems safer than checking the document.