### PR TITLE
fix(@clayui/css): Buttons and Cadmin Buttons `.btn-monospaced` icons …

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -88,47 +88,25 @@ $btn-sm: map-deep-merge(
 
 // Button Monospaced
 
-$btn-monospaced-padding-y: 0.25rem !default; // 4px
 $btn-monospaced-size: 2.5rem !default; // 40px
 
 $btn-monospaced: () !default;
 $btn-monospaced: map-deep-merge(
 	(
 		height: $btn-monospaced-size,
-		padding-bottom: $btn-monospaced-padding-y,
-		padding-top: $btn-monospaced-padding-y,
 		width: $btn-monospaced-size,
 	),
 	$btn-monospaced
 );
 
-// Button Monospaced Lg
-
-$btn-monospaced-padding-y-lg: 0.375rem !default; // 6px
-
-$btn-monospaced-lg: () !default;
-$btn-monospaced-lg: map-deep-merge(
-	(
-		padding-bottom: $btn-monospaced-padding-y-lg,
-		padding-top: $btn-monospaced-padding-y-lg,
-	),
-	$btn-monospaced-lg
-);
-
 // Button Monospaced Sm
 
-$btn-monospaced-padding-x-sm: null !default;
-$btn-monospaced-padding-y-sm: 0.1875rem !default; // 3px
 $btn-monospaced-size-sm: 2rem !default; // 32px
 
 $btn-monospaced-sm: () !default;
 $btn-monospaced-sm: map-deep-merge(
 	(
 		height: $btn-monospaced-size-sm,
-		padding-bottom: $btn-monospaced-padding-y-sm,
-		padding-left: $btn-monospaced-padding-x-sm,
-		padding-right: $btn-monospaced-padding-x-sm,
-		padding-top: $btn-monospaced-padding-y-sm,
 		width: $btn-monospaced-size-sm,
 	),
 	$btn-monospaced-sm

--- a/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
@@ -190,7 +190,7 @@ $cadmin-btn-sm: map-deep-merge(
 // Button Monospaced
 
 $cadmin-btn-monospaced-padding-x: 0 !default;
-$cadmin-btn-monospaced-padding-y: 4px !default; // 4px
+$cadmin-btn-monospaced-padding-y: 0 !default;
 $cadmin-btn-monospaced-size: 40px !default; // 40px
 
 $cadmin-btn-monospaced-size-mobile: null !default;
@@ -198,7 +198,11 @@ $cadmin-btn-monospaced-size-mobile: null !default;
 $cadmin-btn-monospaced: () !default;
 $cadmin-btn-monospaced: map-deep-merge(
 	(
+		align-items: center,
+		display: inline-flex,
+		flex-direction: column,
 		height: $cadmin-btn-monospaced-size,
+		justify-content: center,
 		line-height: 1,
 		overflow: hidden,
 		padding-bottom: $cadmin-btn-monospaced-padding-y,
@@ -217,7 +221,7 @@ $cadmin-btn-monospaced: map-deep-merge(
 			align-items: center,
 			display: flex,
 			flex-direction: column,
-			height: calc(100% + #{$cadmin-btn-monospaced-padding-y * 2}),
+			height: 100%,
 			justify-content: center,
 			padding: 0,
 			width: 100%,
@@ -228,8 +232,8 @@ $cadmin-btn-monospaced: map-deep-merge(
 
 // Button Monospaced Lg
 
-$cadmin-btn-monospaced-padding-x-lg: 0 !default;
-$cadmin-btn-monospaced-padding-y-lg: 6px !default; // 6px
+$cadmin-btn-monospaced-padding-x-lg: null !default;
+$cadmin-btn-monospaced-padding-y-lg: null !default;
 $cadmin-btn-monospaced-size-lg: 48px !default; // 48px
 
 $cadmin-btn-monospaced-size-lg-mobile: null !default;
@@ -247,9 +251,6 @@ $cadmin-btn-monospaced-lg: map-deep-merge(
 			height: $cadmin-btn-monospaced-size-lg-mobile,
 			width: $cadmin-btn-monospaced-size-lg-mobile,
 		),
-		c-inner: (
-			height: calc(100% + #{$cadmin-btn-monospaced-padding-y-lg * 2}),
-		),
 	),
 	$cadmin-btn-monospaced-lg
 );
@@ -257,7 +258,7 @@ $cadmin-btn-monospaced-lg: map-deep-merge(
 // Button Monospaced Sm
 
 $cadmin-btn-monospaced-padding-x-sm: null !default;
-$cadmin-btn-monospaced-padding-y-sm: 3px !default; // 3px
+$cadmin-btn-monospaced-padding-y-sm: null !default;
 $cadmin-btn-monospaced-size-sm: 32px !default; // 32px
 
 $cadmin-btn-monospaced-size-sm-mobile: null !default;
@@ -274,9 +275,6 @@ $cadmin-btn-monospaced-sm: map-deep-merge(
 		mobile: (
 			height: $cadmin-btn-monospaced-size-sm-mobile,
 			width: $cadmin-btn-monospaced-size-sm-mobile,
-		),
-		c-inner: (
-			height: calc(100% + #{$cadmin-btn-monospaced-padding-y-sm * 2}),
 		),
 	),
 	$cadmin-btn-monospaced-sm

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -188,7 +188,7 @@ $btn-sm: map-deep-merge(
 // Button Monospaced
 
 $btn-monospaced-padding-x: 0 !default;
-$btn-monospaced-padding-y: 0.1875rem !default; // 3px
+$btn-monospaced-padding-y: 0 !default;
 $btn-monospaced-size: 2.375rem !default; // 38px
 
 $btn-monospaced-size-mobile: null !default;
@@ -196,7 +196,11 @@ $btn-monospaced-size-mobile: null !default;
 $btn-monospaced: () !default;
 $btn-monospaced: map-deep-merge(
 	(
+		align-items: center,
+		display: inline-flex,
+		flex-direction: column,
 		height: $btn-monospaced-size,
+		justify-content: center,
 		line-height: 1,
 		overflow: hidden,
 		padding-bottom: $btn-monospaced-padding-y,
@@ -215,7 +219,7 @@ $btn-monospaced: map-deep-merge(
 			align-items: center,
 			display: flex,
 			flex-direction: column,
-			height: calc(100% + #{$btn-monospaced-padding-y * 2}),
+			height: 100%,
 			justify-content: center,
 			padding: 0,
 			width: 100%,
@@ -226,8 +230,8 @@ $btn-monospaced: map-deep-merge(
 
 // Button Monospaced Lg
 
-$btn-monospaced-padding-x-lg: 0 !default;
-$btn-monospaced-padding-y-lg: 0.3125rem !default; // 5px
+$btn-monospaced-padding-x-lg: null !default;
+$btn-monospaced-padding-y-lg: null !default;
 $btn-monospaced-size-lg: 3rem !default; // 48px
 
 $btn-monospaced-size-lg-mobile: null !default;
@@ -245,17 +249,14 @@ $btn-monospaced-lg: map-deep-merge(
 			height: $btn-monospaced-size-lg-mobile,
 			width: $btn-monospaced-size-lg-mobile,
 		),
-		c-inner: (
-			height: calc(100% + #{$btn-monospaced-padding-y-lg * 2}),
-		),
 	),
 	$btn-monospaced-lg
 );
 
 // Button Monospaced Sm
 
-$btn-monospaced-padding-x-sm: 0 !default;
-$btn-monospaced-padding-y-sm: 0.125rem !default; // 2px
+$btn-monospaced-padding-x-sm: null !default;
+$btn-monospaced-padding-y-sm: null !default;
 $btn-monospaced-size-sm: 1.9375rem !default; // 31px
 
 $btn-monospaced-size-sm-mobile: null !default;
@@ -272,9 +273,6 @@ $btn-monospaced-sm: map-deep-merge(
 		mobile: (
 			height: $btn-monospaced-size-sm-mobile,
 			width: $btn-monospaced-size-sm-mobile,
-		),
-		c-inner: (
-			height: calc(100% + #{$btn-monospaced-padding-y-sm * 2}),
 		),
 	),
 	$btn-monospaced-sm


### PR DESCRIPTION
…are off center by a pixel, use `display: inline-flex` to center and remove padding. If you need items to display inline in `.btn-monospaced` wrap them in a `span` tag.

fixes #4274