### PR TITLE
feat(@clayui/css): Move .hide from liferay-portal to clay-css

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
@@ -186,6 +186,10 @@
 	}
 }
 
+.hide {
+	display: none !important;
+}
+
 // Display Print
 
 @media print {

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -166,6 +166,10 @@
 	}
 }
 
+.hide {
+	display: none !important;
+}
+
 // Display Print
 
 @media print {


### PR DESCRIPTION
In the attempt of reduce the CSS footprint in Liferay Portal, we are moving CSS classes where they make more sense.

https://issues.liferay.com/browse/LPS-134071

---

In this case, we are moving the class `.hide`, an alias of `.d-none`.

https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/base/_util.scss#L1-L3