### PR TITLE
 fix(@clayui/css): Atlas `select.form-control` size and multiple styles should match Lexicon

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -371,11 +371,43 @@ $input-select-icon-disabled: clay-icon(
 	$input-select-icon-disabled-color
 ) !default;
 
+// select.form-control[size]
+
+// focus.option.checked: Chrome can't style text, we invert colors to make text white
+// option.checked: hack for changing the background-color
+// firefox-only: overwrite some styles for Chrome to make it match Lexicon
+
 $input-select-size: () !default;
 $input-select-size: map-deep-merge(
 	(
+		focus: (
+			option: (
+				checked: (
+					background-image: linear-gradient(#ffa700, #ffa700),
+					color: #fff,
+					filter: invert(100%),
+				),
+			),
+		),
 		option: (
-			padding: 0.25rem 0.5rem,
+			padding: 0.4375rem 0.5rem,
+			checked: (
+				background-image: linear-gradient(#{$gray-300}, #{$gray-300}),
+			),
+		),
+		firefox-only: (
+			focus: (
+				option: (
+					checked: (
+						background-image:
+							linear-gradient(#{$primary-d2}, #{$primary-d2}),
+						filter: invert(0),
+					),
+				),
+			),
+			option: (
+				padding: 0.40625rem 0.5rem,
+			),
 		),
 	),
 	$input-select-size

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -872,6 +872,9 @@ $cadmin-form-control-select-sm: map-deep-merge(
 
 // scrollbar-width: Future proof https://github.com/w3c/csswg-drafts/issues/1958
 // if/when it gets added
+// focus.option.checked: Chrome can't style text, we invert colors to make text white
+// option.checked: hack for changing the background-color
+// firefox-only: undo some styles for Chrome to make it match Lexicon
 
 $cadmin-input-select-size: () !default;
 $cadmin-input-select-size: map-deep-merge(
@@ -883,9 +886,36 @@ $cadmin-input-select-size: map-deep-merge(
 		scrollbar-width: thin,
 		focus: (
 			background-image: none,
+			option: (
+				checked: (
+					background-image: linear-gradient(#ffa700, #ffa700),
+					filter: invert(100%),
+				),
+			),
 		),
 		option: (
-			padding: 4px 8px,
+			padding: 7px 8px,
+			checked: (
+				background-image:
+					linear-gradient(#{$cadmin-gray-300}, #{$cadmin-gray-300}),
+			),
+		),
+		firefox-only: (
+			focus: (
+				option: (
+					checked: (
+						background-image:
+							linear-gradient(
+								#{$cadmin-primary-d2},
+								#{$cadmin-primary-d2}
+							),
+						filter: invert(0),
+					),
+				),
+			),
+			option: (
+				padding: 0.40625rem 0.5rem,
+			),
 		),
 	),
 	$cadmin-input-select-size

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -532,18 +532,62 @@
 /// A mixin to create Select Form Control variants. You can base your variant off Bootstrap's `select.form-control` selector or create your own base class (e.g., `<select class="form-control my-custom-form-control"></select>` or `<select class="my-custom-form-control"></select>`).
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
-/// See Mixin `clay-css` for available keys to pass into the base selector
+/// (
+/// 	enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// 	// select.form-control
+/// 	hover: (
+/// 		// select.form-control:hover
+/// 		option: (
+/// 			// select.form-control:hover > option
+/// 			checked: (
+/// 				// select.form-control:hover > option:checked
+/// 			),
+/// 		),
+/// 	),
+/// 	focus: (
+/// 		// select.form-control:focus,
+/// 		// select.form-control.focus
+/// 		option: (
+/// 			// select.form-control:focus > option,
+/// 			// select.form-control.focus > option
+/// 			checked: (
+/// 				// select.form-control:focus > option:checked,
+/// 				// select.form-control.focus > option:checked
+/// 			),
+/// 		),
+/// 	),
+/// 	disabled: (
+/// 		// select.form-control:disabled,
+/// 		// select.form-control.disabled
+/// 		option: (
+/// 			// select.form-control:disabled > option,
+/// 			// select.form-control.disabled > option
+/// 			checked: (
+/// 				// select.form-control:disabled > option:checked,
+/// 				// select.form-control.disabled > option:checked
+/// 			),
+/// 		),
+/// 	),
+/// 	option: (
+/// 		// select.form-control option
+/// 		checked: (
+/// 			// select.form-control option:checked
+/// 		),
+/// 	),
+/// 	firefox-only: (
+/// 		// Same selectors as above scoped only for firefox browsers
+/// 	),
+/// )
+/// -=-=-=-=-=- Deprecated -=-=-=-=-=-
 /// hover-bg: {Color | String | Null}, // deprecated after 3.7.0
 /// hover-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
 /// hover-box-shadow: {String | List | Null}, // deprecated after 3.7.0
 /// hover-color: {Color | String | Null}, // deprecated after 3.7.0
-/// hover: {Map | Null}, // See Mixin `clay-css` for available keys
 /// focus-bg: {Color | String | Null}, // deprecated after 3.7.0
 /// focus-bg-image: {String | List | Null}, // deprecated after 3.7.0
 /// focus-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
 /// focus-box-shadow: {String | List | Null}, // deprecated after 3.7.0
 /// focus-color: {Color | String | Null}, // deprecated after 3.7.0
-/// focus: {Map | Null}, // See Mixin `clay-css` for available keys
 /// disabled-bg: {Color | String | Null}, // deprecated after 3.7.0
 /// disabled-bg-image: {String | List | Null}, // deprecated after 3.7.0
 /// disabled-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
@@ -551,7 +595,6 @@
 /// disabled-color: {Color | String | Null}, // deprecated after 3.7.0
 /// disabled-cursor: {String | Null}, // deprecated after 3.7.0
 /// disabled-opacity: {Number | String | Null}, // deprecated after 3.7.0
-/// disabled: {Map | Null}, // See Mixin `clay-css` for available keys
 /// @todo
 /// - Add @example
 /// - Add @link to documentation
@@ -702,11 +745,27 @@
 
 		&:hover {
 			@include clay-css($hover);
+
+			> option {
+				@include clay-css(map-get($hover, option));
+
+				&:checked {
+					@include clay-css(map-deep-get($hover, option, checked));
+				}
+			}
 		}
 
 		&:focus,
 		&.focus {
 			@include clay-css($focus);
+
+			> option {
+				@include clay-css(map-get($focus, option));
+
+				&:checked {
+					@include clay-css(map-deep-get($focus, option, checked));
+				}
+			}
 		}
 
 		&:disabled,
@@ -715,11 +774,105 @@
 
 			> option {
 				@include clay-css($disabled-option);
+
+				&:checked {
+					@include clay-css(map-get($disabled-option, checked));
+				}
 			}
 		}
 
 		option {
 			@include clay-css($option);
+
+			&:checked {
+				@include clay-css(map-get($option, checked));
+			}
+		}
+
+		@if (map-get($map, firefox-only)) {
+			@-moz-document url-prefix() {
+				@include clay-css(map-get($map, firefox-only));
+
+				&:hover {
+					@include clay-css(map-deep-get($map, firefox-only, hover));
+
+					> option {
+						@include clay-css(
+							map-deep-get($map, firefox-only, hover, option)
+						);
+
+						&:checked {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									firefox-only,
+									hover,
+									option,
+									checked
+								)
+							);
+						}
+					}
+				}
+
+				&:focus,
+				&.focus {
+					@include clay-css(map-deep-get($map, firefox-only, focus));
+
+					> option {
+						@include clay-css(
+							map-deep-get($map, firefox-only, focus, option)
+						);
+
+						&:checked {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									firefox-only,
+									focus,
+									option,
+									checked
+								)
+							);
+						}
+					}
+				}
+
+				&:disabled,
+				&.disabled {
+					@include clay-css(
+						map-deep-get($map, firefox-only, disabled)
+					);
+
+					> option {
+						@include clay-css(
+							map-deep-get($map, firefox-only, disabled, option)
+						);
+
+						&:checked {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									firefox-only,
+									disabled,
+									option,
+									checked
+								)
+							);
+						}
+					}
+				}
+
+				option {
+					@include clay-css(map-deep-get($map, firefox-only, option));
+
+					&:checked {
+						@include clay-css(
+							map-deep-get($map, firefox-only, option, checked)
+						);
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
fixes #4430

The checked unfocused styles have background `#e7e7ed`. Still have to confirm styles for Microsoft Edge browsers.

Chrome (Mac) 96.0.4664.55
![chrome-select](https://user-images.githubusercontent.com/788266/142701057-93a62bc5-856c-41fe-8e79-dfb066e60314.jpg)

Firefox (Mac) 94.0.1
![firefox-select](https://user-images.githubusercontent.com/788266/142701170-5daa4b28-fa3a-490f-b6fb-f383eae12b12.jpg)

Safari (Mac) 14.1.2
![safari-select](https://user-images.githubusercontent.com/788266/142701275-7fd72085-c15d-4655-918e-483d4f95ffb8.jpg)