### PR TITLE
fix(clay-link): listens for the `handleClick` event and removes the preventDefault call by default

### DIFF
--- a/packages/clay-link/demos/index.html
+++ b/packages/clay-link/demos/index.html
@@ -109,7 +109,7 @@
 			{
 				ariaLabel: 'My Link',
 				defaultEventHandler: {
-					handleItemClicked(event) {
+					handleClick(event) {
 						event.preventDefault();
 
 						var linkElement = event.currentTarget;

--- a/packages/clay-link/src/ClayLink.js
+++ b/packages/clay-link/src/ClayLink.js
@@ -26,13 +26,15 @@ class ClayLink extends ClayComponent {
 	}
 
 	/**
-	 * Handles click.
+	 * HandleClick is a void callback which is just a workaround so we can
+	 * explicitly add a click listener to force invoke the
+	 * `defaultEventHandler` method, this is for when only the
+	 * `defaultEventHandler` method is set on the component property and when
+	 * the `events` property and the native Metal.js `on` method is not used.
 	 * @param {!Event} event
 	 * @protected
 	 */
-	_handleClick(event) {
-		event.preventDefault();
-	}
+	_handleClick() {}
 }
 
 /**


### PR DESCRIPTION
Calling the `preventDefault` method every time on Click will change the behavior for all components and we don't want that because we will be breaking all existing behaviors.

I'm also changing the demo to listen for the `handleClick` event, it is called internally due to the explicit listener added in the component but its name is changed due to the ClayComponent implementation.