### PR TITLE
feat(@clayui/css): Buttons allow setting a variety of button sizes via `$btn-sizes` and `$btn-monospaced-sizes`

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -448,11 +448,6 @@ $btn-outline-info: map-deep-merge(
 				box-shadow: map-deep-get($btn-info, active, focus, box-shadow),
 			),
 		),
-		disabled: (
-			background-color: transparent,
-			border-color: map-get($btn-info, background-color),
-			color: map-get($btn-info, background-color),
-		),
 	),
 	$btn-outline-info
 );
@@ -469,11 +464,6 @@ $btn-outline-success: map-deep-merge(
 				map-deep-get($btn-success, hover, background-color),
 			box-shadow: map-deep-get($btn-success, focus, box-shadow),
 			color: $white,
-		),
-		disabled: (
-			background-color: transparent,
-			border-color: map-get($btn-success, background-color),
-			color: map-get($btn-success, background-color),
 		),
 		active: (
 			background-color:
@@ -510,11 +500,6 @@ $btn-outline-warning: map-deep-merge(
 					map-deep-get($btn-warning, active, focus, box-shadow),
 			),
 		),
-		disabled: (
-			background-color: transparent,
-			border-color: map-get($btn-warning, background-color),
-			color: map-get($btn-warning, background-color),
-		),
 	),
 	$btn-outline-warning
 );
@@ -531,16 +516,12 @@ $btn-outline-danger: map-deep-merge(
 			color: $white,
 		),
 		active: (
-			background-color: map-get($btn-danger, active-bg),
+			background-color:
+				map-deep-get($btn-danger, active, background-color),
 			box-shadow: map-deep-get($btn-danger, active, box-shadow),
 			focus: (
 				box-shadow: map-deep-get($btn-danger, active, focus, box-shadow),
 			),
-		),
-		disabled: (
-			background-color: transparent,
-			border-color: map-get($btn-danger, background-color),
-			color: map-get($btn-danger, background-color),
 		),
 	),
 	$btn-outline-danger
@@ -564,11 +545,6 @@ $btn-outline-light: map-deep-merge(
 				box-shadow: map-deep-get($btn-light, active, focus, box-shadow),
 			),
 		),
-		disabled: (
-			background-color: transparent,
-			border-color: map-get($btn-light, background-color),
-			color: map-get($btn-light, background-color),
-		),
 	),
 	$btn-outline-light
 );
@@ -590,11 +566,6 @@ $btn-outline-dark: map-deep-merge(
 			focus: (
 				box-shadow: map-deep-get($btn-dark, active, focus, box-shadow),
 			),
-		),
-		disabled: (
-			background-color: transparent,
-			border-color: map-get($btn-dark, background-color),
-			color: map-get($btn-dark, background-color),
 		),
 	),
 	$btn-outline-dark

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -18,20 +18,26 @@ fieldset:disabled a.btn {
 
 // Button Sizes
 
-%clay-btn-lg {
-	@include clay-button-variant($btn-lg);
-}
+@each $size, $value in $btn-sizes {
+	$placeholder: if(
+		starts-with($size, 'btn-'),
+		'%clay-#{$size}',
+		'%#{str-slice($size, 2)}'
+	);
 
-.btn-lg {
-	@extend %clay-btn-lg !optional;
-}
+	$selector: if(
+		starts-with($size, 'btn-'),
+		clay-str-replace($size, 'btn-', '.btn-'),
+		$size
+	);
 
-%clay-btn-sm {
-	@include clay-button-variant($btn-sm);
-}
+	#{$placeholder} {
+		@include clay-button-variant($value);
+	}
 
-.btn-sm {
-	@extend %clay-btn-sm !optional;
+	#{$selector} {
+		@extend #{$placeholder} !optional;
+	}
 }
 
 // Button Block
@@ -67,28 +73,30 @@ input[type='button'] {
 
 // Button Monospaced
 
-.btn-monospaced {
-	@include clay-button-variant($btn-monospaced);
+@each $size, $value in $btn-monospaced-sizes {
+	$placeholder: if(
+		starts-with($size, 'btn-monospaced'),
+		'%clay-#{$size}',
+		'%#{str-slice($size, 2)}'
+	);
 
-	&.btn .lexicon-icon {
-		margin-top: 0;
+	$selector: if(
+		starts-with($size, 'btn-monospaced-'),
+		clay-str-replace($size, 'btn-monospaced', '.btn-monospaced.btn'),
+		if(
+			$size == 'btn-monospaced',
+			clay-str-replace($size, 'btn-monospaced', '.btn-monospaced'),
+			$size
+		)
+	);
+
+	#{$placeholder} {
+		@include clay-button-variant($value);
 	}
-}
 
-%clay-btn-monospaced-lg {
-	@include clay-button-variant($btn-monospaced-lg);
-}
-
-.btn-monospaced.btn-lg {
-	@extend %clay-btn-monospaced-lg !optional;
-}
-
-%clay-btn-monospaced-sm {
-	@include clay-button-variant($btn-monospaced-sm);
-}
-
-.btn-monospaced.btn-sm {
-	@extend %clay-btn-monospaced-sm !optional;
+	#{$selector} {
+		@extend #{$placeholder} !optional;
+	}
 }
 
 // Button Variants

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -102,38 +102,68 @@ input[type='button'] {
 // Button Variants
 
 @each $color, $value in $btn-palette {
-	%btn-#{$color} {
+	$placeholder: if(
+		starts-with($color, '.') or starts-with($color, '#'),
+		'%#{str-slice($color, 2)}',
+		'%btn-#{$color}'
+	);
+
+	$placeholder-focus: if(
+		starts-with($color, '.') or starts-with($color, '#'),
+		'%#{str-slice($color, 2)}-focus',
+		'%btn-#{$color}-focus'
+	);
+
+	$selector: if(
+		starts-with($color, '.') or starts-with($color, '#'),
+		$color,
+		str-insert($color, '.btn-', 1)
+	);
+
+	#{$placeholder} {
 		@include clay-button-variant($value);
 	}
 
-	.btn-#{$color} {
-		@extend %btn-#{$color} !optional;
+	#{$selector} {
+		@extend #{$placeholder} !optional;
 	}
 
-	%btn-#{$color}-focus {
-		background-color: map-get($value, focus-bg);
-		border-color: map-get($value, focus-border-color);
-		box-shadow: map-get($value, focus-box-shadow);
-		color: map-get($value, focus-color);
+	#{$placeholder-focus} {
+		@include clay-button-variant(map-get($value, focus));
 	}
 }
 
 // Button Outline Variants
 
 @each $color, $value in $btn-outline-palette {
-	%btn-outline-#{$color} {
+	$placeholder: if(
+		starts-with($color, '.') or starts-with($color, '#'),
+		'%#{str-slice($color, 2)}',
+		'%btn-outline-#{$color}'
+	);
+
+	$placeholder-focus: if(
+		starts-with($color, '.') or starts-with($color, '#'),
+		'%#{str-slice($color, 2)}-focus',
+		'%btn-outline-#{$color}-focus'
+	);
+
+	$selector: if(
+		starts-with($color, '.') or starts-with($color, '#'),
+		$color,
+		str-insert($color, '.btn-outline-', 1)
+	);
+
+	#{$placeholder} {
 		@include clay-button-variant($value);
 	}
 
-	.btn-outline-#{$color} {
-		@extend %btn-outline-#{$color} !optional;
+	#{$selector} {
+		@extend #{$placeholder} !optional;
 	}
 
-	%btn-outline-#{$color}-focus {
-		background-color: map-get($value, focus-bg);
-		border-color: map-get($value, focus-border-color);
-		box-shadow: map-get($value, focus-box-shadow);
-		color: map-get($value, focus-color);
+	#{$placeholder-focus} {
+		@include clay-button-variant(map-get($value, focus));
 	}
 }
 

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -185,7 +185,18 @@ $btn-sm: map-deep-merge(
 	$btn-sm
 );
 
-// Button Monospaced
+// Button Sizes
+
+$btn-sizes: () !default;
+$btn-sizes: map-deep-merge(
+	(
+		btn-lg: $btn-lg,
+		btn-sm: $btn-sm,
+	),
+	$btn-sizes
+);
+
+// .btn-monospaced
 
 $btn-monospaced-padding-x: 0 !default;
 $btn-monospaced-padding-y: 0 !default;
@@ -228,7 +239,7 @@ $btn-monospaced: map-deep-merge(
 	$btn-monospaced
 );
 
-// Button Monospaced Lg
+// .btn-monospaced.btn-lg
 
 $btn-monospaced-padding-x-lg: null !default;
 $btn-monospaced-padding-y-lg: null !default;
@@ -253,7 +264,7 @@ $btn-monospaced-lg: map-deep-merge(
 	$btn-monospaced-lg
 );
 
-// Button Monospaced Sm
+// .btn-monospaced.btn-sm
 
 $btn-monospaced-padding-x-sm: null !default;
 $btn-monospaced-padding-y-sm: null !default;
@@ -276,6 +287,18 @@ $btn-monospaced-sm: map-deep-merge(
 		),
 	),
 	$btn-monospaced-sm
+);
+
+// Button Monospaced Sizes
+
+$btn-monospaced-sizes: () !default;
+$btn-monospaced-sizes: map-deep-merge(
+	(
+		btn-monospaced: $btn-monospaced,
+		btn-monospaced-lg: $btn-monospaced-lg,
+		btn-monospaced-sm: $btn-monospaced-sm,
+	),
+	$btn-monospaced-sizes
 );
 
 // Button Block


### PR DESCRIPTION
fixes #4521 

This creates the Sass maps `$btn-sizes` and `$btn-monospaced-sizes` and loops through it outputting Sass placeholders and styles. It allows devs to modify or create their own button sizes.

```scss
$btn-sizes: (
    btn-sm: (
        padding-bottom: 2px,
        padding-left: 4px,
        padding-right: 4px,
        padding-left: 2px,
    ),
    '.extra-small-button': (
    	padding: 0,
    ),
);
```

Outputs:

```scss
%clay-btn-sm {
    padding-bottom: 2px;
    padding-left: 4px;
    padding-right: 4px;
    padding-left: 2px;
}

.btn-sm {
    @extend %clay-btn-sm !optional;
}

%extra-small-button {
    padding: 0;
}

.extra-small-button {
    @extend %extra-small-button !optional;
}
```

Other fixes:

- Atlas Buttons some disabled button-outline variants have white text on hover