### PR TITLE
chore(@clayui/core): add the feature to add actions to the item in TreeView

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ There are two types of documents, repository infrastructure documents, release c
 -   [Developing components](developing_components.md)
 -   [How are clayui.com pages created](creating_pages.md)
 -   [Clay CSS Version History](clay_css_version_history.md)
+-   [TreeView Performance Analysis](treeview_performance.md)
 
 ## RFCs
 

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -91,7 +91,6 @@ export const TreeViewItem = React.forwardRef<
 					}
 					className={classNames('treeview-link', {
 						collapsed: group && expandedKeys.has(item.key),
-						disabled: isDragging,
 						focus,
 						'treeview-dropping-bottom':
 							overTarget && overPosition === 'bottom',

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -28,7 +28,15 @@ export const TreeViewItem = React.forwardRef<
 	HTMLDivElement,
 	ITreeViewItemProps
 >(function TreeViewItemInner(
-	{actions, children, className, isDragging, overPosition, overTarget, ...otherProps},
+	{
+		actions,
+		children,
+		className,
+		isDragging,
+		overPosition,
+		overTarget,
+		...otherProps
+	},
 	ref
 ) {
 	const spacing = useContext(SpacingContext);
@@ -83,6 +91,7 @@ export const TreeViewItem = React.forwardRef<
 					}
 					className={classNames('treeview-link', {
 						collapsed: group && expandedKeys.has(item.key),
+						disabled: isDragging,
 						focus,
 						'treeview-dropping-bottom':
 							overTarget && overPosition === 'bottom',
@@ -90,8 +99,6 @@ export const TreeViewItem = React.forwardRef<
 							overTarget && overPosition === 'middle',
 						'treeview-dropping-top':
 							overTarget && overPosition === 'top',
-
-						disabled: isDragging,
 					})}
 					onBlur={({currentTarget, relatedTarget}) => {
 						if (
@@ -122,52 +129,49 @@ export const TreeViewItem = React.forwardRef<
 					}}
 					onFocus={() => actions && setFocus(true)}
 					onKeyDown={async (event) => {
-							const {key} = event;
+						const {key} = event;
 
-							if (key === Keys.Left) {
-								if (
-									!close(item.key) &&
-									item.parentItemRef?.current
-								) {
-									item.parentItemRef.current.focus();
-								}
+						if (key === Keys.Left) {
+							if (
+								!close(item.key) &&
+								item.parentItemRef?.current
+							) {
+								item.parentItemRef.current.focus();
 							}
+						}
 
-							if (key === Keys.Right) {
-								if (!group) {
-									if (onLoadMore) {
-										try {
-											const items = await onLoadMore(
-												item
-											);
-											if (!items) {
-												return;
-											}
-											insert([...item.indexes, 0], items);
-										} catch (error) {
-											console.error(error);
+						if (key === Keys.Right) {
+							if (!group) {
+								if (onLoadMore) {
+									try {
+										const items = await onLoadMore(item);
+										if (!items) {
 											return;
 										}
-									} else {
+										insert([...item.indexes, 0], items);
+									} catch (error) {
+										console.error(error);
+
 										return;
 									}
-								}
-								if (!open(item.key) && item.itemRef.current) {
-									const group =
-										item.itemRef.current.parentElement?.querySelector<HTMLDivElement>(
-											'.treeview-group'
-										);
-									const firstItemElement =
-										group?.querySelector<HTMLDivElement>(
-											'.treeview-link'
-										);
-									firstItemElement?.focus();
 								} else {
-									item.itemRef.current?.focus();
+									return;
 								}
 							}
-
-
+							if (!open(item.key) && item.itemRef.current) {
+								const group =
+									item.itemRef.current.parentElement?.querySelector<HTMLDivElement>(
+										'.treeview-group'
+									);
+								const firstItemElement =
+									group?.querySelector<HTMLDivElement>(
+										'.treeview-link'
+									);
+								firstItemElement?.focus();
+							} else {
+								item.itemRef.current?.focus();
+							}
+						}
 
 						if (key === Keys.Backspace || key === Keys.Del) {
 							remove(item.indexes);
@@ -220,44 +224,40 @@ export const TreeViewItem = React.forwardRef<
 					}}
 					tabIndex={0}
 				>
+					<span
+						className="c-inner"
+						style={{
+							marginLeft: `-${spacing + (group ? 0 : 24)}px`,
+						}}
+						tabIndex={-2}
+					>
+						{typeof left === 'string' ? (
+							<Layout.ContentRow>
+								<Layout.ContentCol expand>
+									<div className="component-text">{left}</div>
+								</Layout.ContentCol>
 
-						<span
-							className="c-inner"
-							style={{
-								marginLeft: `-${spacing + (group ? 0 : 24)}px`,
-							}}
-							tabIndex={-2}
-						>
-							{typeof left === 'string' ? (
-								<Layout.ContentRow>
-									<Layout.ContentCol expand>
-										<div className="component-text">
-											{left}
-										</div>
-									</Layout.ContentCol>
-
-									{actions && <Actions>{actions}</Actions>}
-								</Layout.ContentRow>
-							) : group ? (
-								React.cloneElement(left as React.ReactElement, {
-									actions,
-								})
-							) : (
-								<TreeViewItemStack
-									actions={actions}
-									expandable={false}
-								>
-									{children}
-								</TreeViewItemStack>
-							)}
-						</span>
-					</div>
-					{group}
-				</li>
-			</SpacingContext.Provider>
-		);
-	}
-);
+								{actions && <Actions>{actions}</Actions>}
+							</Layout.ContentRow>
+						) : group ? (
+							React.cloneElement(left as React.ReactElement, {
+								actions,
+							})
+						) : (
+							<TreeViewItemStack
+								actions={actions}
+								expandable={false}
+							>
+								{children}
+							</TreeViewItemStack>
+						)}
+					</span>
+				</div>
+				{group}
+			</li>
+		</SpacingContext.Provider>
+	);
+});
 
 TreeViewItem.displayName = 'ClayTreeViewItem';
 

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -90,6 +90,7 @@ export const TreeViewItem = React.forwardRef<
 							overTarget && overPosition === 'middle',
 						'treeview-dropping-top':
 							overTarget && overPosition === 'top',
+
 						disabled: isDragging,
 					})}
 					onBlur={({currentTarget, relatedTarget}) => {
@@ -121,53 +122,52 @@ export const TreeViewItem = React.forwardRef<
 					}}
 					onFocus={() => actions && setFocus(true)}
 					onKeyDown={async (event) => {
-						const {key} = event;
+							const {key} = event;
 
-						if (key === Keys.Left) {
-							if (
-								!close(item.key) &&
-								item.parentItemRef?.current
-							) {
-								item.parentItemRef.current.focus();
-							}
-						}
-
-						if (key === Keys.Right) {
-							if (!group) {
-								if (onLoadMore) {
-									try {
-										const items = await onLoadMore(item);
-
-										if (!items) {
-											return;
-										}
-
-										insert([...item.indexes, 0], items);
-									} catch (error) {
-										console.error(error);
-
-										return;
-									}
-								} else {
-									return;
+							if (key === Keys.Left) {
+								if (
+									!close(item.key) &&
+									item.parentItemRef?.current
+								) {
+									item.parentItemRef.current.focus();
 								}
 							}
 
-							if (!open(item.key) && item.itemRef.current) {
-								const group =
-									item.itemRef.current.parentElement?.querySelector<HTMLDivElement>(
-										'.treeview-group'
-									);
-								const firstItemElement =
-									group?.querySelector<HTMLDivElement>(
-										'.treeview-link'
-									);
-
-								firstItemElement?.focus();
-							} else {
-								item.itemRef.current?.focus();
+							if (key === Keys.Right) {
+								if (!group) {
+									if (onLoadMore) {
+										try {
+											const items = await onLoadMore(
+												item
+											);
+											if (!items) {
+												return;
+											}
+											insert([...item.indexes, 0], items);
+										} catch (error) {
+											console.error(error);
+											return;
+										}
+									} else {
+										return;
+									}
+								}
+								if (!open(item.key) && item.itemRef.current) {
+									const group =
+										item.itemRef.current.parentElement?.querySelector<HTMLDivElement>(
+											'.treeview-group'
+										);
+									const firstItemElement =
+										group?.querySelector<HTMLDivElement>(
+											'.treeview-link'
+										);
+									firstItemElement?.focus();
+								} else {
+									item.itemRef.current?.focus();
+								}
 							}
-						}
+
+
 
 						if (key === Keys.Backspace || key === Keys.Del) {
 							remove(item.indexes);
@@ -395,7 +395,64 @@ function Actions({children}: TreeViewItemActionsProps) {
 									'component-action',
 									child.props.className
 								),
+								onClick: (
+									event: React.MouseEvent<
+										HTMLButtonElement,
+										MouseEvent
+									>
+								) => {
+									event.stopPropagation();
+
+									if (child.props.onClick) {
+										child.props.onClick(event);
+									}
+								},
 								tabIndex: -1,
+							})}
+						</Layout.ContentCol>
+					);
+				} else if (child.type.displayName === 'ClayDropDownWithItems') {
+					return (
+						<Layout.ContentCol key={index}>
+							{React.cloneElement(child, {
+								trigger: React.cloneElement(
+									child.props.trigger,
+									{
+										children: (
+											<div
+												className="c-inner"
+												tabIndex={-2}
+											>
+												{
+													child.props.trigger.props
+														.children
+												}
+											</div>
+										),
+										className: classNames(
+											'component-action',
+											child.props.trigger.props.className
+										),
+										onClick: (
+											event: React.MouseEvent<
+												HTMLButtonElement,
+												MouseEvent
+											>
+										) => {
+											event.stopPropagation();
+
+											if (
+												child.props.trigger.props
+													.onClick
+											) {
+												child.props.trigger.props.onClick(
+													event
+												);
+											}
+										},
+										tabIndex: -1,
+									}
+								),
 							})}
 						</Layout.ContentCol>
 					);

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -6,7 +6,9 @@
 import '@clayui/css/lib/css/atlas.css';
 
 import '@clayui/css/src/scss/cadmin.scss';
+import Button from '@clayui/button';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import DropDown from '@clayui/drop-down';
 import {ClayCheckbox as Checkbox, ClayInput as Input} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {Provider} from '@clayui/provider';
@@ -203,6 +205,54 @@ storiesOf('Components|ClayTreeView', module)
 			</TreeView>
 		</Provider>
 	))
+	.add('actions', () => {
+		const [active, setActive] = React.useState(false);
+
+		const triggerRef = React.useRef(null);
+		const menuRef = React.useRef(null);
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView>
+					<TreeView.Item
+						actions={
+							<>
+								<Button displayType={null} monospaced>
+									<Icon symbol="times" />
+								</Button>
+								<Button
+									displayType={null}
+									monospaced
+									onClick={() => setActive(!active)}
+									ref={triggerRef}
+								>
+									<Icon symbol="ellipsis-v" />
+								</Button>
+								<DropDown.Menu
+									active={active}
+									alignElementRef={triggerRef}
+									onSetActive={setActive}
+									ref={menuRef}
+								>
+									<DropDown.ItemList>
+										<DropDown.Item>One</DropDown.Item>
+									</DropDown.ItemList>
+								</DropDown.Menu>
+							</>
+						}
+					>
+						<TreeView.ItemStack>
+							<Icon symbol="folder" />
+							Root
+						</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item>Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+	})
 	.add('dynamic', () => (
 		<Provider spritemap={spritemap} theme="cadmin">
 			<TreeView

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -231,10 +231,43 @@ storiesOf('Components|ClayTreeView', module)
 				>
 					<TreeView.ItemStack>
 						<Icon symbol="folder" />
-						Root
+						Folder 1
 					</TreeView.ItemStack>
 					<TreeView.Group>
-						<TreeView.Item>Item</TreeView.Item>
+						<TreeView.Item>Item 1</TreeView.Item>
+						<TreeView.Item>Item 2</TreeView.Item>
+						<TreeView.Item>Item 3</TreeView.Item>
+					</TreeView.Group>
+				</TreeView.Item>
+				<TreeView.Item
+					actions={
+						<>
+							<Button displayType={null} monospaced>
+								<Icon symbol="times" />
+							</Button>
+							<DropDownWithItems
+								items={[
+									{label: 'Four'},
+									{label: 'Five'},
+									{label: 'Six'},
+								]}
+								trigger={
+									<Button displayType={null} monospaced>
+										<Icon symbol="ellipsis-v" />
+									</Button>
+								}
+							/>
+						</>
+					}
+				>
+					<TreeView.ItemStack>
+						<Icon symbol="folder" />
+						Folder 2
+					</TreeView.ItemStack>
+					<TreeView.Group>
+						<TreeView.Item>Item 4</TreeView.Item>
+						<TreeView.Item>Item 5</TreeView.Item>
+						<TreeView.Item>Item 6</TreeView.Item>
 					</TreeView.Group>
 				</TreeView.Item>
 			</TreeView>

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -8,7 +8,7 @@ import '@clayui/css/lib/css/atlas.css';
 import '@clayui/css/src/scss/cadmin.scss';
 import Button from '@clayui/button';
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
-import DropDown from '@clayui/drop-down';
+import {ClayDropDownWithItems as DropDownWithItems} from '@clayui/drop-down';
 import {ClayCheckbox as Checkbox, ClayInput as Input} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {Provider} from '@clayui/provider';
@@ -205,54 +205,41 @@ storiesOf('Components|ClayTreeView', module)
 			</TreeView>
 		</Provider>
 	))
-	.add('actions', () => {
-		const [active, setActive] = React.useState(false);
-
-		const triggerRef = React.useRef(null);
-		const menuRef = React.useRef(null);
-
-		return (
-			<Provider spritemap={spritemap} theme="cadmin">
-				<TreeView>
-					<TreeView.Item
-						actions={
-							<>
-								<Button displayType={null} monospaced>
-									<Icon symbol="times" />
-								</Button>
-								<Button
-									displayType={null}
-									monospaced
-									onClick={() => setActive(!active)}
-									ref={triggerRef}
-								>
-									<Icon symbol="ellipsis-v" />
-								</Button>
-								<DropDown.Menu
-									active={active}
-									alignElementRef={triggerRef}
-									onSetActive={setActive}
-									ref={menuRef}
-								>
-									<DropDown.ItemList>
-										<DropDown.Item>One</DropDown.Item>
-									</DropDown.ItemList>
-								</DropDown.Menu>
-							</>
-						}
-					>
-						<TreeView.ItemStack>
-							<Icon symbol="folder" />
-							Root
-						</TreeView.ItemStack>
-						<TreeView.Group>
-							<TreeView.Item>Item</TreeView.Item>
-						</TreeView.Group>
-					</TreeView.Item>
-				</TreeView>
-			</Provider>
-		);
-	})
+	.add('actions', () => (
+		<Provider spritemap={spritemap} theme="cadmin">
+			<TreeView>
+				<TreeView.Item
+					actions={
+						<>
+							<Button displayType={null} monospaced>
+								<Icon symbol="times" />
+							</Button>
+							<DropDownWithItems
+								items={[
+									{label: 'One'},
+									{label: 'Two'},
+									{label: 'Three'},
+								]}
+								trigger={
+									<Button displayType={null} monospaced>
+										<Icon symbol="ellipsis-v" />
+									</Button>
+								}
+							/>
+						</>
+					}
+				>
+					<TreeView.ItemStack>
+						<Icon symbol="folder" />
+						Root
+					</TreeView.ItemStack>
+					<TreeView.Group>
+						<TreeView.Item>Item</TreeView.Item>
+					</TreeView.Group>
+				</TreeView.Item>
+			</TreeView>
+		</Provider>
+	))
 	.add('dynamic', () => (
 		<Provider spritemap={spritemap} theme="cadmin">
 			<TreeView

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -469,3 +469,5 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 		</ClayDropDown>
 	);
 };
+
+ClayDropDownWithItems.displayName = 'ClayDropDownWithItems';


### PR DESCRIPTION
See #4389

Added a new API to `TreeView.Item` so that the developer still has the freedom to add the actions using composition, there's not a very clear way to do this on `children` because `children` is used to building the Node and groups and do this using `children` in a simple way without generating new complexities.

There are some markup issues here though, see example in Storybook of `Actions`, this will work fine with `Button` and `Icon` compositing, but it won't work well using directly eg `DropDown`, because it has a wrapper on the trigger and we need to add the `component-action` to the `Button`. @pat270 is there any way we can get this to work with DropDown's markup, without necessarily being a `Button`?

We also have a limitation for the case of DropDown as an action, the actions are visible and invisible when the mouse is over the Node but the problem is when you try to open DropDown and the trigger will disappear and the Menu will be moved by not find more trigger to reposition the Menu. @pat270 can we do this manually? maybe we have to control the actions show manually via JS to keep the Action visible when the user opens DropDown for example.