### PR TITLE
fix(@clayui/css): Cadmin Input Groups `input-group-sm` missing mixin …

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
@@ -109,6 +109,8 @@
 }
 
 %clay-input-group-sm {
+	@include clay-input-group-variant($cadmin-input-group-sm);
+
 	&.clay-color {
 		> .input-group-item > .input-group-text {
 			@extend %clay-color-sm-input-group-text !optional;


### PR DESCRIPTION
…declaration

fixes #4537