### PR TITLE
fix(@clayui/css): Buttons create Sass placeholders for Clay CSS btn-*…

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_buttons.scss
@@ -330,8 +330,12 @@ input[type='button'] {
 // Button Variants
 
 @each $cadmin-color, $cadmin-value in $cadmin-btn-palette {
-	.btn-#{$cadmin-color} {
+	%btn-#{$cadmin-color} {
 		@include clay-button-variant($cadmin-value);
+	}
+
+	.btn-#{$cadmin-color} {
+		@extend %btn-#{$cadmin-color} !optional;
 	}
 
 	%btn-#{$cadmin-color}-focus {
@@ -345,8 +349,12 @@ input[type='button'] {
 // Button Outline Variants
 
 @each $cadmin-color, $cadmin-value in $cadmin-btn-outline-palette {
-	.btn-outline-#{$cadmin-color} {
+	%btn-outline-#{$cadmin-color} {
 		@include clay-button-variant($cadmin-value);
+	}
+
+	.btn-outline-#{$cadmin-color} {
+		@extend %btn-outline-#{$cadmin-color} !optional;
 	}
 
 	%btn-outline-#{$cadmin-color}-focus {

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -326,8 +326,12 @@ input[type='button'] {
 // Button Variants
 
 @each $color, $value in $btn-palette {
-	.btn-#{$color} {
+	%btn-#{$color} {
 		@include clay-button-variant($value);
+	}
+
+	.btn-#{$color} {
+		@extend %btn-#{$color} !optional;
 	}
 
 	%btn-#{$color}-focus {
@@ -341,8 +345,12 @@ input[type='button'] {
 // Button Outline Variants
 
 @each $color, $value in $btn-outline-palette {
-	.btn-outline-#{$color} {
+	%btn-outline-#{$color} {
 		@include clay-button-variant($value);
+	}
+
+	.btn-outline-#{$color} {
+		@extend %btn-outline-#{$color} !optional;
 	}
 
 	%btn-outline-#{$color}-focus {


### PR DESCRIPTION
… classes to allow theme devs to @extend their button classes from it

fixes #4248