### PR TITLE
fix(@clayui/css): Cadmin reset `nav-link` pseudo elements

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_navs.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_navs.scss
@@ -6,6 +6,14 @@
 
 .nav-link {
 	@include clay-link($cadmin-nav-link);
+
+	&::before {
+		@extend %cadmin-pseudo-reset !optional;
+	}
+
+	&::after {
+		@extend %cadmin-pseudo-reset !optional;
+	}
 }
 
 .nav-link.btn-unstyled {


### PR DESCRIPTION
fixes #4572