### PR TITLE
fix(@clayui/css): Cadmin Nav adds `background-color` to `.active` pseudo element

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_navs.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navs.scss
@@ -473,6 +473,7 @@ $cadmin-nav-underline-link: map-deep-merge(
 		active-class: (
 			color: $cadmin-nav-underline-link-active-color,
 			after: (
+				background-color: $cadmin-nav-underline-link-active-highlight,
 				content: $cadmin-nav-underline-link-active-content,
 				height: $cadmin-nav-underline-link-active-highlight-height,
 			),


### PR DESCRIPTION
Prevents theme nav-underline active highlight from bleeding into cadmin components fixes #4562