### PR TITLE
chore(@clayui/alert): adds the indicator and changes the markup for text alignment in the feedback variant

### DIFF
--- a/packages/clay-alert/src/__tests__/__snapshots__/ClayAlert.tsx.snap
+++ b/packages/clay-alert/src/__tests__/__snapshots__/ClayAlert.tsx.snap
@@ -104,14 +104,14 @@ exports[`ClayAlert renders alert inline with action 1`] = `
 exports[`ClayAlert renders as \`feedback\` variant 1`] = `
 <div>
   <div
-    class="alert alert-feedback alert-info"
+    class="alert alert-feedback alert-indicator-start alert-info"
     role="alert"
   >
     <div
       class="alert-autofit-row autofit-row"
     >
       <div
-        class="autofit-col"
+        class="autofit-col autofit-col-expand"
       >
         <div
           class="autofit-section"
@@ -128,14 +128,6 @@ exports[`ClayAlert renders as \`feedback\` variant 1`] = `
               />
             </svg>
           </span>
-        </div>
-      </div>
-      <div
-        class="autofit-col autofit-col-expand"
-      >
-        <div
-          class="autofit-section"
-        >
           <strong
             class="lead"
           >

--- a/packages/clay-alert/src/index.tsx
+++ b/packages/clay-alert/src/index.tsx
@@ -109,6 +109,8 @@ const ICON_MAP = {
 	warning: 'warning-full',
 };
 
+const VARIANTS = ['inline', 'feedback'];
+
 const ClayAlert: React.FunctionComponent<IClayAlertProps> & {
 	Footer: typeof Footer;
 	ToastContainer: typeof ToastContainer;
@@ -150,7 +152,7 @@ const ClayAlert: React.FunctionComponent<IClayAlertProps> & {
 			{...otherProps}
 			className={classNames(className, 'alert', {
 				'alert-dismissible': showDismissible,
-				'alert-feedback': variant === 'feedback',
+				'alert-feedback alert-indicator-start': variant === 'feedback',
 				'alert-fluid': variant === 'stripe',
 				'alert-inline': variant === 'inline',
 				[`alert-${displayType}`]: displayType,
@@ -161,7 +163,7 @@ const ClayAlert: React.FunctionComponent<IClayAlertProps> & {
 		>
 			<ConditionalContainer>
 				<ClayLayout.ContentRow className="alert-autofit-row">
-					{variant !== 'inline' && (
+					{!VARIANTS.includes(variant as string) && (
 						<ClayLayout.ContentCol>
 							<ClayLayout.ContentSection>
 								<AlertIndicator />
@@ -171,7 +173,9 @@ const ClayAlert: React.FunctionComponent<IClayAlertProps> & {
 
 					<ClayLayout.ContentCol expand>
 						<ClayLayout.ContentSection>
-							{variant === 'inline' && <AlertIndicator />}
+							{VARIANTS.includes(variant as string) && (
+								<AlertIndicator />
+							)}
 
 							{title && <strong className="lead">{title}</strong>}
 


### PR DESCRIPTION
Fixes #4408

For the text alignment to work well I also needed to change the markup to the feedback variant which requires the Indicator not to be separated from the text due to the CSS implementation.