### PR TITLE
chore(release): publish v3.44.2 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.44.2](https://github.com/liferay/clay/compare/v3.44.1...v3.44.2) (2022-01-12)
+
+### Bug Fixes
+
+-   **@clayui/css:** Cadmin Nav adds `background-color` to `.active` pseudo element ([865b037](https://github.com/liferay/clay/commit/865b037338d3f10c28823c076aa3f93a525dbf5e)), closes [#4562](https://github.com/liferay/clay/issues/4562)
+-   **@clayui/css:** Mixins `clay-button-variant` removes unnecessary `setter()`'s ([3709d7f](https://github.com/liferay/clay/commit/3709d7fae89656e9fa3db2acc3ba0b539cbb8c2b)), closes [#4550](https://github.com/liferay/clay/issues/4550)
+
 ## [3.44.1](https://github.com/liferay/clay/compare/v3.44.0...v3.44.1) (2022-01-11)
 
 ### Bug Fixes

--- a/clayui.com/CHANGELOG.md
+++ b/clayui.com/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.44.2](https://github.com/julien/clay/compare/v3.44.1...v3.44.2) (2022-01-12)
+
+**Note:** Version bump only for package clayui.com
+
 ## [3.44.1](https://github.com/julien/clay/compare/v3.44.0...v3.44.1) (2022-01-11)
 
 **Note:** Version bump only for package clayui.com

--- a/clayui.com/package.json
+++ b/clayui.com/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "clayui.com",
-	"version": "3.44.1",
+	"version": "3.44.2",
 	"license": "MIT",
 	"scripts": {
 		"copy:clay-css": "yarn copy:clay-css-js && yarn copy:clay-css-site-images && yarn copy:clay-css-images",
@@ -19,7 +19,7 @@
 		"@clayui/card": "^3.43.0",
 		"@clayui/charts": "^3.40.0",
 		"@clayui/color-picker": "^3.43.0",
-		"@clayui/css": "^3.44.1",
+		"@clayui/css": "^3.44.2",
 		"@clayui/data-provider": "^3.40.0",
 		"@clayui/date-picker": "^3.43.0",
 		"@clayui/drop-down": "^3.43.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"lerna": "3.4.0",
-	"version": "3.44.1",
+	"version": "3.44.2",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/packages/clay-css/CHANGELOG.md
+++ b/packages/clay-css/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.44.2](https://github.com/liferay/clay/compare/v3.44.1...v3.44.2) (2022-01-12)
+
+
+### Bug Fixes
+
+* **@clayui/css:** Cadmin Nav adds `background-color` to `.active` pseudo element ([865b037](https://github.com/liferay/clay/commit/865b037338d3f10c28823c076aa3f93a525dbf5e)), closes [#4562](https://github.com/liferay/clay/issues/4562)
+* **@clayui/css:** Mixins `clay-button-variant` removes unnecessary `setter()`'s ([3709d7f](https://github.com/liferay/clay/commit/3709d7fae89656e9fa3db2acc3ba0b539cbb8c2b)), closes [#4550](https://github.com/liferay/clay/issues/4550)
+
+
+
+
+
 ## [3.44.1](https://github.com/liferay/clay/compare/v3.44.0...v3.44.1) (2022-01-11)
 
 

--- a/packages/clay-css/package.json
+++ b/packages/clay-css/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/css",
-	"version": "3.44.1",
+	"version": "3.44.2",
 	"description": "Liferay's web implementation of the Lexicon Design Language",
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
## [3.44.2](https://github.com/liferay/clay/compare/v3.44.1...v3.44.2) (2022-01-12)

### Bug Fixes

-   **@clayui/css:** Cadmin Nav adds `background-color` to `.active` pseudo element ([865b037](https://github.com/liferay/clay/commit/865b037338d3f10c28823c076aa3f93a525dbf5e)), closes [#4562](https://github.com/liferay/clay/issues/4562)
-   **@clayui/css:** Mixins `clay-button-variant` removes unnecessary `setter()`'s ([3709d7f](https://github.com/liferay/clay/commit/3709d7fae89656e9fa3db2acc3ba0b539cbb8c2b)), closes [#4550](https://github.com/liferay/clay/issues/4550)
