### PR TITLE
feat(@clayui/multi-step-nav): add the new indicatorLabel API to indicate the position of the indicator label

### DIFF
--- a/packages/clay-multi-step-nav/README.mdx
+++ b/packages/clay-multi-step-nav/README.mdx
@@ -24,6 +24,29 @@ Each step can have two different states: `active` or `complete` defined by props
 
 <MultiStepNav />
 
+## Indicator position
+
+Some use cases don't need the title or subtitle to add context to the steps, in those cases you might just want the label to be rendered to the `top` of the indicator, so it can truncate the text if it is long.
+
+```jsx
+<ClayMultiStepNav indicatorLabel="top">
+	<ClayMultiStepNav.Item
+		active={active}
+		complete={complete}
+		expand={i + 1 !== steps.length}
+		key={i}
+	>
+		<ClayMultiStepNav.Divider />
+		<ClayMultiStepNav.Indicator
+			complete={complete}
+			label={1 + i}
+			onClick={onClick}
+			subTitle={label}
+		/>
+	</ClayMultiStepNav.Item>
+</ClayMultiStepNav>
+```
+
 ## Collapsable Steps
 
 Using `ClayMultiStepNavWithBasicItems` in combination with `maxStepsShown` prop you can collapse the steps that don't fit into a dropdown to ensure good user experience.

--- a/packages/clay-multi-step-nav/src/MultiStepNav.tsx
+++ b/packages/clay-multi-step-nav/src/MultiStepNav.tsx
@@ -21,6 +21,11 @@ interface IProps extends React.HTMLAttributes<HTMLOListElement> {
 	 * Flag to indicate if nav should add `multi-step-item-fixed-width` class.
 	 */
 	fixedWidth?: boolean;
+
+	/**
+	 * Flag to indicate the position of the indicator label.
+	 */
+	indicatorLabel?: 'bottom' | 'top';
 }
 
 const ClayMultiStepNav: React.FunctionComponent<IProps> & {
@@ -33,18 +38,17 @@ const ClayMultiStepNav: React.FunctionComponent<IProps> & {
 	children,
 	className,
 	fixedWidth,
+	indicatorLabel = 'bottom',
 	...otherProps
 }: IProps) => {
 	return (
 		<ol
-			className={classNames(
-				'multi-step-nav multi-step-indicator-label-bottom',
-				className,
-				{
-					['multi-step-item-fixed-width']: fixedWidth,
-					['multi-step-nav-collapse-sm']: autoCollapse,
-				}
-			)}
+			className={classNames('multi-step-nav', className, {
+				'multi-step-item-fixed-width': fixedWidth,
+				'multi-step-nav-collapse-sm': autoCollapse,
+				[`multi-step-indicator-label-${indicatorLabel}`]:
+					indicatorLabel,
+			})}
 			{...otherProps}
 		>
 			{children}

--- a/packages/clay-multi-step-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-step-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ClayMultiStepNav activates step on click 1`] = `
 <div>
   <ol
-    class="multi-step-nav multi-step-indicator-label-bottom multi-step-nav-collapse-sm"
+    class="multi-step-nav multi-step-nav-collapse-sm multi-step-indicator-label-bottom"
   >
     <li
       class="multi-step-item complete multi-step-item-expand"
@@ -134,7 +134,7 @@ exports[`ClayMultiStepNav activates step on click 1`] = `
 exports[`ClayMultiStepNav renders 1`] = `
 <div>
   <ol
-    class="multi-step-nav multi-step-indicator-label-bottom multi-step-nav-collapse-sm"
+    class="multi-step-nav multi-step-nav-collapse-sm multi-step-indicator-label-bottom"
   >
     <li
       class="multi-step-item complete multi-step-item-expand"
@@ -258,7 +258,7 @@ exports[`ClayMultiStepNav renders 1`] = `
 exports[`ClayMultiStepNavWithBasicItems renders 1`] = `
 <div>
   <ol
-    class="multi-step-nav multi-step-indicator-label-bottom multi-step-nav-collapse-sm"
+    class="multi-step-nav multi-step-nav-collapse-sm multi-step-indicator-label-bottom"
   >
     <li
       class="multi-step-item active multi-step-item-expand"


### PR DESCRIPTION
Fixes #4507

Well, that PR just add a new API but does not improve the API to improve the DX, since you need to make `subTitle` the title, for example, is quite counterintuitive but we can not change the API now to do this, but maybe we can add a new API to change the names and remove the idea Subtitle for something like label for example and depreciate the subtitle of `<ClayMultiStepNav.Indicator />` and `<ClayMultiStepNavWithBasicItems />`.