### PR TITLE
fix(@clayui/css): Accessibility unique fix for 7.0.x, add 'box-shadow' property when using 'outline: 0;'

### DIFF
--- a/src/scss/bootstrap/_dropdowns.scss
+++ b/src/scss/bootstrap/_dropdowns.scss
@@ -24,6 +24,7 @@
 
 // Prevent the focus on the dropdown toggle when closing dropdowns
 .dropdown-toggle:focus {
+  @include box-shadow(0 3px 9px rgba(0, 0, 0, .5));
   outline: 0;
 }
 


### PR DESCRIPTION
fix(@clayui/css): Accessibility unique fix for 7.0.x, add `box-shadow` property when using `outline: 0;` in `src/scss/bootstrap/_dropdowns.scss`

Affected file: `/o/classic-theme/css/aui.css`

For more details please check: [LPS-133314](https://issues.liferay.com/browse/LPS-133314) and [LPS-140134](https://issues.liferay.com/browse/LPS-140134)

Fixes #4318

/cc  @georgel-pop-lr