### PR TITLE
feat(@clayui/css): Input Group convert to Clay mixin pattern

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
@@ -69,117 +69,27 @@
 // Input Group
 
 .input-group {
-	align-items: stretch;
-	display: flex;
-	flex-wrap: wrap;
-	position: relative;
-	width: 100%;
-
-	.btn-unstyled {
-		color: inherit;
-	}
+	@include clay-input-group-variant($cadmin-input-group);
 }
 
 // Input Group Item
 
 .input-group-item {
-	display: flex;
-	flex-grow: 1;
-	flex-wrap: wrap;
-	margin-left: $cadmin-input-group-item-margin-left;
-	width: 1%;
-	word-wrap: break-word;
-
-	&:first-child {
-		margin-left: 0;
-	}
-
-	> .btn {
-		align-self: flex-start;
-	}
-
-	> .dropdown {
-		display: flex;
-		flex-wrap: wrap;
-		word-wrap: break-word;
-		width: 100%;
-	}
+	@include clay-input-group-item-variant($cadmin-input-group-item);
 }
 
 .input-group-item-shrink {
-	flex-grow: 0;
-	width: auto;
+	@include clay-input-group-item-variant($cadmin-input-group-item-shrink);
 }
 
 // Input Group Text
 
 .input-group-text {
-	align-items: center;
-	background-color: $cadmin-input-group-addon-bg;
-	border-color: $cadmin-input-group-addon-border-color;
-	border-style: solid;
-
-	border-bottom-width: $cadmin-input-border-bottom-width;
-	border-left-width: $cadmin-input-border-left-width;
-	border-right-width: $cadmin-input-border-right-width;
-	border-top-width: $cadmin-input-border-top-width;
-
-	@include border-radius($cadmin-input-border-radius);
-
-	color: $cadmin-input-group-addon-color;
-	display: flex;
-	font-size: $cadmin-input-font-size;
-	font-weight: $cadmin-input-group-addon-font-weight;
-	height: $cadmin-input-height;
-	justify-content: center;
-	line-height: $cadmin-input-line-height;
-
-	// Allow use of <label> elements by overriding our default margin-bottom
-
-	margin-bottom: 0;
-	min-width: $cadmin-input-group-addon-min-width;
-	padding-bottom: $cadmin-input-group-addon-padding-y;
-	padding-left: $cadmin-input-group-addon-padding-x;
-	padding-right: $cadmin-input-group-addon-padding-x;
-	padding-top: $cadmin-input-group-addon-padding-y;
-	text-align: center;
-	white-space: nowrap;
-
-	@include clay-scale-component {
-		height: $cadmin-input-height-mobile;
-	}
-
-	label {
-		color: $cadmin-input-group-addon-color;
-	}
-
-	// Nuke default margins from checkboxes and radios to vertically center within.
-
-	input[type='radio'],
-	input[type='checkbox'] {
-		margin-top: 0;
-	}
-
-	.custom-control,
-	.form-check {
-		margin-bottom: 0;
-	}
-
-	.lexicon-icon {
-		margin-top: 0;
-	}
+	@include clay-input-group-text-variant($cadmin-input-group-text);
 }
 
 .input-group-text-secondary {
-	background-color: $cadmin-input-group-secondary-addon-bg;
-	border-color: $cadmin-input-group-secondary-addon-border-color;
-	border-width: $cadmin-input-group-secondary-addon-border-width;
-	color: $cadmin-input-group-secondary-addon-color;
-	z-index: 2;
-
-	label {
-		color: $cadmin-input-group-secondary-addon-color;
-	}
+	@include clay-input-group-text-variant($cadmin-input-group-text-secondary);
 }
 
 // Input Group Stacked
@@ -191,85 +101,7 @@
 // Input Group Sizes
 
 %clay-input-group-lg {
-	> .input-group-item {
-		> .btn {
-			@include clay-button-size($cadmin-input-group-lg-item-btn);
-		}
-
-		> .btn-monospaced {
-			@include clay-button-size(
-				$cadmin-input-group-lg-item-btn-monospaced
-			);
-		}
-
-		> .form-control,
-		> .form-file .btn {
-			@include border-radius($cadmin-input-border-radius-lg);
-
-			font-size: $cadmin-input-font-size-lg;
-			height: $cadmin-input-height-lg;
-			line-height: $cadmin-input-line-height-lg;
-			padding-bottom: $cadmin-input-padding-y-lg;
-			padding-left: $cadmin-input-padding-x-lg;
-			padding-right: $cadmin-input-padding-x-lg;
-			padding-top: $cadmin-input-padding-y-lg;
-
-			@include clay-scale-component {
-				height: $cadmin-input-height-lg-mobile;
-			}
-		}
-
-		> textarea.form-control,
-		> .form-control-textarea {
-			height: $cadmin-input-textarea-height-lg;
-		}
-
-		> .form-control-plaintext {
-			font-size: $cadmin-input-font-size-lg;
-			height: $cadmin-input-height-lg;
-			line-height: $cadmin-input-line-height-lg;
-			padding-bottom: $cadmin-input-padding-y-lg;
-			padding-top: $cadmin-input-padding-y-lg;
-
-			@include clay-scale-component {
-				height: $cadmin-input-height-lg-mobile;
-			}
-		}
-
-		> .input-group-text {
-			@include border-radius($cadmin-input-border-radius-lg);
-
-			font-size: $cadmin-input-font-size-lg;
-			height: $cadmin-input-height-lg;
-			min-width: $cadmin-input-group-addon-min-width-lg;
-			padding-bottom: $cadmin-input-group-addon-padding-y-lg;
-			padding-left: $cadmin-input-group-addon-padding-x-lg;
-			padding-right: $cadmin-input-group-addon-padding-x-lg;
-			padding-top: $cadmin-input-group-addon-padding-y-lg;
-		}
-	}
-
-	> .input-group-inset-item {
-		> .btn {
-			@include clay-button-size($cadmin-input-group-lg-inset-item-btn);
-		}
-
-		> .btn-monospaced {
-			@include clay-button-variant(
-				$cadmin-input-group-lg-inset-item-btn-monospaced
-			);
-		}
-
-		> .form-file {
-			height: 75%;
-
-			.btn {
-				@include clay-button-size(
-					$cadmin-input-group-lg-inset-item-form-file-btn
-				);
-			}
-		}
-	}
+	@include clay-input-group-variant($cadmin-input-group-lg);
 }
 
 .input-group-lg {
@@ -277,86 +109,6 @@
 }
 
 %clay-input-group-sm {
-	> .input-group-item {
-		> .btn {
-			@include clay-button-size($cadmin-input-group-sm-item-btn);
-		}
-
-		> .btn-monospaced {
-			@include clay-button-size(
-				$cadmin-input-group-sm-item-btn-monospaced
-			);
-		}
-
-		> .form-control,
-		> .form-file .btn {
-			@include border-radius($cadmin-input-border-radius-sm);
-
-			font-size: $cadmin-input-font-size-sm;
-			height: $cadmin-input-height-sm;
-			line-height: $cadmin-input-line-height-sm;
-			padding-bottom: $cadmin-input-padding-y-sm;
-			padding-left: $cadmin-input-padding-x-sm;
-			padding-right: $cadmin-input-padding-x-sm;
-			padding-top: $cadmin-input-padding-y-sm;
-
-			@include clay-scale-component {
-				height: $cadmin-input-height-sm-mobile;
-			}
-		}
-
-		> .form-control-plaintext {
-			font-size: $cadmin-input-font-size-sm;
-			height: $cadmin-input-height-sm;
-			line-height: $cadmin-input-line-height-sm;
-			padding-bottom: $cadmin-input-padding-y-sm;
-			padding-top: $cadmin-input-padding-y-sm;
-
-			@include clay-scale-component {
-				height: $cadmin-input-height-sm-mobile;
-			}
-		}
-
-		> textarea.form-control,
-		> .form-control-textarea {
-			height: $cadmin-input-textarea-height-sm;
-		}
-
-		> .input-group-text {
-			@include border-radius($cadmin-input-border-radius-sm);
-
-			font-size: $cadmin-input-font-size-sm;
-			height: $cadmin-input-height-sm;
-			min-width: $cadmin-input-group-addon-min-width-sm;
-			padding-bottom: $cadmin-input-group-addon-padding-y-sm;
-			padding-left: $cadmin-input-group-addon-padding-x-sm;
-			padding-right: $cadmin-input-group-addon-padding-x-sm;
-			padding-top: $cadmin-input-group-addon-padding-y-sm;
-		}
-	}
-
-	> .input-group-inset-item {
-		> .btn {
-			@include clay-button-size($cadmin-input-group-sm-inset-item-btn);
-		}
-
-		> .btn-monospaced {
-			@include clay-button-variant(
-				$cadmin-input-group-sm-inset-item-btn-monospaced
-			);
-		}
-
-		> .form-file {
-			height: 75%;
-
-			.btn {
-				@include clay-button-size(
-					$cadmin-input-group-sm-inset-item-form-file-btn
-				);
-			}
-		}
-	}
-
 	&.clay-color {
 		> .input-group-item > .input-group-text {
 			@extend %clay-color-sm-input-group-text !optional;
@@ -384,70 +136,16 @@
 
 // Input Group Inset
 
-.input-group-item.focus {
-	@include border-radius($cadmin-input-border-radius);
-
-	box-shadow: $cadmin-input-focus-box-shadow;
-
-	.form-control,
-	.form-control[readonly] ~ .input-group-inset-item,
-	.input-group-inset-item {
-		background-color: $cadmin-input-focus-bg;
-		border-color: $cadmin-input-focus-border-color;
-	}
-}
-
-.input-group-item.input-group-prepend.focus {
-	@include border-right-radius(0);
-
-	z-index: 1;
-}
-
-.input-group-item.input-group-append.focus {
-	@include border-left-radius(0);
-}
-
 .input-group-inset {
-	flex-grow: 1;
-	order: 5;
-	width: 1%;
-
-	&[readonly] {
-		&:focus {
-			~ .input-group-inset-item {
-				background-color: $cadmin-input-readonly-focus-bg;
-				border-color: $cadmin-input-readonly-focus-border-color;
-				color: $cadmin-input-readonly-focus-color;
-			}
-		}
-
-		~ .input-group-inset-item {
-			background-color: $cadmin-input-readonly-bg;
-			border-color: $cadmin-input-readonly-border-color;
-			color: $cadmin-input-readonly-color;
-			cursor: $cadmin-input-readonly-cursor;
-		}
-	}
-
-	&:focus {
-		box-shadow: none;
-
-		~ .input-group-inset-item {
-			background-color: $cadmin-input-focus-bg;
-			border-color: $cadmin-input-focus-border-color;
-		}
-	}
-
-	&:disabled {
-		~ .input-group-inset-item {
-			background-color: $cadmin-input-disabled-bg;
-			border-color: $cadmin-input-disabled-border-color;
-		}
-	}
+	@include clay-form-control-variant($cadmin-input-group-inset);
 
 	~ .form-feedback-group {
 		order: 13;
 	}
+}
+
+.input-group-inset[readonly] {
+	@include clay-form-control-variant($cadmin-input-group-inset-readonly);
 }
 
 .input-group {

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -1257,7 +1257,24 @@ $cadmin-form-group-item-label-spacer: (
 		$cadmin-input-label-font-size * $cadmin-line-height-base
 	) + $cadmin-input-label-margin-bottom !default;
 
-// Input Group
+// .input-group
+
+$cadmin-input-group: () !default;
+$cadmin-input-group: map-deep-merge(
+	(
+		align-items: stretch,
+		display: flex,
+		flex-wrap: wrap,
+		position: relative,
+		width: 100%,
+		btn-unstyled: (
+			color: inherit,
+		),
+	),
+	$cadmin-input-group
+);
+
+// .input-group-text
 
 $cadmin-input-group-addon-bg: $cadmin-gray-300 !default;
 $cadmin-input-group-addon-border-color: $cadmin-input-group-addon-bg !default;
@@ -1267,16 +1284,139 @@ $cadmin-input-group-addon-min-width: 40px !default; // 40px
 $cadmin-input-group-addon-padding-x: 12px !default; // 12px
 $cadmin-input-group-addon-padding-y: $cadmin-input-padding-y !default;
 
-// Input Group Secondary
+$cadmin-input-group-text: () !default;
+$cadmin-input-group-text: map-deep-merge(
+	(
+		align-items: center,
+		background-color: $cadmin-input-group-addon-bg,
+		border-bottom-width: $cadmin-input-border-bottom-width,
+		border-color: $cadmin-input-group-addon-border-color,
+		border-left-width: $cadmin-input-border-left-width,
+		border-radius: clay-enable-rounded($cadmin-input-border-radius),
+		border-right-width: $cadmin-input-border-right-width,
+		border-style: solid,
+		border-top-width: $cadmin-input-border-top-width,
+		color: $cadmin-input-group-addon-color,
+		display: flex,
+		font-size: $cadmin-input-font-size,
+		font-weight: $cadmin-input-group-addon-font-weight,
+		height: $cadmin-input-height,
+		justify-content: center,
+		line-height: $cadmin-input-line-height,
+		margin-bottom: 0,
+		min-width: $cadmin-input-group-addon-min-width,
+		padding-bottom: $cadmin-input-group-addon-padding-y,
+		padding-left: $cadmin-input-group-addon-padding-x,
+		padding-right: $cadmin-input-group-addon-padding-x,
+		padding-top: $cadmin-input-group-addon-padding-y,
+		text-align: center,
+		white-space: nowrap,
+		label: (
+			color: $cadmin-input-group-addon-color,
+		),
+		custom-control: (
+			margin-bottom: 0,
+		),
+		form-check: (
+			margin-bottom: 0,
+			input: (
+				margin-top: 0,
+			),
+		),
+		lexicon-icon: (
+			margin-top: 0,
+		),
+		media-breakpoint-down: (
+			sm: (
+				height: $cadmin-input-height-mobile,
+			),
+		),
+	),
+	$cadmin-input-group-text
+);
+
+// .input-group-text-secondary
 
 $cadmin-input-group-secondary-addon-bg: $cadmin-white !default;
 $cadmin-input-group-secondary-addon-border-color: $cadmin-secondary-l2 !default;
 $cadmin-input-group-secondary-addon-border-width: 1px !default; // 1px
 $cadmin-input-group-secondary-addon-color: $cadmin-secondary !default;
 
-// Input Group Item
+$cadmin-input-group-text-secondary: () !default;
+$cadmin-input-group-text-secondary: map-deep-merge(
+	(
+		background-color: $cadmin-input-group-secondary-addon-bg,
+		border-color: $cadmin-input-group-secondary-addon-border-color,
+		border-width: $cadmin-input-group-secondary-addon-border-width,
+		color: $cadmin-input-group-secondary-addon-color,
+		z-index: 2,
+		label: (
+			color: $cadmin-input-group-secondary-addon-color,
+		),
+	),
+	$cadmin-input-group-text-secondary
+);
+
+// .input-group-item
 
 $cadmin-input-group-item-margin-left: 8px !default;
+
+$cadmin-input-group-item: () !default;
+$cadmin-input-group-item: map-deep-merge(
+	(
+		display: flex,
+		flex-grow: 1,
+		flex-wrap: wrap,
+		margin-left: $cadmin-input-group-item-margin-left,
+		width: 1%,
+		word-wrap: break-word,
+		focus: (
+			border-radius: clay-enable-rounded($cadmin-input-border-radius),
+			box-shadow: $cadmin-input-focus-box-shadow,
+			input-group-prepend: (
+				border-bottom-right-radius: clay-enable-rounded(0),
+				border-top-right-radius: clay-enable-rounded(0),
+				z-index: 1,
+			),
+			input-group-append: (
+				border-bottom-left-radius: clay-enable-rounded(0),
+				border-top-left-radius: clay-enable-rounded(0),
+			),
+			form-control: (
+				background-color: $cadmin-input-focus-bg,
+				border-color: $cadmin-input-focus-border-color,
+			),
+			input-group-inset-item: (
+				background-color: $cadmin-input-focus-bg,
+				border-color: $cadmin-input-focus-border-color,
+			),
+		),
+		first-child: (
+			margin-left: 0,
+		),
+		btn: (
+			align-self: flex-start,
+		),
+		dropdown: (
+			display: flex,
+			flex-wrap: wrap,
+			word-wrap: break-word,
+			width: 100%,
+		),
+	),
+	$cadmin-input-group-item
+);
+
+// .input-group-item-shrink
+
+$cadmin-input-group-item-shrink: () !default;
+$cadmin-input-group-item-shrink: map-deep-merge(
+	(
+		flex-grow: 0,
+		width: auto,
+	),
+	$cadmin-input-group-item-shrink
+);
 
 // Input Group Inset
 
@@ -1332,7 +1472,7 @@ $cadmin-input-group-inset-form-file-btn: map-deep-merge(
 	$cadmin-input-group-inset-form-file-btn
 );
 
-// Input Group Lg
+// .input-group-lg
 
 $cadmin-input-group-addon-min-width-lg: 48px !default; // 48px
 $cadmin-input-group-addon-padding-x-lg: $cadmin-input-padding-x-lg !default;
@@ -1391,7 +1531,92 @@ $cadmin-input-group-lg-inset-item-form-file-btn: map-deep-merge(
 	$cadmin-input-group-lg-inset-item-form-file-btn
 );
 
-// Input Group Sm
+$cadmin-input-group-lg: () !default;
+$cadmin-input-group-lg: map-deep-merge(
+	(
+		input-group-item: (
+			btn: $cadmin-input-group-lg-item-btn,
+			btn-monospaced: $cadmin-input-group-lg-item-btn-monospaced,
+			form-control: (
+				border-radius:
+					clay-enable-rounded($cadmin-input-border-radius-lg),
+				font-size: $cadmin-input-font-size-lg,
+				height: $cadmin-input-height-lg,
+				line-height: $cadmin-input-line-height-lg,
+				padding-bottom: $cadmin-input-padding-y-lg,
+				padding-left: $cadmin-input-padding-x-lg,
+				padding-right: $cadmin-input-padding-x-lg,
+				padding-top: $cadmin-input-padding-y-lg,
+			),
+			form-control-inset: (
+				margin-bottom: 0,
+				margin-top: 0,
+			),
+			form-file: (
+				btn: (
+					border-radius:
+						clay-enable-rounded($cadmin-input-border-radius-lg),
+					font-size: $cadmin-input-font-size-lg,
+					height: $cadmin-input-height-lg,
+					line-height: $cadmin-input-line-height-lg,
+					padding-bottom: $cadmin-input-padding-y-lg,
+					padding-left: $cadmin-input-padding-x-lg,
+					padding-right: $cadmin-input-padding-x-lg,
+					padding-top: $cadmin-input-padding-y-lg,
+				),
+			),
+			textarea: (
+				height: $cadmin-input-textarea-height-lg,
+			),
+			form-control-plaintext: (
+				font-size: $cadmin-input-font-size-lg,
+				height: $cadmin-input-height-lg,
+				line-height: $cadmin-input-line-height-lg,
+				padding-bottom: $cadmin-input-padding-y-lg,
+				padding-top: $cadmin-input-padding-y-lg,
+			),
+			input-group-text: (
+				border-radius:
+					clay-enable-rounded($cadmin-input-border-radius-lg),
+				font-size: $cadmin-input-font-size-lg,
+				height: $cadmin-input-height-lg,
+				min-width: $cadmin-input-group-addon-min-width-lg,
+				padding-bottom: $cadmin-input-group-addon-padding-y-lg,
+				padding-left: $cadmin-input-group-addon-padding-x-lg,
+				padding-right: $cadmin-input-group-addon-padding-x-lg,
+				padding-top: $cadmin-input-group-addon-padding-y-lg,
+			),
+			input-group-inset-item: (
+				btn: $cadmin-input-group-lg-inset-item-btn,
+				btn-monospaced: $cadmin-input-group-lg-inset-item-btn-monospaced,
+				form-file: (
+					height: 75%,
+					btn: $cadmin-input-group-lg-inset-item-form-file-btn,
+				),
+			),
+		),
+		media-breakpoint-down: (
+			sm: (
+				input-group-item: (
+					form-control: (
+						height: $cadmin-input-height-lg-mobile,
+					),
+					form-file: (
+						btn: (
+							height: $cadmin-input-height-lg-mobile,
+						),
+					),
+					form-control-plaintext: (
+						height: $cadmin-input-height-lg-mobile,
+					),
+				),
+			),
+		),
+	),
+	$cadmin-input-group-lg
+);
+
+// .input-group-sm
 
 $cadmin-input-group-addon-min-width-sm: 32px !default; // 32px
 $cadmin-input-group-addon-padding-x-sm: $cadmin-input-padding-x-sm !default;
@@ -1462,6 +1687,142 @@ $cadmin-input-group-sm-inset-item-form-file-btn: map-deep-merge(
 		padding-top: 0,
 	),
 	$cadmin-input-group-sm-inset-item-form-file-btn
+);
+
+$cadmin-input-group-sm: () !default;
+$cadmin-input-group-sm: map-deep-merge(
+	(
+		input-group-item: (
+			btn: $cadmin-input-group-sm-item-btn,
+			btn-monospaced: $cadmin-input-group-sm-item-btn-monospaced,
+			form-control: (
+				border-radius:
+					clay-enable-rounded($cadmin-input-border-radius-sm),
+				font-size: $cadmin-input-font-size-sm,
+				height: $cadmin-input-height-sm,
+				line-height: $cadmin-input-line-height-sm,
+				padding-bottom: $cadmin-input-padding-y-sm,
+				padding-left: $cadmin-input-padding-x-sm,
+				padding-right: $cadmin-input-padding-x-sm,
+				padding-top: $cadmin-input-padding-y-sm,
+				label: (
+					margin-bottom: 0.1875rem,
+					margin-top: 0.1875rem,
+				),
+			),
+			form-control-inset: (
+				margin-bottom: 0.125rem,
+				margin-top: 0.1875rem,
+			),
+			form-file: (
+				btn: (
+					border-radius:
+						clay-enable-rounded($cadmin-input-border-radius-sm),
+					font-size: $cadmin-input-font-size-sm,
+					height: $cadmin-input-height-sm,
+					line-height: $cadmin-input-line-height-sm,
+					padding-bottom: $cadmin-input-padding-y-sm,
+					padding-left: $cadmin-input-padding-x-sm,
+					padding-right: $cadmin-input-padding-x-sm,
+					padding-top: $cadmin-input-padding-y-sm,
+				),
+			),
+			form-control-plaintext: (
+				font-size: $cadmin-input-font-size-sm,
+				height: $cadmin-input-height-sm,
+				line-height: $cadmin-input-line-height-sm,
+				padding-bottom: $cadmin-input-padding-y-sm,
+				padding-top: $cadmin-input-padding-y-sm,
+			),
+			textarea: (
+				height: $cadmin-input-textarea-height-sm,
+			),
+			input-group-text: (
+				border-radius:
+					clay-enable-rounded($cadmin-input-border-radius-sm),
+				font-size: $cadmin-input-font-size-sm,
+				height: $cadmin-input-height-sm,
+				min-width: $cadmin-input-group-addon-min-width-sm,
+				padding-bottom: $cadmin-input-group-addon-padding-y-sm,
+				padding-left: $cadmin-input-group-addon-padding-x-sm,
+				padding-right: $cadmin-input-group-addon-padding-x-sm,
+				padding-top: $cadmin-input-group-addon-padding-y-sm,
+			),
+			input-group-inset-item: (
+				btn: $cadmin-input-group-sm-inset-item-btn,
+				btn-monospaced: $cadmin-input-group-sm-inset-item-btn-monospaced,
+				form-file: (
+					height: 75%,
+					btn: $cadmin-input-group-sm-inset-item-form-file-btn,
+				),
+			),
+		),
+		media-breakpoint-down: (
+			sm: (
+				input-group-item: (
+					form-control: (
+						height: $cadmin-input-height-sm-mobile,
+					),
+					form-file: (
+						btn: (
+							height: $cadmin-input-height-sm-mobile,
+						),
+					),
+					form-control-plaintext: (
+						height: $cadmin-input-height-sm-mobile,
+					),
+				),
+			),
+		),
+	),
+	$cadmin-input-group-sm
+);
+
+// .input-group-inset
+
+$cadmin-input-group-inset: () !default;
+$cadmin-input-group-inset: map-deep-merge(
+	(
+		flex-grow: 1,
+		order: 5,
+		width: 1%,
+		focus: (
+			box-shadow: none,
+			input-group-inset-item: (
+				background-color: $cadmin-input-focus-bg,
+				border-color: $cadmin-input-focus-border-color,
+			),
+		),
+		disabled: (
+			input-group-inset-item: (
+				background-color: $cadmin-input-disabled-bg,
+				border-color: $cadmin-input-disabled-border-color,
+			),
+		),
+	),
+	$cadmin-input-group-inset
+);
+
+// .input-group-inset[readonly]
+
+$cadmin-input-group-inset-readonly: () !default;
+$cadmin-input-group-inset-readonly: map-deep-merge(
+	(
+		input-group-inset-item: (
+			background-color: $cadmin-input-readonly-bg,
+			border-color: $cadmin-input-readonly-border-color,
+			color: $cadmin-input-readonly-color,
+			cursor: $cadmin-input-readonly-cursor,
+		),
+		focus: (
+			input-group-inset-item: (
+				background-color: $cadmin-input-readonly-focus-bg,
+				border-color: $cadmin-input-readonly-focus-border-color,
+				color: $cadmin-input-readonly-focus-color,
+			),
+		),
+	),
+	$cadmin-input-group-inset-readonly
 );
 
 // Input Group Stacked

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -121,117 +121,27 @@
 // Input Group
 
 .input-group {
-	align-items: stretch;
-	display: flex;
-	flex-wrap: wrap;
-	position: relative;
-	width: 100%;
-
-	.btn-unstyled {
-		color: inherit;
-	}
+	@include clay-input-group-variant($input-group);
 }
 
 // Input Group Item
 
 .input-group-item {
-	display: flex;
-	flex-grow: 1;
-	flex-wrap: wrap;
-	margin-left: $input-group-item-margin-left;
-	width: 1%;
-	word-wrap: break-word;
-
-	&:first-child {
-		margin-left: 0;
-	}
-
-	> .btn {
-		align-self: flex-start;
-	}
-
-	> .dropdown {
-		display: flex;
-		flex-wrap: wrap;
-		word-wrap: break-word;
-		width: 100%;
-	}
+	@include clay-input-group-item-variant($input-group-item);
 }
 
 .input-group-item-shrink {
-	flex-grow: 0;
-	width: auto;
+	@include clay-input-group-item-variant($input-group-item-shrink);
 }
 
 // Input Group Text
 
 .input-group-text {
-	align-items: center;
-	background-color: $input-group-addon-bg;
-	border-color: $input-group-addon-border-color;
-	border-style: solid;
-
-	border-bottom-width: $input-border-bottom-width;
-	border-left-width: $input-border-left-width;
-	border-right-width: $input-border-right-width;
-	border-top-width: $input-border-top-width;
-
-	@include border-radius($input-border-radius);
-
-	color: $input-group-addon-color;
-	display: flex;
-	font-size: $input-font-size;
-	font-weight: $input-group-addon-font-weight;
-	height: $input-height;
-	justify-content: center;
-	line-height: $input-line-height;
-
-	// Allow use of <label> elements by overriding our default margin-bottom
-
-	margin-bottom: 0;
-	min-width: $input-group-addon-min-width;
-	padding-bottom: $input-group-addon-padding-y;
-	padding-left: $input-group-addon-padding-x;
-	padding-right: $input-group-addon-padding-x;
-	padding-top: $input-group-addon-padding-y;
-	text-align: center;
-	white-space: nowrap;
-
-	@include clay-scale-component {
-		height: $input-height-mobile;
-	}
-
-	label {
-		color: $input-group-addon-color;
-	}
-
-	// Nuke default margins from checkboxes and radios to vertically center within.
-
-	input[type='radio'],
-	input[type='checkbox'] {
-		margin-top: 0;
-	}
-
-	.custom-control,
-	.form-check {
-		margin-bottom: 0;
-	}
-
-	.lexicon-icon {
-		margin-top: 0;
-	}
+	@include clay-input-group-text-variant($input-group-text);
 }
 
 .input-group-text-secondary {
-	background-color: $input-group-secondary-addon-bg;
-	border-color: $input-group-secondary-addon-border-color;
-	border-width: $input-group-secondary-addon-border-width;
-	color: $input-group-secondary-addon-color;
-	z-index: 2;
-
-	label {
-		color: $input-group-secondary-addon-color;
-	}
+	@include clay-input-group-text-variant($input-group-text-secondary);
 }
 
 // Input Group Stacked
@@ -243,83 +153,7 @@
 // Input Group Sizes
 
 %clay-input-group-lg {
-	> .input-group-item {
-		> .btn {
-			@include clay-button-size($input-group-lg-item-btn);
-		}
-
-		> .btn-monospaced {
-			@include clay-button-size($input-group-lg-item-btn-monospaced);
-		}
-
-		> .form-control,
-		> .form-file .btn {
-			@include border-radius($input-border-radius-lg);
-
-			font-size: $input-font-size-lg;
-			height: $input-height-lg;
-			line-height: $input-line-height-lg;
-			padding-bottom: $input-padding-y-lg;
-			padding-left: $input-padding-x-lg;
-			padding-right: $input-padding-x-lg;
-			padding-top: $input-padding-y-lg;
-
-			@include clay-scale-component {
-				height: $input-height-lg-mobile;
-			}
-		}
-
-		> textarea.form-control,
-		> .form-control-textarea {
-			height: $input-textarea-height-lg;
-		}
-
-		> .form-control-plaintext {
-			font-size: $input-font-size-lg;
-			height: $input-height-lg;
-			line-height: $input-line-height-lg;
-			padding-bottom: $input-padding-y-lg;
-			padding-top: $input-padding-y-lg;
-
-			@include clay-scale-component {
-				height: $input-height-lg-mobile;
-			}
-		}
-
-		> .input-group-text {
-			@include border-radius($input-border-radius-lg);
-
-			font-size: $input-font-size-lg;
-			height: $input-height-lg;
-			min-width: $input-group-addon-min-width-lg;
-			padding-bottom: $input-group-addon-padding-y-lg;
-			padding-left: $input-group-addon-padding-x-lg;
-			padding-right: $input-group-addon-padding-x-lg;
-			padding-top: $input-group-addon-padding-y-lg;
-		}
-
-		> .input-group-inset-item {
-			> .btn {
-				@include clay-button-size($input-group-lg-inset-item-btn);
-			}
-
-			> .btn-monospaced {
-				@include clay-button-variant(
-					$input-group-lg-inset-item-btn-monospaced
-				);
-			}
-
-			> .form-file {
-				height: 75%;
-
-				.btn {
-					@include clay-button-size(
-						$input-group-lg-inset-item-form-file-btn
-					);
-				}
-			}
-		}
-	}
+	@include clay-input-group-variant($input-group-lg);
 }
 
 .input-group-lg {
@@ -327,83 +161,7 @@
 }
 
 %clay-input-group-sm {
-	> .input-group-item {
-		> .btn {
-			@include clay-button-size($input-group-sm-item-btn);
-		}
-
-		> .btn-monospaced {
-			@include clay-button-size($input-group-sm-item-btn-monospaced);
-		}
-
-		> .form-control,
-		> .form-file .btn {
-			@include border-radius($input-border-radius-sm);
-
-			font-size: $input-font-size-sm;
-			height: $input-height-sm;
-			line-height: $input-line-height-sm;
-			padding-bottom: $input-padding-y-sm;
-			padding-left: $input-padding-x-sm;
-			padding-right: $input-padding-x-sm;
-			padding-top: $input-padding-y-sm;
-
-			@include clay-scale-component {
-				height: $input-height-sm-mobile;
-			}
-		}
-
-		> .form-control-plaintext {
-			font-size: $input-font-size-sm;
-			height: $input-height-sm;
-			line-height: $input-line-height-sm;
-			padding-bottom: $input-padding-y-sm;
-			padding-top: $input-padding-y-sm;
-
-			@include clay-scale-component {
-				height: $input-height-sm-mobile;
-			}
-		}
-
-		> textarea.form-control,
-		> .form-control-textarea {
-			height: $input-textarea-height-sm;
-		}
-
-		> .input-group-text {
-			@include border-radius($input-border-radius-sm);
-
-			font-size: $input-font-size-sm;
-			height: $input-height-sm;
-			min-width: $input-group-addon-min-width-sm;
-			padding-bottom: $input-group-addon-padding-y-sm;
-			padding-left: $input-group-addon-padding-x-sm;
-			padding-right: $input-group-addon-padding-x-sm;
-			padding-top: $input-group-addon-padding-y-sm;
-		}
-
-		> .input-group-inset-item {
-			> .btn {
-				@include clay-button-size($input-group-sm-inset-item-btn);
-			}
-
-			> .btn-monospaced {
-				@include clay-button-variant(
-					$input-group-sm-inset-item-btn-monospaced
-				);
-			}
-
-			> .form-file {
-				height: 75%;
-
-				.btn {
-					@include clay-button-size(
-						$input-group-sm-inset-item-form-file-btn
-					);
-				}
-			}
-		}
-	}
+	@include clay-input-group-variant($input-group-sm);
 
 	&.clay-color {
 		> .input-group-item > .input-group-text {
@@ -432,70 +190,16 @@
 
 // Input Group Inset
 
-.input-group-item.focus {
-	@include border-radius($input-border-radius);
-
-	box-shadow: $input-focus-box-shadow;
-
-	.form-control,
-	.form-control[readonly] ~ .input-group-inset-item,
-	.input-group-inset-item {
-		background-color: $input-focus-bg;
-		border-color: $input-focus-border-color;
-	}
-}
-
-.input-group-item.input-group-prepend.focus {
-	@include border-right-radius(0);
-
-	z-index: 1;
-}
-
-.input-group-item.input-group-append.focus {
-	@include border-left-radius(0);
-}
-
 .input-group-inset {
-	flex-grow: 1;
-	order: 5;
-	width: 1%;
-
-	&[readonly] {
-		&:focus {
-			~ .input-group-inset-item {
-				background-color: $input-readonly-focus-bg;
-				border-color: $input-readonly-focus-border-color;
-				color: $input-readonly-focus-color;
-			}
-		}
-
-		~ .input-group-inset-item {
-			background-color: $input-readonly-bg;
-			border-color: $input-readonly-border-color;
-			color: $input-readonly-color;
-			cursor: $input-readonly-cursor;
-		}
-	}
-
-	&:focus {
-		box-shadow: none;
-
-		~ .input-group-inset-item {
-			background-color: $input-focus-bg;
-			border-color: $input-focus-border-color;
-		}
-	}
-
-	&:disabled {
-		~ .input-group-inset-item {
-			background-color: $input-disabled-bg;
-			border-color: $input-disabled-border-color;
-		}
-	}
+	@include clay-form-control-variant($input-group-inset);
 
 	~ .form-feedback-group {
 		order: 13;
 	}
+}
+
+.input-group-inset[readonly] {
+	@include clay-form-control-variant($input-group-inset-readonly);
 }
 
 .input-group {

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -205,26 +205,65 @@
 /// A mixin to create Form Control variants. You can base your variant off Bootstrap's `.form-control` class or create your own base class (e.g., `<input class="form-control my-custom-form-control" type="text" />` or `<input class="my-custom-form-control" type="text" />`).
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
-/// See Mixin `clay-css` for available keys to pass into the base selector
-/// enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// (
+/// 	enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// 	// .form-control
+/// 	placeholder: (
+/// 		// .form-control::placeholder
+/// 	),
+/// 	selection: (
+/// 		// .form-control::-moz-selection, .form-control::selection
+/// 	),
+/// 	input-group-inset-item: (
+/// 		// .form-control ~ .input-group-inset-item
+/// 	),
+/// 	hover: (
+/// 		// .form-control:hover
+/// 		placeholder: (
+/// 			// .form-control:hover::placeholder
+/// 		),
+/// 		input-group-inset-item: (
+/// 			// .form-control:hover ~ .input-group-inset-item
+/// 		),
+/// 	),
+/// 	focus: (
+/// 		// .form-control:focus, .form-control.focus
+/// 		placeholder: (
+/// 			// .form-control:focus::placeholder,
+/// 			// .form-control.focus::placeholder
+/// 		),
+/// 		input-group-inset-item: (
+/// 			// .form-control:focus ~ .input-group-inset-item,
+/// 			// .form-control.focus ~ .input-group-inset-item
+/// 		),
+/// 	),
+/// 	disabled: (
+/// 		// .form-control:disabled, .form-control.disabled
+/// 		placeholder: (
+/// 			// .form-control:disabled::placeholder,
+/// 			// .form-control.disabled::placeholder
+/// 		),
+/// 		input-group-inset-item: (
+/// 			// .form-control:disabled ~ .input-group-inset-item,
+/// 			// .form-control.disabled ~ .input-group-inset-item
+/// 		),
+/// 	),
+/// )
+/// -=-=-=-=-=- Deprecated -=-=-=-=-=-
 /// placeholder-color: {Color | String | Null}, // deprecated after 3.7.0
 /// placeholder-opacity: {Number | String | Null}, // deprecated after 3.7.0
-/// placeholder: {Map | Null}, // See Mixin `clay-css` for available keys
 /// selection-bg: {Color | String | Null}, // deprecated after 3.7.0
 /// selection-color: {Color | String | Null}, // deprecated after 3.7.0
-/// selection: {Map | Null}, // See Mixin `clay-css` for available keys
 /// hover-bg: {Color | String | Null}, // deprecated after 3.7.0
 /// hover-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
 /// hover-box-shadow: {String | List | Null}, // deprecated after 3.7.0
 /// hover-color: {Color | String | Null}, // deprecated after 3.7.0
 /// hover-placeholder-color: {Color | String | Null}, // deprecated after 3.7.0
-/// hover: {Map | Null}, // See Mixin `clay-css` for available keys
 /// focus-bg: {Color | String | Null}, // deprecated after 3.7.0
 /// focus-bg-image: {String | List | Null}, // deprecated after 3.7.0
 /// focus-border-color: {Color | String | List | Null}, // deprecated after 3.7.0
 /// focus-box-shadow: {String | List | Null}, // deprecated after 3.7.0
 /// focus-color: {Color | String | Null}, // deprecated after 3.7.0
-/// focus: {Map | Null}, // See Mixin `clay-css` for available keys
 /// focus-placeholder-color: {Color | String | Null}, // deprecated after 3.7.0
 /// focus-placeholder: {Map | Null}, // See Mixin `clay-css` for available keys
 /// readonly-bg: {Color | String | Null}, // deprecated after v2.18.0
@@ -242,12 +281,8 @@
 /// disabled-color: {Color | String | Null}, // deprecated after 3.7.0
 /// disabled-cursor: {String | Null}, // deprecated after 3.7.0
 /// disabled-opacity: {Number | String | Null}, // deprecated after 3.7.0
-/// disabled: {Map | Null}, // See Mixin `clay-css` for available keys
 /// disabled-placeholder-color: {Color | String | Null}, // deprecated after 3.7.0
 /// disabled-placeholder: {Map | Null}, // See Mixin `clay-css` for available keys
-/// @todo
-/// - Add @example
-/// - Add @link to documentation
 
 @mixin clay-form-control-variant($map) {
 	@if (type-of($map) == 'map') {
@@ -495,11 +530,21 @@
 				@include clay-css($selection);
 			}
 
+			~ .input-group-inset-item {
+				@include clay-css(map-deep-get($map, input-group-inset-item));
+			}
+
 			&:hover {
 				@include clay-css($hover);
 
 				&::placeholder {
 					@include clay-css($hover-placeholder);
+				}
+
+				~ .input-group-inset-item {
+					@include clay-css(
+						map-deep-get($map, hover, input-group-inset-item)
+					);
 				}
 			}
 
@@ -509,6 +554,12 @@
 
 				&::placeholder {
 					@include clay-css($focus-placeholder);
+				}
+
+				~ .input-group-inset-item {
+					@include clay-css(
+						map-deep-get($map, focus, input-group-inset-item)
+					);
 				}
 			}
 
@@ -542,6 +593,12 @@
 
 				&::placeholder {
 					@include clay-css($disabled-placeholder);
+				}
+
+				~ .input-group-inset-item {
+					@include clay-css(
+						map-deep-get($map, disabled, input-group-inset-item)
+					);
 				}
 			}
 		}

--- a/packages/clay-css/src/scss/mixins/_input-groups.scss
+++ b/packages/clay-css/src/scss/mixins/_input-groups.scss
@@ -98,22 +98,416 @@
 	}
 }
 
-/// A mixin for customizing or creating variants of `input-group-text`.
-/// @deprecated use `clay-container` instead
+/// A mixin to create `input-group-item` variants
 /// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
 /// @example
-/// See Mixin `clay-css` for available keys to pass into the base selector
+/// (
+/// 	enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// 	// .input-group-text
+/// 	label: (
+/// 		// .input-group-text label
+/// 	),
+/// 	custom-control: (
+/// 		// .input-group-text .custom-control
+/// 		//     @include clay-custom-control-variant();
+/// 	),
+/// 	form-check: (
+/// 		// .input-group-text .form-check
+/// 		input: (
+/// 			// .input-group-text .form-check input[type='radio'],
+/// 			// .input-group-text .form-check input[type='checkbox']
+/// 		),
+/// 	),
+/// 	lexicon-icon: (
+/// 		// .input-group-text .lexicon-icon
+/// 	),
+/// 	media-breakpoint-down: (
+/// 		xs: (
+/// 			// @include media-breakpoint-down(xs) {
+/// 			//      @include clay-input-group-text-variant();
+/// 			// }
+/// 		),
+/// 		sm: (
+/// 			// @include media-breakpoint-down(sm) {
+/// 			//      @include clay-input-group-text-variant();
+/// 			// }
+/// 		),
+/// 		md: (
+/// 			// @include media-breakpoint-down(md) {
+/// 			//      @include clay-input-group-text-variant();
+/// 			// }
+/// 		),
+/// 		lg: (
+/// 			// @include media-breakpoint-down(lg) {
+/// 			//      @include clay-input-group-text-variant();
+/// 			// }
+/// 		),
+/// 	),
+/// )
 /// -=-=-=-=-=- Deprecated -=-=-=-=-=-
 /// bg: {Color | String | Null}, // deprecated after 3.9.0
 
 @mixin clay-input-group-text-variant($map) {
-	$base: map-merge(
-		$map,
-		(
-			background-color:
-				setter(map-get($map, bg), map-get($map, background-color)),
-		)
-	);
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
 
-	@include clay-css($base);
+		$base: map-merge(
+			$map,
+			(
+				background-color:
+					setter(map-get($map, bg), map-get($map, background-color)),
+			)
+		);
+
+		@if ($enabled) {
+			@include clay-css($base);
+
+			label {
+				@include clay-css(map-deep-get($map, label));
+			}
+
+			.custom-control {
+				@include clay-custom-control-variant(
+					map-deep-get($map, custom-control)
+				);
+			}
+
+			.form-check {
+				@include clay-css(map-deep-get($map, form-check));
+
+				input[type='radio'],
+				input[type='checkbox'] {
+					@include clay-css(map-deep-get($map, form-check, input));
+				}
+			}
+
+			.lexicon-icon {
+				@include clay-css(map-deep-get($map, lexicon-icon));
+			}
+
+			@if (map-get($map, media-breakpoint-down)) {
+				@each $breakpoint
+					in map-keys(map-get($map, media-breakpoint-down))
+				{
+					$media-breakpoint-down: map-deep-get(
+						$map,
+						media-breakpoint-down,
+						$breakpoint
+					);
+
+					@if ($breakpoint) {
+						@include media-breakpoint-down($breakpoint) {
+							@include clay-input-group-text-variant(
+								$media-breakpoint-down
+							);
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+/// A mixin to create `input-group-item` variants
+/// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
+/// @example
+/// (
+/// 	enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// 	// .input-group-item
+/// 	focus: (
+/// 		// .input-group-item.focus
+/// 		//     @include clay-input-group-item-variant();
+/// 	),
+/// 	first-child: (
+/// 		// .input-group-item:first-child
+/// 	),
+/// 	input-group-prepend: (
+/// 		// .input-group-item.input-group-prepend
+/// 	),
+/// 	input-group-append: (
+/// 		// .input-group-item.input-group-append
+/// 	),
+/// 	btn: (
+/// 		// .input-group-item > .btn
+/// 		//     @include clay-button-variant();
+/// 	),
+/// 	btn-monospaced: (
+/// 		// .input-group-item > .btn-monospaced
+/// 		//     @include clay-button-variant();
+/// 	),
+/// 	dropdown: (
+/// 		// .input-group-item > .dropdown
+/// 	),
+/// 	form-control: (
+/// 		// .input-group-item > .form-control
+/// 		//     @include clay-form-control-variant();
+/// 		label: (
+/// 			// .input-group-item > .form-control .label
+/// 			//     @include clay-label-variant();
+/// 		),
+/// 	),
+/// 	form-file: (
+/// 		// .input-group-item > .form-file
+/// 		btn: (
+/// 			// .input-group-item > .form-file .btn
+/// 			//     @include clay-button-variant();
+/// 		),
+/// 	),
+/// 	textarea: (
+/// 		// .input-group-item > textarea.form-control,
+/// 		// .input-group-item > .form-control-textarea
+/// 		//     @include clay-form-control-variant();
+/// 	),
+/// 	form-control-plaintext: (
+/// 		// .input-group-item > .form-control-plaintext
+/// 		//     @include clay-form-control-variant();
+/// 	),
+/// 	input-group-text: (
+/// 		// .input-group-item > .input-group-text
+/// 		//     @include clay-input-group-text-variant();
+/// 	),
+/// 	input-group-inset-item: (
+/// 		// .input-group-item > .input-group-inset-item
+/// 		btn: (
+/// 			// .input-group-item > .input-group-inset-item > .btn
+/// 			//     @include clay-button-variant();
+/// 		),
+/// 		btn-monospaced: (
+/// 			// .input-group-item > .input-group-inset-item > .btn-monospaced
+/// 			//     @include clay-button-variant();
+/// 		),
+/// 		form-file: (
+/// 			// .input-group-item > .input-group-inset-item > .form-file
+/// 			btn: (
+/// 				// .input-group-item > .input-group-inset-item > .form-file .btn
+/// 				//     @include clay-button-variant();
+/// 			),
+/// 		),
+/// 	),
+/// 	form-control-inset: (
+/// 		// .input-group-item .form-control-inset
+/// 	),
+/// )
+
+@mixin clay-input-group-item-variant($map) {
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
+
+		@if ($enabled) {
+			@include clay-css($map);
+
+			&.focus {
+				@include clay-input-group-item-variant(
+					map-deep-get($map, focus)
+				);
+			}
+
+			&:first-child {
+				@include clay-css(map-deep-get($map, first-child));
+			}
+
+			&.input-group-prepend {
+				@include clay-css(map-deep-get($map, input-group-prepend));
+			}
+
+			&.input-group-append {
+				@include clay-css(map-deep-get($map, input-group-append));
+			}
+
+			> .btn {
+				@include clay-button-variant(map-deep-get($map, btn));
+			}
+
+			> .btn-monospaced {
+				@include clay-button-variant(
+					map-deep-get($map, btn-monospaced)
+				);
+			}
+
+			> .dropdown {
+				@include clay-css(map-deep-get($map, dropdown));
+			}
+
+			> .form-control {
+				@include clay-form-control-variant(
+					map-deep-get($map, form-control)
+				);
+
+				.label {
+					@include clay-label-variant(
+						map-deep-get($map, form-control, label)
+					);
+				}
+			}
+
+			> .form-file {
+				@include clay-css(map-deep-get($map, form-file));
+
+				.btn {
+					@include clay-button-variant(
+						map-deep-get($map, form-file, btn)
+					);
+				}
+			}
+
+			> textarea.form-control,
+			> .form-control-textarea {
+				@include clay-form-control-variant(
+					map-deep-get($map, textarea)
+				);
+			}
+
+			> .form-control-plaintext {
+				@include clay-form-control-variant(
+					map-deep-get($map, form-control-plaintext)
+				);
+			}
+
+			> .input-group-text {
+				@include clay-input-group-text-variant(
+					map-deep-get($map, input-group-text)
+				);
+			}
+
+			> .input-group-inset-item {
+				@include clay-css(map-deep-get($map, input-group-inset-item));
+
+				> .btn {
+					@include clay-button-variant(
+						map-deep-get($map, input-group-inset-item, btn)
+					);
+				}
+
+				> .btn-monospaced {
+					@include clay-button-variant(
+						map-deep-get(
+							$map,
+							input-group-inset-item,
+							btn-monospaced
+						)
+					);
+				}
+
+				> .form-file {
+					@include clay-css(map-deep-get($map, form-file));
+
+					.btn {
+						@include clay-button-variant(
+							map-deep-get($map, form-file, btn)
+						);
+					}
+				}
+			}
+
+			.form-control-inset {
+				@include clay-form-control-variant(
+					map-deep-get($map, form-control-inset)
+				);
+			}
+		}
+	}
+}
+
+/// A mixin to create `input-group` variants
+/// @param {Map} $map - A map of `key: value` pairs. The keys and value types are listed below:
+/// @example
+/// (
+/// 	enabled: {Bool}, // Set to false to prevent mixin styles from being output. Default: true
+/// 	// .input-group
+/// 	input-group-item: (
+/// 		// .input-group > .input-group-item
+/// 		//     @include clay-input-group-item-variant();
+/// 	),
+/// 	input-group-item-shrink: (
+/// 		// .input-group > .input-group-item-shrink
+/// 		//     @include clay-input-group-item-variant();
+/// 	),
+/// 	btn-primary: (
+/// 		// .input-group .btn-primary
+/// 		//     @include clay-button-variant();
+/// 	),
+/// 	btn-secondary: (
+/// 		// .input-group .btn-secondary
+/// 		//     @include clay-button-variant();
+/// 	),
+/// 	btn-unstyled: (
+/// 		// .input-group .btn-unstyled
+/// 		//     @include clay-button-variant();
+/// 	),
+/// 	media-breakpoint-down: (
+/// 		xs: (
+/// 			// @include media-breakpoint-down(xs) {
+/// 			//     @include clay-input-group-variant();
+/// 			// }
+/// 		),
+/// 		sm: (
+/// 			// @include media-breakpoint-down(sm) {
+/// 			//     @include clay-input-group-variant();
+/// 			// }
+/// 		),
+/// 		md: (
+/// 			// @include media-breakpoint-down(md) {
+/// 			//     @include clay-input-group-variant();
+/// 			// }
+/// 		),
+/// 		lg: (
+/// 			// @include media-breakpoint-down(lg) {
+/// 			//     @include clay-input-group-variant();
+/// 			// }
+/// 		),
+/// 	),
+/// )
+
+@mixin clay-input-group-variant($map) {
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
+
+		@if ($enabled) {
+			@include clay-css($map);
+
+			> .input-group-item {
+				@include clay-input-group-item-variant(
+					map-deep-get($map, input-group-item)
+				);
+			}
+
+			> .input-group-item-shrink {
+				@include clay-input-group-item-variant(
+					map-deep-get($map, input-group-item-shrink)
+				);
+			}
+
+			.btn-primary {
+				@include clay-button-variant(map-deep-get($map, btn-primary));
+			}
+
+			.btn-secondary {
+				@include clay-button-variant(map-deep-get($map, btn-secondary));
+			}
+
+			.btn-unstyled {
+				@include clay-button-variant(map-deep-get($map, btn-unstyled));
+			}
+
+			@if (map-get($map, media-breakpoint-down)) {
+				@each $breakpoint
+					in map-keys(map-get($map, media-breakpoint-down))
+				{
+					$media-breakpoint-down: map-deep-get(
+						$map,
+						media-breakpoint-down,
+						$breakpoint
+					);
+
+					@if ($breakpoint) {
+						@include media-breakpoint-down($breakpoint) {
+							@include clay-input-group-variant(
+								$media-breakpoint-down
+							);
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -323,358 +323,382 @@
 /// link-hover: {Map | Null}, // deprecated after 3.38.0
 
 @mixin clay-label-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
 
-	$base: setter($map, ());
-	$base: map-merge(
-		$base,
-		(
-			background-color:
-				setter(map-get($map, bg), map-get($base, background-color)),
-			padding-bottom:
-				setter(map-get($map, padding-y), map-get($base, padding-bottom)),
-			padding-left:
-				setter(map-get($map, padding-x), map-get($base, padding-left)),
-			padding-right:
-				setter(map-get($map, padding-x), map-get($base, padding-right)),
-			padding-top:
-				setter(map-get($map, padding-y), map-get($base, padding-top)),
-		)
-	);
+		$base: setter($map, ());
+		$base: map-merge(
+			$base,
+			(
+				background-color:
+					setter(map-get($map, bg), map-get($base, background-color)),
+				padding-bottom:
+					setter(
+						map-get($map, padding-y),
+						map-get($base, padding-bottom)
+					),
+				padding-left:
+					setter(
+						map-get($map, padding-x),
+						map-get($base, padding-left)
+					),
+				padding-right:
+					setter(
+						map-get($map, padding-x),
+						map-get($base, padding-right)
+					),
+				padding-top:
+					setter(
+						map-get($map, padding-y),
+						map-get($base, padding-top)
+					),
+			)
+		);
 
-	$disabled: setter(map-get($map, disabled), ());
-	$disabled: map-merge(
-		$disabled,
-		(
-			background-color:
-				setter(
-					map-get($map, disabled-bg),
-					map-get($disabled, background-color)
-				),
-			border-color:
-				setter(
-					map-get($map, disabled-border-color),
-					map-get($disabled, border-color)
-				),
-			box-shadow:
-				setter(
-					map-get($map, disabled-box-shadow),
-					map-get($disabled, box-shadow)
-				),
-			color:
-				setter(map-get($map, disabled-color), map-get($disabled, color)),
-		)
-	);
-
-	$href: setter(map-get($map, href), ());
-	$href: map-deep-merge(
-		$href,
-		(
-			hover: (
+		$disabled: setter(map-get($map, disabled), ());
+		$disabled: map-merge(
+			$disabled,
+			(
 				background-color:
 					setter(
-						map-get($map, hover-bg),
-						map-deep-get($map, hover, background-color),
-						map-deep-get($href, hover, background-color)
+						map-get($map, disabled-bg),
+						map-get($disabled, background-color)
 					),
 				border-color:
 					setter(
-						map-get($map, hover-border-color),
-						map-deep-get($map, hover, border-color),
-						map-deep-get($href, hover, border-color)
-					),
-				color:
-					setter(
-						map-get($map, hover-color),
-						map-deep-get($map, hover, color),
-						map-deep-get($href, hover, color)
-					),
-				text-decoration:
-					setter(
-						map-get($map, hover-text-decoration),
-						map-deep-get($map, hover, text-decoration),
-						map-deep-get($href, hover, text-decoration)
-					),
-			),
-			focus: (
-				background-color:
-					setter(
-						map-get($map, focus-bg),
-						map-deep-get($map, focus, background-color),
-						map-deep-get($href, focus, background-color)
-					),
-				border-color:
-					setter(
-						map-get($map, focus-border-color),
-						map-deep-get($map, focus, border-color),
-						map-deep-get($href, focus, border-color)
+						map-get($map, disabled-border-color),
+						map-get($disabled, border-color)
 					),
 				box-shadow:
 					setter(
-						map-get($map, focus-box-shadow),
-						map-deep-get($map, focus, box-shadow),
-						map-deep-get($href, focus, box-shadow)
+						map-get($map, disabled-box-shadow),
+						map-get($disabled, box-shadow)
 					),
 				color:
 					setter(
-						map-get($map, focus-color),
-						map-deep-get($map, focus, color),
-						map-deep-get($href, focus, color)
+						map-get($map, disabled-color),
+						map-get($disabled, color)
 					),
-				outline:
-					setter(
-						map-get($map, focus-outline),
-						map-deep-get($map, focus, outline),
-						map-deep-get($href, focus, outline)
-					),
-				text-decoration:
-					setter(
-						map-get($map, focus-text-decoration),
-						map-deep-get($map, focus, text-decoration),
-						map-deep-get($href, focus, text-decoration)
-					),
-			),
-		)
-	);
+			)
+		);
 
-	$lexicon-icon: setter(map-get($map, lexicon-icon), ());
-	$lexicon-icon: map-merge(
-		$lexicon-icon,
-		(
-			height:
-				setter(
-					map-get($map, lexicon-icon-height),
-					map-get($lexicon-icon, height),
-					map-get($lexicon-icon, width)
+		$href: setter(map-get($map, href), ());
+		$href: map-deep-merge(
+			$href,
+			(
+				hover: (
+					background-color:
+						setter(
+							map-get($map, hover-bg),
+							map-deep-get($map, hover, background-color),
+							map-deep-get($href, hover, background-color)
+						),
+					border-color:
+						setter(
+							map-get($map, hover-border-color),
+							map-deep-get($map, hover, border-color),
+							map-deep-get($href, hover, border-color)
+						),
+					color:
+						setter(
+							map-get($map, hover-color),
+							map-deep-get($map, hover, color),
+							map-deep-get($href, hover, color)
+						),
+					text-decoration:
+						setter(
+							map-get($map, hover-text-decoration),
+							map-deep-get($map, hover, text-decoration),
+							map-deep-get($href, hover, text-decoration)
+						),
 				),
-			margin-top:
-				setter(
-					map-get($map, lexicon-icon-margin-top),
-					map-get($lexicon-icon, margin-top)
+				focus: (
+					background-color:
+						setter(
+							map-get($map, focus-bg),
+							map-deep-get($map, focus, background-color),
+							map-deep-get($href, focus, background-color)
+						),
+					border-color:
+						setter(
+							map-get($map, focus-border-color),
+							map-deep-get($map, focus, border-color),
+							map-deep-get($href, focus, border-color)
+						),
+					box-shadow:
+						setter(
+							map-get($map, focus-box-shadow),
+							map-deep-get($map, focus, box-shadow),
+							map-deep-get($href, focus, box-shadow)
+						),
+					color:
+						setter(
+							map-get($map, focus-color),
+							map-deep-get($map, focus, color),
+							map-deep-get($href, focus, color)
+						),
+					outline:
+						setter(
+							map-get($map, focus-outline),
+							map-deep-get($map, focus, outline),
+							map-deep-get($href, focus, outline)
+						),
+					text-decoration:
+						setter(
+							map-get($map, focus-text-decoration),
+							map-deep-get($map, focus, text-decoration),
+							map-deep-get($href, focus, text-decoration)
+						),
 				),
-			width:
-				setter(
-					map-get($map, lexicon-icon-width),
-					map-get($lexicon-icon, width)
-				),
-		)
-	);
+			)
+		);
 
-	$label-item: setter(map-get($map, label-item), ());
-	$label-item: map-merge(
-		$label-item,
-		(
-			margin-bottom:
-				setter(
-					map-get($map, item-spacer-y),
-					map-get($label-item, margin-bottom)
-				),
-			margin-top:
-				setter(
-					map-get($map, item-spacer-y),
-					map-get($label-item, margin-top)
-				),
-			lexicon-icon: (
+		$lexicon-icon: setter(map-get($map, lexicon-icon), ());
+		$lexicon-icon: map-merge(
+			$lexicon-icon,
+			(
 				height:
 					setter(
 						map-get($map, lexicon-icon-height),
 						map-get($lexicon-icon, height),
-						map-get($lexicon-icon, width),
-						map-deep-get($label-item, lexicon-icon, height),
-						map-deep-get($label-item, lexicon-icon, width)
+						map-get($lexicon-icon, width)
 					),
 				margin-top:
 					setter(
 						map-get($map, lexicon-icon-margin-top),
-						map-get($lexicon-icon, margin-top),
-						map-deep-get($label-item, lexicon-icon, margin-top)
+						map-get($lexicon-icon, margin-top)
 					),
 				width:
 					setter(
 						map-get($map, lexicon-icon-width),
-						map-get($lexicon-icon, width),
-						map-deep-get($label-item, lexicon-icon, width)
+						map-get($lexicon-icon, width)
 					),
-			),
-		)
-	);
+			)
+		);
 
-	$label-item-before: setter(map-get($map, label-item-before), ());
-	$label-item-before: map-merge(
-		$label-item-before,
-		(
-			margin-right:
-				setter(
-					map-get($map, item-spacer-x),
-					map-get($label-item-before, margin-right)
-				),
-		)
-	);
-
-	$label-item-after: setter(map-get($map, label-item-after), ());
-	$label-item-after: map-merge(
-		$label-item-after,
-		(
-			margin-left:
-				setter(
-					map-get($map, item-spacer-x),
-					map-get($label-item-after, margin-left)
-				),
-		)
-	);
-
-	$link: setter(map-get($map, link), ());
-	$link: map-deep-merge(
-		$link,
-		(
-			color: setter(map-get($map, link-color), map-get($link, color)),
-			text-decoration:
-				setter(
-					map-get($map, link-text-decoration),
-					map-get($link, text-decoration)
-				),
-			hover: (
-				color:
+		$label-item: setter(map-get($map, label-item), ());
+		$label-item: map-merge(
+			$label-item,
+			(
+				margin-bottom:
 					setter(
-						map-get($map, link-hover-color),
-						map-deep-get($link, hover, color)
+						map-get($map, item-spacer-y),
+						map-get($label-item, margin-bottom)
 					),
+				margin-top:
+					setter(
+						map-get($map, item-spacer-y),
+						map-get($label-item, margin-top)
+					),
+				lexicon-icon: (
+					height:
+						setter(
+							map-get($map, lexicon-icon-height),
+							map-get($lexicon-icon, height),
+							map-get($lexicon-icon, width),
+							map-deep-get($label-item, lexicon-icon, height),
+							map-deep-get($label-item, lexicon-icon, width)
+						),
+					margin-top:
+						setter(
+							map-get($map, lexicon-icon-margin-top),
+							map-get($lexicon-icon, margin-top),
+							map-deep-get($label-item, lexicon-icon, margin-top)
+						),
+					width:
+						setter(
+							map-get($map, lexicon-icon-width),
+							map-get($lexicon-icon, width),
+							map-deep-get($label-item, lexicon-icon, width)
+						),
+				),
+			)
+		);
+
+		$label-item-before: setter(map-get($map, label-item-before), ());
+		$label-item-before: map-merge(
+			$label-item-before,
+			(
+				margin-right:
+					setter(
+						map-get($map, item-spacer-x),
+						map-get($label-item-before, margin-right)
+					),
+			)
+		);
+
+		$label-item-after: setter(map-get($map, label-item-after), ());
+		$label-item-after: map-merge(
+			$label-item-after,
+			(
+				margin-left:
+					setter(
+						map-get($map, item-spacer-x),
+						map-get($label-item-after, margin-left)
+					),
+			)
+		);
+
+		$link: setter(map-get($map, link), ());
+		$link: map-deep-merge(
+			$link,
+			(
+				color: setter(map-get($map, link-color), map-get($link, color)),
 				text-decoration:
 					setter(
-						map-get($map, link-hover-text-decoration),
-						map-deep-get($link, hover, text-decoration)
+						map-get($map, link-text-decoration),
+						map-get($link, text-decoration)
 					),
-			),
-		)
-	);
-
-	$close: setter(map-get($map, close), ());
-
-	$sticker: setter(map-get($map, sticker), ());
-	$sticker: map-merge(
-		$sticker,
-		(
-			border-radius:
-				setter(
-					map-get($map, sticker-border-radius),
-					map-get($sticker, border-radius)
+				hover: (
+					color:
+						setter(
+							map-get($map, link-hover-color),
+							map-deep-get($link, hover, color)
+						),
+					text-decoration:
+						setter(
+							map-get($map, link-hover-text-decoration),
+							map-deep-get($link, hover, text-decoration)
+						),
 				),
-			height:
-				setter(map-get($map, sticker-size), map-get($sticker, height)),
-			line-height:
-				setter(
-					map-get($map, sticker-size),
-					map-get($sticker, line-height)
-				),
-			width: setter(map-get($map, sticker-size), map-get($sticker, width)),
-		)
-	);
+			)
+		);
 
-	$sticker-overlay: setter(map-get($map, sticker-overlay), ());
-	$sticker-overlay: map-merge(
-		$sticker-overlay,
-		(
-			border-radius:
-				setter(
-					map-get($sticker-overlay, border-radius),
-					map-get($sticker, border-radius)
-				),
-		)
-	);
+		$close: setter(map-get($map, close), ());
 
-	$c-inner: setter(map-get($map, c-inner), ());
-	$c-inner: map-deep-merge(
-		$c-inner,
-		(
-			enabled:
-				setter(
-					if(
-						variable-exists(enable-c-inner),
-						$enable-c-inner,
+		$sticker: setter(map-get($map, sticker), ());
+		$sticker: map-merge(
+			$sticker,
+			(
+				border-radius:
+					setter(
+						map-get($map, sticker-border-radius),
+						map-get($sticker, border-radius)
+					),
+				height:
+					setter(
+						map-get($map, sticker-size),
+						map-get($sticker, height)
+					),
+				line-height:
+					setter(
+						map-get($map, sticker-size),
+						map-get($sticker, line-height)
+					),
+				width:
+					setter(
+						map-get($map, sticker-size),
+						map-get($sticker, width)
+					),
+			)
+		);
+
+		$sticker-overlay: setter(map-get($map, sticker-overlay), ());
+		$sticker-overlay: map-merge(
+			$sticker-overlay,
+			(
+				border-radius:
+					setter(
+						map-get($sticker-overlay, border-radius),
+						map-get($sticker, border-radius)
+					),
+			)
+		);
+
+		$c-inner: setter(map-get($map, c-inner), ());
+		$c-inner: map-deep-merge(
+			$c-inner,
+			(
+				enabled:
+					setter(
 						if(
-							variable-exists(cadmin-enable-c-inner),
-							$cadmin-enable-c-inner,
-							true
+							variable-exists(enable-c-inner),
+							$enable-c-inner,
+							if(
+								variable-exists(cadmin-enable-c-inner),
+								$cadmin-enable-c-inner,
+								true
+							)
 						)
-					)
-				),
-			margin-bottom:
-				setter(
-					map-get($c-inner, margin-bottom),
-					math-sign(map-get($base, padding-bottom))
-				),
-			margin-left:
-				setter(
-					map-get($c-inner, margin-left),
-					math-sign(map-get($base, padding-left))
-				),
-			margin-right:
-				setter(
-					map-get($c-inner, margin-right),
-					math-sign(map-get($base, padding-right))
-				),
-			margin-top:
-				setter(
-					map-get($c-inner, margin-top),
-					math-sign(map-get($base, padding-top))
-				),
-		)
-	);
+					),
+				margin-bottom:
+					setter(
+						map-get($c-inner, margin-bottom),
+						math-sign(map-get($base, padding-bottom))
+					),
+				margin-left:
+					setter(
+						map-get($c-inner, margin-left),
+						math-sign(map-get($base, padding-left))
+					),
+				margin-right:
+					setter(
+						map-get($c-inner, margin-right),
+						math-sign(map-get($base, padding-right))
+					),
+				margin-top:
+					setter(
+						map-get($c-inner, margin-top),
+						math-sign(map-get($base, padding-top))
+					),
+			)
+		);
 
-	@if ($enabled) {
-		@include clay-css($base);
+		@if ($enabled) {
+			@include clay-css($base);
 
-		&:disabled,
-		&.disabled {
-			@include clay-css($disabled);
-		}
+			&:disabled,
+			&.disabled {
+				@include clay-css($disabled);
+			}
 
-		&[href],
-		&[type],
-		&[tabindex] {
-			@include clay-link($href);
-		}
-
-		.lexicon-icon {
-			@include clay-css($lexicon-icon);
-		}
-
-		.label-item {
-			@include clay-css($label-item);
+			&[href],
+			&[type],
+			&[tabindex] {
+				@include clay-link($href);
+			}
 
 			.lexicon-icon {
 				@include clay-css($lexicon-icon);
 			}
-		}
 
-		.label-item-before {
-			@include clay-css($label-item-before);
-		}
+			.label-item {
+				@include clay-css($label-item);
 
-		.label-item-after {
-			@include clay-css($label-item-after);
-		}
+				.lexicon-icon {
+					@include clay-css($lexicon-icon);
+				}
+			}
 
-		a,
-		.btn-unstyled {
-			@include clay-link($link);
-		}
+			.label-item-before {
+				@include clay-css($label-item-before);
+			}
 
-		.close {
-			@include clay-close($close);
-		}
+			.label-item-after {
+				@include clay-css($label-item-after);
+			}
 
-		.sticker {
-			@include clay-css($sticker);
-		}
+			a,
+			.btn-unstyled {
+				@include clay-link($link);
+			}
 
-		.sticker-overlay {
-			@include clay-css($sticker-overlay);
-		}
+			.close {
+				@include clay-close($close);
+			}
 
-		@if (map-get($c-inner, enabled)) {
-			> .c-inner {
-				@include clay-css($c-inner);
+			.sticker {
+				@include clay-css($sticker);
+			}
+
+			.sticker-overlay {
+				@include clay-css($sticker-overlay);
+			}
+
+			@if (map-get($c-inner, enabled)) {
+				> .c-inner {
+					@include clay-css($c-inner);
+				}
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -1195,7 +1195,24 @@ $input-select-multiple: map-deep-merge(
 $form-group-item-label-max-width: 12.5rem !default; // 200px
 $form-group-item-label-spacer: 2rem !default; // 32px
 
-// Input Group
+// .input-group
+
+$input-group: () !default;
+$input-group: map-deep-merge(
+	(
+		align-items: stretch,
+		display: flex,
+		flex-wrap: wrap,
+		position: relative,
+		width: 100%,
+		btn-unstyled: (
+			color: inherit,
+		),
+	),
+	$input-group
+);
+
+// .input-group-text
 
 $input-group-addon-bg: $gray-200 !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -1205,16 +1222,139 @@ $input-group-addon-min-width: 2.375rem !default; // 38px
 $input-group-addon-padding-x: $input-padding-x !default;
 $input-group-addon-padding-y: $input-padding-y !default;
 
-// Input Group Secondary
+$input-group-text: () !default;
+$input-group-text: map-deep-merge(
+	(
+		align-items: center,
+		background-color: $input-group-addon-bg,
+		border-bottom-width: $input-border-bottom-width,
+		border-color: $input-group-addon-border-color,
+		border-left-width: $input-border-left-width,
+		border-radius: clay-enable-rounded($input-border-radius),
+		border-right-width: $input-border-right-width,
+		border-style: solid,
+		border-top-width: $input-border-top-width,
+		color: $input-group-addon-color,
+		display: flex,
+		font-size: $input-font-size,
+		font-weight: $input-group-addon-font-weight,
+		height: $input-height,
+		justify-content: center,
+		line-height: $input-line-height,
+		margin-bottom: 0,
+		min-width: $input-group-addon-min-width,
+		padding-bottom: $input-group-addon-padding-y,
+		padding-left: $input-group-addon-padding-x,
+		padding-right: $input-group-addon-padding-x,
+		padding-top: $input-group-addon-padding-y,
+		text-align: center,
+		white-space: nowrap,
+		label: (
+			color: $input-group-addon-color,
+		),
+		custom-control: (
+			margin-bottom: 0,
+		),
+		form-check: (
+			margin-bottom: 0,
+			input: (
+				margin-top: 0,
+			),
+		),
+		lexicon-icon: (
+			margin-top: 0,
+		),
+		media-breakpoint-down: (
+			sm: (
+				height: $input-height-mobile,
+			),
+		),
+	),
+	$input-group-text
+);
+
+// .input-group-text-secondary
 
 $input-group-secondary-addon-bg: $secondary !default;
 $input-group-secondary-addon-border-color: $secondary !default;
 $input-group-secondary-addon-border-width: 0.0625rem !default; // 1px
 $input-group-secondary-addon-color: $white !default;
 
-// Input Group Item
+$input-group-text-secondary: () !default;
+$input-group-text-secondary: map-deep-merge(
+	(
+		background-color: $input-group-secondary-addon-bg,
+		border-color: $input-group-secondary-addon-border-color,
+		border-width: $input-group-secondary-addon-border-width,
+		color: $input-group-secondary-addon-color,
+		z-index: 2,
+		label: (
+			color: $input-group-secondary-addon-color,
+		),
+	),
+	$input-group-text-secondary
+);
+
+// .input-group-item
 
 $input-group-item-margin-left: 0.5rem !default;
+
+$input-group-item: () !default;
+$input-group-item: map-deep-merge(
+	(
+		display: flex,
+		flex-grow: 1,
+		flex-wrap: wrap,
+		margin-left: $input-group-item-margin-left,
+		width: 1%,
+		word-wrap: break-word,
+		focus: (
+			border-radius: clay-enable-rounded($input-border-radius),
+			box-shadow: $input-focus-box-shadow,
+			input-group-prepend: (
+				border-bottom-right-radius: clay-enable-rounded(0),
+				border-top-right-radius: clay-enable-rounded(0),
+				z-index: 1,
+			),
+			input-group-append: (
+				border-bottom-left-radius: clay-enable-rounded(0),
+				border-top-left-radius: clay-enable-rounded(0),
+			),
+			form-control: (
+				background-color: $input-focus-bg,
+				border-color: $input-focus-border-color,
+			),
+			input-group-inset-item: (
+				background-color: $input-focus-bg,
+				border-color: $input-focus-border-color,
+			),
+		),
+		first-child: (
+			margin-left: 0,
+		),
+		btn: (
+			align-self: flex-start,
+		),
+		dropdown: (
+			display: flex,
+			flex-wrap: wrap,
+			word-wrap: break-word,
+			width: 100%,
+		),
+	),
+	$input-group-item
+);
+
+// .input-group-item-shrink
+
+$input-group-item-shrink: () !default;
+$input-group-item-shrink: map-deep-merge(
+	(
+		flex-grow: 0,
+		width: auto,
+	),
+	$input-group-item-shrink
+);
 
 // Input Group Inset
 
@@ -1270,7 +1410,7 @@ $input-group-inset-form-file-btn: map-deep-merge(
 	$input-group-inset-form-file-btn
 );
 
-// Input Group Lg
+// .input-group-lg
 
 $input-group-addon-min-width-lg: 3rem !default; // 48px
 $input-group-addon-padding-x-lg: $input-padding-x-lg !default;
@@ -1281,13 +1421,24 @@ $input-group-lg-item-btn: map-deep-merge(
 	(
 		breakpoint-down: null,
 		font-size: $btn-font-size-lg,
-		inline-item-font-size: $btn-inline-item-font-size-lg,
-		section-font-size: $btn-section-font-size-lg,
-		font-size-mobile: $btn-font-size-lg-mobile,
-		padding-bottom-mobile: $btn-padding-y-lg-mobile,
-		padding-left-mobile: $btn-padding-x-lg-mobile,
-		padding-right-mobile: $btn-padding-x-lg-mobile,
-		padding-top-mobile: $btn-padding-y-lg-mobile,
+		line-height: map-get($btn-lg, line-height),
+		padding-bottom: map-get($btn-lg, padding-bottom),
+		padding-left: map-get($btn-lg, padding-left),
+		padding-right: map-get($btn-lg, padding-right),
+		padding-top: map-get($btn-lg, padding-top),
+		inline-item: (
+			font-size: $btn-inline-item-font-size-lg,
+		),
+		btn-section: (
+			font-size: $btn-section-font-size-lg,
+		),
+		mobile: (
+			font-size: $btn-font-size-lg-mobile,
+			padding-bottom: $btn-padding-y-lg-mobile,
+			padding-left: $btn-padding-x-lg-mobile,
+			padding-right: $btn-padding-x-lg-mobile,
+			padding-top: $btn-padding-y-lg-mobile,
+		),
 	),
 	$input-group-lg-item-btn
 );
@@ -1303,8 +1454,10 @@ $input-group-lg-item-btn-monospaced: map-deep-merge(
 		padding-right: $btn-monospaced-padding-x-lg,
 		padding-top: $btn-monospaced-padding-y-lg,
 		width: $btn-monospaced-size-lg,
-		height-mobile: $btn-monospaced-size-lg-mobile,
-		width-mobile: $btn-monospaced-size-lg-mobile,
+		mobile: (
+			height: $btn-monospaced-size-lg-mobile,
+			width: $btn-monospaced-size-lg-mobile,
+		),
 	),
 	$input-group-lg-item-btn-monospaced
 );
@@ -1327,6 +1480,89 @@ $input-group-lg-inset-item-form-file-btn: map-deep-merge(
 	$input-group-lg-inset-item-form-file-btn
 );
 
+$input-group-lg: () !default;
+$input-group-lg: map-deep-merge(
+	(
+		input-group-item: (
+			btn: $input-group-lg-item-btn,
+			btn-monospaced: $input-group-lg-item-btn-monospaced,
+			form-control: (
+				border-radius: clay-enable-rounded($input-border-radius-lg),
+				font-size: $input-font-size-lg,
+				height: auto,
+				line-height: $input-line-height-lg,
+				min-height: $input-height-lg,
+				padding-bottom: $input-padding-y-lg,
+				padding-left: $input-padding-x-lg,
+				padding-right: $input-padding-x-lg,
+				padding-top: $input-padding-y-lg,
+			),
+			form-control-inset: (
+				margin-bottom: 0,
+				margin-top: 0,
+			),
+			form-file: (
+				btn: (
+					border-radius: clay-enable-rounded($input-border-radius-lg),
+					font-size: $input-font-size-lg,
+					height: $input-height-lg,
+					line-height: $input-line-height-lg,
+					padding-bottom: $input-padding-y-lg,
+					padding-left: $input-padding-x-lg,
+					padding-right: $input-padding-x-lg,
+					padding-top: $input-padding-y-lg,
+				),
+			),
+			textarea: (
+				height: $input-textarea-height-lg,
+			),
+			form-control-plaintext: (
+				font-size: $input-font-size-lg,
+				height: $input-height-lg,
+				line-height: $input-line-height-lg,
+				padding-bottom: $input-padding-y-lg,
+				padding-top: $input-padding-y-lg,
+			),
+			input-group-text: (
+				border-radius: clay-enable-rounded($input-border-radius-lg),
+				font-size: $input-font-size-lg,
+				height: $input-height-lg,
+				min-width: $input-group-addon-min-width-lg,
+				padding-bottom: $input-group-addon-padding-y-lg,
+				padding-left: $input-group-addon-padding-x-lg,
+				padding-right: $input-group-addon-padding-x-lg,
+				padding-top: $input-group-addon-padding-y-lg,
+			),
+			input-group-inset-item: (
+				btn: $input-group-lg-inset-item-btn,
+				btn-monospaced: $input-group-lg-inset-item-btn-monospaced,
+				form-file: (
+					height: 75%,
+					btn: $input-group-lg-inset-item-form-file-btn,
+				),
+			),
+		),
+		media-breakpoint-down: (
+			sm: (
+				input-group-item: (
+					form-control: (
+						height: $input-height-lg-mobile,
+					),
+					form-file: (
+						btn: (
+							height: $input-height-lg-mobile,
+						),
+					),
+					form-control-plaintext: (
+						height: $input-height-lg-mobile,
+					),
+				),
+			),
+		),
+	),
+	$input-group-lg
+);
+
 // Input Group Sm
 
 $input-group-addon-min-width-sm: 1.9375rem !default; // 31px
@@ -1337,13 +1573,24 @@ $input-group-sm-item-btn: () !default;
 $input-group-sm-item-btn: map-deep-merge(
 	(
 		font-size: $btn-font-size-sm,
-		inline-item-font-size: $btn-inline-item-font-size-sm,
-		section-font-size: $btn-section-font-size-sm,
-		font-size-mobile: $btn-font-size-sm-mobile,
-		padding-bottom-mobile: $btn-padding-y-sm-mobile,
-		padding-left-mobile: $btn-padding-x-sm-mobile,
-		padding-right-mobile: $btn-padding-x-sm-mobile,
-		padding-top-mobile: $btn-padding-y-sm-mobile,
+		line-height: map-get($btn-sm, line-height),
+		padding-bottom: map-get($btn-sm, padding-bottom),
+		padding-left: map-get($btn-sm, padding-left),
+		padding-right: map-get($btn-sm, padding-right),
+		padding-top: map-get($btn-sm, padding-top),
+		inline-item: (
+			font-size: $btn-inline-item-font-size-sm,
+		),
+		btn-section: (
+			font-size: $btn-section-font-size-sm,
+		),
+		mobile: (
+			font-size: $btn-font-size-sm-mobile,
+			padding-bottom: $btn-padding-y-sm-mobile,
+			padding-left: $btn-padding-x-sm-mobile,
+			padding-right: $btn-padding-x-sm-mobile,
+			padding-top: $btn-padding-y-sm-mobile,
+		),
 	),
 	$input-group-sm-item-btn
 );
@@ -1358,8 +1605,10 @@ $input-group-sm-item-btn-monospaced: map-deep-merge(
 		padding-right: $btn-monospaced-padding-x-sm,
 		padding-top: $btn-monospaced-padding-y-sm,
 		width: $btn-monospaced-size-sm,
-		height-mobile: $btn-monospaced-size-sm-mobile,
-		width-mobile: $btn-monospaced-size-sm-mobile,
+		mobile: (
+			height: $btn-monospaced-size-sm-mobile,
+			width: $btn-monospaced-size-sm-mobile,
+		),
 	),
 	$input-group-sm-item-btn-monospaced
 );
@@ -1398,6 +1647,140 @@ $input-group-sm-inset-item-form-file-btn: map-deep-merge(
 		padding-top: 0,
 	),
 	$input-group-sm-inset-item-form-file-btn
+);
+
+$input-group-sm: () !default;
+$input-group-sm: map-deep-merge(
+	(
+		input-group-item: (
+			btn: $input-group-sm-item-btn,
+			btn-monospaced: $input-group-sm-item-btn-monospaced,
+			form-control: (
+				border-radius: clay-enable-rounded($input-border-radius-sm),
+				font-size: $input-font-size-sm,
+				height: auto,
+				line-height: $input-line-height-sm,
+				min-height: $input-height-sm,
+				padding-bottom: 0,
+				padding-left: $input-padding-x-sm,
+				padding-right: $input-padding-x-sm,
+				padding-top: 0,
+				label: (
+					margin-bottom: 0.1875rem,
+					margin-top: 0.1875rem,
+				),
+			),
+			form-control-inset: (
+				margin-bottom: 0.125rem,
+				margin-top: 0.1875rem,
+			),
+			form-file: (
+				btn: (
+					border-radius: clay-enable-rounded($input-border-radius-sm),
+					font-size: $input-font-size-sm,
+					height: $input-height-sm,
+					line-height: $input-line-height-sm,
+					padding-bottom: $input-padding-y-sm,
+					padding-left: $input-padding-x-sm,
+					padding-right: $input-padding-x-sm,
+					padding-top: $input-padding-y-sm,
+				),
+			),
+			form-control-plaintext: (
+				font-size: $input-font-size-sm,
+				height: $input-height-sm,
+				line-height: $input-line-height-sm,
+				padding-bottom: $input-padding-y-sm,
+				padding-top: $input-padding-y-sm,
+			),
+			textarea: (
+				height: $input-textarea-height-sm,
+			),
+			input-group-text: (
+				border-radius: clay-enable-rounded($input-border-radius-sm),
+				font-size: $input-font-size-sm,
+				height: $input-height-sm,
+				min-width: $input-group-addon-min-width-sm,
+				padding-bottom: $input-group-addon-padding-y-sm,
+				padding-left: $input-group-addon-padding-x-sm,
+				padding-right: $input-group-addon-padding-x-sm,
+				padding-top: $input-group-addon-padding-y-sm,
+			),
+			input-group-inset-item: (
+				btn: $input-group-sm-inset-item-btn,
+				btn-monospaced: $input-group-sm-inset-item-btn-monospaced,
+				form-file: (
+					height: 75%,
+					btn: $input-group-sm-inset-item-form-file-btn,
+				),
+			),
+		),
+		media-breakpoint-down: (
+			sm: (
+				input-group-item: (
+					form-control: (
+						height: $input-height-sm-mobile,
+					),
+					form-file: (
+						btn: (
+							height: $input-height-sm-mobile,
+						),
+					),
+					form-control-plaintext: (
+						height: $input-height-sm-mobile,
+					),
+				),
+			),
+		),
+	),
+	$input-group-sm
+);
+
+// .input-group-inset
+
+$input-group-inset: () !default;
+$input-group-inset: map-deep-merge(
+	(
+		flex-grow: 1,
+		order: 5,
+		width: 1%,
+		focus: (
+			box-shadow: none,
+			input-group-inset-item: (
+				background-color: $input-focus-bg,
+				border-color: $input-focus-border-color,
+			),
+		),
+		disabled: (
+			input-group-inset-item: (
+				background-color: $input-disabled-bg,
+				border-color: $input-disabled-border-color,
+			),
+		),
+	),
+	$input-group-inset
+);
+
+// .input-group-inset[readonly]
+
+$input-group-inset-readonly: () !default;
+$input-group-inset-readonly: map-deep-merge(
+	(
+		input-group-inset-item: (
+			background-color: $input-readonly-bg,
+			border-color: $input-readonly-border-color,
+			color: $input-readonly-color,
+			cursor: $input-readonly-cursor,
+		),
+		focus: (
+			input-group-inset-item: (
+				background-color: $input-readonly-focus-bg,
+				border-color: $input-readonly-focus-border-color,
+				color: $input-readonly-focus-color,
+			),
+		),
+	),
+	$input-group-inset-readonly
 );
 
 // Input Group Stacked


### PR DESCRIPTION
fixes #4514 

This converts most `input-group` to the Clay mixin pattern.