### PR TITLE
fix(@clayui/css): Border utilities `border-color` is the wrong value.…

### DIFF
--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -228,19 +228,19 @@ caption {
 
 @each $color, $value in $table-row-theme-colors {
 	.table-#{$color} {
+		$table-row: setter($value, ());
+
 		&,
 		> th,
 		> td {
-			@include clay-css(setter($value, ()));
+			@include clay-css($table-row);
 		}
-
-		$border-color: setter(map-get($value, border-color), ());
 
 		th,
 		td,
 		thead th,
 		tbody + tbody {
-			border-color: $border-color;
+			border-color: map-get($table-row, border-color);
 		}
 	}
 


### PR DESCRIPTION
… Table Row Variants scoped `$border-color` variable was overwriting global `$border-color` variable

fixes #4350 