### PR TITLE
fix(@clayui/css): Global Functions `math-sign` uses deprecated `@else…

### DIFF
--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -77,8 +77,7 @@
 @function math-sign($num) {
 	@if (type-of($num) == 'number') {
 		@return -($num);
-	}
-	@elseif (type-of($num) == 'string') {
+	} @else if (type-of($num) == 'string') {
 		@if (starts-with($num, 'var(--')) {
 			@return calc(#{$num} * -1);
 		}


### PR DESCRIPTION
…if` syntax, changed to `@else if`

fixes #4353

@matuzalemsteles I thought this one might have been tough, but it turned out to be a non issue.