### PR TITLE
fix(@clayui/css): Labels and Cadmin Labels Sass maps that are used fo…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_labels.scss
@@ -135,9 +135,11 @@ $label-primary: map-deep-merge(
 	(
 		border-color: $label-primary-border-color,
 		color: $label-primary-color,
-		hover: (
-			border-color: $label-primary-hover-border-color,
-			color: $label-primary-hover-color,
+		href: (
+			hover: (
+				border-color: $label-primary-hover-border-color,
+				color: $label-primary-hover-color,
+			),
 		),
 	),
 	$label-primary
@@ -164,9 +166,11 @@ $label-secondary: map-deep-merge(
 	(
 		border-color: $label-secondary-border-color,
 		color: $label-secondary-color,
-		hover: (
-			border-color: $label-secondary-hover-border-color,
-			color: $label-secondary-hover-color,
+		href: (
+			hover: (
+				border-color: $label-secondary-hover-border-color,
+				color: $label-secondary-hover-color,
+			),
 		),
 	),
 	$label-secondary
@@ -193,9 +197,11 @@ $label-success: map-deep-merge(
 	(
 		border-color: $label-success-border-color,
 		color: $label-success-color,
-		hover: (
-			border-color: $label-success-hover-border-color,
-			color: $label-success-hover-color,
+		href: (
+			hover: (
+				border-color: $label-success-hover-border-color,
+				color: $label-success-hover-color,
+			),
 		),
 	),
 	$label-success
@@ -222,9 +228,11 @@ $label-info: map-deep-merge(
 	(
 		border-color: $label-info-border-color,
 		color: $label-info-color,
-		hover: (
-			border-color: $label-info-hover-border-color,
-			color: $label-info-hover-color,
+		href: (
+			hover: (
+				border-color: $label-info-hover-border-color,
+				color: $label-info-hover-color,
+			),
 		),
 	),
 	$label-info
@@ -251,9 +259,11 @@ $label-warning: map-deep-merge(
 	(
 		border-color: $label-warning-border-color,
 		color: $label-warning-color,
-		hover: (
-			border-color: $label-warning-hover-border-color,
-			color: $label-warning-hover-color,
+		href: (
+			hover: (
+				border-color: $label-warning-hover-border-color,
+				color: $label-warning-hover-color,
+			),
 		),
 	),
 	$label-warning
@@ -280,9 +290,11 @@ $label-danger: map-deep-merge(
 	(
 		border-color: $label-danger-border-color,
 		color: $label-danger-color,
-		hover: (
-			border-color: $label-danger-hover-border-color,
-			color: $label-danger-hover-color,
+		href: (
+			hover: (
+				border-color: $label-danger-hover-border-color,
+				color: $label-danger-hover-color,
+			),
 		),
 	),
 	$label-danger
@@ -314,9 +326,11 @@ $label-light: map-deep-merge(
 		background-color: $label-light-bg,
 		border-color: $label-light-border-color,
 		color: $label-light-color,
-		hover: (
-			border-color: $label-light-hover-border-color,
-			color: $label-light-hover-color,
+		href: (
+			hover: (
+				border-color: $label-light-hover-border-color,
+				color: $label-light-hover-color,
+			),
 		),
 	),
 	$label-light
@@ -343,9 +357,11 @@ $label-dark: map-deep-merge(
 	(
 		border-color: $label-dark-border-color,
 		color: $label-dark-color,
-		hover: (
-			border-color: $label-dark-hover-border-color,
-			color: $label-dark-hover-color,
+		href: (
+			hover: (
+				border-color: $label-dark-hover-border-color,
+				color: $label-dark-hover-color,
+			),
 		),
 	),
 	$label-dark
@@ -357,10 +373,12 @@ $label-inverse-primary: () !default;
 $label-inverse-primary: map-deep-merge(
 	(
 		color: $white,
-		hover: (
-			background-color: null,
-			border-color: null,
-			color: $white,
+		href: (
+			hover: (
+				background-color: null,
+				border-color: null,
+				color: $white,
+			),
 		),
 		link: (
 			hover: (
@@ -380,10 +398,12 @@ $label-inverse-secondary: () !default;
 $label-inverse-secondary: map-deep-merge(
 	(
 		color: $white,
-		hover: (
-			background-color: null,
-			border-color: null,
-			color: $white,
+		href: (
+			hover: (
+				background-color: null,
+				border-color: null,
+				color: $white,
+			),
 		),
 		link: (
 			hover: (
@@ -403,10 +423,12 @@ $label-inverse-success: () !default;
 $label-inverse-success: map-deep-merge(
 	(
 		color: $white,
-		hover: (
-			background-color: null,
-			border-color: null,
-			color: $white,
+		href: (
+			hover: (
+				background-color: null,
+				border-color: null,
+				color: $white,
+			),
 		),
 		link: (
 			hover: (
@@ -426,10 +448,12 @@ $label-inverse-info: () !default;
 $label-inverse-info: map-deep-merge(
 	(
 		color: $white,
-		hover: (
-			background-color: null,
-			border-color: null,
-			color: $white,
+		href: (
+			hover: (
+				background-color: null,
+				border-color: null,
+				color: $white,
+			),
 		),
 		link: (
 			hover: (
@@ -449,10 +473,12 @@ $label-inverse-warning: () !default;
 $label-inverse-warning: map-deep-merge(
 	(
 		color: $white,
-		hover: (
-			background-color: null,
-			border-color: null,
-			color: $white,
+		href: (
+			hover: (
+				background-color: null,
+				border-color: null,
+				color: $white,
+			),
 		),
 		link: (
 			hover: (
@@ -472,10 +498,12 @@ $label-inverse-danger: () !default;
 $label-inverse-danger: map-deep-merge(
 	(
 		color: $white,
-		hover: (
-			background-color: null,
-			border-color: null,
-			color: $white,
+		href: (
+			hover: (
+				background-color: null,
+				border-color: null,
+				color: $white,
+			),
 		),
 		link: (
 			hover: (
@@ -495,10 +523,12 @@ $label-inverse-light: () !default;
 $label-inverse-light: map-deep-merge(
 	(
 		color: $dark,
-		hover: (
-			background-color: null,
-			border-color: null,
-			color: $dark,
+		href: (
+			hover: (
+				background-color: null,
+				border-color: null,
+				color: $dark,
+			),
 		),
 		link: (
 			hover: (
@@ -518,10 +548,12 @@ $label-inverse-dark: () !default;
 $label-inverse-dark: map-deep-merge(
 	(
 		color: $white,
-		hover: (
-			background-color: null,
-			border-color: null,
-			color: $white,
+		href: (
+			hover: (
+				background-color: null,
+				border-color: null,
+				color: $white,
+			),
 		),
 		link: (
 			hover: (

--- a/packages/clay-css/src/scss/cadmin/variables/_labels.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_labels.scss
@@ -318,13 +318,15 @@ $cadmin-label-primary: map-deep-merge(
 		background-color: $cadmin-label-primary-bg,
 		border-color: $cadmin-label-primary-border-color,
 		color: $cadmin-label-primary-color,
-		hover: (
-			background-color: $cadmin-label-primary-hover-bg,
-			border-color: $cadmin-label-primary-hover-border-color,
-			color: $cadmin-label-primary-hover-color,
-		),
-		focus: (
-			color: $cadmin-label-primary-hover-color,
+		href: (
+			hover: (
+				background-color: $cadmin-label-primary-hover-bg,
+				border-color: $cadmin-label-primary-hover-border-color,
+				color: $cadmin-label-primary-hover-color,
+			),
+			focus: (
+				color: $cadmin-label-primary-hover-color,
+			),
 		),
 		link: (
 			color: $cadmin-label-primary-link-color,
@@ -388,13 +390,15 @@ $cadmin-label-secondary: map-deep-merge(
 		background-color: $cadmin-label-secondary-bg,
 		border-color: $cadmin-label-secondary-border-color,
 		color: $cadmin-label-secondary-color,
-		hover: (
-			background-color: $cadmin-label-secondary-hover-bg,
-			border-color: $cadmin-label-secondary-hover-border-color,
-			color: $cadmin-label-secondary-hover-color,
-		),
-		focus: (
-			color: $cadmin-label-secondary-hover-color,
+		href: (
+			hover: (
+				background-color: $cadmin-label-secondary-hover-bg,
+				border-color: $cadmin-label-secondary-hover-border-color,
+				color: $cadmin-label-secondary-hover-color,
+			),
+			focus: (
+				color: $cadmin-label-secondary-hover-color,
+			),
 		),
 		link: (
 			color: $cadmin-label-secondary-link-color,
@@ -458,13 +462,15 @@ $cadmin-label-success: map-deep-merge(
 		background-color: $cadmin-label-success-bg,
 		border-color: $cadmin-label-success-border-color,
 		color: $cadmin-label-success-color,
-		hover: (
-			background-color: $cadmin-label-success-hover-bg,
-			border-color: $cadmin-label-success-hover-border-color,
-			color: $cadmin-label-success-hover-color,
-		),
-		focus: (
-			color: $cadmin-label-success-hover-color,
+		href: (
+			hover: (
+				background-color: $cadmin-label-success-hover-bg,
+				border-color: $cadmin-label-success-hover-border-color,
+				color: $cadmin-label-success-hover-color,
+			),
+			focus: (
+				color: $cadmin-label-success-hover-color,
+			),
 		),
 		link: (
 			color: $cadmin-label-success-link-color,
@@ -528,13 +534,15 @@ $cadmin-label-info: map-deep-merge(
 		background-color: $cadmin-label-info-bg,
 		border-color: $cadmin-label-info-border-color,
 		color: $cadmin-label-info-color,
-		hover: (
-			background-color: $cadmin-label-info-hover-bg,
-			border-color: $cadmin-label-info-hover-border-color,
-			color: $cadmin-label-info-hover-color,
-		),
-		focus: (
-			color: $cadmin-label-info-hover-color,
+		href: (
+			hover: (
+				background-color: $cadmin-label-info-hover-bg,
+				border-color: $cadmin-label-info-hover-border-color,
+				color: $cadmin-label-info-hover-color,
+			),
+			focus: (
+				color: $cadmin-label-info-hover-color,
+			),
 		),
 		link: (
 			color: $cadmin-label-info-link-color,
@@ -598,13 +606,15 @@ $cadmin-label-warning: map-deep-merge(
 		background-color: $cadmin-label-warning-bg,
 		border-color: $cadmin-label-warning-border-color,
 		color: $cadmin-label-warning-color,
-		hover: (
-			background-color: $cadmin-label-warning-hover-bg,
-			border-color: $cadmin-label-warning-hover-border-color,
-			color: $cadmin-label-warning-hover-color,
-		),
-		focus: (
-			color: $cadmin-label-warning-hover-color,
+		href: (
+			hover: (
+				background-color: $cadmin-label-warning-hover-bg,
+				border-color: $cadmin-label-warning-hover-border-color,
+				color: $cadmin-label-warning-hover-color,
+			),
+			focus: (
+				color: $cadmin-label-warning-hover-color,
+			),
 		),
 		link: (
 			color: $cadmin-label-warning-link-color,
@@ -668,13 +678,15 @@ $cadmin-label-danger: map-deep-merge(
 		background-color: $cadmin-label-danger-bg,
 		border-color: $cadmin-label-danger-border-color,
 		color: $cadmin-label-danger-color,
-		hover: (
-			background-color: $cadmin-label-danger-hover-bg,
-			border-color: $cadmin-label-danger-hover-border-color,
-			color: $cadmin-label-danger-hover-color,
-		),
-		focus: (
-			color: $cadmin-label-danger-hover-color,
+		href: (
+			hover: (
+				background-color: $cadmin-label-danger-hover-bg,
+				border-color: $cadmin-label-danger-hover-border-color,
+				color: $cadmin-label-danger-hover-color,
+			),
+			focus: (
+				color: $cadmin-label-danger-hover-color,
+			),
 		),
 		link: (
 			color: $cadmin-label-danger-link-color,
@@ -738,13 +750,15 @@ $cadmin-label-light: map-deep-merge(
 		background-color: $cadmin-label-light-bg,
 		border-color: $cadmin-label-light-border-color,
 		color: $cadmin-label-light-color,
-		hover: (
-			background-color: $cadmin-label-light-hover-bg,
-			border-color: $cadmin-label-light-hover-border-color,
-			color: $cadmin-label-light-hover-color,
-		),
-		focus: (
-			color: $cadmin-label-light-hover-color,
+		href: (
+			hover: (
+				background-color: $cadmin-label-light-hover-bg,
+				border-color: $cadmin-label-light-hover-border-color,
+				color: $cadmin-label-light-hover-color,
+			),
+			focus: (
+				color: $cadmin-label-light-hover-color,
+			),
 		),
 		link: (
 			color: $cadmin-label-light-link-color,
@@ -808,13 +822,15 @@ $cadmin-label-dark: map-deep-merge(
 		background-color: $cadmin-label-dark-bg,
 		border-color: $cadmin-label-dark-border-color,
 		color: $cadmin-label-dark-color,
-		hover: (
-			background-color: $cadmin-label-dark-hover-bg,
-			border-color: $cadmin-label-dark-hover-border-color,
-			color: $cadmin-label-dark-hover-color,
-		),
-		focus: (
-			color: $cadmin-label-dark-hover-color,
+		href: (
+			hover: (
+				background-color: $cadmin-label-dark-hover-bg,
+				border-color: $cadmin-label-dark-hover-border-color,
+				color: $cadmin-label-dark-hover-color,
+			),
+			focus: (
+				color: $cadmin-label-dark-hover-color,
+			),
 		),
 		link: (
 			color: $cadmin-label-dark-link-color,
@@ -835,8 +851,10 @@ $cadmin-label-inverse-primary: map-deep-merge(
 		background-color: $cadmin-primary,
 		border-color: $cadmin-primary,
 		color: $cadmin-white,
-		hover: (
-			color: $cadmin-white,
+		href: (
+			hover: (
+				color: $cadmin-white,
+			),
 		),
 	),
 	$cadmin-label-inverse-primary
@@ -848,8 +866,10 @@ $cadmin-label-inverse-secondary: map-deep-merge(
 		background-color: $cadmin-secondary,
 		border-color: $cadmin-secondary,
 		color: $cadmin-white,
-		hover: (
-			color: $cadmin-white,
+		href: (
+			hover: (
+				color: $cadmin-white,
+			),
 		),
 	),
 	$cadmin-label-inverse-secondary
@@ -861,8 +881,10 @@ $cadmin-label-inverse-success: map-deep-merge(
 		background-color: $cadmin-success,
 		border-color: $cadmin-success,
 		color: $cadmin-white,
-		hover: (
-			color: $cadmin-white,
+		href: (
+			hover: (
+				color: $cadmin-white,
+			),
 		),
 	),
 	$cadmin-label-inverse-success
@@ -874,8 +896,10 @@ $cadmin-label-inverse-info: map-deep-merge(
 		background-color: $cadmin-info,
 		border-color: $cadmin-info,
 		color: $cadmin-white,
-		hover: (
-			color: $cadmin-white,
+		href: (
+			hover: (
+				color: $cadmin-white,
+			),
 		),
 	),
 	$cadmin-label-inverse-info
@@ -887,8 +911,10 @@ $cadmin-label-inverse-warning: map-deep-merge(
 		background-color: $cadmin-warning,
 		border-color: $cadmin-warning,
 		color: $cadmin-white,
-		hover: (
-			color: $cadmin-white,
+		href: (
+			hover: (
+				color: $cadmin-white,
+			),
 		),
 	),
 	$cadmin-label-inverse-warning
@@ -900,8 +926,10 @@ $cadmin-label-inverse-danger: map-deep-merge(
 		background-color: $cadmin-danger,
 		border-color: $cadmin-danger,
 		color: $cadmin-white,
-		hover: (
-			color: $cadmin-white,
+		href: (
+			hover: (
+				color: $cadmin-white,
+			),
 		),
 	),
 	$cadmin-label-inverse-danger
@@ -913,8 +941,10 @@ $cadmin-label-inverse-light: map-deep-merge(
 		background-color: $cadmin-light,
 		border-color: $cadmin-light,
 		color: $cadmin-dark,
-		hover: (
-			color: $cadmin-dark,
+		href: (
+			hover: (
+				color: $cadmin-dark,
+			),
 		),
 	),
 	$cadmin-label-inverse-light
@@ -926,8 +956,10 @@ $cadmin-label-inverse-dark: map-deep-merge(
 		background-color: $cadmin-dark,
 		border-color: $cadmin-dark,
 		color: $cadmin-white,
-		hover: (
-			color: $cadmin-white,
+		href: (
+			hover: (
+				color: $cadmin-white,
+			),
 		),
 	),
 	$cadmin-label-inverse-dark

--- a/packages/clay-css/src/scss/variables/_labels.scss
+++ b/packages/clay-css/src/scss/variables/_labels.scss
@@ -303,13 +303,15 @@ $label-primary: map-deep-merge(
 		background-color: $label-primary-bg,
 		border-color: $label-primary-border-color,
 		color: $label-primary-color,
-		hover: (
-			background-color: $label-primary-hover-bg,
-			border-color: $label-primary-hover-border-color,
-			color: $label-primary-hover-color,
-		),
-		focus: (
-			color: $label-primary-hover-color,
+		href: (
+			hover: (
+				background-color: $label-primary-hover-bg,
+				border-color: $label-primary-hover-border-color,
+				color: $label-primary-hover-color,
+			),
+			focus: (
+				color: $label-primary-hover-color,
+			),
 		),
 		link: (
 			color: $label-primary-link-color,
@@ -373,13 +375,15 @@ $label-secondary: map-deep-merge(
 		background-color: $label-secondary-bg,
 		border-color: $label-secondary-border-color,
 		color: $label-secondary-color,
-		hover: (
-			background-color: $label-secondary-hover-bg,
-			border-color: $label-secondary-hover-border-color,
-			color: $label-secondary-hover-color,
-		),
-		focus: (
-			color: $label-secondary-hover-color,
+		href: (
+			hover: (
+				background-color: $label-secondary-hover-bg,
+				border-color: $label-secondary-hover-border-color,
+				color: $label-secondary-hover-color,
+			),
+			focus: (
+				color: $label-secondary-hover-color,
+			),
 		),
 		link: (
 			color: $label-secondary-link-color,
@@ -443,13 +447,15 @@ $label-success: map-deep-merge(
 		background-color: $label-success-bg,
 		border-color: $label-success-border-color,
 		color: $label-success-color,
-		hover: (
-			background-color: $label-success-hover-bg,
-			border-color: $label-success-hover-border-color,
-			color: $label-success-hover-color,
-		),
-		focus: (
-			color: $label-success-hover-color,
+		href: (
+			hover: (
+				background-color: $label-success-hover-bg,
+				border-color: $label-success-hover-border-color,
+				color: $label-success-hover-color,
+			),
+			focus: (
+				color: $label-success-hover-color,
+			),
 		),
 		link: (
 			color: $label-success-link-color,
@@ -513,13 +519,15 @@ $label-info: map-deep-merge(
 		background-color: $label-info-bg,
 		border-color: $label-info-border-color,
 		color: $label-info-color,
-		hover: (
-			background-color: $label-info-hover-bg,
-			border-color: $label-info-hover-border-color,
-			color: $label-info-hover-color,
-		),
-		focus: (
-			color: $label-info-hover-color,
+		href: (
+			hover: (
+				background-color: $label-info-hover-bg,
+				border-color: $label-info-hover-border-color,
+				color: $label-info-hover-color,
+			),
+			focus: (
+				color: $label-info-hover-color,
+			),
 		),
 		link: (
 			color: $label-info-link-color,
@@ -583,13 +591,15 @@ $label-warning: map-deep-merge(
 		background-color: $label-warning-bg,
 		border-color: $label-warning-border-color,
 		color: $label-warning-color,
-		hover: (
-			background-color: $label-warning-hover-bg,
-			border-color: $label-warning-hover-border-color,
-			color: $label-warning-hover-color,
-		),
-		focus: (
-			color: $label-warning-hover-color,
+		href: (
+			hover: (
+				background-color: $label-warning-hover-bg,
+				border-color: $label-warning-hover-border-color,
+				color: $label-warning-hover-color,
+			),
+			focus: (
+				color: $label-warning-hover-color,
+			),
 		),
 		link: (
 			color: $label-warning-link-color,
@@ -653,13 +663,15 @@ $label-danger: map-deep-merge(
 		background-color: $label-danger-bg,
 		border-color: $label-danger-border-color,
 		color: $label-danger-color,
-		hover: (
-			background-color: $label-danger-hover-bg,
-			border-color: $label-danger-hover-border-color,
-			color: $label-danger-hover-color,
-		),
-		focus: (
-			color: $label-danger-hover-color,
+		href: (
+			hover: (
+				background-color: $label-danger-hover-bg,
+				border-color: $label-danger-hover-border-color,
+				color: $label-danger-hover-color,
+			),
+			focus: (
+				color: $label-danger-hover-color,
+			),
 		),
 		link: (
 			color: $label-danger-link-color,
@@ -723,13 +735,15 @@ $label-light: map-deep-merge(
 		background-color: $label-light-bg,
 		border-color: $label-light-border-color,
 		color: $label-light-color,
-		hover: (
-			background-color: $label-light-hover-bg,
-			border-color: $label-light-hover-border-color,
-			color: $label-light-hover-color,
-		),
-		focus: (
-			color: $label-light-hover-color,
+		href: (
+			hover: (
+				background-color: $label-light-hover-bg,
+				border-color: $label-light-hover-border-color,
+				color: $label-light-hover-color,
+			),
+			focus: (
+				color: $label-light-hover-color,
+			),
 		),
 		link: (
 			color: $label-light-link-color,
@@ -793,13 +807,15 @@ $label-dark: map-deep-merge(
 		background-color: $label-dark-bg,
 		border-color: $label-dark-border-color,
 		color: $label-dark-color,
-		hover: (
-			background-color: $label-dark-hover-bg,
-			border-color: $label-dark-hover-border-color,
-			color: $label-dark-hover-color,
-		),
-		focus: (
-			color: $label-dark-hover-color,
+		href: (
+			hover: (
+				background-color: $label-dark-hover-bg,
+				border-color: $label-dark-hover-border-color,
+				color: $label-dark-hover-color,
+			),
+			focus: (
+				color: $label-dark-hover-color,
+			),
 		),
 		link: (
 			color: $label-dark-link-color,
@@ -820,10 +836,12 @@ $label-inverse-primary: map-deep-merge(
 		background-color: $primary,
 		border-color: $primary,
 		color: color-yiq($primary),
-		hover: (
-			background-color: clay-darken($primary, 10%),
-			border-color: clay-darken($primary, 10%),
-			color: color-yiq(clay-darken($primary, 10%)),
+		href: (
+			hover: (
+				background-color: clay-darken($primary, 10%),
+				border-color: clay-darken($primary, 10%),
+				color: color-yiq(clay-darken($primary, 10%)),
+			),
 		),
 		link: (
 			hover: (
@@ -845,10 +863,12 @@ $label-inverse-secondary: map-deep-merge(
 		background-color: $secondary,
 		border-color: $secondary,
 		color: color-yiq($secondary),
-		hover: (
-			background-color: clay-darken($secondary, 10%),
-			border-color: clay-darken($secondary, 10%),
-			color: color-yiq(clay-darken($secondary, 10%)),
+		href: (
+			hover: (
+				background-color: clay-darken($secondary, 10%),
+				border-color: clay-darken($secondary, 10%),
+				color: color-yiq(clay-darken($secondary, 10%)),
+			),
 		),
 		link: (
 			hover: (
@@ -870,10 +890,12 @@ $label-inverse-success: map-deep-merge(
 		background-color: $success,
 		border-color: $success,
 		color: color-yiq($success),
-		hover: (
-			background-color: clay-darken($success, 10%),
-			border-color: clay-darken($success, 10%),
-			color: color-yiq(clay-darken($success, 10%)),
+		href: (
+			hover: (
+				background-color: clay-darken($success, 10%),
+				border-color: clay-darken($success, 10%),
+				color: color-yiq(clay-darken($success, 10%)),
+			),
 		),
 		link: (
 			hover: (
@@ -895,10 +917,12 @@ $label-inverse-info: map-deep-merge(
 		background-color: $info,
 		border-color: $info,
 		color: color-yiq($info),
-		hover: (
-			background-color: clay-darken($info, 10%),
-			border-color: clay-darken($info, 10%),
-			color: color-yiq(clay-darken($info, 10%)),
+		href: (
+			hover: (
+				background-color: clay-darken($info, 10%),
+				border-color: clay-darken($info, 10%),
+				color: color-yiq(clay-darken($info, 10%)),
+			),
 		),
 		link: (
 			hover: (
@@ -920,10 +944,12 @@ $label-inverse-warning: map-deep-merge(
 		background-color: $warning,
 		border-color: $warning,
 		color: color-yiq($warning),
-		hover: (
-			background-color: clay-darken($warning, 10%),
-			border-color: clay-darken($warning, 10%),
-			color: color-yiq(clay-darken($warning, 10%)),
+		href: (
+			hover: (
+				background-color: clay-darken($warning, 10%),
+				border-color: clay-darken($warning, 10%),
+				color: color-yiq(clay-darken($warning, 10%)),
+			),
 		),
 		link: (
 			hover: (
@@ -945,10 +971,12 @@ $label-inverse-danger: map-deep-merge(
 		background-color: $danger,
 		border-color: $danger,
 		color: color-yiq($danger),
-		hover: (
-			background-color: clay-darken($danger, 10%),
-			border-color: clay-darken($danger, 10%),
-			color: color-yiq(clay-darken($danger, 10%)),
+		href: (
+			hover: (
+				background-color: clay-darken($danger, 10%),
+				border-color: clay-darken($danger, 10%),
+				color: color-yiq(clay-darken($danger, 10%)),
+			),
 		),
 		link: (
 			hover: (
@@ -970,10 +998,12 @@ $label-inverse-light: map-deep-merge(
 		background-color: $light,
 		border-color: $light,
 		color: color-yiq($light),
-		hover: (
-			background-color: clay-darken($light, 10%),
-			border-color: clay-darken($light, 10%),
-			color: color-yiq(clay-darken($light, 10%)),
+		href: (
+			hover: (
+				background-color: clay-darken($light, 10%),
+				border-color: clay-darken($light, 10%),
+				color: color-yiq(clay-darken($light, 10%)),
+			),
 		),
 		link: (
 			hover: (
@@ -995,10 +1025,12 @@ $label-inverse-dark: map-deep-merge(
 		background-color: $dark,
 		border-color: $dark,
 		color: color-yiq($dark),
-		hover: (
-			background-color: clay-darken($dark, 10%),
-			border-color: clay-darken($dark, 10%),
-			color: color-yiq(clay-darken($dark, 10%)),
+		href: (
+			hover: (
+				background-color: clay-darken($dark, 10%),
+				border-color: clay-darken($dark, 10%),
+				color: color-yiq(clay-darken($dark, 10%)),
+			),
 		),
 		link: (
 			hover: (


### PR DESCRIPTION
…r `clay-label-variant` hover and focus keys should be nested in `href`. The values are output for the selectors `.label[href]`, `.label[type]`, and `.label[tabindex]`.

fixes #4383