### PR TITLE
fix(@clayui/css): Alerts allow better customization of alert variant components

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_alerts.scss
@@ -105,7 +105,7 @@ $alert-autofit-row: map-deep-merge(
 	$alert-autofit-row
 );
 
-// Alert Variants
+// .alert-primary
 
 $alert-primary-color: $primary !default;
 $alert-primary-bg: $primary-l3 !default;
@@ -123,6 +123,31 @@ $alert-primary-btn: map-deep-merge(
 	$alert-primary-btn
 );
 
+$alert-primary: () !default;
+$alert-primary: map-deep-merge(
+	(
+		background-color: $alert-primary-bg,
+		border-color: $alert-primary-border-color,
+		color: $alert-primary-color,
+		close: (
+			color: $alert-primary-close-color,
+			hover: (
+				color: $alert-primary-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-primary-lead-color,
+		),
+		alert-link: (
+			color: $alert-primary-link-color,
+		),
+		alert-btn: $alert-primary-btn,
+	),
+	$alert-primary
+);
+
+// .alert-secondary
+
 $alert-secondary-color: $secondary !default;
 $alert-secondary-bg: $secondary-l3 !default;
 $alert-secondary-border-color: $secondary-l1 !default;
@@ -138,6 +163,31 @@ $alert-secondary-btn: map-deep-merge(
 	),
 	$alert-secondary-btn
 );
+
+$alert-secondary: () !default;
+$alert-secondary: map-deep-merge(
+	(
+		background-color: $alert-secondary-bg,
+		border-color: $alert-secondary-border-color,
+		color: $alert-secondary-color,
+		close: (
+			color: $alert-secondary-close-color,
+			hover: (
+				color: $alert-secondary-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-secondary-lead-color,
+		),
+		alert-link: (
+			color: $alert-secondary-link-color,
+		),
+		alert-btn: $alert-secondary-btn,
+	),
+	$alert-secondary
+);
+
+// .alert-success
 
 $alert-success-color: $success !default;
 $alert-success-bg: $success-l2 !default;
@@ -155,6 +205,31 @@ $alert-success-btn: map-deep-merge(
 	$alert-success-btn
 );
 
+$alert-success: () !default;
+$alert-success: map-deep-merge(
+	(
+		background-color: $alert-success-bg,
+		border-color: $alert-success-border-color,
+		color: $alert-success-color,
+		close: (
+			color: $alert-success-close-color,
+			hover: (
+				color: $alert-success-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-success-lead-color,
+		),
+		alert-link: (
+			color: $alert-success-link-color,
+		),
+		alert-btn: $alert-success-btn,
+	),
+	$alert-success
+);
+
+// .alert-info
+
 $alert-info-color: $info !default;
 $alert-info-bg: $info-l2 !default;
 $alert-info-border-color: $info-l1 !default;
@@ -170,6 +245,31 @@ $alert-info-btn: map-deep-merge(
 	),
 	$alert-info-btn
 );
+
+$alert-info: () !default;
+$alert-info: map-deep-merge(
+	(
+		background-color: $alert-info-bg,
+		border-color: $alert-info-border-color,
+		color: $alert-info-color,
+		close: (
+			color: $alert-info-close-color,
+			hover: (
+				color: $alert-info-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-info-lead-color,
+		),
+		alert-link: (
+			color: $alert-info-link-color,
+		),
+		alert-btn: $alert-info-btn,
+	),
+	$alert-info
+);
+
+// .alert-warning
 
 $alert-warning-color: $warning !default;
 $alert-warning-bg: $warning-l2 !default;
@@ -187,6 +287,31 @@ $alert-warning-btn: map-deep-merge(
 	$alert-warning-btn
 );
 
+$alert-warning: () !default;
+$alert-warning: map-deep-merge(
+	(
+		background-color: $alert-warning-bg,
+		border-color: $alert-warning-border-color,
+		color: $alert-warning-color,
+		close: (
+			color: $alert-warning-close-color,
+			hover: (
+				color: $alert-warning-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-warning-lead-color,
+		),
+		alert-link: (
+			color: $alert-warning-link-color,
+		),
+		alert-btn: $alert-warning-btn,
+	),
+	$alert-warning
+);
+
+// .alert-danger
+
 $alert-danger-color: $danger !default;
 $alert-danger-bg: $danger-l2 !default;
 $alert-danger-border-color: $danger-l1 !default;
@@ -202,6 +327,31 @@ $alert-danger-btn: map-deep-merge(
 	),
 	$alert-danger-btn
 );
+
+$alert-danger: () !default;
+$alert-danger: map-deep-merge(
+	(
+		background-color: $alert-danger-bg,
+		border-color: $alert-danger-border-color,
+		color: $alert-danger-color,
+		close: (
+			color: $alert-danger-close-color,
+			hover: (
+				color: $alert-danger-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-danger-lead-color,
+		),
+		alert-link: (
+			color: $alert-danger-link-color,
+		),
+		alert-btn: $alert-danger-btn,
+	),
+	$alert-danger
+);
+
+// .alert-light
 
 $alert-light-color: $dark !default;
 $alert-light-bg: $light-l2 !default;
@@ -224,6 +374,31 @@ $alert-light-btn: map-deep-merge(
 	$alert-light-btn
 );
 
+$alert-light: () !default;
+$alert-light: map-deep-merge(
+	(
+		background-color: $alert-light-bg,
+		border-color: $alert-light-border-color,
+		color: $alert-light-color,
+		close: (
+			color: $alert-light-close-color,
+			hover: (
+				color: $alert-light-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-light-lead-color,
+		),
+		link: (
+			color: $alert-light-link-color,
+		),
+		alert-btn: $alert-light-btn,
+	),
+	$alert-light
+);
+
+// .alert-dark
+
 $alert-dark-color: $light !default;
 $alert-dark-bg: $dark-l2 !default;
 $alert-dark-border-color: $dark-l1 !default;
@@ -238,4 +413,27 @@ $alert-dark-btn: map-deep-merge(
 		hover-border-color: $dark,
 	),
 	$alert-dark-btn
+);
+
+$alert-dark: () !default;
+$alert-dark: map-deep-merge(
+	(
+		background-color: $alert-dark-bg,
+		border-color: $alert-dark-border-color,
+		color: $alert-dark-color,
+		close: (
+			color: $alert-dark-close-color,
+			hover: (
+				color: $alert-dark-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-dark-lead-color,
+		),
+		link: (
+			color: $alert-dark-link-color,
+		),
+		alert-btn: $alert-dark-btn,
+	),
+	$alert-dark
 );

--- a/packages/clay-css/src/scss/atlas/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_alerts.scss
@@ -118,7 +118,9 @@ $alert-primary-btn: () !default;
 $alert-primary-btn: map-deep-merge(
 	(
 		border-color: $primary-l1,
-		hover-border-color: $primary,
+		hover: (
+			border-color: $primary,
+		),
 	),
 	$alert-primary-btn
 );
@@ -159,7 +161,9 @@ $alert-secondary-btn: () !default;
 $alert-secondary-btn: map-deep-merge(
 	(
 		border-color: $secondary-l1,
-		hover-border-color: $secondary,
+		hover: (
+			border-color: $secondary,
+		),
 	),
 	$alert-secondary-btn
 );
@@ -200,7 +204,9 @@ $alert-success-btn: () !default;
 $alert-success-btn: map-deep-merge(
 	(
 		border-color: $success-l1,
-		hover-border-color: $success,
+		hover: (
+			border-color: $success,
+		),
 	),
 	$alert-success-btn
 );
@@ -241,7 +247,9 @@ $alert-info-btn: () !default;
 $alert-info-btn: map-deep-merge(
 	(
 		border-color: $info-l1,
-		hover-border-color: $info,
+		hover: (
+			border-color: $info,
+		),
 	),
 	$alert-info-btn
 );
@@ -282,7 +290,9 @@ $alert-warning-btn: () !default;
 $alert-warning-btn: map-deep-merge(
 	(
 		border-color: $warning-l1,
-		hover-border-color: $warning,
+		hover: (
+			border-color: $warning,
+		),
 	),
 	$alert-warning-btn
 );
@@ -323,7 +333,9 @@ $alert-danger-btn: () !default;
 $alert-danger-btn: map-deep-merge(
 	(
 		border-color: $danger-l1,
-		hover-border-color: $danger,
+		hover: (
+			border-color: $danger,
+		),
 	),
 	$alert-danger-btn
 );
@@ -365,11 +377,15 @@ $alert-light-btn: map-deep-merge(
 	(
 		border-color: $dark-l1,
 		color: $dark,
-		hover-bg: $dark,
-		hover-border-color: $dark,
-		hover-color: $white,
-		active-bg: darken($dark, 5%),
-		active-border-color: darken($dark, 5%),
+		hover: (
+			background-color: $dark,
+			border-color: $dark,
+			color: $white,
+		),
+		active: (
+			background-color: darken($dark, 5%),
+			border-color: darken($dark, 5%),
+		),
 	),
 	$alert-light-btn
 );
@@ -410,7 +426,9 @@ $alert-dark-btn: () !default;
 $alert-dark-btn: map-deep-merge(
 	(
 		border-color: $dark-l1,
-		hover-border-color: $dark,
+		hover: (
+			border-color: $dark,
+		),
 	),
 	$alert-dark-btn
 );

--- a/packages/clay-css/src/scss/cadmin/components/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_alerts.scss
@@ -240,38 +240,6 @@
 
 @each $cadmin-color, $cadmin-value in $cadmin-alert-palette {
 	.alert-#{$cadmin-color} {
-		background-color: map-get($cadmin-value, bg);
-		border-color: map-get($cadmin-value, border-color);
-		color: map-get($cadmin-value, color);
-
-		hr {
-			border-top-color: darken(map-get($cadmin-value, border-color), 5%);
-		}
-
-		.alert-btn {
-			@include clay-button-variant(map-get($cadmin-value, alert-btn));
-		}
-
-		.close {
-			color: map-get($cadmin-value, close-color);
-
-			&:hover,
-			&:focus {
-				color: map-get($cadmin-value, close-hover-color);
-			}
-		}
-
-		.alert-link {
-			color: map-get($cadmin-value, link-color);
-
-			&:hover,
-			&:focus {
-				color: map-get($cadmin-value, link-hover-color);
-			}
-		}
-
-		.lead {
-			color: map-get($cadmin-value, lead-color);
-		}
+		@include clay-alert-variant($cadmin-value);
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
@@ -324,14 +324,18 @@ $cadmin-alert-primary-link-hover-color: null !default;
 $cadmin-alert-primary-btn: () !default;
 $cadmin-alert-primary-btn: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-primary-l1,
 		color: $cadmin-primary,
-		hover-bg: $cadmin-primary,
-		hover-border-color: $cadmin-primary,
-		hover-color: color-yiq($cadmin-primary),
-		active-bg: darken($cadmin-primary, 5%),
-		active-border-color: darken($cadmin-primary, 5%),
+		hover: (
+			background-color: $cadmin-primary,
+			border-color: $cadmin-primary,
+			color: color-yiq($cadmin-primary),
+		),
+		active: (
+			background-color: darken($cadmin-primary, 5%),
+			border-color: darken($cadmin-primary, 5%),
+		),
 	),
 	$cadmin-alert-primary-btn
 );
@@ -376,14 +380,18 @@ $cadmin-alert-secondary-link-hover-color: null !default;
 $cadmin-alert-secondary-btn: () !default;
 $cadmin-alert-secondary-btn: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-secondary-l1,
 		color: $cadmin-secondary,
-		hover-bg: $cadmin-secondary,
-		hover-border-color: $cadmin-secondary,
-		hover-color: color-yiq($cadmin-secondary),
-		active-bg: darken($cadmin-secondary, 5%),
-		active-border-color: darken($cadmin-secondary, 5%),
+		hover: (
+			background-color: $cadmin-secondary,
+			border-color: $cadmin-secondary,
+			color: color-yiq($cadmin-secondary),
+		),
+		active: (
+			background-color: darken($cadmin-secondary, 5%),
+			border-color: darken($cadmin-secondary, 5%),
+		),
 	),
 	$cadmin-alert-secondary-btn
 );
@@ -427,14 +435,18 @@ $cadmin-alert-success-link-hover-color: null !default;
 $cadmin-alert-success-btn: () !default;
 $cadmin-alert-success-btn: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-success-l1,
 		color: $cadmin-success,
-		hover-bg: $cadmin-success,
-		hover-border-color: $cadmin-success,
-		hover-color: color-yiq($cadmin-success),
-		active-bg: darken($cadmin-success, 5%),
-		active-border-color: darken($cadmin-success, 5%),
+		hover: (
+			background-color: $cadmin-success,
+			border-color: $cadmin-success,
+			color: color-yiq($cadmin-success),
+		),
+		active: (
+			background-color: darken($cadmin-success, 5%),
+			border-color: darken($cadmin-success, 5%),
+		),
 	),
 	$cadmin-alert-success-btn
 );
@@ -479,14 +491,18 @@ $cadmin-alert-info-link-hover-color: null !default;
 $cadmin-alert-info-btn: () !default;
 $cadmin-alert-info-btn: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-info-l1,
 		color: $cadmin-info,
-		hover-bg: $cadmin-info,
-		hover-border-color: $cadmin-info,
-		hover-color: color-yiq($cadmin-info),
-		active-bg: darken($cadmin-info, 5%),
-		active-border-color: darken($cadmin-info, 5%),
+		hover: (
+			background-color: $cadmin-info,
+			border-color: $cadmin-info,
+			color: color-yiq($cadmin-info),
+		),
+		active: (
+			background-color: darken($cadmin-info, 5%),
+			border-color: darken($cadmin-info, 5%),
+		),
 	),
 	$cadmin-alert-info-btn
 );
@@ -530,14 +546,18 @@ $cadmin-alert-warning-link-hover-color: null !default;
 $cadmin-alert-warning-btn: () !default;
 $cadmin-alert-warning-btn: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-warning-l1,
 		color: $cadmin-warning,
-		hover-bg: $cadmin-warning,
-		hover-border-color: $cadmin-warning,
-		hover-color: color-yiq($cadmin-warning),
-		active-bg: darken($cadmin-warning, 5%),
-		active-border-color: darken($cadmin-warning, 5%),
+		hover: (
+			background-color: $cadmin-warning,
+			border-color: $cadmin-warning,
+			color: color-yiq($cadmin-warning),
+		),
+		active: (
+			background-color: darken($cadmin-warning, 5%),
+			border-color: darken($cadmin-warning, 5%),
+		),
 	),
 	$cadmin-alert-warning-btn
 );
@@ -581,14 +601,18 @@ $cadmin-alert-danger-link-hover-color: null !default;
 $cadmin-alert-danger-btn: () !default;
 $cadmin-alert-danger-btn: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-danger-l1,
 		color: $cadmin-danger,
-		hover-bg: $cadmin-danger,
-		hover-border-color: $cadmin-danger,
-		hover-color: color-yiq($cadmin-danger),
-		active-bg: darken($cadmin-danger, 5%),
-		active-border-color: darken($cadmin-danger, 5%),
+		hover: (
+			background-color: $cadmin-danger,
+			border-color: $cadmin-danger,
+			color: color-yiq($cadmin-danger),
+		),
+		active: (
+			background-color: darken($cadmin-danger, 5%),
+			border-color: darken($cadmin-danger, 5%),
+		),
 	),
 	$cadmin-alert-danger-btn
 );
@@ -633,14 +657,18 @@ $cadmin-alert-light-link-hover-color: null !default;
 $cadmin-alert-light-btn: () !default;
 $cadmin-alert-light-btn: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-dark-l1,
 		color: $cadmin-dark,
-		hover-bg: $cadmin-dark,
-		hover-border-color: $cadmin-dark,
-		hover-color: $cadmin-white,
-		active-bg: darken($cadmin-dark, 5%),
-		active-border-color: darken($cadmin-dark, 5%),
+		hover: (
+			background-color: $cadmin-dark,
+			border-color: $cadmin-dark,
+			color: $cadmin-white,
+		),
+		active: (
+			background-color: darken($cadmin-dark, 5%),
+			border-color: darken($cadmin-dark, 5%),
+		),
 	),
 	$cadmin-alert-light-btn
 );
@@ -685,14 +713,18 @@ $cadmin-alert-dark-link-hover-color: null !default;
 $cadmin-alert-dark-btn: () !default;
 $cadmin-alert-dark-btn: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-dark-l1,
 		color: $cadmin-dark,
-		hover-bg: $cadmin-dark,
-		hover-border-color: $cadmin-dark,
-		hover-color: color-yiq($cadmin-dark),
-		active-bg: darken($cadmin-dark, 5%),
-		active-border-color: darken($cadmin-dark, 5%),
+		hover: (
+			background-color: $cadmin-dark,
+			border-color: $cadmin-dark,
+			color: color-yiq($cadmin-dark),
+		),
+		active: (
+			background-color: darken($cadmin-dark, 5%),
+			border-color: darken($cadmin-dark, 5%),
+		),
 	),
 	$cadmin-alert-dark-btn
 );
@@ -726,94 +758,14 @@ $cadmin-alert-dark: map-deep-merge(
 $cadmin-alert-palette: () !default;
 $cadmin-alert-palette: map-deep-merge(
 	(
-		primary: (
-			bg: $cadmin-alert-primary-bg,
-			border-color: $cadmin-alert-primary-border-color,
-			color: $cadmin-alert-primary-color,
-			close-color: $cadmin-alert-primary-close-color,
-			close-hover-color: $cadmin-alert-primary-close-hover-color,
-			lead-color: $cadmin-alert-primary-lead-color,
-			link-color: $cadmin-alert-primary-link-color,
-			link-hover-color: $cadmin-alert-primary-link-hover-color,
-			alert-btn: $cadmin-alert-primary-btn,
-		),
-		secondary: (
-			bg: $cadmin-alert-secondary-bg,
-			border-color: $cadmin-alert-secondary-border-color,
-			color: $cadmin-alert-secondary-color,
-			close-color: $cadmin-alert-secondary-close-color,
-			close-hover-color: $cadmin-alert-secondary-close-hover-color,
-			lead-color: $cadmin-alert-secondary-lead-color,
-			link-color: $cadmin-alert-secondary-link-color,
-			link-hover-color: $cadmin-alert-secondary-link-hover-color,
-			alert-btn: $cadmin-alert-secondary-btn,
-		),
-		success: (
-			bg: $cadmin-alert-success-bg,
-			border-color: $cadmin-alert-success-border-color,
-			color: $cadmin-alert-success-color,
-			close-color: $cadmin-alert-success-close-color,
-			close-hover-color: $cadmin-alert-success-close-hover-color,
-			lead-color: $cadmin-alert-success-lead-color,
-			link-color: $cadmin-alert-success-link-color,
-			link-hover-color: $cadmin-alert-success-link-hover-color,
-			alert-btn: $cadmin-alert-success-btn,
-		),
-		info: (
-			bg: $cadmin-alert-info-bg,
-			border-color: $cadmin-alert-info-border-color,
-			color: $cadmin-alert-info-color,
-			close-color: $cadmin-alert-info-close-color,
-			close-hover-color: $cadmin-alert-info-close-hover-color,
-			lead-color: $cadmin-alert-info-lead-color,
-			link-color: $cadmin-alert-info-link-color,
-			link-hover-color: $cadmin-alert-info-link-hover-color,
-			alert-btn: $cadmin-alert-info-btn,
-		),
-		warning: (
-			bg: $cadmin-alert-warning-bg,
-			border-color: $cadmin-alert-warning-border-color,
-			color: $cadmin-alert-warning-color,
-			close-color: $cadmin-alert-warning-close-color,
-			close-hover-color: $cadmin-alert-warning-close-hover-color,
-			lead-color: $cadmin-alert-warning-lead-color,
-			link-color: $cadmin-alert-warning-link-color,
-			link-hover-color: $cadmin-alert-warning-link-hover-color,
-			alert-btn: $cadmin-alert-warning-btn,
-		),
-		danger: (
-			bg: $cadmin-alert-danger-bg,
-			border-color: $cadmin-alert-danger-border-color,
-			color: $cadmin-alert-danger-color,
-			close-color: $cadmin-alert-danger-close-color,
-			close-hover-color: $cadmin-alert-danger-close-hover-color,
-			lead-color: $cadmin-alert-danger-lead-color,
-			link-color: $cadmin-alert-danger-link-color,
-			link-hover-color: $cadmin-alert-danger-link-hover-color,
-			alert-btn: $cadmin-alert-danger-btn,
-		),
-		light: (
-			bg: $cadmin-alert-light-bg,
-			border-color: $cadmin-alert-light-border-color,
-			color: $cadmin-alert-light-color,
-			close-color: $cadmin-alert-light-close-color,
-			close-hover-color: $cadmin-alert-light-close-hover-color,
-			lead-color: $cadmin-alert-light-lead-color,
-			link-color: $cadmin-alert-light-link-color,
-			link-hover-color: $cadmin-alert-light-link-hover-color,
-			alert-btn: $cadmin-alert-light-btn,
-		),
-		dark: (
-			bg: $cadmin-alert-dark-bg,
-			border-color: $cadmin-alert-dark-border-color,
-			color: $cadmin-alert-dark-color,
-			close-color: $cadmin-alert-dark-close-color,
-			close-hover-color: $cadmin-alert-dark-close-hover-color,
-			lead-color: $cadmin-alert-dark-lead-color,
-			link-color: $cadmin-alert-dark-link-color,
-			link-hover-color: $cadmin-alert-dark-link-hover-color,
-			alert-btn: $cadmin-alert-dark-btn,
-		),
+		primary: $cadmin-alert-primary,
+		secondary: $cadmin-alert-secondary,
+		success: $cadmin-alert-success,
+		info: $cadmin-alert-info,
+		warning: $cadmin-alert-warning,
+		danger: $cadmin-alert-danger,
+		light: $cadmin-alert-light,
+		dark: $cadmin-alert-dark,
 	),
 	$cadmin-alert-palette
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
@@ -311,7 +311,7 @@ $cadmin-alert-feedback: map-deep-merge(
 	$cadmin-alert-feedback
 );
 
-// Alert Variants
+// .alert-primary
 
 $cadmin-alert-primary-bg: $cadmin-primary-l3 !default;
 $cadmin-alert-primary-border-color: $cadmin-primary-l1 !default;
@@ -335,6 +335,34 @@ $cadmin-alert-primary-btn: map-deep-merge(
 	),
 	$cadmin-alert-primary-btn
 );
+
+$cadmin-alert-primary: () !default;
+$cadmin-alert-primary: map-deep-merge(
+	(
+		background-color: $cadmin-alert-primary-bg,
+		border-color: $cadmin-alert-primary-border-color,
+		color: $cadmin-alert-primary-color,
+		close: (
+			color: $cadmin-alert-primary-close-color,
+			hover: (
+				color: $cadmin-alert-primary-close-hover-color,
+			),
+		),
+		lead: (
+			color: $cadmin-alert-primary-lead-color,
+		),
+		link: (
+			color: $cadmin-alert-primary-link-color,
+			hover: (
+				color: $cadmin-alert-primary-link-hover-color,
+			),
+		),
+		alert-btn: $cadmin-alert-primary-btn,
+	),
+	$cadmin-alert-primary
+);
+
+// .alert-secondary
 
 $cadmin-alert-secondary-bg: $cadmin-secondary-l3 !default;
 $cadmin-alert-secondary-border-color: $cadmin-secondary-l1 !default;
@@ -360,6 +388,34 @@ $cadmin-alert-secondary-btn: map-deep-merge(
 	$cadmin-alert-secondary-btn
 );
 
+$cadmin-alert-secondary: () !default;
+$cadmin-alert-secondary: map-deep-merge(
+	(
+		background-color: $cadmin-alert-secondary-bg,
+		border-color: $cadmin-alert-secondary-border-color,
+		color: $cadmin-alert-secondary-color,
+		close: (
+			color: $cadmin-alert-secondary-close-color,
+			hover: (
+				color: $cadmin-alert-secondary-close-hover-color,
+			),
+		),
+		lead: (
+			color: $cadmin-alert-secondary-lead-color,
+		),
+		link: (
+			color: $cadmin-alert-secondary-link-color,
+			hover: (
+				color: $cadmin-alert-secondary-link-hover-color,
+			),
+		),
+		alert-btn: $cadmin-alert-secondary-btn,
+	),
+	$cadmin-alert-secondary
+);
+
+// .alert-success
+
 $cadmin-alert-success-bg: $cadmin-success-l2 !default;
 $cadmin-alert-success-border-color: $cadmin-success-l1 !default;
 $cadmin-alert-success-color: $cadmin-success !default;
@@ -382,6 +438,34 @@ $cadmin-alert-success-btn: map-deep-merge(
 	),
 	$cadmin-alert-success-btn
 );
+
+$cadmin-alert-success: () !default;
+$cadmin-alert-success: map-deep-merge(
+	(
+		background-color: $cadmin-alert-success-bg,
+		border-color: $cadmin-alert-success-border-color,
+		color: $cadmin-alert-success-color,
+		close: (
+			color: $cadmin-alert-success-close-color,
+			hover: (
+				color: $cadmin-alert-success-close-hover-color,
+			),
+		),
+		lead: (
+			color: $cadmin-alert-success-lead-color,
+		),
+		link: (
+			color: $cadmin-alert-success-link-color,
+			hover: (
+				color: $cadmin-alert-success-link-hover-color,
+			),
+		),
+		alert-btn: $cadmin-alert-success-btn,
+	),
+	$cadmin-alert-success
+);
+
+// .alert-info
 
 $cadmin-alert-info-bg: $cadmin-info-l2 !default;
 $cadmin-alert-info-border-color: $cadmin-info-l1 !default;
@@ -407,6 +491,34 @@ $cadmin-alert-info-btn: map-deep-merge(
 	$cadmin-alert-info-btn
 );
 
+$cadmin-alert-info: () !default;
+$cadmin-alert-info: map-deep-merge(
+	(
+		background-color: $cadmin-alert-info-bg,
+		border-color: $cadmin-alert-info-border-color,
+		color: $cadmin-alert-info-color,
+		close: (
+			color: $cadmin-alert-info-close-color,
+			hover: (
+				color: $cadmin-alert-info-close-hover-color,
+			),
+		),
+		lead: (
+			color: $cadmin-alert-info-lead-color,
+		),
+		link: (
+			color: $cadmin-alert-info-link-color,
+			hover: (
+				color: $cadmin-alert-info-link-hover-color,
+			),
+		),
+		alert-btn: $cadmin-alert-info-btn,
+	),
+	$cadmin-alert-info
+);
+
+// .alert-warning
+
 $cadmin-alert-warning-bg: $cadmin-warning-l2 !default;
 $cadmin-alert-warning-border-color: $cadmin-warning-l1 !default;
 $cadmin-alert-warning-color: $cadmin-warning !default;
@@ -430,6 +542,34 @@ $cadmin-alert-warning-btn: map-deep-merge(
 	$cadmin-alert-warning-btn
 );
 
+$cadmin-alert-warning: () !default;
+$cadmin-alert-warning: map-deep-merge(
+	(
+		background-color: $cadmin-alert-warning-bg,
+		border-color: $cadmin-alert-warning-border-color,
+		color: $cadmin-alert-warning-color,
+		close: (
+			color: $cadmin-alert-warning-close-color,
+			hover: (
+				color: $cadmin-alert-warning-close-hover-color,
+			),
+		),
+		lead: (
+			color: $cadmin-alert-warning-lead-color,
+		),
+		link: (
+			color: $cadmin-alert-warning-link-color,
+			hover: (
+				color: $cadmin-alert-warning-link-hover-color,
+			),
+		),
+		alert-btn: $cadmin-alert-warning-btn,
+	),
+	$cadmin-alert-warning
+);
+
+// .alert-danger
+
 $cadmin-alert-danger-bg: $cadmin-danger-l2 !default;
 $cadmin-alert-danger-border-color: $cadmin-danger-l1 !default;
 $cadmin-alert-danger-color: $cadmin-danger !default;
@@ -452,6 +592,34 @@ $cadmin-alert-danger-btn: map-deep-merge(
 	),
 	$cadmin-alert-danger-btn
 );
+
+$cadmin-alert-danger: () !default;
+$cadmin-alert-danger: map-deep-merge(
+	(
+		background-color: $cadmin-alert-danger-bg,
+		border-color: $cadmin-alert-danger-border-color,
+		color: $cadmin-alert-danger-color,
+		close: (
+			color: $cadmin-alert-danger-close-color,
+			hover: (
+				color: $cadmin-alert-danger-close-hover-color,
+			),
+		),
+		lead: (
+			color: $cadmin-alert-danger-lead-color,
+		),
+		link: (
+			color: $cadmin-alert-danger-link-color,
+			hover: (
+				color: $cadmin-alert-danger-link-hover-color,
+			),
+		),
+		alert-btn: $cadmin-alert-danger-btn,
+	),
+	$cadmin-alert-danger
+);
+
+// .alert-light
 
 $cadmin-alert-light-bg: $cadmin-light-l2 !default;
 $cadmin-alert-light-border-color: $cadmin-light-l1 !default;
@@ -477,6 +645,34 @@ $cadmin-alert-light-btn: map-deep-merge(
 	$cadmin-alert-light-btn
 );
 
+$cadmin-alert-light: () !default;
+$cadmin-alert-light: map-deep-merge(
+	(
+		background-color: $cadmin-alert-light-bg,
+		border-color: $cadmin-alert-light-border-color,
+		color: $cadmin-alert-light-color,
+		close: (
+			color: $cadmin-alert-light-close-color,
+			hover: (
+				color: $cadmin-alert-light-close-hover-color,
+			),
+		),
+		lead: (
+			color: $cadmin-alert-light-lead-color,
+		),
+		link: (
+			color: $cadmin-alert-light-link-color,
+			hover: (
+				color: $cadmin-alert-light-link-hover-color,
+			),
+		),
+		alert-btn: $cadmin-alert-light-btn,
+	),
+	$cadmin-alert-light
+);
+
+// .alert-dark
+
 $cadmin-alert-dark-bg: $cadmin-dark-l2 !default;
 $cadmin-alert-dark-border-color: $cadmin-dark-l1 !default;
 $cadmin-alert-dark-color: $cadmin-light !default;
@@ -499,6 +695,32 @@ $cadmin-alert-dark-btn: map-deep-merge(
 		active-border-color: darken($cadmin-dark, 5%),
 	),
 	$cadmin-alert-dark-btn
+);
+
+$cadmin-alert-dark: () !default;
+$cadmin-alert-dark: map-deep-merge(
+	(
+		background-color: $cadmin-alert-dark-bg,
+		border-color: $cadmin-alert-dark-border-color,
+		color: $cadmin-alert-dark-color,
+		close: (
+			color: $cadmin-alert-dark-close-color,
+			hover: (
+				color: $cadmin-alert-dark-close-hover-color,
+			),
+		),
+		lead: (
+			color: $cadmin-alert-dark-lead-color,
+		),
+		link: (
+			color: $cadmin-alert-dark-link-color,
+			hover: (
+				color: $cadmin-alert-dark-link-hover-color,
+			),
+		),
+		alert-btn: $cadmin-alert-dark-btn,
+	),
+	$cadmin-alert-dark
 );
 
 $cadmin-alert-palette: () !default;

--- a/packages/clay-css/src/scss/components/_alerts.scss
+++ b/packages/clay-css/src/scss/components/_alerts.scss
@@ -237,38 +237,6 @@
 
 @each $color, $value in $alert-palette {
 	.alert-#{$color} {
-		background-color: map-get($value, bg);
-		border-color: map-get($value, border-color);
-		color: map-get($value, color);
-
-		hr {
-			border-top-color: darken(map-get($value, border-color), 5%);
-		}
-
-		.alert-btn {
-			@include clay-button-variant(map-get($value, alert-btn));
-		}
-
-		.close {
-			color: map-get($value, close-color);
-
-			&:hover,
-			&:focus {
-				color: map-get($value, close-hover-color);
-			}
-		}
-
-		.alert-link {
-			color: map-get($value, link-color);
-
-			&:hover,
-			&:focus {
-				color: map-get($value, link-hover-color);
-			}
-		}
-
-		.lead {
-			color: map-get($value, lead-color);
-		}
+		@include clay-alert-variant($value);
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_alerts.scss
+++ b/packages/clay-css/src/scss/mixins/_alerts.scss
@@ -1,3 +1,9 @@
+/// This is Bootstrap 4's Alert Variant Mixin.
+/// @deprecated use the mixin `clay-alert-variant` instead
+/// @param {Color} $background
+/// @param {Color} $border
+/// @param {Color} $color
+
 @mixin alert-variant($background, $border, $color) {
 	@include gradient-bg($background);
 
@@ -10,5 +16,122 @@
 
 	.alert-link {
 		color: darken($color, 10%);
+	}
+}
+
+/// A mixin to create alert variants.
+/// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
+/// @example
+/// enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// hr: {Map | Null}, // See mixin `clay-css`
+/// alert-btn: {Map | Null}, // See mixin `clay-button-variant`
+/// btn-group: {Map | Null}, // See mixin `clay-container`
+/// btn-group-item: {Map | Null}, // See mixin `clay-container`
+/// close: {Map | Null}, // See mixin `clay-close`
+/// lead: {Map | Null}, // See mixin `clay-css`
+/// alert-link: {Map | Null}, // See mixin `clay-link`
+/// component-title: {Map | Null}, // See mixin `clay-text-typography`
+/// component-subtitle: {Map | Null}, // See mixin `clay-text-typography`
+
+@mixin clay-alert-variant($map) {
+	$enabled: setter(map-get($map, enabled), true);
+
+	$base: map-merge(
+		$map,
+		(
+			background-color:
+				setter(map-get($map, bg), map-get($map, background-color)),
+		)
+	);
+
+	$hr: setter(map-get($map, hr), ());
+
+	$alert-btn: setter(map-get($map, alert-btn), ());
+
+	$btn-group: setter(map-get($map, btn-group), ());
+
+	$btn-group-item: setter(map-get($map, btn-group-item), ());
+
+	$close: setter(map-get($map, close), ());
+	$close: map-deep-merge(
+		$close,
+		(
+			color: setter(map-get($map, close-color), map-get($close, color)),
+			hover: (
+				color:
+					setter(
+						map-get($map, close-hover-color),
+						map-deep-get($close, hover, color)
+					),
+			),
+		)
+	);
+
+	$lead: setter(map-get($map, lead), ());
+	$lead: map-deep-merge(
+		$lead,
+		(
+			color: setter(map-get($map, lead-color), map-get($lead, color)),
+		)
+	);
+
+	$alert-link: setter(map-get($map, alert-link), ());
+	$alert-link: map-deep-merge(
+		$alert-link,
+		(
+			color:
+				setter(map-get($map, link-color), map-get($alert-link, color)),
+			hover: (
+				color:
+					setter(
+						map-get($map, link-hover-color),
+						map-deep-get($alert-link, hover, color)
+					),
+			),
+		)
+	);
+
+	$component-title: setter(map-get($map, component-title), ());
+
+	$component-subtitle: setter(map-get($map, component-subtitle), ());
+
+	@if ($enabled) {
+		@include clay-css($base);
+
+		hr {
+			@include clay-css($hr);
+		}
+
+		.alert-btn {
+			@include clay-button-variant($alert-btn);
+		}
+
+		.btn-group {
+			@include clay-container($btn-group);
+		}
+
+		.btn-group-item {
+			@include clay-container($btn-group-item);
+		}
+
+		.close {
+			@include clay-close($close);
+		}
+
+		.lead {
+			@include clay-css($lead);
+		}
+
+		.alert-link {
+			@include clay-link($alert-link);
+		}
+
+		.component-title {
+			@include clay-text-typography($component-title);
+		}
+
+		.component-subtitle {
+			@include clay-text-typography($component-subtitle);
+		}
 	}
 }

--- a/packages/clay-css/src/scss/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/variables/_alerts.scss
@@ -306,13 +306,17 @@ $alert-primary-link-hover-color: null !default;
 $alert-primary-btn: () !default;
 $alert-primary-btn: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $primary,
 		color: $primary,
-		hover-bg: $primary,
-		hover-color: color-yiq($primary),
-		active-bg: darken($primary, 5%),
-		active-border-color: darken($primary, 5%),
+		hover: (
+			background-color: $primary,
+			color: color-yiq($primary),
+		),
+		active: (
+			background-color: darken($primary, 5%),
+			border-color: darken($primary, 5%),
+		),
 	),
 	$alert-primary-btn
 );
@@ -365,13 +369,17 @@ $alert-secondary-link-hover-color: null !default;
 $alert-secondary-btn: () !default;
 $alert-secondary-btn: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $secondary,
 		color: $secondary,
-		hover-bg: $secondary,
-		hover-color: color-yiq($secondary),
-		active-bg: darken($secondary, 5%),
-		active-border-color: darken($secondary, 5%),
+		hover: (
+			background-color: $secondary,
+			color: color-yiq($secondary),
+		),
+		active: (
+			background-color: darken($secondary, 5%),
+			border-color: darken($secondary, 5%),
+		),
 	),
 	$alert-secondary-btn
 );
@@ -418,13 +426,17 @@ $alert-success-link-hover-color: null !default;
 $alert-success-btn: () !default;
 $alert-success-btn: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $success,
 		color: $success,
-		hover-bg: $success,
-		hover-color: color-yiq($success),
-		active-bg: darken($success, 5%),
-		active-border-color: darken($success, 5%),
+		hover: (
+			background-color: $success,
+			color: color-yiq($success),
+		),
+		active: (
+			background-color: darken($success, 5%),
+			border-color: darken($success, 5%),
+		),
 	),
 	$alert-success-btn
 );
@@ -468,13 +480,17 @@ $alert-info-link-hover-color: null !default;
 $alert-info-btn: () !default;
 $alert-info-btn: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $info,
 		color: $info,
-		hover-bg: $info,
-		hover-color: color-yiq($info),
-		active-bg: darken($info, 5%),
-		active-border-color: darken($info, 5%),
+		hover: (
+			background-color: $info,
+			color: color-yiq($info),
+		),
+		active: (
+			background-color: darken($info, 5%),
+			border-color: darken($info, 5%),
+		),
 	),
 	$alert-info-btn
 );
@@ -521,13 +537,17 @@ $alert-warning-link-hover-color: null !default;
 $alert-warning-btn: () !default;
 $alert-warning-btn: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $warning,
 		color: $warning,
-		hover-bg: $warning,
-		hover-color: color-yiq($warning),
-		active-bg: darken($warning, 5%),
-		active-border-color: darken($warning, 5%),
+		hover: (
+			background-color: $warning,
+			color: color-yiq($warning),
+		),
+		active: (
+			background-color: darken($warning, 5%),
+			border-color: darken($warning, 5%),
+		),
 	),
 	$alert-warning-btn
 );
@@ -574,13 +594,17 @@ $alert-danger-link-hover-color: null !default;
 $alert-danger-btn: () !default;
 $alert-danger-btn: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $danger,
 		color: $danger,
-		hover-bg: $danger,
-		hover-color: color-yiq($danger),
-		active-bg: darken($danger, 5%),
-		active-border-color: darken($danger, 5%),
+		hover: (
+			background-color: $danger,
+			color: color-yiq($danger),
+		),
+		active: (
+			background-color: darken($danger, 5%),
+			border-color: darken($danger, 5%),
+		),
 	),
 	$alert-danger-btn
 );
@@ -627,13 +651,17 @@ $alert-light-link-hover-color: null !default;
 $alert-light-btn: () !default;
 $alert-light-btn: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $secondary,
 		color: $secondary,
-		hover-bg: $secondary,
-		hover-color: color-yiq($secondary),
-		active-bg: darken($secondary, 5%),
-		active-border-color: darken($secondary, 5%),
+		hover: (
+			background-color: $secondary,
+			color: color-yiq($secondary),
+		),
+		active: (
+			background-color: darken($secondary, 5%),
+			border-color: darken($secondary, 5%),
+		),
 	),
 	$alert-light-btn
 );
@@ -677,13 +705,17 @@ $alert-dark-link-hover-color: null !default;
 $alert-dark-btn: () !default;
 $alert-dark-btn: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $dark,
 		color: $dark,
-		hover-bg: $dark,
-		hover-color: color-yiq($dark),
-		active-bg: darken($dark, 5%),
-		active-border-color: darken($dark, 5%),
+		hover: (
+			background-color: $dark,
+			color: color-yiq($dark),
+		),
+		active: (
+			background-color: darken($dark, 5%),
+			border-color: darken($dark, 5%),
+		),
 	),
 	$alert-dark-btn
 );

--- a/packages/clay-css/src/scss/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/variables/_alerts.scss
@@ -290,7 +290,7 @@ $alert-feedback: map-deep-merge(
 	$alert-feedback
 );
 
-// Alert Variants
+// .alert-primary
 
 $alert-primary-bg: theme-color-level(primary, $alert-bg-level) !default;
 $alert-primary-border-color: theme-color-level(
@@ -316,6 +316,37 @@ $alert-primary-btn: map-deep-merge(
 	),
 	$alert-primary-btn
 );
+
+$alert-primary: () !default;
+$alert-primary: map-deep-merge(
+	(
+		background-color: $alert-primary-bg,
+		border-color: $alert-primary-border-color,
+		color: $alert-primary-color,
+		hr: (
+			border-top-color: darken($alert-primary-border-color, 5%),
+		),
+		alert-btn: $alert-primary-btn,
+		close: (
+			color: $alert-primary-close-color,
+			hover: (
+				color: $alert-primary-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-primary-lead-color,
+		),
+		alert-link: (
+			color: $alert-primary-link-color,
+			hover: (
+				color: $alert-primary-link-hover-color,
+			),
+		),
+	),
+	$alert-primary
+);
+
+// .alert-secondary
 
 $alert-secondary-bg: theme-color-level(secondary, $alert-bg-level) !default;
 $alert-secondary-border-color: theme-color-level(
@@ -345,6 +376,34 @@ $alert-secondary-btn: map-deep-merge(
 	$alert-secondary-btn
 );
 
+$alert-secondary: () !default;
+$alert-secondary: map-deep-merge(
+	(
+		background-color: $alert-secondary-bg,
+		border-color: $alert-secondary-border-color,
+		color: $alert-secondary-color,
+		close: (
+			color: $alert-secondary-close-color,
+			hover: (
+				color: $alert-secondary-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-secondary-lead-color,
+		),
+		alert-link: (
+			color: $alert-secondary-link-color,
+			hover: (
+				color: $alert-secondary-link-hover-color,
+			),
+		),
+		alert-btn: $alert-secondary-btn,
+	),
+	$alert-secondary
+);
+
+// .alert-success
+
 $alert-success-bg: theme-color-level(success, $alert-bg-level) !default;
 $alert-success-border-color: theme-color-level(
 	success,
@@ -370,6 +429,34 @@ $alert-success-btn: map-deep-merge(
 	$alert-success-btn
 );
 
+$alert-success: () !default;
+$alert-success: map-deep-merge(
+	(
+		background-color: $alert-success-bg,
+		border-color: $alert-success-border-color,
+		color: $alert-success-color,
+		close: (
+			color: $alert-success-close-color,
+			hover: (
+				color: $alert-success-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-success-lead-color,
+		),
+		alert-link: (
+			color: $alert-success-link-color,
+			hover: (
+				color: $alert-success-link-hover-color,
+			),
+		),
+		alert-btn: $alert-success-btn,
+	),
+	$alert-success
+);
+
+// .alert-info
+
 $alert-info-bg: theme-color-level(info, $alert-bg-level) !default;
 $alert-info-border-color: theme-color-level(info, $alert-border-level) !default;
 $alert-info-color: theme-color-level(info, $alert-color-level) !default;
@@ -391,6 +478,34 @@ $alert-info-btn: map-deep-merge(
 	),
 	$alert-info-btn
 );
+
+$alert-info: () !default;
+$alert-info: map-deep-merge(
+	(
+		background-color: $alert-info-bg,
+		border-color: $alert-info-border-color,
+		color: $alert-info-color,
+		close: (
+			color: $alert-info-close-color,
+			hover: (
+				color: $alert-info-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-info-lead-color,
+		),
+		link: (
+			color: $alert-info-link-color,
+			hover: (
+				color: $alert-info-link-hover-color,
+			),
+		),
+		alert-btn: $alert-info-btn,
+	),
+	$alert-info
+);
+
+// .alert-warning
 
 $alert-warning-bg: theme-color-level(warning, $alert-bg-level) !default;
 $alert-warning-border-color: theme-color-level(
@@ -417,6 +532,34 @@ $alert-warning-btn: map-deep-merge(
 	$alert-warning-btn
 );
 
+$alert-warning: () !default;
+$alert-warning: map-deep-merge(
+	(
+		background-color: $alert-warning-bg,
+		border-color: $alert-warning-border-color,
+		color: $alert-warning-color,
+		close: (
+			color: $alert-warning-close-color,
+			hover: (
+				color: $alert-warning-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-warning-lead-color,
+		),
+		link: (
+			color: $alert-warning-link-color,
+			hover: (
+				color: $alert-warning-link-hover-color,
+			),
+		),
+		alert-btn: $alert-warning-btn,
+	),
+	$alert-warning
+);
+
+// .alert-danger
+
 $alert-danger-bg: theme-color-level(danger, $alert-bg-level) !default;
 $alert-danger-border-color: theme-color-level(
 	danger,
@@ -441,6 +584,34 @@ $alert-danger-btn: map-deep-merge(
 	),
 	$alert-danger-btn
 );
+
+$alert-danger: () !default;
+$alert-danger: map-deep-merge(
+	(
+		background-color: $alert-danger-bg,
+		border-color: $alert-danger-border-color,
+		color: $alert-danger-color,
+		close: (
+			color: $alert-danger-close-color,
+			hover: (
+				color: $alert-danger-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-danger-lead-color,
+		),
+		link: (
+			color: $alert-danger-link-color,
+			hover: (
+				color: $alert-danger-link-hover-color,
+			),
+		),
+		alert-btn: $alert-danger-btn,
+	),
+	$alert-danger
+);
+
+// .alert-light
 
 $alert-light-bg: theme-color-level(light, $alert-bg-level) !default;
 $alert-light-border-color: theme-color-level(
@@ -467,6 +638,34 @@ $alert-light-btn: map-deep-merge(
 	$alert-light-btn
 );
 
+$alert-light: () !default;
+$alert-light: map-deep-merge(
+	(
+		background-color: $alert-light-bg,
+		border-color: $alert-light-border-color,
+		color: $alert-light-color,
+		close: (
+			color: $alert-light-close-color,
+			hover: (
+				color: $alert-light-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-light-lead-color,
+		),
+		link: (
+			color: $alert-light-link-color,
+			hover: (
+				color: $alert-light-link-hover-color,
+			),
+		),
+		alert-btn: $alert-light-btn,
+	),
+	$alert-light
+);
+
+// .alert-dark
+
 $alert-dark-bg: theme-color-level(dark, $alert-bg-level) !default;
 $alert-dark-border-color: theme-color-level(dark, $alert-border-level) !default;
 $alert-dark-color: theme-color-level(dark, $alert-color-level) !default;
@@ -489,97 +688,43 @@ $alert-dark-btn: map-deep-merge(
 	$alert-dark-btn
 );
 
+$alert-dark: () !default;
+$alert-dark: map-deep-merge(
+	(
+		background-color: $alert-dark-bg,
+		border-color: $alert-dark-border-color,
+		color: $alert-dark-color,
+		close: (
+			color: $alert-dark-close-color,
+			hover: (
+				color: $alert-dark-close-hover-color,
+			),
+		),
+		lead: (
+			color: $alert-dark-lead-color,
+		),
+		link: (
+			color: $alert-dark-link-color,
+			hover: (
+				color: $alert-dark-link-hover-color,
+			),
+		),
+		alert-btn: $alert-dark-btn,
+	),
+	$alert-dark
+);
+
 $alert-palette: () !default;
 $alert-palette: map-deep-merge(
 	(
-		primary: (
-			bg: $alert-primary-bg,
-			border-color: $alert-primary-border-color,
-			color: $alert-primary-color,
-			close-color: $alert-primary-close-color,
-			close-hover-color: $alert-primary-close-hover-color,
-			lead-color: $alert-primary-lead-color,
-			link-color: $alert-primary-link-color,
-			link-hover-color: $alert-primary-link-hover-color,
-			alert-btn: $alert-primary-btn,
-		),
-		secondary: (
-			bg: $alert-secondary-bg,
-			border-color: $alert-secondary-border-color,
-			color: $alert-secondary-color,
-			close-color: $alert-secondary-close-color,
-			close-hover-color: $alert-secondary-close-hover-color,
-			lead-color: $alert-secondary-lead-color,
-			link-color: $alert-secondary-link-color,
-			link-hover-color: $alert-secondary-link-hover-color,
-			alert-btn: $alert-secondary-btn,
-		),
-		success: (
-			bg: $alert-success-bg,
-			border-color: $alert-success-border-color,
-			color: $alert-success-color,
-			close-color: $alert-success-close-color,
-			close-hover-color: $alert-success-close-hover-color,
-			lead-color: $alert-success-lead-color,
-			link-color: $alert-success-link-color,
-			link-hover-color: $alert-success-link-hover-color,
-			alert-btn: $alert-success-btn,
-		),
-		info: (
-			bg: $alert-info-bg,
-			border-color: $alert-info-border-color,
-			color: $alert-info-color,
-			close-color: $alert-info-close-color,
-			close-hover-color: $alert-info-close-hover-color,
-			lead-color: $alert-info-lead-color,
-			link-color: $alert-info-link-color,
-			link-hover-color: $alert-info-link-hover-color,
-			alert-btn: $alert-info-btn,
-		),
-		warning: (
-			bg: $alert-warning-bg,
-			border-color: $alert-warning-border-color,
-			color: $alert-warning-color,
-			close-color: $alert-warning-close-color,
-			close-hover-color: $alert-warning-close-hover-color,
-			lead-color: $alert-warning-lead-color,
-			link-color: $alert-warning-link-color,
-			link-hover-color: $alert-warning-link-hover-color,
-			alert-btn: $alert-warning-btn,
-		),
-		danger: (
-			bg: $alert-danger-bg,
-			border-color: $alert-danger-border-color,
-			color: $alert-danger-color,
-			close-color: $alert-danger-close-color,
-			close-hover-color: $alert-danger-close-hover-color,
-			lead-color: $alert-danger-lead-color,
-			link-color: $alert-danger-link-color,
-			link-hover-color: $alert-danger-link-hover-color,
-			alert-btn: $alert-danger-btn,
-		),
-		light: (
-			bg: $alert-light-bg,
-			border-color: $alert-light-border-color,
-			color: $alert-light-color,
-			close-color: $alert-light-close-color,
-			close-hover-color: $alert-light-close-hover-color,
-			lead-color: $alert-light-lead-color,
-			link-color: $alert-light-link-color,
-			link-hover-color: $alert-light-link-hover-color,
-			alert-btn: $alert-light-btn,
-		),
-		dark: (
-			bg: $alert-dark-bg,
-			border-color: $alert-dark-border-color,
-			color: $alert-dark-color,
-			close-color: $alert-dark-close-color,
-			close-hover-color: $alert-dark-close-hover-color,
-			lead-color: $alert-dark-lead-color,
-			link-color: $alert-dark-link-color,
-			link-hover-color: $alert-dark-link-hover-color,
-			alert-btn: $alert-dark-btn,
-		),
+		primary: $alert-primary,
+		secondary: $alert-secondary,
+		success: $alert-success,
+		info: $alert-info,
+		warning: $alert-warning,
+		danger: $alert-danger,
+		light: $alert-light,
+		dark: $alert-dark,
 	),
 	$alert-palette
 );


### PR DESCRIPTION
fixes #4304

- Make same changes to Cadmin
- Adds Sass maps `$alert-primary`, `$alert-secondary`, `$alert-info`, `$alert-warning`, `$alert-danger`, `$alert-light`, `$alert-dark`
- Use `clay-alert-variant` mixin to generate alert variant styles
- Mixins Alerts adds `clay-alert-variant` mixin and deprecate Bootstrap's `alert-variant` mixin