### PR TITLE
chore: increase Node.js memory usage in Storybook build

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"lint": "eslint \".*.js\" \"**/*.{js,ts,tsx}\"",
 		"site": "cd next.clayui.com && yarn build && yarn serve",
 		"sizeLimit": "size-limit",
-		"storybook:build": "build-storybook -c .storybook -o .storybook-static",
+		"storybook:build": "NODE_OPTIONS=--max_old_space_size=4096 build-storybook -c .storybook -o .storybook-static",
 		"storybook": "start-storybook -p 8888",
 		"test": "jest",
 		"version": "prettier --write -- \"**/CHANGELOG.md\" \"lerna.json\" && git add -- \"packages/clay-css/src/scss/_license-text.scss\""


### PR DESCRIPTION
Recently we were seeing the Storybook build failing on Netlify due to lack of memory, I was thinking that the container's memory but doesn't make sense because it looks like the container can use up to 32GB of memory 🙂.

I'm increasing the memory capacity of Node.js to 4 GB, this seems enough because before it was bursting at 2 GB and in some moments finishing the build.