### PR TITLE
fix(@clayui/provider): removes dependency from ClayModal to avoid circular dependency issues

### DIFF
--- a/packages/clay-provider/docs/provider.mdx
+++ b/packages/clay-provider/docs/provider.mdx
@@ -11,7 +11,6 @@ packageNpm: '@clayui/core'
 -   [Application provider](#application-provider)
     -   [Theme](#theme)
     -   [Icon spritemap](#icon-spritemap)
-    -   [Modal](#modal)
 -   [API](#api)
 
 </div>
@@ -51,52 +50,6 @@ Icons need the path where to find the icon collection to be rendered. Clay compo
 	<Icon symbol="books" />
 	<Icon symbol="times" />
 </Provider>
-```
-
-### Modal
-
-By default `Provider` provides the context of [`Modal`](/docs/components/modal.html), manages the state of Modal. Allows you to call a Modal anywhere in your application structure.
-
-```jsx
-import {useContext} from 'react';
-import {Button, ModalContext} from '@clayui/core';
-
-const Back = () => {
-	const [state, dispatch] = useContext(ModalContext);
-
-	return (
-		<Button
-			onClick={() =>
-				dispatch({
-					payload: {
-						body: "Your draft won't be saved.",
-						footer: [
-							,
-							,
-							<Button.Group key={3} spaced>
-								<Button displayType="secondary">Cancel</Button>
-								<Button onClick={state.onClose}>Discard</Button>
-							</Button.Group>,
-						],
-						header: 'Discard draft?',
-						size: 'lg',
-					},
-					type: 1,
-				})
-			}
-		>
-			Back
-		</Button>
-	);
-};
-```
-
-```jsx
-export const App = () => (
-	<Provider>
-		<Back />
-	</Provider>
-);
 ```
 
 ## API

--- a/packages/clay-provider/package.json
+++ b/packages/clay-provider/package.json
@@ -26,8 +26,7 @@
 		"react"
 	],
 	"dependencies": {
-		"@clayui/icon": "^3.39.0",
-		"@clayui/modal": "^3.39.0"
+		"@clayui/icon": "^3.39.0"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-provider/src/Provider.tsx
+++ b/packages/clay-provider/src/Provider.tsx
@@ -4,7 +4,6 @@
  */
 
 import {ClayIconSpriteContext} from '@clayui/icon';
-import {ClayModalProvider} from '@clayui/modal';
 import React, {useContext} from 'react';
 
 interface IProviderProps extends IProviderContext {
@@ -38,9 +37,7 @@ export const Provider = ({
 }: IProviderProps) => (
 	<Context.Provider value={{theme, ...otherProps}}>
 		<ClayIconSpriteContext.Provider value={spritemap}>
-			<ClayModalProvider>
-				{theme ? <div className={theme}>{children}</div> : children}
-			</ClayModalProvider>
+			{theme ? <div className={theme}>{children}</div> : children}
 		</ClayIconSpriteContext.Provider>
 	</Context.Provider>
 );

--- a/packages/clay-shared/package.json
+++ b/packages/clay-shared/package.json
@@ -28,12 +28,12 @@
 	"dependencies": {
 		"@clayui/button": "^3.39.0",
 		"@clayui/link": "^3.39.0",
+		"@clayui/provider": "^3.39.0",
 		"classnames": "^2.2.6",
 		"dom-align": "^1.10.2"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",
-		"@clayui/provider": "^3.39.0",
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0"
 	},


### PR DESCRIPTION
Fixes #4399

Unfortunately, this is the only option we have for not using `peerDependencies`. We can for now remove the ClayModalProvider from the ClayProvider and when we can stabilize the package dependencies on `@clayui/core` we can add that support again, it's safe to remove the ClayProvider because it's not used yet.