### PR TITLE
fix(@clayui/css): Cadmin reset Custom Checkbox and Radio pseudo elements

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_custom-forms.scss
@@ -108,11 +108,15 @@ label.custom-control-label {
 .custom-control-label::before {
 	$before: setter(map-get($cadmin-custom-control-label, before), ());
 
+	@extend %cadmin-pseudo-reset !optional;
+
 	@include clay-css($before);
 }
 
 .custom-control-label::after {
 	$after: setter(map-get($cadmin-custom-control-label, after), ());
+
+	@extend %cadmin-pseudo-reset !optional;
 
 	@include clay-css($after);
 }

--- a/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
@@ -136,6 +136,7 @@ $cadmin-custom-control-label: map-deep-merge(
 			top: $cadmin-custom-control-indicator-position-top,
 			transition: clay-enable-transitions($cadmin-custom-forms-transition),
 			width: $cadmin-custom-control-indicator-size,
+			z-index: 0,
 		),
 		after: (
 			background: no-repeat 50% / #{$cadmin-custom-control-indicator-bg-size},
@@ -146,6 +147,7 @@ $cadmin-custom-control-label: map-deep-merge(
 			position: absolute,
 			top: $cadmin-custom-control-indicator-position-top,
 			width: $cadmin-custom-control-indicator-size,
+			z-index: 0,
 		),
 	),
 	$cadmin-custom-control-label
@@ -216,6 +218,7 @@ $cadmin-custom-control: map-deep-merge(
 			display: inline,
 			font-size: $cadmin-font-size-base,
 			margin-bottom: 0,
+			position: static,
 		),
 	),
 	$cadmin-custom-control


### PR DESCRIPTION
    - Set `z-index` on `custom-control` psuedo elements and `position` on the `label` element to prevent customizations on custom-control from impacting Cadmin custom controls

fixes #4570