### PR TITLE
fix(clay-css): SF import `components/_reboot.scss` in `packages/clay-…

### DIFF
--- a/packages/clay-css/ATLAS-THEME.md
+++ b/packages/clay-css/ATLAS-THEME.md
@@ -242,6 +242,7 @@ src/scss/mixins/_utilities.scss
 ## Clay CSS Components
 
 ```
+src/scss/components/_reboot.scss
 src/scss/components/_grid.scss
 src/scss/components/_alerts.scss
 src/scss/components/_aspect-ratio.scss

--- a/packages/clay-css/BASE-THEME.md
+++ b/packages/clay-css/BASE-THEME.md
@@ -200,6 +200,7 @@ src/scss/mixins/_utilities.scss
 ## Clay CSS Components
 
 ```
+src/scss/components/_reboot.scss
 src/scss/components/_grid.scss
 src/scss/components/_alerts.scss
 src/scss/components/_aspect-ratio.scss

--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -2,7 +2,7 @@
 	@import url($font-import-url);
 }
 
-@import "components/_reboot.scss";
+@import "components/_reboot";
 
 @import "components/_grid";
 


### PR DESCRIPTION
…css/src/scss/_components.scss`

fix(clay-css): Add 'components/_reboot.scss' file to ATLAS-THEME.md and BASE-THEME.md files

For more details please check: https://issues.liferay.com/browse/LPS-133314

fixes liferay#4124