### PR TITLE
feat(@clayui/css): Toggle Switch adds option to customize hover, focus, disabled, checked, indeterminate styles

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_toggle-switch.scss
@@ -1,10 +1,43 @@
+// Toggle Switch
+
+.toggle-switch {
+	@include clay-toggle-switch-variant($cadmin-toggle-switch);
+}
+
+.toggle-switch-check-bar {
+	@include clay-css($cadmin-toggle-switch-check-bar);
+}
+
+.toggle-switch-bar {
+	@include clay-toggle-switch-bar-variant($cadmin-toggle-switch-bar);
+}
+
+.toggle-switch-check {
+	@include clay-toggle-switch-check-variant($cadmin-toggle-switch-check);
+}
+
+.toggle-switch-label {
+	@include clay-css($cadmin-toggle-switch-label);
+}
+
+.toggle-switch-text {
+	@include clay-css($cadmin-toggle-switch-text);
+}
+
+.toggle-switch-text-left {
+	@include clay-css($cadmin-toggle-switch-text-left);
+}
+
+.toggle-switch-text-right {
+	@include clay-css($cadmin-toggle-switch-text-right);
+}
+
 // Simple Toggle Switch
 
 .simple-toggle-switch {
-	&.toggle-switch {
-		align-items: center;
-		display: inline-flex;
-	}
+	@include clay-toggle-switch-variant($cadmin-simple-toggle-switch);
+
+	// deprecated
 
 	.toggle-switch-check + .toggle-switch-label {
 		margin-right: $cadmin-simple-toggle-switch-label-spacer-x;
@@ -13,379 +46,8 @@
 	.toggle-switch-label + .toggle-switch-check-bar {
 		margin-left: $cadmin-simple-toggle-switch-label-spacer-x;
 	}
-
-	.toggle-switch-label {
-		line-height: $cadmin-simple-toggle-switch-label-line-height;
-		margin-bottom: 0;
-		max-width: calc(
-			100% - #{clay-data-label-text-position(
-					$cadmin-toggle-switch-bar-width,
-					$cadmin-toggle-switch-bar-padding
-				)}
-		);
-
-		@include clay-scale-component {
-			max-width: calc(
-				100% - #{clay-data-label-text-position(
-						$cadmin-toggle-switch-bar-width-mobile,
-						$cadmin-toggle-switch-bar-padding-mobile
-					)}
-			);
-		}
-	}
 }
 
 .simple-toggle-switch-reverse {
-	.toggle-switch-label {
-		margin-right: $cadmin-simple-toggle-switch-label-spacer-x;
-	}
-
-	.toggle-switch-check-bar {
-		order: 5;
-
-		.toggle-switch-bar {
-			order: 0;
-		}
-	}
-
-	.toggle-switch-bar {
-		order: 5;
-	}
-}
-
-// Toggle Switch
-
-label.toggle-switch {
-	cursor: $cadmin-toggle-switch-cursor;
-
-	&.disabled {
-		cursor: $cadmin-toggle-switch-disabled-cursor;
-	}
-}
-
-.toggle-switch {
-	display: inline-block;
-	font-weight: $cadmin-toggle-switch-font-weight;
-	max-width: 100%;
-	position: relative;
-
-	&.disabled {
-		.toggle-switch-label {
-			color: $cadmin-toggle-switch-label-disabled-color;
-			cursor: $cadmin-toggle-switch-disabled-cursor;
-		}
-
-		.toggle-switch-text {
-			color: $cadmin-toggle-switch-text-disabled-color;
-		}
-	}
-}
-
-.toggle-switch-check-bar {
-	display: inline-flex;
-	position: relative;
-}
-
-.toggle-switch-bar {
-	.toggle-switch-handle {
-		display: block;
-		min-width: $cadmin-toggle-switch-bar-width;
-		text-transform: uppercase;
-	}
-
-	.toggle-switch-icon {
-		font-size: $cadmin-toggle-switch-bar-font-size;
-
-		.lexicon-icon {
-			margin-top: -0.2em;
-		}
-	}
-
-	.button-icon {
-		font-size: $cadmin-toggle-switch-button-font-size;
-	}
-}
-
-.toggle-switch-check {
-	bottom: 0;
-	font-size: 62.5%;
-	height: $cadmin-toggle-switch-bar-height;
-	opacity: 0;
-	position: absolute;
-	width: $cadmin-toggle-switch-bar-width;
-	z-index: 2;
-
-	@include clay-scale-component {
-		height: $cadmin-toggle-switch-bar-height-mobile;
-		width: $cadmin-toggle-switch-bar-width-mobile;
-	}
-
-	&:empty ~ .toggle-switch-bar {
-		display: inline-flex;
-		font-size: $cadmin-toggle-switch-bar-font-size;
-		height: $cadmin-toggle-switch-bar-height;
-		line-height: $cadmin-toggle-switch-bar-height;
-		position: relative;
-		text-indent: 0;
-
-		-ms-user-select: none;
-		user-select: none;
-
-		&:after {
-			background-color: $cadmin-toggle-switch-button-bg;
-			border-color: $cadmin-toggle-switch-button-border-color;
-
-			@include border-radius($cadmin-toggle-switch-button-border-radius);
-
-			border-style: solid;
-			border-width: $cadmin-toggle-switch-button-border-width;
-			bottom: $cadmin-toggle-switch-bar-padding;
-			content: '';
-			display: block;
-			height: $cadmin-toggle-switch-button-width;
-			left: $cadmin-toggle-switch-bar-padding;
-			position: absolute;
-			top: $cadmin-toggle-switch-bar-padding;
-			transition: $cadmin-toggle-switch-transition;
-			width: $cadmin-toggle-switch-button-width;
-		}
-
-		&:before {
-			background-color: $cadmin-toggle-switch-bar-bg;
-			border-color: $cadmin-toggle-switch-bar-border-color;
-
-			@include border-radius($cadmin-toggle-switch-bar-border-radius);
-
-			border-style: solid;
-			border-width: $cadmin-toggle-switch-bar-border-width;
-			bottom: 0;
-			content: ' ';
-			display: block;
-			left: 0;
-			position: absolute;
-			top: 0;
-			transition: $cadmin-toggle-switch-transition;
-			width: $cadmin-toggle-switch-bar-width;
-		}
-
-		.toggle-switch-handle {
-			&:after {
-				content: attr(data-label-off);
-				margin-left: clay-data-label-text-position(
-					$cadmin-toggle-switch-bar-width,
-					$cadmin-toggle-switch-bar-padding
-				);
-				transition: $cadmin-toggle-switch-transition;
-				white-space: nowrap;
-			}
-
-			&:before {
-				transition: $cadmin-toggle-switch-transition;
-			}
-		}
-
-		.toggle-switch-icon {
-			color: $cadmin-toggle-switch-bar-icon-color;
-			left: $cadmin-toggle-switch-bar-padding;
-			line-height: $cadmin-toggle-switch-button-width;
-			position: absolute;
-			text-align: center;
-			text-indent: 0;
-			top: $cadmin-toggle-switch-bar-padding;
-			transition: $cadmin-toggle-switch-transition;
-			width: $cadmin-toggle-switch-button-width;
-			z-index: 1;
-		}
-
-		.toggle-switch-icon-on {
-			left: $cadmin-toggle-switch-bar-padding;
-			opacity: 0;
-		}
-
-		.toggle-switch-icon-off {
-			left: $cadmin-toggle-switch-bar-width -
-				$cadmin-toggle-switch-bar-padding -
-				$cadmin-toggle-switch-button-width;
-		}
-
-		.button-icon {
-			color: $cadmin-toggle-switch-button-icon-color;
-		}
-
-		.button-icon-on {
-			opacity: 0;
-		}
-	}
-
-	&:checked ~ .toggle-switch-bar {
-		&:after {
-			background-color: $cadmin-toggle-switch-button-on-bg;
-			border-color: $cadmin-toggle-switch-button-on-border-color;
-
-			@include border-radius(
-				$cadmin-toggle-switch-button-on-border-radius
-			);
-
-			border-style: solid;
-			border-width: $cadmin-toggle-switch-button-border-width;
-			left: $cadmin-toggle-switch-bar-width -
-				$cadmin-toggle-switch-bar-padding -
-				$cadmin-toggle-switch-button-width;
-		}
-
-		&:before {
-			background-color: $cadmin-toggle-switch-bar-on-bg;
-			border-color: $cadmin-toggle-switch-bar-on-border-color;
-
-			@include border-radius($cadmin-toggle-switch-bar-border-radius);
-
-			border-style: solid;
-			border-width: $cadmin-toggle-switch-bar-border-width;
-		}
-
-		.toggle-switch-handle:after {
-			content: attr(data-label-on);
-		}
-
-		.toggle-switch-icon {
-			color: $cadmin-toggle-switch-bar-on-icon-color;
-		}
-
-		.button-icon {
-			color: $cadmin-toggle-switch-button-on-icon-color;
-			left: $cadmin-toggle-switch-bar-width -
-				$cadmin-toggle-switch-bar-padding -
-				$cadmin-toggle-switch-button-width;
-		}
-
-		.button-icon-on,
-		.toggle-switch-icon-on {
-			opacity: 1;
-		}
-
-		.button-icon-off,
-		.toggle-switch-icon-off {
-			opacity: 0;
-		}
-	}
-
-	&:disabled,
-	&.disabled {
-		~ .toggle-switch-bar {
-			cursor: $cadmin-toggle-switch-disabled-cursor;
-			opacity: $cadmin-toggle-switch-disabled-opacity;
-		}
-	}
-
-	&:focus ~ .toggle-switch-bar:before {
-		box-shadow: $cadmin-toggle-switch-bar-focus-box-shadow;
-	}
-}
-
-.toggle-switch-label {
-	display: block;
-	margin-bottom: 2px;
-}
-
-.toggle-switch-text {
-	display: block;
-	font-size: $cadmin-toggle-switch-text-font-size;
-}
-
-.toggle-switch-text-left {
-	display: inline-flex;
-	line-height: $cadmin-toggle-switch-bar-height;
-	margin-right: 8px;
-}
-
-.toggle-switch-text-right {
-	display: inline-flex;
-	line-height: $cadmin-toggle-switch-bar-height;
-	margin-left: 8px;
-}
-
-@include clay-scale-component {
-	.toggle-switch-bar {
-		.toggle-switch-handle {
-			min-width: $cadmin-toggle-switch-bar-width-mobile;
-		}
-
-		.toggle-switch-icon {
-			font-size: $cadmin-toggle-switch-bar-font-size-mobile;
-		}
-
-		.button-icon {
-			font-size: $cadmin-toggle-switch-button-font-size-mobile;
-		}
-	}
-
-	.toggle-switch-check {
-		&:empty ~ .toggle-switch-bar {
-			height: $cadmin-toggle-switch-bar-height-mobile;
-			line-height: $cadmin-toggle-switch-bar-height-mobile;
-			text-indent: 0;
-
-			&:after {
-				bottom: $cadmin-toggle-switch-bar-padding-mobile;
-				height: $cadmin-toggle-switch-button-width-mobile;
-				left: $cadmin-toggle-switch-bar-padding-mobile;
-				top: $cadmin-toggle-switch-bar-padding-mobile;
-				width: $cadmin-toggle-switch-button-width-mobile;
-			}
-
-			&:before {
-				width: $cadmin-toggle-switch-bar-width-mobile;
-			}
-
-			.toggle-switch-handle:after {
-				margin-left: clay-data-label-text-position(
-					$cadmin-toggle-switch-bar-width-mobile,
-					$cadmin-toggle-switch-bar-padding-mobile
-				);
-			}
-
-			.toggle-switch-icon {
-				left: $cadmin-toggle-switch-bar-padding-mobile;
-				line-height: $cadmin-toggle-switch-button-width-mobile;
-				top: $cadmin-toggle-switch-bar-padding-mobile;
-				width: $cadmin-toggle-switch-button-width-mobile;
-			}
-
-			.toggle-switch-icon-on {
-				left: $cadmin-toggle-switch-bar-padding-mobile;
-			}
-
-			.toggle-switch-icon-off {
-				left: $cadmin-toggle-switch-bar-width-mobile -
-					$cadmin-toggle-switch-bar-padding-mobile -
-					$cadmin-toggle-switch-button-width-mobile;
-			}
-		}
-
-		&:checked ~ .toggle-switch-bar {
-			&:after {
-				left: $cadmin-toggle-switch-bar-width-mobile -
-					$cadmin-toggle-switch-bar-padding-mobile -
-					$cadmin-toggle-switch-button-width-mobile;
-			}
-
-			.toggle-switch-handle:after {
-				margin-left: clay-data-label-text-position(
-					$cadmin-toggle-switch-bar-width-mobile,
-					$cadmin-toggle-switch-bar-padding-mobile
-				);
-			}
-
-			.button-icon {
-				left: $cadmin-toggle-switch-bar-width-mobile -
-					$cadmin-toggle-switch-bar-padding-mobile -
-					$cadmin-toggle-switch-button-width-mobile;
-			}
-		}
-	}
-
-	.toggle-switch-text-left,
-	.toggle-switch-text-right {
-		line-height: $cadmin-toggle-switch-bar-height-mobile;
-	}
+	@include clay-toggle-switch-variant($cadmin-simple-toggle-switch-reverse);
 }

--- a/packages/clay-css/src/scss/cadmin/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_toggle-switch.scss
@@ -62,7 +62,410 @@ $cadmin-toggle-switch-text-font-size: 12px !default;
 
 $cadmin-toggle-switch-text-disabled-color: $cadmin-input-label-disabled-color !default;
 
-// Simple Toggle Switch
+// .toggle-switch
+
+$cadmin-toggle-switch: () !default;
+$cadmin-toggle-switch: map-deep-merge(
+	(
+		breakpoint-down: sm,
+		cursor: $cadmin-toggle-switch-cursor,
+		display: inline-block,
+		font-weight: $cadmin-toggle-switch-font-weight,
+		max-width: 100%,
+		position: relative,
+		disabled: (
+			cursor: $cadmin-toggle-switch-disabled-cursor,
+			toggle-switch-label: (
+				color: $cadmin-toggle-switch-label-disabled-color,
+				cursor: $cadmin-toggle-switch-disabled-cursor,
+			),
+			toggle-switch-text: (
+				color: $cadmin-toggle-switch-text-disabled-color,
+			),
+		),
+	),
+	$cadmin-toggle-switch
+);
+
+// .toggle-switch-check-bar
+
+$cadmin-toggle-switch-check-bar: () !default;
+$cadmin-toggle-switch-check-bar: map-merge(
+	(
+		display: inline-flex,
+		position: relative,
+	),
+	$cadmin-toggle-switch-check-bar
+);
+
+// .toggle-switch-bar
+
+$cadmin-toggle-switch-bar: () !default;
+$cadmin-toggle-switch-bar: map-deep-merge(
+	(
+		toggle-switch-handle: (
+			display: block,
+			min-width: $cadmin-toggle-switch-bar-width,
+			text-transform: uppercase,
+		),
+		toggle-switch-icon: (
+			font-size: $cadmin-toggle-switch-bar-font-size,
+			lexicon-icon: (
+				margin-top: -0.2em,
+			),
+		),
+		button-icon: (
+			font-size: $cadmin-toggle-switch-button-font-size,
+		),
+	),
+	$cadmin-toggle-switch-bar
+);
+
+// .toggle-switch-check
+
+$cadmin-toggle-switch-check: () !default;
+$cadmin-toggle-switch-check: map-deep-merge(
+	(
+		breakpoint-down: sm,
+		bottom: 0,
+		font-size: 62.5%,
+		height: $cadmin-toggle-switch-bar-height,
+		opacity: 0,
+		position: absolute,
+		width: $cadmin-toggle-switch-bar-width,
+		z-index: 2,
+		toggle-switch-bar: (
+			display: inline-flex,
+			font-size: $cadmin-toggle-switch-bar-font-size,
+			height: $cadmin-toggle-switch-bar-height,
+			line-height: $cadmin-toggle-switch-bar-height,
+			position: relative,
+			text-indent: 0,
+			user-select: none,
+			before: (
+				background-color: $cadmin-toggle-switch-bar-bg,
+				border-color: $cadmin-toggle-switch-bar-border-color,
+				border-radius:
+					clay-enable-rounded($cadmin-toggle-switch-bar-border-radius),
+				border-style: solid,
+				border-width: $cadmin-toggle-switch-bar-border-width,
+				bottom: 0,
+				content: ' ',
+				display: block,
+				left: 0,
+				position: absolute,
+				top: 0,
+				transition: $cadmin-toggle-switch-transition,
+				width: $cadmin-toggle-switch-bar-width,
+			),
+			after: (
+				background-color: $cadmin-toggle-switch-button-bg,
+				border-color: $cadmin-toggle-switch-button-border-color,
+				border-radius:
+					clay-enable-rounded(
+						$cadmin-toggle-switch-button-border-radius
+					),
+				border-style: solid,
+				border-width: $cadmin-toggle-switch-button-border-width,
+				bottom: $cadmin-toggle-switch-bar-padding,
+				content: '',
+				display: block,
+				height: $cadmin-toggle-switch-button-width,
+				left: $cadmin-toggle-switch-bar-padding,
+				position: absolute,
+				top: $cadmin-toggle-switch-bar-padding,
+				transition: $cadmin-toggle-switch-transition,
+				width: $cadmin-toggle-switch-button-width,
+			),
+			toggle-switch-handle: (
+				before: (
+					transition: $cadmin-toggle-switch-transition,
+				),
+				after: (
+					content: attr(data-label-off),
+					margin-left:
+						clay-data-label-text-position(
+							$cadmin-toggle-switch-bar-width,
+							$cadmin-toggle-switch-bar-padding
+						),
+					transition: $cadmin-toggle-switch-transition,
+					white-space: nowrap,
+				),
+			),
+			toggle-switch-icon: (
+				color: $cadmin-toggle-switch-bar-icon-color,
+				left: $cadmin-toggle-switch-bar-padding,
+				line-height: $cadmin-toggle-switch-button-width,
+				position: absolute,
+				text-align: center,
+				text-indent: 0,
+				top: $cadmin-toggle-switch-bar-padding,
+				transition: $cadmin-toggle-switch-transition,
+				width: $cadmin-toggle-switch-button-width,
+				z-index: 1,
+			),
+			toggle-switch-icon-on: (
+				left: $cadmin-toggle-switch-bar-padding,
+				opacity: 0,
+			),
+			toggle-switch-icon-off: (
+				left: $cadmin-toggle-switch-bar-width -
+					$cadmin-toggle-switch-bar-padding -
+					$cadmin-toggle-switch-button-width,
+			),
+			button-icon: (
+				color: $cadmin-toggle-switch-button-icon-color,
+			),
+			button-icon-on: (
+				opacity: 0,
+			),
+		),
+		focus: (
+			toggle-switch-bar: (
+				before: (
+					box-shadow: $cadmin-toggle-switch-bar-focus-box-shadow,
+				),
+			),
+		),
+		disabled: (
+			toggle-switch-bar: (
+				cursor: $cadmin-toggle-switch-disabled-cursor,
+				opacity: $cadmin-toggle-switch-disabled-opacity,
+			),
+		),
+		checked: (
+			toggle-switch-bar: (
+				before: (
+					background-color: $cadmin-toggle-switch-bar-on-bg,
+					border-color: $cadmin-toggle-switch-bar-on-border-color,
+					border-radius:
+						clay-enable-rounded(
+							$cadmin-toggle-switch-bar-border-radius
+						),
+					border-style: solid,
+					border-width: $cadmin-toggle-switch-bar-border-width,
+				),
+				after: (
+					background-color: $cadmin-toggle-switch-button-on-bg,
+					border-color: $cadmin-toggle-switch-button-on-border-color,
+					border-radius:
+						clay-enable-rounded(
+							$cadmin-toggle-switch-button-on-border-radius
+						),
+					border-style: solid,
+					border-width: $cadmin-toggle-switch-button-border-width,
+					left: $cadmin-toggle-switch-bar-width -
+						$cadmin-toggle-switch-bar-padding -
+						$cadmin-toggle-switch-button-width,
+				),
+				toggle-switch-handle: (
+					after: (
+						content: attr(data-label-on),
+					),
+				),
+				toggle-switch-icon: (
+					color: $cadmin-toggle-switch-bar-on-icon-color,
+				),
+				toggle-switch-icon-on: (
+					opacity: 1,
+				),
+				toggle-switch-icon-off: (
+					opacity: 0,
+				),
+				button-icon: (
+					color: $cadmin-toggle-switch-button-on-icon-color,
+					left: $cadmin-toggle-switch-bar-width -
+						$cadmin-toggle-switch-bar-padding -
+						$cadmin-toggle-switch-button-width,
+				),
+				button-icon-on: (
+					opacity: 1,
+				),
+				button-icon-off: (
+					opacity: 0,
+				),
+			),
+		),
+		mobile: (
+			height: $cadmin-toggle-switch-bar-height-mobile,
+			width: $cadmin-toggle-switch-bar-width-mobile,
+			toggle-switch-bar: (
+				height: $cadmin-toggle-switch-bar-height-mobile,
+				line-height: $cadmin-toggle-switch-bar-height-mobile,
+				text-indent: 0,
+				before: (
+					width: $cadmin-toggle-switch-bar-width-mobile,
+				),
+				after: (
+					bottom: $cadmin-toggle-switch-bar-padding-mobile,
+					height: $cadmin-toggle-switch-button-width-mobile,
+					left: $cadmin-toggle-switch-bar-padding-mobile,
+					top: $cadmin-toggle-switch-bar-padding-mobile,
+					width: $cadmin-toggle-switch-button-width-mobile,
+				),
+				toggle-switch-handle: (
+					min-width: $cadmin-toggle-switch-bar-width-mobile,
+					after: (
+						margin-left:
+							clay-data-label-text-position(
+								$cadmin-toggle-switch-bar-width-mobile,
+								$cadmin-toggle-switch-bar-padding-mobile
+							),
+					),
+				),
+				toggle-switch-icon: (
+					font-size: $cadmin-toggle-switch-bar-font-size-mobile,
+					left: $cadmin-toggle-switch-bar-padding-mobile,
+					line-height: $cadmin-toggle-switch-button-width-mobile,
+					top: $cadmin-toggle-switch-bar-padding-mobile,
+					width: $cadmin-toggle-switch-button-width-mobile,
+				),
+				toggle-switch-icon-on: (
+					left: $cadmin-toggle-switch-bar-padding-mobile,
+				),
+				toggle-switch-icon-off: (
+					left: $cadmin-toggle-switch-bar-width-mobile -
+						$cadmin-toggle-switch-bar-padding-mobile -
+						$cadmin-toggle-switch-button-width-mobile,
+				),
+				button-icon: (
+					font-size: $cadmin-toggle-switch-button-font-size-mobile,
+				),
+			),
+			checked: (
+				toggle-switch-bar: (
+					after: (
+						left: $cadmin-toggle-switch-bar-width-mobile -
+							$cadmin-toggle-switch-bar-padding-mobile -
+							$cadmin-toggle-switch-button-width-mobile,
+					),
+					toggle-switch-handle: (
+						after: (
+							margin-left:
+								clay-data-label-text-position(
+									$cadmin-toggle-switch-bar-width-mobile,
+									$cadmin-toggle-switch-bar-padding-mobile
+								),
+						),
+					),
+					button-icon: (
+						left: $cadmin-toggle-switch-bar-width-mobile -
+							$cadmin-toggle-switch-bar-padding-mobile -
+							$cadmin-toggle-switch-button-width-mobile,
+					),
+				),
+			),
+			toggle-switch-text-left: (
+				line-height: $cadmin-toggle-switch-bar-height-mobile,
+			),
+			toggle-switch-text-right: (
+				line-height: $cadmin-toggle-switch-bar-height-mobile,
+			),
+		),
+	),
+	$cadmin-toggle-switch-check
+);
+
+// .toggle-switch-label
+
+$cadmin-toggle-switch-label: () !default;
+$cadmin-toggle-switch-label: map-merge(
+	(
+		display: block,
+		margin-bottom: 2px,
+	),
+	$cadmin-toggle-switch-label
+);
+
+// .toggle-switch-text
+
+$cadmin-toggle-switch-text: () !default;
+$cadmin-toggle-switch-text: map-merge(
+	(
+		display: block,
+		font-size: $cadmin-toggle-switch-text-font-size,
+	),
+	$cadmin-toggle-switch-text
+);
+
+// .toggle-switch-text-left
+
+$cadmin-toggle-switch-text-left: () !default;
+$cadmin-toggle-switch-text-left: map-deep-merge(
+	(
+		display: inline-flex,
+		line-height: $cadmin-toggle-switch-bar-height,
+		margin-right: 8px,
+	),
+	$cadmin-toggle-switch-text-left
+);
+
+// .toggle-switch-text-right
+
+$cadmin-toggle-switch-text-right: () !default;
+$cadmin-toggle-switch-text-right: map-merge(
+	(
+		display: inline-flex,
+		line-height: $cadmin-toggle-switch-bar-height,
+		margin-left: 8px,
+	),
+	$cadmin-toggle-switch-text-right
+);
+
+// .simple-toggle-switch
 
 $cadmin-simple-toggle-switch-label-line-height: 1 !default;
 $cadmin-simple-toggle-switch-label-spacer-x: 8px !default;
+
+$cadmin-simple-toggle-switch: () !default;
+$cadmin-simple-toggle-switch: map-deep-merge(
+	(
+		breakpoint-down: sm,
+		align-items: center,
+		display: inline-flex,
+		toggle-switch-label: (
+			line-height: $cadmin-simple-toggle-switch-label-line-height,
+			margin-bottom: 0,
+			max-width:
+				calc(
+					100% - #{clay-data-label-text-position(
+							$cadmin-toggle-switch-bar-width,
+							$cadmin-toggle-switch-bar-padding
+						)}
+				),
+		),
+		mobile: (
+			toggle-switch-label: (
+				max-width:
+					calc(
+						100% - #{clay-data-label-text-position(
+								$cadmin-toggle-switch-bar-width-mobile,
+								$cadmin-toggle-switch-bar-padding-mobile
+							)}
+					),
+			),
+		),
+	),
+	$cadmin-simple-toggle-switch
+);
+
+// .simple-toggle-switch-reverse
+
+$cadmin-simple-toggle-switch-reverse: () !default;
+$cadmin-simple-toggle-switch-reverse: map-deep-merge(
+	(
+		breakpoint-down: sm,
+		toggle-switch-label: (
+			margin-right: $cadmin-simple-toggle-switch-label-spacer-x,
+		),
+		toggle-switch-check-bar: (
+			order: 5,
+		),
+		toggle-switch-check: (
+			toggle-switch-bar: (
+				order: 5,
+			),
+		),
+	),
+	$cadmin-simple-toggle-switch-reverse
+);

--- a/packages/clay-css/src/scss/components/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/components/_toggle-switch.scss
@@ -1,10 +1,61 @@
+// Toggle Switch
+
+.toggle-switch {
+	@include clay-toggle-switch-variant($toggle-switch);
+}
+
+.toggle-switch-check-bar {
+	@include clay-css($toggle-switch-check-bar);
+}
+
+.toggle-switch-bar {
+	@include clay-toggle-switch-bar-variant($toggle-switch-bar);
+}
+
+.toggle-switch-check {
+	@include clay-toggle-switch-check-variant($toggle-switch-check);
+}
+
+.toggle-switch-label {
+	@include clay-css($toggle-switch-label);
+}
+
+.toggle-switch-text {
+	@include clay-css($toggle-switch-text);
+}
+
+.toggle-switch-text-left {
+	$breakpoint-down: setter(
+		map-get($toggle-switch-text-left, breakpoint-down),
+		sm
+	);
+
+	@include clay-css($toggle-switch-text-left);
+
+	@include media-breakpoint-down($breakpoint-down) {
+		@include clay-css(map-get($toggle-switch-text-left, mobile));
+	}
+}
+
+.toggle-switch-text-right {
+	$breakpoint-down: setter(
+		map-get($toggle-switch-text-right, breakpoint-down),
+		sm
+	);
+
+	@include clay-css($toggle-switch-text-right);
+
+	@include media-breakpoint-down($breakpoint-down) {
+		@include clay-css(map-get($toggle-switch-text-right, mobile));
+	}
+}
+
 // Simple Toggle Switch
 
 .simple-toggle-switch {
-	&.toggle-switch {
-		align-items: center;
-		display: inline-flex;
-	}
+	@include clay-toggle-switch-variant($simple-toggle-switch);
+
+	// deprecated
 
 	.toggle-switch-check + .toggle-switch-label {
 		margin-right: $simple-toggle-switch-label-spacer-x;
@@ -13,374 +64,8 @@
 	.toggle-switch-label + .toggle-switch-check-bar {
 		margin-left: $simple-toggle-switch-label-spacer-x;
 	}
-
-	.toggle-switch-label {
-		line-height: $simple-toggle-switch-label-line-height;
-		margin-bottom: 0;
-		max-width: calc(
-			100% - #{clay-data-label-text-position(
-					$toggle-switch-bar-width,
-					$toggle-switch-bar-padding
-				)}
-		);
-
-		@include clay-scale-component {
-			max-width: calc(
-				100% - #{clay-data-label-text-position(
-						$toggle-switch-bar-width-mobile,
-						$toggle-switch-bar-padding-mobile
-					)}
-			);
-		}
-	}
 }
 
 .simple-toggle-switch-reverse {
-	.toggle-switch-label {
-		margin-right: $simple-toggle-switch-label-spacer-x;
-	}
-
-	.toggle-switch-check-bar {
-		order: 5;
-
-		.toggle-switch-bar {
-			order: 0;
-		}
-	}
-
-	.toggle-switch-bar {
-		order: 5;
-	}
-}
-
-// Toggle Switch
-
-label.toggle-switch {
-	cursor: $toggle-switch-cursor;
-
-	&.disabled {
-		cursor: $toggle-switch-disabled-cursor;
-	}
-}
-
-.toggle-switch {
-	display: inline-block;
-	font-weight: $toggle-switch-font-weight;
-	max-width: 100%;
-	position: relative;
-
-	&.disabled {
-		.toggle-switch-label {
-			color: $toggle-switch-label-disabled-color;
-			cursor: $toggle-switch-disabled-cursor;
-		}
-
-		.toggle-switch-text {
-			color: $toggle-switch-text-disabled-color;
-		}
-	}
-}
-
-.toggle-switch-check-bar {
-	display: inline-flex;
-	position: relative;
-}
-
-.toggle-switch-bar {
-	.toggle-switch-handle {
-		display: block;
-		min-width: $toggle-switch-bar-width;
-		text-transform: uppercase;
-	}
-
-	.toggle-switch-icon {
-		font-size: $toggle-switch-bar-font-size;
-
-		.lexicon-icon {
-			margin-top: -0.2em;
-		}
-	}
-
-	.button-icon {
-		font-size: $toggle-switch-button-font-size;
-	}
-}
-
-.toggle-switch-check {
-	bottom: 0;
-	font-size: 62.5%;
-	height: $toggle-switch-bar-height;
-	opacity: 0;
-	position: absolute;
-	width: $toggle-switch-bar-width;
-	z-index: 2;
-
-	@include clay-scale-component {
-		height: $toggle-switch-bar-height-mobile;
-		width: $toggle-switch-bar-width-mobile;
-	}
-
-	&:empty ~ .toggle-switch-bar {
-		display: inline-flex;
-		font-size: $toggle-switch-bar-font-size;
-		height: $toggle-switch-bar-height;
-		line-height: $toggle-switch-bar-height;
-		position: relative;
-		text-indent: 0;
-
-		-ms-user-select: none;
-		user-select: none;
-
-		&:after {
-			background-color: $toggle-switch-button-bg;
-			border-color: $toggle-switch-button-border-color;
-
-			@include border-radius($toggle-switch-button-border-radius);
-
-			border-style: solid;
-			border-width: $toggle-switch-button-border-width;
-			bottom: $toggle-switch-bar-padding;
-			content: '';
-			display: block;
-			height: $toggle-switch-button-width;
-			left: $toggle-switch-bar-padding;
-			position: absolute;
-			top: $toggle-switch-bar-padding;
-			transition: $toggle-switch-transition;
-			width: $toggle-switch-button-width;
-		}
-
-		&:before {
-			background-color: $toggle-switch-bar-bg;
-			border-color: $toggle-switch-bar-border-color;
-
-			@include border-radius($toggle-switch-bar-border-radius);
-
-			border-style: solid;
-			border-width: $toggle-switch-bar-border-width;
-			bottom: 0;
-			content: ' ';
-			display: block;
-			left: 0;
-			position: absolute;
-			top: 0;
-			transition: $toggle-switch-transition;
-			width: $toggle-switch-bar-width;
-		}
-
-		.toggle-switch-handle {
-			&:after {
-				content: attr(data-label-off);
-				margin-left: clay-data-label-text-position(
-					$toggle-switch-bar-width,
-					$toggle-switch-bar-padding
-				);
-				transition: $toggle-switch-transition;
-				white-space: nowrap;
-			}
-
-			&:before {
-				transition: $toggle-switch-transition;
-			}
-		}
-
-		.toggle-switch-icon {
-			color: $toggle-switch-bar-icon-color;
-			left: $toggle-switch-bar-padding;
-			line-height: $toggle-switch-button-width;
-			position: absolute;
-			text-align: center;
-			text-indent: 0;
-			top: $toggle-switch-bar-padding;
-			transition: $toggle-switch-transition;
-			width: $toggle-switch-button-width;
-			z-index: 1;
-		}
-
-		.toggle-switch-icon-on {
-			left: $toggle-switch-bar-padding;
-			opacity: 0;
-		}
-
-		.toggle-switch-icon-off {
-			left: $toggle-switch-bar-width - $toggle-switch-bar-padding -
-				$toggle-switch-button-width;
-		}
-
-		.button-icon {
-			color: $toggle-switch-button-icon-color;
-		}
-
-		.button-icon-on {
-			opacity: 0;
-		}
-	}
-
-	&:checked ~ .toggle-switch-bar {
-		&:after {
-			background-color: $toggle-switch-button-on-bg;
-			border-color: $toggle-switch-button-on-border-color;
-
-			@include border-radius($toggle-switch-button-on-border-radius);
-
-			border-style: solid;
-			border-width: $toggle-switch-button-border-width;
-			left: $toggle-switch-bar-width - $toggle-switch-bar-padding -
-				$toggle-switch-button-width;
-		}
-
-		&:before {
-			background-color: $toggle-switch-bar-on-bg;
-			border-color: $toggle-switch-bar-on-border-color;
-
-			@include border-radius($toggle-switch-bar-border-radius);
-
-			border-style: solid;
-			border-width: $toggle-switch-bar-border-width;
-		}
-
-		.toggle-switch-handle:after {
-			content: attr(data-label-on);
-		}
-
-		.toggle-switch-icon {
-			color: $toggle-switch-bar-on-icon-color;
-		}
-
-		.button-icon {
-			color: $toggle-switch-button-on-icon-color;
-			left: $toggle-switch-bar-width - $toggle-switch-bar-padding -
-				$toggle-switch-button-width;
-		}
-
-		.button-icon-on,
-		.toggle-switch-icon-on {
-			opacity: 1;
-		}
-
-		.button-icon-off,
-		.toggle-switch-icon-off {
-			opacity: 0;
-		}
-	}
-
-	&:disabled,
-	&.disabled {
-		~ .toggle-switch-bar {
-			cursor: $toggle-switch-disabled-cursor;
-			opacity: $toggle-switch-disabled-opacity;
-		}
-	}
-
-	&:focus ~ .toggle-switch-bar:before {
-		box-shadow: $toggle-switch-bar-focus-box-shadow;
-	}
-}
-
-.toggle-switch-label {
-	display: block;
-	margin-bottom: 2px;
-}
-
-.toggle-switch-text {
-	display: block;
-	font-size: $toggle-switch-text-font-size;
-}
-
-.toggle-switch-text-left {
-	display: inline-flex;
-	line-height: $toggle-switch-bar-height;
-	margin-right: 8px;
-}
-
-.toggle-switch-text-right {
-	display: inline-flex;
-	line-height: $toggle-switch-bar-height;
-	margin-left: 8px;
-}
-
-@include clay-scale-component {
-	.toggle-switch-bar {
-		.toggle-switch-handle {
-			min-width: $toggle-switch-bar-width-mobile;
-		}
-
-		.toggle-switch-icon {
-			font-size: $toggle-switch-bar-font-size-mobile;
-		}
-
-		.button-icon {
-			font-size: $toggle-switch-button-font-size-mobile;
-		}
-	}
-
-	.toggle-switch-check {
-		&:empty ~ .toggle-switch-bar {
-			height: $toggle-switch-bar-height-mobile;
-			line-height: $toggle-switch-bar-height-mobile;
-			text-indent: 0;
-
-			&:after {
-				bottom: $toggle-switch-bar-padding-mobile;
-				height: $toggle-switch-button-width-mobile;
-				left: $toggle-switch-bar-padding-mobile;
-				top: $toggle-switch-bar-padding-mobile;
-				width: $toggle-switch-button-width-mobile;
-			}
-
-			&:before {
-				width: $toggle-switch-bar-width-mobile;
-			}
-
-			.toggle-switch-handle:after {
-				margin-left: clay-data-label-text-position(
-					$toggle-switch-bar-width-mobile,
-					$toggle-switch-bar-padding-mobile
-				);
-			}
-
-			.toggle-switch-icon {
-				left: $toggle-switch-bar-padding-mobile;
-				line-height: $toggle-switch-button-width-mobile;
-				top: $toggle-switch-bar-padding-mobile;
-				width: $toggle-switch-button-width-mobile;
-			}
-
-			.toggle-switch-icon-on {
-				left: $toggle-switch-bar-padding-mobile;
-			}
-
-			.toggle-switch-icon-off {
-				left: $toggle-switch-bar-width-mobile -
-					$toggle-switch-bar-padding-mobile -
-					$toggle-switch-button-width-mobile;
-			}
-		}
-
-		&:checked ~ .toggle-switch-bar {
-			&:after {
-				left: $toggle-switch-bar-width-mobile -
-					$toggle-switch-bar-padding-mobile -
-					$toggle-switch-button-width-mobile;
-			}
-
-			.toggle-switch-handle:after {
-				margin-left: clay-data-label-text-position(
-					$toggle-switch-bar-width-mobile,
-					$toggle-switch-bar-padding-mobile
-				);
-			}
-
-			.button-icon {
-				left: $toggle-switch-bar-width-mobile -
-					$toggle-switch-bar-padding-mobile -
-					$toggle-switch-button-width-mobile;
-			}
-		}
-	}
-
-	.toggle-switch-text-left,
-	.toggle-switch-text-right {
-		line-height: $toggle-switch-bar-height-mobile;
-	}
+	@include clay-toggle-switch-variant($simple-toggle-switch-reverse);
 }

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -8,6 +8,24 @@
 @import '_lx-icons-generated.scss';
 @import '_type-conversion-functions.scss';
 
+/// A helper function that calculates text-indent of data-label-on and data-label-off in a `.toggle-switch`.
+/// @param {Number} $toggle-switch-width - Width of switch bar
+/// @param {Number} $toggle-switch-padding - Space between button and bar
+/// @param {Number} $label-spacer-x[8px] - Space between toggle-switch-bar and data-label
+
+@function clay-data-label-text-position(
+	$toggle-switch-width,
+	$toggle-switch-padding,
+	$label-spacer-x: 8px
+) {
+	@if ($toggle-switch-padding < 0) {
+		$toggle-switch-width: $toggle-switch-width +
+			abs($toggle-switch-padding);
+	}
+
+	@return $toggle-switch-width + $label-spacer-x;
+}
+
 /// A function that returns a new map with all the keys and values including nested keys and values from both `$map1` and `$map2`. If both `$map1` and `$map2` have the same key, `$map2`’s value takes precedence.
 /// @param {Map, Null} $map1[()]
 /// @param {Map, Null} $map2[()]

--- a/packages/clay-css/src/scss/mixins/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/mixins/_toggle-switch.scss
@@ -2,20 +2,1082 @@
 /// @group toggleSwitch
 ////
 
-/// A helper function that calculates text-indent of data-label-on and data-label-off in a `.toggle-switch`.
-/// @param {Number} $toggle-switch-width - Width of switch bar
-/// @param {Number} $toggle-switch-padding - Space between button and bar
-/// @param {Number} $label-spacer-x[8px] - Space between toggle-switch-bar and data-label
+/// A mixin to help create `.toggle-switch-bar` variants.
+/// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
+/// @example
+/// (
+/// 	enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// 	// .toggle-switch-bar
+/// 	before: (
+/// 		// .toggle-switch-bar::before
+/// 	),
+/// 	after: (
+/// 		// .toggle-switch-bar::after
+/// 	),
+/// 	toggle-switch-handle: (
+/// 		// .toggle-switch-bar .toggle-switch-handle
+/// 		before: (
+/// 			// .toggle-switch-bar .toggle-switch-handle::before
+/// 		),
+/// 		after: (
+/// 			// .toggle-switch-bar .toggle-switch-handle::after
+/// 		),
+/// 	),
+/// 	toggle-switch-icon: (
+/// 		// .toggle-switch-bar .toggle-switch-icon
+/// 		lexicon-icon: (
+/// 			// .toggle-switch-bar .toggle-switch-icon .lexicon-icon
+/// 		),
+/// 	),
+/// 	toggle-switch-icon-on: (
+/// 		// .toggle-switch-bar .toggle-switch-icon-on
+/// 		lexicon-icon: (
+/// 			// .toggle-switch-bar .toggle-switch-icon-on .lexicon-icon
+/// 		),
+/// 	),
+/// 	toggle-switch-icon-off: (
+/// 		// .toggle-switch-bar .toggle-switch-icon-off
+/// 		lexicon-icon: (
+/// 			// .toggle-switch-bar .toggle-switch-icon-off .lexicon-icon
+/// 		),
+/// 	),
+/// 	button-icon: (
+/// 		// .toggle-switch-bar .button-icon
+/// 		lexicon-icon: (
+/// 			// .toggle-switch-bar .button-icon .lexicon-icon
+/// 		),
+/// 	),
+/// 	button-icon-on: (
+/// 		// .toggle-switch-bar .button-icon-on
+/// 		lexicon-icon: (
+/// 			// .toggle-switch-bar .button-icon-on .lexicon-icon
+/// 		),
+/// 	),
+/// )
 
-@function clay-data-label-text-position(
-	$toggle-switch-width,
-	$toggle-switch-padding,
-	$label-spacer-x: 8px
-) {
-	@if ($toggle-switch-padding < 0) {
-		$toggle-switch-width: $toggle-switch-width +
-			abs($toggle-switch-padding);
+@mixin clay-toggle-switch-bar-variant($map) {
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
+
+		@if ($enabled) {
+			@include clay-css($map);
+
+			&::before {
+				@include clay-css(map-get($map, before));
+			}
+
+			&::after {
+				@include clay-css(map-get($map, after));
+			}
+
+			.toggle-switch-handle {
+				@include clay-css(map-get($map, toggle-switch-handle));
+
+				&::before {
+					@include clay-css(
+						map-deep-get($map, toggle-switch-handle, before)
+					);
+				}
+
+				&::after {
+					@include clay-css(
+						map-deep-get($map, toggle-switch-handle, after)
+					);
+				}
+			}
+
+			.toggle-switch-icon {
+				@include clay-css(map-get($map, toggle-switch-icon));
+
+				.lexicon-icon {
+					@include clay-css(
+						map-deep-get($map, toggle-switch-icon, lexicon-icon)
+					);
+				}
+			}
+
+			.toggle-switch-icon-on {
+				@include clay-css(map-get($map, toggle-switch-icon-on));
+
+				.lexicon-icon {
+					@include clay-css(
+						map-deep-get($map, toggle-switch-icon-on, lexicon-icon)
+					);
+				}
+			}
+
+			.toggle-switch-icon-off {
+				@include clay-css(map-get($map, toggle-switch-icon-off));
+
+				.lexicon-icon {
+					@include clay-css(
+						map-deep-get($map, toggle-switch-icon-off, lexicon-icon)
+					);
+				}
+			}
+
+			.button-icon {
+				@include clay-css(map-get($map, button-icon));
+
+				.lexicon-icon {
+					@include clay-css(
+						map-deep-get($map, button-icon, lexicon-icon)
+					);
+				}
+			}
+
+			.button-icon-on {
+				@include clay-css(map-get($map, button-icon-on));
+
+				.lexicon-icon {
+					@include clay-css(
+						map-deep-get($map, button-icon-on, lexicon-icon)
+					);
+				}
+			}
+		}
 	}
+}
 
-	@return $toggle-switch-width + $label-spacer-x;
+/// A mixin to help create `.toggle-switch-check` variants.
+/// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
+/// @example
+/// (
+/// 	enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// 	breakpoint-down: {String},
+/// 	// .toggle-switch-check
+/// 	toggle-switch-bar: (
+/// 		// .toggle-switch-check ~ .toggle-switch-bar
+/// 		before: (
+/// 			// .toggle-switch-check ~ .toggle-switch-bar::before
+/// 		),
+/// 		after: (
+/// 			// .toggle-switch-check ~ .toggle-switch-bar::after
+/// 		),
+/// 		toggle-switch-handle: (
+/// 			// .toggle-switch-check ~ .toggle-switch-bar .toggle-switch-handle
+/// 			before: (
+/// 				// .toggle-switch-check ~ .toggle-switch-bar .toggle-switch-handle::before
+/// 			),
+/// 			after: (
+/// 				// .toggle-switch-check ~ .toggle-switch-bar .toggle-switch-handle::after
+/// 			),
+/// 		),
+/// 		toggle-switch-icon: (
+/// 			// .toggle-switch-check ~ .toggle-switch-bar .toggle-switch-icon
+/// 			lexicon-icon: (
+/// 				// .toggle-switch-check ~ .toggle-switch-bar .toggle-switch-icon .lexicon-icon
+/// 			),
+/// 		),
+/// 		toggle-switch-icon-on: (
+/// 			// .toggle-switch-check ~ .toggle-switch-bar .toggle-switch-icon-on
+/// 			lexicon-icon: (
+/// 				// .toggle-switch-check ~ .toggle-switch-bar .toggle-switch-icon-on .lexicon-icon
+/// 			),
+/// 		),
+/// 		toggle-switch-icon-off: (
+/// 			// .toggle-switch-check ~ .toggle-switch-bar .toggle-switch-icon-off
+/// 			lexicon-icon: (
+/// 				// .toggle-switch-check ~ .toggle-switch-bar .toggle-switch-icon-off .lexicon-icon
+/// 			),
+/// 		),
+/// 		button-icon: (
+/// 			// .toggle-switch-check ~ .toggle-switch-bar .button-icon
+/// 			lexicon-icon: (
+/// 				// .toggle-switch-check ~ .toggle-switch-bar .button-icon .lexicon-icon
+/// 			),
+/// 		),
+/// 		button-icon-on: (
+/// 			// .toggle-switch-check ~ .toggle-switch-bar .button-icon-on
+/// 			lexicon-icon: (
+/// 				// .toggle-switch-check ~ .toggle-switch-bar .button-icon-on .lexicon-icon
+/// 			),
+/// 		),
+/// 	),
+/// 	hover: (
+/// 		// N/A
+/// 		toggle-switch-bar: (
+/// 			// .toggle-switch-check:hover ~ .toggle-switch-bar
+/// 			before: (),
+/// 			after: (),
+/// 			toggle-switch-handle: (
+/// 				before: (),
+/// 				after: (),
+/// 			),
+/// 			toggle-switch-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-off: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 		),
+/// 	),
+/// 	focus: (
+/// 		// N/A
+/// 		toggle-switch-bar: (
+/// 			// .toggle-switch-check:focus ~ .toggle-switch-bar
+/// 			before: (),
+/// 			after: (),
+/// 			toggle-switch-handle: (
+/// 				before: (),
+/// 				after: (),
+/// 			),
+/// 			toggle-switch-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-off: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 		),
+/// 	),
+/// 	active: (
+/// 		// N/A
+/// 		toggle-switch-bar: (
+/// 			// .toggle-switch-check:active ~ .toggle-switch-bar
+/// 			before: (),
+/// 			after: (),
+/// 			toggle-switch-handle: (
+/// 				before: (),
+/// 				after: (),
+/// 			),
+/// 			toggle-switch-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-off: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 		),
+/// 	),
+/// 	disabled: (
+/// 		// N/A
+/// 		toggle-switch-bar: (
+/// 			// .toggle-switch-check[disabled] ~ .toggle-switch-bar,
+/// 			// .toggle-switch-check:disabled ~ .toggle-switch-bar
+/// 			before: (),
+/// 			after: (),
+/// 			toggle-switch-handle: (
+/// 				before: (),
+/// 				after: (),
+/// 			),
+/// 			toggle-switch-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-off: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 		),
+/// 	),
+/// 	checked: (
+/// 		// N/A
+/// 		toggle-switch-bar: (
+/// 			// .toggle-switch-check:checked ~ .toggle-switch-bar
+/// 			before: (),
+/// 			after: (),
+/// 			toggle-switch-handle: (
+/// 				before: (),
+/// 				after: (),
+/// 			),
+/// 			toggle-switch-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			toggle-switch-icon-off: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 			button-icon-on: (
+/// 				lexicon-icon: (),
+/// 			),
+/// 		),
+/// 		hover: (
+/// 			// N/A
+/// 			toggle-switch-bar: (
+/// 				// .toggle-switch-check:checked:hover ~ .toggle-switch-bar
+/// 				before: (),
+/// 				after: (),
+/// 				toggle-switch-handle: (
+/// 					before: (),
+/// 					after: (),
+/// 				),
+/// 				toggle-switch-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-off: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 			),
+/// 		),
+/// 		focus: (
+/// 			// N/A
+/// 			toggle-switch-bar: (
+/// 				// .toggle-switch-check:checked:focus ~ .toggle-switch-bar
+/// 				before: (),
+/// 				after: (),
+/// 				toggle-switch-handle: (
+/// 					before: (),
+/// 					after: (),
+/// 				),
+/// 				toggle-switch-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-off: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 			),
+/// 		),
+/// 		active: (
+/// 			// N/A
+/// 			toggle-switch-bar: (
+/// 				// .toggle-switch-check:checked:active ~ .toggle-switch-bar
+/// 				before: (),
+/// 				after: (),
+/// 				toggle-switch-handle: (
+/// 					before: (),
+/// 					after: (),
+/// 				),
+/// 				toggle-switch-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-off: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 			),
+/// 		),
+/// 		disabled: (
+/// 			// N/A
+/// 			toggle-switch-bar: (
+/// 				// .toggle-switch-check:checked[disabled] ~ .toggle-switch-bar,
+/// 				// .toggle-switch-check:checked:disabled ~ .toggle-switch-bar
+/// 				before: (),
+/// 				after: (),
+/// 				toggle-switch-handle: (
+/// 					before: (),
+/// 					after: (),
+/// 				),
+/// 				toggle-switch-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-off: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 			),
+/// 		),
+/// 	),
+/// 	indeterminate: (
+/// 		// N/A
+/// 		toggle-switch-bar: (
+/// 			// .toggle-switch-check:indeterminate ~ .toggle-switch-bar
+/// 			before: (),
+/// 				after: (),
+/// 				toggle-switch-handle: (
+/// 					before: (),
+/// 					after: (),
+/// 				),
+/// 				toggle-switch-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-off: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 		),
+/// 		hover: (
+/// 			// N/A
+/// 			toggle-switch-bar: (
+/// 				// .toggle-switch-check:indeterminate:hover ~ .toggle-switch-bar
+/// 				before: (),
+/// 				after: (),
+/// 				toggle-switch-handle: (
+/// 					before: (),
+/// 					after: (),
+/// 				),
+/// 				toggle-switch-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-off: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 			),
+/// 		),
+/// 		focus: (
+/// 			// N/A
+/// 			toggle-switch-bar: (
+/// 				// .toggle-switch-check:indeterminate:focus ~ .toggle-switch-bar
+/// 				before: (),
+/// 				after: (),
+/// 				toggle-switch-handle: (
+/// 					before: (),
+/// 					after: (),
+/// 				),
+/// 				toggle-switch-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-off: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 			),
+/// 		),
+/// 		active: (
+/// 			// N/A
+/// 			toggle-switch-bar: (
+/// 				// .toggle-switch-check:indeterminate:active ~ .toggle-switch-bar
+/// 				before: (),
+/// 				after: (),
+/// 				toggle-switch-handle: (
+/// 					before: (),
+/// 					after: (),
+/// 				),
+/// 				toggle-switch-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-off: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 			),
+/// 		),
+/// 		disabled: (
+/// 			// N/A
+/// 			toggle-switch-bar: (
+/// 				// .toggle-switch-check:indeterminate[disabled] ~ .toggle-switch-bar,
+/// 				// .toggle-switch-check:indeterminate:disabled ~ .toggle-switch-bar
+/// 				before: (),
+/// 				after: (),
+/// 				toggle-switch-handle: (
+/// 					before: (),
+/// 					after: (),
+/// 				),
+/// 				toggle-switch-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				toggle-switch-icon-off: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 				button-icon-on: (
+/// 					lexicon-icon: (),
+/// 				),
+/// 			),
+/// 		),
+/// 	),
+/// )
+
+@mixin clay-toggle-switch-check-variant($map) {
+	@if (type-of($map) == 'map') {
+		$breakpoint-down: setter(map-get($map, breakpoint-down), sm);
+		$enabled: setter(map-get($map, enabled), true);
+
+		@include clay-css($map);
+
+		@if ($enabled) {
+			~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-get($map, toggle-switch-bar)
+				);
+			}
+
+			&:hover ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, hover, toggle-switch-bar)
+				);
+			}
+
+			&:focus ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, focus, toggle-switch-bar)
+				);
+			}
+
+			&:active ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, active, toggle-switch-bar)
+				);
+			}
+
+			&[disabled] ~ .toggle-switch-bar,
+			&:disabled ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, disabled, toggle-switch-bar)
+				);
+			}
+
+			&:checked ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, checked, toggle-switch-bar)
+				);
+			}
+
+			&:checked:hover ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, checked, hover, toggle-switch-bar)
+				);
+			}
+
+			&:checked:focus ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, checked, focus, toggle-switch-bar)
+				);
+			}
+
+			&:checked:active ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, checked, active, toggle-switch-bar)
+				);
+			}
+
+			&:checked[disabled] ~ .toggle-switch-bar,
+			&:checked:disabled ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, checked, disabled, toggle-switch-bar)
+				);
+			}
+
+			&:indeterminate ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, indeterminate, toggle-switch-bar)
+				);
+			}
+
+			&:indeterminate:hover ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, indeterminate, hover, toggle-switch-bar)
+				);
+			}
+
+			&:indeterminate:focus ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, indeterminate, focus, toggle-switch-bar)
+				);
+			}
+
+			&:indeterminate:active ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get($map, indeterminate, active, toggle-switch-bar)
+				);
+			}
+
+			&:indeterminate[disabled] ~ .toggle-switch-bar,
+			&:indeterminate:disabled ~ .toggle-switch-bar {
+				@include clay-toggle-switch-bar-variant(
+					map-deep-get(
+						$map,
+						indeterminate,
+						disabled,
+						toggle-switch-bar
+					)
+				);
+			}
+
+			@include media-breakpoint-down($breakpoint-down) {
+				@include clay-css(map-get($map, mobile));
+
+				~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get($map, mobile, toggle-switch-bar)
+					);
+				}
+
+				&:hover ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get($map, mobile, hover, toggle-switch-bar)
+					);
+				}
+
+				&:focus ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get($map, mobile, focus, toggle-switch-bar)
+					);
+				}
+
+				&:active ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get($map, mobile, active, toggle-switch-bar)
+					);
+				}
+
+				&[disabled] ~ .toggle-switch-bar,
+				&:disabled ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get($map, mobile, disabled, toggle-switch-bar)
+					);
+				}
+
+				&:checked ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get($map, mobile, checked, toggle-switch-bar)
+					);
+				}
+
+				&:checked:hover ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get(
+							$map,
+							mobile,
+							checked,
+							hover,
+							toggle-switch-bar
+						)
+					);
+				}
+
+				&:checked:focus ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get(
+							$map,
+							mobile,
+							checked,
+							focus,
+							toggle-switch-bar
+						)
+					);
+				}
+
+				&:checked:active ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get(
+							$map,
+							mobile,
+							checked,
+							active,
+							toggle-switch-bar
+						)
+					);
+				}
+
+				&:checked[disabled] ~ .toggle-switch-bar,
+				&:checked:disabled ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get(
+							$map,
+							mobile,
+							checked,
+							disabled,
+							toggle-switch-bar
+						)
+					);
+				}
+
+				&:indeterminate ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get(
+							$map,
+							mobile,
+							indeterminate,
+							toggle-switch-bar
+						)
+					);
+				}
+
+				&:indeterminate:hover ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get(
+							$map,
+							mobile,
+							indeterminate,
+							hover,
+							toggle-switch-bar
+						)
+					);
+				}
+
+				&:indeterminate:focus ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get(
+							$map,
+							mobile,
+							indeterminate,
+							focus,
+							toggle-switch-bar
+						)
+					);
+				}
+
+				&:indeterminate:active ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get(
+							$map,
+							mobile,
+							indeterminate,
+							active,
+							toggle-switch-bar
+						)
+					);
+				}
+
+				&:indeterminate[disabled] ~ .toggle-switch-bar,
+				&:indeterminate:disabled ~ .toggle-switch-bar {
+					@include clay-toggle-switch-bar-variant(
+						map-deep-get(
+							$map,
+							mobile,
+							indeterminate,
+							disabled,
+							toggle-switch-bar
+						)
+					);
+				}
+			}
+		}
+	}
+}
+
+/// A mixin to help create `.toggle-switch` variants.
+/// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
+/// @example
+/// (
+/// 	enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// 	breakpoint-down: {String},
+/// 	// .toggle-switch
+/// 	toggle-switch-check-bar: (
+/// 		// .toggle-switch .toggle-switch-check-bar
+/// 		before: (
+/// 			// .toggle-switch .toggle-switch-check-bar::before
+/// 		),
+/// 		after: (
+/// 			// .toggle-switch .toggle-switch-check-bar::after
+/// 		),
+/// 	),
+/// 	toggle-switch-check: (
+/// 		// .toggle-switch .toggle-switch-check
+/// 		// See clay-toggle-switch-check-variant
+/// 	),
+/// 	toggle-switch-label: (
+/// 		// .toggle-switch .toggle-switch-label
+/// 	),
+/// 	toggle-switch-text: (
+/// 		// .toggle-switch .toggle-switch-text
+/// 	),
+/// 	toggle-switch-text-left: (
+/// 		// .toggle-switch .toggle-switch-text-left
+/// 	),
+/// 	toggle-switch-text-right: (
+/// 		// .toggle-switch .toggle-switch-text-right
+/// 	),
+/// 	disabled: (
+/// 		// .toggle-switch.disabled
+/// 		toggle-switch-label: (
+/// 			// .toggle-switch.disabled .toggle-switch-label
+/// 		),
+/// 		toggle-switch-text: (
+/// 			// .toggle-switch.disabled .toggle-switch-text
+/// 		),
+/// 		toggle-switch-text-left: (
+/// 			// .toggle-switch.disabled .toggle-switch-text-left
+/// 		),
+/// 		toggle-switch-text-right: (
+/// 			// .toggle-switch.disabled .toggle-switch-text-right
+/// 		),
+/// 	),
+/// 	mobile: (
+/// 		toggle-switch-check-bar: (
+/// 			before: (),
+/// 			after: (),
+/// 		),
+/// 		toggle-switch-check: (),
+/// 		toggle-switch-label: (),
+/// 		toggle-switch-text: (),
+/// 		toggle-switch-text-left: (),
+/// 		toggle-switch-text-right: (),
+/// 		disabled: (
+/// 			toggle-switch-label: (),
+/// 			toggle-switch-text: (),
+/// 			toggle-switch-text-left: (),
+/// 			toggle-switch-text-right: (),
+/// 		),
+/// 	),
+/// )
+
+@mixin clay-toggle-switch-variant($map) {
+	@if (type-of($map) == 'map') {
+		$breakpoint-down: setter(map-get($map, breakpoint-down), sm);
+		$enabled: setter(map-get($map, enabled), true);
+
+		@include clay-css($map);
+
+		.toggle-switch-check-bar {
+			@include clay-css(map-get($map, toggle-switch-check-bar));
+
+			&::before {
+				@include clay-css(
+					map-deep-get($map, toggle-switch-check-bar, before)
+				);
+			}
+
+			&::after {
+				@include clay-css(
+					map-deep-get($map, toggle-switch-check-bar, after)
+				);
+			}
+		}
+
+		.toggle-switch-check {
+			@include clay-toggle-switch-check-variant(
+				map-get($map, toggle-switch-check)
+			);
+		}
+
+		.toggle-switch-label {
+			@include clay-css(map-get($map, toggle-switch-label));
+		}
+
+		.toggle-switch-text {
+			@include clay-css(map-get($map, toggle-switch-text));
+		}
+
+		.toggle-switch-text-left {
+			@include clay-css(map-get($map, toggle-switch-text-left));
+		}
+
+		.toggle-switch-text-right {
+			@include clay-css(map-get($map, toggle-switch-text-right));
+		}
+
+		&.disabled {
+			@include clay-css(map-get($map, disabled));
+
+			.toggle-switch-label {
+				@include clay-css(
+					map-deep-get($map, disabled, toggle-switch-label)
+				);
+			}
+
+			.toggle-switch-text {
+				@include clay-css(
+					map-deep-get($map, disabled, toggle-switch-text)
+				);
+			}
+
+			.toggle-switch-text-left {
+				@include clay-css(
+					map-deep-get($map, disabled, toggle-switch-text-left)
+				);
+			}
+
+			.toggle-switch-text-right {
+				@include clay-css(
+					map-deep-get($map, disabled, toggle-switch-text-right)
+				);
+			}
+		}
+
+		@include media-breakpoint-down($breakpoint-down) {
+			@include clay-css(map-get($map, mobile));
+
+			.toggle-switch-check-bar {
+				@include clay-css(
+					map-deep-get($map, mobile, toggle-switch-check-bar)
+				);
+
+				&::before {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							mobile,
+							toggle-switch-check-bar,
+							before
+						)
+					);
+				}
+
+				&::after {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							mobile,
+							toggle-switch-check-bar,
+							after
+						)
+					);
+				}
+			}
+
+			.toggle-switch-check {
+				@include clay-toggle-switch-check-variant(
+					map-deep-get($map, mobile, toggle-switch-check)
+				);
+			}
+
+			.toggle-switch-label {
+				@include clay-css(
+					map-deep-get($map, mobile, toggle-switch-label)
+				);
+			}
+
+			.toggle-switch-text {
+				@include clay-css(
+					map-deep-get($map, mobile, toggle-switch-text)
+				);
+			}
+
+			.toggle-switch-text-left {
+				@include clay-css(
+					map-deep-get($map, mobile, toggle-switch-text-left)
+				);
+			}
+
+			.toggle-switch-text-right {
+				@include clay-css(
+					map-deep-get($map, mobile, toggle-switch-text-right)
+				);
+			}
+
+			&.disabled {
+				@include clay-css(map-deep-get($map, mobile, disabled));
+
+				.toggle-switch-label {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							mobile,
+							disabled,
+							toggle-switch-label
+						)
+					);
+				}
+
+				.toggle-switch-text {
+					@include clay-css(
+						map-deep-get($map, mobile, disabled, toggle-switch-text)
+					);
+				}
+
+				.toggle-switch-text-left {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							mobile,
+							disabled,
+							toggle-switch-text-left
+						)
+					);
+				}
+
+				.toggle-switch-text-right {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							mobile,
+							disabled,
+							toggle-switch-text-right
+						)
+					);
+				}
+			}
+		}
+	}
 }

--- a/packages/clay-css/src/scss/variables/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/variables/_toggle-switch.scss
@@ -6,14 +6,14 @@ $toggle-switch-transition: background-color 100ms ease-in,
 
 // must all be same units--start
 $toggle-switch-bar-padding: 0 !default; // space between button and bar, can be negative value
-$toggle-switch-bar-padding-mobile: $toggle-switch-bar-padding !default;
 $toggle-switch-button-width: 25px !default;
-$toggle-switch-button-width-mobile: $toggle-switch-button-width !default;
-
 $toggle-switch-bar-height: ($toggle-switch-bar-padding * 2) +
 	$toggle-switch-button-width !default;
-$toggle-switch-bar-height-mobile: $toggle-switch-bar-height !default;
 $toggle-switch-bar-width: 50px !default; // width of switch bar
+
+$toggle-switch-bar-padding-mobile: $toggle-switch-bar-padding !default;
+$toggle-switch-button-width-mobile: $toggle-switch-button-width !default;
+$toggle-switch-bar-height-mobile: $toggle-switch-bar-height !default;
 $toggle-switch-bar-width-mobile: $toggle-switch-bar-width !default;
 // must all be same units--end
 
@@ -60,7 +60,406 @@ $toggle-switch-text-font-size: 0.75rem !default;
 
 $toggle-switch-text-disabled-color: $input-label-disabled-color !default;
 
-// Simple Toggle Switch
+// .toggle-switch
+
+$toggle-switch: () !default;
+$toggle-switch: map-deep-merge(
+	(
+		breakpoint-down: sm,
+		cursor: $toggle-switch-cursor,
+		display: inline-block,
+		font-weight: $toggle-switch-font-weight,
+		max-width: 100%,
+		position: relative,
+		disabled: (
+			cursor: $toggle-switch-disabled-cursor,
+			toggle-switch-label: (
+				color: $toggle-switch-label-disabled-color,
+				cursor: $toggle-switch-disabled-cursor,
+			),
+			toggle-switch-text: (
+				color: $toggle-switch-text-disabled-color,
+			),
+		),
+	),
+	$toggle-switch
+);
+
+// .toggle-switch-check-bar
+
+$toggle-switch-check-bar: () !default;
+$toggle-switch-check-bar: map-merge(
+	(
+		display: inline-flex,
+		position: relative,
+	),
+	$toggle-switch-check-bar
+);
+
+// .toggle-switch-bar
+
+$toggle-switch-bar: () !default;
+$toggle-switch-bar: map-deep-merge(
+	(
+		toggle-switch-handle: (
+			display: block,
+			min-width: $toggle-switch-bar-width,
+			text-transform: uppercase,
+		),
+		toggle-switch-icon: (
+			font-size: $toggle-switch-bar-font-size,
+			lexicon-icon: (
+				margin-top: -0.2em,
+			),
+		),
+		button-icon: (
+			font-size: $toggle-switch-button-font-size,
+		),
+	),
+	$toggle-switch-bar
+);
+
+// .toggle-switch-check
+
+$toggle-switch-check: () !default;
+$toggle-switch-check: map-deep-merge(
+	(
+		breakpoint-down: sm,
+		bottom: 0,
+		font-size: 62.5%,
+		height: $toggle-switch-bar-height,
+		opacity: 0,
+		position: absolute,
+		width: $toggle-switch-bar-width,
+		z-index: 2,
+		toggle-switch-bar: (
+			display: inline-flex,
+			font-size: $toggle-switch-bar-font-size,
+			height: $toggle-switch-bar-height,
+			line-height: $toggle-switch-bar-height,
+			position: relative,
+			text-indent: 0,
+			user-select: none,
+			before: (
+				background-color: $toggle-switch-bar-bg,
+				border-color: $toggle-switch-bar-border-color,
+				border-radius:
+					clay-enable-rounded($toggle-switch-bar-border-radius),
+				border-style: solid,
+				border-width: $toggle-switch-bar-border-width,
+				bottom: 0,
+				content: ' ',
+				display: block,
+				left: 0,
+				position: absolute,
+				top: 0,
+				transition: $toggle-switch-transition,
+				width: $toggle-switch-bar-width,
+			),
+			after: (
+				background-color: $toggle-switch-button-bg,
+				border-color: $toggle-switch-button-border-color,
+				border-radius:
+					clay-enable-rounded($toggle-switch-button-border-radius),
+				border-style: solid,
+				border-width: $toggle-switch-button-border-width,
+				bottom: $toggle-switch-bar-padding,
+				content: '',
+				display: block,
+				height: $toggle-switch-button-width,
+				left: $toggle-switch-bar-padding,
+				position: absolute,
+				top: $toggle-switch-bar-padding,
+				transition: $toggle-switch-transition,
+				width: $toggle-switch-button-width,
+			),
+			toggle-switch-handle: (
+				before: (
+					transition:
+						clay-enable-transitions($toggle-switch-transition),
+				),
+				after: (
+					content: attr(data-label-off),
+					margin-left:
+						clay-data-label-text-position(
+							$toggle-switch-bar-width,
+							$toggle-switch-bar-padding
+						),
+					transition: $toggle-switch-transition,
+					white-space: nowrap,
+				),
+			),
+			toggle-switch-icon: (
+				color: $toggle-switch-bar-icon-color,
+				left: $toggle-switch-bar-padding,
+				line-height: $toggle-switch-button-width,
+				position: absolute,
+				text-align: center,
+				text-indent: 0,
+				top: $toggle-switch-bar-padding,
+				transition: $toggle-switch-transition,
+				width: $toggle-switch-button-width,
+				z-index: 1,
+			),
+			toggle-switch-icon-on: (
+				left: $toggle-switch-bar-padding,
+				opacity: 0,
+			),
+			toggle-switch-icon-off: (
+				left: $toggle-switch-bar-width - $toggle-switch-bar-padding -
+					$toggle-switch-button-width,
+			),
+			button-icon: (
+				color: $toggle-switch-button-icon-color,
+			),
+			button-icon-on: (
+				opacity: 0,
+			),
+		),
+		focus: (
+			toggle-switch-bar: (
+				before: (
+					box-shadow: $toggle-switch-bar-focus-box-shadow,
+				),
+			),
+		),
+		disabled: (
+			toggle-switch-bar: (
+				cursor: $toggle-switch-disabled-cursor,
+				opacity: $toggle-switch-disabled-opacity,
+			),
+		),
+		checked: (
+			toggle-switch-bar: (
+				before: (
+					background-color: $toggle-switch-bar-on-bg,
+					border-color: $toggle-switch-bar-on-border-color,
+					border-radius:
+						clay-enable-rounded($toggle-switch-bar-border-radius),
+					border-style: solid,
+					border-width: $toggle-switch-bar-border-width,
+				),
+				after: (
+					background-color: $toggle-switch-button-on-bg,
+					border-color: $toggle-switch-button-on-border-color,
+					border-radius:
+						clay-enable-rounded(
+							$toggle-switch-button-on-border-radius
+						),
+					border-style: solid,
+					border-width: $toggle-switch-button-border-width,
+					left: $toggle-switch-bar-width - $toggle-switch-bar-padding -
+						$toggle-switch-button-width,
+				),
+				toggle-switch-handle: (
+					after: (
+						content: attr(data-label-on),
+					),
+				),
+				toggle-switch-icon: (
+					color: $toggle-switch-bar-on-icon-color,
+				),
+				toggle-switch-icon-on: (
+					opacity: 1,
+				),
+				toggle-switch-icon-off: (
+					opacity: 0,
+				),
+				button-icon: (
+					color: $toggle-switch-button-on-icon-color,
+					left: $toggle-switch-bar-width - $toggle-switch-bar-padding -
+						$toggle-switch-button-width,
+				),
+				button-icon-on: (
+					opacity: 1,
+				),
+				button-icon-off: (
+					opacity: 0,
+				),
+			),
+		),
+		mobile: (
+			height: $toggle-switch-bar-height-mobile,
+			width: $toggle-switch-bar-width-mobile,
+			toggle-switch-bar: (
+				height: $toggle-switch-bar-height-mobile,
+				line-height: $toggle-switch-bar-height-mobile,
+				text-indent: 0,
+				before: (
+					width: $toggle-switch-bar-width-mobile,
+				),
+				after: (
+					bottom: $toggle-switch-bar-padding-mobile,
+					height: $toggle-switch-button-width-mobile,
+					left: $toggle-switch-bar-padding-mobile,
+					top: $toggle-switch-bar-padding-mobile,
+					width: $toggle-switch-button-width-mobile,
+				),
+				toggle-switch-handle: (
+					min-width: $toggle-switch-bar-width-mobile,
+					after: (
+						margin-left:
+							clay-data-label-text-position(
+								$toggle-switch-bar-width-mobile,
+								$toggle-switch-bar-padding-mobile
+							),
+					),
+				),
+				toggle-switch-icon: (
+					font-size: $toggle-switch-bar-font-size-mobile,
+					left: $toggle-switch-bar-padding-mobile,
+					line-height: $toggle-switch-button-width-mobile,
+					top: $toggle-switch-bar-padding-mobile,
+					width: $toggle-switch-button-width-mobile,
+				),
+				toggle-switch-icon-on: (
+					left: $toggle-switch-bar-padding-mobile,
+				),
+				toggle-switch-icon-off: (
+					left: $toggle-switch-bar-width-mobile -
+						$toggle-switch-bar-padding-mobile -
+						$toggle-switch-button-width-mobile,
+				),
+				button-icon: (
+					font-size: $toggle-switch-button-font-size-mobile,
+				),
+			),
+			checked: (
+				toggle-switch-bar: (
+					after: (
+						left: $toggle-switch-bar-width-mobile -
+							$toggle-switch-bar-padding-mobile -
+							$toggle-switch-button-width-mobile,
+					),
+					toggle-switch-handle: (
+						after: (
+							margin-left:
+								clay-data-label-text-position(
+									$toggle-switch-bar-width-mobile,
+									$toggle-switch-bar-padding-mobile
+								),
+						),
+					),
+					button-icon: (
+						left: $toggle-switch-bar-width-mobile -
+							$toggle-switch-bar-padding-mobile -
+							$toggle-switch-button-width-mobile,
+					),
+				),
+			),
+		),
+	),
+	$toggle-switch-check
+);
+
+// .toggle-switch-label
+
+$toggle-switch-label: () !default;
+$toggle-switch-label: map-merge(
+	(
+		display: block,
+		margin-bottom: 2px,
+	),
+	$toggle-switch-label
+);
+
+// .toggle-switch-text
+
+$toggle-switch-text: () !default;
+$toggle-switch-text: map-merge(
+	(
+		display: block,
+		font-size: $toggle-switch-text-font-size,
+	),
+	$toggle-switch-text
+);
+
+// .toggle-switch-text-left
+
+$toggle-switch-text-left: () !default;
+$toggle-switch-text-left: map-merge(
+	(
+		breakpoint-down: sm,
+		display: inline-flex,
+		line-height: $toggle-switch-bar-height,
+		margin-right: 8px,
+		mobile: (
+			line-height: $toggle-switch-bar-height-mobile,
+		),
+	),
+	$toggle-switch-text-left
+);
+
+// .toggle-switch-text-right
+
+$toggle-switch-text-right: () !default;
+$toggle-switch-text-right: map-deep-merge(
+	(
+		breakpoint-down: sm,
+		display: inline-flex,
+		line-height: $toggle-switch-bar-height,
+		margin-left: 8px,
+		mobile: (
+			line-height: $toggle-switch-bar-height-mobile,
+		),
+	),
+	$toggle-switch-text-right
+);
+
+// .simple-toggle-switch
 
 $simple-toggle-switch-label-line-height: 1 !default;
 $simple-toggle-switch-label-spacer-x: 0.5rem !default;
+
+$simple-toggle-switch: () !default;
+$simple-toggle-switch: map-deep-merge(
+	(
+		breakpoint-down: sm,
+		align-items: center,
+		display: inline-flex,
+		toggle-switch-label: (
+			line-height: $simple-toggle-switch-label-line-height,
+			margin-bottom: 0,
+			max-width:
+				calc(
+					100% - #{clay-data-label-text-position(
+							$toggle-switch-bar-width,
+							$toggle-switch-bar-padding
+						)}
+				),
+		),
+		mobile: (
+			toggle-switch-label: (
+				max-width:
+					calc(
+						100% - #{clay-data-label-text-position(
+								$toggle-switch-bar-width-mobile,
+								$toggle-switch-bar-padding-mobile
+							)}
+					),
+			),
+		),
+	),
+	$simple-toggle-switch
+);
+
+// .simple-toggle-switch-reverse
+
+$simple-toggle-switch-reverse: () !default;
+$simple-toggle-switch-reverse: map-deep-merge(
+	(
+		breakpoint-down: sm,
+		toggle-switch-check-bar: (
+			order: 5,
+		),
+		toggle-switch-check: (
+			toggle-switch-bar: (
+				order: 5,
+			),
+		),
+		toggle-switch-label: (
+			margin-right: $simple-toggle-switch-label-spacer-x,
+		),
+	),
+	$simple-toggle-switch-reverse
+);


### PR DESCRIPTION
This adds mixins `clay-toggle-switch-bar-variant`, `toggle-switch-check-variant`, and `toggle-switch-variant`. The styles haven't changed, but the option to change them is available.

fixes #4375