### PR TITLE
feat(@clayui/form): add the new `sizing` API to Select component

### DIFF
--- a/packages/clay-form/docs/api-select.mdx
+++ b/packages/clay-form/docs/api-select.mdx
@@ -7,6 +7,10 @@ mainTabURL: 'docs/components/select.html'
 
 ClaySelect have the same React API of `<select>` element. Also, `ClaySelect.Option` has the same API of `<option>` React element.
 
+## Select
+
+<div>[APITable "clay-form/src/Select.tsx"]</div>
+
 ## SelectWithOption
 
 <div>[APITable "clay-form/src/SelectWithOption.tsx"]</div>

--- a/packages/clay-form/src/Select.tsx
+++ b/packages/clay-form/src/Select.tsx
@@ -16,13 +16,23 @@ const Option: React.FunctionComponent<
 	React.OptionHTMLAttributes<HTMLOptionElement>
 > = ({label, ...otherProps}) => <option {...otherProps}>{label}</option>;
 
-const ClaySelect: React.FunctionComponent<
-	React.SelectHTMLAttributes<HTMLSelectElement>
-> & {
+interface IProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+	/**
+	 * Set the proportional size of the Select component.
+	 */
+	sizing?: 'lg' | 'sm';
+}
+
+const ClaySelect: React.FunctionComponent<IProps> & {
 	OptGroup: typeof OptGroup;
 	Option: typeof Option;
-} = ({children, className, ...otherProps}) => (
-	<select {...otherProps} className={classNames('form-control', className)}>
+} = ({children, className, sizing, ...otherProps}: IProps) => (
+	<select
+		{...otherProps}
+		className={classNames('form-control', className, {
+			[`form-control-${sizing}`]: sizing,
+		})}
+	>
 		{children}
 	</select>
 );


### PR DESCRIPTION
Fixes #4370

Well most of our components use the `size` naming to set the size of the component but specifically `size` is a property for the `input` and `select` elements that sets the height of the element, so instead, I'm using the same pattern as `sizing`.