### PR TITLE
feat(@clayui/css): Mixin `clay-card-variant` make `form-check-card` and `form-check-input` customizable

### DIFF
--- a/packages/clay-css/src/scss/mixins/_cards.scss
+++ b/packages/clay-css/src/scss/mixins/_cards.scss
@@ -275,7 +275,6 @@
 	@if (type-of($map) == 'map') {
 		$enabled: setter(map-get($map, enabled), true);
 
-		$base: setter($map, ());
 		$base: map-merge(
 			$map,
 			(
@@ -770,6 +769,12 @@
 				setter(map-get($map, after-highlight), ())
 			);
 
+			&.form-check-card {
+				@include clay-form-check-card-variant(
+					map-get($map, form-check-card)
+				);
+			}
+
 			.aspect-ratio {
 				@include clay-aspect-ratio-variant(
 					setter(map-get($map, aspect-ratio), ())
@@ -900,6 +905,62 @@
 							map-get(
 								$card-type-asset-icon-sticker,
 								sticker-overlay
+							)
+						);
+					}
+				}
+			}
+
+			.form-check-input {
+				&:hover {
+					~ .card {
+						@include clay-card-variant(
+							map-deep-get($map, custom-control, hover, card)
+						);
+					}
+				}
+
+				&:focus {
+					~ .card {
+						@include clay-card-variant(
+							map-deep-get($map, custom-control, focus, card)
+						);
+					}
+				}
+
+				&:active {
+					~ .card {
+						@include clay-card-variant(
+							map-deep-get($map, custom-control, active, card)
+						);
+					}
+				}
+
+				&[disabled],
+				&:disabled {
+					~ .card {
+						@include clay-card-variant(
+							map-deep-get($map, custom-control, disabled, card)
+						);
+					}
+				}
+
+				&:checked {
+					~ .card {
+						@include clay-card-variant(
+							map-deep-get($map, custom-control, checked, card)
+						);
+					}
+				}
+
+				&:indeterminate {
+					~ .card {
+						@include clay-card-variant(
+							map-deep-get(
+								$map,
+								custom-control,
+								indeterminate,
+								card
 							)
 						);
 					}

--- a/packages/clay-css/src/scss/variables/_cards.scss
+++ b/packages/clay-css/src/scss/variables/_cards.scss
@@ -268,11 +268,6 @@ $form-check-card: map-deep-merge(
 			),
 			custom-control-input: (
 				z-index: 2,
-				hover: (
-					card: (
-						box-shadow: $form-check-card-checked-box-shadow,
-					),
-				),
 				checked: (
 					card: (
 						box-shadow: $form-check-card-checked-box-shadow,


### PR DESCRIPTION
fixes #4552