### PR TITLE
fix(@clayui/shared): fixes error when importing the type that is not available in the module

### DIFF
--- a/packages/clay-shared/src/doAlign.ts
+++ b/packages/clay-shared/src/doAlign.ts
@@ -3,11 +3,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import domAlign, {IConfigOptional} from 'dom-align';
+import domAlign from 'dom-align';
 
-type AlignProps<T, K> = Omit<IConfigOptional, 'useCssRight'> & {
+type AlignProps<T, K> = {
+	offset?: readonly [number, number];
+	overflow?: {adjustX: boolean; adjustY: boolean};
+	points?: readonly [string, string];
 	sourceElement: K;
 	targetElement: T;
+	targetOffset?: readonly [string, string];
 };
 
 function isRtl<T extends HTMLElement>(element: T) {


### PR DESCRIPTION

Well, the types for `dom-align` are defined inside Clay but we don't export them because they are `declare module` in our types root, it wouldn't make much sense either, in this case, I'm just adding the types that are needed as part of the `shared` package to allow error-free distribution.