### PR TITLE
feat(@clayui/css): _reboot convert `a` tag to use `clay-link` mixin

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -442,6 +442,19 @@ $link-decoration: none !default;
 $link-hover-color: $primary-d2 !default;
 $link-hover-decoration: underline !default;
 
+$link: () !default;
+$link: map-deep-merge(
+	(
+		color: $link-color,
+		text-decoration: $link-decoration,
+		hover: (
+			color: $link-hover-color,
+			text-decoration: $link-hover-decoration,
+		),
+	),
+	$link
+);
+
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 
 $emphasized-link-hover-darken-percentage: 15% !default;

--- a/packages/clay-css/src/scss/cadmin/components/_reboot.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_reboot.scss
@@ -173,14 +173,7 @@ html#{$cadmin-selector} {
 		}
 
 		a {
-			color: $cadmin-link-color;
-			cursor: $cadmin-link-cursor;
-			text-decoration: $cadmin-link-decoration;
-
-			&:hover {
-				color: $cadmin-link-hover-color;
-				text-decoration: $cadmin-link-hover-decoration;
-			}
+			@include clay-link($cadmin-link);
 		}
 
 		// Code

--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -568,6 +568,20 @@ $cadmin-link-decoration: none !default;
 $cadmin-link-hover-color: $cadmin-primary-d2 !default;
 $cadmin-link-hover-decoration: underline !default;
 
+$cadmin-link: () !default;
+$cadmin-link: map-deep-merge(
+	(
+		color: $cadmin-link-color,
+		cursor: $cadmin-link-cursor,
+		text-decoration: $cadmin-link-decoration,
+		hover: (
+			color: $cadmin-link-hover-color,
+			text-decoration: $cadmin-link-hover-decoration,
+		),
+	),
+	$cadmin-link
+);
+
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 
 $cadmin-emphasized-link-hover-darken-percentage: 15% !default;

--- a/packages/clay-css/src/scss/components/_reboot.scss
+++ b/packages/clay-css/src/scss/components/_reboot.scss
@@ -134,14 +134,7 @@ sup {
 }
 
 a {
-	color: $link-color;
-	cursor: $link-cursor;
-	text-decoration: $link-decoration;
-
-	&:hover {
-		color: $link-hover-color;
-		text-decoration: $link-hover-decoration;
-	}
+	@include clay-link($link);
 }
 
 // Code

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -432,6 +432,19 @@ $link-decoration: none !default;
 $link-hover-color: clay-darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
 
+$link: () !default;
+$link: map-deep-merge(
+	(
+		color: $link-color,
+		text-decoration: $link-decoration,
+		hover: (
+			color: $link-hover-color,
+			text-decoration: $link-hover-decoration,
+		),
+	),
+	$link
+);
+
 /// Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 /// @deprecated as of v3.x with no replacement, fixed percentages do not propagate well for all colors; manually define them for each theme color in `$text-theme-colors`.
 


### PR DESCRIPTION
fixes #4462