### PR TITLE
feat(@clayui/css): Dropdowns and Cadmin Dropdowns add Sass map `$cadmin-dropdown-menu` and generate styles for `.dropdown-menu` using `clay-dropdown-menu-variant`

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -1,14 +1,55 @@
+// .dropdown-menu
+
+// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-bg: $white !default;
+// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-border-color: $gray-300 !default;
+
+// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-border-width: 0 !default;
+
+// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-box-shadow: 0 1px 5px -1px rgba(0, 0, 0, 0.3) !default;
+
+// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-font-size: 0.875rem !default; // 14px
 
-$dropdown-padding-y: 0.375rem !default; // 6px
+// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-min-height: 40px !default;
+
+// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-min-width: 240px !default;
+
+// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-max-width: 240px !default;
+
+$dropdown-padding-y: 0.375rem !default; // 6px
 $dropdown-spacer: 0.3125rem !default; // 5px
+
+$dropdown-menu: () !default;
+$dropdown-menu: map-deep-merge(
+	(
+		background-color: $dropdown-bg,
+		border-color: $dropdown-border-color,
+		border-width: $dropdown-border-width,
+		box-shadow: clay-enable-shadows($dropdown-box-shadow),
+		font-size: $dropdown-font-size,
+		margin: $dropdown-spacer 0 0,
+		max-width: $dropdown-max-width,
+		min-height: $dropdown-min-height,
+		min-width: $dropdown-min-width,
+		padding: $dropdown-padding-y 0,
+	),
+	$dropdown-menu
+);
 
 $dropdown-header-color: $gray-900 !default;
 $dropdown-header-font-size: 0.875rem !default; // 14px

--- a/packages/clay-css/src/scss/cadmin/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_dropdowns.scss
@@ -122,41 +122,7 @@
 
 .dropdown-menu,
 &.dropdown-menu {
-	background-clip: padding-box;
-	background-color: $cadmin-dropdown-bg;
-	border-color: $cadmin-dropdown-border-color;
-	border-style: $cadmin-dropdown-border-style;
-	border-width: $cadmin-dropdown-border-width;
-
-	@include border-radius($cadmin-dropdown-border-radius);
-	@include box-shadow($cadmin-dropdown-box-shadow);
-
-	color: $cadmin-dropdown-color;
-	display: none;
-	float: left;
-	font-size: $cadmin-dropdown-font-size;
-	left: 0;
-	list-style: none;
-	margin: $cadmin-dropdown-spacer 0 0;
-	max-height: $cadmin-dropdown-max-height;
-	max-width: $cadmin-dropdown-max-width;
-	min-height: $cadmin-dropdown-min-height;
-	min-width: $cadmin-dropdown-min-width;
-	overflow: auto;
-	padding: $cadmin-dropdown-padding-y 0;
-	position: absolute;
-	text-align: left;
-	top: 100%;
-	z-index: $cadmin-zindex-dropdown;
-
-	@include media-breakpoint-down(md, $cadmin-grid-breakpoints) {
-		max-height: $cadmin-dropdown-max-height-mobile;
-		max-width: $cadmin-dropdown-max-width-mobile;
-	}
-
-	@include clay-scale-component {
-		font-size: $cadmin-dropdown-font-size-mobile;
-	}
+	@include clay-dropdown-menu-variant($cadmin-dropdown-menu);
 
 	.alert {
 		font-size: $cadmin-dropdown-alert-font-size;

--- a/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
@@ -1,3 +1,5 @@
+// .dropdown-menu
+
 $cadmin-dropdown-bg: $cadmin-white !default;
 $cadmin-dropdown-border-color: $cadmin-gray-300 !default;
 $cadmin-dropdown-border-style: solid !default;
@@ -14,13 +16,50 @@ $cadmin-dropdown-max-height: 500px !default;
 $cadmin-dropdown-max-width: 240px !default;
 $cadmin-dropdown-min-height: 40px !default;
 $cadmin-dropdown-min-width: 240px !default;
-$cadmin-dropdown-padding-y: 6px !default; // 6px
 
 $cadmin-dropdown-font-size-mobile: null !default;
 $cadmin-dropdown-max-height-mobile: 295px !default;
 $cadmin-dropdown-max-width-mobile: 230px !default;
 
+$cadmin-dropdown-padding-y: 6px !default; // 6px
 $cadmin-dropdown-spacer: 5px !default; // 5px
+
+$cadmin-dropdown-menu: () !default;
+$cadmin-dropdown-menu: map-deep-merge(
+	(
+		breakpoint-down: md,
+		background-clip: padding-box,
+		background-color: $cadmin-dropdown-bg,
+		border-color: $cadmin-dropdown-border-color,
+		border-style: $cadmin-dropdown-border-style,
+		border-width: $cadmin-dropdown-border-width,
+		border-radius: clay-enable-rounded($cadmin-dropdown-border-radius),
+		box-shadow: clay-enable-shadows($cadmin-dropdown-box-shadow),
+		color: $cadmin-dropdown-color,
+		display: none,
+		float: left,
+		font-size: $cadmin-dropdown-font-size,
+		left: 0,
+		list-style: none,
+		margin: $cadmin-dropdown-spacer 0 0,
+		max-height: $cadmin-dropdown-max-height,
+		max-width: $cadmin-dropdown-max-width,
+		min-height: $cadmin-dropdown-min-height,
+		min-width: $cadmin-dropdown-min-width,
+		overflow: auto,
+		padding: $cadmin-dropdown-padding-y 0,
+		position: absolute,
+		text-align: left,
+		top: 100%,
+		z-index: $cadmin-zindex-dropdown,
+		mobile: (
+			font-size: $cadmin-dropdown-font-size-mobile,
+			max-height: $cadmin-dropdown-max-height-mobile,
+			max-width: $cadmin-dropdown-max-width-mobile,
+		),
+	),
+	$cadmin-dropdown-menu
+);
 
 $cadmin-dropdown-divider-bg: $cadmin-dropdown-border-color !default;
 $cadmin-dropdown-divider-margin-y: $cadmin-spacer * 0.5 !default;

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -124,41 +124,7 @@
 // Dropdown Menu
 
 .dropdown-menu {
-	background-clip: padding-box;
-	background-color: $dropdown-bg;
-	border-color: $dropdown-border-color;
-	border-style: $dropdown-border-style;
-	border-width: $dropdown-border-width;
-
-	@include border-radius($dropdown-border-radius);
-	@include box-shadow($dropdown-box-shadow);
-
-	color: $dropdown-color;
-	display: none;
-	float: left;
-	font-size: $dropdown-font-size;
-	left: 0;
-	list-style: none;
-	margin: $dropdown-spacer 0 0;
-	max-height: $dropdown-max-height;
-	max-width: $dropdown-max-width;
-	min-height: $dropdown-min-height;
-	min-width: $dropdown-min-width;
-	overflow: auto;
-	padding: $dropdown-padding-y 0;
-	position: absolute;
-	text-align: left;
-	top: 100%;
-	z-index: $zindex-dropdown;
-
-	@include media-breakpoint-down(md) {
-		max-height: $dropdown-max-height-mobile;
-		max-width: $dropdown-max-width-mobile;
-	}
-
-	@include clay-scale-component {
-		font-size: $dropdown-font-size-mobile;
-	}
+	@include clay-dropdown-menu-variant($dropdown-menu);
 
 	.alert {
 		font-size: $dropdown-alert-font-size;
@@ -203,10 +169,6 @@
 	> .list-unstyled {
 		margin-bottom: 0;
 	}
-}
-
-.dropdown-menu.show {
-	display: block;
 }
 
 // Dropdown Menu Alignment

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -5,19 +5,28 @@
 /// A mixin to create Dropdown Menu variants. You can base your variant off Bootstrap's `.dropdown-menu` class or create your own base class (e.g., `<div class="dropdown-menu my-custom-dropdown-menu"></div>` or `<div class="my-custom-dropdown-menu"></div>`).
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
-/// enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
-/// breakpoint-down: {String, Null}, // The Bootstrap 4 Breakpoint {xs | sm | md | lg | xl}
-/// See Mixin `clay-css` for available keys to pass into the base selector
-/// mobile: {Map | Null}, // See Mixin `clay-css` for available keys
+/// (
+/// 	enabled: {Bool}, // Set to false to prevent .dropdown-item styles from being output. Default: true
+/// 	breakpoint-down: {String}, // The breakpoint to use in `media-breakpoint-down`
+/// 	mobile: (
+/// 		// .dropdown-menu { @include media-breakpoint-down(breakpoint-down) {} }
+/// 	),
+/// 	before: (
+/// 		// .dropdown-menu::before
+/// 	),
+/// 	after: (
+/// 		// .dropdown-menu::after
+/// 	),
+/// 	show: (
+/// 		// .dropdown-menu.show
+/// 	),
+/// )
 /// -=-=-=-=-=- Deprecated -=-=-=-=-=-
 /// bg: {Color | String | Null}, // deprecated after 3.9.0
 /// bg-clip: {String | Null}, // deprecated after 3.9.0
 /// font-size-mobile: {Number | String | Null}, // deprecated after 3.9.0
 /// max-height-mobile: {Number | String | Null}, // deprecated after 3.9.0
 /// max-width-mobile: {Number | String | Null}, // deprecated after 3.9.0
-/// @todo
-/// - Add @example
-/// - Add @link to documentation
 
 @mixin clay-dropdown-menu-variant($map) {
 	$enabled: setter(map-get($map, enabled), true);
@@ -63,6 +72,18 @@
 			@include media-breakpoint-down($breakpoint-down) {
 				@include clay-css($mobile);
 			}
+		}
+
+		&::before {
+			@include clay-css(setter(map-get($map, before), ()));
+		}
+
+		&::after {
+			@include clay-css(setter(map-get($map, after), ()));
+		}
+
+		&.show {
+			@include clay-css(setter(map-get($map, show), ()));
 		}
 	}
 }

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -1,26 +1,112 @@
+// .dropdown-menu
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-bg: $white !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-border-color: rgba($black, 0.15) !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-border-style: solid !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-border-width: $border-width !default;
 
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-border-radius: $border-radius !default;
+
+/// @deprecated as of v3.x with no replacement
+
 $dropdown-inner-border-radius: $dropdown-border-radius
 	math-sign($dropdown-border-width) !default;
 
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-box-shadow: 0 0.5rem 1rem rgba($black, 0.175) !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-color: $body-color !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-font-size: $font-size-base !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-max-height: 500px !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-max-width: 260px !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-min-height: null !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-min-width: 10rem !default;
-$dropdown-padding-y: 0.5rem !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
 
 $dropdown-font-size-mobile: null !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-max-height-mobile: 295px !default;
+
+/// @deprecated as of v3.x use map $dropdown-menu instead
+
 $dropdown-max-width-mobile: 230px !default;
 
+$dropdown-padding-y: 0.5rem !default;
 $dropdown-spacer: 0.125rem !default;
+
+$dropdown-menu: () !default;
+$dropdown-menu: map-deep-merge(
+	(
+		breakpoint-down: md,
+		background-clip: padding-box,
+		background-color: $dropdown-bg,
+		border-color: $dropdown-border-color,
+		border-radius: clay-enable-rounded($dropdown-border-radius),
+		border-style: $dropdown-border-style,
+		border-width: $dropdown-border-width,
+		box-shadow: clay-enable-shadows($dropdown-box-shadow),
+		color: $dropdown-color,
+		display: none,
+		float: left,
+		font-size: $dropdown-font-size,
+		left: 0,
+		list-style: none,
+		margin: $dropdown-spacer 0 0,
+		max-height: $dropdown-max-height,
+		max-width: $dropdown-max-width,
+		min-height: $dropdown-min-height,
+		min-width: $dropdown-min-width,
+		overflow: auto,
+		padding: $dropdown-padding-y 0,
+		position: absolute,
+		text-align: left,
+		top: 100%,
+		z-index: $zindex-dropdown,
+		mobile: (
+			font-size: $dropdown-font-size-mobile,
+			max-height: $dropdown-max-height-mobile,
+			max-width: $dropdown-max-width-mobile,
+		),
+		show: (
+			display: block,
+		),
+	),
+	$dropdown-menu
+);
 
 $dropdown-divider-bg: $gray-200 !default;
 $dropdown-divider-margin-y: $spacer * 0.5 !default;


### PR DESCRIPTION
fixes #4380