### PR TITLE
fix(@clayui/css): Cadmin and Clay Input Group move `.btn` and `.form-control` z-index styles to `input-group-prepend` and `input-group-append`

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
@@ -47,6 +47,23 @@
 	> .input-group-text + .btn {
 		margin-left: math-sign($cadmin-input-border-width);
 	}
+
+	.btn {
+		z-index: 1;
+
+		&:hover {
+			z-index: $cadmin-zindex-input-group-hover;
+		}
+	}
+
+	.btn,
+	.form-control {
+		position: relative;
+
+		&:focus {
+			z-index: $cadmin-zindex-input-group-focus;
+		}
+	}
 }
 
 // Input Group
@@ -57,20 +74,6 @@
 	flex-wrap: wrap;
 	position: relative;
 	width: 100%;
-
-	.btn {
-		position: relative;
-		z-index: 1;
-
-		&:hover {
-			z-index: $cadmin-zindex-input-group-hover;
-		}
-	}
-
-	.btn:focus,
-	.form-control:focus {
-		z-index: $cadmin-zindex-input-group-focus;
-	}
 
 	.btn-unstyled {
 		color: inherit;

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -99,6 +99,23 @@
 	> .input-group-text + .btn {
 		margin-left: math-sign($input-border-width);
 	}
+
+	.btn {
+		z-index: 1;
+
+		&:hover {
+			z-index: $zindex-input-group-hover;
+		}
+	}
+
+	.btn,
+	.form-control {
+		position: relative;
+
+		&:focus {
+			z-index: $zindex-input-group-focus;
+		}
+	}
 }
 
 // Input Group
@@ -109,20 +126,6 @@
 	flex-wrap: wrap;
 	position: relative;
 	width: 100%;
-
-	.btn {
-		position: relative;
-		z-index: 1;
-
-		&:hover {
-			z-index: $zindex-input-group-hover;
-		}
-	}
-
-	.btn:focus,
-	.form-control:focus {
-		z-index: $zindex-input-group-focus;
-	}
 
 	.btn-unstyled {
 		color: inherit;


### PR DESCRIPTION
fixes #4423

Input Groups input disappears when focused inside a modal with iframe.