### PR TITLE
fix(@clayui/css): Mixins `clay-navbar-variant` should be able to output selectors that `clay-navbar-size` can

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_application-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_application-bar.scss
@@ -9,11 +9,19 @@ $application-bar-size: map-deep-merge(
 $application-bar-base: () !default;
 $application-bar-base: map-deep-merge(
 	(
-		link-border-radius: $border-radius,
-		link-outline: 0,
-		link-transition: box-shadow 0.15s ease-in-out,
-		link-focus-box-shadow: $btn-focus-box-shadow,
-		link-disabled-box-shadow: none,
+		navbar-nav: (
+			nav-link: (
+				border-radius: $border-radius,
+				outline: 0,
+				transition: box-shadow 0.15s ease-in-out,
+				focus: (
+					box-shadow: $btn-focus-box-shadow,
+				),
+				disabled: (
+					box-shadow: none,
+				),
+			),
+		),
 	),
 	$application-bar-base
 );
@@ -21,13 +29,25 @@ $application-bar-base: map-deep-merge(
 $application-bar-dark: () !default;
 $application-bar-dark: map-deep-merge(
 	(
-		bg: $dark-l1,
-		link-font-weight: $font-weight-semi-bold,
-		link-hover-bg: rgba(255, 255, 255, 0.03),
-		link-focus-bg: rgba(255, 255, 255, 0.03),
-		link-active-bg: rgba(255, 255, 255, 0.06),
-		link-disabled-bg: transparent,
-		link-disabled-opacity: 0.5,
+		background-color: $dark-l1,
+		navbar-nav: (
+			nav-link: (
+				font-weight: $font-weight-semi-bold,
+				hover: (
+					background-color: rgba(255, 255, 255, 0.03),
+				),
+				focus: (
+					background-color: rgba(255, 255, 255, 0.03),
+				),
+				active: (
+					background-color: rgba(255, 255, 255, 0.06),
+				),
+				disabled: (
+					background-color: transparent,
+					opacity: 0.5,
+				),
+			),
+		),
 	),
 	$application-bar-dark
 );

--- a/packages/clay-css/src/scss/atlas/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_management-bar.scss
@@ -1,11 +1,19 @@
 $management-bar-base: () !default;
 $management-bar-base: map-deep-merge(
 	(
-		link-border-radius: $border-radius,
-		link-outline: 0,
-		link-transition: box-shadow 0.15s ease-in-out,
-		link-focus-box-shadow: $btn-focus-box-shadow,
-		link-disabled-box-shadow: none,
+		navbar-nav: (
+			nav-link: (
+				border-radius: $border-radius,
+				outline: 0,
+				transition: box-shadow 0.15s ease-in-out,
+				focus: (
+					box-shadow: $btn-focus-box-shadow,
+				),
+				disabled: (
+					box-shadow: none,
+				),
+			),
+		),
 	),
 	$management-bar-base
 );
@@ -13,14 +21,26 @@ $management-bar-base: map-deep-merge(
 $management-bar-light: () !default;
 $management-bar-light: map-deep-merge(
 	(
-		bg: $white,
-		link-font-weight: $font-weight-semi-bold,
-		link-hover-color: $gray-900,
-		link-hover-bg: rgba($gray-900, 0.03),
-		link-focus-color: $gray-900,
-		link-focus-bg: rgba($gray-900, 0.03),
-		link-active-bg: rgba($gray-900, 0.06),
-		link-disabled-bg: transparent,
+		background-color: $white,
+		navbar-nav: (
+			nav-link: (
+				font-weight: $font-weight-semi-bold,
+				hover: (
+					background-color: rgba($gray-900, 0.03),
+					color: $gray-900,
+				),
+				focus: (
+					background-color: rgba($gray-900, 0.03),
+					color: $gray-900,
+				),
+				active: (
+					background-color: rgba($gray-900, 0.06),
+				),
+				disabled: (
+					background-color: transparent,
+				),
+			),
+		),
 	),
 	$management-bar-light
 );
@@ -28,14 +48,26 @@ $management-bar-light: map-deep-merge(
 $management-bar-primary: () !default;
 $management-bar-primary: map-deep-merge(
 	(
-		link-border-radius: $border-radius,
-		link-font-weight: $font-weight-semi-bold,
-		link-hover-color: $gray-900,
-		link-hover-bg: rgba($gray-900, 0.03),
-		link-focus-color: $gray-900,
-		link-focus-bg: rgba($gray-900, 0.03),
-		link-active-bg: rgba($gray-900, 0.06),
-		link-disabled-bg: transparent,
+		navbar-nav: (
+			nav-link: (
+				border-radius: $border-radius,
+				font-weight: $font-weight-semi-bold,
+				hover: (
+					background-color: rgba($gray-900, 0.03),
+					color: $gray-900,
+				),
+				focus: (
+					background-color: rgba($gray-900, 0.03),
+					color: $gray-900,
+				),
+				active: (
+					background-color: rgba($gray-900, 0.06),
+				),
+				disabled: (
+					background-color: transparent,
+				),
+			),
+		),
 	),
 	$management-bar-primary
 );

--- a/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
@@ -15,10 +15,18 @@ $navigation-bar-size: map-deep-merge(
 $navigation-bar-base: () !default;
 $navigation-bar-base: map-deep-merge(
 	(
-		link-border-radius: 0,
-		link-outline: 0,
-		link-focus-box-shadow: $btn-focus-box-shadow,
-		link-disabled-box-shadow: none,
+		navbar-nav: (
+			nav-link: (
+				border-radius: 0,
+				outline: 0,
+				focus: (
+					box-shadow: $btn-focus-box-shadow,
+				),
+				disabled: (
+					box-shadow: none,
+				),
+			),
+		),
 	),
 	$navigation-bar-base
 );
@@ -26,13 +34,23 @@ $navigation-bar-base: map-deep-merge(
 $navigation-bar-light: () !default;
 $navigation-bar-light: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $gray-200,
-		link-font-weight: $font-weight-semi-bold,
-		link-hover-color: $gray-900,
-		link-focus-color: $gray-900,
-		link-disabled-color: $gray-600,
-		link-disabled-opacity: $btn-disabled-opacity,
+		navbar-nav: (
+			nav-link: (
+				font-weight: $font-weight-semi-bold,
+				hover: (
+					color: $gray-900,
+				),
+				focus: (
+					color: $gray-900,
+				),
+				disabled: (
+					color: $gray-600,
+					opacity: $btn-disabled-opacity,
+				),
+			),
+		),
 	),
 	$navigation-bar-light
 );
@@ -40,14 +58,26 @@ $navigation-bar-light: map-deep-merge(
 $navigation-bar-secondary: () !default;
 $navigation-bar-secondary: map-deep-merge(
 	(
-		bg: $secondary-d1,
-		link-color: $secondary-l2,
-		link-font-weight: $font-weight-semi-bold,
-		link-hover-color: $white,
-		link-focus-color: $white,
-		link-active-color: $white,
-		link-disabled-color: $gray-400,
-		link-disabled-opacity: $btn-disabled-opacity,
+		background-color: $secondary-d1,
+		navbar-nav: (
+			nav-link: (
+				color: $secondary-l2,
+				font-weight: $font-weight-semi-bold,
+				hover: (
+					color: $white,
+				),
+				focus: (
+					color: $white,
+				),
+				active: (
+					color: $white,
+				),
+				disabled: (
+					color: $gray-400,
+					opacity: $btn-disabled-opacity,
+				),
+			),
+		),
 	),
 	$navigation-bar-secondary
 );

--- a/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
@@ -27,6 +27,8 @@ $navigation-bar-base: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$navigation-bar-base
 );
@@ -48,6 +50,33 @@ $navigation-bar-light: map-deep-merge(
 				disabled: (
 					color: $gray-600,
 					opacity: $btn-disabled-opacity,
+				),
+			),
+		),
+		media-breakpoint-down: (
+			sm: (
+				navbar-expand-md: (
+					navbar-collapse: (
+						navbar-nav: (
+							dropdown-item: (
+								color: $navbar-light-color,
+								font-weight: $font-weight-semi-bold,
+								hover: (
+									color: $gray-900,
+								),
+								focus: (
+									color: $gray-900,
+								),
+								active: (
+									color: $gray-900,
+								),
+								disabled: (
+									color: $gray-600,
+									opacity: $btn-disabled-opacity,
+								),
+							),
+						),
+					),
 				),
 			),
 		),
@@ -75,6 +104,33 @@ $navigation-bar-secondary: map-deep-merge(
 				disabled: (
 					color: $gray-400,
 					opacity: $btn-disabled-opacity,
+				),
+			),
+		),
+		media-breakpoint-down: (
+			sm: (
+				navbar-expand-md: (
+					navbar-collapse: (
+						navbar-nav: (
+							dropdown-item: (
+								color: $secondary-l2,
+								font-weight: $font-weight-semi-bold,
+								hover: (
+									color: $white,
+								),
+								focus: (
+									color: $white,
+								),
+								active: (
+									color: $white,
+								),
+								disabled: (
+									color: $gray-400,
+									opacity: $btn-disabled-opacity,
+								),
+							),
+						),
+					),
 				),
 			),
 		),

--- a/packages/clay-css/src/scss/atlas/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sidebar.scss
@@ -73,7 +73,7 @@ $sidebar-light: map-deep-merge(
 $sidebar-light-navigation-bar: () !default;
 $sidebar-light-navigation-bar: map-deep-merge(
 	(
-		bg: $white,
+		background-color: $white,
 		border-color: $secondary-l2,
 	),
 	$sidebar-light-navigation-bar

--- a/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
@@ -1,6 +1,8 @@
 $cadmin-management-bar-base: () !default;
 $cadmin-management-bar-base: map-deep-merge(
 	(
+		border-color: transparent,
+		border-style: solid,
 		navbar-nav: (
 			nav-link: (
 				border-radius: $cadmin-border-radius,

--- a/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
@@ -16,6 +16,8 @@ $cadmin-management-bar-base: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$cadmin-management-bar-base
 );
@@ -73,6 +75,8 @@ $cadmin-management-bar-light: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$cadmin-management-bar-light
 );
@@ -107,6 +111,8 @@ $cadmin-management-bar-primary: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$cadmin-management-bar-primary
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
@@ -1,11 +1,19 @@
 $cadmin-management-bar-base: () !default;
 $cadmin-management-bar-base: map-deep-merge(
 	(
-		link-border-radius: $cadmin-border-radius,
-		link-outline: 0,
-		link-transition: box-shadow 0.15s ease-in-out,
-		link-focus-box-shadow: $cadmin-btn-focus-box-shadow,
-		link-disabled-box-shadow: none,
+		navbar-nav: (
+			nav-link: (
+				border-radius: $cadmin-border-radius,
+				outline: 0,
+				transition: box-shadow 0.15s ease-in-out,
+				focus: (
+					box-shadow: $cadmin-btn-focus-box-shadow,
+				),
+				disabled: (
+					box-shadow: none,
+				),
+			),
+		),
 	),
 	$cadmin-management-bar-base
 );
@@ -39,18 +47,30 @@ $cadmin-management-bar-size: map-deep-merge(
 $cadmin-management-bar-light: () !default;
 $cadmin-management-bar-light: map-deep-merge(
 	(
-		bg: $cadmin-white,
-		link-color: $cadmin-navbar-light-color,
-		link-font-weight: $cadmin-font-weight-semi-bold,
-		link-hover-color: $cadmin-gray-900,
-		link-hover-bg: rgba($cadmin-gray-900, 0.03),
-		link-focus-color: $cadmin-gray-900,
-		link-focus-bg: rgba($cadmin-gray-900, 0.03),
-		link-active-bg: rgba($cadmin-gray-900, 0.06),
-		link-active-color: $cadmin-navbar-light-active-color,
-		link-disabled-bg: transparent,
-		link-disabled-color: $cadmin-navbar-light-disabled-color,
-		link-disabled-opacity: 1,
+		background-color: $cadmin-white,
+		navbar-nav: (
+			nav-link: (
+				color: $cadmin-navbar-light-color,
+				font-weight: $cadmin-font-weight-semi-bold,
+				hover: (
+					color: $cadmin-gray-900,
+					background-color: rgba($cadmin-gray-900, 0.03),
+				),
+				focus: (
+					color: $cadmin-gray-900,
+					background-color: rgba($cadmin-gray-900, 0.03),
+				),
+				active: (
+					background-color: rgba($cadmin-gray-900, 0.06),
+					color: $cadmin-navbar-light-active-color,
+				),
+				disabled: (
+					background-color: transparent,
+					color: $cadmin-navbar-light-disabled-color,
+					opacity: 1,
+				),
+			),
+		),
 	),
 	$cadmin-management-bar-light
 );
@@ -58,21 +78,33 @@ $cadmin-management-bar-light: map-deep-merge(
 $cadmin-management-bar-primary: () !default;
 $cadmin-management-bar-primary: map-deep-merge(
 	(
-		bg: $cadmin-primary-l3,
+		background-color: $cadmin-primary-l3,
 		border-color: $cadmin-primary,
 		color: $cadmin-navbar-light-color,
-		link-border-radius: $cadmin-border-radius,
-		link-color: $cadmin-navbar-light-color,
-		link-font-weight: $cadmin-font-weight-semi-bold,
-		link-hover-color: $cadmin-gray-900,
-		link-hover-bg: rgba($cadmin-gray-900, 0.03),
-		link-focus-color: $cadmin-gray-900,
-		link-focus-bg: rgba($cadmin-gray-900, 0.03),
-		link-active-bg: rgba($cadmin-gray-900, 0.06),
-		link-active-color: $cadmin-navbar-light-active-color,
-		link-disabled-bg: transparent,
-		link-disabled-color: $cadmin-navbar-light-disabled-color,
-		link-disabled-opacity: 1,
+		navbar-nav: (
+			nav-link: (
+				border-radius: $cadmin-border-radius,
+				color: $cadmin-navbar-light-color,
+				font-weight: $cadmin-font-weight-semi-bold,
+				hover: (
+					color: $cadmin-gray-900,
+					background-color: rgba($cadmin-gray-900, 0.03),
+				),
+				focus: (
+					color: $cadmin-gray-900,
+					background-color: rgba($cadmin-gray-900, 0.03),
+				),
+				active: (
+					background-color: rgba($cadmin-gray-900, 0.06),
+					color: $cadmin-navbar-light-active-color,
+				),
+				disabled: (
+					background-color: transparent,
+					color: $cadmin-navbar-light-disabled-color,
+					opacity: 1,
+				),
+			),
+		),
 	),
 	$cadmin-management-bar-primary
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
@@ -24,10 +24,18 @@ $cadmin-navigation-bar-size: map-deep-merge(
 $cadmin-navigation-bar-base: () !default;
 $cadmin-navigation-bar-base: map-deep-merge(
 	(
-		link-border-radius: 0,
-		link-outline: 0,
-		link-focus-box-shadow: $cadmin-btn-focus-box-shadow,
-		link-disabled-box-shadow: none,
+		navbar-nav: (
+			nav-link: (
+				border-radius: 0,
+				outline: 0,
+				focus: (
+					box-shadow: $cadmin-btn-focus-box-shadow,
+				),
+				disabled: (
+					box-shadow: none,
+				),
+			),
+		),
 	),
 	$cadmin-navigation-bar-base
 );
@@ -35,15 +43,27 @@ $cadmin-navigation-bar-base: map-deep-merge(
 $cadmin-navigation-bar-light: () !default;
 $cadmin-navigation-bar-light: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-gray-200,
-		link-color: $cadmin-navbar-light-color,
-		link-font-weight: $cadmin-font-weight-semi-bold,
-		link-hover-color: $cadmin-gray-900,
-		link-focus-color: $cadmin-gray-900,
-		link-active-color: $cadmin-navbar-light-active-color,
-		link-disabled-color: $cadmin-gray-600,
-		link-disabled-opacity: $cadmin-btn-disabled-opacity,
+		navbar-nav: (
+			nav-link: (
+				color: $cadmin-navbar-light-color,
+				font-weight: $cadmin-font-weight-semi-bold,
+				hover: (
+					color: $cadmin-gray-900,
+				),
+				focus: (
+					color: $cadmin-gray-900,
+				),
+				active: (
+					color: $cadmin-navbar-light-active-color,
+				),
+				disabled: (
+					color: $cadmin-gray-600,
+					opacity: $cadmin-btn-disabled-opacity,
+				),
+			),
+		),
 	),
 	$cadmin-navigation-bar-light
 );
@@ -51,17 +71,33 @@ $cadmin-navigation-bar-light: map-deep-merge(
 $cadmin-navigation-bar-secondary: () !default;
 $cadmin-navigation-bar-secondary: map-deep-merge(
 	(
-		bg: $cadmin-secondary-d1,
+		background-color: $cadmin-secondary-d1,
 		color: $cadmin-white,
-		link-color: $cadmin-secondary-l2,
-		link-font-weight: $cadmin-font-weight-semi-bold,
-		link-hover-color: $cadmin-white,
-		link-focus-color: $cadmin-white,
-		link-active-color: $cadmin-white,
-		link-disabled-color: $cadmin-gray-400,
-		link-disabled-opacity: $cadmin-btn-disabled-opacity,
-		brand-color: rgba(255, 255, 255, 0.9),
-		brand-hover-color: rgba(255, 255, 255, 0.9),
+		navbar-nav: (
+			nav-link: (
+				color: $cadmin-secondary-l2,
+				font-weight: $cadmin-font-weight-semi-bold,
+				hover: (
+					color: $cadmin-white,
+				),
+				focus: (
+					color: $cadmin-white,
+				),
+				active: (
+					color: $cadmin-white,
+				),
+				disabled: (
+					color: $cadmin-gray-400,
+					opacity: $cadmin-btn-disabled-opacity,
+				),
+			),
+		),
+		navbar-brand: (
+			color: rgba(255, 255, 255, 0.9),
+			hover: (
+				color: rgba(255, 255, 255, 0.9),
+			),
+		),
 	),
 	$cadmin-navigation-bar-secondary
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
@@ -24,6 +24,8 @@ $cadmin-navigation-bar-size: map-deep-merge(
 $cadmin-navigation-bar-base: () !default;
 $cadmin-navigation-bar-base: map-deep-merge(
 	(
+		border-color: transparent,
+		border-style: solid,
 		navbar-nav: (
 			nav-link: (
 				border-radius: 0,

--- a/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
@@ -38,6 +38,8 @@ $cadmin-navigation-bar-base: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$cadmin-navigation-bar-base
 );
@@ -66,6 +68,34 @@ $cadmin-navigation-bar-light: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (
+			sm: (
+				navbar-expand-md: (
+					navbar-collapse: (
+						navbar-nav: (
+							dropdown-item: (
+								color: $cadmin-navbar-light-color,
+								font-weight: $cadmin-font-weight-semi-bold,
+								hover: (
+									color: $cadmin-gray-900,
+								),
+								focus: (
+									color: $cadmin-gray-900,
+								),
+								active: (
+									color: $cadmin-navbar-light-active-color,
+								),
+								disabled: (
+									color: $cadmin-gray-600,
+									opacity: $cadmin-btn-disabled-opacity,
+								),
+							),
+						),
+					),
+				),
+			),
+		),
+		media-breakpoint-up: (),
 	),
 	$cadmin-navigation-bar-light
 );
@@ -100,6 +130,34 @@ $cadmin-navigation-bar-secondary: map-deep-merge(
 				color: rgba(255, 255, 255, 0.9),
 			),
 		),
+		media-breakpoint-down: (
+			sm: (
+				navbar-expand-md: (
+					navbar-collapse: (
+						navbar-nav: (
+							dropdown-item: (
+								color: $cadmin-secondary-l2,
+								font-weight: $cadmin-font-weight-semi-bold,
+								hover: (
+									color: $cadmin-white,
+								),
+								focus: (
+									color: $cadmin-white,
+								),
+								active: (
+									color: $cadmin-white,
+								),
+								disabled: (
+									color: $cadmin-gray-400,
+									opacity: $cadmin-btn-disabled-opacity,
+								),
+							),
+						),
+					),
+				),
+			),
+		),
+		media-breakpoint-up: (),
 	),
 	$cadmin-navigation-bar-secondary
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_sidebar.scss
@@ -113,12 +113,22 @@ $cadmin-sidebar-light: map-deep-merge(
 $cadmin-sidebar-light-navigation-bar: () !default;
 $cadmin-sidebar-light-navigation-bar: map-deep-merge(
 	(
-		bg: $cadmin-white,
+		background-color: $cadmin-white,
 		border-color: $cadmin-secondary-l2,
-		link-color: $cadmin-navbar-light-color,
-		link-hover-color: $cadmin-navbar-light-hover-color,
-		link-active-color: $cadmin-navbar-light-active-color,
-		link-disabled-color: $cadmin-navbar-light-disabled-color,
+		navbar-nav: (
+			nav-link: (
+				color: $cadmin-navbar-light-color,
+				hover: (
+					color: $cadmin-navbar-light-hover-color,
+				),
+				active: (
+					color: $cadmin-navbar-light-active-color,
+				),
+				disabled: (
+					color: $cadmin-navbar-light-disabled-color,
+				),
+			),
+		),
 	),
 	$cadmin-sidebar-light-navigation-bar
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_sidebar.scss
@@ -129,6 +129,8 @@ $cadmin-sidebar-light-navigation-bar: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$cadmin-sidebar-light-navigation-bar
 );

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -245,624 +245,673 @@
 /// - Add @link to documentation
 
 @mixin clay-button-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
 
-	$breakpoint-down: map-get($map, breakpoint-down);
+		$breakpoint-down: map-get($map, breakpoint-down);
 
-	$base: map-merge(
-		$map,
-		(
-			background-color:
-				setter(map-get($map, bg), map-get($map, background-color)),
-		)
-	);
+		$base: map-merge(
+			$map,
+			(
+				background-color:
+					setter(map-get($map, bg), map-get($map, background-color)),
+			)
+		);
 
-	$hover: setter(map-get($map, hover), ());
-	$hover: map-merge(
-		$hover,
-		(
-			background-color:
-				setter(
-					map-get($map, hover-bg),
-					map-get($hover, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, hover-border-color),
-					map-get($hover, border-color)
-				),
-			color: setter(map-get($map, hover-color), map-get($hover, color)),
-			opacity:
-				setter(map-get($map, hover-opacity), map-get($hover, opacity)),
-			text-decoration:
-				setter(
-					map-get($map, hover-text-decoration),
-					map-get($hover, text-decoration)
-				),
-			z-index:
-				setter(map-get($map, hover-z-index), map-get($hover, z-index)),
-		)
-	);
-
-	$focus: setter(map-get($map, focus), ());
-	$focus: map-merge(
-		$focus,
-		(
-			background-color:
-				setter(
-					map-get($map, focus-bg),
-					map-get($focus, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, focus-border-color),
-					map-get($focus, border-color)
-				),
-			box-shadow:
-				setter(
-					map-get($map, focus-box-shadow),
-					map-get($focus, box-shadow)
-				),
-			color: setter(map-get($map, focus-color), map-get($focus, color)),
-			opacity:
-				setter(map-get($map, focus-opacity), map-get($focus, opacity)),
-			outline:
-				setter(map-get($map, focus-outline), map-get($focus, outline)),
-			z-index:
-				setter(map-get($map, focus-z-index), map-get($focus, z-index)),
-		)
-	);
-
-	$active: setter(map-get($map, active), ());
-	$active: map-merge(
-		$active,
-		(
-			background-color:
-				setter(
-					map-get($map, active-bg),
-					map-get($active, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, active-border-color),
-					map-get($active, border-color)
-				),
-			box-shadow:
-				setter(
-					map-get($map, active-box-shadow),
-					map-get($active, box-shadow)
-				),
-			color: setter(map-get($map, active-color), map-get($active, color)),
-			opacity:
-				setter(map-get($map, active-opacity), map-get($active, opacity)),
-			z-index:
-				setter(map-get($map, active-z-index), map-get($active, z-index)),
-		)
-	);
-
-	$nested-active-focus: setter(map-get($active, focus), ());
-	$active-focus: setter(map-get($map, active-focus), ());
-	$active-focus: map-merge($nested-active-focus, $active-focus);
-	$active-focus: map-merge(
-		$active-focus,
-		(
-			box-shadow:
-				setter(
-					map-get($map, active-focus-box-shadow),
-					map-get($active-focus, box-shadow),
-					map-get($nested-active-focus, box-shadow),
-					map-get($focus, box-shadow)
-				),
-		)
-	);
-
-	$active-class: setter(map-get($map, active-class), ());
-	$active-class: map-merge($active, $active-class);
-
-	$active-class-after: setter(map-get($map, active-class-after), ());
-
-	$show: map-deep-merge($active-class, map-get($map, show));
-
-	$disabled: setter(map-get($map, disabled), ());
-	$disabled: map-merge(
-		$disabled,
-		(
-			background-color:
-				setter(
-					map-get($map, disabled-bg),
-					map-get($disabled, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, disabled-border-color),
-					map-get($disabled, border-color)
-				),
-			box-shadow:
-				setter(
-					map-get($map, disabled-box-shadow),
-					map-get($disabled, box-shadow)
-				),
-			color:
-				setter(map-get($map, disabled-color), map-get($disabled, color)),
-			cursor:
-				setter(
-					map-get($map, disabled-cursor),
-					map-get($disabled, cursor)
-				),
-			opacity:
-				setter(
-					map-get($map, disabled-opacity),
-					map-get($disabled, opacity)
-				),
-			z-index:
-				setter(
-					map-get($map, disabled-z-index),
-					map-get($disabled, z-index)
-				),
-		)
-	);
-
-	$disabled-focus: setter(map-get($disabled, focus), ());
-
-	$nested-disabled-active: setter(map-get($disabled, active), ());
-	$disabled-active: setter(map-get($map, disabled-active), ());
-	$disabled-active: map-merge($nested-disabled-active, $disabled-active);
-
-	$lexicon-icon: setter(map-get($map, lexicon-icon), ());
-	$lexicon-icon: map-merge(
-		$lexicon-icon,
-		(
-			font-size:
-				setter(
-					map-get($map, lexicon-icon-font-size),
-					map-get($lexicon-icon, font-size)
-				),
-			margin-bottom:
-				setter(
-					map-get($map, lexicon-icon-margin-bottom),
-					map-get($lexicon-icon, margin-bottom)
-				),
-			margin-right:
-				setter(
-					map-get($map, lexicon-icon-margin-right),
-					map-get($lexicon-icon, margin-right)
-				),
-			margin-left:
-				setter(
-					map-get($map, lexicon-icon-margin-left),
-					map-get($lexicon-icon, margin-left)
-				),
-			margin-top:
-				setter(
-					map-get($map, lexicon-icon-margin-top),
-					map-get($lexicon-icon, margin-top)
-				),
-		)
-	);
-
-	$inline-item: setter(map-get($map, inline-item), ());
-	$inline-item: map-merge(
-		$inline-item,
-		(
-			font-size:
-				setter(
-					map-get($map, inline-item-font-size),
-					map-get($inline-item, font-size)
-				),
-		)
-	);
-
-	$btn-section: setter(map-get($map, btn-section), ());
-	$section: setter(map-get($map, section), ());
-	$section: map-merge($btn-section, $section);
-	$section: map-merge(
-		$section,
-		(
-			font-size:
-				setter(
-					map-get($map, section-font-size),
-					map-get($section, font-size)
-				),
-			font-weight:
-				setter(
-					map-get($map, section-font-weight),
-					map-get($section, font-weight)
-				),
-			line-height:
-				setter(
-					map-get($map, section-line-height),
-					map-get($section, line-height)
-				),
-		)
-	);
-
-	$mobile: setter(map-get($map, mobile), ());
-	$mobile: map-merge(
-		$mobile,
-		(
-			font-size:
-				setter(
-					map-get($map, font-size-mobile),
-					map-get($mobile, font-size)
-				),
-			height:
-				setter(map-get($map, height-mobile), map-get($mobile, height)),
-			padding-bottom:
-				setter(
-					map-get($map, padding-bottom-mobile),
-					map-get($mobile, padding-bottom)
-				),
-			padding-left:
-				setter(
-					map-get($map, padding-left-mobile),
-					map-get($mobile, padding-left)
-				),
-			padding-right:
-				setter(
-					map-get($map, padding-right-mobile),
-					map-get($mobile, padding-right)
-				),
-			padding-top:
-				setter(
-					map-get($map, padding-top-mobile),
-					map-get($mobile, padding-top)
-				),
-			width: setter(map-get($map, width-mobile), map-get($mobile, width)),
-		)
-	);
-
-	$mobile-c-inner: setter(map-get($mobile, c-inner), ());
-	$mobile-c-inner: map-merge(
-		(
-			enabled:
-				setter(
-					if(
-						variable-exists(enable-c-inner),
-						$enable-c-inner,
-						$cadmin-enable-c-inner
+		$hover: setter(map-get($map, hover), ());
+		$hover: map-merge(
+			$hover,
+			(
+				background-color:
+					setter(
+						map-get($map, hover-bg),
+						map-get($hover, background-color)
 					),
-					true
-				),
-			margin-bottom: math-sign(map-get($mobile, padding-bottom)),
-			margin-left: math-sign(map-get($mobile, padding-left)),
-			margin-right: math-sign(map-get($mobile, padding-right)),
-			margin-top: math-sign(map-get($mobile, padding-top)),
-		),
-		$mobile-c-inner
-	);
-
-	$unset: setter(
-		if(
-			variable-exists(clay-unset-placeholder),
-			$clay-unset-placeholder,
-			$cadmin-clay-unset-placeholder
-		),
-		clay-unset-placeholder
-	);
-
-	$loading-animation: setter(map-get($map, loading-animation), $unset);
-
-	$c-inner: setter(map-get($map, c-inner), ());
-	$c-inner: map-merge(
-		(
-			enabled:
-				setter(
-					if(
-						variable-exists(enable-c-inner),
-						$enable-c-inner,
-						$cadmin-enable-c-inner
+				border-color:
+					setter(
+						map-get($map, hover-border-color),
+						map-get($hover, border-color)
 					),
-					true
-				),
-			margin-bottom: math-sign(map-get($map, padding-bottom)),
-			margin-left: math-sign(map-get($map, padding-left)),
-			margin-right: math-sign(map-get($map, padding-right)),
-			margin-top: math-sign(map-get($map, padding-top)),
-		),
-		$c-inner
-	);
+				color:
+					setter(map-get($map, hover-color), map-get($hover, color)),
+				opacity:
+					setter(
+						map-get($map, hover-opacity),
+						map-get($hover, opacity)
+					),
+				text-decoration:
+					setter(
+						map-get($map, hover-text-decoration),
+						map-get($hover, text-decoration)
+					),
+				z-index:
+					setter(
+						map-get($map, hover-z-index),
+						map-get($hover, z-index)
+					),
+			)
+		);
 
-	@if ($enabled) {
-		@include clay-css($base);
+		$focus: setter(map-get($map, focus), ());
+		$focus: map-merge(
+			$focus,
+			(
+				background-color:
+					setter(
+						map-get($map, focus-bg),
+						map-get($focus, background-color)
+					),
+				border-color:
+					setter(
+						map-get($map, focus-border-color),
+						map-get($focus, border-color)
+					),
+				box-shadow:
+					setter(
+						map-get($map, focus-box-shadow),
+						map-get($focus, box-shadow)
+					),
+				color:
+					setter(map-get($map, focus-color), map-get($focus, color)),
+				opacity:
+					setter(
+						map-get($map, focus-opacity),
+						map-get($focus, opacity)
+					),
+				outline:
+					setter(
+						map-get($map, focus-outline),
+						map-get($focus, outline)
+					),
+				z-index:
+					setter(
+						map-get($map, focus-z-index),
+						map-get($focus, z-index)
+					),
+			)
+		);
 
-		@if ($breakpoint-down) {
-			@include media-breakpoint-down($breakpoint-down) {
-				@include clay-css($mobile);
+		$active: setter(map-get($map, active), ());
+		$active: map-merge(
+			$active,
+			(
+				background-color:
+					setter(
+						map-get($map, active-bg),
+						map-get($active, background-color)
+					),
+				border-color:
+					setter(
+						map-get($map, active-border-color),
+						map-get($active, border-color)
+					),
+				box-shadow:
+					setter(
+						map-get($map, active-box-shadow),
+						map-get($active, box-shadow)
+					),
+				color:
+					setter(
+						map-get($map, active-color),
+						map-get($active, color)
+					),
+				opacity:
+					setter(
+						map-get($map, active-opacity),
+						map-get($active, opacity)
+					),
+				z-index:
+					setter(
+						map-get($map, active-z-index),
+						map-get($active, z-index)
+					),
+			)
+		);
 
-				@if (map-get($c-inner, enabled)) {
-					.c-inner {
-						@include clay-css($mobile-c-inner);
+		$nested-active-focus: setter(map-get($active, focus), ());
+		$active-focus: setter(map-get($map, active-focus), ());
+		$active-focus: map-merge($nested-active-focus, $active-focus);
+		$active-focus: map-merge(
+			$active-focus,
+			(
+				box-shadow:
+					setter(
+						map-get($map, active-focus-box-shadow),
+						map-get($active-focus, box-shadow),
+						map-get($nested-active-focus, box-shadow),
+						map-get($focus, box-shadow)
+					),
+			)
+		);
+
+		$active-class: setter(map-get($map, active-class), ());
+		$active-class: map-merge($active, $active-class);
+
+		$active-class-after: setter(map-get($map, active-class-after), ());
+
+		$show: map-deep-merge($active-class, map-get($map, show));
+
+		$disabled: setter(map-get($map, disabled), ());
+		$disabled: map-merge(
+			$disabled,
+			(
+				background-color:
+					setter(
+						map-get($map, disabled-bg),
+						map-get($disabled, background-color)
+					),
+				border-color:
+					setter(
+						map-get($map, disabled-border-color),
+						map-get($disabled, border-color)
+					),
+				box-shadow:
+					setter(
+						map-get($map, disabled-box-shadow),
+						map-get($disabled, box-shadow)
+					),
+				color:
+					setter(
+						map-get($map, disabled-color),
+						map-get($disabled, color)
+					),
+				cursor:
+					setter(
+						map-get($map, disabled-cursor),
+						map-get($disabled, cursor)
+					),
+				opacity:
+					setter(
+						map-get($map, disabled-opacity),
+						map-get($disabled, opacity)
+					),
+				z-index:
+					setter(
+						map-get($map, disabled-z-index),
+						map-get($disabled, z-index)
+					),
+			)
+		);
+
+		$disabled-focus: setter(map-get($disabled, focus), ());
+
+		$nested-disabled-active: setter(map-get($disabled, active), ());
+		$disabled-active: setter(map-get($map, disabled-active), ());
+		$disabled-active: map-merge($nested-disabled-active, $disabled-active);
+
+		$lexicon-icon: setter(map-get($map, lexicon-icon), ());
+		$lexicon-icon: map-merge(
+			$lexicon-icon,
+			(
+				font-size:
+					setter(
+						map-get($map, lexicon-icon-font-size),
+						map-get($lexicon-icon, font-size)
+					),
+				margin-bottom:
+					setter(
+						map-get($map, lexicon-icon-margin-bottom),
+						map-get($lexicon-icon, margin-bottom)
+					),
+				margin-right:
+					setter(
+						map-get($map, lexicon-icon-margin-right),
+						map-get($lexicon-icon, margin-right)
+					),
+				margin-left:
+					setter(
+						map-get($map, lexicon-icon-margin-left),
+						map-get($lexicon-icon, margin-left)
+					),
+				margin-top:
+					setter(
+						map-get($map, lexicon-icon-margin-top),
+						map-get($lexicon-icon, margin-top)
+					),
+			)
+		);
+
+		$inline-item: setter(map-get($map, inline-item), ());
+		$inline-item: map-merge(
+			$inline-item,
+			(
+				font-size:
+					setter(
+						map-get($map, inline-item-font-size),
+						map-get($inline-item, font-size)
+					),
+			)
+		);
+
+		$btn-section: setter(map-get($map, btn-section), ());
+		$section: setter(map-get($map, section), ());
+		$section: map-merge($btn-section, $section);
+		$section: map-merge(
+			$section,
+			(
+				font-size:
+					setter(
+						map-get($map, section-font-size),
+						map-get($section, font-size)
+					),
+				font-weight:
+					setter(
+						map-get($map, section-font-weight),
+						map-get($section, font-weight)
+					),
+				line-height:
+					setter(
+						map-get($map, section-line-height),
+						map-get($section, line-height)
+					),
+			)
+		);
+
+		$mobile: setter(map-get($map, mobile), ());
+		$mobile: map-merge(
+			$mobile,
+			(
+				font-size:
+					setter(
+						map-get($map, font-size-mobile),
+						map-get($mobile, font-size)
+					),
+				height:
+					setter(
+						map-get($map, height-mobile),
+						map-get($mobile, height)
+					),
+				padding-bottom:
+					setter(
+						map-get($map, padding-bottom-mobile),
+						map-get($mobile, padding-bottom)
+					),
+				padding-left:
+					setter(
+						map-get($map, padding-left-mobile),
+						map-get($mobile, padding-left)
+					),
+				padding-right:
+					setter(
+						map-get($map, padding-right-mobile),
+						map-get($mobile, padding-right)
+					),
+				padding-top:
+					setter(
+						map-get($map, padding-top-mobile),
+						map-get($mobile, padding-top)
+					),
+				width:
+					setter(
+						map-get($map, width-mobile),
+						map-get($mobile, width)
+					),
+			)
+		);
+
+		$mobile-c-inner: setter(map-get($mobile, c-inner), ());
+		$mobile-c-inner: map-merge(
+			(
+				enabled:
+					setter(
+						if(
+							variable-exists(enable-c-inner),
+							$enable-c-inner,
+							$cadmin-enable-c-inner
+						),
+						true
+					),
+				margin-bottom: math-sign(map-get($mobile, padding-bottom)),
+				margin-left: math-sign(map-get($mobile, padding-left)),
+				margin-right: math-sign(map-get($mobile, padding-right)),
+				margin-top: math-sign(map-get($mobile, padding-top)),
+			),
+			$mobile-c-inner
+		);
+
+		$unset: setter(
+			if(
+				variable-exists(clay-unset-placeholder),
+				$clay-unset-placeholder,
+				$cadmin-clay-unset-placeholder
+			),
+			clay-unset-placeholder
+		);
+
+		$loading-animation: setter(map-get($map, loading-animation), $unset);
+
+		$c-inner: setter(map-get($map, c-inner), ());
+		$c-inner: map-merge(
+			(
+				enabled:
+					setter(
+						if(
+							variable-exists(enable-c-inner),
+							$enable-c-inner,
+							$cadmin-enable-c-inner
+						),
+						true
+					),
+				margin-bottom: math-sign(map-get($map, padding-bottom)),
+				margin-left: math-sign(map-get($map, padding-left)),
+				margin-right: math-sign(map-get($map, padding-right)),
+				margin-top: math-sign(map-get($map, padding-top)),
+			),
+			$c-inner
+		);
+
+		@if ($enabled) {
+			@include clay-css($base);
+
+			@if ($breakpoint-down) {
+				@include media-breakpoint-down($breakpoint-down) {
+					@include clay-css($mobile);
+
+					@if (map-get($c-inner, enabled)) {
+						.c-inner {
+							@include clay-css($mobile-c-inner);
+						}
 					}
 				}
 			}
-		}
-
-		&::before {
-			@include clay-css(map-get($map, before));
-		}
-
-		&::after {
-			@include clay-css(map-get($map, after));
-		}
-
-		&:hover {
-			@include clay-css($hover);
 
 			&::before {
-				@include clay-css(map-deep-get($map, hover, before));
+				@include clay-css(map-get($map, before));
 			}
 
 			&::after {
-				@include clay-css(map-deep-get($map, hover, after));
+				@include clay-css(map-get($map, after));
 			}
 
-			.inline-item {
-				@include clay-css(setter(map-get($hover, inline-item), ()));
-			}
-
-			.inline-item-before {
-				@include clay-css(
-					setter(map-get($hover, inline-item-before), ())
-				);
-			}
-
-			.inline-item-middle {
-				@include clay-css(
-					setter(map-get($hover, inline-item-middle), ())
-				);
-			}
-
-			.inline-item-after {
-				@include clay-css(
-					setter(map-get($hover, inline-item-after), ())
-				);
-			}
-		}
-
-		&:focus,
-		&.focus {
-			@include clay-css($focus);
-
-			&::before {
-				@include clay-css(map-deep-get($map, focus, before));
-			}
-
-			&::after {
-				@include clay-css(map-deep-get($map, focus, after));
-			}
-
-			.inline-item {
-				@include clay-css(setter(map-get($focus, inline-item), ()));
-			}
-
-			.inline-item-before {
-				@include clay-css(
-					setter(map-get($focus, inline-item-before), ())
-				);
-			}
-
-			.inline-item-middle {
-				@include clay-css(
-					setter(map-get($focus, inline-item-middle), ())
-				);
-			}
-
-			.inline-item-after {
-				@include clay-css(
-					setter(map-get($focus, inline-item-after), ())
-				);
-			}
-		}
-
-		&:active {
-			@include clay-css($active);
-
-			&::before {
-				@include clay-css(map-deep-get($map, active, before));
-			}
-
-			&::after {
-				@include clay-css(map-deep-get($map, active, after));
-			}
-
-			&:focus {
-				@include clay-css($active-focus);
+			&:hover {
+				@include clay-css($hover);
 
 				&::before {
-					@include clay-css(
-						map-deep-get($map, active, focus, before)
-					);
+					@include clay-css(map-deep-get($map, hover, before));
 				}
 
 				&::after {
-					@include clay-css(map-deep-get($map, active, focus, after));
+					@include clay-css(map-deep-get($map, hover, after));
 				}
-			}
 
-			.inline-item {
-				@include clay-css(setter(map-get($active, inline-item), ()));
-			}
+				.inline-item {
+					@include clay-css(setter(map-get($hover, inline-item), ()));
+				}
 
-			.inline-item-before {
-				@include clay-css(
-					setter(map-get($active, inline-item-before), ())
-				);
-			}
-
-			.inline-item-middle {
-				@include clay-css(
-					setter(map-get($active, inline-item-middle), ())
-				);
-			}
-
-			.inline-item-after {
-				@include clay-css(
-					setter(map-get($active, inline-item-after), ())
-				);
-			}
-		}
-
-		&.active {
-			@include clay-css($active-class);
-
-			&::before {
-				@include clay-css(map-deep-get($map, active-class, before));
-			}
-
-			&::after {
-				@include clay-css($active-class-after);
-			}
-
-			.inline-item {
-				@include clay-css(
-					setter(map-get($active-class, inline-item), ())
-				);
-			}
-
-			.inline-item-before {
-				@include clay-css(
-					setter(map-get($active-class, inline-item-before), ())
-				);
-			}
-
-			.inline-item-middle {
-				@include clay-css(
-					setter(map-get($active-class, inline-item-middle), ())
-				);
-			}
-
-			.inline-item-after {
-				@include clay-css(
-					setter(map-get($active-class, inline-item-after), ())
-				);
-			}
-		}
-
-		&:disabled,
-		&.disabled {
-			@include clay-css($disabled);
-
-			&::before {
-				@include clay-css(map-deep-get($map, disabled, before));
-			}
-
-			&::after {
-				@include clay-css(map-deep-get($map, disabled, after));
-			}
-
-			&:focus {
-				@include clay-css($disabled-focus);
-
-				&::before {
+				.inline-item-before {
 					@include clay-css(
-						map-deep-get($map, disabled, focus, before)
+						setter(map-get($hover, inline-item-before), ())
 					);
 				}
 
-				&::after {
+				.inline-item-middle {
 					@include clay-css(
-						map-deep-get($map, disabled, focus, after)
+						setter(map-get($hover, inline-item-middle), ())
+					);
+				}
+
+				.inline-item-after {
+					@include clay-css(
+						setter(map-get($hover, inline-item-after), ())
+					);
+				}
+			}
+
+			&:focus,
+			&.focus {
+				@include clay-css($focus);
+
+				&::before {
+					@include clay-css(map-deep-get($map, focus, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, focus, after));
+				}
+
+				.inline-item {
+					@include clay-css(setter(map-get($focus, inline-item), ()));
+				}
+
+				.inline-item-before {
+					@include clay-css(
+						setter(map-get($focus, inline-item-before), ())
+					);
+				}
+
+				.inline-item-middle {
+					@include clay-css(
+						setter(map-get($focus, inline-item-middle), ())
+					);
+				}
+
+				.inline-item-after {
+					@include clay-css(
+						setter(map-get($focus, inline-item-after), ())
 					);
 				}
 			}
 
 			&:active {
-				@include clay-css($disabled-active);
+				@include clay-css($active);
 
 				&::before {
-					@include clay-css(
-						map-deep-get($map, disabled, active, before)
-					);
+					@include clay-css(map-deep-get($map, active, before));
 				}
 
 				&::after {
+					@include clay-css(map-deep-get($map, active, after));
+				}
+
+				&:focus {
+					@include clay-css($active-focus);
+
+					&::before {
+						@include clay-css(
+							map-deep-get($map, active, focus, before)
+						);
+					}
+
+					&::after {
+						@include clay-css(
+							map-deep-get($map, active, focus, after)
+						);
+					}
+				}
+
+				.inline-item {
 					@include clay-css(
-						map-deep-get($map, disabled, active, after)
+						setter(map-get($active, inline-item), ())
+					);
+				}
+
+				.inline-item-before {
+					@include clay-css(
+						setter(map-get($active, inline-item-before), ())
+					);
+				}
+
+				.inline-item-middle {
+					@include clay-css(
+						setter(map-get($active, inline-item-middle), ())
+					);
+				}
+
+				.inline-item-after {
+					@include clay-css(
+						setter(map-get($active, inline-item-after), ())
 					);
 				}
 			}
 
+			&.active {
+				@include clay-css($active-class);
+
+				&::before {
+					@include clay-css(map-deep-get($map, active-class, before));
+				}
+
+				&::after {
+					@include clay-css($active-class-after);
+				}
+
+				.inline-item {
+					@include clay-css(
+						setter(map-get($active-class, inline-item), ())
+					);
+				}
+
+				.inline-item-before {
+					@include clay-css(
+						setter(map-get($active-class, inline-item-before), ())
+					);
+				}
+
+				.inline-item-middle {
+					@include clay-css(
+						setter(map-get($active-class, inline-item-middle), ())
+					);
+				}
+
+				.inline-item-after {
+					@include clay-css(
+						setter(map-get($active-class, inline-item-after), ())
+					);
+				}
+			}
+
+			&:disabled,
+			&.disabled {
+				@include clay-css($disabled);
+
+				&::before {
+					@include clay-css(map-deep-get($map, disabled, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, disabled, after));
+				}
+
+				&:focus {
+					@include clay-css($disabled-focus);
+
+					&::before {
+						@include clay-css(
+							map-deep-get($map, disabled, focus, before)
+						);
+					}
+
+					&::after {
+						@include clay-css(
+							map-deep-get($map, disabled, focus, after)
+						);
+					}
+				}
+
+				&:active {
+					@include clay-css($disabled-active);
+
+					&::before {
+						@include clay-css(
+							map-deep-get($map, disabled, active, before)
+						);
+					}
+
+					&::after {
+						@include clay-css(
+							map-deep-get($map, disabled, active, after)
+						);
+					}
+				}
+
+				.inline-item {
+					@include clay-css(
+						setter(map-get($disabled, inline-item), ())
+					);
+				}
+
+				.inline-item-before {
+					@include clay-css(
+						setter(map-get($disabled, inline-item-before), ())
+					);
+				}
+
+				.inline-item-middle {
+					@include clay-css(
+						setter(map-get($disabled, inline-item-middle), ())
+					);
+				}
+
+				.inline-item-after {
+					@include clay-css(
+						setter(map-get($disabled, inline-item-after), ())
+					);
+				}
+			}
+
+			&[aria-expanded='true'],
+			&.show {
+				@include clay-css($show);
+
+				&::before {
+					@include clay-css(map-deep-get($map, show, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, show, after));
+				}
+			}
+
+			@if (map-get($c-inner, enabled)) {
+				.c-inner {
+					@include clay-css($c-inner);
+				}
+			}
+
+			.lexicon-icon {
+				@include clay-css($lexicon-icon);
+			}
+
 			.inline-item {
-				@include clay-css(setter(map-get($disabled, inline-item), ()));
+				@include clay-css($inline-item);
 			}
 
 			.inline-item-before {
 				@include clay-css(
-					setter(map-get($disabled, inline-item-before), ())
+					setter(map-get($map, inline-item-before), ())
 				);
 			}
 
 			.inline-item-middle {
 				@include clay-css(
-					setter(map-get($disabled, inline-item-middle), ())
+					setter(map-get($map, inline-item-middle), ())
 				);
+
+				+ .inline-item-middle {
+					@include clay-css(
+						setter(
+							map-deep-get(
+								$map,
+								inline-item-middle,
+								inline-item-middle
+							),
+							()
+						)
+					);
+				}
 			}
 
 			.inline-item-after {
-				@include clay-css(
-					setter(map-get($disabled, inline-item-after), ())
-				);
-			}
-		}
-
-		&[aria-expanded='true'],
-		&.show {
-			@include clay-css($show);
-
-			&::before {
-				@include clay-css(map-deep-get($map, show, before));
+				@include clay-css(setter(map-get($map, inline-item-after), ()));
 			}
 
-			&::after {
-				@include clay-css(map-deep-get($map, show, after));
+			.btn-section {
+				@include clay-css($section);
 			}
-		}
 
-		@if (map-get($c-inner, enabled)) {
-			.c-inner {
-				@include clay-css($c-inner);
+			.loading-animation {
+				@extend %#{$loading-animation} !optional;
 			}
-		}
-
-		.lexicon-icon {
-			@include clay-css($lexicon-icon);
-		}
-
-		.inline-item {
-			@include clay-css($inline-item);
-		}
-
-		.inline-item-before {
-			@include clay-css(setter(map-get($map, inline-item-before), ()));
-		}
-
-		.inline-item-middle {
-			@include clay-css(setter(map-get($map, inline-item-middle), ()));
-
-			+ .inline-item-middle {
-				@include clay-css(
-					setter(
-						map-deep-get(
-							$map,
-							inline-item-middle,
-							inline-item-middle
-						),
-						()
-					)
-				);
-			}
-		}
-
-		.inline-item-after {
-			@include clay-css(setter(map-get($map, inline-item-after), ()));
-		}
-
-		.btn-section {
-			@include clay-css($section);
-		}
-
-		.loading-animation {
-			@extend %#{$loading-animation} !optional;
 		}
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_custom-forms.scss
+++ b/packages/clay-css/src/scss/mixins/_custom-forms.scss
@@ -616,53 +616,65 @@
 /// );
 
 @mixin clay-custom-control-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
 
-	@include clay-css(setter($map, ()));
+		@include clay-css(setter($map, ()));
 
-	@if ($enabled) {
-		label {
-			@include clay-css(setter(map-deep-get($map, label), ()));
-		}
-
-		.custom-control-label {
-			@include clay-css(
-				setter(map-deep-get($map, custom-control-label), ())
-			);
-
-			&::before {
-				@include clay-css(
-					setter(map-deep-get($map, custom-control-label, before), ())
-				);
+		@if ($enabled) {
+			label {
+				@include clay-css(setter(map-deep-get($map, label), ()));
 			}
 
-			&::after {
+			.custom-control-label {
 				@include clay-css(
-					setter(map-deep-get($map, custom-control-label, after), ())
+					setter(map-deep-get($map, custom-control-label), ())
+				);
+
+				&::before {
+					@include clay-css(
+						setter(
+							map-deep-get($map, custom-control-label, before),
+							()
+						)
+					);
+				}
+
+				&::after {
+					@include clay-css(
+						setter(
+							map-deep-get($map, custom-control-label, after),
+							()
+						)
+					);
+				}
+			}
+
+			.custom-control-label-text {
+				@include clay-css(
+					setter(map-deep-get($map, custom-control-label-text), ())
+				);
+
+				small,
+				.small {
+					@include clay-css(
+						setter(
+							map-deep-get(
+								$map,
+								custom-control-label-text,
+								small
+							),
+							()
+						)
+					);
+				}
+			}
+
+			.custom-control-input {
+				@include clay-custom-control-input-variant(
+					setter(map-deep-get($map, custom-control-input), ())
 				);
 			}
-		}
-
-		.custom-control-label-text {
-			@include clay-css(
-				setter(map-deep-get($map, custom-control-label-text), ())
-			);
-
-			small,
-			.small {
-				@include clay-css(
-					setter(
-						map-deep-get($map, custom-control-label-text, small),
-						()
-					)
-				);
-			}
-		}
-
-		.custom-control-input {
-			@include clay-custom-control-input-variant(
-				setter(map-deep-get($map, custom-control-input), ())
-			);
 		}
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -29,61 +29,66 @@
 /// max-width-mobile: {Number | String | Null}, // deprecated after 3.9.0
 
 @mixin clay-dropdown-menu-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
 
-	$breakpoint-down: map-get($map, breakpoint-down);
+		$breakpoint-down: map-get($map, breakpoint-down);
 
-	$base: map-merge(
-		$map,
-		(
-			background-color:
-				setter(map-get($map, bg), map-get($map, background-color)),
-			background-clip:
-				setter(map-get($map, bg-clip), map-get($map, background-clip)),
-		)
-	);
+		$base: map-merge(
+			$map,
+			(
+				background-color:
+					setter(map-get($map, bg), map-get($map, background-color)),
+				background-clip:
+					setter(
+						map-get($map, bg-clip),
+						map-get($map, background-clip)
+					),
+			)
+		);
 
-	$mobile: setter(map-get($map, mobile), ());
-	$mobile: map-merge(
-		$mobile,
-		(
-			font-size:
-				setter(
-					map-get($map, font-size-mobile),
-					map-get($mobile, font-size)
-				),
-			max-height:
-				setter(
-					map-get($map, max-height-mobile),
-					map-get($mobile, max-height)
-				),
-			max-width:
-				setter(
-					map-get($map, max-width-mobile),
-					map-get($mobile, max-width)
-				),
-		)
-	);
+		$mobile: setter(map-get($map, mobile), ());
+		$mobile: map-merge(
+			$mobile,
+			(
+				font-size:
+					setter(
+						map-get($map, font-size-mobile),
+						map-get($mobile, font-size)
+					),
+				max-height:
+					setter(
+						map-get($map, max-height-mobile),
+						map-get($mobile, max-height)
+					),
+				max-width:
+					setter(
+						map-get($map, max-width-mobile),
+						map-get($mobile, max-width)
+					),
+			)
+		);
 
-	@if ($enabled) {
-		@include clay-css($base);
+		@if ($enabled) {
+			@include clay-css($base);
 
-		@if ($breakpoint-down) {
-			@include media-breakpoint-down($breakpoint-down) {
-				@include clay-css($mobile);
+			@if ($breakpoint-down) {
+				@include media-breakpoint-down($breakpoint-down) {
+					@include clay-css($mobile);
+				}
 			}
-		}
 
-		&::before {
-			@include clay-css(setter(map-get($map, before), ()));
-		}
+			&::before {
+				@include clay-css(setter(map-get($map, before), ()));
+			}
 
-		&::after {
-			@include clay-css(setter(map-get($map, after), ()));
-		}
+			&::after {
+				@include clay-css(setter(map-get($map, after), ()));
+			}
 
-		&.show {
-			@include clay-css(setter(map-get($map, show), ()));
+			&.show {
+				@include clay-css(setter(map-get($map, show), ()));
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -250,280 +250,299 @@
 /// - Add @link to documentation
 
 @mixin clay-form-control-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
 
-	$base: setter($map, ());
-	$base: map-merge(
-		$map,
-		(
-			background-color:
-				setter(map-get($map, bg), map-get($map, background-color)),
-			background-clip:
-				setter(map-get($map, bg-clip), map-get($map, background-clip)),
-			background-image:
-				setter(map-get($map, bg-image), map-get($map, background-image)),
-			background-position:
-				setter(
-					map-get($map, bg-position),
-					map-get($map, background-position)
-				),
-			background-repeat:
-				setter(
-					map-get($map, bg-repeat),
-					map-get($map, background-repeat)
-				),
-			background-size:
-				setter(map-get($map, bg-size), map-get($map, background-size)),
-		)
-	);
+		$base: setter($map, ());
+		$base: map-merge(
+			$map,
+			(
+				background-color:
+					setter(map-get($map, bg), map-get($map, background-color)),
+				background-clip:
+					setter(
+						map-get($map, bg-clip),
+						map-get($map, background-clip)
+					),
+				background-image:
+					setter(
+						map-get($map, bg-image),
+						map-get($map, background-image)
+					),
+				background-position:
+					setter(
+						map-get($map, bg-position),
+						map-get($map, background-position)
+					),
+				background-repeat:
+					setter(
+						map-get($map, bg-repeat),
+						map-get($map, background-repeat)
+					),
+				background-size:
+					setter(
+						map-get($map, bg-size),
+						map-get($map, background-size)
+					),
+			)
+		);
 
-	$placeholder: setter(map-get($map, placeholder), ());
-	$placeholder: map-deep-merge(
-		$placeholder,
-		(
-			color:
-				setter(
-					map-get($map, placeholder-color),
-					map-get($placeholder, color)
-				),
-			opacity:
-				setter(
-					map-get($map, placeholder-opacity),
-					map-get($placeholder, opacity)
-				),
-		)
-	);
+		$placeholder: setter(map-get($map, placeholder), ());
+		$placeholder: map-deep-merge(
+			$placeholder,
+			(
+				color:
+					setter(
+						map-get($map, placeholder-color),
+						map-get($placeholder, color)
+					),
+				opacity:
+					setter(
+						map-get($map, placeholder-opacity),
+						map-get($placeholder, opacity)
+					),
+			)
+		);
 
-	$selection: setter(map-get($map, selection), ());
-	$selection: map-deep-merge(
-		$selection,
-		(
-			background-color:
-				setter(
-					map-get($map, selection-bg),
-					map-get($selection, background-color)
-				),
-			color:
-				setter(
-					map-get($map, selection-color),
-					map-get($selection, color)
-				),
-		)
-	);
+		$selection: setter(map-get($map, selection), ());
+		$selection: map-deep-merge(
+			$selection,
+			(
+				background-color:
+					setter(
+						map-get($map, selection-bg),
+						map-get($selection, background-color)
+					),
+				color:
+					setter(
+						map-get($map, selection-color),
+						map-get($selection, color)
+					),
+			)
+		);
 
-	$hover: setter(map-get($map, hover), ());
-	$hover: map-deep-merge(
-		$hover,
-		(
-			background-color:
-				setter(
-					map-get($map, hover-bg),
-					map-get($hover, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, hover-border-color),
-					map-get($hover, border-color)
-				),
-			box-shadow:
-				setter(
-					map-get($map, hover-box-shadow),
-					map-get($hover, box-shadow)
-				),
-			color: setter(map-get($map, hover-color), map-get($hover, color)),
-		)
-	);
+		$hover: setter(map-get($map, hover), ());
+		$hover: map-deep-merge(
+			$hover,
+			(
+				background-color:
+					setter(
+						map-get($map, hover-bg),
+						map-get($hover, background-color)
+					),
+				border-color:
+					setter(
+						map-get($map, hover-border-color),
+						map-get($hover, border-color)
+					),
+				box-shadow:
+					setter(
+						map-get($map, hover-box-shadow),
+						map-get($hover, box-shadow)
+					),
+				color:
+					setter(map-get($map, hover-color), map-get($hover, color)),
+			)
+		);
 
-	$old-hover-placeholder: setter(map-get($map, hover-placeholder), ());
-	$hover-placeholder: setter(map-get($hover, placeholder), ());
-	$hover-placeholder: map-deep-merge(
-		$hover-placeholder,
-		$old-hover-placeholder
-	);
-	$hover-placeholder: map-deep-merge(
-		$hover-placeholder,
-		(
-			color:
-				setter(
-					map-get($map, hover-placeholder-color),
-					map-get($hover-placeholder, color)
-				),
-		)
-	);
+		$old-hover-placeholder: setter(map-get($map, hover-placeholder), ());
+		$hover-placeholder: setter(map-get($hover, placeholder), ());
+		$hover-placeholder: map-deep-merge(
+			$hover-placeholder,
+			$old-hover-placeholder
+		);
+		$hover-placeholder: map-deep-merge(
+			$hover-placeholder,
+			(
+				color:
+					setter(
+						map-get($map, hover-placeholder-color),
+						map-get($hover-placeholder, color)
+					),
+			)
+		);
 
-	$focus: setter(map-get($map, focus), ());
-	$focus: map-deep-merge(
-		$focus,
-		(
-			background-color:
-				setter(
-					map-get($map, focus-bg),
-					map-get($focus, background-color)
-				),
-			background-image:
-				setter(
-					map-get($map, focus-bg-image),
-					map-get($focus, background-image)
-				),
-			border-color:
-				setter(
-					map-get($map, focus-border-color),
-					map-get($focus, border-color)
-				),
-			box-shadow:
-				setter(
-					map-get($map, focus-box-shadow),
-					map-get($focus, box-shadow)
-				),
-			color: setter(map-get($map, focus-color), map-get($focus, color)),
-		)
-	);
+		$focus: setter(map-get($map, focus), ());
+		$focus: map-deep-merge(
+			$focus,
+			(
+				background-color:
+					setter(
+						map-get($map, focus-bg),
+						map-get($focus, background-color)
+					),
+				background-image:
+					setter(
+						map-get($map, focus-bg-image),
+						map-get($focus, background-image)
+					),
+				border-color:
+					setter(
+						map-get($map, focus-border-color),
+						map-get($focus, border-color)
+					),
+				box-shadow:
+					setter(
+						map-get($map, focus-box-shadow),
+						map-get($focus, box-shadow)
+					),
+				color:
+					setter(map-get($map, focus-color), map-get($focus, color)),
+			)
+		);
 
-	$old-focus-placeholder: setter(map-get($map, focus-placeholder), ());
-	$focus-placeholder: setter(map-get($focus, placeholder), ());
-	$focus-placeholder: map-deep-merge(
-		$focus-placeholder,
-		$old-focus-placeholder
-	);
-	$focus-placeholder: map-deep-merge(
-		$focus-placeholder,
-		(
-			color:
-				setter(
-					map-get($map, focus-placeholder-color),
-					map-get($focus-placeholder, color)
-				),
-		)
-	);
+		$old-focus-placeholder: setter(map-get($map, focus-placeholder), ());
+		$focus-placeholder: setter(map-get($focus, placeholder), ());
+		$focus-placeholder: map-deep-merge(
+			$focus-placeholder,
+			$old-focus-placeholder
+		);
+		$focus-placeholder: map-deep-merge(
+			$focus-placeholder,
+			(
+				color:
+					setter(
+						map-get($map, focus-placeholder-color),
+						map-get($focus-placeholder, color)
+					),
+			)
+		);
 
-	// deprecated after v2.18.0 [readonly] can have hover focus styles, declare a separate selector and use `clay-form-control-variant` mixin (e.g., `.form-control[readonly] { @include clay-form-control-variant($the-readonly-map); }`).
+		// deprecated after v2.18.0 [readonly] can have hover focus styles, declare a separate selector and use `clay-form-control-variant` mixin (e.g., `.form-control[readonly] { @include clay-form-control-variant($the-readonly-map); }`).
 
-	$readonly-bg: map-get($map, readonly-bg);
-	$readonly-bg-image: map-get($map, readonly-bg-image);
-	$readonly-border-color: map-get($map, readonly-border-color);
-	$readonly-box-shadow: map-get($map, readonly-box-shadow);
-	$readonly-color: map-get($map, readonly-color);
-	$readonly-cursor: map-get($map, readonly-cursor);
-	$readonly-opacity: map-get($map, readonly-opacity);
-	$readonly-placeholder-color: map-get($map, readonly-placeholder-color);
+		$readonly-bg: map-get($map, readonly-bg);
+		$readonly-bg-image: map-get($map, readonly-bg-image);
+		$readonly-border-color: map-get($map, readonly-border-color);
+		$readonly-box-shadow: map-get($map, readonly-box-shadow);
+		$readonly-color: map-get($map, readonly-color);
+		$readonly-cursor: map-get($map, readonly-cursor);
+		$readonly-opacity: map-get($map, readonly-opacity);
+		$readonly-placeholder-color: map-get($map, readonly-placeholder-color);
 
-	$disabled: setter(map-get($map, disabled), ());
-	$disabled: map-deep-merge(
-		$disabled,
-		(
-			background-color:
-				setter(
-					map-get($map, disabled-bg),
-					map-get($disabled, background-color)
-				),
-			background-image:
-				setter(
-					map-get($map, disabled-bg-image),
-					map-get($disabled, background-image)
-				),
-			border-color:
-				setter(
-					map-get($map, disabled-border-color),
-					map-get($disabled, border-color)
-				),
-			box-shadow:
-				setter(
-					map-get($map, disabled-box-shadow),
-					map-get($disabled, box-shadow)
-				),
-			color:
-				setter(map-get($map, disabled-color), map-get($disabled, color)),
-			cursor:
-				setter(
-					map-get($map, disabled-cursor),
-					map-get($disabled, cursor)
-				),
-			opacity:
-				setter(
-					map-get($map, disabled-opacity),
-					map-get($disabled, opacity)
-				),
-		)
-	);
+		$disabled: setter(map-get($map, disabled), ());
+		$disabled: map-deep-merge(
+			$disabled,
+			(
+				background-color:
+					setter(
+						map-get($map, disabled-bg),
+						map-get($disabled, background-color)
+					),
+				background-image:
+					setter(
+						map-get($map, disabled-bg-image),
+						map-get($disabled, background-image)
+					),
+				border-color:
+					setter(
+						map-get($map, disabled-border-color),
+						map-get($disabled, border-color)
+					),
+				box-shadow:
+					setter(
+						map-get($map, disabled-box-shadow),
+						map-get($disabled, box-shadow)
+					),
+				color:
+					setter(
+						map-get($map, disabled-color),
+						map-get($disabled, color)
+					),
+				cursor:
+					setter(
+						map-get($map, disabled-cursor),
+						map-get($disabled, cursor)
+					),
+				opacity:
+					setter(
+						map-get($map, disabled-opacity),
+						map-get($disabled, opacity)
+					),
+			)
+		);
 
-	$old-disabled-placeholder: setter(map-get($map, disabled-placeholder), ());
-	$disabled-placeholder: setter(map-get($disabled, placeholder), ());
-	$disabled-placeholder: map-deep-merge(
-		$disabled-placeholder,
-		$old-disabled-placeholder
-	);
-	$disabled-placeholder: map-deep-merge(
-		$disabled-placeholder,
-		(
-			color:
-				setter(
-					map-get($map, disabled-placeholder-color),
-					map-get($disabled-placeholder, color)
-				),
-		)
-	);
+		$old-disabled-placeholder: setter(
+			map-get($map, disabled-placeholder),
+			()
+		);
+		$disabled-placeholder: setter(map-get($disabled, placeholder), ());
+		$disabled-placeholder: map-deep-merge(
+			$disabled-placeholder,
+			$old-disabled-placeholder
+		);
+		$disabled-placeholder: map-deep-merge(
+			$disabled-placeholder,
+			(
+				color:
+					setter(
+						map-get($map, disabled-placeholder-color),
+						map-get($disabled-placeholder, color)
+					),
+			)
+		);
 
-	@if ($enabled) {
-		@include clay-css($base);
-
-		&::placeholder {
-			// opacity: 1, override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
-
-			@include clay-css($placeholder);
-		}
-
-		&::-moz-selection,
-		&::selection {
-			@include clay-css($selection);
-		}
-
-		&:hover {
-			@include clay-css($hover);
+		@if ($enabled) {
+			@include clay-css($base);
 
 			&::placeholder {
-				@include clay-css($hover-placeholder);
+				// opacity: 1, override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
+
+				@include clay-css($placeholder);
 			}
-		}
 
-		&:focus,
-		&.focus {
-			@include clay-css($focus);
-
-			&::placeholder {
-				@include clay-css($focus-placeholder);
+			&::-moz-selection,
+			&::selection {
+				@include clay-css($selection);
 			}
-		}
 
-		// @deprecated after v2.18.0 [readonly] can have hover focus styles, declare a separate selector and use `clay-form-control-variant` mixin (e.g., `.form-control[readonly] { @include clay-form-control-variant($the-readonly-map); }`).
+			&:hover {
+				@include clay-css($hover);
 
-		&[readonly] {
-			background-color: $readonly-bg;
-			background-image: $readonly-bg-image;
-			border-color: $readonly-border-color;
-			box-shadow: $readonly-box-shadow;
-			color: $readonly-color;
-			cursor: $readonly-cursor;
-			opacity: $readonly-opacity;
-
-			&::placeholder {
-				color: $readonly-placeholder-color;
+				&::placeholder {
+					@include clay-css($hover-placeholder);
+				}
 			}
-		}
 
-		// Disabled
-		// HTML5 says that controls under a fieldset > legend:first-child won't be
-		// disabled if the fieldset is disabled. Due to implementation difficulty, we
-		// don't honor that edge case; we style them as disabled anyway.
+			&:focus,
+			&.focus {
+				@include clay-css($focus);
 
-		&:disabled,
-		&.disabled {
-			// `opacity: 1;` iOS fix for unreadable disabled content;
-			// see https://github.com/twbs/bootstrap/issues/11655.
+				&::placeholder {
+					@include clay-css($focus-placeholder);
+				}
+			}
 
-			@include clay-css($disabled);
+			// @deprecated after v2.18.0 [readonly] can have hover focus styles, declare a separate selector and use `clay-form-control-variant` mixin (e.g., `.form-control[readonly] { @include clay-form-control-variant($the-readonly-map); }`).
 
-			&::placeholder {
-				@include clay-css($disabled-placeholder);
+			&[readonly] {
+				background-color: $readonly-bg;
+				background-image: $readonly-bg-image;
+				border-color: $readonly-border-color;
+				box-shadow: $readonly-box-shadow;
+				color: $readonly-color;
+				cursor: $readonly-cursor;
+				opacity: $readonly-opacity;
+
+				&::placeholder {
+					color: $readonly-placeholder-color;
+				}
+			}
+
+			// Disabled
+			// HTML5 says that controls under a fieldset > legend:first-child won't be
+			// disabled if the fieldset is disabled. Due to implementation difficulty, we
+			// don't honor that edge case; we style them as disabled anyway.
+
+			&:disabled,
+			&.disabled {
+				// `opacity: 1;` iOS fix for unreadable disabled content;
+				// see https://github.com/twbs/bootstrap/issues/11655.
+
+				@include clay-css($disabled);
+
+				&::placeholder {
+					@include clay-css($disabled-placeholder);
+				}
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -250,555 +250,600 @@
 /// lexicon-icon-margin-top: {Number | String | Null}, // deprecated after 3.9.0
 
 @mixin clay-link($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
 
-	$base: map-merge(
-		$map,
-		(
-			background-color:
-				setter(map-get($map, bg), map-get($map, background-color)),
-		)
-	);
+		$base: map-merge(
+			$map,
+			(
+				background-color:
+					setter(map-get($map, bg), map-get($map, background-color)),
+			)
+		);
 
-	$hover: setter(map-get($map, hover), ());
-	$hover: map-merge(
-		$hover,
-		(
-			background-color:
-				setter(
-					map-get($map, hover-bg),
-					map-get($hover, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, hover-border-color),
-					map-get($hover, border-color)
-				),
-			color: setter(map-get($map, hover-color), map-get($hover, color)),
-			opacity:
-				setter(map-get($map, hover-opacity), map-get($hover, opacity)),
-			text-decoration:
-				setter(
-					map-get($map, hover-text-decoration),
-					map-get($hover, text-decoration)
-				),
-			z-index:
-				setter(map-get($map, hover-z-index), map-get($hover, z-index)),
-		)
-	);
-
-	$focus: setter(map-get($map, focus), ());
-	$focus: map-merge(
-		$focus,
-		(
-			background-color:
-				setter(
-					map-get($map, focus-bg),
-					map-get($focus, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, focus-border-color),
-					map-get($focus, border-color)
-				),
-			border-radius:
-				setter(
-					map-get($map, focus-border-radius),
-					map-get($focus, border-radius)
-				),
-			box-shadow:
-				setter(
-					map-get($map, focus-box-shadow),
-					map-get($focus, box-shadow)
-				),
-			color: setter(map-get($map, focus-color), map-get($focus, color)),
-			opacity:
-				setter(map-get($map, focus-opacity), map-get($focus, opacity)),
-			outline:
-				setter(map-get($map, focus-outline), map-get($focus, outline)),
-			text-decoration:
-				setter(
-					map-get($map, focus-text-decoration),
-					map-get($focus, text-decoration)
-				),
-			z-index:
-				setter(map-get($map, focus-z-index), map-get($focus, z-index)),
-		)
-	);
-
-	$active: setter(map-get($map, active), ());
-	$active: map-merge(
-		$active,
-		(
-			background-color:
-				setter(
-					map-get($map, active-bg),
-					map-get($active, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, active-border-color),
-					map-get($active, border-color)
-				),
-			color: setter(map-get($map, active-color), map-get($active, color)),
-			font-weight:
-				setter(
-					map-get($map, active-font-weight),
-					map-get($active, font-weight)
-				),
-			z-index:
-				setter(map-get($map, active-z-index), map-get($active, z-index)),
-		)
-	);
-
-	$active-class: setter(map-get($map, active-class), ());
-	$active-class: map-merge(
-		$active-class,
-		(
-			background-color:
-				setter(
-					map-get($map, active-class-bg),
-					map-get($active-class, background-color),
-					map-get($active, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, active-class-border-color),
-					map-get($active-class, border-color),
-					map-get($active, border-color)
-				),
-			color:
-				setter(
-					map-get($map, active-class-color),
-					map-get($active-class, color),
-					map-get($active, color)
-				),
-			font-weight:
-				setter(
-					map-get($map, active-class-font-weight),
-					map-get($active-class, font-weight),
-					map-get($active, font-weight)
-				),
-			z-index:
-				setter(
-					map-get($map, active-class-z-index),
-					map-get($active-class, z-index),
-					map-get($active, z-index)
-				),
-		)
-	);
-
-	$disabled: setter(map-get($map, disabled), ());
-	$disabled: map-merge(
-		$disabled,
-		(
-			background-color:
-				setter(
-					map-get($map, disabled-bg),
-					map-get($disabled, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, disabled-border-color),
-					map-get($disabled, border-color)
-				),
-			box-shadow:
-				setter(
-					map-get($map, disabled-box-shadow),
-					map-get($disabled, box-shadow)
-				),
-			color:
-				setter(map-get($map, disabled-color), map-get($disabled, color)),
-			cursor:
-				setter(
-					map-get($map, disabled-cursor),
-					map-get($disabled, cursor)
-				),
-			opacity:
-				setter(
-					map-get($map, disabled-opacity),
-					map-get($disabled, opacity)
-				),
-			pointer-events:
-				setter(
-					map-get($map, disabled-pointer-events),
-					map-get($disabled, pointer-events)
-				),
-			text-decoration:
-				setter(
-					map-get($map, disabled-text-decoration),
-					map-get($disabled, text-decoration)
-				),
-		)
-	);
-
-	$disabled-active: setter(map-get($disabled, active), ());
-	$disabled-active: map-deep-merge(
-		$disabled-active,
-		map-get($map, disabled-active)
-	);
-	$disabled-active: map-deep-merge(
-		$disabled-active,
-		(
-			pointer-events:
-				setter(
-					map-get($map, disabled-active-pointer-events),
-					map-get($disabled-active, pointer-events)
-				),
-		)
-	);
-
-	$show: setter(map-get($map, show), ());
-	$show: map-merge($active-class, $show);
-
-	$btn-focus: setter(map-get($map, btn-focus), ());
-	$btn-focus: map-merge(
-		$btn-focus,
-		(
-			box-shadow:
-				setter(
-					map-get($map, btn-focus-box-shadow),
-					map-get($btn-focus, box-shadow)
-				),
-			outline:
-				setter(
-					map-get($map, btn-focus-outline),
-					map-get($btn-focus, outline)
-				),
-		)
-	);
-
-	$lexicon-icon: setter(map-get($map, lexicon-icon), ());
-	$lexicon-icon: map-merge(
-		$lexicon-icon,
-		(
-			font-size:
-				setter(
-					map-get($map, lexicon-icon-font-size),
-					map-get($lexicon-icon, font-size)
-				),
-			margin-bottom:
-				setter(
-					map-get($map, lexicon-icon-margin-bottom),
-					map-get($lexicon-icon, margin-bottom)
-				),
-			margin-left:
-				setter(
-					map-get($map, lexicon-icon-margin-left),
-					map-get($lexicon-icon, margin-left)
-				),
-			margin-right:
-				setter(
-					map-get($map, lexicon-icon-margin-right),
-					map-get($lexicon-icon, margin-right)
-				),
-			margin-top:
-				setter(
-					map-get($map, lexicon-icon-margin-top),
-					map-get($lexicon-icon, margin-top)
-				),
-		)
-	);
-
-	$c-inner: setter(map-get($map, c-inner), ());
-	$c-inner: map-merge(
-		(
-			enabled:
-				setter(
-					if(
-						variable-exists(enable-c-inner),
-						$enable-c-inner,
-						$cadmin-enable-c-inner
+		$hover: setter(map-get($map, hover), ());
+		$hover: map-merge(
+			$hover,
+			(
+				background-color:
+					setter(
+						map-get($map, hover-bg),
+						map-get($hover, background-color)
 					),
-					true
-				),
-			margin-bottom: math-sign(map-get($map, padding-bottom)),
-			margin-left: math-sign(map-get($map, padding-left)),
-			margin-right: math-sign(map-get($map, padding-right)),
-			margin-top: math-sign(map-get($map, padding-top)),
-		),
-		$c-inner
-	);
+				border-color:
+					setter(
+						map-get($map, hover-border-color),
+						map-get($hover, border-color)
+					),
+				color:
+					setter(map-get($map, hover-color), map-get($hover, color)),
+				opacity:
+					setter(
+						map-get($map, hover-opacity),
+						map-get($hover, opacity)
+					),
+				text-decoration:
+					setter(
+						map-get($map, hover-text-decoration),
+						map-get($hover, text-decoration)
+					),
+				z-index:
+					setter(
+						map-get($map, hover-z-index),
+						map-get($hover, z-index)
+					),
+			)
+		);
 
-	@if ($enabled) {
-		@include clay-css($base);
+		$focus: setter(map-get($map, focus), ());
+		$focus: map-merge(
+			$focus,
+			(
+				background-color:
+					setter(
+						map-get($map, focus-bg),
+						map-get($focus, background-color)
+					),
+				border-color:
+					setter(
+						map-get($map, focus-border-color),
+						map-get($focus, border-color)
+					),
+				border-radius:
+					setter(
+						map-get($map, focus-border-radius),
+						map-get($focus, border-radius)
+					),
+				box-shadow:
+					setter(
+						map-get($map, focus-box-shadow),
+						map-get($focus, box-shadow)
+					),
+				color:
+					setter(map-get($map, focus-color), map-get($focus, color)),
+				opacity:
+					setter(
+						map-get($map, focus-opacity),
+						map-get($focus, opacity)
+					),
+				outline:
+					setter(
+						map-get($map, focus-outline),
+						map-get($focus, outline)
+					),
+				text-decoration:
+					setter(
+						map-get($map, focus-text-decoration),
+						map-get($focus, text-decoration)
+					),
+				z-index:
+					setter(
+						map-get($map, focus-z-index),
+						map-get($focus, z-index)
+					),
+			)
+		);
 
-		&::before {
-			@include clay-css(map-get($map, before));
-		}
+		$active: setter(map-get($map, active), ());
+		$active: map-merge(
+			$active,
+			(
+				background-color:
+					setter(
+						map-get($map, active-bg),
+						map-get($active, background-color)
+					),
+				border-color:
+					setter(
+						map-get($map, active-border-color),
+						map-get($active, border-color)
+					),
+				color:
+					setter(
+						map-get($map, active-color),
+						map-get($active, color)
+					),
+				font-weight:
+					setter(
+						map-get($map, active-font-weight),
+						map-get($active, font-weight)
+					),
+				z-index:
+					setter(
+						map-get($map, active-z-index),
+						map-get($active, z-index)
+					),
+			)
+		);
 
-		&::after {
-			@include clay-css(map-get($map, after));
-		}
+		$active-class: setter(map-get($map, active-class), ());
+		$active-class: map-merge(
+			$active-class,
+			(
+				background-color:
+					setter(
+						map-get($map, active-class-bg),
+						map-get($active-class, background-color),
+						map-get($active, background-color)
+					),
+				border-color:
+					setter(
+						map-get($map, active-class-border-color),
+						map-get($active-class, border-color),
+						map-get($active, border-color)
+					),
+				color:
+					setter(
+						map-get($map, active-class-color),
+						map-get($active-class, color),
+						map-get($active, color)
+					),
+				font-weight:
+					setter(
+						map-get($map, active-class-font-weight),
+						map-get($active-class, font-weight),
+						map-get($active, font-weight)
+					),
+				z-index:
+					setter(
+						map-get($map, active-class-z-index),
+						map-get($active-class, z-index),
+						map-get($active, z-index)
+					),
+			)
+		);
 
-		&:link {
-			@include clay-css(map-get($map, link));
+		$disabled: setter(map-get($map, disabled), ());
+		$disabled: map-merge(
+			$disabled,
+			(
+				background-color:
+					setter(
+						map-get($map, disabled-bg),
+						map-get($disabled, background-color)
+					),
+				border-color:
+					setter(
+						map-get($map, disabled-border-color),
+						map-get($disabled, border-color)
+					),
+				box-shadow:
+					setter(
+						map-get($map, disabled-box-shadow),
+						map-get($disabled, box-shadow)
+					),
+				color:
+					setter(
+						map-get($map, disabled-color),
+						map-get($disabled, color)
+					),
+				cursor:
+					setter(
+						map-get($map, disabled-cursor),
+						map-get($disabled, cursor)
+					),
+				opacity:
+					setter(
+						map-get($map, disabled-opacity),
+						map-get($disabled, opacity)
+					),
+				pointer-events:
+					setter(
+						map-get($map, disabled-pointer-events),
+						map-get($disabled, pointer-events)
+					),
+				text-decoration:
+					setter(
+						map-get($map, disabled-text-decoration),
+						map-get($disabled, text-decoration)
+					),
+			)
+		);
+
+		$disabled-active: setter(map-get($disabled, active), ());
+		$disabled-active: map-deep-merge(
+			$disabled-active,
+			map-get($map, disabled-active)
+		);
+		$disabled-active: map-deep-merge(
+			$disabled-active,
+			(
+				pointer-events:
+					setter(
+						map-get($map, disabled-active-pointer-events),
+						map-get($disabled-active, pointer-events)
+					),
+			)
+		);
+
+		$show: setter(map-get($map, show), ());
+		$show: map-merge($active-class, $show);
+
+		$btn-focus: setter(map-get($map, btn-focus), ());
+		$btn-focus: map-merge(
+			$btn-focus,
+			(
+				box-shadow:
+					setter(
+						map-get($map, btn-focus-box-shadow),
+						map-get($btn-focus, box-shadow)
+					),
+				outline:
+					setter(
+						map-get($map, btn-focus-outline),
+						map-get($btn-focus, outline)
+					),
+			)
+		);
+
+		$lexicon-icon: setter(map-get($map, lexicon-icon), ());
+		$lexicon-icon: map-merge(
+			$lexicon-icon,
+			(
+				font-size:
+					setter(
+						map-get($map, lexicon-icon-font-size),
+						map-get($lexicon-icon, font-size)
+					),
+				margin-bottom:
+					setter(
+						map-get($map, lexicon-icon-margin-bottom),
+						map-get($lexicon-icon, margin-bottom)
+					),
+				margin-left:
+					setter(
+						map-get($map, lexicon-icon-margin-left),
+						map-get($lexicon-icon, margin-left)
+					),
+				margin-right:
+					setter(
+						map-get($map, lexicon-icon-margin-right),
+						map-get($lexicon-icon, margin-right)
+					),
+				margin-top:
+					setter(
+						map-get($map, lexicon-icon-margin-top),
+						map-get($lexicon-icon, margin-top)
+					),
+			)
+		);
+
+		$c-inner: setter(map-get($map, c-inner), ());
+		$c-inner: map-merge(
+			(
+				enabled:
+					setter(
+						if(
+							variable-exists(enable-c-inner),
+							$enable-c-inner,
+							$cadmin-enable-c-inner
+						),
+						true
+					),
+				margin-bottom: math-sign(map-get($map, padding-bottom)),
+				margin-left: math-sign(map-get($map, padding-left)),
+				margin-right: math-sign(map-get($map, padding-right)),
+				margin-top: math-sign(map-get($map, padding-top)),
+			),
+			$c-inner
+		);
+
+		@if ($enabled) {
+			@include clay-css($base);
 
 			&::before {
-				@include clay-css(map-deep-get($map, link, before));
+				@include clay-css(map-get($map, before));
 			}
 
 			&::after {
-				@include clay-css(map-deep-get($map, link, after));
+				@include clay-css(map-get($map, after));
 			}
 
-			.inline-item {
-				@include clay-css(map-deep-get($map, link, inline-item));
-			}
-
-			.inline-item-before {
-				@include clay-css(map-deep-get($map, link, inline-item-before));
-			}
-
-			.inline-item-middle {
-				@include clay-css(map-deep-get($map, link, inline-item-middle));
-			}
-
-			.inline-item-after {
-				@include clay-css(map-deep-get($map, link, inline-item-after));
-			}
-		}
-
-		&:visited {
-			@include clay-css(map-get($map, visited));
-
-			&::before {
-				@include clay-css(map-deep-get($map, visited, before));
-			}
-
-			&::after {
-				@include clay-css(map-deep-get($map, visited, after));
-			}
-
-			.inline-item {
-				@include clay-css(map-deep-get($map, visited, inline-item));
-			}
-
-			.inline-item-before {
-				@include clay-css(
-					map-deep-get($map, visited, inline-item-before)
-				);
-			}
-
-			.inline-item-middle {
-				@include clay-css(
-					map-deep-get($map, visited, inline-item-middle)
-				);
-			}
-
-			.inline-item-after {
-				@include clay-css(
-					map-deep-get($map, visited, inline-item-after)
-				);
-			}
-		}
-
-		&:hover {
-			@include clay-css($hover);
-
-			&::before {
-				@include clay-css(map-deep-get($map, hover, before));
-			}
-
-			&::after {
-				@include clay-css(map-deep-get($map, hover, after));
-			}
-
-			.inline-item {
-				@include clay-css(map-get($hover, inline-item));
-			}
-
-			.inline-item-before {
-				@include clay-css(map-get($hover, inline-item-before));
-			}
-
-			.inline-item-middle {
-				@include clay-css(map-get($hover, inline-item-middle));
-			}
-
-			.inline-item-after {
-				@include clay-css(map-get($hover, inline-item-after));
-			}
-		}
-
-		&:focus {
-			@include clay-css($focus);
-
-			&::before {
-				@include clay-css(map-deep-get($map, focus, before));
-			}
-
-			&::after {
-				@include clay-css(map-deep-get($map, focus, after));
-			}
-
-			.inline-item {
-				@include clay-css(map-get($focus, inline-item));
-			}
-
-			.inline-item-before {
-				@include clay-css(map-get($focus, inline-item-before));
-			}
-
-			.inline-item-middle {
-				@include clay-css(map-get($focus, inline-item-middle));
-			}
-
-			.inline-item-after {
-				@include clay-css(map-get($focus, inline-item-after));
-			}
-		}
-
-		&:active {
-			@include clay-css($active);
-
-			&::before {
-				@include clay-css(map-deep-get($map, active, before));
-			}
-
-			&::after {
-				@include clay-css(map-deep-get($map, active, after));
-			}
-
-			.inline-item {
-				@include clay-css(map-get($active, inline-item));
-			}
-
-			.inline-item-before {
-				@include clay-css(map-get($active, inline-item-before));
-			}
-
-			.inline-item-middle {
-				@include clay-css(map-get($active, inline-item-middle));
-			}
-
-			.inline-item-after {
-				@include clay-css(map-get($active, inline-item-after));
-			}
-		}
-
-		&.active {
-			@include clay-css($active-class);
-
-			&::before {
-				@include clay-css(map-deep-get($map, active-class, before));
-			}
-
-			&::after {
-				@include clay-css(map-deep-get($map, active-class, after));
-			}
-
-			.inline-item {
-				@include clay-css(map-get($active-class, inline-item));
-			}
-
-			.inline-item-before {
-				@include clay-css(map-get($active-class, inline-item-before));
-			}
-
-			.inline-item-middle {
-				@include clay-css(map-get($active-class, inline-item-middle));
-			}
-
-			.inline-item-after {
-				@include clay-css(map-get($active-class, inline-item-after));
-			}
-		}
-
-		&:disabled,
-		&.disabled {
-			@include clay-css($disabled);
-
-			&::before {
-				@include clay-css(map-deep-get($map, disabled, before));
-			}
-
-			&::after {
-				@include clay-css(map-deep-get($map, disabled, after));
-			}
-
-			&:active {
-				@include clay-css($disabled-active);
+			&:link {
+				@include clay-css(map-get($map, link));
 
 				&::before {
-					@include clay-css(
-						map-deep-get($map, disabled, active, before)
-					);
+					@include clay-css(map-deep-get($map, link, before));
 				}
 
 				&::after {
+					@include clay-css(map-deep-get($map, link, after));
+				}
+
+				.inline-item {
+					@include clay-css(map-deep-get($map, link, inline-item));
+				}
+
+				.inline-item-before {
 					@include clay-css(
-						map-deep-get($map, disabled, active, after)
+						map-deep-get($map, link, inline-item-before)
+					);
+				}
+
+				.inline-item-middle {
+					@include clay-css(
+						map-deep-get($map, link, inline-item-middle)
+					);
+				}
+
+				.inline-item-after {
+					@include clay-css(
+						map-deep-get($map, link, inline-item-after)
 					);
 				}
 			}
 
+			&:visited {
+				@include clay-css(map-get($map, visited));
+
+				&::before {
+					@include clay-css(map-deep-get($map, visited, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, visited, after));
+				}
+
+				.inline-item {
+					@include clay-css(map-deep-get($map, visited, inline-item));
+				}
+
+				.inline-item-before {
+					@include clay-css(
+						map-deep-get($map, visited, inline-item-before)
+					);
+				}
+
+				.inline-item-middle {
+					@include clay-css(
+						map-deep-get($map, visited, inline-item-middle)
+					);
+				}
+
+				.inline-item-after {
+					@include clay-css(
+						map-deep-get($map, visited, inline-item-after)
+					);
+				}
+			}
+
+			&:hover {
+				@include clay-css($hover);
+
+				&::before {
+					@include clay-css(map-deep-get($map, hover, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, hover, after));
+				}
+
+				.inline-item {
+					@include clay-css(map-get($hover, inline-item));
+				}
+
+				.inline-item-before {
+					@include clay-css(map-get($hover, inline-item-before));
+				}
+
+				.inline-item-middle {
+					@include clay-css(map-get($hover, inline-item-middle));
+				}
+
+				.inline-item-after {
+					@include clay-css(map-get($hover, inline-item-after));
+				}
+			}
+
+			&:focus {
+				@include clay-css($focus);
+
+				&::before {
+					@include clay-css(map-deep-get($map, focus, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, focus, after));
+				}
+
+				.inline-item {
+					@include clay-css(map-get($focus, inline-item));
+				}
+
+				.inline-item-before {
+					@include clay-css(map-get($focus, inline-item-before));
+				}
+
+				.inline-item-middle {
+					@include clay-css(map-get($focus, inline-item-middle));
+				}
+
+				.inline-item-after {
+					@include clay-css(map-get($focus, inline-item-after));
+				}
+			}
+
+			&:active {
+				@include clay-css($active);
+
+				&::before {
+					@include clay-css(map-deep-get($map, active, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, active, after));
+				}
+
+				.inline-item {
+					@include clay-css(map-get($active, inline-item));
+				}
+
+				.inline-item-before {
+					@include clay-css(map-get($active, inline-item-before));
+				}
+
+				.inline-item-middle {
+					@include clay-css(map-get($active, inline-item-middle));
+				}
+
+				.inline-item-after {
+					@include clay-css(map-get($active, inline-item-after));
+				}
+			}
+
+			&.active {
+				@include clay-css($active-class);
+
+				&::before {
+					@include clay-css(map-deep-get($map, active-class, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, active-class, after));
+				}
+
+				.inline-item {
+					@include clay-css(map-get($active-class, inline-item));
+				}
+
+				.inline-item-before {
+					@include clay-css(
+						map-get($active-class, inline-item-before)
+					);
+				}
+
+				.inline-item-middle {
+					@include clay-css(
+						map-get($active-class, inline-item-middle)
+					);
+				}
+
+				.inline-item-after {
+					@include clay-css(
+						map-get($active-class, inline-item-after)
+					);
+				}
+			}
+
+			&:disabled,
+			&.disabled {
+				@include clay-css($disabled);
+
+				&::before {
+					@include clay-css(map-deep-get($map, disabled, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, disabled, after));
+				}
+
+				&:active {
+					@include clay-css($disabled-active);
+
+					&::before {
+						@include clay-css(
+							map-deep-get($map, disabled, active, before)
+						);
+					}
+
+					&::after {
+						@include clay-css(
+							map-deep-get($map, disabled, active, after)
+						);
+					}
+				}
+
+				.inline-item {
+					@include clay-css(map-get($disabled, inline-item));
+				}
+
+				.inline-item-before {
+					@include clay-css(map-get($disabled, inline-item-before));
+				}
+
+				.inline-item-middle {
+					@include clay-css(map-get($disabled, inline-item-middle));
+				}
+
+				.inline-item-after {
+					@include clay-css(map-get($disabled, inline-item-after));
+				}
+			}
+
+			&[type] {
+				&:focus {
+					@include clay-css($btn-focus);
+				}
+			}
+
+			&[aria-expanded='true'],
+			&.show {
+				@include clay-css($show);
+
+				&::before {
+					@include clay-css(map-deep-get($map, show, before));
+				}
+
+				&::after {
+					@include clay-css(map-deep-get($map, show, after));
+				}
+			}
+
+			@if (map-get($c-inner, enabled)) {
+				> .c-inner {
+					@include clay-css($c-inner);
+				}
+			}
+
 			.inline-item {
-				@include clay-css(map-get($disabled, inline-item));
+				@include clay-css(map-get($map, inline-item));
 			}
 
 			.inline-item-before {
-				@include clay-css(map-get($disabled, inline-item-before));
+				@include clay-css(map-get($map, inline-item-before));
 			}
 
 			.inline-item-middle {
-				@include clay-css(map-get($disabled, inline-item-middle));
+				@include clay-css(map-get($map, inline-item-middle));
+
+				+ .inline-item-middle {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							inline-item-middle,
+							inline-item-middle
+						)
+					);
+				}
 			}
 
 			.inline-item-after {
-				@include clay-css(map-get($disabled, inline-item-after));
-			}
-		}
-
-		&[type] {
-			&:focus {
-				@include clay-css($btn-focus);
-			}
-		}
-
-		&[aria-expanded='true'],
-		&.show {
-			@include clay-css($show);
-
-			&::before {
-				@include clay-css(map-deep-get($map, show, before));
+				@include clay-css(map-get($map, inline-item-after));
 			}
 
-			&::after {
-				@include clay-css(map-deep-get($map, show, after));
+			.lexicon-icon {
+				@include clay-css($lexicon-icon);
 			}
-		}
-
-		@if (map-get($c-inner, enabled)) {
-			> .c-inner {
-				@include clay-css($c-inner);
-			}
-		}
-
-		.inline-item {
-			@include clay-css(map-get($map, inline-item));
-		}
-
-		.inline-item-before {
-			@include clay-css(map-get($map, inline-item-before));
-		}
-
-		.inline-item-middle {
-			@include clay-css(map-get($map, inline-item-middle));
-
-			+ .inline-item-middle {
-				@include clay-css(
-					map-deep-get($map, inline-item-middle, inline-item-middle)
-				);
-			}
-		}
-
-		.inline-item-after {
-			@include clay-css(map-get($map, inline-item-after));
-		}
-
-		.lexicon-icon {
-			@include clay-css($lexicon-icon);
 		}
 	}
 }
@@ -816,18 +861,20 @@
 /// - Add @link to documentation
 
 @mixin clay-text-typography($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
 
-	@if ($enabled) {
-		$clay-link: setter(map-get($map, clay-link), ());
+		@if ($enabled) {
+			$clay-link: setter(map-get($map, clay-link), ());
 
-		$link: setter(map-get($map, link), ());
-		$link: map-merge($link, $clay-link);
+			$link: setter(map-get($map, link), ());
+			$link: map-merge($link, $clay-link);
 
-		@include clay-css($map);
+			@include clay-css($map);
 
-		a {
-			@include clay-link($link);
+			a {
+				@include clay-link($link);
+			}
 		}
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -935,8 +935,6 @@
 			(
 				background-color:
 					setter(map-get($map, bg), map-get($map, background-color)),
-				border-color: setter(map-get($map, border-color), transparent),
-				border-style: setter(map-get($map, border-style), solid),
 			)
 		);
 

--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -917,9 +917,229 @@
 	}
 }
 
-// `clay-navbar-variant` is deprecated as of v2.11.1
-// Creates a Navbar color variant
-// @param $map - Sass map that contain Navbar Variant properties to modify
+@mixin clay-navbar-expand-variant($map) {
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
+
+		@if ($enabled) {
+			@include clay-css($map);
+
+			&.navbar-underline {
+				@include clay-css(map-deep-get($map, navbar-underline));
+
+				.navbar-nav {
+					@include clay-css(
+						map-deep-get($map, navbar-underline, navbar-nav)
+					);
+
+					.nav-link,
+					.btn-unstyled {
+						@include clay-link(
+							map-deep-get(
+								$map,
+								navbar-underline,
+								navbar-nav,
+								nav-link
+							)
+						);
+					}
+
+					.nav-link-monospaced {
+						@include clay-link(
+							map-deep-get(
+								$map,
+								navbar-underline,
+								navbar-nav,
+								nav-link-monospaced
+							)
+						);
+					}
+
+					.nav-btn {
+						@include clay-button-variant(
+							map-deep-get(
+								$map,
+								navbar-underline,
+								navbar-nav,
+								nav-btn
+							)
+						);
+					}
+
+					.nav-btn-monospaced {
+						@include clay-button-variant(
+							map-deep-get(
+								$map,
+								navbar-underline,
+								navbar-nav,
+								nav-btn-monospaced
+							)
+						);
+					}
+				}
+			}
+
+			&.navbar-collapse-absolute .navbar-collapse {
+				@include clay-css(
+					map-deep-get(
+						$map,
+						navbar-collapse-absolute,
+						navbar-collapse
+					)
+				);
+			}
+
+			.navbar-collapse {
+				@include clay-css(map-deep-get($map, navbar-collapse));
+
+				.navbar-nav {
+					@include clay-css(
+						map-deep-get($map, navbar-collapse, navbar-nav)
+					);
+
+					.dropdown-header {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								navbar-collapse,
+								navbar-nav,
+								dropdown-header
+							)
+						);
+					}
+
+					.dropdown-divider {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								navbar-collapse,
+								navbar-nav,
+								dropdown-divider
+							)
+						);
+					}
+
+					.dropdown-item {
+						@include clay-link(
+							map-deep-get(
+								$map,
+								navbar-collapse,
+								navbar-nav,
+								dropdown-item
+							)
+						);
+					}
+				}
+			}
+
+			.container {
+				@include clay-css(map-deep-get($map, container));
+			}
+
+			.container-fluid {
+				@include clay-css(map-deep-get($map, container-fluid));
+			}
+
+			.navbar-nav {
+				.nav-link,
+				.btn-unstyled {
+					@include clay-link(
+						map-deep-get($map, navbar-nav, nav-link)
+					);
+				}
+
+				.nav-link-monospaced {
+					@include clay-link(
+						map-deep-get($map, navbar-nav, nav-link-monospaced)
+					);
+				}
+
+				.nav-btn {
+					@include clay-button-variant(
+						map-deep-get($map, navbar-nav, nav-btn)
+					);
+				}
+
+				.nav-btn-monospaced {
+					@include clay-button-variant(
+						map-deep-get($map, navbar-nav, nav-btn-monospaced)
+					);
+				}
+
+				.nav-item {
+					> .custom-control {
+						@include clay-custom-control-variant(
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-item,
+								custom-control
+							)
+						);
+					}
+				}
+			}
+
+			.navbar-form {
+				@include clay-css(map-deep-get($map, navbar-form));
+
+				> .container {
+					@include clay-css(
+						map-deep-get($map, navbar-form, container)
+					);
+				}
+
+				> .container-fluid {
+					@include clay-css(
+						map-deep-get($map, navbar-form, container-fluid)
+					);
+				}
+
+				.form-control {
+					@include clay-form-control-variant(
+						map-deep-get($map, navbar-form, form-control)
+					);
+				}
+			}
+
+			.navbar-brand {
+				@include clay-link(map-deep-get($map, navbar-brand));
+			}
+
+			.navbar-title {
+				@include clay-link(map-get($map, navbar-title));
+			}
+
+			.navbar-text {
+				@include clay-link(map-get($map, navbar-text));
+			}
+
+			.navbar-toggler {
+				@include clay-button-variant(
+					map-deep-get($map, navbar-toggler)
+				);
+			}
+
+			.navbar-toggler-link {
+				@include clay-link(map-get($map, navbar-toggler-link));
+			}
+
+			.navbar-overlay {
+				@include clay-css(map-deep-get($map, navbar-overlay));
+			}
+
+			.dropdown-menu {
+				@include clay-dropdown-menu-variant(
+					map-get($map, dropdown-menu)
+				);
+			}
+		}
+	}
+}
+
+/// A mixin to create `.navbar` variants.
+/// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
+/// @example
 
 @mixin clay-navbar-variant($map) {
 	@if (type-of($map) == 'map') {
@@ -1197,19 +1417,82 @@
 		@if ($enabled) {
 			@include clay-css($base);
 
+			.container {
+				@include clay-css(map-get($map, container));
+			}
+
+			.container-fluid {
+				@include clay-css(map-get($map, container-fluid));
+			}
+
 			.navbar-nav {
 				.nav-link,
 				.btn-unstyled {
 					@include clay-link($nav-link);
 				}
 
+				.nav-link-monospaced {
+					@include clay-link(
+						map-deep-get($map, navbar-nav, nav-link-monospaced)
+					);
+				}
+
 				.nav-btn {
 					@include clay-button-variant($nav-btn);
+				}
+
+				.nav-btn-monospaced {
+					@include clay-button-variant(
+						map-deep-get($map, navbar-nav, nav-btn-monospaced)
+					);
+				}
+
+				.nav-item {
+					> .custom-control {
+						@include clay-custom-control-variant(
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-item,
+								custom-control
+							)
+						);
+					}
+				}
+			}
+
+			.navbar-form {
+				@include clay-css(map-deep-get($map, navbar-form));
+
+				> .container {
+					@include clay-css(
+						map-deep-get($map, navbar-form, container)
+					);
+				}
+
+				> .container-fluid {
+					@include clay-css(
+						map-deep-get($map, navbar-form, container-fluid)
+					);
+				}
+
+				.form-control {
+					@include clay-form-control-variant(
+						map-deep-get($map, navbar-form, form-control)
+					);
 				}
 			}
 
 			.navbar-brand {
 				@include clay-link($navbar-brand);
+			}
+
+			.navbar-title {
+				@include clay-link(map-get($map, navbar-title));
+			}
+
+			.navbar-text {
+				@include clay-link(map-get($map, navbar-text));
 			}
 
 			.navbar-toggler {
@@ -1222,6 +1505,24 @@
 
 			.navbar-overlay {
 				@include clay-css($navbar-overlay);
+			}
+
+			.dropdown-menu {
+				@include clay-dropdown-menu-variant(
+					map-get($map, dropdown-menu)
+				);
+			}
+
+			&.navbar-underline {
+				.navbar-toggler-link {
+					@include clay-link(
+						map-deep-get(
+							$map,
+							navbar-underline,
+							navbar-toggler-link
+						)
+					);
+				}
 			}
 
 			// only output specific media-breakpoint-down styles
@@ -1238,82 +1539,44 @@
 
 					@if ($breakpoint) {
 						@include media-breakpoint-down($breakpoint) {
-							$is-first-breakpoint: index(
-									$breakpoints,
-									$breakpoint
-										map-get($breakpoints, $breakpoint)
-								)
-								== 1;
+							$breakpoint-position: index(
+								$breakpoints,
+								$breakpoint map-get($breakpoints, $breakpoint)
+							);
 
-							&.navbar-expand#{if($is-first-breakpoint, '', '-' + $breakpoint)} {
-								&.navbar-collapse-absolute .navbar-collapse {
-									@include clay-css(
+							$is-first-breakpoint: $breakpoint-position == 1;
+
+							$is-last-breakpoint: $breakpoint-position ==
+								length($breakpoints);
+
+							@if not($is-last-breakpoint) {
+								$infix: '-' + breakpoint-next($breakpoint);
+
+								&.navbar-expand#{$infix} {
+									@include clay-navbar-expand-variant(
 										map-deep-get(
 											$media-breakpoint-down,
-											$breakpoint,
-											navbar-expand,
-											navbar-collapse-absolute,
-											navbar-collapse
+											'navbar-expand#{$infix}'
 										)
 									);
 								}
 
-								.navbar-collapse {
+								.navbar-overlay-#{$breakpoint}-down {
 									@include clay-css(
 										map-deep-get(
 											$media-breakpoint-down,
-											$breakpoint,
-											navbar-expand,
-											navbar-collapse
+											'navbar-overlay-#{$breakpoint}-down'
 										)
 									);
 
-									.navbar-nav {
+									&.show {
 										@include clay-css(
 											map-deep-get(
 												$media-breakpoint-down,
-												$breakpoint,
-												navbar-expand,
-												navbar-collapse,
-												navbar-nav
+												'navbar-overlay-#{$breakpoint}-down',
+												show
 											)
 										);
-
-										.dropdown-header {
-											@include clay-css(
-												map-deep-get(
-													$media-breakpoint-down,
-													$breakpoint,
-													navbar-expand,
-													navbar-collapse,
-													dropdown-header
-												)
-											);
-										}
-
-										.dropdown-divider {
-											@include clay-css(
-												map-deep-get(
-													$media-breakpoint-down,
-													$breakpoint,
-													navbar-expand,
-													navbar-collapse,
-													dropdown-divider
-												)
-											);
-										}
-
-										.dropdown-item {
-											@include clay-link(
-												map-deep-get(
-													$media-breakpoint-down,
-													$breakpoint,
-													navbar-expand,
-													navbar-collapse,
-													dropdown-item
-												)
-											);
-										}
 									}
 								}
 							}
@@ -1343,11 +1606,16 @@
 								)
 								== 1;
 
-							&.navbar-expand#{if($is-first-breakpoint, '', '-' + $breakpoint)} {
-								&.navbar-underline .navbar-nav {
-									.nav-link.active:after {
-										background-color: $underline-active-bg;
-									}
+							@if not($is-first-breakpoint) {
+								$infix: '-' + $breakpoint;
+
+								&.navbar-expand#{$infix} {
+									@include clay-navbar-expand-variant(
+										map-deep-get(
+											$media-breakpoint-up,
+											'navbar-expand#{$infix}'
+										)
+									);
 								}
 							}
 						}

--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -922,189 +922,542 @@
 // @param $map - Sass map that contain Navbar Variant properties to modify
 
 @mixin clay-navbar-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
-	$breakpoints: if(
-		variable-exists(grid-breakpoints),
-		$grid-breakpoints,
-		$cadmin-grid-breakpoints
-	);
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
+		$breakpoints: if(
+			variable-exists(grid-breakpoints),
+			$grid-breakpoints,
+			$cadmin-grid-breakpoints
+		);
 
-	$bg: map-get($map, bg);
-	$border-color: setter(map-get($map, border-color), transparent);
-	$border-style: setter(map-get($map, border-style), solid);
-	$color: map-get($map, color);
-	$link-border-radius: map-get($map, link-border-radius);
-	$link-bg: map-get($map, link-bg);
-	$link-color: map-get($map, link-color);
-	$link-font-weight: map-get($map, link-font-weight);
-	$link-outline: map-get($map, link-outline);
-	$link-transition: map-get($map, link-transition);
-	$link-hover-bg: map-get($map, link-hover-bg);
-	$link-hover-color: map-get($map, link-hover-color);
-	$link-focus-bg: map-get($map, link-focus-bg);
-	$link-focus-box-shadow: map-get($map, link-focus-box-shadow);
-	$link-focus-color: map-get($map, link-focus-color);
-	$link-active-bg: map-get($map, link-active-bg);
-	$link-active-color: map-get($map, link-active-color);
-	$link-disabled-bg: map-get($map, link-disabled-bg);
-	$link-disabled-box-shadow: map-get($map, link-disabled-box-shadow);
-	$link-disabled-color: map-get($map, link-disabled-color);
-	$link-disabled-opacity: map-get($map, link-disabled-opacity);
-	$link-disabled-pointer-events: map-get($map, link-disabled-pointer-events);
-	$btn-font-weight: setter(map-get($map, btn-font-weight), $link-font-weight);
-	$brand-color: map-get($map, brand-color);
-	$brand-hover-color: map-get($map, brand-hover-color);
-	$brand-bg: map-get($map, brand-bg);
-	$brand-hover-bg: map-get($map, brand-hover-bg);
-	$toggler-color: setter(map-get($map, toggler-color), $link-color);
-	$toggler-font-weight: setter(
-		map-get($map, toggler-font-weight),
-		$link-font-weight
-	);
-	$underline-active-bg: map-get($map, underline-active-bg);
+		$base: map-merge(
+			$map,
+			(
+				background-color:
+					setter(map-get($map, bg), map-get($map, background-color)),
+				border-color: setter(map-get($map, border-color), transparent),
+				border-style: setter(map-get($map, border-style), solid),
+			)
+		);
 
-	@if ($enabled) {
-		background-color: $bg;
-		border-color: $border-color;
-		border-style: $border-style;
-		color: $color;
+		$nav-link: map-deep-merge(
+			map-deep-get($map, navbar-nav, nav-link),
+			(
+				background-color:
+					setter(
+						map-deep-get($map, link-bg),
+						map-deep-get(
+							$map,
+							navbar-nav,
+							nav-link,
+							background-color
+						)
+					),
+				border-radius:
+					setter(
+						map-deep-get($map, link-border-radius),
+						map-deep-get($map, navbar-nav, nav-link, border-radius)
+					),
+				color:
+					setter(
+						map-deep-get($map, link-color),
+						map-deep-get($map, navbar-nav, nav-link, color)
+					),
+				font-weight:
+					setter(
+						map-deep-get($map, link-font-weight),
+						map-deep-get($map, navbar-nav, nav-link, font-weight)
+					),
+				outline:
+					setter(
+						map-deep-get($map, link-outline),
+						map-deep-get($map, navbar-nav, nav-link, outline)
+					),
+				transition:
+					setter(
+						map-deep-get($map, link-transition),
+						map-deep-get($map, navbar-nav, nav-link, transition)
+					),
+				hover: (
+					background-color:
+						setter(
+							map-deep-get($map, link-hover-bg),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								hover,
+								background-color
+							)
+						),
+					color:
+						setter(
+							map-deep-get($map, link-hover-color),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								hover,
+								color
+							)
+						),
+				),
+				focus: (
+					background-color:
+						setter(
+							map-deep-get($map, link-focus-bg),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								focus,
+								background-color
+							)
+						),
+					box-shadow:
+						setter(
+							map-deep-get($map, link-focus-box-shadow),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								focus,
+								box-shadow
+							)
+						),
+					color:
+						setter(
+							map-deep-get($map, link-focus-color),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								focus-color
+							)
+						),
+				),
+				active: (
+					background-color:
+						setter(
+							map-deep-get($map, link-active-bg),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								active,
+								background-color
+							)
+						),
+					color:
+						setter(
+							map-deep-get($map, link-active-color),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								active,
+								color
+							)
+						),
+				),
+				disabled: (
+					background-color:
+						setter(
+							map-deep-get($map, link-disabled-bg),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								disabled,
+								background-color
+							)
+						),
+					box-shadow:
+						setter(
+							map-deep-get($map, link-disabled-box-shadow),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								disabled,
+								box-shadow
+							)
+						),
+					color:
+						setter(
+							map-deep-get($map, link-disabled-color),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								disabled,
+								color
+							)
+						),
+					opacity:
+						setter(
+							map-deep-get($map, link-disabled-opacity),
+							map-deep-get(
+								$map,
+								navbar-nav,
+								nav-link,
+								disabled,
+								opacity
+							)
+						),
+					pointer-events: (
+						map-deep-get($map, link-disabled-pointer-events),
+						map-deep-get(
+							$map,
+							navbar-nav,
+							nav-link,
+							disabled,
+							pointer-events
+						),
+					),
+				),
+			)
+		);
 
-		.nav-link,
-		.navbar-nav .btn-unstyled {
-			background-color: $link-bg;
+		$nav-btn: map-deep-merge(
+			map-deep-get($map, navbar-nav, nav-btn),
+			(
+				font-weight:
+					setter(
+						map-deep-get($map, btn-font-weight),
+						map-deep-get($map, navbar-nav, nav-btn, font-weight),
+						map-deep-get($nav-link, font-weight)
+					),
+			)
+		);
 
-			@include border-radius($link-border-radius);
+		$navbar-brand: map-deep-merge($nav-link, map-get($map, navbar-brand));
+		$navbar-brand: map-deep-merge(
+			$navbar-brand,
+			(
+				background-color:
+					setter(
+						map-deep-get($map, brand-bg),
+						map-deep-get($map, navbar-brand, background-color)
+					),
+				color:
+					setter(
+						map-deep-get($map, brand-color),
+						map-deep-get($map, navbar-brand, color)
+					),
+				hover: (
+					background-color:
+						setter(
+							map-deep-get($map, brand-hover-bg),
+							map-deep-get(
+								$map,
+								navbar-brand,
+								hover,
+								background-color
+							)
+						),
+					color:
+						setter(
+							map-deep-get($map, brand-hover-color),
+							map-deep-get($map, navbar-brand, hover, color)
+						),
+				),
+			)
+		);
 
-			color: $link-color;
-			font-weight: $link-font-weight;
-			outline: $link-outline;
-			transition: $link-transition;
+		$navbar-toggler: map-deep-merge(
+			map-get($map, navbar-toggler),
+			(
+				color:
+					setter(
+						map-deep-get($map, toggler-color),
+						map-deep-get($map, navbar-toggler, color),
+						map-get($nav-link, color)
+					),
+				font-weight:
+					setter(
+						map-deep-get($map, toggler-font-weight),
+						map-deep-get($map, navbar-toggler, font-weight),
+						map-get($nav-link, font-weight)
+					),
+			)
+		);
 
-			&:hover {
-				background-color: $link-hover-bg;
-				color: $link-hover-color;
+		$navbar-overlay: map-deep-merge(
+			map-get($map, navbar-overlay),
+			(
+				background-color:
+					setter(
+						map-deep-get($map, navbar-overlay, background-color),
+						map-deep-get($map, background-color)
+					),
+			)
+		);
+
+		$underline-active-bg: map-get($map, underline-active-bg);
+
+		@if ($enabled) {
+			@include clay-css($base);
+
+			.navbar-nav {
+				.nav-link,
+				.btn-unstyled {
+					@include clay-link($nav-link);
+				}
+
+				.nav-btn {
+					@include clay-button-variant($nav-btn);
+				}
 			}
 
-			&:focus {
-				background-color: $link-focus-bg;
-				box-shadow: $link-focus-box-shadow;
-				color: $link-focus-color;
+			.navbar-brand {
+				@include clay-link($navbar-brand);
 			}
 
-			&.active,
-			&[aria-expanded='true'] {
-				background-color: $link-active-bg;
-				color: $link-active-color;
+			.navbar-toggler {
+				@include clay-button-variant($navbar-toggler);
 			}
 
-			&.disabled,
-			&:disabled {
-				background-color: $link-disabled-bg;
-				box-shadow: $link-disabled-box-shadow;
-				color: $link-disabled-color;
-				opacity: $link-disabled-opacity;
-				pointer-events: $link-disabled-pointer-events;
-			}
-		}
-
-		.nav-btn {
-			font-weight: $btn-font-weight;
-		}
-
-		.navbar-brand {
-			background-color: $brand-bg;
-
-			@include border-radius($link-border-radius);
-
-			color: $brand-color;
-			outline: $link-outline;
-			transition: $link-transition;
-
-			&:hover {
-				background-color: $brand-bg;
-				color: $brand-hover-color;
+			.navbar-toggler-link {
+				@include clay-link(map-get($map, navbar-toggler-link));
 			}
 
-			&:focus {
-				box-shadow: $link-focus-box-shadow;
-				color: $link-focus-color;
+			.navbar-overlay {
+				@include clay-css($navbar-overlay);
 			}
-		}
 
-		.navbar-toggler {
-			color: $toggler-color;
-			font-weight: $toggler-font-weight;
-			outline: $link-outline;
-			transition: $link-transition;
+			// only output specific media-breakpoint-down styles
 
-			&:focus {
-				box-shadow: $link-focus-box-shadow;
-				color: $link-focus-color;
-			}
-		}
+			@if (map-get($map, media-breakpoint-down)) {
+				@each $breakpoint
+					in map-keys(map-get($map, media-breakpoint-down))
+				{
+					$media-breakpoint-down: map-deep-get(
+						$map,
+						media-breakpoint-down,
+						$breakpoint
+					);
 
-		.navbar-toggler-link {
-			&[aria-expanded='true'] {
-				color: $link-active-color;
-			}
-		}
-
-		.navbar-overlay {
-			background-color: $bg;
-		}
-
-		&.navbar-expand {
-			@each $breakpoint in map-keys($breakpoints) {
-				$next: breakpoint-next($breakpoint, $breakpoints);
-				$infix: breakpoint-infix($next, $breakpoints);
-
-				&#{$infix} {
-					// .navbar-expand, sm, md, lg, xl
-					@if not($infix == '') {
-						// .navbar-expand-sm, md, lg, xl
+					@if ($breakpoint) {
 						@include media-breakpoint-down($breakpoint) {
-							&.navbar-collapse-absolute .navbar-collapse {
-								background-color: $bg;
-								border-color: $border-color;
+							$is-first-breakpoint: index(
+									$breakpoints,
+									$breakpoint
+										map-get($breakpoints, $breakpoint)
+								)
+								== 1;
+
+							&.navbar-expand#{if($is-first-breakpoint, '', '-' + $breakpoint)} {
+								&.navbar-collapse-absolute .navbar-collapse {
+									@include clay-css(
+										map-deep-get(
+											$media-breakpoint-down,
+											$breakpoint,
+											navbar-expand,
+											navbar-collapse-absolute,
+											navbar-collapse
+										)
+									);
+								}
+
+								.navbar-collapse {
+									@include clay-css(
+										map-deep-get(
+											$media-breakpoint-down,
+											$breakpoint,
+											navbar-expand,
+											navbar-collapse
+										)
+									);
+
+									.navbar-nav {
+										@include clay-css(
+											map-deep-get(
+												$media-breakpoint-down,
+												$breakpoint,
+												navbar-expand,
+												navbar-collapse,
+												navbar-nav
+											)
+										);
+
+										.dropdown-header {
+											@include clay-css(
+												map-deep-get(
+													$media-breakpoint-down,
+													$breakpoint,
+													navbar-expand,
+													navbar-collapse,
+													dropdown-header
+												)
+											);
+										}
+
+										.dropdown-divider {
+											@include clay-css(
+												map-deep-get(
+													$media-breakpoint-down,
+													$breakpoint,
+													navbar-expand,
+													navbar-collapse,
+													dropdown-divider
+												)
+											);
+										}
+
+										.dropdown-item {
+											@include clay-link(
+												map-deep-get(
+													$media-breakpoint-down,
+													$breakpoint,
+													navbar-expand,
+													navbar-collapse,
+													dropdown-item
+												)
+											);
+										}
+									}
+								}
 							}
-
-							.navbar-collapse .navbar-nav {
-								.dropdown-header,
-								.dropdown-item {
-									color: $link-color;
-									font-weight: $link-font-weight;
-								}
-
-								.dropdown-divider {
-									border-color: $link-color;
-								}
-
-								.dropdown-item {
-									&:hover {
-										color: $link-hover-color;
-									}
-
-									&.active {
-										color: $link-active-color;
-									}
-
-									&.disabled {
-										color: $link-disabled-color;
-									}
-								}
-							}
-						}
-					}
-
-					@include media-breakpoint-up($next) {
-						&.navbar-underline .navbar-nav .nav-link.active:after {
-							background-color: $underline-active-bg;
 						}
 					}
 				}
 			}
-		}
 
-		@content;
+			// only output specific media-breakpoint-up styles
+
+			@if (map-get($map, media-breakpoint-up)) {
+				@each $breakpoint
+					in map-keys(map-get($map, media-breakpoint-up))
+				{
+					$media-breakpoint-up: map-deep-get(
+						$map,
+						media-breakpoint-up,
+						$breakpoint
+					);
+
+					@if ($breakpoint) {
+						@include media-breakpoint-up($breakpoint) {
+							$is-first-breakpoint: index(
+									$breakpoints,
+									$breakpoint
+										map-get($breakpoints, $breakpoint)
+								)
+								== 1;
+
+							&.navbar-expand#{if($is-first-breakpoint, '', '-' + $breakpoint)} {
+								&.navbar-underline .navbar-nav {
+									.nav-link.active:after {
+										background-color: $underline-active-bg;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// if media-breakpoint-down doesn't exist output styles .navbar-expand-{sm|md|lg|xl|??}
+			// deprecated use `media-breakpoint-down` key instead
+
+			@if not(map-get($map, media-breakpoint-down)) {
+				&.navbar-expand {
+					@each $breakpoint in map-keys($breakpoints) {
+						$next: breakpoint-next($breakpoint, $breakpoints);
+						$infix: breakpoint-infix($next, $breakpoints);
+
+						&#{$infix} {
+							// .navbar-expand, sm, md, lg, xl
+							@if not($infix == '') {
+								// .navbar-expand-sm, md, lg, xl
+								@include media-breakpoint-down($breakpoint) {
+									&.navbar-collapse-absolute {
+										.navbar-collapse {
+											background-color: map-get(
+												$base,
+												background-color
+											);
+											border-color: map-get(
+												$base,
+												border-color
+											);
+										}
+									}
+
+									.navbar-collapse .navbar-nav {
+										.dropdown-header,
+										.dropdown-item {
+											color: map-get($nav-link, color);
+											font-weight: map-get(
+												$nav-link,
+												font-weight
+											);
+										}
+
+										.dropdown-divider {
+											border-color: map-get(
+												$nav-link,
+												color
+											);
+										}
+
+										.dropdown-item {
+											&:hover {
+												color: map-deep-get(
+													$nav-link,
+													hover,
+													color
+												);
+											}
+
+											&.active {
+												color: map-deep-get(
+													$nav-link,
+													active-class,
+													color
+												);
+											}
+
+											&.disabled {
+												color: map-deep-get(
+													$nav-link,
+													disabled,
+													color
+												);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// if media-breakpoint-up doesn't exist output styles .navbar-expand through .navbar-expand-{sm|md|lg|xl|??}
+			// deprecated use `media-breakpoint-up` key instead
+
+			@if not(map-get($map, media-breakpoint-up)) {
+				&.navbar-expand {
+					@each $breakpoint in map-keys($breakpoints) {
+						$next: breakpoint-next($breakpoint, $breakpoints);
+						$infix: breakpoint-infix($next, $breakpoints);
+
+						&#{$infix} {
+							// .navbar-expand, sm, md, lg, xl
+							@include media-breakpoint-up($next) {
+								&.navbar-underline .navbar-nav {
+									.nav-link.active:after {
+										background-color: $underline-active-bg;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			@content;
+		}
 	}
 }

--- a/packages/clay-css/src/scss/variables/_application-bar.scss
+++ b/packages/clay-css/src/scss/variables/_application-bar.scss
@@ -21,13 +21,23 @@ $application-bar-base: () !default;
 $application-bar-dark: () !default;
 $application-bar-dark: map-deep-merge(
 	(
-		bg: $dark,
+		background-color: $dark,
 		color: $navbar-dark-color,
-		link-color: $navbar-dark-color,
-		link-hover-color: $navbar-dark-hover-color,
-		link-active-color: $navbar-dark-active-color,
-		link-disabled-color: $navbar-dark-disabled-color,
-		link-disabled-opacity: 1,
+		navbar-nav: (
+			nav-link: (
+				color: $navbar-dark-color,
+				hover: (
+					color: $navbar-dark-hover-color,
+				),
+				active: (
+					color: $navbar-dark-active-color,
+				),
+				disabled: (
+					color: $navbar-dark-disabled-color,
+					opacity: 1,
+				),
+			),
+		),
 	),
 	$application-bar-dark
 );

--- a/packages/clay-css/src/scss/variables/_application-bar.scss
+++ b/packages/clay-css/src/scss/variables/_application-bar.scss
@@ -38,6 +38,8 @@ $application-bar-dark: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$application-bar-dark
 );

--- a/packages/clay-css/src/scss/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/variables/_management-bar.scss
@@ -1,4 +1,11 @@
 $management-bar-base: () !default;
+$management-bar-base: map-deep-merge(
+	(
+		border-color: transparent,
+		border-style: solid,
+	),
+	$management-bar-base
+);
 
 $management-bar-size: () !default;
 $management-bar-size: map-deep-merge(

--- a/packages/clay-css/src/scss/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/variables/_management-bar.scss
@@ -3,6 +3,8 @@ $management-bar-base: map-deep-merge(
 	(
 		border-color: transparent,
 		border-style: solid,
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$management-bar-base
 );
@@ -52,6 +54,8 @@ $management-bar-light: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$management-bar-light
 );
@@ -77,6 +81,8 @@ $management-bar-primary: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$management-bar-primary
 );

--- a/packages/clay-css/src/scss/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/variables/_management-bar.scss
@@ -29,12 +29,22 @@ $management-bar-size: map-deep-merge(
 $management-bar-light: () !default;
 $management-bar-light: map-deep-merge(
 	(
-		bg: $light,
-		link-color: $navbar-light-color,
-		link-hover-color: $navbar-light-hover-color,
-		link-active-color: $navbar-light-active-color,
-		link-disabled-color: $navbar-light-disabled-color,
-		link-disabled-opacity: 1,
+		background-color: $light,
+		navbar-nav: (
+			nav-link: (
+				color: $navbar-light-color,
+				hover: (
+					color: $navbar-light-hover-color,
+				),
+				active: (
+					color: $navbar-light-active-color,
+				),
+				disabled: (
+					color: $navbar-light-disabled-color,
+					opacity: 1,
+				),
+			),
+		),
 	),
 	$management-bar-light
 );
@@ -42,14 +52,24 @@ $management-bar-light: map-deep-merge(
 $management-bar-primary: () !default;
 $management-bar-primary: map-deep-merge(
 	(
-		bg: $primary-l3,
+		background-color: $primary-l3,
 		border-color: $primary,
 		color: $navbar-light-color,
-		link-color: $navbar-light-color,
-		link-hover-color: $navbar-light-hover-color,
-		link-active-color: $navbar-light-active-color,
-		link-disabled-color: $navbar-light-disabled-color,
-		link-disabled-opacity: 1,
+		navbar-nav: (
+			nav-link: (
+				color: $navbar-light-color,
+				hover: (
+					color: $navbar-light-hover-color,
+				),
+				active: (
+					color: $navbar-light-active-color,
+				),
+				disabled: (
+					disabled-color: $navbar-light-disabled-color,
+					disabled-opacity: 1,
+				),
+			),
+		),
 	),
 	$management-bar-primary
 );

--- a/packages/clay-css/src/scss/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/variables/_navigation-bar.scss
@@ -21,12 +21,22 @@ $navigation-bar-base: () !default;
 $navigation-bar-light: () !default;
 $navigation-bar-light: map-deep-merge(
 	(
-		bg: $light,
-		link-color: $navbar-light-color,
-		link-hover-color: $navbar-light-hover-color,
-		link-active-color: $navbar-light-active-color,
-		link-disabled-color: $navbar-light-disabled-color,
-		link-disabled-opacity: 1,
+		background-color: $light,
+		navbar-nav: (
+			nav-link: (
+				color: $navbar-light-color,
+				hover: (
+					color: $navbar-light-hover-color,
+				),
+				active: (
+					color: $navbar-light-active-color,
+				),
+				disabled: (
+					color: $navbar-light-disabled-color,
+					opacity: 1,
+				),
+			),
+		),
 	),
 	$navigation-bar-light
 );
@@ -34,15 +44,29 @@ $navigation-bar-light: map-deep-merge(
 $navigation-bar-secondary: () !default;
 $navigation-bar-secondary: map-deep-merge(
 	(
-		bg: $secondary,
+		background-color: $secondary,
 		color: $white,
-		link-color: rgba(255, 255, 255, 0.65),
-		link-hover-color: rgba(255, 255, 255, 0.9),
-		link-active-color: rgba(255, 255, 255, 0.9),
-		link-disabled-color: rgba(255, 255, 255, 0.25),
-		link-disabled-opacity: 1,
-		brand-color: rgba(255, 255, 255, 0.9),
-		brand-hover-color: rgba(255, 255, 255, 0.9),
+		navbar-nav: (
+			nav-link: (
+				color: rgba(255, 255, 255, 0.65),
+				hover: (
+					color: rgba(255, 255, 255, 0.9),
+				),
+				active: (
+					color: rgba(255, 255, 255, 0.9),
+				),
+				disabled: (
+					color: rgba(255, 255, 255, 0.25),
+					opacity: 1,
+				),
+			),
+		),
+		navbar-brand: (
+			color: rgba(255, 255, 255, 0.9),
+			hover: (
+				color: rgba(255, 255, 255, 0.9),
+			),
+		),
 	),
 	$navigation-bar-secondary
 );

--- a/packages/clay-css/src/scss/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/variables/_navigation-bar.scss
@@ -17,6 +17,13 @@ $navigation-bar-size: map-deep-merge(
 );
 
 $navigation-bar-base: () !default;
+$navigation-bar-base: map-deep-merge(
+	(
+		border-color: transparent,
+		border-style: solid,
+	),
+	$navigation-bar-base
+);
 
 $navigation-bar-light: () !default;
 $navigation-bar-light: map-deep-merge(

--- a/packages/clay-css/src/scss/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/variables/_navigation-bar.scss
@@ -21,6 +21,8 @@ $navigation-bar-base: map-deep-merge(
 	(
 		border-color: transparent,
 		border-style: solid,
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$navigation-bar-base
 );
@@ -44,6 +46,30 @@ $navigation-bar-light: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (
+			sm: (
+				navbar-expand-md: (
+					navbar-collapse: (
+						navbar-nav: (
+							dropdown-item: (
+								color: $navbar-light-color,
+								hover: (
+									color: $navbar-light-hover-color,
+								),
+								active: (
+									color: $navbar-light-active-color,
+								),
+								disabled: (
+									color: $navbar-light-disabled-color,
+									opacity: 1,
+								),
+							),
+						),
+					),
+				),
+			),
+		),
+		media-breakpoint-up: (),
 	),
 	$navigation-bar-light
 );
@@ -74,6 +100,30 @@ $navigation-bar-secondary: map-deep-merge(
 				color: rgba(255, 255, 255, 0.9),
 			),
 		),
+		media-breakpoint-down: (
+			sm: (
+				navbar-expand-md: (
+					navbar-collapse: (
+						navbar-nav: (
+							dropdown-item: (
+								color: rgba(255, 255, 255, 0.65),
+								hover: (
+									color: rgba(255, 255, 255, 0.9),
+								),
+								active: (
+									color: rgba(255, 255, 255, 0.9),
+								),
+								disabled: (
+									color: rgba(255, 255, 255, 0.25),
+									opacity: 1,
+								),
+							),
+						),
+					),
+				),
+			),
+		),
+		media-breakpoint-up: (),
 	),
 	$navigation-bar-secondary
 );

--- a/packages/clay-css/src/scss/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/variables/_sidebar.scss
@@ -103,12 +103,22 @@ $sidebar-light: map-deep-merge(
 $sidebar-light-navigation-bar: () !default;
 $sidebar-light-navigation-bar: map-deep-merge(
 	(
-		bg: $light,
+		background-color: $light,
 		border-color: $gray-300,
-		link-color: $navbar-light-color,
-		link-hover-color: $navbar-light-hover-color,
-		link-active-color: $navbar-light-active-color,
-		link-disabled-color: $navbar-light-disabled-color,
+		navbar-nav: (
+			nav-link: (
+				color: $navbar-light-color,
+				hover: (
+					color: $navbar-light-hover-color,
+				),
+				active: (
+					color: $navbar-light-active-color,
+				),
+				disabled: (
+					color: $navbar-light-disabled-color,
+				),
+			),
+		),
 	),
 	$sidebar-light-navigation-bar
 );

--- a/packages/clay-css/src/scss/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/variables/_sidebar.scss
@@ -119,6 +119,8 @@ $sidebar-light-navigation-bar: map-deep-merge(
 				),
 			),
 		),
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$sidebar-light-navigation-bar
 );


### PR DESCRIPTION
This provides complete customization of all the Navbar spin off components. There are some breaking changes in this pr.

- The mixin `clay-navbar-variant` output `border-color: transparent` and `border-style: solid` by default. This has been removed to reduce unnecessary CSS. You will need to declare them in your Sass map if you relied upon it.
- We previously output `navbar-expand-{sm|md|lg|xl}` for the variants of Application Bar, Management Bar, Navigation Bar, Sidebar Navigation Bar. We only output those that are needed namely, `navbar-expand-md`. If you relied upon other breakpoints you will need to declare them in the respective Sass map.

These changes reduced ~17kb from Atlas. For the future I'd like to move away from using `clay-navbar-size` since it outputs a lot of unused styles. I'm predicting that converting to `clay-navbar-variant` would further reduce Atlas ~43kb.

fixes #4481