### PR TITLE
fix(clayui.com): Incorrect import for ClayCardWithNavigation

### DIFF
--- a/packages/clay-card/docs/index.js
+++ b/packages/clay-card/docs/index.js
@@ -203,7 +203,7 @@ const CardWithInfo = () => {
 	);
 };
 
-const cardWithNavigationImportsCode = `import {ClayCardWithInfo} from '@clayui/card';
+const cardWithNavigationImportsCode = `import {ClayCardWithNavigation} from '@clayui/card';
 import ClayIcon from '@clayui/icon';
 `;
 


### PR DESCRIPTION
Looks like this was missed at some point.