### PR TITLE
fix(@clayui/form): change the Dual List Box ordering side following the right side as the default behavior

### DIFF
--- a/packages/clay-form/src/DualListBox.tsx
+++ b/packages/clay-form/src/DualListBox.tsx
@@ -150,9 +150,7 @@ const ClayDualListBox: React.FunctionComponent<IProps> = ({
 						onItemsChange([newLeftItems, rightItems])
 					}
 					onSelectChange={handleLeftSelectedChange}
-					showArrows
 					size={size}
-					spritemap={spritemap}
 					value={leftSelected}
 				/>
 
@@ -206,7 +204,9 @@ const ClayDualListBox: React.FunctionComponent<IProps> = ({
 						onItemsChange([leftItems, newRightItems])
 					}
 					onSelectChange={handleRightSelectedChange}
+					showArrows
 					size={size}
+					spritemap={spritemap}
 					value={rightSelected}
 				/>
 			</div>

--- a/packages/clay-form/src/__tests__/__snapshots__/DualListBox.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/DualListBox.tsx.snap
@@ -46,45 +46,6 @@ exports[`Rendering renders ClayDualListBox 1`] = `
           <div
             class="clay-reorder-underlay form-control"
           />
-          <div
-            class="clay-reorder-footer"
-          >
-            <div
-              class="reorder-order-buttons btn-group"
-              role="group"
-            >
-              <button
-                aria-label="Reorder Up"
-                class="reorder-button reorder-button-up btn btn-monospaced btn-sm btn-secondary"
-                disabled=""
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-caret-top"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="/path/to/some/resource.svg#caret-top"
-                  />
-                </svg>
-              </button>
-              <button
-                aria-label="Reorder Down"
-                class="reorder-button reorder-button-down btn btn-monospaced btn-sm btn-secondary"
-                disabled=""
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-caret-bottom"
-                  role="presentation"
-                >
-                  <use
-                    xlink:href="/path/to/some/resource.svg#caret-bottom"
-                  />
-                </svg>
-              </button>
-            </div>
-          </div>
         </div>
       </div>
       <div
@@ -153,6 +114,45 @@ exports[`Rendering renders ClayDualListBox 1`] = `
           <div
             class="clay-reorder-underlay form-control"
           />
+          <div
+            class="clay-reorder-footer"
+          >
+            <div
+              class="reorder-order-buttons btn-group"
+              role="group"
+            >
+              <button
+                aria-label="Reorder Up"
+                class="reorder-button reorder-button-up btn btn-monospaced btn-sm btn-secondary"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-top"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#caret-top"
+                  />
+                </svg>
+              </button>
+              <button
+                aria-label="Reorder Down"
+                class="reorder-button reorder-button-down btn btn-monospaced btn-sm btn-secondary"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-bottom"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="/path/to/some/resource.svg#caret-bottom"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/clay-form/stories/index.tsx
+++ b/packages/clay-form/stories/index.tsx
@@ -41,6 +41,20 @@ const ClayCheckboxWithState = () => {
 const moveBoxesOptions = [
 	[
 		{
+			label: 'Reddit',
+			value: 'reddit',
+		},
+		{
+			label: 'Slack',
+			value: 'slack',
+		},
+		{
+			label: 'Twitter',
+			value: 'twitter',
+		},
+	],
+	[
+		{
 			label: 'Discord',
 			value: 'discord',
 		},
@@ -57,20 +71,6 @@ const moveBoxesOptions = [
 			value: 'linkedin',
 		},
 	],
-	[
-		{
-			label: 'Reddit',
-			value: 'reddit',
-		},
-		{
-			label: 'Slack',
-			value: 'slack',
-		},
-		{
-			label: 'Twitter',
-			value: 'twitter',
-		},
-	],
 ];
 
 storiesOf('Components|ClayDualListBox', module).add('default', () => {
@@ -80,8 +80,8 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 
 	const [firstSelectBoxItems, secondSelectBoxItems] = items;
 
-	const leftMaxItems = number('leftMaxItems', 3);
-	const rightMaxItems = number('rightMaxItems', 5);
+	const leftMaxItems = number('leftMaxItems', 5);
+	const rightMaxItems = number('rightMaxItems', 3);
 
 	return (
 		<ClayDualListBox
@@ -96,14 +96,14 @@ storiesOf('Components|ClayDualListBox', module).add('default', () => {
 			items={items}
 			left={{
 				id: 'leftSelectBox',
-				label: 'In Use',
+				label: 'Available',
 				onSelectChange: setLeftSelected,
 				selected: leftSelected,
 			}}
 			onItemsChange={setItems}
 			right={{
 				id: 'rightSelectBox',
-				label: 'Available',
+				label: 'In Use',
 				onSelectChange: setRightSelected,
 				selected: rightSelected,
 			}}


### PR DESCRIPTION
Fixes #4312

See issue https://github.com/liferay/clay/issues/4312 to understand the context of the change and why we are following this as a fix rather than not changing this default behavior now.