### PR TITLE
fix(@clayui/css): Mixins `clay-label-variant` target [tabindex] inste…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -631,7 +631,7 @@
 
 		&[href],
 		&[type],
-		&[tabindex='0'] {
+		&[tabindex] {
 			@include clay-link($href);
 		}
 


### PR DESCRIPTION
…ad of [tabindex="0"] so styles still apply when an element is disabled with negative tabindex

fixes #4384