### PR TITLE
feat(@clayui/date-picker): adds 12-hour time support

### DIFF
--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -8,6 +8,8 @@ import {useCallback, useState} from 'react';
 import {IDay, Month, WeekDays, clone, formatDate, setDate} from './Helpers';
 import {FirstDayOfWeek} from './types';
 
+import type {Input} from '@clayui/time-picker';
+
 const normalizeTime = (date: Date) =>
 	setDate(date, {hours: 12, milliseconds: 0, minutes: 0, seconds: 0});
 
@@ -64,7 +66,11 @@ export const useCurrentTime = (format: string) => {
 	);
 
 	const setCurrentTime = useCallback(
-		(hours: number | string, minutes: number | string) => {
+		(
+			hours: number | string,
+			minutes: number | string,
+			ampm?: Input['ampm']
+		) => {
 			const date = setDate(new Date(), {hours, minutes});
 
 			if (typeof hours !== 'string') {
@@ -75,15 +81,12 @@ export const useCurrentTime = (format: string) => {
 				minutes = formatDate(date, 'mm');
 			}
 
-			set(`${hours}:${minutes}`);
+			set(ampm ? `${hours}:${minutes} ${ampm}` : `${hours}:${minutes}`);
 		},
 		[]
 	);
 
-	return [currentTime, setCurrentTime] as [
-		string,
-		(hours: number | string, minutes: number | string) => void
-	];
+	return [currentTime, setCurrentTime] as const;
 };
 
 function getDaysInMonth(d: Date) {

--- a/packages/clay-date-picker/src/TimePicker.tsx
+++ b/packages/clay-date-picker/src/TimePicker.tsx
@@ -9,7 +9,11 @@ import React from 'react';
 interface IProps {
 	currentTime: string;
 	disabled?: boolean;
-	onTimeChange: (hours: number | string, minutes: number | string) => void;
+	onTimeChange: (
+		hours: number | string,
+		minutes: number | string,
+		ampm: Input['ampm']
+	) => void;
 
 	/**
 	 * Path to the location of the spritemap resource.
@@ -17,6 +21,7 @@ interface IProps {
 	spritemap?: string;
 
 	timezone?: string;
+	use12Hours?: boolean;
 }
 
 const DEFAULT_VALUE = '--';
@@ -27,6 +32,7 @@ const ClayDatePickerTimePicker: React.FunctionComponent<IProps> = ({
 	onTimeChange,
 	spritemap,
 	timezone,
+	use12Hours,
 }) => {
 	const [values, setValues] = React.useState<Input>({
 		ampm: DEFAULT_VALUE,
@@ -46,18 +52,22 @@ const ClayDatePickerTimePicker: React.FunctionComponent<IProps> = ({
 			values.minutes === DEFAULT_VALUE
 				? DEFAULT_VALUE
 				: Number(values.minutes);
+		const ampm = values.ampm ? values.ampm : DEFAULT_VALUE;
 
 		setValues(values);
-		onTimeChange(hours, minutes);
+		onTimeChange(hours, minutes, ampm);
 	};
 
 	React.useEffect(() => {
-		const time = currentTime.split(':');
+		const [hours, minutesAndAmpm] = currentTime.split(':');
+
+		const [minutes, ampm] = minutesAndAmpm.split(' ');
 
 		setValues((prevValues) => ({
 			...prevValues,
-			hours: String(time[0]),
-			minutes: String(time[1]),
+			ampm: ampm as Input['ampm'],
+			hours: String(hours),
+			minutes: String(minutes),
 		}));
 	}, [currentTime]);
 
@@ -69,6 +79,7 @@ const ClayDatePickerTimePicker: React.FunctionComponent<IProps> = ({
 				onInputChange={handleOnChange}
 				spritemap={spritemap}
 				timezone={timezone}
+				use12Hours={use12Hours}
 				values={values}
 			/>
 		</div>

--- a/packages/clay-date-picker/stories/index.tsx
+++ b/packages/clay-date-picker/stories/index.tsx
@@ -67,10 +67,11 @@ storiesOf('Components|ClayDatePicker', module)
 	))
 	.add('time', () => (
 		<ClayDatePickerWithState
-			placeholder="YYYY-MM-DD HH:mm"
+			placeholder="YYYY-MM-DD --:-- --"
 			spritemap={spritemap}
 			time
 			timezone="GMT+01:00"
+			use12Hours={boolean('12 Hours', false)}
 			years={{
 				end: 2024,
 				start: 1997,


### PR DESCRIPTION
Fixes #4505

Even though TimePicker already supports 12-hour time we need to add more rules for formatting and interpreting the syntax in DatePicker so that everything works fine.