### PR TITLE
chore(@clayui/core): select children in collapsed nodes

### DIFF
--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -62,6 +62,7 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 	});
 
 	const selection = useMultipleSelection({
+		items: props.items,
 		onSelectionChange: props.onSelectionChange,
 		selectedKeys: props.selectedKeys,
 	});
@@ -386,6 +387,7 @@ export function createImmutableTree<T extends Array<Record<string, any>>>(
 
 	return {
 		applyPatches,
+		nodeByPath,
 		produce,
 	};
 }


### PR DESCRIPTION
Up to now, when a node was collapsed and selected, its
children weren't selected, so in this change we're making
that possible

Related to #4396 and #4389