### PR TITLE
fix(@clayui/css): Forms `fieldset[disabled] .form-control` should use values from the `$input` Sass map and move rule-set closer to the `.form-control` rule-set

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -69,6 +69,22 @@ label {
 	@include clay-css($cadmin-form-control-label-text);
 }
 
+// Label Disabled
+
+fieldset[disabled] label,
+label.disabled {
+	$disabled: setter(map-get($cadmin-input-label, disabled), ());
+
+	@include clay-css($disabled);
+}
+
+fieldset[disabled] label {
+	.form-control {
+		font-weight: normal;
+		opacity: 1;
+	}
+}
+
 // Inputs
 
 .form-control {
@@ -394,20 +410,6 @@ textarea.form-control-plaintext,
 }
 
 // Disabled State
-
-fieldset[disabled] label,
-label.disabled {
-	color: $cadmin-input-label-disabled-color;
-	cursor: $cadmin-input-label-disabled-cursor;
-	opacity: $cadmin-input-disabled-opacity;
-}
-
-fieldset[disabled] label {
-	.form-control {
-		font-weight: normal;
-		opacity: 1;
-	}
-}
 
 .form-control {
 	fieldset[disabled] &,

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -129,6 +129,14 @@ fieldset[disabled] label {
 	}
 }
 
+// This adds disabled styles to div.form-control inside a disabled fielset.
+
+fieldset[disabled] .form-control {
+	$disabled: setter(map-get($cadmin-input, disabled), ());
+
+	@include clay-css($disabled);
+}
+
 // Readonly controls as plain text
 // Apply class to a readonly input to make it appear like regular plain
 // text (without any border, background color, focus indicator)
@@ -410,20 +418,6 @@ textarea.form-control-plaintext,
 }
 
 // Disabled State
-
-.form-control {
-	fieldset[disabled] &,
-	&[disabled] {
-		border-color: $cadmin-input-disabled-border-color;
-		color: $cadmin-input-disabled-color;
-		cursor: $cadmin-input-disabled-cursor;
-		opacity: $cadmin-input-disabled-opacity;
-
-		&::placeholder {
-			color: $cadmin-input-placeholder-disabled-color;
-		}
-	}
-}
 
 .form-control[disabled] > option {
 	// Webkit only

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -198,6 +198,11 @@ $cadmin-input-label: map-deep-merge(
 		focus: (
 			color: $cadmin-input-label-focus-color,
 		),
+		disabled: (
+			color: $cadmin-input-label-disabled-color,
+			cursor: $cadmin-input-label-disabled-cursor,
+			opacity: $cadmin-input-disabled-opacity,
+		),
 		for: (
 			cursor: $cadmin-input-label-for-cursor,
 		),

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -126,6 +126,14 @@ fieldset[disabled] label {
 	}
 }
 
+// This adds disabled styles to div.form-control inside a disabled fielset.
+
+fieldset[disabled] .form-control {
+	$disabled: setter(map-get($input, disabled), ());
+
+	@include clay-css($disabled);
+}
+
 // Readonly controls as plain text
 // Apply class to a readonly input to make it appear like regular plain
 // text (without any border, background color, focus indicator)
@@ -403,20 +411,6 @@ textarea.form-control-plaintext,
 }
 
 // Disabled State
-
-.form-control {
-	fieldset[disabled] &,
-	&[disabled] {
-		border-color: $input-disabled-border-color;
-		color: $input-disabled-color;
-		cursor: $input-disabled-cursor;
-		opacity: $input-disabled-opacity;
-
-		&::placeholder {
-			color: $input-placeholder-disabled-color;
-		}
-	}
-}
 
 .form-control[disabled] > option {
 	// Webkit only

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -66,6 +66,22 @@ label {
 	@include clay-css($form-control-label-text);
 }
 
+// Label Disabled
+
+fieldset[disabled] label,
+label.disabled {
+	$disabled: setter(map-get($input-label, disabled), ());
+
+	@include clay-css($disabled);
+}
+
+fieldset[disabled] label {
+	.form-control {
+		font-weight: normal;
+		opacity: 1;
+	}
+}
+
 // Inputs
 
 .form-control {
@@ -387,20 +403,6 @@ textarea.form-control-plaintext,
 }
 
 // Disabled State
-
-fieldset[disabled] label,
-label.disabled {
-	color: $input-label-disabled-color;
-	cursor: $input-label-disabled-cursor;
-	opacity: $input-disabled-opacity;
-}
-
-fieldset[disabled] label {
-	.form-control {
-		font-weight: normal;
-		opacity: 1;
-	}
-}
 
 .form-control {
 	fieldset[disabled] &,

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -194,6 +194,11 @@ $input-label: map-deep-merge(
 		focus: (
 			color: $input-label-focus-color,
 		),
+		disabled: (
+			color: $input-label-disabled-color,
+			cursor: $input-label-disabled-cursor,
+			opacity: $input-disabled-opacity,
+		),
 		for: (
 			cursor: $input-label-for-cursor,
 		),


### PR DESCRIPTION
fixes #4285

This also fixes a similar issue with `fieldset[disabled] label`. Forms `label.disabled` should use properties declared in `$input-label` map and move the `label.disabled` rule-set closer to the `label` rule-set.