### PR TITLE
fix(@clayui/css): Icons make them more configurable via `$lexicon-ico…

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_icons.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_icons.scss
@@ -1,10 +1,5 @@
 .lexicon-icon {
-	display: inline-block;
-	fill: currentColor;
-	height: $cadmin-lexicon-icon-size;
-	margin-top: -3px;
-	vertical-align: middle;
-	width: $cadmin-lexicon-icon-size;
+	@include clay-css(setter($cadmin-lexicon-icon, ()));
 }
 
 .order-arrow-down-active {

--- a/packages/clay-css/src/scss/cadmin/variables/_icons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_icons.scss
@@ -1,3 +1,18 @@
+$cadmin-lexicon-icon-size: 1em !default; // 16px
+
+$cadmin-lexicon-icon: () !default;
+$cadmin-lexicon-icon: map-merge(
+	(
+		display: inline-block,
+		fill: currentColor,
+		height: $cadmin-lexicon-icon-size,
+		margin-top: -3px,
+		vertical-align: middle,
+		width: $cadmin-lexicon-icon-size,
+	),
+	$cadmin-lexicon-icon
+);
+
 $cadmin-collapse-icon-padding-left: null !default;
 $cadmin-collapse-icon-padding-right: 45px !default; // 45px
 
@@ -9,8 +24,6 @@ $cadmin-collapse-icon-position-top: clay-collapse-icon-align(
 	1px,
 	0.9375em
 ) !default;
-
-$cadmin-lexicon-icon-size: 1em !default; // 16px
 
 $cadmin-order-arrow-down-active-color: $cadmin-gray-500 !default;
 $cadmin-order-arrow-up-active-color: $cadmin-order-arrow-down-active-color !default;

--- a/packages/clay-css/src/scss/components/_icons.scss
+++ b/packages/clay-css/src/scss/components/_icons.scss
@@ -1,22 +1,17 @@
 .lexicon-icon {
-	display: inline-block;
-	fill: currentColor;
-	height: $lexicon-icon-size;
-	margin-top: -3px;
-	vertical-align: middle;
-	width: $lexicon-icon-size;
+	@include clay-css(setter($lexicon-icon, ()));
 }
 
 .lexicon-icon-sm {
-	font-size: $lexicon-icon-sm-font-size;
+	@include clay-css(setter($lexicon-icon-sm, ()));
 }
 
 .lexicon-icon-lg {
-	font-size: $lexicon-icon-lg-font-size;
+	@include clay-css(setter($lexicon-icon-lg, ()));
 }
 
 .lexicon-icon-xl {
-	font-size: $lexicon-icon-xl-font-size;
+	@include clay-css(setter($lexicon-icon-xl, ()));
 }
 
 .order-arrow-down-active {

--- a/packages/clay-css/src/scss/variables/_icons.scss
+++ b/packages/clay-css/src/scss/variables/_icons.scss
@@ -1,3 +1,63 @@
+// .lexicon-icon
+
+$lexicon-icon-size: 1em !default; // 16px
+
+$lexicon-icon: () !default;
+$lexicon-icon: map-merge(
+	(
+		display: inline-block,
+		fill: currentColor,
+		height: $lexicon-icon-size,
+		margin-top: -3px,
+		vertical-align: middle,
+		width: $lexicon-icon-size,
+	),
+	$lexicon-icon
+);
+
+// .lexicon-icon-sm
+
+$lexicon-icon-sm-font-size: 0.5rem !default; // 8px
+
+$lexicon-icon-sm: () !default;
+$lexicon-icon-sm: map-merge(
+	(
+		font-size: $lexicon-icon-sm-font-size,
+	),
+	$lexicon-icon-sm
+);
+
+// .lexicon-icon-lg
+
+$lexicon-icon-lg-font-size: 2rem !default; // 32px
+
+$lexicon-icon-lg: () !default;
+$lexicon-icon-lg: map-merge(
+	(
+		font-size: $lexicon-icon-lg-font-size,
+	),
+	$lexicon-icon-lg
+);
+
+// .lexicon-icon-xl
+
+$lexicon-icon-xl-font-size: 8rem !default; // 128px
+
+$lexicon-icon-xl: () !default;
+$lexicon-icon-xl: map-merge(
+	(
+		font-size: $lexicon-icon-xl-font-size,
+	),
+	$lexicon-icon-xl
+);
+
+// .order-arrow
+
+$order-arrow-down-active-color: rgba($black, 0.9) !default;
+$order-arrow-up-active-color: $order-arrow-down-active-color !default;
+
+// .collapse-icon[href], .collapse-icon[type]
+
 $collapse-icon-padding-left: null !default;
 $collapse-icon-padding-right: 2.28125rem !default; // 45px
 
@@ -9,12 +69,3 @@ $collapse-icon-position-top: clay-collapse-icon-align(
 	0.0625rem,
 	0.9375em
 ) !default;
-
-$lexicon-icon-size: 1em !default; // 16px
-
-$lexicon-icon-sm-font-size: 0.5rem !default; // 8px
-$lexicon-icon-lg-font-size: 2rem !default; // 32px
-$lexicon-icon-xl-font-size: 8rem !default; // 128px
-
-$order-arrow-down-active-color: rgba($black, 0.9) !default;
-$order-arrow-up-active-color: $order-arrow-down-active-color !default;


### PR DESCRIPTION
…n`, `$lexicon-icon-sm`, `$lexicon-icon-lg`, `$lexicon-icon-xl` Sass maps

fix(@clayui/css): Cadmin Icons make them more configurable via `$cadmin-lexicon-icon` Sass map

I wanted to convert the whole thing, but ran into some naming issues that lead me to toy with #4409.

fixes #4406