### PR TITLE
chore: update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -5,12 +5,9 @@ labels: 'type: bug'
 ---
 
 <!--
-
-Before making a bug, have you used the issue search functionality?
-
+Before filling this bug, have you used the issue search functionality?
+Please provide a clear and concise description of what the issue is.
 -->
-
--   [ ] I have searched the [issues](https://github.com/liferay/clay/issues) of this repository and believe that this is not a duplicate.
 
 ## Is there an example you can provide via codesandbox.com?
 

--- a/.github/ISSUE_TEMPLATE/Clayui.md
+++ b/.github/ISSUE_TEMPLATE/Clayui.md
@@ -5,12 +5,9 @@ labels: 'comp: clayui.com'
 ---
 
 <!--
-
-Before making an issue, have you used the issue search functionality?
-
+Before filling an issue, have you used the issue search functionality?
+Please provide a clear and concise description of what the issue is.
 -->
-
--   [ ] I have searched the [issues](https://github.com/liferay/clay/issues) of this repository and believe that this is not a duplicate.
 
 ## What are the steps to reproduce?
 

--- a/.github/ISSUE_TEMPLATE/Icon.md
+++ b/.github/ISSUE_TEMPLATE/Icon.md
@@ -5,12 +5,9 @@ labels: 'comp: icons'
 ---
 
 <!--
-
-Before making an issue, have you used the issue search functionality?
-
+Before filling this bug, have you used the issue search functionality?
+Please provide a clear and concise description of what the issue is.
 -->
-
--   [ ] I have searched the [issues](https://github.com/liferay/clay/issues) of this repository and believe that this is not a duplicate.
 
 ## Link the LEXI Jira Issue.
 

--- a/.github/ISSUE_TEMPLATE/Proposal.md
+++ b/.github/ISSUE_TEMPLATE/Proposal.md
@@ -5,9 +5,8 @@ labels: rfc
 ---
 
 <!--
-
 Before making a proposal, have you used the issue search functionality?
-
+Please provide a clear and concise description of your proposal.
 -->
 
 ## What is your proposal?

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -5,9 +5,7 @@ labels: 'type: question'
 ---
 
 <!--
-
-Before posting a question, have you used the issue search functionality?
-
+Before asking a question, have you used the issue search functionality?
 -->
 
 ## What is your question?


### PR DESCRIPTION
As discussed in https://github.com/liferay/clay/issues/4362#issuecomment-952599481,
we're removing the "checkbox" from our GitHub issue 
templates, because GitHub considers this as a ["task list"](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists), 
which can create some confusion.
