### PR TITLE
feat(@clayui/css): Form Validation adds `$input-danger`, `$input-warning`, `$input-success`, `$input-danger-select`, `$input-warning-select`, `$input-success-select` Sass maps with `clay-form-control-variant` and `clay-select-variant` for more customization options

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -196,13 +196,15 @@ $input-danger: map-deep-merge(
 $input-danger-readonly: () !default;
 $input-danger-readonly: map-deep-merge(
 	(
-		bg:
+		background-color:
 			setter(
 				map-get($input-readonly, bg),
 				map-get($input-readonly, background-color)
 			),
 		border-color: map-get($input-readonly, border-color),
-		focus-border-color: $input-focus-border-color,
+		focus: (
+			border-color: $input-focus-border-color,
+		),
 	),
 	$input-danger-readonly
 );
@@ -254,13 +256,15 @@ $input-warning: map-deep-merge(
 $input-warning-readonly: () !default;
 $input-warning-readonly: map-deep-merge(
 	(
-		bg:
+		background-color:
 			setter(
 				map-get($input-readonly, bg),
 				map-get($input-readonly, background-color)
 			),
 		border-color: map-get($input-readonly, border-color),
-		focus-border-color: $input-focus-border-color,
+		focus: (
+			border-color: $input-focus-border-color,
+		),
 	),
 	$input-warning-readonly
 );
@@ -312,13 +316,15 @@ $input-success: map-deep-merge(
 $input-success-readonly: () !default;
 $input-success-readonly: map-deep-merge(
 	(
-		bg:
+		background-color:
 			setter(
 				map-get($input-readonly, bg),
 				map-get($input-readonly, background-color)
 			),
 		border-color: map-get($input-readonly, border-color),
-		focus-border-color: $input-focus-border-color,
+		focus: (
+			border-color: $input-focus-border-color,
+		),
 	),
 	$input-success-readonly
 );

--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -167,14 +167,31 @@ $form-feedback-font-weight: $font-weight-semi-bold !default;
 
 $form-feedback-indicator-margin-x: 0 !default;
 
-// Input Variants
+// .has-error .form-control
 
 $input-danger-bg: $danger-l2 !default;
 $input-danger-border-color: $danger-l1 !default;
 // Will need to be revisited if https://github.com/twbs/bootstrap/pull/24821 merge error is fixed
 $input-danger-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
-$input-danger-focus-box-shadow: $input-focus-box-shadow !default;
 $input-danger-color: $input-color !default;
+
+$input-danger-focus-box-shadow: $input-focus-box-shadow !default;
+
+$input-danger: () !default;
+$input-danger: map-deep-merge(
+	(
+		background-color: $input-danger-bg,
+		border-color: $input-danger-border-color,
+		box-shadow: $input-danger-box-shadow,
+		color: $input-danger-color,
+		focus: (
+			box-shadow: $input-danger-focus-box-shadow,
+		),
+	),
+	$input-danger
+);
+
+// .has-error .form-control[readonly]
 
 $input-danger-readonly: () !default;
 $input-danger-readonly: map-deep-merge(
@@ -191,18 +208,106 @@ $input-danger-readonly: map-deep-merge(
 );
 
 $input-danger-checkbox-label-color: $danger !default;
+
+// .has-error select.form-control
+
 $input-danger-select-icon-color: $input-danger-border-color !default;
 $input-danger-select-icon: clay-icon(
 	caret-double-l,
 	$input-danger-select-icon-color
 ) !default;
 
+$input-danger-select: () !default;
+$input-danger-select: map-deep-merge(
+	(
+		background-image: $input-danger-select-icon,
+	),
+	$input-danger-select
+);
+
+// .has-warning .form-control
+
+$input-warning-bg: $warning-l2 !default;
+$input-warning-border-color: $warning-l1 !default;
+// Will need to be revisited if https://github.com/twbs/bootstrap/pull/24821 merge error is fixed
+$input-warning-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
+$input-warning-color: $input-color !default;
+
+$input-warning-focus-box-shadow: $input-focus-box-shadow !default;
+
+$input-warning: () !default;
+$input-warning: map-deep-merge(
+	(
+		background-color: $input-warning-bg,
+		border-color: $input-warning-border-color,
+		box-shadow: $input-warning-box-shadow,
+		color: $input-warning-color,
+		focus: (
+			box-shadow: $input-warning-focus-box-shadow,
+		),
+	),
+	$input-warning
+);
+
+// .has-warning .form-control[readonly]
+
+$input-warning-readonly: () !default;
+$input-warning-readonly: map-deep-merge(
+	(
+		bg:
+			setter(
+				map-get($input-readonly, bg),
+				map-get($input-readonly, background-color)
+			),
+		border-color: map-get($input-readonly, border-color),
+		focus-border-color: $input-focus-border-color,
+	),
+	$input-warning-readonly
+);
+
+$input-warning-checkbox-label-color: $warning !default;
+
+// .has-warning select.form-control
+
+$input-warning-select-icon-color: $input-warning-border-color !default;
+$input-warning-select-icon: clay-icon(
+	caret-double-l,
+	$input-warning-select-icon-color
+) !default;
+
+$input-warning-select: () !default;
+$input-warning-select: map-deep-merge(
+	(
+		background-image: $input-warning-select-icon,
+	),
+	$input-warning-select
+);
+
+// .has-success .form-control
+
 $input-success-bg: $success-l2 !default;
 $input-success-border-color: $success-l1 !default;
 // Will need to be revisited if https://github.com/twbs/bootstrap/pull/24821 merge error is fixed
 $input-success-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
-$input-success-focus-box-shadow: $input-focus-box-shadow !default;
 $input-success-color: $input-color !default;
+
+$input-success-focus-box-shadow: $input-focus-box-shadow !default;
+
+$input-success: () !default;
+$input-success: map-deep-merge(
+	(
+		background-color: $input-success-bg,
+		border-color: $input-success-border-color,
+		box-shadow: $input-success-box-shadow,
+		color: $input-success-color,
+		focus: (
+			box-shadow: $input-success-focus-box-shadow,
+		),
+	),
+	$input-success
+);
+
+// .has-success .form-control[readonly]
 
 $input-success-readonly: () !default;
 $input-success-readonly: map-deep-merge(
@@ -219,39 +324,22 @@ $input-success-readonly: map-deep-merge(
 );
 
 $input-success-checkbox-label-color: $success !default;
+
+// .has-success select.form-control
+
 $input-success-select-icon-color: $input-success-border-color !default;
 $input-success-select-icon: clay-icon(
 	caret-double-l,
 	$input-success-select-icon-color
 ) !default;
 
-$input-warning-bg: $warning-l2 !default;
-$input-warning-border-color: $warning-l1 !default;
-// Will need to be revisited if https://github.com/twbs/bootstrap/pull/24821 merge error is fixed
-$input-warning-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
-$input-warning-focus-box-shadow: $input-focus-box-shadow !default;
-
-$input-warning-readonly: () !default;
-$input-warning-readonly: map-deep-merge(
+$input-success-select: () !default;
+$input-success-select: map-deep-merge(
 	(
-		bg:
-			setter(
-				map-get($input-readonly, bg),
-				map-get($input-readonly, background-color)
-			),
-		border-color: map-get($input-readonly, border-color),
-		focus-border-color: $input-focus-border-color,
+		background-image: $input-success-select-icon,
 	),
-	$input-warning-readonly
+	$input-success-select
 );
-
-$input-warning-color: $input-color !default;
-$input-warning-checkbox-label-color: $warning !default;
-$input-warning-select-icon-color: $input-warning-border-color !default;
-$input-warning-select-icon: clay-icon(
-	caret-double-l,
-	$input-warning-select-icon-color
-) !default;
 
 // Select Element
 

--- a/packages/clay-css/src/scss/cadmin/components/_form-validation.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_form-validation.scss
@@ -11,21 +11,11 @@
 	}
 
 	.form-control {
-		background-color: $cadmin-input-danger-bg;
-		border-color: $cadmin-input-danger-border-color;
-		box-shadow: $cadmin-input-danger-box-shadow;
-		color: $cadmin-input-danger-color;
-
-		&:focus {
-			background-color: $cadmin-input-danger-focus-bg;
-			border-color: $cadmin-input-danger-focus-border-color;
-			box-shadow: $cadmin-input-danger-focus-box-shadow;
-			color: $cadmin-input-danger-focus-color;
-		}
+		@include clay-form-control-variant($cadmin-input-danger);
 	}
 
 	.form-control[readonly] {
-		@include clay-button-variant($cadmin-input-danger-readonly);
+		@include clay-form-control-variant($cadmin-input-danger-readonly);
 	}
 
 	.form-feedback-item {
@@ -33,7 +23,7 @@
 	}
 
 	select.form-control {
-		background-image: $cadmin-input-danger-select-icon;
+		@include clay-select-variant($cadmin-input-danger-select);
 
 		&[size] {
 			@include clay-select-variant($cadmin-input-danger-select-size);
@@ -98,21 +88,11 @@
 	}
 
 	.form-control {
-		background-color: $cadmin-input-warning-bg;
-		border-color: $cadmin-input-warning-border-color;
-		box-shadow: $cadmin-input-warning-box-shadow;
-		color: $cadmin-input-warning-color;
-
-		&:focus {
-			background-color: $cadmin-input-warning-focus-bg;
-			border-color: $cadmin-input-warning-focus-border-color;
-			box-shadow: $cadmin-input-warning-focus-box-shadow;
-			color: $cadmin-input-warning-focus-color;
-		}
+		@include clay-form-control-variant($cadmin-input-warning);
 	}
 
 	.form-control[readonly] {
-		@include clay-button-variant($cadmin-input-warning-readonly);
+		@include clay-form-control-variant($cadmin-input-warning-readonly);
 	}
 
 	.form-feedback-item {
@@ -120,7 +100,7 @@
 	}
 
 	select.form-control {
-		background-image: $cadmin-input-warning-select-icon;
+		@include clay-select-variant($cadmin-input-warning-select);
 
 		&[size] {
 			@include clay-select-variant($cadmin-input-warning-select-size);
@@ -185,21 +165,11 @@
 	}
 
 	.form-control {
-		background-color: $cadmin-input-success-bg;
-		border-color: $cadmin-input-success-border-color;
-		box-shadow: $cadmin-input-success-box-shadow;
-		color: $cadmin-input-success-color;
-
-		&:focus {
-			background-color: $cadmin-input-success-focus-bg;
-			border-color: $cadmin-input-success-focus-border-color;
-			box-shadow: $cadmin-input-success-focus-box-shadow;
-			color: $cadmin-input-success-focus-color;
-		}
+		@include clay-form-control-variant($cadmin-input-success);
 	}
 
 	.form-control[readonly] {
-		@include clay-button-variant($cadmin-input-success-readonly);
+		@include clay-form-control-variant($cadmin-input-success-readonly);
 	}
 
 	.form-feedback-item {
@@ -207,7 +177,7 @@
 	}
 
 	select.form-control {
-		background-image: $cadmin-input-success-select-icon;
+		@include clay-select-variant($cadmin-input-success-select);
 
 		&[size] {
 			@include clay-select-variant($cadmin-input-success-select-size);

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -518,34 +518,69 @@ $cadmin-form-feedback-warning-color: $cadmin-warning !default;
 
 $cadmin-form-feedback-invalid-color: $cadmin-danger !default;
 
-// Input Variants
+// .has-error .form-control
 
 $cadmin-input-danger-bg: $cadmin-danger-l2 !default;
-$cadmin-input-danger-focus-bg: null !default;
 $cadmin-input-danger-border-color: $cadmin-danger-l1 !default;
-$cadmin-input-danger-focus-border-color: null !default;
 $cadmin-input-danger-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
-$cadmin-input-danger-focus-box-shadow: $cadmin-input-focus-box-shadow !default;
 $cadmin-input-danger-color: $cadmin-input-color !default;
+
+$cadmin-input-danger-focus-bg: null !default;
+$cadmin-input-danger-focus-border-color: null !default;
+$cadmin-input-danger-focus-box-shadow: $cadmin-input-focus-box-shadow !default;
 $cadmin-input-danger-focus-color: null !default;
+
+$cadmin-input-danger: () !default;
+$cadmin-input-danger: map-deep-merge(
+	(
+		background-color: $cadmin-input-danger-bg,
+		border-color: $cadmin-input-danger-border-color,
+		box-shadow: $cadmin-input-danger-box-shadow,
+		color: $cadmin-input-danger-color,
+		focus: (
+			background-color: $cadmin-input-danger-focus-bg,
+			border-color: $cadmin-input-danger-focus-border-color,
+			box-shadow: $cadmin-input-danger-focus-box-shadow,
+			color: $cadmin-input-danger-focus-color,
+		),
+	),
+	$cadmin-input-danger
+);
+
+// .has-error .form-control[readonly]
 
 $cadmin-input-danger-readonly: () !default;
 $cadmin-input-danger-readonly: map-deep-merge(
 	(
-		bg: map-get($cadmin-input-readonly, bg),
+		background-color: map-get($cadmin-input-readonly, background-color),
 		border-color: map-get($cadmin-input-readonly, border-color),
-		focus-border-color: $cadmin-input-focus-border-color,
+		focus: (
+			border-color: $cadmin-input-focus-border-color,
+		),
 	),
 	$cadmin-input-danger-readonly
 );
 
 $cadmin-input-danger-checkbox-label-color: $cadmin-danger !default;
 $cadmin-input-danger-label-color: null !default;
+
+// .has-error select.form-control
+
 $cadmin-input-danger-select-icon-color: $cadmin-input-danger-border-color !default;
 $cadmin-input-danger-select-icon: clay-icon(
 	caret-double-l,
 	$cadmin-input-danger-select-icon-color
 ) !default;
+
+$cadmin-input-danger-select: () !default;
+$cadmin-input-danger-select: map-deep-merge(
+	(
+		background-image: $cadmin-input-danger-select-icon,
+	),
+	$cadmin-input-danger-select
+);
+
+// .has-error select.form-control[size]
 
 $cadmin-input-danger-select-size: () !default;
 $cadmin-input-danger-select-size: map-deep-merge(
@@ -555,79 +590,77 @@ $cadmin-input-danger-select-size: map-deep-merge(
 	$cadmin-input-danger-select-size
 );
 
+// .has-error select.form-control[multiple]
+
 $cadmin-input-danger-select-multiple: () !default;
 $cadmin-input-danger-select-multiple: map-deep-merge(
 	$cadmin-input-danger-select-size,
 	$cadmin-input-danger-select-multiple
 );
 
-$cadmin-input-success-bg: $cadmin-success-l2 !default;
-$cadmin-input-success-focus-bg: null !default;
-$cadmin-input-success-border-color: $cadmin-success-l1 !default;
-$cadmin-input-success-focus-border-color: null !default;
-$cadmin-input-success-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
-$cadmin-input-success-focus-box-shadow: $cadmin-input-focus-box-shadow !default;
-$cadmin-input-success-color: $cadmin-input-color !default;
-$cadmin-input-success-focus-color: null !default;
-
-$cadmin-input-success-readonly: () !default;
-$cadmin-input-success-readonly: map-deep-merge(
-	(
-		bg: map-get($cadmin-input-readonly, bg),
-		border-color: map-get($cadmin-input-readonly, border-color),
-		focus-border-color: $cadmin-input-focus-border-color,
-	),
-	$cadmin-input-success-readonly
-);
-
-$cadmin-input-success-checkbox-label-color: $cadmin-success !default;
-$cadmin-input-success-label-color: null !default;
-$cadmin-input-success-select-icon-color: $cadmin-input-success-border-color !default;
-$cadmin-input-success-select-icon: clay-icon(
-	caret-double-l,
-	$cadmin-input-success-select-icon-color
-) !default;
-
-$cadmin-input-success-select-size: () !default;
-$cadmin-input-success-select-size: map-deep-merge(
-	(
-		background-image: none,
-	),
-	$cadmin-input-success-select-size
-);
-
-$cadmin-input-success-select-multiple: () !default;
-$cadmin-input-success-select-multiple: map-deep-merge(
-	$cadmin-input-success-select-size,
-	$cadmin-input-success-select-multiple
-);
+// .has-warning .form-control
 
 $cadmin-input-warning-bg: $cadmin-warning-l2 !default;
-$cadmin-input-warning-focus-bg: null !default;
 $cadmin-input-warning-border-color: $cadmin-warning-l1 !default;
-$cadmin-input-warning-focus-border-color: null !default;
 $cadmin-input-warning-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
-$cadmin-input-warning-focus-box-shadow: $cadmin-input-focus-box-shadow !default;
 $cadmin-input-warning-color: $cadmin-input-color !default;
+
+$cadmin-input-warning-focus-bg: null !default;
+$cadmin-input-warning-focus-border-color: null !default;
+$cadmin-input-warning-focus-box-shadow: $cadmin-input-focus-box-shadow !default;
 $cadmin-input-warning-focus-color: null !default;
+
+$cadmin-input-warning: () !default;
+$cadmin-input-warning: map-deep-merge(
+	(
+		background-color: $cadmin-input-warning-bg,
+		border-color: $cadmin-input-warning-border-color,
+		box-shadow: $cadmin-input-warning-box-shadow,
+		color: $cadmin-input-warning-color,
+		focus: (
+			background-color: $cadmin-input-warning-focus-bg,
+			border-color: $cadmin-input-warning-focus-border-color,
+			box-shadow: $cadmin-input-warning-focus-box-shadow,
+			color: $cadmin-input-warning-focus-color,
+		),
+	),
+	$cadmin-input-warning
+);
+
+// .has-warning .form-control[readonly]
 
 $cadmin-input-warning-readonly: () !default;
 $cadmin-input-warning-readonly: map-deep-merge(
 	(
-		bg: map-get($cadmin-input-readonly, bg),
+		background-color: map-get($cadmin-input-readonly, background-color),
 		border-color: map-get($cadmin-input-readonly, border-color),
-		focus-border-color: $cadmin-input-focus-border-color,
+		focus: (
+			border-color: $cadmin-input-focus-border-color,
+		),
 	),
 	$cadmin-input-warning-readonly
 );
 
 $cadmin-input-warning-checkbox-label-color: $cadmin-warning !default;
 $cadmin-input-warning-label-color: null !default;
+
+// .has-warning select.form-control
+
 $cadmin-input-warning-select-icon-color: $cadmin-input-warning-border-color !default;
 $cadmin-input-warning-select-icon: clay-icon(
 	caret-double-l,
 	$cadmin-input-warning-select-icon-color
 ) !default;
+
+$cadmin-input-warning-select: () !default;
+$cadmin-input-warning-select: map-deep-merge(
+	(
+		background-image: $cadmin-input-warning-select-icon,
+	),
+	$cadmin-input-warning-select
+);
+
+// .has-warning select.form-control[size]
 
 $cadmin-input-warning-select-size: () !default;
 $cadmin-input-warning-select-size: map-deep-merge(
@@ -637,10 +670,92 @@ $cadmin-input-warning-select-size: map-deep-merge(
 	$cadmin-input-warning-select-size
 );
 
+// .has-warning select.form-control[multiple]
+
 $cadmin-input-warning-select-multiple: () !default;
 $cadmin-input-warning-select-multiple: map-deep-merge(
 	$cadmin-input-warning-select-size,
 	$cadmin-input-warning-select-multiple
+);
+
+// .has-success .form-control
+
+$cadmin-input-success-bg: $cadmin-success-l2 !default;
+$cadmin-input-success-border-color: $cadmin-success-l1 !default;
+$cadmin-input-success-box-shadow: 0 0 rgba(0, 0, 0, 0) !default;
+$cadmin-input-success-color: $cadmin-input-color !default;
+
+$cadmin-input-success-focus-bg: null !default;
+$cadmin-input-success-focus-border-color: null !default;
+$cadmin-input-success-focus-box-shadow: $cadmin-input-focus-box-shadow !default;
+$cadmin-input-success-focus-color: null !default;
+
+$cadmin-input-success: () !default;
+$cadmin-input-success: map-deep-merge(
+	(
+		background-color: $cadmin-input-success-bg,
+		border-color: $cadmin-input-success-border-color,
+		box-shadow: $cadmin-input-success-box-shadow,
+		color: $cadmin-input-success-color,
+		focus: (
+			background-color: $cadmin-input-success-focus-bg,
+			border-color: $cadmin-input-success-focus-border-color,
+			box-shadow: $cadmin-input-success-focus-box-shadow,
+			color: $cadmin-input-success-focus-color,
+		),
+	),
+	$cadmin-input-success
+);
+
+// .has-success .form-control[readonly]
+
+$cadmin-input-success-readonly: () !default;
+$cadmin-input-success-readonly: map-deep-merge(
+	(
+		background-color: map-get($cadmin-input-readonly, background-color),
+		border-color: map-get($cadmin-input-readonly, border-color),
+		focus: (
+			border-color: $cadmin-input-focus-border-color,
+		),
+	),
+	$cadmin-input-success-readonly
+);
+
+$cadmin-input-success-checkbox-label-color: $cadmin-success !default;
+$cadmin-input-success-label-color: null !default;
+
+// .has-success select.form-control
+
+$cadmin-input-success-select-icon-color: $cadmin-input-success-border-color !default;
+$cadmin-input-success-select-icon: clay-icon(
+	caret-double-l,
+	$cadmin-input-success-select-icon-color
+) !default;
+
+$cadmin-input-success-select: () !default;
+$cadmin-input-success-select: map-deep-merge(
+	(
+		background-image: $cadmin-input-success-select-icon,
+	),
+	$cadmin-input-success-select
+);
+
+// .has-success select.form-control[size]
+
+$cadmin-input-success-select-size: () !default;
+$cadmin-input-success-select-size: map-deep-merge(
+	(
+		background-image: none,
+	),
+	$cadmin-input-success-select-size
+);
+
+// .has-success select.form-control[multiple]
+
+$cadmin-input-success-select-multiple: () !default;
+$cadmin-input-success-select-multiple: map-deep-merge(
+	$cadmin-input-success-select-size,
+	$cadmin-input-success-select-multiple
 );
 
 // Select Element

--- a/packages/clay-css/src/scss/components/_form-validation.scss
+++ b/packages/clay-css/src/scss/components/_form-validation.scss
@@ -99,17 +99,7 @@
 	}
 
 	.form-control {
-		background-color: $input-danger-bg;
-		border-color: $input-danger-border-color;
-		box-shadow: $input-danger-box-shadow;
-		color: $input-danger-color;
-
-		&:focus {
-			background-color: $input-danger-focus-bg;
-			border-color: $input-danger-focus-border-color;
-			box-shadow: $input-danger-focus-box-shadow;
-			color: $input-danger-focus-color;
-		}
+		@include clay-form-control-variant($input-danger);
 	}
 
 	.form-control[readonly] {
@@ -121,7 +111,7 @@
 	}
 
 	select.form-control {
-		background-image: $input-danger-select-icon;
+		@include clay-select-variant($input-danger-select);
 
 		&[size] {
 			@include clay-select-variant($input-danger-select-size);
@@ -186,17 +176,7 @@
 	}
 
 	.form-control {
-		background-color: $input-warning-bg;
-		border-color: $input-warning-border-color;
-		box-shadow: $input-warning-box-shadow;
-		color: $input-warning-color;
-
-		&:focus {
-			background-color: $input-warning-focus-bg;
-			border-color: $input-warning-focus-border-color;
-			box-shadow: $input-warning-focus-box-shadow;
-			color: $input-warning-focus-color;
-		}
+		@include clay-form-control-variant($input-warning);
 	}
 
 	.form-control[readonly] {
@@ -208,7 +188,7 @@
 	}
 
 	select.form-control {
-		background-image: $input-warning-select-icon;
+		@include clay-select-variant($input-warning-select);
 
 		&[size] {
 			@include clay-select-variant($input-warning-select-size);
@@ -273,17 +253,7 @@
 	}
 
 	.form-control {
-		background-color: $input-success-bg;
-		border-color: $input-success-border-color;
-		box-shadow: $input-success-box-shadow;
-		color: $input-success-color;
-
-		&:focus {
-			background-color: $input-success-focus-bg;
-			border-color: $input-success-focus-border-color;
-			box-shadow: $input-success-focus-box-shadow;
-			color: $input-success-focus-color;
-		}
+		@include clay-form-control-variant($input-success);
 	}
 
 	.form-control[readonly] {
@@ -295,7 +265,7 @@
 	}
 
 	select.form-control {
-		background-image: $input-success-select-icon;
+		@include clay-select-variant($input-success-select);
 
 		&[size] {
 			@include clay-select-variant($input-success-select-size);

--- a/packages/clay-css/src/scss/components/_form-validation.scss
+++ b/packages/clay-css/src/scss/components/_form-validation.scss
@@ -103,7 +103,7 @@
 	}
 
 	.form-control[readonly] {
-		@include clay-button-variant($input-danger-readonly);
+		@include clay-form-control-variant($input-danger-readonly);
 	}
 
 	.form-feedback-item {
@@ -180,7 +180,7 @@
 	}
 
 	.form-control[readonly] {
-		@include clay-button-variant($input-warning-readonly);
+		@include clay-form-control-variant($input-warning-readonly);
 	}
 
 	.form-feedback-item {
@@ -257,7 +257,7 @@
 	}
 
 	.form-control[readonly] {
-		@include clay-button-variant($input-success-readonly);
+		@include clay-form-control-variant($input-success-readonly);
 	}
 
 	.form-feedback-item {

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -545,28 +545,59 @@ $form-validation-states: map-merge(
 	$form-validation-states
 );
 
-// Input Variants
+// .has-error .form-control
 
 $input-danger-bg: null !default;
-$input-danger-focus-bg: null !default;
 $input-danger-border-color: $form-feedback-invalid-color !default;
-$input-danger-focus-border-color: null !default;
 $input-danger-box-shadow: null !default;
+$input-danger-color: null !default;
+
+$input-danger-focus-bg: null !default;
+$input-danger-focus-border-color: null !default;
 $input-danger-focus-box-shadow: 0 0 0 $input-focus-width
 	rgba($form-feedback-invalid-color, 0.25) !default;
-$input-danger-color: null !default;
 $input-danger-focus-color: null !default;
+
+$input-danger: () !default;
+$input-danger: map-deep-merge(
+	(
+		background-color: $input-danger-bg,
+		border-color: $input-danger-border-color,
+		box-shadow: $input-danger-box-shadow,
+		color: $input-danger-color,
+		focus: (
+			background-color: $input-danger-focus-bg,
+			border-color: $input-danger-focus-border-color,
+			box-shadow: $input-danger-focus-box-shadow,
+			color: $input-danger-focus-color,
+		),
+	),
+	$input-danger
+);
 
 $input-danger-readonly: () !default;
 
 $input-danger-checkbox-label-color: $form-feedback-invalid-color !default;
 $input-danger-label-color: null !default;
+
+// .has-error select.form-control
+
 $input-danger-select-icon-color: $input-danger-border-color !default;
 $input-danger-select-icon: clay-str-replace(
 	url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='#{$input-danger-select-icon-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E"),
 	'#',
 	'%23'
 ) !default;
+
+$input-danger-select: () !default;
+$input-danger-select: map-deep-merge(
+	(
+		background-image: $input-danger-select-icon,
+	),
+	$input-danger-select
+);
+
+// .has-error select.form-control[size]
 
 $input-danger-select-size: () !default;
 $input-danger-select-size: map-deep-merge(
@@ -576,67 +607,69 @@ $input-danger-select-size: map-deep-merge(
 	$input-danger-select-size
 );
 
+// .has-error select.form-control[multiple]
+
 $input-danger-select-multiple: () !default;
 $input-danger-select-multiple: map-deep-merge(
 	$input-danger-select-size,
 	$input-danger-select-multiple
 );
 
-$input-success-bg: null !default;
-$input-success-focus-bg: null !default;
-$input-success-border-color: $form-feedback-valid-color !default;
-$input-success-focus-border-color: null !default;
-$input-success-box-shadow: null !default;
-$input-success-focus-box-shadow: 0 0 0 $input-focus-width
-	rgba($form-feedback-valid-color, 0.25) !default;
-$input-success-color: null !default;
-$input-success-focus-color: null !default;
-
-$input-success-readonly: () !default;
-
-$input-success-checkbox-label-color: $form-feedback-valid-color !default;
-$input-success-label-color: null !default;
-$input-success-select-icon-color: $input-success-border-color !default;
-$input-success-select-icon: clay-str-replace(
-	url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='#{$input-success-select-icon-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E"),
-	'#',
-	'%23'
-) !default;
-
-$input-success-select-size: () !default;
-$input-success-select-size: map-deep-merge(
-	(
-		background-image: none,
-	),
-	$input-success-select-size
-);
-
-$input-success-select-multiple: () !default;
-$input-success-select-multiple: map-deep-merge(
-	$input-success-select-size,
-	$input-success-select-multiple
-);
+// .has-warning .form-control
 
 $input-warning-bg: null !default;
-$input-warning-focus-bg: null !default;
 $input-warning-border-color: $form-feedback-warning-color !default;
-$input-warning-focus-border-color: null !default;
 $input-warning-box-shadow: null !default;
+$input-warning-color: null !default;
+
+$input-warning-focus-bg: null !default;
+$input-warning-focus-border-color: null !default;
 $input-warning-focus-box-shadow: 0 0 0 $input-focus-width
 	rgba($form-feedback-warning-color, 0.25) !default;
-$input-warning-color: null !default;
 $input-warning-focus-color: null !default;
+
+$input-warning: () !default;
+$input-warning: map-deep-merge(
+	(
+		background-color: $input-warning-bg,
+		border-color: $input-warning-border-color,
+		box-shadow: $input-warning-box-shadow,
+		color: $input-warning-color,
+		focus: (
+			background-color: $input-warning-focus-bg,
+			border-color: $input-warning-focus-border-color,
+			box-shadow: $input-warning-focus-box-shadow,
+			color: $input-warning-focus-color,
+		),
+	),
+	$input-warning
+);
+
+// .has-warning .form-control[readonly]
 
 $input-warning-readonly: () !default;
 
 $input-warning-checkbox-label-color: $form-feedback-warning-color !default;
 $input-warning-label-color: null !default;
+
+// .has-warning select.form-control
+
 $input-warning-select-icon-color: $input-warning-border-color !default;
 $input-warning-select-icon: clay-str-replace(
 	url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='#{$input-warning-select-icon-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E"),
 	'#',
 	'%23'
 ) !default;
+
+$input-warning-select: () !default;
+$input-warning-select: map-deep-merge(
+	(
+		background-image: $input-warning-select-icon,
+	),
+	$input-warning-select
+);
+
+// .has-warning select.form-control[size]
 
 $input-warning-select-size: () !default;
 $input-warning-select-size: map-deep-merge(
@@ -646,10 +679,84 @@ $input-warning-select-size: map-deep-merge(
 	$input-warning-select-size
 );
 
+// .has-warning select.form-control[multiple]
+
 $input-warning-select-multiple: () !default;
 $input-warning-select-multiple: map-deep-merge(
 	$input-warning-select-size,
 	$input-warning-select-multiple
+);
+
+// .has-success .form-control
+
+$input-success-bg: null !default;
+$input-success-border-color: $form-feedback-valid-color !default;
+$input-success-box-shadow: null !default;
+$input-success-color: null !default;
+
+$input-success-focus-bg: null !default;
+$input-success-focus-border-color: null !default;
+$input-success-focus-box-shadow: 0 0 0 $input-focus-width
+	rgba($form-feedback-valid-color, 0.25) !default;
+$input-success-focus-color: null !default;
+
+$input-success: () !default;
+$input-success: map-deep-merge(
+	(
+		background-color: $input-success-bg,
+		border-color: $input-success-border-color,
+		box-shadow: $input-success-box-shadow,
+		color: $input-success-color,
+		focus: (
+			background-color: $input-success-focus-bg,
+			border-color: $input-success-focus-border-color,
+			box-shadow: $input-success-focus-box-shadow,
+			color: $input-success-focus-color,
+		),
+	),
+	$input-success
+);
+
+// .has-success .form-control[readonly]
+
+$input-success-readonly: () !default;
+
+$input-success-checkbox-label-color: $form-feedback-valid-color !default;
+$input-success-label-color: null !default;
+
+// .has-success select.form-control
+
+$input-success-select-icon-color: $input-success-border-color !default;
+$input-success-select-icon: clay-str-replace(
+	url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='#{$input-success-select-icon-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E"),
+	'#',
+	'%23'
+) !default;
+
+$input-success-select: () !default;
+$input-success-select: map-deep-merge(
+	(
+		background-image: $input-success-select-icon,
+	),
+	$input-success-select
+);
+
+// .has-success select.form-control[size]
+
+$input-success-select-size: () !default;
+$input-success-select-size: map-deep-merge(
+	(
+		background-image: none,
+	),
+	$input-success-select-size
+);
+
+// .has-success select.form-control[multiple]
+
+$input-success-select-multiple: () !default;
+$input-success-select-multiple: map-deep-merge(
+	$input-success-select-size,
+	$input-success-select-multiple
 );
 
 // Select Element

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -575,6 +575,8 @@ $input-danger: map-deep-merge(
 	$input-danger
 );
 
+// .has-error .form-control[readonly]
+
 $input-danger-readonly: () !default;
 
 $input-danger-checkbox-label-color: $form-feedback-invalid-color !default;


### PR DESCRIPTION
fixes #4296