### PR TITLE
feat(@clayui/css): Forms adds `.form-fieldset` and `.form-legend` to provide alternative fieldset and legend styles without overriding all `fieldset` and `legend` elements

### DIFF
--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -547,6 +547,67 @@ textarea.form-control-sm,
 	height: $input-textarea-height-sm;
 }
 
+// Fieldset
+
+.form-fieldset {
+	@include clay-css($form-fieldset);
+
+	&[disabled] {
+		@include clay-css(setter(map-get($form-fieldset, disabled), ()));
+
+		label {
+			@include clay-css(
+				setter(map-deep-get($form-fieldset, disabled, label), ())
+			);
+
+			.form-control {
+				@include clay-css(
+					setter(
+						map-deep-get(
+							$form-fieldset,
+							disabled,
+							label,
+							form-control
+						),
+						()
+					)
+				);
+			}
+		}
+
+		.form-control-label-text {
+			@include clay-css(
+				setter(
+					map-deep-get(
+						$form-fieldset,
+						disabled,
+						form-control-label-text
+					),
+					()
+				)
+			);
+		}
+
+		.form-legend {
+			@include clay-css(
+				setter(map-deep-get($form-fieldset, disabled, form-legend), ())
+			);
+		}
+
+		.form-control {
+			@include clay-css(
+				setter(map-deep-get($form-fieldset, disabled, form-control), ())
+			);
+		}
+	}
+}
+
+// Legend
+
+.form-legend {
+	@include clay-css($form-legend);
+}
+
 // Form groups
 // Designed to help with the organization and spacing of vertical forms. For
 // horizontal forms, use the predefined grid classes.

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -18,10 +18,6 @@
 	}
 }
 
-fieldset {
-	word-wrap: break-word;
-}
-
 label {
 	@include clay-css($input-label);
 

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -262,40 +262,11 @@ textarea {
 }
 
 fieldset {
-	border: 0;
-	margin: 0;
-
-	// Browsers set a default `min-width: min-content;` on fieldsets,
-	// unlike e.g. `<div>`s, which have `min-width: 0;` by default.
-	// So we reset that to ensure fieldsets behave more like a standard block element.
-	// See https://github.com/twbs/bootstrap/issues/12359
-	// and https://html.spec.whatwg.org/multipage/#the-fieldset-and-legend-elements
-
-	min-width: 0;
-
-	// Reset the default outline behavior of fieldsets so they don't affect page layout.
-
-	padding: 0;
+	@include clay-css($fieldset);
 }
 
 legend {
-	// Correct the color inheritance from `fieldset` elements in IE
-
-	color: inherit;
-	display: block;
-	font-size: 1.5rem;
-	line-height: inherit;
-	margin-bottom: 0.5rem;
-
-	// Correct the text wrapping in Edge and IE
-
-	max-width: 100%;
-	padding: 0;
-
-	// Correct the text wrapping in Edge and IE
-
-	white-space: normal;
-	width: 100%;
+	@include clay-css($legend);
 }
 
 progress {

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -456,6 +456,14 @@ $form-control-tag-group-component-action: map-deep-merge(
 
 $form-grid-gutter-width: 10px !default;
 
+// .form-fieldset
+
+$form-fieldset: () !default;
+
+// .form-legend
+
+$form-legend: () !default;
+
 // Form Group
 
 $form-group-margin-bottom: 1rem !default;

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -490,6 +490,46 @@ $list-inline-padding: 0.5rem !default;
 
 $mark-bg: #fcf8e3 !default;
 
+// fieldset
+
+// `min-width`: Browsers set a default `min-width: min-content;` on fieldsets, unlike e.g. `<div>`s, which have `min-width: 0;` by default. So we reset that to ensure fieldsets behave more like a standard block element.
+// See https://github.com/twbs/bootstrap/issues/12359 and https://html.spec.whatwg.org/multipage/#the-fieldset-and-legend-elements
+// `padding`: Reset the default outline behavior of fieldsets so they don't affect page layout.
+
+$fieldset: () !default;
+$fieldset: map-merge(
+	(
+		border: 0,
+		margin: 0,
+		min-width: 0,
+		padding: 0,
+	),
+	$fieldset
+);
+
+// legend
+
+// `color`: Correct the color inheritance from `fieldset` elements in IE
+// `max-width`: Correct the text wrapping in Edge and IE
+// `white-space`: Correct the text wrapping in Edge and IE
+// `width`: Correct the text wrapping in Edge and IE
+
+$legend: () !default;
+$legend: map-merge(
+	(
+		color: inherit,
+		display: block,
+		font-size: 1.5rem,
+		line-height: inherit,
+		margin-bottom: 0.5rem,
+		max-width: 100%,
+		padding: 0,
+		white-space: normal,
+		width: 100%,
+	),
+	$legend
+);
+
 // Buttons + Forms
 
 $label-margin-bottom: 0.5rem !default;


### PR DESCRIPTION
fixes #4416