### PR TITLE
fix(@clayui/css): Cadmin convert a few places where we are still using slash as division

### DIFF
--- a/clayui.com/plugins/gatsby-plugin-clay-css-tasks/gatsby-node.js
+++ b/clayui.com/plugins/gatsby-plugin-clay-css-tasks/gatsby-node.js
@@ -132,17 +132,20 @@ const generateCSSFiles = (pluginOptions) => {
 	const clayuiSrcDir = path.join(pluginOptions.clayuiSrc, 'styles');
 
 	const atlas = compileSass({
-		file: path.join(scssDir, 'atlas.scss'),
+		file: path.join(clayuiSrcDir, 'dart-sass-atlas.scss'),
+		includePaths: [scssDir],
 		outFile: path.join(cssDir, 'atlas.css'),
 	});
 
 	const base = compileSass({
-		file: path.join(scssDir, 'base.scss'),
+		file: path.join(clayuiSrcDir, 'dart-sass-base.scss'),
+		includePaths: [scssDir],
 		outFile: path.join(cssDir, 'base.css'),
 	});
 
 	const cadmin = compileSass({
-		file: path.join(scssDir, 'cadmin.scss'),
+		file: path.join(clayuiSrcDir, 'dart-sass-cadmin.scss'),
+		includePaths: [scssDir],
 		outFile: path.join(cssDir, 'cadmin.css'),
 	});
 

--- a/clayui.com/src/styles/colors-base.scss
+++ b/clayui.com/src/styles/colors-base.scss
@@ -1,3 +1,5 @@
+@use 'sass:math' as *;
+
 @import 'base-variables';
 @import 'site/variables';
 

--- a/clayui.com/src/styles/colors.scss
+++ b/clayui.com/src/styles/colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:math' as *;
+
 @import 'atlas-variables';
 @import 'site/variables';
 

--- a/clayui.com/src/styles/dart-sass-atlas.scss
+++ b/clayui.com/src/styles/dart-sass-atlas.scss
@@ -1,0 +1,3 @@
+@use 'sass:math' as *;
+
+@import 'atlas.scss';

--- a/clayui.com/src/styles/dart-sass-base.scss
+++ b/clayui.com/src/styles/dart-sass-base.scss
@@ -1,0 +1,3 @@
+@use 'sass:math' as *;
+
+@import 'base.scss';

--- a/clayui.com/src/styles/dart-sass-cadmin.scss
+++ b/clayui.com/src/styles/dart-sass-cadmin.scss
@@ -1,0 +1,3 @@
+@use 'sass:math' as *;
+
+@import 'cadmin.scss';

--- a/clayui.com/src/styles/main.scss
+++ b/clayui.com/src/styles/main.scss
@@ -1,3 +1,5 @@
+@use 'sass:math' as *;
+
 @import 'atlas-variables';
 @import 'charts';
 

--- a/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
@@ -246,9 +246,10 @@
 
 	.embed-responsive-#{$cadmin-embed-responsive-aspect-ratio-x}by#{$cadmin-embed-responsive-aspect-ratio-y} {
 		&::before {
-			padding-top: percentage(
-				$cadmin-embed-responsive-aspect-ratio-y /
-					$cadmin-embed-responsive-aspect-ratio-x
+			padding-top: calc(
+				#{$cadmin-embed-responsive-aspect-ratio-y} /
+					#{$cadmin-embed-responsive-aspect-ratio-x} *
+					100%
 			);
 		}
 	}

--- a/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
@@ -283,8 +283,8 @@ $cadmin-alert-fluid-dismissible-container: map-merge(
 		padding-left: $cadmin-alert-dismissible-padding-left,
 		padding-right:
 			calc(
-				#{$cadmin-alert-dismissible-padding-right} + #{$cadmin-grid-gutter-width /
-					2}
+				#{$cadmin-alert-dismissible-padding-right} + #{$cadmin-grid-gutter-width} *
+					0.5
 			),
 		padding-top: $cadmin-alert-dismissible-padding-top,
 		position: relative,


### PR DESCRIPTION
fixes #4493 

This uses `calc()` to fix the deprecation warnings for using / as division in Cadmin. This also updates clayui.com to `@use 'sass:math' as *;`. The deprecation warnings shouldn't show when running clayui.com.