### PR TITLE
feat(@clayui/core): expand child nodes when parent is checked

### DIFF
--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -31,6 +31,11 @@ interface ITreeViewProps<T>
 	dragAndDrop?: boolean;
 
 	/**
+	 * Flag to expand child nodes when a parent node is checked.
+	 */
+	expandOnCheck?: boolean;
+
+	/**
 	 * Flag to modify Node expansion state icons.
 	 */
 	expanderIcons?: Icons;
@@ -71,6 +76,7 @@ export function TreeView<T>({
 	className,
 	displayType = 'light',
 	dragAndDrop = false,
+	expandOnCheck = false,
 	expandedKeys,
 	expanderIcons,
 	items,
@@ -107,6 +113,7 @@ export function TreeView<T>({
 	const context = {
 		childrenRoot: childrenRootRef,
 		dragAndDrop,
+		expandOnCheck,
 		expanderIcons,
 		nestedKey,
 		onLoadMore,

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -320,8 +320,14 @@ export function TreeViewItemStack({
 	loading = false,
 	...otherProps
 }: ITreeViewItemStackProps) {
-	const {expandedKeys, expanderIcons, selection, toggle} =
-		useTreeViewContext();
+	const {
+		expandOnCheck,
+		expandedKeys,
+		expanderIcons,
+		open,
+		selection,
+		toggle,
+	} = useTreeViewContext();
 
 	const item = useItem();
 
@@ -373,7 +379,13 @@ export function TreeViewItemStack({
 						checked: selection.selectedKeys.has(item.key),
 						disabled: loading,
 						indeterminate: selection.isIntermediate(item.key),
-						onChange: () => selection.toggleSelection(item.key),
+						onChange: () => {
+							selection.toggleSelection(item.key);
+
+							if (expandOnCheck) {
+								open(item.key);
+							}
+						},
 						onClick: (
 							event: React.MouseEvent<
 								HTMLInputElement,

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -16,6 +16,7 @@ export type Icons = {
 export interface ITreeViewContext<T> extends ITreeState<T> {
 	childrenRoot: React.MutableRefObject<ChildrenFunction<Object> | null>;
 	dragAndDrop?: boolean;
+	expandOnCheck?: boolean;
 	expanderIcons?: Icons;
 	nestedKey?: string;
 	onLoadMore?: (item: any) => Promise<unknown>;

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -694,6 +694,93 @@ storiesOf('Components|ClayTreeView', module)
 			</Provider>
 		);
 	})
+	.add('expand on check', () => {
+		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
+			new Set()
+		);
+
+		// Just to avoid TypeScript error with required props
+		const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
+
+		OptionalCheckbox.displayName = 'ClayCheckbox';
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView
+					dragAndDrop
+					expandOnCheck
+					items={ITEMS_DRIVE}
+					nestedKey="children"
+					onSelectionChange={(keys) => setSelectionChange(keys)}
+					selectedKeys={selectedKeys}
+					showExpanderOnHover={false}
+				>
+					{(item) => (
+						<TreeView.Item>
+							<TreeView.ItemStack>
+								<OptionalCheckbox />
+								<Icon symbol="folder" />
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item>
+										<OptionalCheckbox />
+										<Icon symbol="folder" />
+										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
+	.add('expand on check w/single selection', () => {
+		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
+			new Set()
+		);
+
+		// Just to avoid TypeScript error with required props
+		const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
+
+		OptionalCheckbox.displayName = 'ClayCheckbox';
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView
+					dragAndDrop
+					expandOnCheck
+					items={ITEMS_DRIVE}
+					nestedKey="children"
+					onSelectionChange={(keys) => setSelectionChange(keys)}
+					selectedKeys={selectedKeys}
+					selectionMode="single"
+					showExpanderOnHover={false}
+				>
+					{(item) => (
+						<TreeView.Item>
+							<TreeView.ItemStack>
+								<OptionalCheckbox />
+								<Icon symbol="folder" />
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item>
+										<OptionalCheckbox />
+										<Icon symbol="folder" />
+										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
 	.add('single selection', () => {
 		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
 			new Set()


### PR DESCRIPTION
This will only happen when the expandOnCheck prop is passed to
TreeView

Fixes #4523