### PR TITLE
chore: update github actions workflow definition to use node lts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                node-version: 'lts/*'
+                node-version: '16'
             - name: Clean yarn cache
               run: yarn cache clean
             - name: Install Dependencies
@@ -45,7 +45,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
-                node-version: 'lts/*'
+                node-version: '16'
             - name: Fetch and Diff
               id: diff
               run: |
@@ -77,7 +77,7 @@ jobs:
                   clean: false
             - uses: actions/setup-node@v2
               with:
-                node-version: 'lts/*'
+                node-version: '16'
             - name: Generate Bundle Size Table
               if: ${{ steps.diff.outputs.packages }}
               run: |


### PR DESCRIPTION
In this change, we're updating the github actions workflow
definition to use node lts. 
