### PR TITLE
fix(@clayui/drop-down): Provide a default on submit function to avoid form navigation

### DIFF
--- a/packages/clay-drop-down/src/Search.tsx
+++ b/packages/clay-drop-down/src/Search.tsx
@@ -31,17 +31,20 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	value: React.ReactText;
 }
 
+const defaultOnSubmit = (event: React.SyntheticEvent) => event.preventDefault();
+
 const ClayDropDownSearch: React.FunctionComponent<IProps> = ({
 	className,
 	formProps = {},
 	spritemap,
 	...otherProps
 }: IProps) => {
-	const {className: formClassName, ...otherFormProps} = formProps;
+	const {className: formClassName, onSubmit, ...otherFormProps} = formProps;
 
 	return (
 		<form
 			className={classNames(className, formClassName)}
+			onSubmit={onSubmit ? onSubmit : defaultOnSubmit}
 			{...otherFormProps}
 		>
 			<div className="dropdown-section">

--- a/packages/clay-drop-down/stories/index.tsx
+++ b/packages/clay-drop-down/stories/index.tsx
@@ -160,7 +160,6 @@ storiesOf('Components|ClayDropDown', module)
 		return (
 			<DropDownWithState>
 				<ClayDropDown.Search
-					formProps={{onSubmit: (event) => event.preventDefault()}}
 					onChange={(event) => setQuery(event.target.value)}
 					spritemap={spritemap}
 					value={query}


### PR DESCRIPTION
Fixes: https://github.com/liferay/clay/issues/4434

In this PR, a default function is provided for the onSubmit handler in the ClayDropDown.Search component. This prevents de form submission when pressing enter and the input is focused.

This can also be done from the outside passing a custom onSubmit function, but I believe that it is better to control this from the inside since the behaviour is a bit weird.

Let me know what do you think  :) 