### PR TITLE
feat(@clayui/core): adds `onLoadMore` API to TreeView

### DIFF
--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -21,6 +21,7 @@ interface ITreeViewProps<T>
 		ICollectionProps<T> {
 	displayType?: 'light' | 'dark';
 	expanderIcons?: Icons;
+	onLoadMore?: (item: T) => void;
 	showExpanderOnHover?: boolean;
 }
 
@@ -42,6 +43,7 @@ export function TreeView<T>({
 	nestedKey,
 	onExpandedChange,
 	onItemsChange,
+	onLoadMore,
 	onSelectionChange,
 	selectedKeys,
 	showExpanderOnHover = true,
@@ -64,6 +66,7 @@ export function TreeView<T>({
 				: undefined,
 		expanderIcons,
 		nestedKey,
+		onLoadMore,
 		showExpanderOnHover,
 		...state,
 	};

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -21,7 +21,7 @@ interface ITreeViewProps<T>
 		ICollectionProps<T> {
 	displayType?: 'light' | 'dark';
 	expanderIcons?: Icons;
-	onLoadMore?: (item: T) => void;
+	onLoadMore?: (item: T) => Promise<unknown>;
 	showExpanderOnHover?: boolean;
 }
 

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -48,6 +48,7 @@ export function TreeViewGroup<T extends Record<any, any>>({
 			onExit={(el) => setElementFullHeight(el)}
 			onExiting={(el) => el.setAttribute('style', 'height: 0px')}
 			timeout={250}
+			unmountOnExit
 		>
 			<div>
 				<ul className="treeview-group" role="group">

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -85,13 +85,13 @@ export const TreeViewItem = React.forwardRef<HTMLDivElement, TreeViewItemProps>(
 						ref={ref}
 						role="treeitem"
 						style={{
-							paddingLeft: `${spacing}px`,
+							paddingLeft: `${spacing + (group ? 0 : 24)}px`,
 						}}
 						tabIndex={0}
 					>
 						<span
 							className="c-inner"
-							style={{marginLeft: `-${spacing}px`}}
+							style={{marginLeft: `-${spacing + (group ? 0 : 24)}px`}}
 							tabIndex={-2}
 						>
 							{typeof left === 'string' ? (

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -31,6 +31,7 @@ export const TreeViewItem = React.forwardRef<HTMLDivElement, TreeViewItemProps>(
 			childrenRoot,
 			expandedKeys,
 			nestedKey,
+			onLoadMore,
 			toggle,
 		} = useTreeViewContext();
 
@@ -72,7 +73,15 @@ export const TreeViewItem = React.forwardRef<HTMLDivElement, TreeViewItemProps>(
 							'treeview-dropping-top':
 								overTarget && overPosition === 'top',
 						})}
-						onClick={() => group && toggle(item.key)}
+						onClick={() => {
+							if (group) {
+								toggle(item.key);
+							} else {
+								if (onLoadMore) {
+									onLoadMore(item);
+								}
+							}
+						}}
 						ref={ref}
 						role="treeitem"
 						style={{

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -30,6 +30,7 @@ export const TreeViewItem = React.forwardRef<HTMLDivElement, TreeViewItemProps>(
 		const {
 			childrenRoot,
 			expandedKeys,
+			insert,
 			nestedKey,
 			onLoadMore,
 			toggle,
@@ -73,12 +74,15 @@ export const TreeViewItem = React.forwardRef<HTMLDivElement, TreeViewItemProps>(
 							'treeview-dropping-top':
 								overTarget && overPosition === 'top',
 						})}
-						onClick={() => {
+						onClick={async () => {
 							if (group) {
 								toggle(item.key);
 							} else {
 								if (onLoadMore) {
-									onLoadMore(item);
+									const items = await onLoadMore(item);
+
+									insert([...item.indexes, 0], items);
+									toggle(item.key);
 								}
 							}
 						}}
@@ -91,7 +95,9 @@ export const TreeViewItem = React.forwardRef<HTMLDivElement, TreeViewItemProps>(
 					>
 						<span
 							className="c-inner"
-							style={{marginLeft: `-${spacing + (group ? 0 : 24)}px`}}
+							style={{
+								marginLeft: `-${spacing + (group ? 0 : 24)}px`,
+							}}
 							tabIndex={-2}
 						>
 							{typeof left === 'string' ? (

--- a/packages/clay-core/src/tree-view/__tests__/useTree.ts
+++ b/packages/clay-core/src/tree-view/__tests__/useTree.ts
@@ -27,7 +27,7 @@ describe('useTree', () => {
 
 		const immutableTree = createImmutableTree(tree, 'children');
 
-		immutableTree.produce([0, 1], [0, 0]);
+		immutableTree.produce({from: [0, 1], op: 'move', path: [0, 0]});
 
 		expect(immutableTree.applyPatches()).not.toMatchObject(tree);
 	});
@@ -69,7 +69,7 @@ describe('useTree', () => {
 
 		const immutableTree = createImmutableTree(tree, 'children');
 
-		immutableTree.produce([2, 0], [1, 0]);
+		immutableTree.produce({from: [2, 0], op: 'move', path: [1, 0]});
 
 		const result = immutableTree.applyPatches();
 
@@ -117,7 +117,7 @@ describe('useTree', () => {
 
 		const immutableTree = createImmutableTree(tree, 'children');
 
-		immutableTree.produce([2, 0], [0, 1, 0]);
+		immutableTree.produce({from: [2, 0], op: 'move', path: [0, 1, 0]});
 
 		const result = immutableTree.applyPatches();
 
@@ -151,7 +151,7 @@ describe('useTree', () => {
 
 		const immutableTree = createImmutableTree(tree, 'children');
 
-		immutableTree.produce([1], [0]);
+		immutableTree.produce({from: [1], op: 'move', path: [0]});
 
 		const result = immutableTree.applyPatches();
 
@@ -185,7 +185,7 @@ describe('useTree', () => {
 
 		const immutableTree = createImmutableTree(tree, 'children');
 
-		immutableTree.produce([0], [1]);
+		immutableTree.produce({from: [0], op: 'move', path: [1]});
 
 		const result = immutableTree.applyPatches();
 
@@ -223,7 +223,7 @@ describe('useTree', () => {
 
 		const immutableTree = createImmutableTree(tree, 'children');
 
-		immutableTree.produce([0, 0], [0, 2]);
+		immutableTree.produce({from: [0, 0], op: 'move', path: [0, 2]});
 
 		const result = immutableTree.applyPatches();
 
@@ -263,7 +263,7 @@ describe('useTree', () => {
 
 		const immutableTree = createImmutableTree(tree, 'children');
 
-		immutableTree.produce([0, 1], [0, 0, 0]);
+		immutableTree.produce({from: [0, 1], op: 'move', path: [0, 0, 0]});
 
 		const result = immutableTree.applyPatches();
 
@@ -311,7 +311,7 @@ describe('useTree', () => {
 
 		const immutableTree = createImmutableTree(tree, 'children');
 
-		immutableTree.produce([0, 0], [0, 1, 0]);
+		immutableTree.produce({from: [0, 0], op: 'move', path: [0, 1, 0]});
 
 		const result = immutableTree.applyPatches();
 

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -16,6 +16,7 @@ export interface ITreeViewContext<T> extends ITreeState<T> {
 	childrenRoot?: (item: Object) => React.ReactElement;
 	expanderIcons?: Icons;
 	nestedKey?: string;
+	onLoadMore?: (item: any) => void;
 	showExpanderOnHover?: boolean;
 }
 

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -16,7 +16,7 @@ export interface ITreeViewContext<T> extends ITreeState<T> {
 	childrenRoot?: (item: Object) => React.ReactElement;
 	expanderIcons?: Icons;
 	nestedKey?: string;
-	onLoadMore?: (item: any) => void;
+	onLoadMore?: (item: any) => Promise<unknown>;
 	showExpanderOnHover?: boolean;
 }
 

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -109,20 +109,27 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 	};
 }
 
-// RFC 6902 4.4
+// Operation of `move` value to the same document structure, removing from
+// `from` and then adding to `path`.
+// RFC 6902 (JSON Patch) 4.4
 type PatchMove = {
 	op: 'move';
 	from: Array<number>;
 	path: Array<number>;
 };
 
-// RFC 6902 4.1
+// Operation of `add` value to the document structure.
+// RFC 6902 (JSON Patch) 4.1
 type PatchAdd = {
 	op: 'add';
 	path: Array<number>;
 	value: unknown;
 };
 
+// Patch refers to the implementation of RFC 6902 operations (JSON Patch)
+// https://datatracker.ietf.org/doc/html/rfc6902, we just borrow the document
+// structure to make partial updates to a JSON document.
+// Implementation Detail https://github.com/liferay/clay/pull/4254.
 type Patch = PatchMove | PatchAdd;
 
 export function createImmutableTree<T extends Array<Record<string, any>>>(

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -35,6 +35,7 @@ export interface ITreeProps<T>
 
 export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {
 	expandedKeys: Set<Key>;
+	insert: (path: Array<number>, value: unknown) => void;
 	open: (key: Key) => void;
 	reorder: (from: Array<number>, path: Array<number>) => void;
 	selection: IMultipleSelectionState;
@@ -62,7 +63,15 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 	const reorder = (from: Array<number>, path: Array<number>) => {
 		const tree = createImmutableTree(items, props.nestedKey!);
 
-		tree.produce(from, path);
+		tree.produce({from, op: 'move', path});
+
+		setItems(tree.applyPatches());
+	};
+
+	const insert = (path: Array<number>, value: unknown) => {
+		const tree = createImmutableTree(items, props.nestedKey!);
+
+		tree.produce({op: 'add', path, value});
 
 		setItems(tree.applyPatches());
 	};
@@ -91,6 +100,7 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 
 	return {
 		expandedKeys,
+		insert,
 		items,
 		open,
 		reorder,
@@ -100,11 +110,20 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 }
 
 // RFC 6902 4.4
-type Patch = {
+type PatchMove = {
 	op: 'move';
 	from: Array<number>;
 	path: Array<number>;
 };
+
+// RFC 6902 4.1
+type PatchAdd = {
+	op: 'add';
+	path: Array<number>;
+	value: unknown;
+};
+
+type Patch = PatchMove | PatchAdd;
 
 export function createImmutableTree<T extends Array<Record<string, any>>>(
 	initialTree: T,
@@ -181,14 +200,25 @@ export function createImmutableTree<T extends Array<Record<string, any>>>(
 
 	function applyPatches(): T {
 		patches.forEach((patch) => {
-			const {from, op, path} = patch;
+			switch (patch.op) {
+				case 'add': {
+					const {path, value} = patch;
 
-			switch (op) {
+					const node = nodeByPath(path);
+
+					if (node.parent) {
+						node.parent[nestedKey] = value;
+					}
+
+					break;
+				}
 				// Applies the operation on the tree, the move is functionally
 				// identical to a "remove" operation on the `from` location and
 				// immediately followed by the "add" operation at the target
 				// location with the value that was removed.
 				case 'move': {
+					const {from, path} = patch;
+
 					const nodeToRemove = nodeByPath(from);
 
 					if (nodeToRemove.parent) {
@@ -236,8 +266,8 @@ export function createImmutableTree<T extends Array<Record<string, any>>>(
 		return immutableTree;
 	}
 
-	function produce(from: Array<number>, path: Array<number>) {
-		patches.push({from, op: 'move', path});
+	function produce(patch: Patch) {
+		patches.push(patch);
 	}
 
 	return {

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -85,6 +85,28 @@ const ITEMS_DRIVE = [
 	},
 ];
 
+let nodeId = 0;
+
+const createNode = (depth: number = 0) => {
+	const node = {
+		children: [],
+		id: nodeId,
+		name: `node-${nodeId}`,
+	};
+
+	nodeId += 1;
+
+	if (depth === 5) {
+		return node;
+	}
+
+	for (let i = 0; i < 10; i++) {
+		node.children.push(createNode(depth + 1));
+	}
+
+	return node;
+};
+
 storiesOf('Components|ClayTreeView', module)
 	.add('light', () => (
 		<Provider spritemap={spritemap} theme="cadmin">
@@ -443,6 +465,30 @@ storiesOf('Components|ClayTreeView', module)
 										<Icon symbol="folder" />
 										{item.name}
 									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
+	.add('large data', () => {
+		const rootNode = createNode();
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView
+					items={[rootNode]}
+					nestedKey="children"
+					showExpanderOnHover={false}
+				>
+					{(item) => (
+						<TreeView.Item>
+							<TreeView.ItemStack>{item.name}</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item>{item.name}</TreeView.Item>
 								)}
 							</TreeView.Group>
 						</TreeView.Item>

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -87,8 +87,14 @@ const ITEMS_DRIVE = [
 
 let nodeId = 0;
 
+type Node = {
+	children: Array<Node>;
+	id: number;
+	name: string;
+};
+
 const createNode = (depth: number = 0) => {
-	const node = {
+	const node: Node = {
 		children: [],
 		id: nodeId,
 		name: `node-${nodeId}`,
@@ -487,8 +493,57 @@ storiesOf('Components|ClayTreeView', module)
 						<TreeView.Item>
 							<TreeView.ItemStack>{item.name}</TreeView.ItemStack>
 							<TreeView.Group items={item.children}>
-								{(item) => (
+								{(item: typeof rootNode) => (
 									<TreeView.Item>{item.name}</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
+	.add('async load', () => {
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView
+					items={ITEMS_DRIVE}
+					nestedKey="children"
+					onLoadMore={async (item) => {
+						// Delay to simulate loading of new data
+						await new Promise((resolve) => {
+							setTimeout(() => resolve(''), 100);
+						});
+
+						return [
+							{
+								id: Math.random(),
+								name: `${item.name} ${Math.random()}`,
+							},
+							{
+								id: Math.random(),
+								name: `${item.name} ${Math.random()}`,
+							},
+							{
+								id: Math.random(),
+								name: `${item.name} ${Math.random()}`,
+							},
+						];
+					}}
+					showExpanderOnHover={false}
+				>
+					{(item) => (
+						<TreeView.Item>
+							<TreeView.ItemStack>
+								<Icon symbol="folder" />
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item>
+										<Icon symbol="folder" />
+										{item.name}
+									</TreeView.Item>
 								)}
 							</TreeView.Group>
 						</TreeView.Item>


### PR DESCRIPTION
Well, this is a very early draft for implementing "load more" or allowing the TreeView to load a large amount of data and still work fine without causing any slowdowns or crashes, yet this component doesn't implement any improvement related to loading a render a big payload.

One of the first attempts here is to allow you to load parts of the structure asynchronously, the final implementation is not yet ready to deal with this, there are some tradeoffs we will have to deal with and we can also try different strategies on how to approach this:

- The TreeView shouldn't handle the responsibility of loading asynchronous data or handling it, it's data agnostic. This is responsible for the `useResource` hook which will load the data with the possibility of aggregating the data and fetching using a "cursor". Currently `useResource` doesn't support this type of loading and also doesn't know how to handle multiple requests what we would have to do here is create a hook like `useTreeResource` to handle the data and aggregate.
- The TreeView uses the return from `onLoadMore` which must be a promise with the items and internally we do the aggregation and update the state.

There are some tradeoffs that we still have to deal with, the implementation of "load more" will harm the multiple selection, because we depend on creating the structure layout using the flat structure to reduce very high operating costs, and not using this will be slow but there are strategies that can mitigate this problem, such as treating the selected items only the visible ones and providing methods that retrieve all the ids of the selected items, because we would have to traverse the entire tree looking for these ids, so it would be less costly to do this every time select an item.

There is also a problem that "load more" does not solve, as the nodes are being expanded, it gets slower and slower. I did some tests on the storybook demo that renders a large number of nodes distributed in 10 items per level and the maximum depth of 5 levels, we reached 111,110 items, when having at least 120 nodes open up to half of this it is possible to notice a slowness too high, reaching around ~200ms for React to complete the commit in the DOM, this number can also be higher if you use the performance to evaluate instead of checking the React Profiler. We can also see a slow page with a smaller amount of expanded items if the same level has much more than 10, so maybe having 150 items may be that just opening 10 nodes can be very slow, the "load more" doesn't solve it because it just saves the using memory but not rendering, I still insist that the best way to handle rendering is to use virtualization.

There are many performance fronts that we are tackling so far, the multiple selection implementation, the expandable APIs, and the DnD implementation that avoids traversing the tree every time you do an operation but we haven't solved the rendering part yet.