### PR TITLE
feat(@clayui/css): Stickers and Cadmin Stickers convert to using Sass maps for more customizability

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_stickers.scss
@@ -1,7 +1,18 @@
+// .sticker
+
 $sticker-font-size: 1rem !default; // 16px
 $sticker-font-weight: $font-weight-bold !default;
 
-// Sticker Sizes
+$sticker: () !default;
+$sticker: map-deep-merge(
+	(
+		font-size: $sticker-font-size,
+		font-weight: $sticker-font-weight,
+	),
+	$sticker
+);
+
+// .sticker-sm
 
 $sticker-sm: () !default;
 $sticker-sm: map-deep-merge(
@@ -11,6 +22,8 @@ $sticker-sm: map-deep-merge(
 	$sticker-sm
 );
 
+// .sticker-lg
+
 $sticker-lg: () !default;
 $sticker-lg: map-deep-merge(
 	(
@@ -18,6 +31,8 @@ $sticker-lg: map-deep-merge(
 	),
 	$sticker-lg
 );
+
+// .sticker-xl
 
 $sticker-xl: () !default;
 $sticker-xl: map-deep-merge(
@@ -31,7 +46,60 @@ $sticker-xl: map-deep-merge(
 
 $sticker-inside-offset: 1rem !default; // 16px
 
-// Sticker User Icon
+// .sticker-bottom-left
+
+$sticker-bottom-left: () !default;
+$sticker-bottom-left: map-merge(
+	(
+		bottom: $sticker-inside-offset,
+		left: $sticker-inside-offset,
+		position: absolute,
+		right: auto,
+		top: auto,
+	),
+	$sticker-bottom-left
+);
+
+// .sticker-bottom-right
+
+$sticker-bottom-right: () !default;
+$sticker-bottom-right: map-merge(
+	(
+		bottom: $sticker-inside-offset,
+		left: auto,
+		position: absolute,
+		right: $sticker-inside-offset,
+		top: auto,
+	),
+	$sticker-bottom-right
+);
+
+// .sticker-top-left
+
+$sticker-top-left: () !default;
+$sticker-top-left: map-merge(
+	(
+		left: $sticker-inside-offset,
+		position: absolute,
+		top: $sticker-inside-offset,
+	),
+	$sticker-top-left
+);
+
+// .sticker-top-right
+
+$sticker-top-right: () !default;
+$sticker-top-right: map-merge(
+	(
+		left: auto,
+		position: absolute,
+		right: $sticker-inside-offset,
+		top: $sticker-inside-offset,
+	),
+	$sticker-top-right
+);
+
+// .sticker-user-icon
 
 $sticker-user-icon: () !default;
 $sticker-user-icon: map-deep-merge(
@@ -41,28 +109,114 @@ $sticker-user-icon: map-deep-merge(
 	$sticker-user-icon
 );
 
-// Sticker Variants
+// .sticker-primary
 
 $sticker-primary-bg: $white !default;
 $sticker-primary-color: $primary !default;
 
+$sticker-primary: () !default;
+$sticker-primary: map-deep-merge(
+	(
+		background-color: $sticker-primary-bg,
+		color: $sticker-primary-color,
+	),
+	$sticker-primary
+);
+
+// .sticker-secondary
+
 $sticker-secondary-bg: $white !default;
 $sticker-secondary-color: $secondary !default;
+
+$sticker-secondary: () !default;
+$sticker-secondary: map-deep-merge(
+	(
+		background-color: $sticker-secondary-bg,
+		color: $sticker-secondary-color,
+	),
+	$sticker-secondary
+);
+
+// .sticker-info
 
 $sticker-info-bg: $white !default;
 $sticker-info-color: $info !default;
 
+$sticker-info: () !default;
+$sticker-info: map-deep-merge(
+	(
+		background-color: $sticker-info-bg,
+		color: $sticker-info-color,
+	),
+	$sticker-info
+);
+
+// .sticker-success
+
 $sticker-success-bg: $white !default;
 $sticker-success-color: $success !default;
+
+$sticker-success: () !default;
+$sticker-success: map-deep-merge(
+	(
+		background-color: $sticker-success-bg,
+		color: $sticker-success-color,
+	),
+	$sticker-success
+);
+
+// .sticker-warning
 
 $sticker-warning-bg: $white !default;
 $sticker-warning-color: $warning !default;
 
+$sticker-warning: () !default;
+$sticker-warning: map-deep-merge(
+	(
+		background-color: $sticker-warning-bg,
+		color: $sticker-warning-color,
+	),
+	$sticker-warning
+);
+
+// .sticker-danger
+
 $sticker-danger-bg: $white !default;
 $sticker-danger-color: $danger !default;
+
+$sticker-danger: () !default;
+$sticker-danger: map-deep-merge(
+	(
+		background-color: $sticker-danger-bg,
+		color: $sticker-danger-color,
+	),
+	$sticker-danger
+);
+
+// .sticker-light
 
 $sticker-light-bg: color-yiq($white) !default;
 $sticker-light-color: $light !default;
 
+$sticker-light: () !default;
+$sticker-light: map-deep-merge(
+	(
+		background-color: $sticker-light-bg,
+		color: $sticker-light-color,
+	),
+	$sticker-light
+);
+
+// .sticker-dark
+
 $sticker-dark-bg: $white !default;
 $sticker-dark-color: $dark !default;
+
+$sticker-dark: () !default;
+$sticker-dark: map-deep-merge(
+	(
+		background-color: $sticker-dark-bg,
+		color: $sticker-dark-color,
+	),
+	$sticker-dark
+);

--- a/packages/clay-css/src/scss/atlas/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_stickers.scss
@@ -42,6 +42,16 @@ $sticker-xl: map-deep-merge(
 	$sticker-xl
 );
 
+$sticker-sizes: () !default;
+$sticker-sizes: map-deep-merge(
+	(
+		sticker-sm: $sticker-sm,
+		sticker-lg: $sticker-lg,
+		sticker-xl: $sticker-xl,
+	),
+	$sticker-sizes
+);
+
 // Sticker Positions
 
 $sticker-inside-offset: 1rem !default; // 16px

--- a/packages/clay-css/src/scss/cadmin/components/_sidebar.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_sidebar.scss
@@ -90,7 +90,7 @@
 	}
 
 	.sticker {
-		@include clay-sticker-size($cadmin-sidebar-list-group-sticker-size);
+		@include clay-sticker-variant($cadmin-sidebar-list-group-sticker-size);
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_stickers.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_stickers.scss
@@ -1,44 +1,5 @@
 .sticker {
-	align-items: center;
-	border-color: $cadmin-sticker-border-color;
-
-	@include border-radius($cadmin-sticker-border-radius);
-
-	border-style: $cadmin-sticker-border-style;
-	border-width: $cadmin-sticker-border-width;
-	color: $cadmin-sticker-color;
-
-	@include clay-monospace($cadmin-sticker-size);
-
-	display: inline-flex;
-	font-size: $cadmin-sticker-font-size;
-	font-weight: $cadmin-sticker-font-weight;
-	justify-content: center;
-	position: relative;
-	text-align: center;
-	vertical-align: middle;
-
-	> .inline-item {
-		font-size: $cadmin-sticker-inline-item-font-size;
-		justify-content: center;
-	}
-
-	> .inline-item .lexicon-icon,
-	.lexicon-icon {
-		margin-top: 0;
-	}
-
-	&.rounded .sticker-overlay {
-		border-radius: $cadmin-rounded-border-radius;
-	}
-
-	&.rounded-circle .sticker-overlay {
-		border-radius: $cadmin-rounded-circle-border-radius;
-	}
-
-	&.rounded-0 .sticker-overlay {
-		border-radius: 0;
-	}
+	@include clay-sticker-variant($cadmin-sticker);
 }
 
 .sticker-img {
@@ -47,70 +8,55 @@
 }
 
 .sticker-overlay {
-	align-items: center;
-
-	@include border-radius($cadmin-sticker-border-radius);
-
-	bottom: 0;
-	display: flex;
-	justify-content: center;
-	left: 0;
-	overflow: hidden;
-	position: absolute;
-	right: 0;
-	top: 0;
+	@include clay-css($cadmin-sticker-overlay);
 }
 
 // Sticker Positions
 
 .sticker-bottom-left {
-	bottom: $cadmin-sticker-inside-offset;
-	left: $cadmin-sticker-inside-offset;
-	position: absolute;
-	right: auto;
-	top: auto;
+	@include clay-css($cadmin-sticker-bottom-left);
 }
 
 .sticker-bottom-right {
-	bottom: $cadmin-sticker-inside-offset;
-	left: auto;
-	position: absolute;
-	right: $cadmin-sticker-inside-offset;
-	top: auto;
+	@include clay-css($cadmin-sticker-bottom-right);
 }
 
 .sticker-top-left {
-	left: $cadmin-sticker-inside-offset;
-	position: absolute;
-	top: $cadmin-sticker-inside-offset;
+	@include clay-css($cadmin-sticker-top-left);
 }
 
 .sticker-top-right {
-	left: auto;
-	position: absolute;
-	right: $cadmin-sticker-inside-offset;
-	top: $cadmin-sticker-inside-offset;
+	@include clay-css($cadmin-sticker-top-right);
 }
 
 .sticker-outside {
-	left: $cadmin-sticker-outside-offset;
-	top: $cadmin-sticker-outside-offset;
+	@include clay-css($cadmin-sticker-outside);
 
 	&.sticker-bottom-left {
-		bottom: $cadmin-sticker-outside-offset;
-		top: auto;
+		$bottom-left: setter(
+			map-get($cadmin-sticker-outside, sticker-bottom-left),
+			()
+		);
+
+		@include clay-css($bottom-left);
 	}
 
 	&.sticker-bottom-right {
-		bottom: $cadmin-sticker-outside-offset;
-		left: auto;
-		right: $cadmin-sticker-outside-offset;
-		top: auto;
+		$bottom-right: setter(
+			map-get($cadmin-sticker-outside, sticker-bottom-right),
+			()
+		);
+
+		@include clay-css($bottom-right);
 	}
 
 	&.sticker-top-right {
-		left: auto;
-		right: $cadmin-sticker-outside-offset;
+		$top-right: setter(
+			map-get($cadmin-sticker-outside, sticker-top-right),
+			()
+		);
+
+		@include clay-css($top-right);
 	}
 }
 
@@ -122,31 +68,30 @@
 
 // Sticker Sizes
 
-.sticker-sm {
-	@include clay-sticker-size($cadmin-sticker-sm);
-}
+@each $cadmin-selector, $cadmin-value in $cadmin-sticker-sizes {
+	%#{$cadmin-selector} {
+		@include clay-sticker-variant($cadmin-value);
+	}
 
-.sticker-lg {
-	@include clay-sticker-size($cadmin-sticker-lg);
-}
-
-.sticker-xl {
-	@include clay-sticker-size($cadmin-sticker-xl);
+	.#{$cadmin-selector} {
+		@extend %#{$cadmin-selector} !optional;
+	}
 }
 
 // Sticker Variants
 
 @each $cadmin-color, $cadmin-value in $cadmin-sticker-palette {
+	%sticker-#{$cadmin-color} {
+		@include clay-sticker-variant($cadmin-value);
+	}
+
 	.sticker-#{$cadmin-color} {
-		background-color: map-get($cadmin-value, bg);
-		border-color: map-get($cadmin-value, border-color);
-		color: map-get($cadmin-value, color);
+		@extend %sticker-#{$cadmin-color} !optional;
 	}
 }
 
 // Sticker Circle
 
-.sticker-circle,
-.sticker-circle .sticker-overlay {
-	@include border-radius($cadmin-sticker-circle-border-radius);
+.sticker-circle {
+	@include clay-sticker-variant($cadmin-sticker-circle);
 }

--- a/packages/clay-css/src/scss/cadmin/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_stickers.scss
@@ -1,3 +1,5 @@
+// .sticker
+
 $cadmin-sticker-border-color: null !default;
 $cadmin-sticker-border-radius: $cadmin-border-radius !default;
 $cadmin-sticker-border-style: null !default;
@@ -8,6 +10,58 @@ $cadmin-sticker-font-weight: $cadmin-font-weight-bold !default;
 $cadmin-sticker-size: 32px !default; // 32px
 
 $cadmin-sticker-inline-item-font-size: null !default;
+
+$cadmin-sticker: () !default;
+$cadmin-sticker: map-deep-merge(
+	(
+		align-items: center,
+		border-color: $cadmin-sticker-border-color,
+		border-radius: clay-enable-rounded($cadmin-sticker-border-radius),
+		border-style: $cadmin-sticker-border-style,
+		border-width: $cadmin-sticker-border-width,
+		color: $cadmin-sticker-color,
+		display: inline-flex,
+		font-size: $cadmin-sticker-font-size,
+		font-weight: $cadmin-sticker-font-weight,
+		height: $cadmin-sticker-size,
+		justify-content: center,
+		line-height: $cadmin-sticker-size,
+		position: relative,
+		text-align: center,
+		vertical-align: middle,
+		width: $cadmin-sticker-size,
+		inline-item: (
+			font-size: $cadmin-sticker-inline-item-font-size,
+			justify-content: center,
+			lexicon-icon: (
+				margin-top: 0,
+			),
+		),
+		lexicon-icon: (
+			margin-top: 0,
+		),
+	),
+	$cadmin-sticker
+);
+
+// .sticker-overlay
+
+$cadmin-sticker-overlay: () !default;
+$cadmin-sticker-overlay: map-merge(
+	(
+		align-items: center,
+		border-radius: inherit,
+		bottom: 0,
+		display: flex,
+		justify-content: center,
+		left: 0,
+		overflow: hidden,
+		position: absolute,
+		right: 0,
+		top: 0,
+	),
+	$cadmin-sticker-overlay
+);
 
 // Sticker Sizes
 
@@ -38,104 +92,263 @@ $cadmin-sticker-xl: map-deep-merge(
 	$cadmin-sticker-xl
 );
 
+$cadmin-sticker-sizes: () !default;
+$cadmin-sticker-sizes: map-deep-merge(
+	(
+		sticker-sm: $cadmin-sticker-sm,
+		sticker-lg: $cadmin-sticker-lg,
+		sticker-xl: $cadmin-sticker-xl,
+	),
+	$cadmin-sticker-sizes
+);
+
 // Sticker Positions
 
 $cadmin-sticker-inside-offset: 16px !default; // 16px
+
+// .sticker-bottom-left
+
+$cadmin-sticker-bottom-left: () !default;
+$cadmin-sticker-bottom-left: map-merge(
+	(
+		bottom: $cadmin-sticker-inside-offset,
+		left: $cadmin-sticker-inside-offset,
+		position: absolute,
+		right: auto,
+		top: auto,
+	),
+	$cadmin-sticker-bottom-left
+);
+
+// .sticker-bottom-right
+
+$cadmin-sticker-bottom-right: () !default;
+$cadmin-sticker-bottom-right: map-merge(
+	(
+		bottom: $cadmin-sticker-inside-offset,
+		left: auto,
+		position: absolute,
+		right: $cadmin-sticker-inside-offset,
+		top: auto,
+	),
+	$cadmin-sticker-bottom-right
+);
+
+// .sticker-top-left
+
+$cadmin-sticker-top-left: () !default;
+$cadmin-sticker-top-left: map-merge(
+	(
+		left: $cadmin-sticker-inside-offset,
+		position: absolute,
+		top: $cadmin-sticker-inside-offset,
+	),
+	$cadmin-sticker-top-left
+);
+
+// .sticker-top-right
+
+$cadmin-sticker-top-right: () !default;
+$cadmin-sticker-top-right: map-merge(
+	(
+		left: auto,
+		position: absolute,
+		right: $cadmin-sticker-inside-offset,
+		top: $cadmin-sticker-inside-offset,
+	),
+	$cadmin-sticker-top-right
+);
+
+// .sticker-outside
+
 $cadmin-sticker-outside-offset: -($cadmin-sticker-size / 2) !default;
 
-// Sticker Circle
+$cadmin-sticker-outside: () !default;
+$cadmin-sticker-outside: map-deep-merge(
+	(
+		left: $cadmin-sticker-outside-offset,
+		top: $cadmin-sticker-outside-offset,
+		sticker-bottom-left: (
+			bottom: $cadmin-sticker-outside-offset,
+			top: auto,
+		),
+		sticker-bottom-right: (
+			bottom: $cadmin-sticker-outside-offset,
+			left: auto,
+			right: $cadmin-sticker-outside-offset,
+			top: auto,
+		),
+		sticker-top-right: (
+			left: auto,
+			right: $cadmin-sticker-outside-offset,
+		),
+	),
+	$cadmin-sticker-outside
+);
+
+// .sticker-circle
 
 $cadmin-sticker-circle-border-radius: $cadmin-rounded-circle-border-radius !default;
 
-// Sticker User Icon
+$cadmin-sticker-circle: () !default;
+$cadmin-sticker-circle: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($cadmin-sticker-circle-border-radius),
+	),
+	$cadmin-sticker-circle
+);
+
+// .sticker-user-icon
 
 $cadmin-sticker-user-icon: () !default;
 $cadmin-sticker-user-icon: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-radius: $cadmin-rounded-circle-border-radius,
 		box-shadow: 0 0 0 1px $cadmin-gray-300,
 	),
 	$cadmin-sticker-user-icon
 );
 
-// Sticker Variants
+// .sticker-primary
 
 $cadmin-sticker-primary-bg: $cadmin-white !default;
 $cadmin-sticker-primary-border-color: null !default;
 $cadmin-sticker-primary-color: $cadmin-primary !default;
 
+$cadmin-sticker-primary: () !default;
+$cadmin-sticker-primary: map-deep-merge(
+	(
+		background-color: $cadmin-sticker-primary-bg,
+		border-color: $cadmin-sticker-primary-border-color,
+		color: $cadmin-sticker-primary-color,
+	),
+	$cadmin-sticker-primary
+);
+
+// .sticker-secondary
+
 $cadmin-sticker-secondary-bg: $cadmin-white !default;
 $cadmin-sticker-secondary-border-color: null !default;
 $cadmin-sticker-secondary-color: $cadmin-secondary !default;
+
+$cadmin-sticker-secondary: () !default;
+$cadmin-sticker-secondary: map-deep-merge(
+	(
+		background-color: $cadmin-sticker-secondary-bg,
+		border-color: $cadmin-sticker-secondary-border-color,
+		color: $cadmin-sticker-secondary-color,
+	),
+	$cadmin-sticker-secondary
+);
+
+// .sticker-info
 
 $cadmin-sticker-info-bg: $cadmin-white !default;
 $cadmin-sticker-info-border-color: null !default;
 $cadmin-sticker-info-color: $cadmin-info !default;
 
+$cadmin-sticker-info: () !default;
+$cadmin-sticker-info: map-deep-merge(
+	(
+		background-color: $cadmin-sticker-info-bg,
+		border-color: $cadmin-sticker-info-border-color,
+		color: $cadmin-sticker-info-color,
+	),
+	$cadmin-sticker-info
+);
+
+// .sticker-success
+
 $cadmin-sticker-success-bg: $cadmin-white !default;
 $cadmin-sticker-success-border-color: null !default;
 $cadmin-sticker-success-color: $cadmin-success !default;
+
+$cadmin-sticker-success: () !default;
+$cadmin-sticker-success: map-deep-merge(
+	(
+		background-color: $cadmin-sticker-success-bg,
+		border-color: $cadmin-sticker-success-border-color,
+		color: $cadmin-sticker-success-color,
+	),
+	$cadmin-sticker-success
+);
+
+// .sticker-warning
 
 $cadmin-sticker-warning-bg: $cadmin-white !default;
 $cadmin-sticker-warning-border-color: null !default;
 $cadmin-sticker-warning-color: $cadmin-warning !default;
 
+$cadmin-sticker-warning: () !default;
+$cadmin-sticker-warning: map-deep-merge(
+	(
+		background-color: $cadmin-sticker-warning-bg,
+		border-color: $cadmin-sticker-warning-border-color,
+		color: $cadmin-sticker-warning-color,
+	),
+	$cadmin-sticker-warning
+);
+
+// .sticker-danger
+
 $cadmin-sticker-danger-bg: $cadmin-white !default;
 $cadmin-sticker-danger-border-color: null !default;
 $cadmin-sticker-danger-color: $cadmin-danger !default;
+
+$cadmin-sticker-danger: () !default;
+$cadmin-sticker-danger: map-deep-merge(
+	(
+		background-color: $cadmin-sticker-danger-bg,
+		border-color: $cadmin-sticker-danger-border-color,
+		color: $cadmin-sticker-danger-color,
+	),
+	$cadmin-sticker-danger
+);
+
+// .sticker-light
 
 $cadmin-sticker-light-bg: color-yiq($cadmin-white) !default;
 $cadmin-sticker-light-border-color: null !default;
 $cadmin-sticker-light-color: $cadmin-light !default;
 
+$cadmin-sticker-light: () !default;
+$cadmin-sticker-light: map-deep-merge(
+	(
+		background-color: $cadmin-sticker-light-bg,
+		border-color: $cadmin-sticker-light-border-color,
+		color: $cadmin-sticker-light-color,
+	),
+	$cadmin-sticker-light
+);
+
+// .sticker-dark
+
 $cadmin-sticker-dark-bg: $cadmin-white !default;
 $cadmin-sticker-dark-border-color: null !default;
 $cadmin-sticker-dark-color: $cadmin-dark !default;
 
+$cadmin-sticker-dark: () !default;
+$cadmin-sticker-dark: map-deep-merge(
+	(
+		background-color: $cadmin-sticker-dark-bg,
+		border-color: $cadmin-sticker-dark-border-color,
+		color: $cadmin-sticker-dark-color,
+	),
+	$cadmin-sticker-dark
+);
+
 $cadmin-sticker-palette: () !default;
 $cadmin-sticker-palette: map-deep-merge(
 	(
-		primary: (
-			bg: $cadmin-sticker-primary-bg,
-			border-color: $cadmin-sticker-primary-border-color,
-			color: $cadmin-sticker-primary-color,
-		),
-		secondary: (
-			bg: $cadmin-sticker-secondary-bg,
-			border-color: $cadmin-sticker-secondary-border-color,
-			color: $cadmin-sticker-secondary-color,
-		),
-		success: (
-			bg: $cadmin-sticker-success-bg,
-			border-color: $cadmin-sticker-success-border-color,
-			color: $cadmin-sticker-success-color,
-		),
-		info: (
-			bg: $cadmin-sticker-info-bg,
-			border-color: $cadmin-sticker-info-border-color,
-			color: $cadmin-sticker-info-color,
-		),
-		warning: (
-			bg: $cadmin-sticker-warning-bg,
-			border-color: $cadmin-sticker-warning-border-color,
-			color: $cadmin-sticker-warning-color,
-		),
-		danger: (
-			bg: $cadmin-sticker-danger-bg,
-			border-color: $cadmin-sticker-danger-border-color,
-			color: $cadmin-sticker-danger-color,
-		),
-		light: (
-			bg: $cadmin-sticker-light-bg,
-			border-color: $cadmin-sticker-light-border-color,
-			color: $cadmin-sticker-light-color,
-		),
-		dark: (
-			bg: $cadmin-sticker-dark-bg,
-			border-color: $cadmin-sticker-dark-border-color,
-			color: $cadmin-sticker-dark-color,
-		),
+		primary: $cadmin-sticker-primary,
+		secondary: $cadmin-sticker-secondary,
+		success: $cadmin-sticker-success,
+		info: $cadmin-sticker-info,
+		warning: $cadmin-sticker-warning,
+		danger: $cadmin-sticker-danger,
+		light: $cadmin-sticker-light,
+		dark: $cadmin-sticker-dark,
 	),
 	$cadmin-sticker-palette
 );

--- a/packages/clay-css/src/scss/components/_sidebar.scss
+++ b/packages/clay-css/src/scss/components/_sidebar.scss
@@ -87,7 +87,7 @@
 	}
 
 	.sticker {
-		@include clay-sticker-size($sidebar-list-group-sticker-size);
+		@include clay-sticker-variant($sidebar-list-group-sticker-size);
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_stickers.scss
+++ b/packages/clay-css/src/scss/components/_stickers.scss
@@ -65,16 +65,14 @@
 
 // Sticker Sizes
 
-.sticker-sm {
-	@include clay-sticker-variant($sticker-sm);
-}
+@each $selector, $value in $sticker-sizes {
+	%#{$selector} {
+		@include clay-sticker-variant($value);
+	}
 
-.sticker-lg {
-	@include clay-sticker-variant($sticker-lg);
-}
-
-.sticker-xl {
-	@include clay-sticker-variant($sticker-xl);
+	.#{$selector} {
+		@extend %#{$selector} !optional;
+	}
 }
 
 // Sticker Variants

--- a/packages/clay-css/src/scss/components/_stickers.scss
+++ b/packages/clay-css/src/scss/components/_stickers.scss
@@ -1,44 +1,5 @@
 .sticker {
-	align-items: center;
-	border-color: $sticker-border-color;
-
-	@include border-radius($sticker-border-radius);
-
-	border-style: $sticker-border-style;
-	border-width: $sticker-border-width;
-	color: $sticker-color;
-
-	@include clay-monospace($sticker-size);
-
-	display: inline-flex;
-	font-size: $sticker-font-size;
-	font-weight: $sticker-font-weight;
-	justify-content: center;
-	position: relative;
-	text-align: center;
-	vertical-align: middle;
-
-	> .inline-item {
-		font-size: $sticker-inline-item-font-size;
-		justify-content: center;
-	}
-
-	> .inline-item .lexicon-icon,
-	.lexicon-icon {
-		margin-top: 0;
-	}
-
-	&.rounded .sticker-overlay {
-		border-radius: $rounded-border-radius;
-	}
-
-	&.rounded-circle .sticker-overlay {
-		border-radius: $rounded-circle-border-radius;
-	}
-
-	&.rounded-0 .sticker-overlay {
-		border-radius: 0;
-	}
+	@include clay-sticker-variant($sticker);
 }
 
 .sticker-img {
@@ -47,70 +8,52 @@
 }
 
 .sticker-overlay {
-	align-items: center;
-
-	@include border-radius($sticker-border-radius);
-
-	bottom: 0;
-	display: flex;
-	justify-content: center;
-	left: 0;
-	overflow: hidden;
-	position: absolute;
-	right: 0;
-	top: 0;
+	@include clay-css($sticker-overlay);
 }
 
 // Sticker Positions
 
 .sticker-bottom-left {
-	bottom: $sticker-inside-offset;
-	left: $sticker-inside-offset;
-	position: absolute;
-	right: auto;
-	top: auto;
+	@include clay-css($sticker-bottom-left);
 }
 
 .sticker-bottom-right {
-	bottom: $sticker-inside-offset;
-	left: auto;
-	position: absolute;
-	right: $sticker-inside-offset;
-	top: auto;
+	@include clay-css($sticker-bottom-right);
 }
 
 .sticker-top-left {
-	left: $sticker-inside-offset;
-	position: absolute;
-	top: $sticker-inside-offset;
+	@include clay-css($sticker-top-left);
 }
 
 .sticker-top-right {
-	left: auto;
-	position: absolute;
-	right: $sticker-inside-offset;
-	top: $sticker-inside-offset;
+	@include clay-css($sticker-top-right);
 }
 
 .sticker-outside {
-	left: $sticker-outside-offset;
-	top: $sticker-outside-offset;
+	@include clay-css($sticker-outside);
 
 	&.sticker-bottom-left {
-		bottom: $sticker-outside-offset;
-		top: auto;
+		$bottom-left: setter(
+			map-get($sticker-outside, sticker-bottom-left),
+			()
+		);
+
+		@include clay-css($bottom-left);
 	}
 
 	&.sticker-bottom-right {
-		bottom: $sticker-outside-offset;
-		left: auto;
-		right: $sticker-outside-offset;
-		top: auto;
+		$bottom-right: setter(
+			map-get($sticker-outside, sticker-bottom-right),
+			()
+		);
+
+		@include clay-css($bottom-right);
 	}
 
 	&.sticker-top-right {
-		left: auto;
-		right: $sticker-outside-offset;
+		$top-right: setter(map-get($sticker-outside, sticker-top-right), ());
+
+		@include clay-css($top-right);
 	}
 }
 
@@ -123,30 +66,31 @@
 // Sticker Sizes
 
 .sticker-sm {
-	@include clay-sticker-size($sticker-sm);
+	@include clay-sticker-variant($sticker-sm);
 }
 
 .sticker-lg {
-	@include clay-sticker-size($sticker-lg);
+	@include clay-sticker-variant($sticker-lg);
 }
 
 .sticker-xl {
-	@include clay-sticker-size($sticker-xl);
+	@include clay-sticker-variant($sticker-xl);
 }
 
 // Sticker Variants
 
 @each $color, $value in $sticker-palette {
+	%sticker-#{$color} {
+		@include clay-sticker-variant($value);
+	}
+
 	.sticker-#{$color} {
-		background-color: map-get($value, bg);
-		border-color: map-get($value, border-color);
-		color: map-get($value, color);
+		@extend %sticker-#{$color} !optional;
 	}
 }
 
 // Sticker Circle
 
-.sticker-circle,
-.sticker-circle .sticker-overlay {
-	@include border-radius($sticker-circle-border-radius);
+.sticker-circle {
+	@include clay-sticker-variant($sticker-circle);
 }

--- a/packages/clay-css/src/scss/mixins/_stickers.scss
+++ b/packages/clay-css/src/scss/mixins/_stickers.scss
@@ -57,9 +57,55 @@
 /// A mixin to create sticker variants. You can base your variant off `.sticker` or create your own base class (e.g., `<span class="sticker my-custom-sticker-variant"></span>` or `<span class="my-custom-sticker"></span>`).
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
-/// enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
-/// See Mixin `clay-css` for available keys to pass into the base selector
-/// sticker-overlay: {Map | Null}, // See Mixin `clay-css` for available keys
+///
+/// (
+///     enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+///     inline-item: (
+///         // .your-variant-name > .inline-item
+///         lexicon-icon: (
+///             // .your-variant-name > .inline-item .lexicon-icon
+///         ),
+///     ),
+///     lexicon-icon: (
+///         // .your-variant-name .lexicon-icon
+///     ),
+///     sticker-img: (
+///         // .your-variant-name .sticker-img
+///     ),
+///     sticker-overlay: (
+///         // .your-variant-name .sticker-overlay
+///     ),
+///     rounded: (
+///         // .your-variant-name.rounded
+///         sticker-overlay: (
+///             // .your-variant-name.rounded .sticker-overlay
+///         ),
+///     ),
+///     rounded-circle: (
+///         // .your-variant-name.rounded-circle
+///         sticker-overlay: (
+///             // .your-variant-name.rounded-circle .sticker-overlay
+///         ),
+///     ),
+///     rounded-0: (
+///         // .your-variant-name.rounded-0
+///         sticker-overlay: (
+///             // .your-variant-name.rounded-0 .sticker-overlay
+///         ),
+///     ),
+///     sticker-outside: (
+///         // .your-variant-name.sticker-outside
+///         sticker-bottom-left: (
+///             // .your-variant-name.sticker-outside.sticker-bottom-left
+///         ),
+///         sticker-bottom-right: (
+///             // .your-variant-name.sticker-outside.sticker-bottom-right
+///         ),
+///         sticker-top-right: (
+///             // .your-variant-name.sticker-outside.sticker-top-right
+///         ),
+///     ),
+/// )
 /// -=-=-=-=-=- Deprecated -=-=-=-=-=-
 /// bg: {Color | String | Null}, // deprecated after 3.9.0
 /// @todo
@@ -74,49 +120,154 @@
 		(
 			background-color:
 				setter(map-get($map, bg), map-get($map, background-color)),
+			height: setter(map-get($map, size), map-get($map, height)),
+			line-height: setter(map-get($map, size), map-get($map, line-height)),
+			width: setter(map-get($map, size), map-get($map, width)),
 		)
 	);
 
 	$inline-item: setter(map-get($map, inline-item), ());
-
-	$sticker-overlay: setter(map-get($map, sticker-overlay), ());
-	$sticker-overlay: map-merge(
+	$inline-item: map-merge(
+		$inline-item,
 		(
-			border-radius:
+			font-size:
 				setter(
-					map-get($sticker-overlay, border-radius),
-					map-get($base, border-radius)
+					map-get($map, inline-item-font-size),
+					map-get($inline-item, font-size)
 				),
-		),
-		$sticker-overlay
+		)
+	);
+
+	$outside-offset: setter(
+		map-get($map, outside-offset),
+		if(
+			map-get($map, size),
+			calc(#{math-sign(map-get($map, size))} / 2),
+			null
+		)
 	);
 
 	$sticker-outside: setter(map-get($map, sticker-outside), ());
 
 	$sticker-outside-bottom-left: setter(
-		map-get($map, sticker-outside-bottom-left),
+		map-get($sticker-outside, sticker-bottom-left),
 		()
+	);
+	$sticker-outside-bottom-left: map-merge(
+		$sticker-outside-bottom-left,
+		setter(map-get($map, sticker-outside-bottom-left), ())
 	);
 
 	$sticker-outside-bottom-right: setter(
-		map-get($map, sticker-outside-bottom-right),
+		map-get($sticker-outside, sticker-bottom-right),
 		()
+	);
+	$sticker-outside-bottom-right: map-merge(
+		$sticker-outside-bottom-right,
+		setter(map-get($map, sticker-outside-bottom-right), ())
 	);
 
 	$sticker-outside-top-right: setter(
-		map-get($map, sticker-outside-top-right),
+		map-get($sticker-outside, sticker-top-right),
 		()
 	);
+	$sticker-outside-top-right: map-merge(
+		$sticker-outside-top-right,
+		setter(map-get($map, sticker-outside-top-right), ())
+	);
+
+	@if ($outside-offset) {
+		$sticker-outside: map-merge(
+			$sticker-outside,
+			(
+				left: $outside-offset,
+				top: $outside-offset,
+			)
+		);
+
+		$sticker-outside-bottom-left: map-merge(
+			$sticker-outside-bottom-left,
+			(
+				bottom: $outside-offset,
+				top: auto,
+			)
+		);
+
+		$sticker-outside-bottom-right: map-merge(
+			$sticker-outside-bottom-right,
+			(
+				bottom: $outside-offset,
+				left: auto,
+				right: $outside-offset,
+				top: auto,
+			)
+		);
+
+		$sticker-outside-top-right: map-merge(
+			$sticker-outside-top-right,
+			(
+				left: auto,
+				right: $outside-offset,
+			)
+		);
+	}
 
 	@if ($enabled) {
 		@include clay-css($base);
 
 		> .inline-item {
 			@include clay-css($inline-item);
+
+			.lexicon-icon {
+				@include clay-css(
+					setter(map-deep-get($map, inline-item, lexicon-icon), ())
+				);
+			}
+		}
+
+		.lexicon-icon {
+			@include clay-css(setter(map-get($map, lexicon-icon), ()));
+		}
+
+		.sticker-img {
+			@include clay-css(setter(map-get($map, sticker-img), ()));
 		}
 
 		.sticker-overlay {
-			@include clay-css($sticker-overlay);
+			@include clay-css(setter(map-get($map, sticker-overlay), ()));
+		}
+
+		&.rounded {
+			@include clay-css(setter(map-get($map, rounded), ()));
+
+			.sticker-overlay {
+				@include clay-css(
+					setter(map-deep-get($map, rounded, sticker-overlay), ())
+				);
+			}
+		}
+
+		&.rounded-circle {
+			@include clay-css(setter(map-get($map, rounded-circle), ()));
+
+			.sticker-overlay {
+				@include clay-css(
+					setter(
+						map-deep-get($map, rounded-circle, sticker-overlay),
+						()
+					)
+				);
+			}
+		}
+
+		&.rounded-0 {
+			@include clay-css(setter(map-get($map, rounded-0), ()));
+
+			.sticker-overlay {
+				@include clay-css(
+					setter(map-deep-get($map, rounded-0, sticker-overlay), ())
+				);
+			}
 		}
 
 		&.sticker-outside {

--- a/packages/clay-css/src/scss/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/variables/_stickers.scss
@@ -1,3 +1,5 @@
+// .sticker
+
 $sticker-border-color: null !default;
 $sticker-border-radius: $border-radius !default;
 $sticker-border-style: null !default;
@@ -9,31 +11,147 @@ $sticker-size: 2rem !default; // 32px
 
 $sticker-inline-item-font-size: null !default;
 
-// Sticker Sizes
+$sticker: () !default;
+$sticker: map-deep-merge(
+	(
+		align-items: center,
+		border-color: $sticker-border-color,
+		border-radius: clay-enable-rounded($sticker-border-radius),
+		border-style: $sticker-border-style,
+		border-width: $sticker-border-width,
+		color: $sticker-color,
+		height: $sticker-size,
+		line-height: $sticker-size,
+		display: inline-flex,
+		font-size: $sticker-font-size,
+		font-weight: $sticker-font-weight,
+		justify-content: center,
+		position: relative,
+		text-align: center,
+		vertical-align: middle,
+		width: $sticker-size,
+		inline-item: (
+			font-size: $sticker-inline-item-font-size,
+			justify-content: center,
+			lexicon-icon: (
+				margin-top: 0,
+			),
+		),
+		lexicon-icon: (
+			margin-top: 0,
+		),
+	),
+	$sticker
+);
+
+// .sticker-overlay
+
+$sticker-overlay: () !default;
+$sticker-overlay: map-merge(
+	(
+		align-items: center,
+		border-radius: inherit,
+		bottom: 0,
+		display: flex,
+		justify-content: center,
+		left: 0,
+		overflow: hidden,
+		position: absolute,
+		right: 0,
+		top: 0,
+	),
+	$sticker-overlay
+);
+
+// .sticker-sm
 
 $sticker-sm: () !default;
 $sticker-sm: map-deep-merge(
 	(
 		font-size: 0.75rem,
-		size: 1.5rem,
+		height: 1.5rem,
+		line-height: 1.5rem,
+		width: 1.5rem,
+		sticker-outside: (
+			left: -0.75rem,
+			top: -0.75rem,
+			sticker-bottom-left: (
+				bottom: -0.75rem,
+				top: auto,
+			),
+			sticker-bottomr-right: (
+				bottom: -0.75rem,
+				left: auto,
+				right: -0.75rem,
+				top: auto,
+			),
+			sticker-top-right: (
+				left: auto,
+				right: -0.75rem,
+			),
+		),
 	),
 	$sticker-sm
 );
+
+// .sticker-lg
 
 $sticker-lg: () !default;
 $sticker-lg: map-deep-merge(
 	(
 		font-size: 1.125rem,
-		size: 2.5rem,
+		height: 2.5rem,
+		line-height: 2.5rem,
+		width: 2.5rem,
+		sticker-outside: (
+			left: -1.25rem,
+			top: -1.25rem,
+			sticker-bottom-left: (
+				bottom: -1.25rem,
+				top: auto,
+			),
+			sticker-bottomr-right: (
+				bottom: -1.25rem,
+				left: auto,
+				right: -1.25rem,
+				top: auto,
+			),
+			sticker-top-right: (
+				left: auto,
+				right: -1.25rem,
+			),
+		),
 	),
 	$sticker-lg
 );
+
+// .sticker-xl
 
 $sticker-xl: () !default;
 $sticker-xl: map-deep-merge(
 	(
 		font-size: 1.25rem,
-		size: 3rem,
+		height: 3rem,
+		line-height: 3rem,
+		width: 3rem,
+		sticker-outside: (
+			left: -1.5rem,
+			top: -1.5rem,
+			sticker-bottom-left: (
+				bottom: -1.5rem,
+				top: auto,
+			),
+			sticker-bottomr-right: (
+				bottom: -1.5rem,
+				left: auto,
+				right: -1.5rem,
+				top: auto,
+			),
+			sticker-top-right: (
+				left: auto,
+				right: -1.5rem,
+			),
+		),
 	),
 	$sticker-xl
 );
@@ -41,101 +159,250 @@ $sticker-xl: map-deep-merge(
 // Sticker Positions
 
 $sticker-inside-offset: $grid-gutter-width / 2 !default;
+
+// .sticker-bottom-left
+
+$sticker-bottom-left: () !default;
+$sticker-bottom-left: map-merge(
+	(
+		bottom: $sticker-inside-offset,
+		left: $sticker-inside-offset,
+		position: absolute,
+		right: auto,
+		top: auto,
+	),
+	$sticker-bottom-left
+);
+
+// .sticker-bottom-right
+
+$sticker-bottom-right: () !default;
+$sticker-bottom-right: map-merge(
+	(
+		bottom: $sticker-inside-offset,
+		left: auto,
+		position: absolute,
+		right: $sticker-inside-offset,
+		top: auto,
+	),
+	$sticker-bottom-right
+);
+
+// .sticker-top-left
+
+$sticker-top-left: () !default;
+$sticker-top-left: map-merge(
+	(
+		left: $sticker-inside-offset,
+		position: absolute,
+		top: $sticker-inside-offset,
+	),
+	$sticker-top-left
+);
+
+// .sticker-top-right
+
+$sticker-top-right: () !default;
+$sticker-top-right: map-merge(
+	(
+		left: auto,
+		position: absolute,
+		right: $sticker-inside-offset,
+		top: $sticker-inside-offset,
+	),
+	$sticker-top-right
+);
+
+// .sticker-outside
+
 $sticker-outside-offset: -($sticker-size / 2) !default;
 
-// Sticker Circle
+$sticker-outside: () !default;
+$sticker-outside: map-deep-merge(
+	(
+		left: $sticker-outside-offset,
+		top: $sticker-outside-offset,
+		sticker-bottom-left: (
+			bottom: $sticker-outside-offset,
+			top: auto,
+		),
+		sticker-bottom-right: (
+			bottom: $sticker-outside-offset,
+			left: auto,
+			right: $sticker-outside-offset,
+			top: auto,
+		),
+		sticker-top-right: (
+			left: auto,
+			right: $sticker-outside-offset,
+		),
+	),
+	$sticker-outside
+);
+
+// .sticker-circle
 
 $sticker-circle-border-radius: $rounded-circle-border-radius !default;
 
-// Sticker User Icon
+$sticker-circle: () !default;
+$sticker-circle: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($sticker-circle-border-radius),
+	),
+	$sticker-circle
+);
+
+// .sticker-user-icon
 
 $sticker-user-icon: () !default;
 $sticker-user-icon: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-radius: $rounded-circle-border-radius,
 		box-shadow: 0 0 0 1px rgba($black, 0.125),
 	),
 	$sticker-user-icon
 );
 
-// Sticker Variants
+// .sticker-primary
 
 $sticker-primary-bg: $primary !default;
 $sticker-primary-border-color: null !default;
 $sticker-primary-color: color-yiq($sticker-primary-bg) !default;
 
+$sticker-primary: () !default;
+$sticker-primary: map-deep-merge(
+	(
+		background-color: $sticker-primary-bg,
+		border-color: $sticker-primary-border-color,
+		color: $sticker-primary-color,
+	),
+	$sticker-primary
+);
+
+// .sticker-secondary
+
 $sticker-secondary-bg: $secondary !default;
 $sticker-secondary-border-color: null !default;
 $sticker-secondary-color: color-yiq($sticker-secondary-bg) !default;
+
+$sticker-secondary: () !default;
+$sticker-secondary: map-deep-merge(
+	(
+		background-color: $sticker-secondary-bg,
+		border-color: $sticker-secondary-border-color,
+		color: $sticker-secondary-color,
+	),
+	$sticker-secondary
+);
+
+// .sticker-info
 
 $sticker-info-bg: $info !default;
 $sticker-info-border-color: null !default;
 $sticker-info-color: color-yiq($sticker-info-bg) !default;
 
+$sticker-info: () !default;
+$sticker-info: map-deep-merge(
+	(
+		background-color: $sticker-info-bg,
+		border-color: $sticker-info-border-color,
+		color: $sticker-info-color,
+	),
+	$sticker-info
+);
+
+// .sticker-success
+
 $sticker-success-bg: $success !default;
 $sticker-success-border-color: null !default;
 $sticker-success-color: color-yiq($sticker-success-bg) !default;
+
+$sticker-success: () !default;
+$sticker-success: map-deep-merge(
+	(
+		background-color: $sticker-success-bg,
+		border-color: $sticker-success-border-color,
+		color: $sticker-success-color,
+	),
+	$sticker-success
+);
+
+// .sticker-warning
 
 $sticker-warning-bg: $warning !default;
 $sticker-warning-border-color: null !default;
 $sticker-warning-color: color-yiq($sticker-warning-bg) !default;
 
+$sticker-warning: () !default;
+$sticker-warning: map-deep-merge(
+	(
+		background-color: $sticker-warning-bg,
+		border-color: $sticker-warning-border-color,
+		color: $sticker-warning-color,
+	),
+	$sticker-warning
+);
+
+// .sticker-danger
+
 $sticker-danger-bg: $danger !default;
 $sticker-danger-border-color: null !default;
 $sticker-danger-color: color-yiq($sticker-danger-bg) !default;
+
+$sticker-danger: () !default;
+$sticker-danger: map-deep-merge(
+	(
+		background-color: $sticker-danger-bg,
+		border-color: $sticker-danger-border-color,
+		color: $sticker-danger-color,
+	),
+	$sticker-danger
+);
+
+// .sticker-light
 
 $sticker-light-bg: $light !default;
 $sticker-light-border-color: null !default;
 $sticker-light-color: color-yiq($sticker-light-bg) !default;
 
+$sticker-light: () !default;
+$sticker-light: map-deep-merge(
+	(
+		background-color: $sticker-light-bg,
+		border-color: $sticker-light-border-color,
+		color: $sticker-light-color,
+	),
+	$sticker-light
+);
+
+// .sticker-dark
+
 $sticker-dark-bg: $dark !default;
 $sticker-dark-border-color: null !default;
 $sticker-dark-color: color-yiq($sticker-dark-bg) !default;
 
+$sticker-dark: () !default;
+$sticker-dark: map-deep-merge(
+	(
+		background-color: $sticker-dark-bg,
+		border-color: $sticker-dark-border-color,
+		color: $sticker-dark-color,
+	),
+	$sticker-dark
+);
+
 $sticker-palette: () !default;
 $sticker-palette: map-deep-merge(
 	(
-		primary: (
-			bg: $sticker-primary-bg,
-			border-color: $sticker-primary-border-color,
-			color: $sticker-primary-color,
-		),
-		secondary: (
-			bg: $sticker-secondary-bg,
-			border-color: $sticker-secondary-border-color,
-			color: $sticker-secondary-color,
-		),
-		success: (
-			bg: $sticker-success-bg,
-			border-color: $sticker-success-border-color,
-			color: $sticker-success-color,
-		),
-		info: (
-			bg: $sticker-info-bg,
-			border-color: $sticker-info-border-color,
-			color: $sticker-info-color,
-		),
-		warning: (
-			bg: $sticker-warning-bg,
-			border-color: $sticker-warning-border-color,
-			color: $sticker-warning-color,
-		),
-		danger: (
-			bg: $sticker-danger-bg,
-			border-color: $sticker-danger-border-color,
-			color: $sticker-danger-color,
-		),
-		light: (
-			bg: $sticker-light-bg,
-			border-color: $sticker-light-border-color,
-			color: $sticker-light-color,
-		),
-		dark: (
-			bg: $sticker-dark-bg,
-			border-color: $sticker-dark-border-color,
-			color: $sticker-dark-color,
-		),
+		primary: $sticker-primary,
+		secondary: $sticker-secondary,
+		success: $sticker-success,
+		info: $sticker-info,
+		warning: $sticker-warning,
+		danger: $sticker-danger,
+		light: $sticker-light,
+		dark: $sticker-dark,
 	),
 	$sticker-palette
 );

--- a/packages/clay-css/src/scss/variables/_stickers.scss
+++ b/packages/clay-css/src/scss/variables/_stickers.scss
@@ -156,6 +156,16 @@ $sticker-xl: map-deep-merge(
 	$sticker-xl
 );
 
+$sticker-sizes: () !default;
+$sticker-sizes: map-deep-merge(
+	(
+		sticker-sm: $sticker-sm,
+		sticker-lg: $sticker-lg,
+		sticker-xl: $sticker-xl,
+	),
+	$sticker-sizes
+);
+
 // Sticker Positions
 
 $sticker-inside-offset: $grid-gutter-width / 2 !default;


### PR DESCRIPTION
fixes #4342

Everything should look the same, just the internals were re-arranged to provide more options.