### PR TITLE
fix(@clayui/css): Add 'components/_reboot.scss' file to css map and m…

### DIFF
--- a/clayui.com/static/css/atlas.css.map
+++ b/clayui.com/static/css/atlas.css.map
@@ -209,6 +209,7 @@
 		"lib/css/mixins/_type.scss",
 		"lib/css/mixins/_utilities.scss",
 		"lib/css/_components.scss",
+		"lib/css/components/_reboot.scss",
 		"lib/css/components/_grid.scss",
 		"lib/css/components/_alerts.scss",
 		"lib/css/components/_aspect-ratio.scss",

--- a/clayui.com/static/css/base.css.map
+++ b/clayui.com/static/css/base.css.map
@@ -169,6 +169,7 @@
 		"lib/css/mixins/_type.scss",
 		"lib/css/mixins/_utilities.scss",
 		"lib/css/_components.scss",
+		"lib/css/components/_reboot.scss",
 		"lib/css/components/_grid.scss",
 		"lib/css/components/_alerts.scss",
 		"lib/css/components/_aspect-ratio.scss",

--- a/packages/clay-css/ATLAS-THEME.md
+++ b/packages/clay-css/ATLAS-THEME.md
@@ -242,6 +242,7 @@ src/scss/mixins/_utilities.scss
 ## Clay CSS Components
 
 ```
+src/scss/components/_reboot.scss
 src/scss/components/_grid.scss
 src/scss/components/_alerts.scss
 src/scss/components/_aspect-ratio.scss

--- a/packages/clay-css/BASE-THEME.md
+++ b/packages/clay-css/BASE-THEME.md
@@ -200,6 +200,7 @@ src/scss/mixins/_utilities.scss
 ## Clay CSS Components
 
 ```
+src/scss/components/_reboot.scss
 src/scss/components/_grid.scss
 src/scss/components/_alerts.scss
 src/scss/components/_aspect-ratio.scss

--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -2,7 +2,7 @@
 	@import url($font-import-url);
 }
 
-@import "components/_reboot.scss";
+@import "components/_reboot";
 
 @import "components/_grid";
 


### PR DESCRIPTION
…d files

For more details please check: https://issues.liferay.com/browse/LPS-133314

I guess this is why we don't see the changes. 

For example if you create a theme for 7.2.x with the latest version of "liferay-frontend-theme-unstyled": "4.0.37", which is using "clay-css": "2.22.4" containing the new file we added @import "components/_reboot";

If I do a gulp build, I don't see the new file added in the build folder, somehow is not getting integrated in the build package themes/7-2-fa-theme/build/css/clay/_components.scss

Please let me know if you think this is the issue here.

fixes liferay#4124