### PR TITLE
chore(@clayui/core): suppresses the error from the `onLoadMore` request and returns void does nothing

### DIFF
--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -87,10 +87,16 @@ export const TreeViewItem = React.forwardRef<HTMLDivElement, TreeViewItemProps>(
 								toggle(item.key);
 							} else {
 								if (onLoadMore) {
-									const items = await onLoadMore(item);
+									try {
+										const items = await onLoadMore(item);
 
-									insert([...item.indexes, 0], items);
-									toggle(item.key);
+										if (items) {
+											insert([...item.indexes, 0], items);
+											toggle(item.key);
+										}
+									} catch (error) {
+										console.error(error);
+									}
 								}
 							}
 						}}
@@ -109,9 +115,21 @@ export const TreeViewItem = React.forwardRef<HTMLDivElement, TreeViewItemProps>(
 							if (key === Keys.Right) {
 								if (!group) {
 									if (onLoadMore) {
-										const items = await onLoadMore(item);
+										try {
+											const items = await onLoadMore(
+												item
+											);
 
-										insert([...item.indexes, 0], items);
+											if (!items) {
+												return;
+											}
+
+											insert([...item.indexes, 0], items);
+										} catch (error) {
+											console.error(error);
+
+											return;
+										}
 									} else {
 										return;
 									}


### PR DESCRIPTION
See #4389

When a Node is asynchronous, we must handle the request's error, in this case, we only suppress the error but don't show anything to the user, this can be up to whoever is implementing the method, returning an empty value also means that the Node it is not asynchronous or should do nothing.