### PR TITLE
fix(@clayui/drop-down): fixes the values of the `width` property of the Menu

### DIFF
--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -166,9 +166,13 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	onSetActive: (val: boolean) => void;
 
 	/**
-	 * `dropdown-menu-width-${width}`
+	 * The modifier class `dropdown-menu-width-${width}` makes the menu expand
+	 * the full width of the page.
+	 *
+	 * - sm makes the menu 500px wide.
+	 * - full makes the menu 100% wide.
 	 */
-	width?: 'sm' | 'auto';
+	width?: 'sm' | 'full';
 }
 
 const useIsomorphicLayoutEffect =


### PR DESCRIPTION
Fixes #4288

Adds a more detailed description about the API and removes the `auto` value that doesn't exist for `width` and adds the `full` that was missing.