### PR TITLE
fix(@clayui/core): don't export TreeView as UNSAFE_TreeView

### DIFF
--- a/packages/clay-core/docs/treeview.js
+++ b/packages/clay-core/docs/treeview.js
@@ -4,7 +4,7 @@
  */
 
 import Editor from '$clayui.com/src/components/Editor';
-import {Provider, UNSAFE_TreeView as TreeView} from '@clayui/core';
+import {Provider, TreeView} from '@clayui/core';
 import {ClayCheckbox as Checkbox} from '@clayui/form';
 import Icon from '@clayui/icon';
 import React from 'react';

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -20,4 +20,4 @@ export {
 } from '@clayui/modal';
 export {Provider, useProvider} from '@clayui/provider';
 
-export {TreeView as UNSAFE_TreeView} from './tree-view';
+export {TreeView} from './tree-view';


### PR DESCRIPTION
In [3939f07](https://github.com/liferay/clay/commit/3939f07b9df6ba39116ec1291a30caf2b0ea514b), we decided
to export the TreeView component as UNSAFE_TreeView. This doesn't have
any benefit since the component is still exported (and thus can be
imported), it just makes it look a bit "strange" when importing the
component, and there's nothing "unsafe" about this component.

Fixes #4528
Depends on #4531 #4532