### PR TITLE
feat(@clayui/css): Buttons convert components to use `clay-button-variant` mixin for more customizing options

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -42,7 +42,7 @@ $btn: map-deep-merge(
 
 $btn-link-disabled-color: $link-color !default;
 
-// Button Sizes
+// Button Lg
 
 $btn-border-radius-lg: $border-radius !default;
 $btn-font-size-lg: $font-size-lg !default; // 18px
@@ -50,10 +50,41 @@ $btn-padding-x-lg: 1.5rem !default; // 24px
 $btn-padding-y-lg: 0.59375rem !default; // 9.5px
 $btn-inline-item-font-size-lg: $font-size-lg !default; // 18px
 
+$btn-lg: () !default;
+$btn-lg: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($btn-border-radius-lg),
+		font-size: $btn-font-size-lg,
+		padding-bottom: $btn-padding-y-lg,
+		padding-left: $btn-padding-x-lg,
+		padding-right: $btn-padding-x-lg,
+		padding-top: $btn-padding-y-lg,
+		inline-item: (
+			font-size: $btn-inline-item-font-size-lg,
+		),
+	),
+	$btn-lg
+);
+
+// Button Sm
+
 $btn-font-size-sm: $font-size-sm !default; // 14px
 $btn-line-height-sm: 1.15 !default;
 $btn-padding-x-sm: 0.75rem !default; // 12px
 $btn-padding-y-sm: 0.4375rem !default; // 7px
+
+$btn-sm: () !default;
+$btn-sm: map-deep-merge(
+	(
+		font-size: $btn-font-size-sm,
+		line-height: $btn-line-height-sm,
+		padding-bottom: $btn-padding-y-sm,
+		padding-left: $btn-padding-x-sm,
+		padding-right: $btn-padding-x-sm,
+		padding-top: $btn-padding-y-sm,
+	),
+	$btn-sm
+);
 
 // Button Monospaced
 

--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -91,11 +91,48 @@ $btn-sm: map-deep-merge(
 $btn-monospaced-padding-y: 0.25rem !default; // 4px
 $btn-monospaced-size: 2.5rem !default; // 40px
 
+$btn-monospaced: () !default;
+$btn-monospaced: map-deep-merge(
+	(
+		height: $btn-monospaced-size,
+		padding-bottom: $btn-monospaced-padding-y,
+		padding-top: $btn-monospaced-padding-y,
+		width: $btn-monospaced-size,
+	),
+	$btn-monospaced
+);
+
+// Button Monospaced Lg
+
+$btn-monospaced-padding-y-lg: 0.375rem !default; // 6px
+
+$btn-monospaced-lg: () !default;
+$btn-monospaced-lg: map-deep-merge(
+	(
+		padding-bottom: $btn-monospaced-padding-y-lg,
+		padding-top: $btn-monospaced-padding-y-lg,
+	),
+	$btn-monospaced-lg
+);
+
+// Button Monospaced Sm
+
 $btn-monospaced-padding-x-sm: null !default;
 $btn-monospaced-padding-y-sm: 0.1875rem !default; // 3px
 $btn-monospaced-size-sm: 2rem !default; // 32px
 
-$btn-monospaced-padding-y-lg: 0.375rem !default; // 6px
+$btn-monospaced-sm: () !default;
+$btn-monospaced-sm: map-deep-merge(
+	(
+		height: $btn-monospaced-size-sm,
+		padding-bottom: $btn-monospaced-padding-y-sm,
+		padding-left: $btn-monospaced-padding-x-sm,
+		padding-right: $btn-monospaced-padding-x-sm,
+		padding-top: $btn-monospaced-padding-y-sm,
+		width: $btn-monospaced-size-sm,
+	),
+	$btn-monospaced-sm
+);
 
 // Button Group
 

--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -10,11 +10,37 @@ $btn-focus-box-shadow: $component-focus-box-shadow !default;
 
 $btn-disabled-opacity: 0.4 !default;
 
-$btn-link-disabled-color: $link-color !default;
-
 $btn-active-box-shadow: none !default;
 
 $btn-inline-item-font-size: 1rem !default; // 16px
+
+$btn: () !default;
+$btn: map-deep-merge(
+	(
+		box-shadow: $btn-box-shadow,
+		font-weight: $btn-font-weight,
+		padding-bottom: $btn-padding-y,
+		padding-left: $btn-padding-x,
+		padding-right: $btn-padding-x,
+		padding-top: $btn-padding-y,
+		transition: clay-enable-transitions($btn-transition),
+		focus: (
+			box-shadow: $btn-focus-box-shadow,
+		),
+		active: (
+			box-shadow: $btn-active-box-shadow,
+		),
+		disabled: (
+			opacity: $btn-disabled-opacity,
+		),
+		inline-item: (
+			font-size: $btn-inline-item-font-size,
+		),
+	),
+	$btn
+);
+
+$btn-link-disabled-color: $link-color !default;
 
 // Button Sizes
 

--- a/packages/clay-css/src/scss/cadmin/components/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_buttons.scss
@@ -1,126 +1,25 @@
 .btn {
-	background-color: transparent;
-	border: $cadmin-btn-border-width solid transparent;
-
-	@include border-radius($cadmin-btn-border-radius, 0);
-	@include box-shadow($cadmin-btn-box-shadow);
-
-	color: $cadmin-body-color;
-	cursor: $cadmin-btn-cursor;
-	display: inline-block;
-	font-family: $cadmin-btn-font-family;
-	font-size: $cadmin-btn-font-size;
-	font-weight: $cadmin-btn-font-weight;
-	line-height: $cadmin-btn-line-height;
-	padding: $cadmin-btn-padding-y $cadmin-btn-padding-x;
-	text-align: center;
-	text-transform: none;
-
-	@include transition($cadmin-btn-transition);
-
-	user-select: none;
-	vertical-align: middle;
-	white-space: $cadmin-btn-white-space;
-
-	@include clay-scale-component {
-		font-size: $cadmin-btn-font-size-mobile;
-		padding-bottom: $cadmin-btn-padding-y-mobile;
-		padding-left: $cadmin-btn-padding-x-mobile;
-		padding-right: $cadmin-btn-padding-x-mobile;
-		padding-top: $cadmin-btn-padding-y-mobile;
-	}
-
-	&:hover {
-		color: $cadmin-body-color;
-		text-decoration: none;
-	}
-
-	&:focus,
-	&.focus {
-		box-shadow: $cadmin-btn-focus-box-shadow;
-		outline: 0;
-	}
-
-	&:active,
-	&.active {
-		@include box-shadow($cadmin-btn-active-box-shadow);
-
-		&:focus {
-			@if (
-				$cadmin-enable-shadows and $cadmin-btn-active-box-shadow != none
-			) {
-				box-shadow: $cadmin-btn-focus-box-shadow,
-					$cadmin-btn-active-box-shadow;
-			} @else {
-				box-shadow: $cadmin-btn-focus-box-shadow;
-			}
-		}
-	}
-
-	&.disabled,
-	&:disabled {
-		cursor: $cadmin-btn-disabled-cursor;
-		opacity: $cadmin-btn-disabled-opacity;
-
-		&:focus,
-		&:focus:active {
-			box-shadow: none;
-		}
-
-		&:active {
-			pointer-events: none;
-		}
-	}
+	@include clay-button-variant($cadmin-btn);
 }
 
 fieldset:disabled a.btn {
-	box-shadow: none;
-	cursor: $cadmin-btn-disabled-cursor;
-	opacity: $cadmin-btn-disabled-opacity;
+	$btn-disabled: setter(map-get($cadmin-btn, disabled), ());
+
+	@include clay-css($btn-disabled);
+
+	&:focus {
+		@include clay-css(setter(map-get($btn-disabled, focus), ()));
+	}
 
 	&:active {
-		pointer-events: none;
+		@include clay-css(setter(map-get($btn-disabled, active), ()));
 	}
-}
-
-.btn .inline-item {
-	font-size: $cadmin-btn-inline-item-font-size;
-}
-
-.btn-section {
-	display: block;
-	font-size: $cadmin-btn-section-font-size;
-	font-weight: $cadmin-btn-section-font-weight;
-	line-height: $cadmin-btn-section-line-height;
 }
 
 // Button Sizes
 
 %clay-btn-lg {
-	@include border-radius($cadmin-btn-border-radius-lg, 0);
-
-	font-size: $cadmin-btn-font-size-lg;
-	line-height: $cadmin-btn-line-height-lg;
-	padding-bottom: $cadmin-btn-padding-y-lg;
-	padding-left: $cadmin-btn-padding-x-lg;
-	padding-right: $cadmin-btn-padding-x-lg;
-	padding-top: $cadmin-btn-padding-y-lg;
-
-	@include clay-scale-component {
-		font-size: $cadmin-btn-font-size-lg-mobile;
-		padding-bottom: $cadmin-btn-padding-y-lg-mobile;
-		padding-left: $cadmin-btn-padding-x-lg-mobile;
-		padding-right: $cadmin-btn-padding-x-lg-mobile;
-		padding-top: $cadmin-btn-padding-y-lg-mobile;
-	}
-
-	.inline-item {
-		font-size: $cadmin-btn-inline-item-font-size-lg;
-	}
-
-	.btn-section {
-		font-size: $cadmin-btn-section-font-size-lg;
-	}
+	@include clay-button-variant($cadmin-btn-lg);
 }
 
 .btn-lg {
@@ -128,30 +27,7 @@ fieldset:disabled a.btn {
 }
 
 %clay-btn-sm {
-	@include border-radius($cadmin-btn-border-radius-sm, 0);
-
-	font-size: $cadmin-btn-font-size-sm;
-	line-height: $cadmin-btn-line-height-sm;
-	padding-bottom: $cadmin-btn-padding-y-sm;
-	padding-left: $cadmin-btn-padding-x-sm;
-	padding-right: $cadmin-btn-padding-x-sm;
-	padding-top: $cadmin-btn-padding-y-sm;
-
-	@include clay-scale-component {
-		font-size: $cadmin-btn-font-size-sm-mobile;
-		padding-bottom: $cadmin-btn-padding-y-sm-mobile;
-		padding-left: $cadmin-btn-padding-x-sm-mobile;
-		padding-right: $cadmin-btn-padding-x-sm-mobile;
-		padding-top: $cadmin-btn-padding-y-sm-mobile;
-	}
-
-	.inline-item {
-		font-size: $cadmin-btn-inline-item-font-size-sm;
-	}
-
-	.btn-section {
-		font-size: $cadmin-btn-section-font-size-sm;
-	}
+	@include clay-button-variant($cadmin-btn-sm);
 }
 
 .btn-sm {
@@ -182,17 +58,7 @@ input[type='button'] {
 // Button Unstyled
 
 %btn-unstyled {
-	background-color: rgba(0, 0, 0, 0.001);
-	border-width: 0;
-	cursor: $cadmin-btn-cursor;
-	font-size: inherit;
-	font-weight: inherit;
-	line-height: inherit;
-	max-width: 100%;
-	padding: 0;
-	text-align: left;
-	text-transform: inherit;
-	vertical-align: baseline;
+	@include clay-button-variant($cadmin-btn-unstyled);
 }
 
 .btn-unstyled {
@@ -202,22 +68,7 @@ input[type='button'] {
 // Button Monospaced
 
 .btn-monospaced {
-	height: $cadmin-btn-monospaced-size;
-	line-height: 1;
-	overflow: hidden;
-	padding-bottom: $cadmin-btn-monospaced-padding-y;
-	padding-left: $cadmin-btn-monospaced-padding-x;
-	padding-right: $cadmin-btn-monospaced-padding-x;
-	padding-top: $cadmin-btn-monospaced-padding-y;
-	text-align: center;
-	white-space: normal;
-	width: $cadmin-btn-monospaced-size;
-	word-wrap: break-word;
-
-	@include clay-scale-component {
-		height: $cadmin-btn-monospaced-size-mobile;
-		width: $cadmin-btn-monospaced-size-mobile;
-	}
+	@include clay-button-variant($cadmin-btn-monospaced);
 
 	&.btn .lexicon-icon {
 		margin-top: 0;
@@ -225,17 +76,7 @@ input[type='button'] {
 }
 
 %clay-btn-monospaced-lg {
-	height: $cadmin-btn-monospaced-size-lg;
-	padding-bottom: $cadmin-btn-monospaced-padding-y-lg;
-	padding-left: $cadmin-btn-monospaced-padding-x-lg;
-	padding-right: $cadmin-btn-monospaced-padding-x-lg;
-	padding-top: $cadmin-btn-monospaced-padding-y-lg;
-	width: $cadmin-btn-monospaced-size-lg;
-
-	@include clay-scale-component {
-		height: $cadmin-btn-monospaced-size-lg-mobile;
-		width: $cadmin-btn-monospaced-size-lg-mobile;
-	}
+	@include clay-button-variant($cadmin-btn-monospaced-lg);
 }
 
 .btn-monospaced.btn-lg {
@@ -243,88 +84,11 @@ input[type='button'] {
 }
 
 %clay-btn-monospaced-sm {
-	height: $cadmin-btn-monospaced-size-sm;
-	padding-bottom: $cadmin-btn-monospaced-padding-y-sm;
-	padding-left: $cadmin-btn-monospaced-padding-x-sm;
-	padding-right: $cadmin-btn-monospaced-padding-x-sm;
-	padding-top: $cadmin-btn-monospaced-padding-y-sm;
-	width: $cadmin-btn-monospaced-size-sm;
-
-	@include clay-scale-component {
-		height: $cadmin-btn-monospaced-size-sm-mobile;
-		width: $cadmin-btn-monospaced-size-sm-mobile;
-	}
+	@include clay-button-variant($cadmin-btn-monospaced-sm);
 }
 
 .btn-monospaced.btn-sm {
 	@extend %clay-btn-monospaced-sm !optional;
-}
-
-// Button C Inner
-
-@if ($cadmin-enable-c-inner) {
-	.btn .c-inner {
-		margin: #{math-sign($cadmin-btn-padding-y)}
-			#{math-sign($cadmin-btn-padding-x)};
-
-		@include clay-scale-component {
-			margin: #{math-sign($cadmin-btn-padding-y-mobile)} #{math-sign(
-					$cadmin-btn-padding-x-mobile
-				)};
-		}
-	}
-
-	.btn-unstyled .c-inner {
-		margin: 0;
-		max-width: none;
-	}
-
-	.btn-monospaced .c-inner {
-		align-items: center;
-		display: flex;
-		flex-direction: column;
-		height: calc(100% + #{$cadmin-btn-monospaced-padding-y * 2});
-		justify-content: center;
-		margin: #{math-sign($cadmin-btn-monospaced-padding-y)} 0;
-		padding: 0;
-		width: 100%;
-	}
-
-	.btn-sm {
-		.c-inner {
-			margin: #{math-sign($cadmin-btn-padding-y-sm)}
-				#{math-sign($cadmin-btn-padding-x-sm)};
-
-			@include clay-scale-component {
-				margin: #{math-sign($cadmin-btn-padding-y-sm-mobile)} #{math-sign(
-						$cadmin-btn-padding-x-sm-mobile
-					)};
-			}
-		}
-
-		&.btn-monospaced .c-inner {
-			height: calc(100% + #{$cadmin-btn-monospaced-padding-y-sm * 2});
-			margin: #{math-sign($cadmin-btn-monospaced-padding-y-sm)} 0;
-		}
-	}
-
-	.btn-lg {
-		.c-inner {
-			margin: #{math-sign($cadmin-btn-padding-y-lg)}
-				#{math-sign($cadmin-btn-padding-x-lg)};
-
-			@include clay-scale-component {
-				margin: #{math-sign($cadmin-btn-padding-y-lg-mobile)} #{math-sign(
-						$cadmin-btn-padding-x-lg-mobile
-					)};
-			}
-		}
-
-		&.btn-monospaced .c-inner {
-			height: calc(100% + #{$cadmin-btn-monospaced-padding-y-lg * 2});
-			margin: #{math-sign($cadmin-btn-monospaced-padding-y-lg)} 0;
-		}
-	}
 }
 
 // Button Variants
@@ -366,17 +130,7 @@ input[type='button'] {
 }
 
 .btn-outline-borderless {
-	border-color: transparent;
-
-	&:hover,
-	&:focus {
-		border-color: transparent;
-	}
-
-	&:disabled,
-	&.disabled {
-		border-color: transparent;
-	}
+	@include clay-button-variant($cadmin-btn-outline-borderless);
 }
 
 .btn-outline-borderless:not(:disabled):not(.disabled):active {

--- a/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
@@ -32,6 +32,79 @@ $cadmin-btn-section-font-size: 11px !default; // 11px
 $cadmin-btn-section-font-weight: $cadmin-font-weight-normal !default;
 $cadmin-btn-section-line-height: 1 !default;
 
+$cadmin-btn: () !default;
+$cadmin-btn: map-deep-merge(
+	(
+		background-color: transparent,
+		border-color: transparent,
+		border-style: solid,
+		border-width: $cadmin-btn-border-width,
+		border-radius: clay-enable-rounded($cadmin-btn-border-radius),
+		box-shadow: clay-enable-shadows([$cadmin-btn-box-shadow]),
+		color: $cadmin-body-color,
+		cursor: $cadmin-btn-cursor,
+		display: inline-block,
+		font-family: $cadmin-btn-font-family,
+		font-size: $cadmin-btn-font-size,
+		font-weight: $cadmin-btn-font-weight,
+		line-height: $cadmin-btn-line-height,
+		padding-bottom: $cadmin-btn-padding-y,
+		padding-left: $cadmin-btn-padding-x,
+		padding-right: $cadmin-btn-padding-x,
+		padding-top: $cadmin-btn-padding-y,
+		text-align: center,
+		text-transform: none,
+		transition: clay-enable-transitions($cadmin-btn-transition),
+		user-select: none,
+		vertical-align: middle,
+		white-space: $cadmin-btn-white-space,
+		mobile: (
+			font-size: $cadmin-btn-font-size-mobile,
+			padding-bottom: $cadmin-btn-padding-y-mobile,
+			padding-left: $cadmin-btn-padding-x-mobile,
+			padding-right: $cadmin-btn-padding-x-mobile,
+			padding-top: $cadmin-btn-padding-y-mobile,
+		),
+		hover: (
+			color: $cadmin-body-color,
+			text-decoration: none,
+		),
+		focus: (
+			box-shadow: $cadmin-btn-focus-box-shadow,
+			outline: 0,
+		),
+		active: (
+			box-shadow: clay-enable-shadows([$cadmin-btn-active-box-shadow]),
+			focus: (
+				box-shadow: clay-enable-shadows([$cadmin-btn-focus-box-shadow]),
+			),
+		),
+		active-class: (
+			box-shadow: clay-enable-shadows([$cadmin-btn-active-box-shadow]),
+		),
+		disabled: (
+			cursor: $cadmin-btn-disabled-cursor,
+			opacity: $cadmin-btn-disabled-opacity,
+			focus: (
+				box-shadow: none,
+			),
+			active: (
+				pointer-events: none,
+			),
+		),
+		inline-item: (
+			font-size: $cadmin-btn-inline-item-font-size,
+		),
+		btn-section: (
+			display: block,
+			font-size: $cadmin-btn-section-font-size,
+			font-weight: $cadmin-btn-section-font-weight,
+			line-height: $cadmin-btn-section-line-height,
+		),
+	),
+	$cadmin-btn
+);
+
 // Button Lg
 
 $cadmin-btn-border-radius-lg: $cadmin-border-radius !default;
@@ -45,6 +118,33 @@ $cadmin-btn-section-font-size-lg: 13px !default; // 13px
 $cadmin-btn-font-size-lg-mobile: null !default;
 $cadmin-btn-padding-x-lg-mobile: null !default;
 $cadmin-btn-padding-y-lg-mobile: null !default;
+
+$cadmin-btn-lg: () !default;
+$cadmin-btn-lg: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($cadmin-btn-border-radius-lg),
+		font-size: $cadmin-btn-font-size-lg,
+		line-height: $cadmin-btn-line-height-lg,
+		padding-bottom: $cadmin-btn-padding-y-lg,
+		padding-left: $cadmin-btn-padding-x-lg,
+		padding-right: $cadmin-btn-padding-x-lg,
+		padding-top: $cadmin-btn-padding-y-lg,
+		mobile: (
+			font-size: $cadmin-btn-font-size-lg-mobile,
+			padding-bottom: $cadmin-btn-padding-y-lg-mobile,
+			padding-left: $cadmin-btn-padding-x-lg-mobile,
+			padding-right: $cadmin-btn-padding-x-lg-mobile,
+			padding-top: $cadmin-btn-padding-y-lg-mobile,
+		),
+		inline-item: (
+			font-size: $cadmin-btn-inline-item-font-size-lg,
+		),
+		btn-section: (
+			font-size: $cadmin-btn-section-font-size-lg,
+		),
+	),
+	$cadmin-btn-lg
+);
 
 // Button Sm
 
@@ -60,27 +160,155 @@ $cadmin-btn-font-size-sm-mobile: null !default;
 $cadmin-btn-padding-x-sm-mobile: null !default;
 $cadmin-btn-padding-y-sm-mobile: null !default;
 
+$cadmin-btn-sm: () !default;
+$cadmin-btn-sm: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($cadmin-btn-border-radius-sm),
+		font-size: $cadmin-btn-font-size-sm,
+		line-height: $cadmin-btn-line-height-sm,
+		padding-bottom: $cadmin-btn-padding-y-sm,
+		padding-left: $cadmin-btn-padding-x-sm,
+		padding-right: $cadmin-btn-padding-x-sm,
+		padding-top: $cadmin-btn-padding-y-sm,
+		mobile: (
+			font-size: $cadmin-btn-font-size-sm-mobile,
+			padding-bottom: $cadmin-btn-padding-y-sm-mobile,
+			padding-left: $cadmin-btn-padding-x-sm-mobile,
+			padding-right: $cadmin-btn-padding-x-sm-mobile,
+			padding-top: $cadmin-btn-padding-y-sm-mobile,
+		),
+		inline-item: (
+			font-size: $cadmin-btn-inline-item-font-size-sm,
+		),
+		btn-section: (
+			font-size: $cadmin-btn-section-font-size-sm,
+		),
+	),
+	$cadmin-btn-sm
+);
+
 // Button Monospaced
 
 $cadmin-btn-monospaced-padding-x: 0 !default;
 $cadmin-btn-monospaced-padding-y: 4px !default; // 4px
 $cadmin-btn-monospaced-size: 40px !default; // 40px
 
+$cadmin-btn-monospaced-size-mobile: null !default;
+
+$cadmin-btn-monospaced: () !default;
+$cadmin-btn-monospaced: map-deep-merge(
+	(
+		height: $cadmin-btn-monospaced-size,
+		line-height: 1,
+		overflow: hidden,
+		padding-bottom: $cadmin-btn-monospaced-padding-y,
+		padding-left: $cadmin-btn-monospaced-padding-x,
+		padding-right: $cadmin-btn-monospaced-padding-x,
+		padding-top: $cadmin-btn-monospaced-padding-y,
+		text-align: center,
+		white-space: normal,
+		width: $cadmin-btn-monospaced-size,
+		word-wrap: break-word,
+		mobile: (
+			height: $cadmin-btn-monospaced-size-mobile,
+			width: $cadmin-btn-monospaced-size-mobile,
+		),
+		c-inner: (
+			align-items: center,
+			display: flex,
+			flex-direction: column,
+			height: calc(100% + #{$cadmin-btn-monospaced-padding-y * 2}),
+			justify-content: center,
+			padding: 0,
+			width: 100%,
+		),
+	),
+	$cadmin-btn-monospaced
+);
+
+// Button Monospaced Lg
+
 $cadmin-btn-monospaced-padding-x-lg: 0 !default;
 $cadmin-btn-monospaced-padding-y-lg: 6px !default; // 6px
 $cadmin-btn-monospaced-size-lg: 48px !default; // 48px
+
+$cadmin-btn-monospaced-size-lg-mobile: null !default;
+
+$cadmin-btn-monospaced-lg: () !default;
+$cadmin-btn-monospaced-lg: map-deep-merge(
+	(
+		height: $cadmin-btn-monospaced-size-lg,
+		padding-bottom: $cadmin-btn-monospaced-padding-y-lg,
+		padding-left: $cadmin-btn-monospaced-padding-x-lg,
+		padding-right: $cadmin-btn-monospaced-padding-x-lg,
+		padding-top: $cadmin-btn-monospaced-padding-y-lg,
+		width: $cadmin-btn-monospaced-size-lg,
+		mobile: (
+			height: $cadmin-btn-monospaced-size-lg-mobile,
+			width: $cadmin-btn-monospaced-size-lg-mobile,
+		),
+		c-inner: (
+			height: calc(100% + #{$cadmin-btn-monospaced-padding-y-lg * 2}),
+		),
+	),
+	$cadmin-btn-monospaced-lg
+);
+
+// Button Monospaced Sm
 
 $cadmin-btn-monospaced-padding-x-sm: null !default;
 $cadmin-btn-monospaced-padding-y-sm: 3px !default; // 3px
 $cadmin-btn-monospaced-size-sm: 32px !default; // 32px
 
-$cadmin-btn-monospaced-size-mobile: null !default;
-$cadmin-btn-monospaced-size-lg-mobile: null !default;
 $cadmin-btn-monospaced-size-sm-mobile: null !default;
+
+$cadmin-btn-monospaced-sm: () !default;
+$cadmin-btn-monospaced-sm: map-deep-merge(
+	(
+		height: $cadmin-btn-monospaced-size-sm,
+		padding-bottom: $cadmin-btn-monospaced-padding-y-sm,
+		padding-left: $cadmin-btn-monospaced-padding-x-sm,
+		padding-right: $cadmin-btn-monospaced-padding-x-sm,
+		padding-top: $cadmin-btn-monospaced-padding-y-sm,
+		width: $cadmin-btn-monospaced-size-sm,
+		mobile: (
+			height: $cadmin-btn-monospaced-size-sm-mobile,
+			width: $cadmin-btn-monospaced-size-sm-mobile,
+		),
+		c-inner: (
+			height: calc(100% + #{$cadmin-btn-monospaced-padding-y-sm * 2}),
+		),
+	),
+	$cadmin-btn-monospaced-sm
+);
 
 // Button Block
 
 $cadmin-btn-block-spacing-y: 8px !default;
+
+// Button Unstyled
+
+$cadmin-btn-unstyled: () !default;
+$cadmin-btn-unstyled: map-deep-merge(
+	(
+		background-color: rgba(0, 0, 0, 0.001),
+		border-width: 0,
+		cursor: $cadmin-btn-cursor,
+		font-size: inherit,
+		font-weight: inherit,
+		line-height: inherit,
+		max-width: 100%,
+		padding: 0,
+		text-align: left,
+		text-transform: inherit,
+		vertical-align: baseline,
+		c-inner: (
+			margin: 0,
+			max-width: none,
+		),
+	),
+	$cadmin-btn-unstyled
+);
 
 // Button Group
 
@@ -700,6 +928,23 @@ $cadmin-btn-outline-dark: map-deep-merge(
 		),
 	),
 	$cadmin-btn-outline-dark
+);
+
+$cadmin-btn-outline-borderless: () !default;
+$cadmin-btn-outline-borderless: map-deep-merge(
+	(
+		border-color: transparent,
+		hover: (
+			border-color: transparent,
+		),
+		focus: (
+			border-color: transparent,
+		),
+		disabled: (
+			border-color: transparent,
+		),
+	),
+	$cadmin-btn-outline-borderless
 );
 
 $cadmin-btn-outline-palette: () !default;

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -19,30 +19,7 @@ fieldset:disabled a.btn {
 // Button Sizes
 
 %clay-btn-lg {
-	@include border-radius($btn-border-radius-lg, 0);
-
-	font-size: $btn-font-size-lg;
-	line-height: $btn-line-height-lg;
-	padding-bottom: $btn-padding-y-lg;
-	padding-left: $btn-padding-x-lg;
-	padding-right: $btn-padding-x-lg;
-	padding-top: $btn-padding-y-lg;
-
-	@include clay-scale-component {
-		font-size: $btn-font-size-lg-mobile;
-		padding-bottom: $btn-padding-y-lg-mobile;
-		padding-left: $btn-padding-x-lg-mobile;
-		padding-right: $btn-padding-x-lg-mobile;
-		padding-top: $btn-padding-y-lg-mobile;
-	}
-
-	.inline-item {
-		font-size: $btn-inline-item-font-size-lg;
-	}
-
-	.btn-section {
-		font-size: $btn-section-font-size-lg;
-	}
+	@include clay-button-variant($btn-lg);
 }
 
 .btn-lg {
@@ -50,30 +27,7 @@ fieldset:disabled a.btn {
 }
 
 %clay-btn-sm {
-	@include border-radius($btn-border-radius-sm, 0);
-
-	font-size: $btn-font-size-sm;
-	line-height: $btn-line-height-sm;
-	padding-bottom: $btn-padding-y-sm;
-	padding-left: $btn-padding-x-sm;
-	padding-right: $btn-padding-x-sm;
-	padding-top: $btn-padding-y-sm;
-
-	@include clay-scale-component {
-		font-size: $btn-font-size-sm-mobile;
-		padding-bottom: $btn-padding-y-sm-mobile;
-		padding-left: $btn-padding-x-sm-mobile;
-		padding-right: $btn-padding-x-sm-mobile;
-		padding-top: $btn-padding-y-sm-mobile;
-	}
-
-	.inline-item {
-		font-size: $btn-inline-item-font-size-sm;
-	}
-
-	.btn-section {
-		font-size: $btn-section-font-size-sm;
-	}
+	@include clay-button-variant($btn-sm);
 }
 
 .btn-sm {

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -58,17 +58,7 @@ input[type='button'] {
 // Button Unstyled
 
 %btn-unstyled {
-	background-color: rgba(0, 0, 0, 0.001);
-	border-width: 0;
-	cursor: $btn-cursor;
-	font-size: inherit;
-	font-weight: inherit;
-	line-height: inherit;
-	max-width: 100%;
-	padding: 0;
-	text-align: left;
-	text-transform: inherit;
-	vertical-align: baseline;
+	@include clay-button-variant($btn-unstyled);
 }
 
 .btn-unstyled {
@@ -78,22 +68,7 @@ input[type='button'] {
 // Button Monospaced
 
 .btn-monospaced {
-	height: $btn-monospaced-size;
-	line-height: 1;
-	overflow: hidden;
-	padding-bottom: $btn-monospaced-padding-y;
-	padding-left: $btn-monospaced-padding-x;
-	padding-right: $btn-monospaced-padding-x;
-	padding-top: $btn-monospaced-padding-y;
-	text-align: center;
-	white-space: normal;
-	width: $btn-monospaced-size;
-	word-wrap: break-word;
-
-	@include clay-scale-component {
-		height: $btn-monospaced-size-mobile;
-		width: $btn-monospaced-size-mobile;
-	}
+	@include clay-button-variant($btn-monospaced);
 
 	&.btn .lexicon-icon {
 		margin-top: 0;
@@ -101,17 +76,7 @@ input[type='button'] {
 }
 
 %clay-btn-monospaced-lg {
-	height: $btn-monospaced-size-lg;
-	padding-bottom: $btn-monospaced-padding-y-lg;
-	padding-left: $btn-monospaced-padding-x-lg;
-	padding-right: $btn-monospaced-padding-x-lg;
-	padding-top: $btn-monospaced-padding-y-lg;
-	width: $btn-monospaced-size-lg;
-
-	@include clay-scale-component {
-		height: $btn-monospaced-size-lg-mobile;
-		width: $btn-monospaced-size-lg-mobile;
-	}
+	@include clay-button-variant($btn-monospaced-lg);
 }
 
 .btn-monospaced.btn-lg {
@@ -119,77 +84,11 @@ input[type='button'] {
 }
 
 %clay-btn-monospaced-sm {
-	height: $btn-monospaced-size-sm;
-	padding-bottom: $btn-monospaced-padding-y-sm;
-	padding-left: $btn-monospaced-padding-x-sm;
-	padding-right: $btn-monospaced-padding-x-sm;
-	padding-top: $btn-monospaced-padding-y-sm;
-	width: $btn-monospaced-size-sm;
-
-	@include clay-scale-component {
-		height: $btn-monospaced-size-sm-mobile;
-		width: $btn-monospaced-size-sm-mobile;
-	}
+	@include clay-button-variant($btn-monospaced-sm);
 }
 
 .btn-monospaced.btn-sm {
 	@extend %clay-btn-monospaced-sm !optional;
-}
-
-// Button C Inner
-
-@if ($enable-c-inner) {
-	.btn-unstyled .c-inner {
-		margin: 0;
-		max-width: none;
-	}
-
-	.btn-monospaced .c-inner {
-		align-items: center;
-		display: flex;
-		flex-direction: column;
-		height: calc(100% + #{$btn-monospaced-padding-y * 2});
-		justify-content: center;
-		margin: #{math-sign($btn-monospaced-padding-y)} 0;
-		padding: 0;
-		width: 100%;
-	}
-
-	.btn-sm {
-		.c-inner {
-			margin: #{math-sign($btn-padding-y-sm)}
-				#{math-sign($btn-padding-x-sm)};
-
-			@include clay-scale-component {
-				margin: #{math-sign($btn-padding-y-sm-mobile)} #{math-sign(
-						$btn-padding-x-sm-mobile
-					)};
-			}
-		}
-
-		&.btn-monospaced .c-inner {
-			height: calc(100% + #{$btn-monospaced-padding-y-sm * 2});
-			margin: #{math-sign($btn-monospaced-padding-y-sm)} 0;
-		}
-	}
-
-	.btn-lg {
-		.c-inner {
-			margin: #{math-sign($btn-padding-y-lg)}
-				#{math-sign($btn-padding-x-lg)};
-
-			@include clay-scale-component {
-				margin: #{math-sign($btn-padding-y-lg-mobile)} #{math-sign(
-						$btn-padding-x-lg-mobile
-					)};
-			}
-		}
-
-		&.btn-monospaced .c-inner {
-			height: calc(100% + #{$btn-monospaced-padding-y-lg * 2});
-			margin: #{math-sign($btn-monospaced-padding-y-lg)} 0;
-		}
-	}
 }
 
 // Button Variants
@@ -231,17 +130,7 @@ input[type='button'] {
 }
 
 .btn-outline-borderless {
-	border-color: transparent;
-
-	&:hover,
-	&:focus {
-		border-color: transparent;
-	}
-
-	&:disabled,
-	&.disabled {
-		border-color: transparent;
-	}
+	@include clay-button-variant($btn-outline-borderless);
 }
 
 .btn-outline-borderless:not(:disabled):not(.disabled):active {

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -1,94 +1,19 @@
 .btn {
-	background-color: transparent;
-	border: $btn-border-width solid transparent;
-
-	@include border-radius($btn-border-radius, 0);
-	@include box-shadow($btn-box-shadow);
-
-	color: $body-color;
-	cursor: $btn-cursor;
-	display: inline-block;
-	font-family: $btn-font-family;
-	font-size: $btn-font-size;
-	font-weight: $btn-font-weight;
-	line-height: $btn-line-height;
-	padding: $btn-padding-y $btn-padding-x;
-	text-align: center;
-	text-transform: none;
-
-	@include transition($btn-transition);
-
-	user-select: none;
-	vertical-align: middle;
-	white-space: $btn-white-space;
-
-	@include clay-scale-component {
-		font-size: $btn-font-size-mobile;
-		padding-bottom: $btn-padding-y-mobile;
-		padding-left: $btn-padding-x-mobile;
-		padding-right: $btn-padding-x-mobile;
-		padding-top: $btn-padding-y-mobile;
-	}
-
-	&:hover {
-		color: $body-color;
-		text-decoration: none;
-	}
-
-	&:focus,
-	&.focus {
-		box-shadow: $btn-focus-box-shadow;
-		outline: 0;
-	}
-
-	&:active,
-	&.active {
-		@include box-shadow($btn-active-box-shadow);
-
-		&:focus {
-			@if ($enable-shadows and $btn-active-box-shadow != none) {
-				box-shadow: $btn-focus-box-shadow, $btn-active-box-shadow;
-			} @else {
-				box-shadow: $btn-focus-box-shadow;
-			}
-		}
-	}
-
-	&.disabled,
-	&:disabled {
-		cursor: $btn-disabled-cursor;
-		opacity: $btn-disabled-opacity;
-
-		&:focus,
-		&:focus:active {
-			box-shadow: none;
-		}
-
-		&:active {
-			pointer-events: none;
-		}
-	}
+	@include clay-button-variant($btn);
 }
 
 fieldset:disabled a.btn {
-	box-shadow: none;
-	cursor: $btn-disabled-cursor;
-	opacity: $btn-disabled-opacity;
+	$btn-disabled: setter(map-get($btn, disabled), ());
+
+	@include clay-css($btn-disabled);
+
+	&:focus {
+		@include clay-css(setter(map-get($btn-disabled, focus), ()));
+	}
 
 	&:active {
-		pointer-events: none;
+		@include clay-css(setter(map-get($btn-disabled, active), ()));
 	}
-}
-
-.btn .inline-item {
-	font-size: $btn-inline-item-font-size;
-}
-
-.btn-section {
-	display: block;
-	font-size: $btn-section-font-size;
-	font-weight: $btn-section-font-weight;
-	line-height: $btn-section-line-height;
 }
 
 // Button Sizes
@@ -260,16 +185,6 @@ input[type='button'] {
 // Button C Inner
 
 @if ($enable-c-inner) {
-	.btn .c-inner {
-		margin: #{math-sign($btn-padding-y)} #{math-sign($btn-padding-x)};
-
-		@include clay-scale-component {
-			margin: #{math-sign($btn-padding-y-mobile)} #{math-sign(
-					$btn-padding-x-mobile
-				)};
-		}
-	}
-
 	.btn-unstyled .c-inner {
 		margin: 0;
 		max-width: none;

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -247,7 +247,7 @@
 	);
 
 	@if ($enable-transitions) {
-		@return $transition;
+		@return $transitions;
 	}
 
 	@return null;

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -246,7 +246,7 @@
 		true
 	);
 
-	@if ($enable-transitions) {
+	@if ($enable) {
 		@return $transitions;
 	}
 

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -372,13 +372,6 @@
 	@if ($enabled) {
 		@include clay-css($base);
 
-		@at-root {
-			a#{&},
-			button#{&} {
-				cursor: map-get($map, cursor);
-			}
-		}
-
 		@if ($breakpoint-down) {
 			@include media-breakpoint-down($breakpoint-down) {
 				@include clay-css($mobile);

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -342,6 +342,26 @@
 		)
 	);
 
+	$mobile-c-inner: setter(map-get($mobile, c-inner), ());
+	$mobile-c-inner: map-merge(
+		(
+			enabled:
+				setter(
+					if(
+						variable-exists(enable-c-inner),
+						$enable-c-inner,
+						$cadmin-enable-c-inner
+					),
+					true
+				),
+			margin-bottom: math-sign(map-get($mobile, padding-bottom)),
+			margin-left: math-sign(map-get($mobile, padding-left)),
+			margin-right: math-sign(map-get($mobile, padding-right)),
+			margin-top: math-sign(map-get($mobile, padding-top)),
+		),
+		$mobile-c-inner
+	);
+
 	$unset: setter(
 		if(
 			variable-exists(clay-unset-placeholder),
@@ -379,6 +399,12 @@
 		@if ($breakpoint-down) {
 			@include media-breakpoint-down($breakpoint-down) {
 				@include clay-css($mobile);
+
+				@if (map-get($c-inner, enabled)) {
+					.c-inner {
+						@include clay-css($mobile-c-inner);
+					}
+				}
 			}
 		}
 

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -233,6 +233,8 @@
 		)
 	);
 
+	$disabled-focus: setter(map-get($disabled, focus), ());
+
 	$nested-disabled-active: setter(map-get($disabled, active), ());
 	$disabled-active: setter(map-get($map, disabled-active), ());
 	$disabled-active: map-merge($nested-disabled-active, $disabled-active);
@@ -281,7 +283,9 @@
 		)
 	);
 
+	$btn-section: setter(map-get($map, btn-section), ());
 	$section: setter(map-get($map, section), ());
+	$section: map-merge($btn-section, $section);
 	$section: map-merge(
 		$section,
 		(
@@ -409,6 +413,10 @@
 		&:disabled,
 		&.disabled {
 			@include clay-css($disabled);
+
+			&:focus {
+				@include clay-css($disabled-focus);
+			}
 
 			&:active {
 				@include clay-css($disabled-active);

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -237,6 +237,14 @@
 			} @else if ($key == 'overflow-wrap') {
 				overflow-wrap: $value;
 				word-wrap: $value;
+			} @else if ($key == 'transition') {
+				transition: $value;
+
+				@if ($value != 'none' and $value != null) {
+					@media (prefers-reduced-motion: reduce) {
+						transition: none;
+					}
+				}
 			} @else if ($key == 'user-select') {
 				-ms-user-select: $value;
 				-moz-user-select: $value;

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -191,21 +191,122 @@ $btn-monospaced-padding-x: 0 !default;
 $btn-monospaced-padding-y: 0.1875rem !default; // 3px
 $btn-monospaced-size: 2.375rem !default; // 38px
 
+$btn-monospaced-size-mobile: null !default;
+
+$btn-monospaced: () !default;
+$btn-monospaced: map-deep-merge(
+	(
+		height: $btn-monospaced-size,
+		line-height: 1,
+		overflow: hidden,
+		padding-bottom: $btn-monospaced-padding-y,
+		padding-left: $btn-monospaced-padding-x,
+		padding-right: $btn-monospaced-padding-x,
+		padding-top: $btn-monospaced-padding-y,
+		text-align: center,
+		white-space: normal,
+		width: $btn-monospaced-size,
+		word-wrap: break-word,
+		mobile: (
+			height: $btn-monospaced-size-mobile,
+			width: $btn-monospaced-size-mobile,
+		),
+		c-inner: (
+			align-items: center,
+			display: flex,
+			flex-direction: column,
+			height: calc(100% + #{$btn-monospaced-padding-y * 2}),
+			justify-content: center,
+			padding: 0,
+			width: 100%,
+		),
+	),
+	$btn-monospaced
+);
+
+// Button Monospaced Lg
+
 $btn-monospaced-padding-x-lg: 0 !default;
 $btn-monospaced-padding-y-lg: 0.3125rem !default; // 5px
 $btn-monospaced-size-lg: 3rem !default; // 48px
+
+$btn-monospaced-size-lg-mobile: null !default;
+
+$btn-monospaced-lg: () !default;
+$btn-monospaced-lg: map-deep-merge(
+	(
+		height: $btn-monospaced-size-lg,
+		padding-bottom: $btn-monospaced-padding-y-lg,
+		padding-left: $btn-monospaced-padding-x-lg,
+		padding-right: $btn-monospaced-padding-x-lg,
+		padding-top: $btn-monospaced-padding-y-lg,
+		width: $btn-monospaced-size-lg,
+		mobile: (
+			height: $btn-monospaced-size-lg-mobile,
+			width: $btn-monospaced-size-lg-mobile,
+		),
+		c-inner: (
+			height: calc(100% + #{$btn-monospaced-padding-y-lg * 2}),
+		),
+	),
+	$btn-monospaced-lg
+);
+
+// Button Monospaced Sm
 
 $btn-monospaced-padding-x-sm: 0 !default;
 $btn-monospaced-padding-y-sm: 0.125rem !default; // 2px
 $btn-monospaced-size-sm: 1.9375rem !default; // 31px
 
-$btn-monospaced-size-mobile: null !default;
-$btn-monospaced-size-lg-mobile: null !default;
 $btn-monospaced-size-sm-mobile: null !default;
+
+$btn-monospaced-sm: () !default;
+$btn-monospaced-sm: map-deep-merge(
+	(
+		height: $btn-monospaced-size-sm,
+		padding-bottom: $btn-monospaced-padding-y-sm,
+		padding-left: $btn-monospaced-padding-x-sm,
+		padding-right: $btn-monospaced-padding-x-sm,
+		padding-top: $btn-monospaced-padding-y-sm,
+		width: $btn-monospaced-size-sm,
+		mobile: (
+			height: $btn-monospaced-size-sm-mobile,
+			width: $btn-monospaced-size-sm-mobile,
+		),
+		c-inner: (
+			height: calc(100% + #{$btn-monospaced-padding-y-sm * 2}),
+		),
+	),
+	$btn-monospaced-sm
+);
 
 // Button Block
 
 $btn-block-spacing-y: 0.5rem !default;
+
+// Button Unstyled
+
+$btn-unstyled: () !default;
+$btn-unstyled: map-deep-merge(
+	(
+		background-color: rgba(0, 0, 0, 0.001),
+		border-width: 0,
+		cursor: $btn-cursor,
+		font-size: inherit,
+		font-weight: inherit,
+		line-height: inherit,
+		max-width: 100%,
+		padding: 0,
+		text-align: left,
+		text-transform: inherit,
+		vertical-align: baseline,
+		c-inner: (
+			margin: 0,
+			max-width: none,
+		),
+	),
+	$btn-unstyled
+);
 
 // Button Group
 
@@ -940,6 +1041,23 @@ $btn-outline-dark: map-deep-merge(
 		),
 	),
 	$btn-outline-dark
+);
+
+$btn-outline-borderless: () !default;
+$btn-outline-borderless: map-deep-merge(
+	(
+		border-color: transparent,
+		hover: (
+			border-color: transparent,
+		),
+		focus: (
+			border-color: transparent,
+		),
+		disabled: (
+			border-color: transparent,
+		),
+	),
+	$btn-outline-borderless
 );
 
 $btn-outline-palette: () !default;

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -117,6 +117,33 @@ $btn-font-size-lg-mobile: null !default;
 $btn-padding-x-lg-mobile: null !default;
 $btn-padding-y-lg-mobile: null !default;
 
+$btn-lg: () !default;
+$btn-lg: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($btn-border-radius-lg),
+		font-size: $btn-font-size-lg,
+		line-height: $btn-line-height-lg,
+		padding-bottom: $btn-padding-y-lg,
+		padding-left: $btn-padding-x-lg,
+		padding-right: $btn-padding-x-lg,
+		padding-top: $btn-padding-y-lg,
+		mobile: (
+			font-size: $btn-font-size-lg-mobile,
+			padding-bottom: $btn-padding-y-lg-mobile,
+			padding-left: $btn-padding-x-lg-mobile,
+			padding-right: $btn-padding-x-lg-mobile,
+			padding-top: $btn-padding-y-lg-mobile,
+		),
+		inline-item: (
+			font-size: $btn-inline-item-font-size-lg,
+		),
+		btn-section: (
+			font-size: $btn-section-font-size-lg,
+		),
+	),
+	$btn-lg
+);
+
 // Button Sm
 
 $btn-border-radius-sm: $border-radius-sm !default;
@@ -130,6 +157,33 @@ $btn-section-font-size-sm: 0.5625rem !default; // 9px
 $btn-font-size-sm-mobile: null !default;
 $btn-padding-x-sm-mobile: null !default;
 $btn-padding-y-sm-mobile: null !default;
+
+$btn-sm: () !default;
+$btn-sm: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($btn-border-radius-sm),
+		font-size: $btn-font-size-sm,
+		line-height: $btn-line-height-sm,
+		padding-bottom: $btn-padding-y-sm,
+		padding-left: $btn-padding-x-sm,
+		padding-right: $btn-padding-x-sm,
+		padding-top: $btn-padding-y-sm,
+		mobile: (
+			font-size: $btn-font-size-sm-mobile,
+			padding-bottom: $btn-padding-y-sm-mobile,
+			padding-left: $btn-padding-x-sm-mobile,
+			padding-right: $btn-padding-x-sm-mobile,
+			padding-top: $btn-padding-y-sm-mobile,
+		),
+		inline-item: (
+			font-size: $btn-inline-item-font-size-sm,
+		),
+		btn-section: (
+			font-size: $btn-section-font-size-sm,
+		),
+	),
+	$btn-sm
+);
 
 // Button Monospaced
 

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -30,6 +30,79 @@ $btn-section-font-size: 0.6875rem !default; // 11px
 $btn-section-font-weight: $font-weight-normal !default;
 $btn-section-line-height: 1 !default;
 
+$btn: () !default;
+$btn: map-deep-merge(
+	(
+		background-color: transparent,
+		border-color: transparent,
+		border-style: solid,
+		border-width: $btn-border-width,
+		border-radius: clay-enable-rounded($btn-border-radius),
+		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		color: $body-color,
+		cursor: $btn-cursor,
+		display: inline-block,
+		font-family: $btn-font-family,
+		font-size: $btn-font-size,
+		font-weight: $btn-font-weight,
+		line-height: $btn-line-height,
+		padding-bottom: $btn-padding-y,
+		padding-left: $btn-padding-x,
+		padding-right: $btn-padding-x,
+		padding-top: $btn-padding-y,
+		text-align: center,
+		text-transform: none,
+		transition: clay-enable-transitions($btn-transition),
+		user-select: none,
+		vertical-align: middle,
+		white-space: $btn-white-space,
+		mobile: (
+			font-size: $btn-font-size-mobile,
+			padding-bottom: $btn-padding-y-mobile,
+			padding-left: $btn-padding-x-mobile,
+			padding-right: $btn-padding-x-mobile,
+			padding-top: $btn-padding-y-mobile,
+		),
+		hover: (
+			color: $body-color,
+			text-decoration: none,
+		),
+		focus: (
+			box-shadow: $btn-focus-box-shadow,
+			outline: 0,
+		),
+		active: (
+			box-shadow: clay-enable-shadows([$btn-active-box-shadow]),
+			focus: (
+				box-shadow: clay-enable-shadows([$btn-focus-box-shadow]),
+			),
+		),
+		active-class: (
+			box-shadow: clay-enable-shadows([$btn-active-box-shadow]),
+		),
+		disabled: (
+			cursor: $btn-disabled-cursor,
+			opacity: $btn-disabled-opacity,
+			focus: (
+				box-shadow: none,
+			),
+			active: (
+				pointer-events: none,
+			),
+		),
+		inline-item: (
+			font-size: $btn-inline-item-font-size,
+		),
+		btn-section: (
+			display: block,
+			font-size: $btn-section-font-size,
+			font-weight: $btn-section-font-weight,
+			line-height: $btn-section-line-height,
+		),
+	),
+	$btn
+);
+
 // Button Lg
 
 $btn-border-radius-lg: $border-radius-lg !default;


### PR DESCRIPTION
feat(@clayui/css): Clay CSS and Cadmin Buttons convert `.btn`, `.btn-lg`, `.btn-sm`, `.btn-monospaced`, `.btn-monospaced-lg`, `.btn-monospaced-sm`, `.btn-unstyled`, and `.btn-outline-borderless` to use `clay-button-variant` mixin

feat(@clayui/css): Buttons adds `$btn`, `$btn-lg`, `$btn-sm`, `$btn-monospaced`, `$btn-monospaced-lg`, `$btn-monospaced-sm`, `$btn-unstyled`, and `$btn-outline-borderless` Sass maps

fixes #4269