### PR TITLE
fix(@clayui/tooltip): forces tooltip to be repositioned when the x-axis is modified

### DIFF
--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -48,6 +48,12 @@ const ALIGNMENTS_INVERSE_MAP = {
 	trbr: 'bottom-right',
 } as const;
 
+const ALIGNMENTS_FORCE_MAP = {
+	...ALIGNMENTS_INVERSE_MAP,
+	bctc: 'top-left',
+	tcbc: 'bottom-left',
+} as const;
+
 interface IState {
 	align?: typeof ALIGNMENTS[number];
 	message?: string;
@@ -335,22 +341,31 @@ const TooltipProvider: React.FunctionComponent<
 		) {
 			const points = ALIGNMENTS_MAP[align || 'top'] as [string, string];
 
-			const newAlignmentString = doAlign({
+			const alignment = doAlign({
 				overflow: {
-					adjustX: autoAlign,
+					adjustX: false,
 					adjustY: autoAlign,
 				},
 				points,
 				sourceElement: (tooltipRef as React.RefObject<HTMLDivElement>)
 					.current!,
 				targetElement: titleNodeRef.current,
-			}).points.join('') as keyof typeof ALIGNMENTS_INVERSE_MAP;
+			});
+
+			const alignmentString = alignment.points.join(
+				''
+			) as keyof typeof ALIGNMENTS_INVERSE_MAP;
 
 			const pointsString = points.join('');
 
-			if (pointsString !== newAlignmentString) {
+			if (alignment.overflow.adjustX) {
 				dispatch({
-					align: ALIGNMENTS_INVERSE_MAP[newAlignmentString],
+					align: ALIGNMENTS_FORCE_MAP[alignmentString],
+					type: 'align',
+				});
+			} else if (pointsString !== alignmentString) {
+				dispatch({
+					align: ALIGNMENTS_INVERSE_MAP[alignmentString],
 					type: 'align',
 				});
 			}

--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -358,12 +358,13 @@ const TooltipProvider: React.FunctionComponent<
 	}, [align, show]);
 
 	warning(
-		!children && !scope,
+		(typeof children === 'undefined' && typeof scope !== 'undefined') ||
+			(typeof scope === 'undefined' && typeof children !== 'undefined'),
 		'<TooltipProvider />: You must use at least one of the following props: `children` or `scope`.'
 	);
 
 	warning(
-		children && scope,
+		typeof children !== 'undefined' || typeof scope !== 'undefined',
 		'<TooltipProvider />: If you want to use `scope`, use <TooltipProvider /> as a singleton and do not pass `children`.'
 	);
 

--- a/packages/demos/stories/ListPage.tsx
+++ b/packages/demos/stories/ListPage.tsx
@@ -12,6 +12,7 @@ import {ClayListWithItems} from '@clayui/list';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import {sub} from '@clayui/shared';
+import {ClayTooltipProvider} from '@clayui/tooltip';
 import React from 'react';
 
 export default () => {
@@ -90,232 +91,243 @@ export default () => {
 	const isActive = !!numOfSelected;
 
 	return (
-		<div>
-			<ClayManagementToolbar active={isActive}>
-				<ClayManagementToolbar.ItemList expand={isActive}>
-					<ClayManagementToolbar.Item>
-						<ClayCheckbox
-							checked={allSelected}
-							onChange={() => {
-								const newMap: any = {};
+		<ClayTooltipProvider>
+			<div>
+				<ClayManagementToolbar active={isActive}>
+					<ClayManagementToolbar.ItemList expand={isActive}>
+						<ClayManagementToolbar.Item>
+							<ClayCheckbox
+								checked={allSelected}
+								data-tooltip-align="top"
+								onChange={() => {
+									const newMap: any = {};
 
-								for (let i = 0; i < totalItems; i++) {
-									newMap[`${startingIndex + i}`] = true;
-								}
+									for (let i = 0; i < totalItems; i++) {
+										newMap[`${startingIndex + i}`] = true;
+									}
 
-								setSelectedMap(!checked ? newMap : {});
+									setSelectedMap(!checked ? newMap : {});
 
-								setChecked(!checked);
-							}}
-						/>
-					</ClayManagementToolbar.Item>
+									setChecked(!checked);
+								}}
+								title="Select all"
+							/>
+						</ClayManagementToolbar.Item>
 
-					{isActive && (
-						<>
-							<ClayManagementToolbar.Item>
-								<span className="navbar-text">
-									{numOfSelected === totalItems ? (
-										'All Selected'
-									) : (
-										<>
-											{sub('{0} of {1}', [
-												numOfSelected,
-												totalItems,
-											])}{' '}
-											<span className="navbar-breakpoint-down-d-none">
-												{'Selected'}
-											</span>
-										</>
-									)}
-								</span>
-							</ClayManagementToolbar.Item>
-							<ClayManagementToolbar.Item className="nav-item-shrink">
-								<ClayButton
-									className="nav-link"
-									displayType="unstyled"
-									onClick={() => {
-										setSelectedMap({});
-										setChecked(false);
-									}}
-									type="button"
-								>
-									<span className="text-truncate-inline">
-										<span className="text-truncate">
-											{'Clear'}
-										</span>
+						{isActive && (
+							<>
+								<ClayManagementToolbar.Item>
+									<span className="navbar-text">
+										{numOfSelected === totalItems ? (
+											'All Selected'
+										) : (
+											<>
+												{sub('{0} of {1}', [
+													numOfSelected,
+													totalItems,
+												])}{' '}
+												<span className="navbar-breakpoint-down-d-none">
+													{'Selected'}
+												</span>
+											</>
+										)}
 									</span>
-								</ClayButton>
-							</ClayManagementToolbar.Item>
-						</>
-					)}
-
-					{!isActive && (
-						<>
-							<ClayDropDownWithItems
-								items={filterItems}
-								spritemap={spritemap}
-								trigger={
+								</ClayManagementToolbar.Item>
+								<ClayManagementToolbar.Item className="nav-item-shrink">
 									<ClayButton
 										className="nav-link"
 										displayType="unstyled"
+										onClick={() => {
+											setSelectedMap({});
+											setChecked(false);
+										}}
+										type="button"
 									>
-										<span className="navbar-breakpoint-down-d-none">
-											<span className="navbar-text-truncate">
-												{'Filter and Order'}
+										<span className="text-truncate-inline">
+											<span className="text-truncate">
+												{'Clear'}
 											</span>
-
-											<ClayIcon
-												className="inline-item inline-item-after"
-												spritemap={spritemap}
-												symbol="caret-bottom"
-											/>
-										</span>
-										<span className="navbar-breakpoint-d-none">
-											<ClayIcon
-												spritemap={spritemap}
-												symbol="filter"
-											/>
 										</span>
 									</ClayButton>
-								}
-							/>
+								</ClayManagementToolbar.Item>
+							</>
+						)}
 
-							<ClayManagementToolbar.Item>
-								<ClayButton
-									className="nav-link nav-link-monospaced"
-									displayType="unstyled"
-									onClick={() => setSortAsc(!sortAsc)}
-								>
-									<ClayIcon
-										spritemap={spritemap}
-										symbol={
-											sortAsc
-												? 'order-list-up'
-												: 'order-list-down'
-										}
-									/>
-								</ClayButton>
-							</ClayManagementToolbar.Item>
-						</>
-					)}
-				</ClayManagementToolbar.ItemList>
-
-				{!isActive && (
-					<>
-						<ClayManagementToolbar.Search showMobile={searchMobile}>
-							<ClayInput.Group>
-								<ClayInput.GroupItem>
-									<ClayInput
-										aria-label="Search"
-										className="form-control input-group-inset input-group-inset-after"
-										defaultValue="Red"
-										onChange={(event) =>
-											setValue(event.target.value)
-										}
-										type="text"
-										value={value}
-									/>
-									<ClayInput.GroupInsetItem after tag="span">
-										<ClayButtonWithIcon
-											className="navbar-breakpoint-d-none"
-											displayType="unstyled"
-											onClick={() =>
-												setSearchMobile(false)
-											}
-											spritemap={spritemap}
-											symbol="times"
-										/>
-										<ClayButtonWithIcon
-											displayType="unstyled"
-											spritemap={spritemap}
-											symbol="search"
-											type="submit"
-										/>
-									</ClayInput.GroupInsetItem>
-								</ClayInput.GroupItem>
-							</ClayInput.Group>
-						</ClayManagementToolbar.Search>
-
-						<ClayManagementToolbar.ItemList>
-							<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
-								<ClayButton
-									className="nav-link nav-link-monospaced"
-									displayType="unstyled"
-									onClick={() => setSearchMobile(true)}
-								>
-									<ClayIcon
-										spritemap={spritemap}
-										symbol="search"
-									/>
-								</ClayButton>
-							</ClayManagementToolbar.Item>
-
-							<ClayManagementToolbar.Item>
-								<ClayButton
-									className="nav-link nav-link-monospaced"
-									displayType="unstyled"
-									onClick={() => {}}
-								>
-									<ClayIcon
-										spritemap={spritemap}
-										symbol="info-circle-open"
-									/>
-								</ClayButton>
-							</ClayManagementToolbar.Item>
-
-							<ClayManagementToolbar.Item>
+						{!isActive && (
+							<>
 								<ClayDropDownWithItems
-									items={viewTypes}
+									items={filterItems}
 									spritemap={spritemap}
 									trigger={
 										<ClayButton
-											className="nav-link nav-link-monospaced"
+											className="nav-link"
 											displayType="unstyled"
 										>
-											<ClayIcon
-												spritemap={spritemap}
-												symbol="list"
-											/>
+											<span className="navbar-breakpoint-down-d-none">
+												<span className="navbar-text-truncate">
+													{'Filter and Order'}
+												</span>
+
+												<ClayIcon
+													className="inline-item inline-item-after"
+													spritemap={spritemap}
+													symbol="caret-bottom"
+												/>
+											</span>
+											<span className="navbar-breakpoint-d-none">
+												<ClayIcon
+													spritemap={spritemap}
+													symbol="filter"
+												/>
+											</span>
 										</ClayButton>
 									}
 								/>
-							</ClayManagementToolbar.Item>
 
-							<ClayManagementToolbar.Item>
-								<ClayButtonWithIcon
-									className="nav-btn nav-btn-monospaced"
-									spritemap={spritemap}
-									symbol="plus"
-								/>
-							</ClayManagementToolbar.Item>
-						</ClayManagementToolbar.ItemList>
-					</>
-				)}
-			</ClayManagementToolbar>
+								<ClayManagementToolbar.Item>
+									<ClayButton
+										className="nav-link nav-link-monospaced"
+										displayType="unstyled"
+										onClick={() => setSortAsc(!sortAsc)}
+									>
+										<ClayIcon
+											spritemap={spritemap}
+											symbol={
+												sortAsc
+													? 'order-list-up'
+													: 'order-list-down'
+											}
+										/>
+									</ClayButton>
+								</ClayManagementToolbar.Item>
+							</>
+						)}
+					</ClayManagementToolbar.ItemList>
 
-			<div className="container" style={{paddingTop: 8}}>
-				<ClayListWithItems
-					itemIdentifier="classPK"
-					items={[
-						{
-							header: 'List of Items',
-							items,
-						},
-					]}
-					onSelectedItemsChange={setSelectedMap}
-					selectedItemsMap={selectedMap}
-					spritemap={spritemap}
-				/>
+					{!isActive && (
+						<>
+							<ClayManagementToolbar.Search
+								showMobile={searchMobile}
+							>
+								<ClayInput.Group>
+									<ClayInput.GroupItem>
+										<ClayInput
+											aria-label="Search"
+											className="form-control input-group-inset input-group-inset-after"
+											defaultValue="Red"
+											onChange={(event) =>
+												setValue(event.target.value)
+											}
+											type="text"
+											value={value}
+										/>
+										<ClayInput.GroupInsetItem
+											after
+											tag="span"
+										>
+											<ClayButtonWithIcon
+												className="navbar-breakpoint-d-none"
+												displayType="unstyled"
+												onClick={() =>
+													setSearchMobile(false)
+												}
+												spritemap={spritemap}
+												symbol="times"
+											/>
+											<ClayButtonWithIcon
+												displayType="unstyled"
+												spritemap={spritemap}
+												symbol="search"
+												type="submit"
+											/>
+										</ClayInput.GroupInsetItem>
+									</ClayInput.GroupItem>
+								</ClayInput.Group>
+							</ClayManagementToolbar.Search>
 
-				<ClayPaginationBarWithBasicItems
-					activeDelta={delta}
-					activePage={activePage}
-					onDeltaChange={setDelta}
-					onPageChange={setActivePage}
-					spritemap={spritemap}
-					totalItems={totalItems}
-				/>
+							<ClayManagementToolbar.ItemList>
+								<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
+									<ClayButton
+										className="nav-link nav-link-monospaced"
+										displayType="unstyled"
+										onClick={() => setSearchMobile(true)}
+									>
+										<ClayIcon
+											spritemap={spritemap}
+											symbol="search"
+										/>
+									</ClayButton>
+								</ClayManagementToolbar.Item>
+
+								<ClayManagementToolbar.Item>
+									<ClayButton
+										className="nav-link nav-link-monospaced"
+										displayType="unstyled"
+										onClick={() => {}}
+									>
+										<ClayIcon
+											spritemap={spritemap}
+											symbol="info-circle-open"
+										/>
+									</ClayButton>
+								</ClayManagementToolbar.Item>
+
+								<ClayManagementToolbar.Item>
+									<ClayDropDownWithItems
+										items={viewTypes}
+										spritemap={spritemap}
+										trigger={
+											<ClayButton
+												className="nav-link nav-link-monospaced"
+												displayType="unstyled"
+											>
+												<ClayIcon
+													spritemap={spritemap}
+													symbol="list"
+												/>
+											</ClayButton>
+										}
+									/>
+								</ClayManagementToolbar.Item>
+
+								<ClayManagementToolbar.Item>
+									<ClayButtonWithIcon
+										className="nav-btn nav-btn-monospaced"
+										data-tooltip-align="bottom"
+										spritemap={spritemap}
+										symbol="plus"
+										title="Add New Item"
+									/>
+								</ClayManagementToolbar.Item>
+							</ClayManagementToolbar.ItemList>
+						</>
+					)}
+				</ClayManagementToolbar>
+
+				<div className="container" style={{paddingTop: 8}}>
+					<ClayListWithItems
+						itemIdentifier="classPK"
+						items={[
+							{
+								header: 'List of Items',
+								items,
+							},
+						]}
+						onSelectedItemsChange={setSelectedMap}
+						selectedItemsMap={selectedMap}
+						spritemap={spritemap}
+					/>
+
+					<ClayPaginationBarWithBasicItems
+						activeDelta={delta}
+						activePage={activePage}
+						onDeltaChange={setDelta}
+						onPageChange={setActivePage}
+						spritemap={spritemap}
+						totalItems={totalItems}
+					/>
+				</div>
 			</div>
-		</div>
+		</ClayTooltipProvider>
 	);
 };


### PR DESCRIPTION
Fixes #4249

The idea here is to force `align` to recalculate the Tooltip position in a position contrary to the center alignment which can happen the x-axis is modified because the Tooltip is on a smaller screen, this avoids having the x-axis modified by choosing the best position.

This fixes when you are in the top or bottom position. See the List Page demo example and play around with increasing and decreasing the Storybook Sidebar to decrease content and reproduce reported use cases, Tooltip has been added at both ends of the Management Toolbar, in Checkbox and in the Add button.