### PR TITLE
fix(@clayui/css): Remove caret from .dropdown-toggle

### DIFF
--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -7,8 +7,6 @@
 
 .dropdown-toggle {
 	white-space: nowrap;
-
-	@include caret();
 }
 
 .dropdown-header {
@@ -246,10 +244,6 @@
 		margin-top: 0;
 		top: auto;
 	}
-
-	.dropdown-toggle {
-		@include caret(up);
-	}
 }
 
 .dropright {
@@ -260,14 +254,6 @@
 		right: auto;
 		top: 0;
 	}
-
-	.dropdown-toggle {
-		@include caret(right);
-
-		&::after {
-			vertical-align: 0;
-		}
-	}
 }
 
 .dropleft {
@@ -277,14 +263,6 @@
 		margin-top: 0;
 		right: 100%;
 		top: 0;
-	}
-
-	.dropdown-toggle {
-		@include caret(left);
-
-		&::before {
-			vertical-align: 0;
-		}
 	}
 }
 


### PR DESCRIPTION
In the attempt of reduce the CSS footprint in Liferay Portal, we are moving CSS classes where they make more sense.

https://issues.liferay.com/browse/LPS-134071

---

In this case, we are removing the caret from `.dropdown-toggle` since it's overwritten in DXP

https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss#L21-L29