### PR TITLE
feat(@clayui/css): Forms convert label and .form-control to use clay-css mixin

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -1,11 +1,5 @@
-$input-font-size-mobile: 1rem !default; // 16px
-
-$input-label-font-size: 0.875rem !default; // 14px
-$input-label-font-weight: $font-weight-semi-bold !default;
-$input-label-margin-bottom: 0.25rem !default; // 4px
-
-$input-label-reference-mark-font-size: 6px !default;
-
+$input-bg: $gray-200 !default;
+$input-border-color: $gray-300 !default;
 $input-border-width: 0.0625rem !default; // 1px
 
 $input-border-bottom-width: $input-border-width !default; // 1px
@@ -13,26 +7,90 @@ $input-border-left-width: $input-border-width !default; // 1px
 $input-border-right-width: $input-border-width !default; // 1px
 $input-border-top-width: $input-border-width !default; // 1px
 
-$input-border-radius-sm: $border-radius !default;
-
+$input-box-shadow: none !default;
+$input-color: $gray-900 !default;
+$input-height: 2.5rem !default; // 40px
 $input-padding-x: 1rem !default; // 16px
 $input-padding-y: 0.4375rem !default; // 7px
 
+$input-font-size-mobile: 1rem !default; // 16px
+
+// .form-control::placeholder
+
+$input-placeholder-color: $gray-600 !default;
+
+// Input Focus (.form-control:focus)
+
+$input-focus-bg: lighten($component-active-bg, 44.9) !default;
+$input-focus-border-color: lighten($component-active-bg, 22.94) !default;
+$input-focus-box-shadow: $component-focus-box-shadow !default;
+
+// Input Disabled (.form-control:disabled)
+
+$input-disabled-color: $gray-500 !default;
+$input-disabled-bg: $input-bg !default;
+$input-disabled-border-color: $input-bg !default;
+
+// .form-control:disabled::placeholder
+
+$input-placeholder-disabled-color: $input-disabled-color !default;
+
+$input: () !default;
+$input: map-deep-merge(
+	(
+		background-color: $input-bg,
+		border-color: $input-border-color,
+		border-width: $input-border-width,
+		border-bottom-width: $input-border-bottom-width,
+		border-left-width: $input-border-left-width,
+		border-right-width: $input-border-right-width,
+		border-top-width: $input-border-top-width,
+		box-shadow: $input-box-shadow,
+		color: $input-color,
+		height: $input-height,
+		padding-bottom: $input-padding-y,
+		padding-left: $input-padding-x,
+		padding-right: $input-padding-x,
+		padding-top: $input-padding-y,
+		mobile: (
+			font-size: $input-font-size-mobile,
+		),
+		placeholder: (
+			color: $input-placeholder-color,
+		),
+		focus: (
+			background-color: $input-focus-bg,
+			border-color: $input-focus-border-color,
+			box-shadow: $input-focus-box-shadow,
+		),
+		disabled: (
+			background-color: $input-disabled-bg,
+			border-color: $input-disabled-border-color,
+			color: $input-disabled-color,
+			placeholder: (
+				color: $input-placeholder-disabled-color,
+			),
+		),
+	),
+	$input
+);
+
+$input-height-border: $input-border-bottom-width + $input-border-top-width !default;
+
+$input-height-inner: $input-height - $input-height-border !default;
+
+// Input Lg (.form-control-lg)
+
+$input-height-lg: 3rem !default; // 48px
 $input-padding-x-lg: $input-padding-x !default;
 $input-padding-y-lg: $input-padding-y !default;
 
+// Input Sm (.form-control-sm)
+
+$input-border-radius-sm: $border-radius !default;
+$input-height-sm: 2rem !default; // 32px
 $input-padding-x-sm: 0.75rem !default; // 12px
 $input-padding-y-sm: 0.25rem !default;
-
-$input-height-border: $input-border-bottom-width + $input-border-top-width !default;
-$input-height: 2.5rem !default; // 40px
-$input-height-inner: $input-height - $input-height-border !default;
-$input-height-lg: 3rem !default; // 48px
-$input-height-sm: 2rem !default; // 32px
-
-$form-feedback-font-size: 0.875rem !default; // 14px
-
-$form-text-color: $gray-600 !default;
 
 // Form Group
 
@@ -42,25 +100,34 @@ $form-group-margin-bottom-mobile: 1rem !default; // 16px
 $form-group-sm-input-label-margin-bottom: 0.1875rem !default; // 3px
 $form-group-sm-item-label-spacer: 1.5625rem !default; // 25px
 
-// Skin
+// Input Label (<label>)
 
-$input-color: $gray-900 !default;
-$input-bg: $gray-200 !default;
-$input-border-color: $gray-300 !default;
-$input-box-shadow: none !default;
-$input-placeholder-color: $gray-600 !default;
 $input-label-color: $gray-900 !default;
+$input-label-font-size: 0.875rem !default; // 14px
+$input-label-font-weight: $font-weight-semi-bold !default;
+$input-label-margin-bottom: 0.25rem !default; // 4px
 
-$input-focus-bg: lighten($component-active-bg, 44.9) !default;
-$input-focus-border-color: lighten($component-active-bg, 22.94) !default;
-$input-focus-box-shadow: $component-focus-box-shadow !default;
-
-$input-disabled-color: $gray-500 !default;
-$input-disabled-bg: $input-bg !default;
-$input-disabled-border-color: $input-bg !default;
-$input-placeholder-disabled-color: $input-disabled-color !default;
+// label.disabled
 
 $input-label-disabled-color: $gray-500 !default;
+
+$input-label: () !default;
+$input-label: map-deep-merge(
+	(
+		color: $input-label-color,
+		font-size: $input-label-font-size,
+		font-weight: $input-label-font-weight,
+		margin-bottom: $input-label-margin-bottom,
+		disabled: (
+			color: $input-label-disabled-color,
+		),
+	),
+	$input-label
+);
+
+// label .reference-mark
+
+$input-label-reference-mark-font-size: 6px !default;
 
 // @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
 
@@ -89,6 +156,18 @@ $input-plaintext-readonly: map-deep-merge(
 	),
 	$input-plaintext-readonly
 );
+
+// Form Feedback
+
+$form-text-color: $gray-600 !default;
+$form-text-font-weight: $font-weight-semi-bold !default;
+
+$form-feedback-font-size: 0.875rem !default; // 14px
+$form-feedback-font-weight: $font-weight-semi-bold !default;
+
+$form-feedback-indicator-margin-x: 0 !default;
+
+// Input Variants
 
 $input-danger-bg: $danger-l2 !default;
 $input-danger-border-color: $danger-l1 !default;
@@ -207,14 +286,6 @@ $input-select-size: map-deep-merge(
 	),
 	$input-select-size
 );
-
-// Form Feedback
-
-$form-feedback-font-weight: $font-weight-semi-bold !default;
-
-$form-feedback-indicator-margin-x: 0 !default;
-
-$form-text-font-weight: $font-weight-semi-bold !default;
 
 // Textarea
 

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -23,129 +23,61 @@ fieldset {
 }
 
 label {
-	color: $cadmin-input-label-color;
-	font-size: $cadmin-input-label-font-size;
-	font-weight: $cadmin-input-label-font-weight;
-	margin-bottom: $cadmin-input-label-margin-bottom;
-	max-width: 100%;
-	word-wrap: break-word;
+	@include clay-css($cadmin-input-label);
 
 	@include clay-scale-component {
-		font-size: $cadmin-input-label-font-size-mobile;
+		$mobile: setter(map-get($cadmin-input-label, mobile), ());
+
+		@include clay-css($mobile);
 	}
 
 	&.focus {
-		color: $cadmin-input-label-focus-color;
+		$focus: setter(map-get($cadmin-input-label, focus), ());
+
+		@include clay-css($focus);
 	}
 
 	&[for] {
-		cursor: $cadmin-input-label-for-cursor;
+		$for: setter(map-get($cadmin-input-label, for), ());
+
+		@include clay-css($for);
 	}
 
 	+ .form-text {
-		margin-bottom: $cadmin-input-label-margin-bottom;
-		margin-top: 0;
+		$form-text: setter(map-get($cadmin-input-label, form-text), ());
+
+		@include clay-css($form-text);
 	}
 
 	.reference-mark {
-		color: $cadmin-input-label-reference-mark-color;
-		font-size: $cadmin-input-label-reference-mark-font-size;
-		margin-left: $cadmin-input-label-reference-mark-spacer;
-		margin-right: $cadmin-input-label-reference-mark-spacer;
-		vertical-align: $cadmin-input-label-reference-mark-vertical-align;
+		$reference-mark: setter(
+			map-get($cadmin-input-label, reference-mark),
+			()
+		);
+
+		@include clay-css($reference-mark);
 	}
 }
 
 // Label without for attribute
 
 .form-control-label {
-	display: inline;
-	margin-bottom: 0;
+	@include clay-css($cadmin-form-control-label);
 }
 
 .form-control-label-text {
-	cursor: $cadmin-input-label-for-cursor;
-	display: inline-block;
-	margin-bottom: $cadmin-input-label-margin-bottom;
-	max-width: 100%;
-	word-wrap: break-word;
+	@include clay-css($cadmin-form-control-label-text);
 }
 
 // Inputs
 
 .form-control {
-	background-color: $cadmin-input-bg;
-	border-color: $cadmin-input-border-color;
-	border-style: $cadmin-input-border-style;
-
-	border-bottom-width: $cadmin-input-border-bottom-width;
-	border-left-width: $cadmin-input-border-left-width;
-	border-right-width: $cadmin-input-border-right-width;
-	border-top-width: $cadmin-input-border-top-width;
-
-	@include border-radius($cadmin-input-border-radius, 0);
-	@include box-shadow($cadmin-input-box-shadow);
-
-	color: $cadmin-input-color;
-	display: block;
-	font-family: $cadmin-input-font-family;
-	font-size: $cadmin-input-font-size;
-	font-weight: $cadmin-input-font-weight;
-	height: $cadmin-input-height;
-	line-height: $cadmin-input-line-height;
-	min-width: 0;
-	padding-bottom: $cadmin-input-padding-y;
-	padding-left: $cadmin-input-padding-x;
-	padding-right: $cadmin-input-padding-x;
-	padding-top: $cadmin-input-padding-y;
-	width: 100%;
-
-	@include transition($cadmin-input-transition);
+	@include clay-form-control-variant($cadmin-input);
 
 	@include clay-scale-component {
-		font-size: $cadmin-input-font-size-mobile;
-		height: $cadmin-input-height-mobile;
-	}
+		$mobile: setter(map-get($cadmin-input, mobile), ());
 
-	// Placeholder
-
-	&::placeholder {
-		color: $cadmin-input-placeholder-color;
-
-		// Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
-
-		opacity: 1;
-	}
-
-	&:focus,
-	&.focus {
-		background-color: $cadmin-input-focus-bg;
-		border-color: $cadmin-input-focus-border-color;
-		box-shadow: $cadmin-input-focus-box-shadow;
-		color: $cadmin-input-focus-color;
-		outline: 0;
-
-		&::placeholder {
-			color: $cadmin-input-placeholder-focus-color;
-		}
-	}
-
-	// Disabled
-	// HTML5 says that controls under a fieldset > legend:first-child won't be
-	// disabled if the fieldset is disabled. Due to implementation difficulty, we
-	// don't honor that edge case; we style them as disabled anyway.
-
-	&:disabled,
-	&.disabled {
-		background-color: $cadmin-input-disabled-bg;
-		border-color: $cadmin-input-disabled-border-color;
-		color: $cadmin-input-disabled-color;
-		cursor: $cadmin-input-disabled-cursor;
-
-		// `opacity: 1;` iOS fix for unreadable disabled content;
-		// see https://github.com/twbs/bootstrap/issues/11655.
-
-		opacity: $cadmin-input-disabled-opacity;
+		@include clay-css($mobile);
 	}
 
 	// Removes inner shadow on inputs in iOS. Bootstrap 4 uses

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -2,14 +2,12 @@ $cadmin-input-bg: $cadmin-gray-200 !default;
 
 $cadmin-input-border-color: $cadmin-gray-300 !default;
 $cadmin-input-border-style: solid !default;
-$cadmin-input-border-top-width: 1px !default;
-$cadmin-input-border-right-width: 1px !default;
-$cadmin-input-border-bottom-width: 1px !default;
-$cadmin-input-border-left-width: 1px !default;
+$cadmin-input-border-width: 1px !default;
 
-$cadmin-input-border-width: $cadmin-input-border-top-width
-	$cadmin-input-border-right-width $cadmin-input-border-bottom-width
-	$cadmin-input-border-left-width !default;
+$cadmin-input-border-top-width: $cadmin-input-border-width !default;
+$cadmin-input-border-right-width: $cadmin-input-border-width !default;
+$cadmin-input-border-bottom-width: $cadmin-input-border-width !default;
+$cadmin-input-border-left-width: $cadmin-input-border-width !default;
 
 $cadmin-input-border-radius: $cadmin-border-radius !default;
 $cadmin-input-box-shadow: null !default;
@@ -51,6 +49,65 @@ $cadmin-input-disabled-opacity: 1 !default;
 $cadmin-input-placeholder-color: $cadmin-gray-600 !default;
 $cadmin-input-placeholder-focus-color: null !default;
 $cadmin-input-placeholder-disabled-color: $cadmin-input-disabled-color !default;
+
+$cadmin-input: () !default;
+$cadmin-input: map-deep-merge(
+	(
+		background-color: $cadmin-input-bg,
+		border-color: $cadmin-input-border-color,
+		border-style: $cadmin-input-border-style,
+		border-width: $cadmin-input-border-width,
+		border-bottom-width: $cadmin-input-border-bottom-width,
+		border-left-width: $cadmin-input-border-left-width,
+		border-right-width: $cadmin-input-border-right-width,
+		border-top-width: $cadmin-input-border-top-width,
+		border-radius: clay-enable-rounded($cadmin-input-border-radius),
+		box-shadow: clay-enable-shadows([$cadmin-input-box-shadow]),
+		color: $cadmin-input-color,
+		display: block,
+		font-family: $cadmin-input-font-family,
+		font-size: $cadmin-input-font-size,
+		font-weight: $cadmin-input-font-weight,
+		height: $cadmin-input-height,
+		line-height: $cadmin-input-line-height,
+		min-width: 0,
+		padding-bottom: $cadmin-input-padding-y,
+		padding-left: $cadmin-input-padding-x,
+		padding-right: $cadmin-input-padding-x,
+		padding-top: $cadmin-input-padding-y,
+		transition: $cadmin-input-transition,
+		width: 100%,
+		mobile: (
+			font-size: $cadmin-input-font-size-mobile,
+			height: $cadmin-input-height-mobile,
+		),
+		placeholder: (
+			color: $cadmin-input-placeholder-color,
+			opacity: 1,
+		),
+		focus: (
+			background-color: $cadmin-input-focus-bg,
+			border-color: $cadmin-input-focus-border-color,
+			box-shadow: $cadmin-input-focus-box-shadow,
+			color: $cadmin-input-focus-color,
+			outline: 0,
+			placeholder: (
+				color: $cadmin-input-placeholder-focus-color,
+			),
+		),
+		disabled: (
+			background-color: $cadmin-input-disabled-bg,
+			border-color: $cadmin-input-disabled-border-color,
+			color: $cadmin-input-disabled-color,
+			cursor: $cadmin-input-disabled-cursor,
+			opacity: $cadmin-input-disabled-opacity,
+			placeholder: (
+				color: $cadmin-input-placeholder-disabled-color,
+			),
+		),
+	),
+	$cadmin-input
+);
 
 // Form Control Plaintext
 
@@ -107,9 +164,10 @@ $cadmin-input-height-sm-mobile: null !default;
 
 $cadmin-input-label-color: $cadmin-gray-900 !default;
 $cadmin-input-label-font-size: 14px !default; // 14px
-$cadmin-input-label-font-size-mobile: null !default;
 $cadmin-input-label-font-weight: $cadmin-font-weight-semi-bold !default;
 $cadmin-input-label-margin-bottom: 4px !default; // 4px
+
+$cadmin-input-label-font-size-mobile: null !default;
 
 $cadmin-input-label-for-cursor: $cadmin-link-cursor !default;
 
@@ -124,6 +182,64 @@ $cadmin-input-label-reference-mark-color: $cadmin-warning !default;
 $cadmin-input-label-reference-mark-font-size: 6px !default;
 $cadmin-input-label-reference-mark-spacer: null !default;
 $cadmin-input-label-reference-mark-vertical-align: null !default;
+
+$cadmin-input-label: () !default;
+$cadmin-input-label: map-deep-merge(
+	(
+		color: $cadmin-input-label-color,
+		font-size: $cadmin-input-label-font-size,
+		font-weight: $cadmin-input-label-font-weight,
+		margin-bottom: $cadmin-input-label-margin-bottom,
+		max-width: 100%,
+		word-wrap: break-word,
+		mobile: (
+			font-size: $cadmin-input-label-font-size-mobile,
+		),
+		focus: (
+			color: $cadmin-input-label-focus-color,
+		),
+		for: (
+			cursor: $cadmin-input-label-for-cursor,
+		),
+		form-text: (
+			margin-bottom: $cadmin-input-label-margin-bottom,
+			margin-top: 0,
+		),
+		reference-mark: (
+			color: $cadmin-input-label-reference-mark-color,
+			font-size: $cadmin-input-label-reference-mark-font-size,
+			margin-left: $cadmin-input-label-reference-mark-spacer,
+			margin-right: $cadmin-input-label-reference-mark-spacer,
+			vertical-align: $cadmin-input-label-reference-mark-vertical-align,
+		),
+	),
+	$cadmin-input-label
+);
+
+// .form-control-label
+
+$cadmin-form-control-label: () !default;
+$cadmin-form-control-label: map-merge(
+	(
+		display: inline,
+		margin-bottom: 0,
+	),
+	$cadmin-form-control-label
+);
+
+// .form-control-label-text
+
+$cadmin-form-control-label-text: () !default;
+$cadmin-form-control-label-text: map-merge(
+	(
+		cursor: map-deep-get($cadmin-input-label, for, cursor),
+		display: inline-block,
+		margin-bottom: map-get($cadmin-input-label, margin-bottom),
+		max-width: 100%,
+		word-wrap: break-word,
+	),
+	$cadmin-form-control-label-text
+);
 
 // @deprecated after v2.18.0 use the Sass map `$cadmin-input-readonly` instead
 

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -23,129 +23,58 @@ fieldset {
 }
 
 label {
-	color: $input-label-color;
-	font-size: $input-label-font-size;
-	font-weight: $input-label-font-weight;
-	margin-bottom: $input-label-margin-bottom;
-	max-width: 100%;
-	word-wrap: break-word;
+	@include clay-css($input-label);
 
 	@include clay-scale-component {
-		font-size: $input-label-font-size-mobile;
+		$mobile: setter(map-get($input-label, mobile), ());
+
+		@include clay-css($mobile);
 	}
 
 	&.focus {
-		color: $input-label-focus-color;
+		$focus: setter(map-get($input-label, focus), ());
+
+		@include clay-css($focus);
 	}
 
 	&[for] {
-		cursor: $input-label-for-cursor;
+		$for: setter(map-get($input-label, for), ());
+
+		@include clay-css($for);
 	}
 
 	+ .form-text {
-		margin-bottom: $input-label-margin-bottom;
-		margin-top: 0;
+		$form-text: setter(map-get($input-label, form-text), ());
+
+		@include clay-css($form-text);
 	}
 
 	.reference-mark {
-		color: $input-label-reference-mark-color;
-		font-size: $input-label-reference-mark-font-size;
-		margin-left: $input-label-reference-mark-spacer;
-		margin-right: $input-label-reference-mark-spacer;
-		vertical-align: $input-label-reference-mark-vertical-align;
+		$reference-mark: setter(map-get($input-label, reference-mark), ());
+
+		@include clay-css($reference-mark);
 	}
 }
 
 // Label without for attribute
 
 .form-control-label {
-	display: inline;
-	margin-bottom: 0;
+	@include clay-css($form-control-label);
 }
 
 .form-control-label-text {
-	cursor: $input-label-for-cursor;
-	display: inline-block;
-	margin-bottom: $input-label-margin-bottom;
-	max-width: 100%;
-	word-wrap: break-word;
+	@include clay-css($form-control-label-text);
 }
 
 // Inputs
 
 .form-control {
-	background-color: $input-bg;
-	border-color: $input-border-color;
-	border-style: $input-border-style;
-
-	border-bottom-width: $input-border-bottom-width;
-	border-left-width: $input-border-left-width;
-	border-right-width: $input-border-right-width;
-	border-top-width: $input-border-top-width;
-
-	@include border-radius($input-border-radius, 0);
-	@include box-shadow($input-box-shadow);
-
-	color: $input-color;
-	display: block;
-	font-family: $input-font-family;
-	font-size: $input-font-size;
-	font-weight: $input-font-weight;
-	height: $input-height;
-	line-height: $input-line-height;
-	min-width: 0;
-	padding-bottom: $input-padding-y;
-	padding-left: $input-padding-x;
-	padding-right: $input-padding-x;
-	padding-top: $input-padding-y;
-	width: 100%;
-
-	@include transition($input-transition);
+	@include clay-form-control-variant($input);
 
 	@include clay-scale-component {
-		font-size: $input-font-size-mobile;
-		height: $input-height-mobile;
-	}
+		$mobile: setter(map-get($input, mobile), ());
 
-	// Placeholder
-
-	&::placeholder {
-		color: $input-placeholder-color;
-
-		// Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
-
-		opacity: 1;
-	}
-
-	&:focus,
-	&.focus {
-		background-color: $input-focus-bg;
-		border-color: $input-focus-border-color;
-		box-shadow: $input-focus-box-shadow;
-		color: $input-focus-color;
-		outline: 0;
-
-		&::placeholder {
-			color: $input-placeholder-focus-color;
-		}
-	}
-
-	// Disabled
-	// HTML5 says that controls under a fieldset > legend:first-child won't be
-	// disabled if the fieldset is disabled. Due to implementation difficulty, we
-	// don't honor that edge case; we style them as disabled anyway.
-
-	&:disabled,
-	&.disabled {
-		background-color: $input-disabled-bg;
-		border-color: $input-disabled-border-color;
-		color: $input-disabled-color;
-		cursor: $input-disabled-cursor;
-
-		// `opacity: 1;` iOS fix for unreadable disabled content;
-		// see https://github.com/twbs/bootstrap/issues/11655.
-
-		opacity: $input-disabled-opacity;
+		@include clay-css($mobile);
 	}
 
 	// Removes inner shadow on inputs in iOS. Bootstrap 4 uses

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -334,7 +334,12 @@
 		)
 	);
 
-	$hover-placeholder: setter(map-get($map, hover-placeholder), ());
+	$old-hover-placeholder: setter(map-get($map, hover-placeholder), ());
+	$hover-placeholder: setter(map-get($hover, placeholder), ());
+	$hover-placeholder: map-deep-merge(
+		$hover-placeholder,
+		$old-hover-placeholder
+	);
 	$hover-placeholder: map-deep-merge(
 		$hover-placeholder,
 		(
@@ -374,7 +379,12 @@
 		)
 	);
 
-	$focus-placeholder: setter(map-get($map, focus-placeholder), ());
+	$old-focus-placeholder: setter(map-get($map, focus-placeholder), ());
+	$focus-placeholder: setter(map-get($focus, placeholder), ());
+	$focus-placeholder: map-deep-merge(
+		$focus-placeholder,
+		$old-focus-placeholder
+	);
 	$focus-placeholder: map-deep-merge(
 		$focus-placeholder,
 		(
@@ -436,7 +446,12 @@
 		)
 	);
 
-	$disabled-placeholder: setter(map-get($map, disabled-placeholder), ());
+	$old-disabled-placeholder: setter(map-get($map, disabled-placeholder), ());
+	$disabled-placeholder: setter(map-get($disabled, placeholder), ());
+	$disabled-placeholder: map-deep-merge(
+		$disabled-placeholder,
+		$old-disabled-placeholder
+	);
 	$disabled-placeholder: map-deep-merge(
 		$disabled-placeholder,
 		(
@@ -452,6 +467,8 @@
 		@include clay-css($base);
 
 		&::placeholder {
+			// opacity: 1, override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
+
 			@include clay-css($placeholder);
 		}
 
@@ -493,8 +510,16 @@
 			}
 		}
 
+		// Disabled
+		// HTML5 says that controls under a fieldset > legend:first-child won't be
+		// disabled if the fieldset is disabled. Due to implementation difficulty, we
+		// don't honor that edge case; we style them as disabled anyway.
+
 		&:disabled,
 		&.disabled {
+			// `opacity: 1;` iOS fix for unreadable disabled content;
+			// see https://github.com/twbs/bootstrap/issues/11655.
+
 			@include clay-css($disabled);
 
 			&::placeholder {

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -1,14 +1,12 @@
 $input-bg: $white !default;
-
 $input-border-color: $gray-400 !default;
 $input-border-style: solid !default;
+$input-border-width: 0.0625rem !default;
+
 $input-border-top-width: 0.0625rem !default;
 $input-border-right-width: 0.0625rem !default;
 $input-border-bottom-width: 0.0625rem !default;
 $input-border-left-width: 0.0625rem !default;
-
-$input-border-width: $input-border-top-width $input-border-right-width
-	$input-border-bottom-width $input-border-left-width !default;
 
 $input-border-radius: $border-radius !default;
 $input-box-shadow: inset 0 1px 1px rgba($black, 0.075) !default;
@@ -25,6 +23,10 @@ $input-transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out 
 $input-font-size-mobile: null !default;
 $input-height-mobile: null !default;
 
+// .form-control::placeholder
+
+$input-placeholder-color: $gray-600 !default;
+
 // Input Focus
 
 $input-focus-bg: $input-bg !default;
@@ -32,6 +34,10 @@ $input-focus-border-color: lighten($component-active-bg, 25%) !default;
 $input-focus-color: $input-color !default;
 $input-focus-width: $input-btn-focus-width !default;
 $input-focus-box-shadow: $input-btn-focus-box-shadow !default;
+
+// .form-control:focus::placeholder
+
+$input-placeholder-focus-color: null !default;
 
 // Input Disabled
 
@@ -41,11 +47,68 @@ $input-disabled-color: null !default;
 $input-disabled-cursor: $disabled-cursor !default;
 $input-disabled-opacity: 1 !default;
 
-// Input Placeholder
+// .form-control:disabled::placeholder
 
-$input-placeholder-color: $gray-600 !default;
-$input-placeholder-focus-color: null !default;
 $input-placeholder-disabled-color: null !default;
+
+$input: () !default;
+$input: map-deep-merge(
+	(
+		background-color: $input-bg,
+		border-color: $input-border-color,
+		border-style: $input-border-style,
+		border-width: $input-border-width,
+		border-bottom-width: $input-border-bottom-width,
+		border-left-width: $input-border-left-width,
+		border-right-width: $input-border-right-width,
+		border-top-width: $input-border-top-width,
+		border-radius: clay-enable-rounded($input-border-radius),
+		box-shadow: clay-enable-shadows([$input-box-shadow]),
+		color: $input-color,
+		display: block,
+		font-family: $input-font-family,
+		font-size: $input-font-size,
+		font-weight: $input-font-weight,
+		height: $input-height,
+		line-height: $input-line-height,
+		min-width: 0,
+		padding-bottom: $input-padding-y,
+		padding-left: $input-padding-x,
+		padding-right: $input-padding-x,
+		padding-top: $input-padding-y,
+		transition: $input-transition,
+		width: 100%,
+		mobile: (
+			font-size: $input-font-size-mobile,
+			height: $input-height-mobile,
+		),
+		placeholder: (
+			color: $input-placeholder-color,
+			opacity: 1,
+		),
+		focus: (
+			background-color: $input-focus-bg,
+			border-color: $input-focus-border-color,
+			box-shadow: $input-focus-box-shadow,
+			color: $input-focus-color,
+			outline: 0,
+			placeholder: (
+				color: $input-placeholder-focus-color,
+			),
+		),
+		disabled: (
+			background-color: $input-disabled-bg,
+			border-color: $input-disabled-border-color,
+			color: $input-disabled-color,
+			cursor: $input-disabled-cursor,
+			opacity: $input-disabled-opacity,
+			placeholder: (
+				color: $input-placeholder-disabled-color,
+			),
+		),
+	),
+	$input
+);
 
 // Form Control Plaintext
 
@@ -76,7 +139,7 @@ $input-height-inner-quarter: add(
 	$input-padding-y / 2
 ) !default;
 
-// Input Lg
+// Input Lg (.form-control-lg)
 
 $input-border-radius-lg: $border-radius-lg !default;
 $input-font-size-lg: $input-btn-font-size-lg !default;
@@ -88,7 +151,7 @@ $input-padding-y-lg: $input-btn-padding-y-lg !default;
 $input-font-size-lg-mobile: null !default;
 $input-height-lg-mobile: null !default;
 
-// Input Sm
+// Input Sm (.form-control-sm)
 
 $input-border-radius-sm: $border-radius-sm !default;
 $input-font-size-sm: $input-btn-font-size-sm !default;
@@ -104,23 +167,84 @@ $input-height-sm-mobile: null !default;
 
 $input-label-color: null !default;
 $input-label-font-size: null !default;
-$input-label-font-size-mobile: null !default;
 $input-label-font-weight: null !default;
 $input-label-margin-bottom: $label-margin-bottom !default;
 
-$input-label-for-cursor: $link-cursor !default;
+$input-label-font-size-mobile: null !default;
 
 $input-label-focus-color: null !default;
 
 $input-label-disabled-color: $gray-600 !default;
 $input-label-disabled-cursor: $disabled-cursor !default;
 
-// Label Reference Mark
+// label[for]
+
+$input-label-for-cursor: $link-cursor !default;
+
+// label .reference-mark
 
 $input-label-reference-mark-color: $warning !default;
 $input-label-reference-mark-font-size: null !default;
 $input-label-reference-mark-spacer: null !default;
 $input-label-reference-mark-vertical-align: null !default;
+
+$input-label: () !default;
+$input-label: map-deep-merge(
+	(
+		color: $input-label-color,
+		font-size: $input-label-font-size,
+		font-weight: $input-label-font-weight,
+		margin-bottom: $input-label-margin-bottom,
+		max-width: 100%,
+		word-wrap: break-word,
+		mobile: (
+			font-size: $input-label-font-size-mobile,
+		),
+		focus: (
+			color: $input-label-focus-color,
+		),
+		for: (
+			cursor: $input-label-for-cursor,
+		),
+		form-text: (
+			margin-bottom: $input-label-margin-bottom,
+			margin-top: 0,
+		),
+		reference-mark: (
+			color: $input-label-reference-mark-color,
+			font-size: $input-label-reference-mark-font-size,
+			margin-left: $input-label-reference-mark-spacer,
+			margin-right: $input-label-reference-mark-spacer,
+			vertical-align: $input-label-reference-mark-vertical-align,
+		),
+	),
+	$input-label
+);
+
+// .form-control-label
+
+$form-control-label: () !default;
+$form-control-label: map-merge(
+	(
+		display: inline,
+		margin-bottom: 0,
+	),
+	$form-control-label
+);
+
+// .form-control-label-text
+
+$form-control-label-text: () !default;
+$form-control-label-text: map-merge(
+	(
+		cursor: $input-label-for-cursor,
+		display: inline-block,
+		margin-bottom: $input-label-margin-bottom,
+		max-width: 100%,
+		word-wrap: break-word,
+	),
+	$form-control-label-text
+);
 
 /// @deprecated after v2.18.0 use the Sass map `$input-readonly` instead
 


### PR DESCRIPTION
fixes #4259