### PR TITLE
chore(@clayui/core): update react-dnd and react-dnd-html5-backend

### DIFF
--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -35,8 +35,8 @@
 		"@clayui/provider": "^3.40.0",
 		"@clayui/shared": "^3.40.0",
 		"classnames": "^2.2.6",
-		"react-dnd": "^10.0.2",
-		"react-dnd-html5-backend": "^10.0.2",
+		"react-dnd": "^11.1.1",
+		"react-dnd-html5-backend": "^11.1.1",
 		"react-transition-group": "^4.4.1"
 	},
 	"peerDependencies": {

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -7,7 +7,7 @@ import {FocusScope} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useRef} from 'react';
 import {DndProvider} from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {ChildrenFunction, Collection, ICollectionProps} from './Collection';
 import DragLayer from './DragLayer';

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -18,8 +18,8 @@
 		"@clayui/pagination-bar": "^3.43.0",
 		"@clayui/panel": "^3.40.0",
 		"classnames": "^2.2.6",
-		"react-dnd": "^10.0.2",
-		"react-dnd-html5-backend": "^10.0.2",
+		"react-dnd": "^11.1.1",
+		"react-dnd-html5-backend": "^11.1.1",
 		"recharts": "1.8.5"
 	},
 	"devDependencies": {

--- a/packages/demos/stories/index.tsx
+++ b/packages/demos/stories/index.tsx
@@ -7,7 +7,7 @@ import '@clayui/css/lib/css/atlas.css';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 import {DndProvider} from 'react-dnd';
-import Backend from 'react-dnd-html5-backend';
+import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import DragDrop from './DragDrop';
 import FilesPage from './FilesPage';
@@ -23,17 +23,17 @@ storiesOf('Demos|Templates', module)
 	.add('Files Page', () => <FilesPage />)
 	.add('Form Page', () => <FormPage />)
 	.add('Table Rows Drag & Drop', () => (
-		<DndProvider backend={Backend}>
+		<DndProvider backend={HTML5Backend}>
 			<ClayTableWithDraggableRows />
 		</DndProvider>
 	))
 	.add('Table Columns Drag & Drop', () => (
-		<DndProvider backend={Backend}>
+		<DndProvider backend={HTML5Backend}>
 			<ClayTableWithDraggableColumns />
 		</DndProvider>
 	))
 	.add('Drag & Drop', () => (
-		<DndProvider backend={Backend}>
+		<DndProvider backend={HTML5Backend}>
 			<DragDrop />
 		</DndProvider>
 	));

--- a/yarn.lock
+++ b/yarn.lock
@@ -10181,10 +10181,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dnd-core@^10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-10.0.2.tgz#051dc119682ea1185622f954667670d3d5f6a574"
-  integrity sha512-PrxEjxF0+6Y1n1n1Z9hSWZ1tvnDXv9syL+BccV1r1RC08uWNsyetf8AnWmUF3NgYPwy0HKQJwTqGkZK+1NlaFA==
+dnd-core@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-11.1.3.tgz#f92099ba7245e49729d2433157031a6267afcc98"
+  integrity sha512-QugF55dNW+h+vzxVJ/LSJeTeUw9MCJ2cllhmVThVPEtF16ooBkxj0WBE5RB+AceFxMFo1rO6bJKXtqKl+JNnyA==
   dependencies:
     "@react-dnd/asap" "^4.0.0"
     "@react-dnd/invariant" "^2.0.0"
@@ -21203,21 +21203,21 @@ react-dev-utils@^9.0.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dnd-html5-backend@^10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-10.0.2.tgz#15cb9d2b923f43576a136df854e288cb5969784c"
-  integrity sha512-ny17gUdInZ6PIGXdzfwPhoztRdNVVvjoJMdG80hkDBamJBeUPuNF2Wv4D3uoQJLjXssX1+i9PhBqc7EpogClwQ==
+react-dnd-html5-backend@^11.1.1:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-11.1.3.tgz#2749f04f416ec230ea193f5c1fbea2de7dffb8f7"
+  integrity sha512-/1FjNlJbW/ivkUxlxQd7o3trA5DE33QiRZgxent3zKme8DwF4Nbw3OFVhTRFGaYhHFNL1rZt6Rdj1D78BjnNLw==
   dependencies:
-    dnd-core "^10.0.2"
+    dnd-core "^11.1.3"
 
-react-dnd@^10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-10.0.2.tgz#a6ad8eb3d9f2c573031f7ce05012e5c767a0b1fc"
-  integrity sha512-SC2Ymvntynhoqtf5zaFhZscm9xenCoMofilxPdlwUlaelAzmbl9fw82C4ZJ//+lNm3kWAKXjGDZg2/aWjKEAtg==
+react-dnd@^11.1.1:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-11.1.3.tgz#f9844f5699ccc55dfc81462c2c19f726e670c1af"
+  integrity sha512-8rtzzT8iwHgdSC89VktwhqdKKtfXaAyC4wiqp0SywpHG12TTLvfOoL6xNEIUWXwIEWu+CFfDn4GZJyynCEuHIQ==
   dependencies:
     "@react-dnd/shallowequal" "^2.0.0"
     "@types/hoist-non-react-statics" "^3.3.1"
-    dnd-core "^10.0.2"
+    dnd-core "^11.1.3"
     hoist-non-react-statics "^3.3.0"
 
 react-docgen-typescript@^2.0.0:


### PR DESCRIPTION
These dependencies need to be in sync with the ones used in DXP.
Additionally, HTML5Backend is now a named export (previously was a
default export).

Another reason to move Clay into DXP

Fixes #4530