### PR TITLE
feat(@clayui/css): Mixins `clay-alert-variant` adds option to pass in styles to `&.alert-dismissible`, `&.alert-dismissible .container-fluid`, `.alert-indicator .lexicon-icon`, and `.container-fluid`

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_alerts.scss
@@ -112,6 +112,8 @@ $alert-footer: map-deep-merge(
 
 // Alert Fluid
 
+// @deprecated use the Sass map `$alert-fluid` instead
+
 $alert-fluid-container: () !default;
 $alert-fluid-container: map-merge(
 	(
@@ -119,6 +121,14 @@ $alert-fluid-container: map-merge(
 		padding-top: 0.96875rem,
 	),
 	$alert-fluid-container
+);
+
+$alert-fluid: () !default;
+$alert-fluid: map-deep-merge(
+	(
+		container-fluid: $alert-fluid-container,
+	),
+	$alert-fluid
 );
 
 // Alert Notification

--- a/packages/clay-css/src/scss/cadmin/components/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_alerts.scss
@@ -35,23 +35,7 @@
 // Alert Fluid
 
 .alert-fluid {
-	@include clay-css($cadmin-alert-fluid);
-
-	&.alert-dismissible {
-		.container,
-		.container-fluid {
-			@include clay-css($cadmin-alert-fluid-dismissible-container);
-		}
-	}
-
-	.container,
-	.container-fluid {
-		@include clay-css($cadmin-alert-fluid-container);
-	}
-
-	.close {
-		@include clay-close($cadmin-alert-fluid-close);
-	}
+	@include clay-alert-variant($cadmin-alert-fluid);
 }
 
 // Alert Notifications

--- a/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
@@ -232,10 +232,23 @@ $cadmin-alert-dismissible: map-deep-merge(
 
 // Alert Fluid
 
+// @deprecated use the Sass map `$alert-fluid` instead
+
 $cadmin-alert-fluid-border-bottom-width: 1px !default;
+
+// @deprecated use the Sass map `$alert-fluid` instead
+
 $cadmin-alert-fluid-border-left-width: 0 !default;
+
+// @deprecated use the Sass map `$alert-fluid` instead
+
 $cadmin-alert-fluid-border-right-width: 0 !default;
+
+// @deprecated use the Sass map `$alert-fluid` instead
+
 $cadmin-alert-fluid-border-top-width: 0 !default;
+
+// @deprecated use the Sass map `$alert-fluid` instead
 
 $cadmin-alert-fluid-border-width: $cadmin-alert-fluid-border-top-width
 	$cadmin-alert-fluid-border-right-width
@@ -243,18 +256,9 @@ $cadmin-alert-fluid-border-width: $cadmin-alert-fluid-border-top-width
 	$cadmin-alert-fluid-border-left-width !default;
 $cadmin-alert-fluid-margin-bottom: 0 !default;
 
-$cadmin-alert-fluid: () !default;
-$cadmin-alert-fluid: map-merge(
-	(
-		border-radius: 0,
-		border-width: $cadmin-alert-fluid-border-width,
-		margin-bottom: $cadmin-alert-fluid-margin-bottom,
-		padding: 0,
-	),
-	$cadmin-alert-fluid
-);
-
 // .alert-fluid .container-fluid
+
+// @deprecated use the Sass map `$alert-fluid` instead
 
 $cadmin-alert-fluid-container: () !default;
 $cadmin-alert-fluid-container: map-merge(
@@ -268,6 +272,8 @@ $cadmin-alert-fluid-container: map-merge(
 );
 
 // .alert-fluid.alert-dismissible .container-fluid
+
+// @deprecated use the Sass map `$alert-fluid` instead
 
 $cadmin-alert-fluid-dismissible-container: () !default;
 $cadmin-alert-fluid-dismissible-container: map-merge(
@@ -287,12 +293,30 @@ $cadmin-alert-fluid-dismissible-container: map-merge(
 
 // .alert-fluid .close
 
+// @deprecated use the Sass map `$alert-fluid` instead
+
 $cadmin-alert-fluid-close: () !default;
 $cadmin-alert-fluid-close: map-deep-merge(
 	(
 		right: calc(#{$cadmin-grid-gutter-width * 0.5} + 4px),
 	),
 	$cadmin-alert-fluid-close
+);
+
+$cadmin-alert-fluid: () !default;
+$cadmin-alert-fluid: map-merge(
+	(
+		border-radius: 0,
+		border-width: $cadmin-alert-fluid-border-width,
+		margin-bottom: $cadmin-alert-fluid-margin-bottom,
+		padding: 0,
+		alert-dismissible: (
+			container-fluid: $cadmin-alert-fluid-dismissible-container,
+		),
+		close: $cadmin-alert-fluid-close,
+		container-fluid: $cadmin-alert-fluid-container,
+	),
+	$cadmin-alert-fluid
 );
 
 // .alert-notifications-absolute

--- a/packages/clay-css/src/scss/components/_alerts.scss
+++ b/packages/clay-css/src/scss/components/_alerts.scss
@@ -20,6 +20,10 @@
 .alert-indicator {
 	@include clay-css($alert-indicator);
 
+	.lexicon-icon {
+		@include clay-css(setter(map-get($alert-indicator, lexicon-icon), ()));
+	}
+
 	+ .lead {
 		$lead: setter(map-get($alert-indicator, lead), ());
 
@@ -36,23 +40,7 @@
 // Alert Fluid
 
 .alert-fluid {
-	@include clay-css($alert-fluid);
-
-	&.alert-dismissible {
-		.container,
-		.container-fluid {
-			@include clay-css($alert-fluid-dismissible-container);
-		}
-	}
-
-	.container,
-	.container-fluid {
-		@include clay-css($alert-fluid-container);
-	}
-
-	.close {
-		@include clay-close($alert-fluid-close);
-	}
+	@include clay-alert-variant($alert-fluid);
 }
 
 // Alert Notifications

--- a/packages/clay-css/src/scss/mixins/_alerts.scss
+++ b/packages/clay-css/src/scss/mixins/_alerts.scss
@@ -106,8 +106,28 @@
 			@include clay-css($hr);
 		}
 
+		&.alert-dismissible {
+			@include clay-css(setter(map-get($map, alert-dismissible), ()));
+
+			.container,
+			.container-fluid {
+				@include clay-css(
+					setter(
+						map-deep-get($map, alert-dismissible, container-fluid),
+						()
+					)
+				);
+			}
+		}
+
 		.alert-indicator {
 			@include clay-css($alert-indicator);
+
+			.lexicon-icon {
+				@include clay-css(
+					setter(map-get($alert-indicator, lexicon-icon), ())
+				);
+			}
 
 			+ .lead {
 				@include clay-css($alert-indicator-lead);
@@ -128,6 +148,11 @@
 
 		.close {
 			@include clay-close($close);
+		}
+
+		.container,
+		.container-fluid {
+			@include clay-css(setter(map-get($map, container-fluid), ()));
 		}
 
 		.lead {

--- a/packages/clay-css/src/scss/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/variables/_alerts.scss
@@ -218,26 +218,30 @@ $alert-dismissible: map-deep-merge(
 
 // Alert Fluid
 
+/// @deprecated use the Sass map `$alert-fluid` instead
+
 $alert-fluid-border-bottom-width: 1px !default;
+
+/// @deprecated use the Sass map `$alert-fluid` instead
+
 $alert-fluid-border-left-width: 0 !default;
+
+/// @deprecated use the Sass map `$alert-fluid` instead
+
 $alert-fluid-border-right-width: 0 !default;
+
+/// @deprecated use the Sass map `$alert-fluid` instead
+
 $alert-fluid-border-top-width: 0 !default;
+
+/// @deprecated use the Sass map `$alert-fluid` instead
 
 $alert-fluid-border-width: $alert-fluid-border-top-width
 	$alert-fluid-border-right-width $alert-fluid-border-bottom-width
 	$alert-fluid-border-left-width !default;
 $alert-fluid-margin-bottom: 0 !default;
 
-$alert-fluid: () !default;
-$alert-fluid: map-merge(
-	(
-		border-radius: 0,
-		border-width: $alert-fluid-border-width,
-		margin-bottom: $alert-fluid-margin-bottom,
-		padding: 0,
-	),
-	$alert-fluid
-);
+/// @deprecated use the Sass map `$alert-fluid` instead
 
 $alert-fluid-container: () !default;
 $alert-fluid-container: map-merge(
@@ -249,6 +253,8 @@ $alert-fluid-container: map-merge(
 	),
 	$alert-fluid-container
 );
+
+/// @deprecated use the Sass map `$alert-fluid` instead
 
 $alert-fluid-dismissible-container: () !default;
 $alert-fluid-dismissible-container: map-merge(
@@ -267,12 +273,30 @@ $alert-fluid-dismissible-container: map-merge(
 
 // .alert-fluid .close
 
+/// @deprecated use the Sass map `$alert-fluid` instead
+
 $alert-fluid-close: () !default;
 $alert-fluid-close: map-deep-merge(
 	(
 		right: calc(#{$grid-gutter-width * 0.5} + 0.25rem),
 	),
 	$alert-fluid-close
+);
+
+$alert-fluid: () !default;
+$alert-fluid: map-deep-merge(
+	(
+		border-radius: 0,
+		border-width: $alert-fluid-border-width,
+		margin-bottom: $alert-fluid-margin-bottom,
+		padding: 0,
+		alert-dismissible: (
+			container-fluid: $alert-fluid-dismissible-container,
+		),
+		container-fluid: $alert-fluid-container,
+		close: $alert-fluid-close,
+	),
+	$alert-fluid
 );
 
 // .alert-notifications-absolute


### PR DESCRIPTION
feat(@clayui/css): Alerts convert `.alert-fluid` to use `clay-alert-variant` mixin

fix(@clayui/css): Alerts deprecates `$alert-fluid-border-bottom-width`, `$alert-fluid-border-left-width`, `$alert-fluid-border-right-width`, `$alert-fluid-border-top-width`, `$alert-fluid-border-width`, `$alert-fluid-container`, `$alert-fluid-dismissible-container`, `$alert-fluid-close`

fixes #4411