### PR TITLE
fix(@clayui/css): C Kbd and Cadmin C Kbd allow passing in properties …

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_type.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_type.scss
@@ -203,7 +203,7 @@ strong {
 	@include clay-css($cadmin-c-kbd-group);
 
 	> .c-kbd {
-		font-size: inherit;
+		@include clay-css(setter(map-get($cadmin-c-kbd-group, c-kbd), ()));
 	}
 }
 
@@ -266,6 +266,10 @@ strong {
 
 .c-kbd-group-sm {
 	@include clay-css($cadmin-c-kbd-group-sm);
+
+	> .c-kbd {
+		@include clay-css(setter(map-get($cadmin-c-kbd-group-sm, c-kbd), ()));
+	}
 }
 
 .c-kbd-sm,
@@ -281,6 +285,10 @@ strong {
 
 .c-kbd-group-lg {
 	@include clay-css($cadmin-c-kbd-group-lg);
+
+	> .c-kbd {
+		@include clay-css(setter(map-get($cadmin-c-kbd-group-lg, c-kbd), ()));
+	}
 }
 
 .c-kbd-lg,

--- a/packages/clay-css/src/scss/cadmin/variables/_type.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_type.scss
@@ -13,6 +13,9 @@ $cadmin-c-kbd-group: () !default;
 $cadmin-c-kbd-group: map-deep-merge(
 	(
 		font-size: 14px,
+		c-kbd: (
+			font-size: inherit,
+		),
 	),
 	$cadmin-c-kbd-group
 );

--- a/packages/clay-css/src/scss/components/_type.scss
+++ b/packages/clay-css/src/scss/components/_type.scss
@@ -202,7 +202,7 @@ strong {
 	@include clay-css($c-kbd-group);
 
 	> .c-kbd {
-		font-size: inherit;
+		@include clay-css(setter(map-get($c-kbd-group, c-kbd), ()));
 	}
 }
 
@@ -265,6 +265,10 @@ strong {
 
 .c-kbd-group-sm {
 	@include clay-css($c-kbd-group-sm);
+
+	> .c-kbd {
+		@include clay-css(setter(map-get($c-kbd-group-sm, c-kbd), ()));
+	}
 }
 
 .c-kbd-sm,
@@ -280,6 +284,10 @@ strong {
 
 .c-kbd-group-lg {
 	@include clay-css($c-kbd-group-lg);
+
+	> .c-kbd {
+		@include clay-css(setter(map-get($c-kbd-group-lg, c-kbd), ()));
+	}
 }
 
 .c-kbd-lg,

--- a/packages/clay-css/src/scss/variables/_type.scss
+++ b/packages/clay-css/src/scss/variables/_type.scss
@@ -13,6 +13,9 @@ $c-kbd-group: () !default;
 $c-kbd-group: map-deep-merge(
 	(
 		font-size: 0.875rem,
+		c-kbd: (
+			font-size: inherit,
+		),
 	),
 	$c-kbd-group
 );


### PR DESCRIPTION
…to `.c-kbd-group > .c-kbd`, `.c-kbd-group-sm > .c-kbd`, and `.c-kbd-group-lg > .c-kbd` from their respective Sass map variables

fixes #4367