### PR TITLE
fix(@clayui/shared): fix error export type from root in package distribution

### DIFF
--- a/packages/clay-shared/src/doAlign.ts
+++ b/packages/clay-shared/src/doAlign.ts
@@ -5,13 +5,16 @@
 
 import domAlign from 'dom-align';
 
-type AlignProps<T, K> = {
+type AlignBase = {
 	offset?: readonly [number, number];
 	overflow?: {adjustX: boolean; adjustY: boolean};
 	points?: readonly [string, string];
+	targetOffset?: readonly [string, string];
+};
+
+type AlignProps<T, K> = AlignBase & {
 	sourceElement: K;
 	targetElement: T;
-	targetOffset?: readonly [string, string];
 };
 
 function isRtl<T extends HTMLElement>(element: T) {
@@ -22,7 +25,7 @@ export function doAlign<T extends HTMLElement, K extends HTMLElement>({
 	sourceElement,
 	targetElement,
 	...config
-}: AlignProps<T, K>) {
+}: AlignProps<T, K>): Required<AlignBase> {
 	return domAlign(sourceElement, targetElement, {
 		...config,
 		useCssRight: isRtl(sourceElement),


### PR DESCRIPTION
Well, again one more error that passed silently 😭 (I'll have to cut one more release patch), this time I did more tests and checked the generated types to make sure it aren't exporting private types.

As we have the explicit return from the `domAlign` method it will also return `IConfig` which is a private type in the package dos types generation. We need to find a way to test this to avoid problems in the future.