### PR TITLE
chore(@lexicon-ux): Don't bump the version number used for copyright …

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,13 +104,14 @@ gulp.task(
 						if (answers.publish) {
 							var args = [
 								'release:git',
+								'release:build',
 								'release:publish',
 								cb
 							];
 
 							if (answers.packageManagers) {
-								args.splice(2, 0, 'maven-publish');
-								args.splice(3, 0, 'release:npm');
+								args.splice(3, 0, 'maven-publish');
+								args.splice(4, 0, 'release:npm');
 							}
 
 							runSequence.apply(null, args);

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -85,8 +85,6 @@ module.exports = function(gulp, plugins, _, config) {
 				}
 			);
 
-			license.metadata.version = bumpedVersion;
-
 			return gulp.src([
 				'src/fonts/**/*',
 				'src/images/icons/*',


### PR DESCRIPTION
…text in `release:build`, it should use the version number in `package.json` as is.

chore(@lexicon-ux): Re-run `release:build` before `release:publish` so copyright text version numbers get updated when `release:git` bumps `package.json` version.

fixes #4332