### PR TITLE
chore(release): publish v3.44.0 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.44.0](https://github.com/liferay/clay/compare/v3.43.1...v3.44.0) (2022-01-10)
+
+### Bug Fixes
+
+-   **@clayui/css:** Cadmin Input Groups `input-group-sm` missing mixin declaration ([d7027be](https://github.com/liferay/clay/commit/d7027be048b1cbc21795bf961ea4e53ac2395f53)), closes [#4537](https://github.com/liferay/clay/issues/4537)
+-   **@clayui/css:** Cards `form-check-card` remove duplicate hover state style ([17ea640](https://github.com/liferay/clay/commit/17ea640507edd0789366d418c730a6f8c5e7f02d))
+-   **@clayui/css:** Mixins Cards check if parameter is map to avoid must be a map error ([2174587](https://github.com/liferay/clay/commit/21745877e04375b22bcccc069c9e9825b05fe9ed))
+-   **@clayui/css:** Mixins Custom Forms remove `setter()`, no longer needed ([4cb30ce](https://github.com/liferay/clay/commit/4cb30ce52bcc3e04daa6be32056bb4dc89100059))
+
+### Features
+
+-   **@clayui/css:** Cadmin Nav adds `nav-divider` and `nav-divider-end` ([66ba6ce](https://github.com/liferay/clay/commit/66ba6ced48e5e30b6635eb0c19c7d7c631166a63))
+-   **@clayui/css:** Cards `form-check-card` checkbox/radio input should be hidden unless position utilities are used ([3120797](https://github.com/liferay/clay/commit/31207976cd1bffb0c4b2309d47a2121232902f38)), closes [#4544](https://github.com/liferay/clay/issues/4544)
+-   **@clayui/css:** Cards `form-check-card` convert to Clay mixin pattern ([5b4424b](https://github.com/liferay/clay/commit/5b4424b38eb9f5e6e18ecfb7eb4e1231eb26ba78))
+-   **@clayui/css:** Mixin `clay-card-variant` make `form-check-card` and `form-check-input` customizable ([c6a3a6f](https://github.com/liferay/clay/commit/c6a3a6f2c8b00c930b4a0c0b3ab5990cc743933d))
+-   **@clayui/css:** Mixins `clay-custom-control-input-variant` add option to customize card ([87682d2](https://github.com/liferay/clay/commit/87682d2c9f2392896f27bbd1a36433e9c96918a3))
+-   **@clayui/css:** Mixins `clay-navbar-variant` adds option to customize `nav-divider` and `nav-divider-end` ([e58c23e](https://github.com/liferay/clay/commit/e58c23e8465daf1b46235d3e7e228658b13326e9))
+-   **@clayui/css:** Mixins Card adds `clay-form-check-card-variant` ([a834502](https://github.com/liferay/clay/commit/a8345029dac2ffdcdf9e59ea77d22224aa27f5dc))
+-   **@clayui/css:** Nav adds `nav-divider` and `nav-divider-end` ([600a379](https://github.com/liferay/clay/commit/600a379eebea42761ff36ae1e0b52f804465b854))
+-   **@clayui/css:** SVG Icons adds date-time ([4bf8d4c](https://github.com/liferay/clay/commit/4bf8d4cf7125f99b7948728cb873ed565115b30b))
+-   **@clayui/popover:** add a closeOnClickOutside prop ([bd722a9](https://github.com/liferay/clay/commit/bd722a997961b7b18b1d0c9929c016cd0606e4e4)), closes [#4536](https://github.com/liferay/clay/issues/4536)
+
 ## [3.43.1](https://github.com/liferay/clay/compare/v3.43.0...v3.43.1) (2022-01-04)
 
 ### Bug Fixes

--- a/clayui.com/CHANGELOG.md
+++ b/clayui.com/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.44.0](https://github.com/julien/clay/compare/v3.43.1...v3.44.0) (2022-01-10)
+
+**Note:** Version bump only for package clayui.com
+
 # [3.43.0](https://github.com/julien/clay/compare/v3.42.0...v3.43.0) (2021-12-29)
 
 **Note:** Version bump only for package clayui.com

--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "clayui.com",
-	"version": "3.43.0",
+	"version": "3.44.0",
 	"license": "MIT",
 	"scripts": {
 		"copy:clay-css": "yarn copy:clay-css-js && yarn copy:clay-css-site-images && yarn copy:clay-css-images",
@@ -19,7 +19,7 @@
 		"@clayui/card": "^3.43.0",
 		"@clayui/charts": "^3.40.0",
 		"@clayui/color-picker": "^3.43.0",
-		"@clayui/css": "^3.43.0",
+		"@clayui/css": "^3.44.0",
 		"@clayui/data-provider": "^3.40.0",
 		"@clayui/date-picker": "^3.43.0",
 		"@clayui/drop-down": "^3.43.0",
@@ -37,7 +37,7 @@
 		"@clayui/pagination": "^3.43.0",
 		"@clayui/pagination-bar": "^3.43.0",
 		"@clayui/panel": "^3.40.0",
-		"@clayui/popover": "^3.40.0",
+		"@clayui/popover": "^3.44.0",
 		"@clayui/sticker": "^3.40.0",
 		"@clayui/time-picker": "^3.42.0",
 		"@clayui/tooltip": "^3.40.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"lerna": "3.4.0",
-	"version": "3.43.1",
+	"version": "3.44.0",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/packages/clay-css/CHANGELOG.md
+++ b/packages/clay-css/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.44.0](https://github.com/liferay/clay/compare/v3.43.1...v3.44.0) (2022-01-10)
+
+
+### Bug Fixes
+
+* **@clayui/css:** Cadmin Input Groups `input-group-sm` missing mixin declaration ([d7027be](https://github.com/liferay/clay/commit/d7027be048b1cbc21795bf961ea4e53ac2395f53)), closes [#4537](https://github.com/liferay/clay/issues/4537)
+* **@clayui/css:** Cards `form-check-card` remove duplicate hover state style ([17ea640](https://github.com/liferay/clay/commit/17ea640507edd0789366d418c730a6f8c5e7f02d))
+* **@clayui/css:** Mixins Cards check if parameter is map to avoid must be a map error ([2174587](https://github.com/liferay/clay/commit/21745877e04375b22bcccc069c9e9825b05fe9ed))
+* **@clayui/css:** Mixins Custom Forms remove `setter()`, no longer needed ([4cb30ce](https://github.com/liferay/clay/commit/4cb30ce52bcc3e04daa6be32056bb4dc89100059))
+
+
+### Features
+
+* **@clayui/css:** Cadmin Nav adds `nav-divider` and `nav-divider-end` ([66ba6ce](https://github.com/liferay/clay/commit/66ba6ced48e5e30b6635eb0c19c7d7c631166a63))
+* **@clayui/css:** Cards `form-check-card` checkbox/radio input should be hidden unless position utilities are used ([3120797](https://github.com/liferay/clay/commit/31207976cd1bffb0c4b2309d47a2121232902f38)), closes [#4544](https://github.com/liferay/clay/issues/4544)
+* **@clayui/css:** Cards `form-check-card` convert to Clay mixin pattern ([5b4424b](https://github.com/liferay/clay/commit/5b4424b38eb9f5e6e18ecfb7eb4e1231eb26ba78))
+* **@clayui/css:** Mixin `clay-card-variant` make `form-check-card` and `form-check-input` customizable ([c6a3a6f](https://github.com/liferay/clay/commit/c6a3a6f2c8b00c930b4a0c0b3ab5990cc743933d))
+* **@clayui/css:** Mixins `clay-custom-control-input-variant` add option to customize card ([87682d2](https://github.com/liferay/clay/commit/87682d2c9f2392896f27bbd1a36433e9c96918a3))
+* **@clayui/css:** Mixins `clay-navbar-variant` adds option to customize `nav-divider` and `nav-divider-end` ([e58c23e](https://github.com/liferay/clay/commit/e58c23e8465daf1b46235d3e7e228658b13326e9))
+* **@clayui/css:** Mixins Card adds `clay-form-check-card-variant` ([a834502](https://github.com/liferay/clay/commit/a8345029dac2ffdcdf9e59ea77d22224aa27f5dc))
+* **@clayui/css:** Nav adds `nav-divider` and `nav-divider-end` ([600a379](https://github.com/liferay/clay/commit/600a379eebea42761ff36ae1e0b52f804465b854))
+* **@clayui/css:** SVG Icons adds date-time ([4bf8d4c](https://github.com/liferay/clay/commit/4bf8d4cf7125f99b7948728cb873ed565115b30b))
+
+
+
+
+
 # [3.43.0](https://github.com/liferay/clay/compare/v3.42.0...v3.43.0) (2021-12-29)
 
 

--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/css",
-	"version": "3.43.0",
+	"version": "3.44.0",
 	"description": "Liferay's web implementation of the Lexicon Design Language",
 	"main": "index.js",
 	"files": [

--- a/packages/clay-popover/CHANGELOG.md
+++ b/packages/clay-popover/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.44.0](https://github.com/liferay/clay/compare/v3.43.1...v3.44.0) (2022-01-10)
+
+### Features
+
+-   **@clayui/popover:** add a closeOnClickOutside prop ([bd722a9](https://github.com/liferay/clay/commit/bd722a997961b7b18b1d0c9929c016cd0606e4e4)), closes [#4536](https://github.com/liferay/clay/issues/4536)
+
 # [3.40.0](https://github.com/liferay/clay/compare/v3.39.0...v3.40.0) (2021-11-17)
 
 **Note:** Version bump only for package @clayui/popover

--- a/packages/clay-popover/package.json
+++ b/packages/clay-popover/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/popover",
-	"version": "3.40.0",
+	"version": "3.44.0",
 	"description": "ClayPopover component",
 	"license": "BSD-3-Clause",
 	"repository": "https://github.com/liferay/clay",


### PR DESCRIPTION
# [3.44.0](https://github.com/liferay/clay/compare/v3.43.1...v3.44.0) (2022-01-10)

### Bug Fixes

-   **@clayui/css:** Cadmin Input Groups `input-group-sm` missing mixin declaration ([d7027be](https://github.com/liferay/clay/commit/d7027be048b1cbc21795bf961ea4e53ac2395f53)), closes [#4537](https://github.com/liferay/clay/issues/4537)
-   **@clayui/css:** Cards `form-check-card` remove duplicate hover state style ([17ea640](https://github.com/liferay/clay/commit/17ea640507edd0789366d418c730a6f8c5e7f02d))
-   **@clayui/css:** Mixins Cards check if parameter is map to avoid must be a map error ([2174587](https://github.com/liferay/clay/commit/21745877e04375b22bcccc069c9e9825b05fe9ed))
-   **@clayui/css:** Mixins Custom Forms remove `setter()`, no longer needed ([4cb30ce](https://github.com/liferay/clay/commit/4cb30ce52bcc3e04daa6be32056bb4dc89100059))

### Features

-   **@clayui/css:** Cadmin Nav adds `nav-divider` and `nav-divider-end` ([66ba6ce](https://github.com/liferay/clay/commit/66ba6ced48e5e30b6635eb0c19c7d7c631166a63))
-   **@clayui/css:** Cards `form-check-card` checkbox/radio input should be hidden unless position utilities are used ([3120797](https://github.com/liferay/clay/commit/31207976cd1bffb0c4b2309d47a2121232902f38)), closes [#4544](https://github.com/liferay/clay/issues/4544)
-   **@clayui/css:** Cards `form-check-card` convert to Clay mixin pattern ([5b4424b](https://github.com/liferay/clay/commit/5b4424b38eb9f5e6e18ecfb7eb4e1231eb26ba78))
-   **@clayui/css:** Mixin `clay-card-variant` make `form-check-card` and `form-check-input` customizable ([c6a3a6f](https://github.com/liferay/clay/commit/c6a3a6f2c8b00c930b4a0c0b3ab5990cc743933d))
-   **@clayui/css:** Mixins `clay-custom-control-input-variant` add option to customize card ([87682d2](https://github.com/liferay/clay/commit/87682d2c9f2392896f27bbd1a36433e9c96918a3))
-   **@clayui/css:** Mixins `clay-navbar-variant` adds option to customize `nav-divider` and `nav-divider-end` ([e58c23e](https://github.com/liferay/clay/commit/e58c23e8465daf1b46235d3e7e228658b13326e9))
-   **@clayui/css:** Mixins Card adds `clay-form-check-card-variant` ([a834502](https://github.com/liferay/clay/commit/a8345029dac2ffdcdf9e59ea77d22224aa27f5dc))
-   **@clayui/css:** Nav adds `nav-divider` and `nav-divider-end` ([600a379](https://github.com/liferay/clay/commit/600a379eebea42761ff36ae1e0b52f804465b854))
-   **@clayui/css:** SVG Icons adds date-time ([4bf8d4c](https://github.com/liferay/clay/commit/4bf8d4cf7125f99b7948728cb873ed565115b30b))
-   **@clayui/popover:** add a closeOnClickOutside prop ([bd722a9](https://github.com/liferay/clay/commit/bd722a997961b7b18b1d0c9929c016cd0606e4e4)), closes [#4536](https://github.com/liferay/clay/issues/4536)
