### PR TITLE
fix(@clayui/css): Atlas and Cadmin Stickers swap background and foreground colors for `sticker-light` and `sticker-dark`

### DIFF
--- a/packages/clay-css/src/content/badges_and_labels.html
+++ b/packages/clay-css/src/content/badges_and_labels.html
@@ -983,9 +983,7 @@ section: Components
 	<span class="sticker sticker-info">133</span>
 	<span class="sticker sticker-warning">133</span>
 	<span class="sticker sticker-danger">133</span>
-	<div class="clay-site-light-container" style="vertical-align: baseline;">
-		<span class="sticker sticker-light">133</span>
-	</div>
+	<span class="sticker sticker-light">133</span>
 	<span class="sticker sticker-dark">133</span>
 </div>
 
@@ -996,9 +994,7 @@ section: Components
 	<span class="sticker sticker-circle sticker-info">133</span>
 	<span class="sticker sticker-circle sticker-warning">133</span>
 	<span class="sticker sticker-circle sticker-danger">133</span>
-	<div class="clay-site-light-container" style="vertical-align: baseline;">
-		<span class="sticker sticker-circle sticker-light">133</span>
-	</div>
+	<span class="sticker sticker-circle sticker-light">133</span>
 	<span class="sticker sticker-circle sticker-dark">133</span>
 </div>
 

--- a/packages/clay-css/src/scss/atlas/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_stickers.scss
@@ -61,8 +61,8 @@ $sticker-warning-color: $warning !default;
 $sticker-danger-bg: $white !default;
 $sticker-danger-color: $danger !default;
 
-$sticker-light-bg: $white !default;
-$sticker-light-color: $dark !default;
+$sticker-light-bg: color-yiq($white) !default;
+$sticker-light-color: $light !default;
 
-$sticker-dark-bg: $dark !default;
-$sticker-dark-color: $white !default;
+$sticker-dark-bg: $white !default;
+$sticker-dark-color: $dark !default;

--- a/packages/clay-css/src/scss/cadmin/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_stickers.scss
@@ -85,13 +85,13 @@ $cadmin-sticker-danger-bg: $cadmin-white !default;
 $cadmin-sticker-danger-border-color: null !default;
 $cadmin-sticker-danger-color: $cadmin-danger !default;
 
-$cadmin-sticker-light-bg: $cadmin-white !default;
+$cadmin-sticker-light-bg: color-yiq($cadmin-white) !default;
 $cadmin-sticker-light-border-color: null !default;
-$cadmin-sticker-light-color: $cadmin-dark !default;
+$cadmin-sticker-light-color: $cadmin-light !default;
 
-$cadmin-sticker-dark-bg: $cadmin-dark !default;
+$cadmin-sticker-dark-bg: $cadmin-white !default;
 $cadmin-sticker-dark-border-color: null !default;
-$cadmin-sticker-dark-color: $cadmin-white !default;
+$cadmin-sticker-dark-color: $cadmin-dark !default;
 
 $cadmin-sticker-palette: () !default;
 $cadmin-sticker-palette: map-deep-merge(


### PR DESCRIPTION
fixes #4310

 BREAKING CHANGE: `sticker-light` now has a light font color and `sticker-dark` has a dark font color. All instances of `sticker-light` should be updated to use `sticker-dark` and all instances of `sticker-dark` should be updated to use `sticker-light`. If you do not want to make this change in your markup, you can revert back to the original styles with:
    
```
$sticker-light-bg: $dark !default;
$sticker-light-color: $white !default;
    
$sticker-dark-bg: $dark !default;
$sticker-dark-color: $white !default;
```