### PR TITLE
fix(@clyaui/tooltip): fixes error when not forcing Tooltip repositioning when X axis is modified

### DIFF
--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -343,7 +343,7 @@ const TooltipProvider: React.FunctionComponent<
 
 			const alignment = doAlign({
 				overflow: {
-					adjustX: false,
+					adjustX: autoAlign,
 					adjustY: autoAlign,
 				},
 				points,


### PR DESCRIPTION
Fixes #4289

I think I ended up commenting with `adjustX` to false doing tests 🤦‍♂️ and I also didn't notice that in the Storybook of the PR build it wasn't working. I tested it on DXP and it works fine too.

<img width="1680" alt="Screen Shot 2021-09-22 at 20 21 04" src="https://user-images.githubusercontent.com/13750819/134434528-6180273e-de38-40e2-9c21-8aa2d72a0ee5.png">

