### PR TITLE
fix(@clayui/css): Mixins `clay-card-variant` allow styling before and…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_cards.scss
+++ b/packages/clay-css/src/scss/mixins/_cards.scss
@@ -769,6 +769,14 @@
 				setter(map-get($map, after-highlight), ())
 			);
 
+			&::before {
+				@include clay-css(map-get($map, before));
+			}
+
+			&::after {
+				@include clay-css(map-get($map, after));
+			}
+
 			&.form-check-card {
 				@include clay-form-check-card-variant(
 					map-get($map, form-check-card)


### PR DESCRIPTION
… after psuedo elements

fixes #4554