### PR TITLE
feat(@clayui/css): Ports over Treeview to Clay from Cadmin

### DIFF
--- a/clayui.com/content/docs/components/markup-treeview.md
+++ b/clayui.com/content/docs/components/markup-treeview.md
@@ -9,11 +9,18 @@ mainTabURL: 'docs/components/treeview.html'
 <div class="nav-toc">
 
 -   [Treeview](#css-treeview)
+
     -   [Group](#css-treeview-group)
     -   [Item](#css-treeview-item)
+    -   [Item](#css-treeview-item-disabled)
     -   [Link](#css-treeview-link)
     -   [Component Expander](#css-treeview-component-expander)
     -   [Component Action](#css-treeview-component-action)
+    -   [Dragging](#css-treeview-dragging)
+    -   [Dropping Bottom](#css-treeview-dropping-bottom)
+    -   [Dropping Top](#css-treeview-dropping-top)
+    -   [Dropping Middle](#css-treeview-dropping-middle)
+
 -   [Variations](#css-variations)
     -   [Expander on Hover](#css-treeview-expander-on-hover)
     -   [Light](#css-treeview-light)
@@ -21,16 +28,6 @@ mainTabURL: 'docs/components/treeview.html'
 
 </div>
 </div>
-
-<div class="clay-site-alert alert alert-warning">This component is a Cadmin only component.</div>
-
-The component must be wrapped in:
-
-```html{expanded}
-<div class="cadmin">
-	...
-</div>
-```
 
 ## Treeview(#css-treeview)
 
@@ -44,1697 +41,1677 @@ The treeview provides a way to display information in a hierarchical structure b
 	Treeview Link indentation must be provided by javascript through inline styles, use the styles `padding-left: 24px;` on `.treeview-link` and `margin-left: -24px` on `.treeview-link > .c-inner`. Increase the indentation for each level by increasing or decreasing `padding-left` or `margin-left` by 24px.
 </div>
 
-<div class="cadmin">
-	<ul class="treeview treeview-light treeview-nested" role="tree">
-		<li class="treeview-item" role="none">
-			<div aria-controls="treeviewCollapse01" aria-expanded="true" class="treeview-link" data-target="#treeviewCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button aria-controls="treeviewCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse01" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewCollapse01" aria-expanded="true" class="treeview-link" data-target="#treeviewCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="treeviewCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
 						</span>
 					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
+					</span>
 				</span>
-			</div>
-			<div class="collapse show" id="treeviewCollapse01">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div aria-controls="treeviewCollapse02" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col">
-										<button aria-controls="treeviewCollapse02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse02" data-toggle="collapse" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#angle-down" />
-												</svg>
-												<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#angle-right" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<span class="component-icon">
-											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-												<use xlink:href="/images/icons/icons.svg#folder" />
+			</span>
+		</div>
+		<div class="collapse show" id="treeviewCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div aria-controls="treeviewCollapse02" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button aria-controls="treeviewCollapse02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse02" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#angle-right" />
 											</svg>
 										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#folder" />
+										</svg>
 									</span>
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text">
-											<span class="text-truncate-inline" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
 										</span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-						<div class="collapse" id="treeviewCollapse02">
-							<ul class="treeview-group" role="group">
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<span class="autofit-row">
-												<span class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" title="Details"><span class="text-truncate">Details</span></span></span>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<span class="autofit-row">
-												<span class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<span class="autofit-row">
-												<span class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<span class="autofit-row">
-												<span class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-							</ul>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div aria-controls="treeviewCollapse03" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1">
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button aria-controls="treeviewCollapse03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse03" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
 						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+					</div>
+					<div class="collapse" id="treeviewCollapse02">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" title="Details"><span class="text-truncate">Details</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewCollapse03" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="treeviewCollapse03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse03" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" title="Repositories"><span class="text-truncate">Repositories</span></span>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
 						</span>
 					</span>
-				</span>
-			</div>
-			<div class="collapse" id="treeviewCollapse03">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Site Map"><span class="text-truncate">Sitemap</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
-								</span>
-							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Robots"><span class="text-truncate">Robots</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
-								</span>
-							</span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div aria-controls="treeviewCollapse04" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse04" data-toggle="collapse" role="treeitem" tabindex="-1">
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button aria-controls="treeviewCollapse04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse04" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Repositories"><span class="text-truncate">Repositories</span></span>
 						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
 							</span>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
-						</span>
+						</button>
 					</span>
 				</span>
-			</div>
-			<div class="collapse" id="treeviewCollapse04">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+			</span>
+		</div>
+		<div class="collapse" id="treeviewCollapse03">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Site Map"><span class="text-truncate">Sitemap</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Staging"><span class="text-truncate">Staging</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Robots"><span class="text-truncate">Robots</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+						</span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewCollapse04" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewCollapse04" data-toggle="collapse" role="treeitem" tabindex="-1">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="treeviewCollapse04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewCollapse04" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
+						</span>
+					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</span>
+		</div>
+		<div class="collapse" id="treeviewCollapse04">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Maps"><span class="text-truncate">Maps</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Staging"><span class="text-truncate">Staging</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-	</ul>
-</div>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Maps"><span class="text-truncate">Maps</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
 
 ```html
-<div class="cadmin">
-	<ul class="treeview treeview-light treeview-nested" role="tree">
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="treeviewCollapse01"
-				aria-expanded="true"
-				class="treeview-link"
-				data-target="#treeviewCollapse01"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="0"
-			>
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button
-								aria-controls="treeviewCollapse01"
-								aria-expanded="true"
-								class="btn btn-monospaced component-expander"
-								data-target="#treeviewCollapse01"
-								data-toggle="collapse"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-angle-down"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-down"
-										/>
-									</svg>
-									<svg
-										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-right"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewCollapse01"
+			aria-expanded="true"
+			class="treeview-link"
+			data-target="#treeviewCollapse01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button
+							aria-controls="treeviewCollapse01"
+							aria-expanded="true"
+							class="btn btn-monospaced component-expander"
+							data-target="#treeviewCollapse01"
+							data-toggle="collapse"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
 								<svg
-									class="lexicon-icon lexicon-icon-folder"
+									class="lexicon-icon lexicon-icon-angle-down"
 									focusable="false"
 									role="presentation"
 								>
 									<use
-										xlink:href="/images/icons/icons.svg#folder"
+										xlink:href="/images/icons/icons.svg#angle-down"
+									/>
+								</svg>
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-right"
 									/>
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span
-									class="text-truncate-inline"
-									title="Liferay Drive"
-									><span class="text-truncate"
-										>Liferay Drive</span
-									></span
-								>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg
+								class="lexicon-icon lexicon-icon-folder"
+								focusable="false"
+								role="presentation"
 							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-times-circle-full"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#times-circle-full"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-ellipsis-v"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#ellipsis-v"
-										/>
-									</svg>
-								</span>
-							</button>
+								<use
+									xlink:href="/images/icons/icons.svg#folder"
+								/>
+							</svg>
 						</span>
 					</span>
-				</span>
-			</div>
-			<div class="collapse show" id="treeviewCollapse01">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div
-							aria-controls="treeviewCollapse02"
-							aria-expanded="false"
-							class="collapsed treeview-link"
-							data-target="#treeviewCollapse02"
-							data-toggle="collapse"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
-						>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
 							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
+								class="text-truncate-inline"
+								title="Liferay Drive"
+								><span class="text-truncate"
+									>Liferay Drive</span
+								></span
 							>
-								<span class="autofit-row">
-									<span class="autofit-col">
-										<button
-											aria-controls="treeviewCollapse02"
-											aria-expanded="false"
-											class="btn btn-monospaced component-expander"
-											data-target="#treeviewCollapse02"
-											data-toggle="collapse"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-angle-down"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#angle-down"
-													/>
-												</svg>
-												<svg
-													class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#angle-right"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<span class="component-icon">
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle-full"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle-full"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-ellipsis-v"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#ellipsis-v"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</span>
+		</div>
+		<div class="collapse show" id="treeviewCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						aria-controls="treeviewCollapse02"
+						aria-expanded="false"
+						class="collapsed treeview-link"
+						data-target="#treeviewCollapse02"
+						data-toggle="collapse"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button
+										aria-controls="treeviewCollapse02"
+										aria-expanded="false"
+										class="btn btn-monospaced component-expander"
+										data-target="#treeviewCollapse02"
+										data-toggle="collapse"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
 											<svg
-												class="lexicon-icon lexicon-icon-folder"
+												class="lexicon-icon lexicon-icon-angle-down"
 												focusable="false"
 												role="presentation"
 											>
 												<use
-													xlink:href="/images/icons/icons.svg#folder"
+													xlink:href="/images/icons/icons.svg#angle-down"
+												/>
+											</svg>
+											<svg
+												class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#angle-right"
 												/>
 											</svg>
 										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg
+											class="lexicon-icon lexicon-icon-folder"
+											focusable="false"
+											role="presentation"
+										>
+											<use
+												xlink:href="/images/icons/icons.svg#folder"
+											/>
+										</svg>
 									</span>
-									<span
-										class="autofit-col autofit-col-expand"
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span
+											class="text-truncate-inline"
+											title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
+											><span class="text-truncate"
+												>Liferay Drive
+												(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
+											></span
+										>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
 									>
-										<span class="component-text">
-											<span
-												class="text-truncate-inline"
-												title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
-												><span class="text-truncate"
-													>Liferay Drive
-													(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
-												></span
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
 											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
 										</span>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-						<div class="collapse" id="treeviewCollapse02">
-							<ul class="treeview-group" role="group">
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<span
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<span class="autofit-row">
-												<span
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															title="Details"
-															><span
-																class="text-truncate"
-																>Details</span
-															></span
-														></span
-													>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<span
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<span class="autofit-row">
-												<span
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															title="Categorization"
-															><span
-																class="text-truncate"
-																>Categorization</span
-															></span
-														></span
-													>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<span
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<span class="autofit-row">
-												<span
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															title="Documents and Media"
-															><span
-																class="text-truncate"
-																>Documents and
-																Media</span
-															></span
-														></span
-													>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<span
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<span class="autofit-row">
-												<span
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															title="Site Template"
-															><span
-																class="text-truncate"
-																>Site
-																Template</span
-															></span
-														></span
-													>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-							</ul>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="treeviewCollapse03"
-				aria-expanded="false"
-				class="collapsed treeview-link"
-				data-target="#treeviewCollapse03"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="-1"
-			>
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button
-								aria-controls="treeviewCollapse03"
-								aria-expanded="false"
-								class="btn btn-monospaced component-expander"
-								data-target="#treeviewCollapse03"
-								data-toggle="collapse"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-angle-down"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-down"
-										/>
-									</svg>
-									<svg
-										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-right"
-										/>
-									</svg>
-								</span>
-							</button>
 						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
+					</div>
+					<div class="collapse" id="treeviewCollapse02">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<span
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<span class="autofit-row">
+											<span
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														title="Details"
+														><span
+															class="text-truncate"
+															>Details</span
+														></span
+													></span
+												>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<span
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<span class="autofit-row">
+											<span
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														title="Categorization"
+														><span
+															class="text-truncate"
+															>Categorization</span
+														></span
+													></span
+												>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<span
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<span class="autofit-row">
+											<span
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														title="Documents and Media"
+														><span
+															class="text-truncate"
+															>Documents and
+															Media</span
+														></span
+													></span
+												>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<span
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<span class="autofit-row">
+											<span
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														title="Site Template"
+														><span
+															class="text-truncate"
+															>Site Template</span
+														></span
+													></span
+												>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewCollapse03"
+			aria-expanded="false"
+			class="collapsed treeview-link"
+			data-target="#treeviewCollapse03"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="-1"
+		>
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button
+							aria-controls="treeviewCollapse03"
+							aria-expanded="false"
+							class="btn btn-monospaced component-expander"
+							data-target="#treeviewCollapse03"
+							data-toggle="collapse"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
 								<svg
-									class="lexicon-icon lexicon-icon-folder"
+									class="lexicon-icon lexicon-icon-angle-down"
 									focusable="false"
 									role="presentation"
 								>
 									<use
-										xlink:href="/images/icons/icons.svg#folder"
+										xlink:href="/images/icons/icons.svg#angle-down"
 									/>
 								</svg>
-							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span
-									class="text-truncate-inline"
-									title="Repositories"
-									><span class="text-truncate"
-										>Repositories</span
-									></span
-								>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-times-circle-full"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#times-circle-full"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-ellipsis-v"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#ellipsis-v"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-					</span>
-				</span>
-			</div>
-			<div class="collapse" id="treeviewCollapse03">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
-						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Site Map"
-												><span class="text-truncate"
-													>Sitemap</span
-												></span
-											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-								</span>
-							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
-						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Robots"
-												><span class="text-truncate"
-													>Robots</span
-												></span
-											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-								</span>
-							</span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="treeviewCollapse04"
-				aria-expanded="false"
-				class="collapsed treeview-link"
-				data-target="#treeviewCollapse04"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="-1"
-			>
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button
-								aria-controls="treeviewCollapse04"
-								aria-expanded="false"
-								class="btn btn-monospaced component-expander"
-								data-target="#treeviewCollapse04"
-								data-toggle="collapse"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-angle-down"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-down"
-										/>
-									</svg>
-									<svg
-										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-right"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
 								<svg
-									class="lexicon-icon lexicon-icon-folder"
+									class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
 									focusable="false"
 									role="presentation"
 								>
 									<use
-										xlink:href="/images/icons/icons.svg#folder"
+										xlink:href="/images/icons/icons.svg#angle-right"
 									/>
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span
-									class="text-truncate-inline"
-									title="Documents and Media"
-									><span class="text-truncate"
-										>Documents and Media</span
-									></span
-								>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg
+								class="lexicon-icon lexicon-icon-folder"
+								focusable="false"
+								role="presentation"
 							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-times-circle-full"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#times-circle-full"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-ellipsis-v"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#ellipsis-v"
-										/>
-									</svg>
-								</span>
-							</button>
+								<use
+									xlink:href="/images/icons/icons.svg#folder"
+								/>
+							</svg>
 						</span>
 					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span
+								class="text-truncate-inline"
+								title="Repositories"
+								><span class="text-truncate"
+									>Repositories</span
+								></span
+							>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle-full"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle-full"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-ellipsis-v"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#ellipsis-v"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
 				</span>
-			</div>
-			<div class="collapse" id="treeviewCollapse04">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+			</span>
+		</div>
+		<div class="collapse" id="treeviewCollapse03">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
 						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Default User Associations"
-												><span class="text-truncate"
-													>Default User
-													Associations</span
-												></span
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Site Map"
+											><span class="text-truncate"
+												>Sitemap</span
 											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
 						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Staging"
-												><span class="text-truncate"
-													>Staging</span
-												></span
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Robots"
+											><span class="text-truncate"
+												>Robots</span
 											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
+						</span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewCollapse04"
+			aria-expanded="false"
+			class="collapsed treeview-link"
+			data-target="#treeviewCollapse04"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="-1"
+		>
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button
+							aria-controls="treeviewCollapse04"
+							aria-expanded="false"
+							class="btn btn-monospaced component-expander"
+							data-target="#treeviewCollapse04"
+							data-toggle="collapse"
 							tabindex="-1"
-							style="padding-left:24px;"
+							type="button"
 						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-down"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-down"
+									/>
+								</svg>
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-right"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg
+								class="lexicon-icon lexicon-icon-folder"
+								focusable="false"
+								role="presentation"
 							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Analytics"
-												><span class="text-truncate"
-													>Analytics</span
-												></span
+								<use
+									xlink:href="/images/icons/icons.svg#folder"
+								/>
+							</svg>
+						</span>
+					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span
+								class="text-truncate-inline"
+								title="Documents and Media"
+								><span class="text-truncate"
+									>Documents and Media</span
+								></span
+							>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle-full"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle-full"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-ellipsis-v"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#ellipsis-v"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</span>
+		</div>
+		<div class="collapse" id="treeviewCollapse04">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Default User Associations"
+											><span class="text-truncate"
+												>Default User Associations</span
 											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
 						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Maps"
-												><span class="text-truncate"
-													>Maps</span
-												></span
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Staging"
+											><span class="text-truncate"
+												>Staging</span
 											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-	</ul>
-</div>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Analytics"
+											><span class="text-truncate"
+												>Analytics</span
+											></span
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Maps"
+											><span class="text-truncate"
+												>Maps</span
+											></span
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
 ```
 
 ### Treeview Group(#css-treeview-group)
@@ -1742,44 +1719,40 @@ The treeview provides a way to display information in a hierarchical structure b
 The class `treeview-group` must be applied to all nested `ul` elements inside `treeview`. This class helps provide the proper spacing for nested `treeview-link`s.
 
 ```html
-<div class="cadmin">
-	<ul class="treeview treeview-light treeview-nested" role="tree">
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="treeviewExpanderCollapse01"
-				aria-expanded="false"
-				class="treeview-link"
-				data-target="#treeviewExpanderCollapse01"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="0"
-			>
-				...
-			</div>
-			<div class="collapse" id="treeviewExpanderCollapse01">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewExpanderCollapse01"
+			aria-expanded="false"
+			class="treeview-link"
+			data-target="#treeviewExpanderCollapse01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			...
+		</div>
+		<div class="collapse" id="treeviewExpanderCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+							><span class="component-text">Tree Item</span></span
 						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-								><span class="component-text"
-									>Tree Item</span
-								></span
-							>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-	</ul>
-</div>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
 ```
 
 ### Treeview Item(#css-treeview-item)
@@ -1787,23 +1760,43 @@ The class `treeview-group` must be applied to all nested `ul` elements inside `t
 The class `treeview-item` must be applied to all `li` elements. This class helps provide the proper spacing for nested `treeview-link`s.
 
 ```html
-<div class="cadmin">
-	<ul class="treeview treeview-light treeview-nested" role="tree">
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="treeviewExpanderCollapse01"
-				aria-expanded="false"
-				class="treeview-link"
-				data-target="#treeviewExpanderCollapse01"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="0"
-			>
-				...
-			</div>
-		</li>
-	</ul>
-</div>
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewExpanderCollapse01"
+			aria-expanded="false"
+			class="treeview-link"
+			data-target="#treeviewExpanderCollapse01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			...
+		</div>
+	</li>
+</ul>
+```
+
+### Treeview Item Disabled(#css-treeview-item-disabled)
+
+The modifier class `disabled` on `treeview-item` items nested inside when dragging an item.
+
+```html
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="disabled treeview-item" role="none">
+		<div
+			aria-controls="treeviewExpanderCollapse01"
+			aria-expanded="false"
+			class="treeview-link"
+			data-target="#treeviewExpanderCollapse01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			...
+		</div>
+	</li>
+</ul>
 ```
 
 ### Treeview Link(#css-treeview-link)
@@ -1811,67 +1804,63 @@ The class `treeview-item` must be applied to all `li` elements. This class helps
 This is the container for all nodes inside `treeview`. If there are auxiliary controls inside the `treeview-link` (e.g., `a` or `button`) it is recommended to use a `div` element with the `tabindex` attribute.
 
 ```html
-<div class="cadmin">
-	<ul class="treeview treeview-light treeview-nested" role="tree">
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="treeviewExpanderCollapse01"
-				aria-expanded="false"
-				class="treeview-link"
-				data-target="#treeviewExpanderCollapse01"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="0"
-			>
-				...
-			</div>
-		</li>
-	</ul>
-</div>
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewExpanderCollapse01"
+			aria-expanded="false"
+			class="treeview-link"
+			data-target="#treeviewExpanderCollapse01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			...
+		</div>
+	</li>
+</ul>
 ```
 
 ### Component Expander(#css-treeview-component-expander)
 
 The expander is used to expand or collapse the nodes and serves as an indicator for those states. The class `component-expander` marks the button as the toggle. The class `component-expanded-d-none` on `lexicon-icon` hides the icon when tree node is expanded.
 
-<div class="cadmin">
-	<ul class="treeview treeview-light treeview-nested" role="tree">
-		<li class="treeview-item" role="none">
-			<div aria-controls="treeviewExpanderCollapse01" aria-expanded="false" class="treeview-link" data-target="#treeviewExpanderCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button aria-controls="treeviewExpanderCollapse01" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewExpanderCollapse01" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewExpanderCollapse01" aria-expanded="false" class="treeview-link" data-target="#treeviewExpanderCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="treeviewExpanderCollapse01" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewExpanderCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
+								</svg>
 							</span>
+						</button>
+					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
 						</span>
 					</span>
 				</span>
-			</div>
-			<div class="collapse" id="treeviewExpanderCollapse01">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Tree Item</span></span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-	</ul>
-</div>
+			</span>
+		</div>
+		<div class="collapse" id="treeviewExpanderCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Tree Item</span></span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
 
 ```html
 <button
@@ -1906,69 +1895,67 @@ The expander is used to expand or collapse the nodes and serves as an indicator 
 
 The action button(s) are used to supply additional features to a tree node, such as removal or a dropdown. The buttons must have the class `component-action`. They are displayed when hovering or focusing a tree node.
 
-<div class="cadmin">
-	<ul class="treeview treeview-light treeview-nested" role="tree">
-		<li class="treeview-item" role="none">
-			<div aria-controls="treeviewActionButtonCollapse01" aria-expanded="true" class="treeview-link" data-target="#treeviewActionButtonCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button aria-controls="treeviewActionButtonCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewActionButtonCollapse01" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewActionButtonCollapse01" aria-expanded="true" class="treeview-link" data-target="#treeviewActionButtonCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="treeviewActionButtonCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewActionButtonCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
 						</span>
 					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
+					</span>
 				</span>
-			</div>
-			<div class="collapse show" id="treeviewActionButtonCollapse01">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Tree Item</span></span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-	</ul>
-</div>
+			</span>
+		</div>
+		<div class="collapse show" id="treeviewActionButtonCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Tree Item</span></span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
 
 ```html
 <button class="btn btn-monospaced component-action" tabindex="-1" type="button">
@@ -1984,3768 +1971,4037 @@ The action button(s) are used to supply additional features to a tree node, such
 </button>
 ```
 
+### Treeview Dragging(#css-treeview-dragging)
+
+The modifier class `treeview-dragging` displays an indicator showing the item being dragged.
+
+<div class="treeview-dragging">Liferay Drive</div>
+
+### Treeview Dropping Bottom(#css-treeview-dropping-bottom)
+
+The modifier class `treeview-dropping-bottom` adds a visual indicator to the bottom of `treeview-link` to show where a dragged `treeview-link` will be inserted.
+
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewDroppoingBottomCollapse01" aria-expanded="true" class="treeview-dropping-bottom treeview-link" data-target="#treeviewDroppoingBottomCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="treeviewDroppoingBottomCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewDroppoingBottomCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
+						</span>
+					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</span>
+		</div>
+		<div class="collapse show" id="treeviewDroppoingBottomCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Tree Item</span></span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
+
+```html
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewDroppoingBottomCollapse01"
+			aria-expanded="true"
+			class="treeview-dropping-bottom treeview-link"
+			data-target="#treeviewDroppoingBottomCollapse01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			...
+		</div>
+		<div class="collapse show" id="treeviewDroppoingBottomCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+							><span class="component-text">Tree Item</span></span
+						>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
+```
+
+### Treeview Dropping Top(#css-treeview-dropping-top)
+
+The modifier class `treeview-dropping-top` adds a visual indicator to the bottom of `treeview-link` to show where a dragged `treeview-link` will be inserted.
+
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewDroppingTopCollapse01" aria-expanded="true" class="treeview-dropping-top treeview-link" data-target="#treeviewDroppingTopCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="treeviewDroppingTopCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewDroppingTopCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
+						</span>
+					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</span>
+		</div>
+		<div class="collapse show" id="treeviewDroppingTopCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Tree Item</span></span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
+
+```html
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewDroppingTopCollapse01"
+			aria-expanded="true"
+			class="treeview-dropping-top treeview-link"
+			data-target="#treeviewDroppingTopCollapse01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			...
+		</div>
+		<div class="collapse show" id="treeviewDroppingTopCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+							><span class="component-text">Tree Item</span></span
+						>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
+```
+
+### Treeview Dropping Middle(#css-treeview-dropping-middle)
+
+The modifier class `treeview-dropping-middle` adds a visual indicator around the `treeview-link` to show where a dragged `treeview-link` will be nested.
+
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewDroppingMiddleCollapse01" aria-expanded="true" class="treeview-dropping-middle treeview-link" data-target="#treeviewDroppingMiddleCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="treeviewDroppingMiddleCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewDroppingMiddleCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
+						</span>
+					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</span>
+		</div>
+		<div class="collapse show" id="treeviewDroppingMiddleCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Tree Item</span></span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
+
+```html
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewDroppingMiddleCollapse01"
+			aria-expanded="true"
+			class="treeview-dropping-middle treeview-link"
+			data-target="#treeviewDroppingMiddleCollapse01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			...
+		</div>
+		<div class="collapse show" id="treeviewDroppingMiddleCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+							><span class="component-text">Tree Item</span></span
+						>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
+```
+
 ## Variations(#css-variations)
 
 ### Show Component Expander on Hover(#css-treeview-expander-on-hover)
 
 The class `show-component-expander-on-hover` displays the `component-expander` when the mouse hovers over the `treeview` component.
 
-<div class="cadmin">
-	<ul class="show-component-expander-on-hover treeview treeview-nested treeview-light" role="tree">
-		<li class="treeview-item" role="none">
-			<div aria-controls="showComponentExpanderCollapse01" aria-expanded="true" class="treeview-link" data-target="#showComponentExpanderCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button aria-controls="showComponentExpanderCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander show" data-target="#showComponentExpanderCollapse01" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+<ul class="show-component-expander-on-hover treeview treeview-nested treeview-light" role="tree">
+	<li class="treeview-item" role="none">
+		<div aria-controls="showComponentExpanderCollapse01" aria-expanded="true" class="treeview-link" data-target="#showComponentExpanderCollapse01" data-toggle="collapse" role="treeitem" tabindex="0">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="showComponentExpanderCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander show" data-target="#showComponentExpanderCollapse01" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
 						</span>
 					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
+					</span>
 				</span>
-			</div>
-			<div class="collapse show" id="showComponentExpanderCollapse01">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div aria-controls="showComponentExpanderCollapse02" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col">
-										<button aria-controls="showComponentExpanderCollapse02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse02" data-toggle="collapse" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#angle-down" />
-												</svg>
-												<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#angle-right" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<span class="component-icon">
-											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-												<use xlink:href="/images/icons/icons.svg#folder" />
+			</span>
+		</div>
+		<div class="collapse show" id="showComponentExpanderCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div aria-controls="showComponentExpanderCollapse02" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button aria-controls="showComponentExpanderCollapse02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse02" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#angle-right" />
 											</svg>
 										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#folder" />
+										</svg>
 									</span>
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text">
-											<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" data-toggle="tooltip" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#info-circle" />
+											</svg>
 										</span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#info-circle" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-						<div class="collapse" id="showComponentExpanderCollapse02">
-							<ul class="treeview-group" role="group">
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<span class="autofit-row">
-												<span class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" data-toggle="tooltip" title="Details">Details</span></span></span>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<span class="autofit-row">
-												<span class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<span class="autofit-row">
-												<span class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<span class="autofit-row">
-												<span class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-							</ul>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div aria-controls="showComponentExpanderCollapse03" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1">
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button aria-controls="showComponentExpanderCollapse03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse03" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
 						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+					</div>
+					<div class="collapse" id="showComponentExpanderCollapse02">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" data-toggle="tooltip" title="Details">Details</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<span class="autofit-row">
+											<span class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div aria-controls="showComponentExpanderCollapse03" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse03" data-toggle="collapse" role="treeitem" tabindex="-1">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="showComponentExpanderCollapse03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse03" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" data-toggle="tooltip" title="Repositories"><span class="text-truncate">Repositories</span></span>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
 						</span>
 					</span>
-				</span>
-			</div>
-			<div class="collapse" id="showComponentExpanderCollapse03">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
-								</span>
-							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Robots"><span class="text-truncate">Robots</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
-								</span>
-							</span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div aria-controls="showComponentExpanderCollapse04" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse04" data-toggle="collapse" role="treeitem" tabindex="-1">
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button aria-controls="showComponentExpanderCollapse04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse04" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" data-toggle="tooltip" title="Repositories"><span class="text-truncate">Repositories</span></span>
 						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
 							</span>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
-						</span>
+						</button>
 					</span>
 				</span>
-			</div>
-			<div class="collapse" id="showComponentExpanderCollapse04">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+			</span>
+		</div>
+		<div class="collapse" id="showComponentExpanderCollapse03">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Staging"><span class="text-truncate">Staging</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Robots"><span class="text-truncate">Robots</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+						</span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div aria-controls="showComponentExpanderCollapse04" aria-expanded="false" class="collapsed treeview-link" data-target="#showComponentExpanderCollapse04" data-toggle="collapse" role="treeitem" tabindex="-1">
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button aria-controls="showComponentExpanderCollapse04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#showComponentExpanderCollapse04" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
+								</svg>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
+						</span>
+					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" data-toggle="tooltip" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</span>
+		</div>
+		<div class="collapse" id="showComponentExpanderCollapse04">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Maps"><span class="text-truncate">Maps</span></span></span>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</span>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Staging"><span class="text-truncate">Staging</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-	</ul>
-</div>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<span class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" data-toggle="tooltip" title="Maps"><span class="text-truncate">Maps</span></span></span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
 
 ```html
-<div class="cadmin">
-	<ul
-		class="show-component-expander-on-hover treeview treeview-nested treeview-light"
-		role="tree"
-	>
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="showComponentExpanderCollapse01"
-				aria-expanded="true"
-				class="treeview-link"
-				data-target="#showComponentExpanderCollapse01"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="0"
-			>
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button
-								aria-controls="showComponentExpanderCollapse01"
-								aria-expanded="true"
-								class="btn btn-monospaced component-expander show"
-								data-target="#showComponentExpanderCollapse01"
-								data-toggle="collapse"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-angle-down"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-down"
-										/>
-									</svg>
-									<svg
-										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-right"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
+<ul
+	class="show-component-expander-on-hover treeview treeview-nested treeview-light"
+	role="tree"
+>
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="showComponentExpanderCollapse01"
+			aria-expanded="true"
+			class="treeview-link"
+			data-target="#showComponentExpanderCollapse01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button
+							aria-controls="showComponentExpanderCollapse01"
+							aria-expanded="true"
+							class="btn btn-monospaced component-expander show"
+							data-target="#showComponentExpanderCollapse01"
+							data-toggle="collapse"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
 								<svg
-									class="lexicon-icon lexicon-icon-folder"
+									class="lexicon-icon lexicon-icon-angle-down"
 									focusable="false"
 									role="presentation"
 								>
 									<use
-										xlink:href="/images/icons/icons.svg#folder"
+										xlink:href="/images/icons/icons.svg#angle-down"
+									/>
+								</svg>
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-right"
 									/>
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span
-									class="text-truncate-inline"
-									data-toggle="tooltip"
-									title="Liferay Drive"
-									><span class="text-truncate"
-										>Liferay Drive</span
-									></span
-								>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg
+								class="lexicon-icon lexicon-icon-folder"
+								focusable="false"
+								role="presentation"
 							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-times-circle-full"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#times-circle-full"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-ellipsis-v"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#ellipsis-v"
-										/>
-									</svg>
-								</span>
-							</button>
+								<use
+									xlink:href="/images/icons/icons.svg#folder"
+								/>
+							</svg>
 						</span>
 					</span>
-				</span>
-			</div>
-			<div class="collapse show" id="showComponentExpanderCollapse01">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div
-							aria-controls="showComponentExpanderCollapse02"
-							aria-expanded="false"
-							class="collapsed treeview-link"
-							data-target="#showComponentExpanderCollapse02"
-							data-toggle="collapse"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
-						>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
 							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
+								class="text-truncate-inline"
+								data-toggle="tooltip"
+								title="Liferay Drive"
+								><span class="text-truncate"
+									>Liferay Drive</span
+								></span
 							>
-								<span class="autofit-row">
-									<span class="autofit-col">
-										<button
-											aria-controls="showComponentExpanderCollapse02"
-											aria-expanded="false"
-											class="btn btn-monospaced component-expander"
-											data-target="#showComponentExpanderCollapse02"
-											data-toggle="collapse"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-angle-down"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#angle-down"
-													/>
-												</svg>
-												<svg
-													class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#angle-right"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<span class="component-icon">
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle-full"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle-full"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-ellipsis-v"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#ellipsis-v"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</span>
+		</div>
+		<div class="collapse show" id="showComponentExpanderCollapse01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						aria-controls="showComponentExpanderCollapse02"
+						aria-expanded="false"
+						class="collapsed treeview-link"
+						data-target="#showComponentExpanderCollapse02"
+						data-toggle="collapse"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button
+										aria-controls="showComponentExpanderCollapse02"
+										aria-expanded="false"
+										class="btn btn-monospaced component-expander"
+										data-target="#showComponentExpanderCollapse02"
+										data-toggle="collapse"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
 											<svg
-												class="lexicon-icon lexicon-icon-folder"
+												class="lexicon-icon lexicon-icon-angle-down"
 												focusable="false"
 												role="presentation"
 											>
 												<use
-													xlink:href="/images/icons/icons.svg#folder"
+													xlink:href="/images/icons/icons.svg#angle-down"
+												/>
+											</svg>
+											<svg
+												class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#angle-right"
 												/>
 											</svg>
 										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg
+											class="lexicon-icon lexicon-icon-folder"
+											focusable="false"
+											role="presentation"
+										>
+											<use
+												xlink:href="/images/icons/icons.svg#folder"
+											/>
+										</svg>
 									</span>
-									<span
-										class="autofit-col autofit-col-expand"
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span
+											class="text-truncate-inline"
+											data-toggle="tooltip"
+											title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
+											><span class="text-truncate"
+												>Liferay Drive
+												(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
+											></span
+										>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
 									>
-										<span class="component-text">
-											<span
-												class="text-truncate-inline"
-												data-toggle="tooltip"
-												title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
-												><span class="text-truncate"
-													>Liferay Drive
-													(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
-												></span
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-info-circle"
+												focusable="false"
+												role="presentation"
 											>
+												<use
+													xlink:href="/images/icons/icons.svg#info-circle"
+												/>
+											</svg>
 										</span>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-info-circle"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#info-circle"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-						<div
-							class="collapse"
-							id="showComponentExpanderCollapse02"
-						>
-							<ul class="treeview-group" role="group">
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<span
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<span class="autofit-row">
-												<span
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															><span
-																class="text-truncate"
-																data-toggle="tooltip"
-																title="Details"
-																>Details</span
-															></span
-														></span
-													>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<span
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<span class="autofit-row">
-												<span
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															data-toggle="tooltip"
-															title="Categorization"
-															><span
-																class="text-truncate"
-																>Categorization</span
-															></span
-														></span
-													>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<span
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<span class="autofit-row">
-												<span
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															data-toggle="tooltip"
-															title="Documents and Media"
-															><span
-																class="text-truncate"
-																>Documents and
-																Media</span
-															></span
-														></span
-													>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<span
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<span class="autofit-row">
-												<span
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															data-toggle="tooltip"
-															title="Site Template"
-															><span
-																class="text-truncate"
-																>Site
-																Template</span
-															></span
-														></span
-													>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-												<span class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</span>
-											</span>
-										</span>
-									</div>
-								</li>
-							</ul>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="showComponentExpanderCollapse03"
-				aria-expanded="false"
-				class="collapsed treeview-link"
-				data-target="#showComponentExpanderCollapse03"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="-1"
-			>
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button
-								aria-controls="showComponentExpanderCollapse03"
-								aria-expanded="false"
-								class="btn btn-monospaced component-expander"
-								data-target="#showComponentExpanderCollapse03"
-								data-toggle="collapse"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-angle-down"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-down"
-										/>
-									</svg>
-									<svg
-										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-right"
-										/>
-									</svg>
-								</span>
-							</button>
 						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
+					</div>
+					<div class="collapse" id="showComponentExpanderCollapse02">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<span
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<span class="autofit-row">
+											<span
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														><span
+															class="text-truncate"
+															data-toggle="tooltip"
+															title="Details"
+															>Details</span
+														></span
+													></span
+												>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<span
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<span class="autofit-row">
+											<span
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														data-toggle="tooltip"
+														title="Categorization"
+														><span
+															class="text-truncate"
+															>Categorization</span
+														></span
+													></span
+												>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<span
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<span class="autofit-row">
+											<span
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														data-toggle="tooltip"
+														title="Documents and Media"
+														><span
+															class="text-truncate"
+															>Documents and
+															Media</span
+														></span
+													></span
+												>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<span
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<span class="autofit-row">
+											<span
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														data-toggle="tooltip"
+														title="Site Template"
+														><span
+															class="text-truncate"
+															>Site Template</span
+														></span
+													></span
+												>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+											<span class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</span>
+										</span>
+									</span>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="showComponentExpanderCollapse03"
+			aria-expanded="false"
+			class="collapsed treeview-link"
+			data-target="#showComponentExpanderCollapse03"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="-1"
+		>
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button
+							aria-controls="showComponentExpanderCollapse03"
+							aria-expanded="false"
+							class="btn btn-monospaced component-expander"
+							data-target="#showComponentExpanderCollapse03"
+							data-toggle="collapse"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
 								<svg
-									class="lexicon-icon lexicon-icon-folder"
+									class="lexicon-icon lexicon-icon-angle-down"
 									focusable="false"
 									role="presentation"
 								>
 									<use
-										xlink:href="/images/icons/icons.svg#folder"
+										xlink:href="/images/icons/icons.svg#angle-down"
 									/>
 								</svg>
-							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span
-									class="text-truncate-inline"
-									data-toggle="tooltip"
-									title="Repositories"
-									><span class="text-truncate"
-										>Repositories</span
-									></span
-								>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-times-circle-full"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#times-circle-full"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-ellipsis-v"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#ellipsis-v"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-					</span>
-				</span>
-			</div>
-			<div class="collapse" id="showComponentExpanderCollapse03">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
-						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												data-toggle="tooltip"
-												title="Sitemap"
-												><span class="text-truncate"
-													>Sitemap</span
-												></span
-											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-								</span>
-							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
-						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												data-toggle="tooltip"
-												title="Robots"
-												><span class="text-truncate"
-													>Robots</span
-												></span
-											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-								</span>
-							</span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="showComponentExpanderCollapse04"
-				aria-expanded="false"
-				class="collapsed treeview-link"
-				data-target="#showComponentExpanderCollapse04"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="-1"
-			>
-				<span class="c-inner" tabindex="-2">
-					<span class="autofit-row">
-						<span class="autofit-col">
-							<button
-								aria-controls="showComponentExpanderCollapse04"
-								aria-expanded="false"
-								class="btn btn-monospaced component-expander"
-								data-target="#showComponentExpanderCollapse04"
-								data-toggle="collapse"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-angle-down"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-down"
-										/>
-									</svg>
-									<svg
-										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-right"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<span class="component-icon">
 								<svg
-									class="lexicon-icon lexicon-icon-folder"
+									class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
 									focusable="false"
 									role="presentation"
 								>
 									<use
-										xlink:href="/images/icons/icons.svg#folder"
+										xlink:href="/images/icons/icons.svg#angle-right"
 									/>
 								</svg>
 							</span>
-						</span>
-						<span class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span
-									class="text-truncate-inline"
-									data-toggle="tooltip"
-									title="Documents and Media"
-									><span class="text-truncate"
-										>Documents and Media</span
-									></span
-								>
-							</span>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg
+								class="lexicon-icon lexicon-icon-folder"
+								focusable="false"
+								role="presentation"
 							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-times-circle-full"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#times-circle-full"
-										/>
-									</svg>
-								</span>
-							</button>
-						</span>
-						<span class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-ellipsis-v"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#ellipsis-v"
-										/>
-									</svg>
-								</span>
-							</button>
+								<use
+									xlink:href="/images/icons/icons.svg#folder"
+								/>
+							</svg>
 						</span>
 					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span
+								class="text-truncate-inline"
+								data-toggle="tooltip"
+								title="Repositories"
+								><span class="text-truncate"
+									>Repositories</span
+								></span
+							>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle-full"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle-full"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-ellipsis-v"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#ellipsis-v"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
 				</span>
-			</div>
-			<div class="collapse" id="showComponentExpanderCollapse04">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+			</span>
+		</div>
+		<div class="collapse" id="showComponentExpanderCollapse03">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
 						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												data-toggle="tooltip"
-												title="Default User Associations"
-												><span class="text-truncate"
-													>Default User
-													Associations</span
-												></span
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											data-toggle="tooltip"
+											title="Sitemap"
+											><span class="text-truncate"
+												>Sitemap</span
 											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
 						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												data-toggle="tooltip"
-												title="Staging"
-												><span class="text-truncate"
-													>Staging</span
-												></span
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											data-toggle="tooltip"
+											title="Robots"
+											><span class="text-truncate"
+												>Robots</span
 											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
+						</span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="showComponentExpanderCollapse04"
+			aria-expanded="false"
+			class="collapsed treeview-link"
+			data-target="#showComponentExpanderCollapse04"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="-1"
+		>
+			<span class="c-inner" tabindex="-2">
+				<span class="autofit-row">
+					<span class="autofit-col">
+						<button
+							aria-controls="showComponentExpanderCollapse04"
+							aria-expanded="false"
+							class="btn btn-monospaced component-expander"
+							data-target="#showComponentExpanderCollapse04"
+							data-toggle="collapse"
 							tabindex="-1"
-							style="padding-left:24px;"
+							type="button"
 						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-down"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-down"
+									/>
+								</svg>
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-right"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<span class="component-icon">
+							<svg
+								class="lexicon-icon lexicon-icon-folder"
+								focusable="false"
+								role="presentation"
 							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												data-toggle="tooltip"
-												title="Analytics"
-												><span class="text-truncate"
-													>Analytics</span
-												></span
+								<use
+									xlink:href="/images/icons/icons.svg#folder"
+								/>
+							</svg>
+						</span>
+					</span>
+					<span class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span
+								class="text-truncate-inline"
+								data-toggle="tooltip"
+								title="Documents and Media"
+								><span class="text-truncate"
+									>Documents and Media</span
+								></span
+							>
+						</span>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle-full"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle-full"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+					<span class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-ellipsis-v"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#ellipsis-v"
+									/>
+								</svg>
+							</span>
+						</button>
+					</span>
+				</span>
+			</span>
+		</div>
+		<div class="collapse" id="showComponentExpanderCollapse04">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											data-toggle="tooltip"
+											title="Default User Associations"
+											><span class="text-truncate"
+												>Default User Associations</span
 											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
 						>
-							<span
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<span class="autofit-row">
-									<span
-										class="autofit-col autofit-col-expand"
-									>
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												data-toggle="tooltip"
-												title="Maps"
-												><span class="text-truncate"
-													>Maps</span
-												></span
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											data-toggle="tooltip"
+											title="Staging"
+											><span class="text-truncate"
+												>Staging</span
 											></span
-										>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
-									<span class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</span>
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</span>
 							</span>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-	</ul>
-</div>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											data-toggle="tooltip"
+											title="Analytics"
+											><span class="text-truncate"
+												>Analytics</span
+											></span
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<span
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<span class="autofit-row">
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											data-toggle="tooltip"
+											title="Maps"
+											><span class="text-truncate"
+												>Maps</span
+											></span
+										></span
+									>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
 ```
 
 ### Treeview Light(#css-treeview-light)
 
 A `treeview` variation for light colored backgrounds.
 
-<div class="cadmin">
-	<ul class="treeview treeview-nested treeview-light" role="tree">
-		<li class="treeview-item" role="none">
-			<div aria-controls="treeviewLightCollapseCheckbox01" aria-expanded="true" class="treeview-link" data-target="#treeviewLightCollapseCheckbox01" data-toggle="collapse" role="treeitem" tabindex="0">
-				<div class="c-inner" tabindex="-2">
-					<div class="autofit-row">
-						<div class="autofit-col">
-							<button aria-controls="treeviewLightCollapseCheckbox01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox01" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
-						</div>
-						<div class="autofit-col">
-							<div class="custom-control custom-checkbox">
-								<label>
-									<input class="custom-control-input" tabindex="-1" type="checkbox" />
-									<span class="custom-control-label"></span>
-								</label>
-							</div>
-						</div>
-						<div class="autofit-col">
-							<div class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+<ul class="treeview treeview-nested treeview-light" role="tree">
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewLightCollapseCheckbox01" aria-expanded="true" class="treeview-link" data-target="#treeviewLightCollapseCheckbox01" data-toggle="collapse" role="treeitem" tabindex="0">
+			<div class="c-inner" tabindex="-2">
+				<div class="autofit-row">
+					<div class="autofit-col">
+						<button aria-controls="treeviewLightCollapseCheckbox01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox01" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
 								</svg>
-							</div>
-						</div>
-						<div class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
+								</svg>
 							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input class="custom-control-input" tabindex="-1" type="checkbox" />
+								<span class="custom-control-label"></span>
+							</label>
 						</div>
-						<div class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
+					</div>
+					<div class="autofit-col">
+						<div class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
 						</div>
-						<div class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
-						</div>
+					</div>
+					<div class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+						</span>
+					</div>
+					<div class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
 					</div>
 				</div>
 			</div>
-			<div class="collapse show" id="treeviewLightCollapseCheckbox01">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div aria-controls="treeviewLightCollapseCheckbox02" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewLightCollapseCheckbox02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<button aria-controls="treeviewLightCollapseCheckbox02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox02" data-toggle="collapse" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#angle-down" />
-												</svg>
-												<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#angle-right" />
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<div class="custom-control custom-checkbox">
-											<label>
-												<input class="custom-control-input" tabindex="-1" type="checkbox" />
-												<span class="custom-control-label"></span>
-											</label>
-										</div>
-									</div>
-									<div class="autofit-col">
-										<div class="component-icon">
-											<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-												<use xlink:href="/images/icons/icons.svg#folder" />
+		</div>
+		<div class="collapse show" id="treeviewLightCollapseCheckbox01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div aria-controls="treeviewLightCollapseCheckbox02" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewLightCollapseCheckbox02" data-toggle="collapse" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<button aria-controls="treeviewLightCollapseCheckbox02" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox02" data-toggle="collapse" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#angle-down" />
 											</svg>
-										</div>
-									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text">
-											<span class="text-truncate-inline" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#angle-right" />
+											</svg>
 										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
 									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
+								</div>
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#folder" />
+										</svg>
 									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"><span class="text-truncate">Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span></span>
+									</span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-						<div class="collapse" id="treeviewLightCollapseCheckbox02">
-							<ul class="treeview-group" role="group">
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<div class="autofit-row">
-												<div class="autofit-col">
-													<div class="custom-control custom-checkbox">
-														<label>
-															<input class="custom-control-input" tabindex="-1" type="checkbox" />
-															<span class="custom-control-label"></span>
-														</label>
-													</div>
+					</div>
+					<div class="collapse" id="treeviewLightCollapseCheckbox02">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
 												</div>
-												<div class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" title="Details">Details</span></span></span>
-												</div>
-												<div class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</div>
-												<div class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline"><span class="text-truncate" title="Details">Details</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
 											</div>
 										</div>
 									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<div class="autofit-row">
-												<div class="autofit-col">
-													<div class="custom-control custom-checkbox">
-														<label>
-															<input class="custom-control-input" tabindex="-1" type="checkbox" />
-															<span class="custom-control-label"></span>
-														</label>
-													</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
 												</div>
-												<div class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
-												</div>
-												<div class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</div>
-												<div class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" title="Categorization"><span class="text-truncate">Categorization</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
 											</div>
 										</div>
 									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<div class="autofit-row">
-												<div class="autofit-col">
-													<div class="custom-control custom-checkbox">
-														<label>
-															<input class="custom-control-input" tabindex="-1" type="checkbox" />
-															<span class="custom-control-label"></span>
-														</label>
-													</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
 												</div>
-												<div class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
-												</div>
-												<div class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</div>
-												<div class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
 											</div>
 										</div>
 									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
-										<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
-											<div class="autofit-row">
-												<div class="autofit-col">
-													<div class="custom-control custom-checkbox">
-														<label>
-															<input class="custom-control-input" tabindex="-1" type="checkbox" />
-															<span class="custom-control-label"></span>
-														</label>
-													</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:48px;">
+									<div class="c-inner" tabindex="-2" style="margin-left:-48px;">
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div class="custom-control custom-checkbox">
+													<label>
+														<input class="custom-control-input" tabindex="-1" type="checkbox" />
+														<span class="custom-control-label"></span>
+													</label>
 												</div>
-												<div class="autofit-col autofit-col-expand">
-													<span class="component-text"><span class="text-truncate-inline" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
-												</div>
-												<div class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-															</svg>
-														</span>
-													</button>
-												</div>
-												<div class="autofit-col">
-													<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-														<span class="c-inner" tabindex="-2">
-															<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-																<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-															</svg>
-														</span>
-													</button>
-												</div>
+											</div>
+											<div class="autofit-col autofit-col-expand">
+												<span class="component-text"><span class="text-truncate-inline" title="Site Template"><span class="text-truncate">Site Template</span></span></span>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+													<span class="c-inner" tabindex="-2">
+														<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+															<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+														</svg>
+													</span>
+												</button>
 											</div>
 										</div>
 									</div>
-								</li>
-							</ul>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div aria-controls="treeviewLightCollapseCheckbox03" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewLightCollapseCheckbox03" data-toggle="collapse" role="treeitem" tabindex="-1">
-				<div class="c-inner" tabindex="-2">
-					<div class="autofit-row">
-						<div class="autofit-col">
-							<button aria-controls="treeviewLightCollapseCheckbox03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox03" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
-						</div>
-						<div class="autofit-col">
-							<div class="custom-control custom-checkbox">
-								<label>
-									<input class="custom-control-input" tabindex="-1" type="checkbox" />
-									<span class="custom-control-label"></span>
-								</label>
-							</div>
-						</div>
-						<div class="autofit-col">
-							<div class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewLightCollapseCheckbox03" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewLightCollapseCheckbox03" data-toggle="collapse" role="treeitem" tabindex="-1">
+			<div class="c-inner" tabindex="-2">
+				<div class="autofit-row">
+					<div class="autofit-col">
+						<button aria-controls="treeviewLightCollapseCheckbox03" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox03" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
 								</svg>
-							</div>
-						</div>
-						<div class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" title="Repositories"><span class="text-truncate">Repositories</span></span>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
+								</svg>
 							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input class="custom-control-input" tabindex="-1" type="checkbox" />
+								<span class="custom-control-label"></span>
+							</label>
 						</div>
-						<div class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
+					</div>
+					<div class="autofit-col">
+						<div class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
 						</div>
-						<div class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
-						</div>
+					</div>
+					<div class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Repositories"><span class="text-truncate">Repositories</span></span>
+						</span>
+					</div>
+					<div class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
 					</div>
 				</div>
 			</div>
-			<div class="collapse" id="treeviewLightCollapseCheckbox03">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div class="custom-control custom-checkbox">
-											<label>
-												<input class="custom-control-input" tabindex="-1" type="checkbox" />
-												<span class="custom-control-label"></span>
-											</label>
-										</div>
+		</div>
+		<div class="collapse" id="treeviewLightCollapseCheckbox03">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
 									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Sitemap"><span class="text-truncate">Sitemap</span></span></span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div class="custom-control custom-checkbox">
-											<label>
-												<input class="custom-control-input" tabindex="-1" type="checkbox" />
-												<span class="custom-control-label"></span>
-											</label>
-										</div>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
 									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Robots"><span class="text-truncate">Robots</span></span></span>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Robots"><span class="text-truncate">Robots</span></span></span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div aria-controls="treeviewLightCollapseCheckbox04" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewLightCollapseCheckbox04" data-toggle="collapse" role="treeitem" tabindex="-1">
-				<div class="c-inner" tabindex="-2">
-					<div class="autofit-row">
-						<div class="autofit-col">
-							<button aria-controls="treeviewLightCollapseCheckbox04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox04" data-toggle="collapse" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-down" />
-									</svg>
-									<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#angle-right" />
-									</svg>
-								</span>
-							</button>
-						</div>
-						<div class="autofit-col">
-							<div class="custom-control custom-checkbox">
-								<label>
-									<input class="custom-control-input" tabindex="-1" type="checkbox" />
-									<span class="custom-control-label"></span>
-								</label>
-							</div>
-						</div>
-						<div class="autofit-col">
-							<div class="component-icon">
-								<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
-									<use xlink:href="/images/icons/icons.svg#folder" />
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div aria-controls="treeviewLightCollapseCheckbox04" aria-expanded="false" class="collapsed treeview-link" data-target="#treeviewLightCollapseCheckbox04" data-toggle="collapse" role="treeitem" tabindex="-1">
+			<div class="c-inner" tabindex="-2">
+				<div class="autofit-row">
+					<div class="autofit-col">
+						<button aria-controls="treeviewLightCollapseCheckbox04" aria-expanded="false" class="btn btn-monospaced component-expander" data-target="#treeviewLightCollapseCheckbox04" data-toggle="collapse" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-down" />
 								</svg>
-							</div>
-						</div>
-						<div class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+								<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#angle-right" />
+								</svg>
 							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input class="custom-control-input" tabindex="-1" type="checkbox" />
+								<span class="custom-control-label"></span>
+							</label>
 						</div>
-						<div class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-									</svg>
-								</span>
-							</button>
+					</div>
+					<div class="autofit-col">
+						<div class="component-icon">
+							<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+								<use xlink:href="/images/icons/icons.svg#folder" />
+							</svg>
 						</div>
-						<div class="autofit-col">
-							<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-								<span class="c-inner" tabindex="-2">
-									<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-										<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</span>
-							</button>
-						</div>
+					</div>
+					<div class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span class="text-truncate-inline" title="Documents and Media"><span class="text-truncate">Documents and Media</span></span>
+						</span>
+					</div>
+					<div class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+								</svg>
+							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+							<span class="c-inner" tabindex="-2">
+								<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+									<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</span>
+						</button>
 					</div>
 				</div>
 			</div>
-			<div class="collapse" id="treeviewLightCollapseCheckbox04">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div class="custom-control custom-checkbox">
-											<label>
-												<input class="custom-control-input" tabindex="-1" type="checkbox" />
-												<span class="custom-control-label"></span>
-											</label>
-										</div>
+		</div>
+		<div class="collapse" id="treeviewLightCollapseCheckbox04">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
 									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Default User Associations"><span class="text-truncate">Default User Associations</span></span></span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div class="custom-control custom-checkbox">
-											<label>
-												<input class="custom-control-input" tabindex="-1" type="checkbox" />
-												<span class="custom-control-label"></span>
-											</label>
-										</div>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
 									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Staging"><span class="text-truncate">Staging</span></span></span>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Staging"><span class="text-truncate">Staging</span></span></span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div class="custom-control custom-checkbox">
-											<label>
-												<input class="custom-control-input" tabindex="-1" type="checkbox" />
-												<span class="custom-control-label"></span>
-											</label>
-										</div>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
 									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Analytics"><span class="text-truncate">Analytics</span></span></span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
-							<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div class="custom-control custom-checkbox">
-											<label>
-												<input class="custom-control-input" tabindex="-1" type="checkbox" />
-												<span class="custom-control-label"></span>
-											</label>
-										</div>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div class="treeview-link" role="treeitem" tabindex="-1" style="padding-left:24px;">
+						<div class="c-inner" tabindex="-2" style="margin-left:-24px;">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" tabindex="-1" type="checkbox" />
+											<span class="custom-control-label"></span>
+										</label>
 									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"><span class="text-truncate-inline" title="Maps"><span class="text-truncate">Maps</span></span></span>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#times-circle-full" />
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
-											<span class="c-inner" tabindex="-2">
-												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
-													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
-												</svg>
-											</span>
-										</button>
-									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"><span class="text-truncate-inline" title="Maps"><span class="text-truncate">Maps</span></span></span>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button class="btn btn-monospaced component-action" tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-	</ul>
-</div>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
 
 ```html
-<div class="cadmin">
-	<ul class="treeview treeview-nested treeview-light" role="tree">
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="treeviewLightCollapseCheckbox01"
-				aria-expanded="true"
-				class="treeview-link"
-				data-target="#treeviewLightCollapseCheckbox01"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="0"
-			>
-				<div class="c-inner" tabindex="-2">
-					<div class="autofit-row">
-						<div class="autofit-col">
-							<button
-								aria-controls="treeviewLightCollapseCheckbox01"
-								aria-expanded="true"
-								class="btn btn-monospaced component-expander"
-								data-target="#treeviewLightCollapseCheckbox01"
-								data-toggle="collapse"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-angle-down"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-down"
-										/>
-									</svg>
-									<svg
-										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-right"
-										/>
-									</svg>
-								</span>
-							</button>
-						</div>
-						<div class="autofit-col">
-							<div class="custom-control custom-checkbox">
-								<label>
-									<input
-										class="custom-control-input"
-										tabindex="-1"
-										type="checkbox"
-									/>
-									<span class="custom-control-label"></span>
-								</label>
-							</div>
-						</div>
-						<div class="autofit-col">
-							<div class="component-icon">
+<ul class="treeview treeview-nested treeview-light" role="tree">
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewLightCollapseCheckbox01"
+			aria-expanded="true"
+			class="treeview-link"
+			data-target="#treeviewLightCollapseCheckbox01"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="0"
+		>
+			<div class="c-inner" tabindex="-2">
+				<div class="autofit-row">
+					<div class="autofit-col">
+						<button
+							aria-controls="treeviewLightCollapseCheckbox01"
+							aria-expanded="true"
+							class="btn btn-monospaced component-expander"
+							data-target="#treeviewLightCollapseCheckbox01"
+							data-toggle="collapse"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
 								<svg
-									class="lexicon-icon lexicon-icon-folder"
+									class="lexicon-icon lexicon-icon-angle-down"
 									focusable="false"
 									role="presentation"
 								>
 									<use
-										xlink:href="/images/icons/icons.svg#folder"
+										xlink:href="/images/icons/icons.svg#angle-down"
 									/>
 								</svg>
-							</div>
-						</div>
-						<div class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span
-									class="text-truncate-inline"
-									title="Liferay Drive"
-									><span class="text-truncate"
-										>Liferay Drive</span
-									></span
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+									focusable="false"
+									role="presentation"
 								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-right"
+									/>
+								</svg>
 							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input
+									class="custom-control-input"
+									tabindex="-1"
+									type="checkbox"
+								/>
+								<span class="custom-control-label"></span>
+							</label>
 						</div>
-						<div class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
+					</div>
+					<div class="autofit-col">
+						<div class="component-icon">
+							<svg
+								class="lexicon-icon lexicon-icon-folder"
+								focusable="false"
+								role="presentation"
 							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-times-circle-full"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#times-circle-full"
-										/>
-									</svg>
-								</span>
-							</button>
+								<use
+									xlink:href="/images/icons/icons.svg#folder"
+								/>
+							</svg>
 						</div>
-						<div class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
+					</div>
+					<div class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span
+								class="text-truncate-inline"
+								title="Liferay Drive"
+								><span class="text-truncate"
+									>Liferay Drive</span
+								></span
 							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-ellipsis-v"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#ellipsis-v"
-										/>
-									</svg>
-								</span>
-							</button>
-						</div>
+						</span>
+					</div>
+					<div class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle-full"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle-full"
+									/>
+								</svg>
+							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-ellipsis-v"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#ellipsis-v"
+									/>
+								</svg>
+							</span>
+						</button>
 					</div>
 				</div>
 			</div>
-			<div class="collapse show" id="treeviewLightCollapseCheckbox01">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
+		</div>
+		<div class="collapse show" id="treeviewLightCollapseCheckbox01">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						aria-controls="treeviewLightCollapseCheckbox02"
+						aria-expanded="false"
+						class="collapsed treeview-link"
+						data-target="#treeviewLightCollapseCheckbox02"
+						data-toggle="collapse"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
 						<div
-							aria-controls="treeviewLightCollapseCheckbox02"
-							aria-expanded="false"
-							class="collapsed treeview-link"
-							data-target="#treeviewLightCollapseCheckbox02"
-							data-toggle="collapse"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
 						>
-							<div
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<button
-											aria-controls="treeviewLightCollapseCheckbox02"
-											aria-expanded="false"
-											class="btn btn-monospaced component-expander"
-											data-target="#treeviewLightCollapseCheckbox02"
-											data-toggle="collapse"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-angle-down"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#angle-down"
-													/>
-												</svg>
-												<svg
-													class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#angle-right"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<div
-											class="custom-control custom-checkbox"
-										>
-											<label>
-												<input
-													class="custom-control-input"
-													tabindex="-1"
-													type="checkbox"
-												/>
-												<span
-													class="custom-control-label"
-												></span>
-											</label>
-										</div>
-									</div>
-									<div class="autofit-col">
-										<div class="component-icon">
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<button
+										aria-controls="treeviewLightCollapseCheckbox02"
+										aria-expanded="false"
+										class="btn btn-monospaced component-expander"
+										data-target="#treeviewLightCollapseCheckbox02"
+										data-toggle="collapse"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
 											<svg
-												class="lexicon-icon lexicon-icon-folder"
+												class="lexicon-icon lexicon-icon-angle-down"
 												focusable="false"
 												role="presentation"
 											>
 												<use
-													xlink:href="/images/icons/icons.svg#folder"
+													xlink:href="/images/icons/icons.svg#angle-down"
 												/>
 											</svg>
-										</div>
-									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text">
-											<span
-												class="text-truncate-inline"
-												title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
-												><span class="text-truncate"
-													>Liferay Drive
-													(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
-												></span
+											<svg
+												class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+												focusable="false"
+												role="presentation"
 											>
+												<use
+													xlink:href="/images/icons/icons.svg#angle-right"
+												/>
+											</svg>
 										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input
+												class="custom-control-input"
+												tabindex="-1"
+												type="checkbox"
+											/>
+											<span
+												class="custom-control-label"
+											></span>
+										</label>
 									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
+								</div>
+								<div class="autofit-col">
+									<div class="component-icon">
+										<svg
+											class="lexicon-icon lexicon-icon-folder"
+											focusable="false"
+											role="presentation"
 										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
+											<use
+												xlink:href="/images/icons/icons.svg#folder"
+											/>
+										</svg>
 									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span
+											class="text-truncate-inline"
+											title="Liferay Drive (ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)"
+											><span class="text-truncate"
+												>Liferay Drive
+												(ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual)</span
+											></span
 										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
+									</span>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-						<div
-							class="collapse"
-							id="treeviewLightCollapseCheckbox02"
+					</div>
+					<div class="collapse" id="treeviewLightCollapseCheckbox02">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<div
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div
+													class="custom-control custom-checkbox"
+												>
+													<label>
+														<input
+															class="custom-control-input"
+															tabindex="-1"
+															type="checkbox"
+														/>
+														<span
+															class="custom-control-label"
+														></span>
+													</label>
+												</div>
+											</div>
+											<div
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														><span
+															class="text-truncate"
+															title="Details"
+															>Details</span
+														></span
+													></span
+												>
+											</div>
+											<div class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<div
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div
+													class="custom-control custom-checkbox"
+												>
+													<label>
+														<input
+															class="custom-control-input"
+															tabindex="-1"
+															type="checkbox"
+														/>
+														<span
+															class="custom-control-label"
+														></span>
+													</label>
+												</div>
+											</div>
+											<div
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														title="Categorization"
+														><span
+															class="text-truncate"
+															>Categorization</span
+														></span
+													></span
+												>
+											</div>
+											<div class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<div
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div
+													class="custom-control custom-checkbox"
+												>
+													<label>
+														<input
+															class="custom-control-input"
+															tabindex="-1"
+															type="checkbox"
+														/>
+														<span
+															class="custom-control-label"
+														></span>
+													</label>
+												</div>
+											</div>
+											<div
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														title="Documents and Media"
+														><span
+															class="text-truncate"
+															>Documents and
+															Media</span
+														></span
+													></span
+												>
+											</div>
+											<div class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+							<li class="treeview-item" role="none">
+								<div
+									class="treeview-link"
+									role="treeitem"
+									tabindex="-1"
+									style="padding-left:48px;"
+								>
+									<div
+										class="c-inner"
+										tabindex="-2"
+										style="margin-left:-48px;"
+									>
+										<div class="autofit-row">
+											<div class="autofit-col">
+												<div
+													class="custom-control custom-checkbox"
+												>
+													<label>
+														<input
+															class="custom-control-input"
+															tabindex="-1"
+															type="checkbox"
+														/>
+														<span
+															class="custom-control-label"
+														></span>
+													</label>
+												</div>
+											</div>
+											<div
+												class="autofit-col autofit-col-expand"
+											>
+												<span class="component-text"
+													><span
+														class="text-truncate-inline"
+														title="Site Template"
+														><span
+															class="text-truncate"
+															>Site Template</span
+														></span
+													></span
+												>
+											</div>
+											<div class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-times-circle-full"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#times-circle-full"
+															/>
+														</svg>
+													</span>
+												</button>
+											</div>
+											<div class="autofit-col">
+												<button
+													class="btn btn-monospaced component-action"
+													tabindex="-1"
+													type="button"
+												>
+													<span
+														class="c-inner"
+														tabindex="-2"
+													>
+														<svg
+															class="lexicon-icon lexicon-icon-ellipsis-v"
+															focusable="false"
+															role="presentation"
+														>
+															<use
+																xlink:href="/images/icons/icons.svg#ellipsis-v"
+															/>
+														</svg>
+													</span>
+												</button>
+											</div>
+										</div>
+									</div>
+								</div>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewLightCollapseCheckbox03"
+			aria-expanded="false"
+			class="collapsed treeview-link"
+			data-target="#treeviewLightCollapseCheckbox03"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="-1"
+		>
+			<div class="c-inner" tabindex="-2">
+				<div class="autofit-row">
+					<div class="autofit-col">
+						<button
+							aria-controls="treeviewLightCollapseCheckbox03"
+							aria-expanded="false"
+							class="btn btn-monospaced component-expander"
+							data-target="#treeviewLightCollapseCheckbox03"
+							data-toggle="collapse"
+							tabindex="-1"
+							type="button"
 						>
-							<ul class="treeview-group" role="group">
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<div
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<div class="autofit-row">
-												<div class="autofit-col">
-													<div
-														class="custom-control custom-checkbox"
-													>
-														<label>
-															<input
-																class="custom-control-input"
-																tabindex="-1"
-																type="checkbox"
-															/>
-															<span
-																class="custom-control-label"
-															></span>
-														</label>
-													</div>
-												</div>
-												<div
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															><span
-																class="text-truncate"
-																title="Details"
-																>Details</span
-															></span
-														></span
-													>
-												</div>
-												<div class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</div>
-												<div class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</div>
-											</div>
-										</div>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<div
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<div class="autofit-row">
-												<div class="autofit-col">
-													<div
-														class="custom-control custom-checkbox"
-													>
-														<label>
-															<input
-																class="custom-control-input"
-																tabindex="-1"
-																type="checkbox"
-															/>
-															<span
-																class="custom-control-label"
-															></span>
-														</label>
-													</div>
-												</div>
-												<div
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															title="Categorization"
-															><span
-																class="text-truncate"
-																>Categorization</span
-															></span
-														></span
-													>
-												</div>
-												<div class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</div>
-												<div class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</div>
-											</div>
-										</div>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<div
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<div class="autofit-row">
-												<div class="autofit-col">
-													<div
-														class="custom-control custom-checkbox"
-													>
-														<label>
-															<input
-																class="custom-control-input"
-																tabindex="-1"
-																type="checkbox"
-															/>
-															<span
-																class="custom-control-label"
-															></span>
-														</label>
-													</div>
-												</div>
-												<div
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															title="Documents and Media"
-															><span
-																class="text-truncate"
-																>Documents and
-																Media</span
-															></span
-														></span
-													>
-												</div>
-												<div class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</div>
-												<div class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</div>
-											</div>
-										</div>
-									</div>
-								</li>
-								<li class="treeview-item" role="none">
-									<div
-										class="treeview-link"
-										role="treeitem"
-										tabindex="-1"
-										style="padding-left:48px;"
-									>
-										<div
-											class="c-inner"
-											tabindex="-2"
-											style="margin-left:-48px;"
-										>
-											<div class="autofit-row">
-												<div class="autofit-col">
-													<div
-														class="custom-control custom-checkbox"
-													>
-														<label>
-															<input
-																class="custom-control-input"
-																tabindex="-1"
-																type="checkbox"
-															/>
-															<span
-																class="custom-control-label"
-															></span>
-														</label>
-													</div>
-												</div>
-												<div
-													class="autofit-col autofit-col-expand"
-												>
-													<span class="component-text"
-														><span
-															class="text-truncate-inline"
-															title="Site Template"
-															><span
-																class="text-truncate"
-																>Site
-																Template</span
-															></span
-														></span
-													>
-												</div>
-												<div class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-times-circle-full"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#times-circle-full"
-																/>
-															</svg>
-														</span>
-													</button>
-												</div>
-												<div class="autofit-col">
-													<button
-														class="btn btn-monospaced component-action"
-														tabindex="-1"
-														type="button"
-													>
-														<span
-															class="c-inner"
-															tabindex="-2"
-														>
-															<svg
-																class="lexicon-icon lexicon-icon-ellipsis-v"
-																focusable="false"
-																role="presentation"
-															>
-																<use
-																	xlink:href="/images/icons/icons.svg#ellipsis-v"
-																/>
-															</svg>
-														</span>
-													</button>
-												</div>
-											</div>
-										</div>
-									</div>
-								</li>
-							</ul>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="treeviewLightCollapseCheckbox03"
-				aria-expanded="false"
-				class="collapsed treeview-link"
-				data-target="#treeviewLightCollapseCheckbox03"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="-1"
-			>
-				<div class="c-inner" tabindex="-2">
-					<div class="autofit-row">
-						<div class="autofit-col">
-							<button
-								aria-controls="treeviewLightCollapseCheckbox03"
-								aria-expanded="false"
-								class="btn btn-monospaced component-expander"
-								data-target="#treeviewLightCollapseCheckbox03"
-								data-toggle="collapse"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-angle-down"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-down"
-										/>
-									</svg>
-									<svg
-										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-right"
-										/>
-									</svg>
-								</span>
-							</button>
-						</div>
-						<div class="autofit-col">
-							<div class="custom-control custom-checkbox">
-								<label>
-									<input
-										class="custom-control-input"
-										tabindex="-1"
-										type="checkbox"
-									/>
-									<span class="custom-control-label"></span>
-								</label>
-							</div>
-						</div>
-						<div class="autofit-col">
-							<div class="component-icon">
+							<span class="c-inner" tabindex="-2">
 								<svg
-									class="lexicon-icon lexicon-icon-folder"
+									class="lexicon-icon lexicon-icon-angle-down"
 									focusable="false"
 									role="presentation"
 								>
 									<use
-										xlink:href="/images/icons/icons.svg#folder"
+										xlink:href="/images/icons/icons.svg#angle-down"
 									/>
 								</svg>
-							</div>
-						</div>
-						<div class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span
-									class="text-truncate-inline"
-									title="Repositories"
-									><span class="text-truncate"
-										>Repositories</span
-									></span
-								>
-							</span>
-						</div>
-						<div class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-times-circle-full"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#times-circle-full"
-										/>
-									</svg>
-								</span>
-							</button>
-						</div>
-						<div class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-ellipsis-v"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#ellipsis-v"
-										/>
-									</svg>
-								</span>
-							</button>
-						</div>
-					</div>
-				</div>
-			</div>
-			<div class="collapse" id="treeviewLightCollapseCheckbox03">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
-						>
-							<div
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div
-											class="custom-control custom-checkbox"
-										>
-											<label>
-												<input
-													class="custom-control-input"
-													tabindex="-1"
-													type="checkbox"
-												/>
-												<span
-													class="custom-control-label"
-												></span>
-											</label>
-										</div>
-									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Sitemap"
-												><span class="text-truncate"
-													>Sitemap</span
-												></span
-											></span
-										>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-								</div>
-							</div>
-						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
-						>
-							<div
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div
-											class="custom-control custom-checkbox"
-										>
-											<label>
-												<input
-													class="custom-control-input"
-													tabindex="-1"
-													type="checkbox"
-												/>
-												<span
-													class="custom-control-label"
-												></span>
-											</label>
-										</div>
-									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Robots"
-												><span class="text-truncate"
-													>Robots</span
-												></span
-											></span
-										>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-								</div>
-							</div>
-						</div>
-					</li>
-				</ul>
-			</div>
-		</li>
-		<li class="treeview-item" role="none">
-			<div
-				aria-controls="treeviewLightCollapseCheckbox04"
-				aria-expanded="false"
-				class="collapsed treeview-link"
-				data-target="#treeviewLightCollapseCheckbox04"
-				data-toggle="collapse"
-				role="treeitem"
-				tabindex="-1"
-			>
-				<div class="c-inner" tabindex="-2">
-					<div class="autofit-row">
-						<div class="autofit-col">
-							<button
-								aria-controls="treeviewLightCollapseCheckbox04"
-								aria-expanded="false"
-								class="btn btn-monospaced component-expander"
-								data-target="#treeviewLightCollapseCheckbox04"
-								data-toggle="collapse"
-								tabindex="-1"
-								type="button"
-							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-angle-down"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-down"
-										/>
-									</svg>
-									<svg
-										class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#angle-right"
-										/>
-									</svg>
-								</span>
-							</button>
-						</div>
-						<div class="autofit-col">
-							<div class="custom-control custom-checkbox">
-								<label>
-									<input
-										class="custom-control-input"
-										tabindex="-1"
-										type="checkbox"
-									/>
-									<span class="custom-control-label"></span>
-								</label>
-							</div>
-						</div>
-						<div class="autofit-col">
-							<div class="component-icon">
 								<svg
-									class="lexicon-icon lexicon-icon-folder"
+									class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
 									focusable="false"
 									role="presentation"
 								>
 									<use
-										xlink:href="/images/icons/icons.svg#folder"
+										xlink:href="/images/icons/icons.svg#angle-right"
 									/>
 								</svg>
-							</div>
-						</div>
-						<div class="autofit-col autofit-col-expand">
-							<span class="component-text">
-								<span
-									class="text-truncate-inline"
-									title="Documents and Media"
-									><span class="text-truncate"
-										>Documents and Media</span
-									></span
-								>
 							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input
+									class="custom-control-input"
+									tabindex="-1"
+									type="checkbox"
+								/>
+								<span class="custom-control-label"></span>
+							</label>
 						</div>
-						<div class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
+					</div>
+					<div class="autofit-col">
+						<div class="component-icon">
+							<svg
+								class="lexicon-icon lexicon-icon-folder"
+								focusable="false"
+								role="presentation"
 							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-times-circle-full"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#times-circle-full"
-										/>
-									</svg>
-								</span>
-							</button>
+								<use
+									xlink:href="/images/icons/icons.svg#folder"
+								/>
+							</svg>
 						</div>
-						<div class="autofit-col">
-							<button
-								class="btn btn-monospaced component-action"
-								tabindex="-1"
-								type="button"
+					</div>
+					<div class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span
+								class="text-truncate-inline"
+								title="Repositories"
+								><span class="text-truncate"
+									>Repositories</span
+								></span
 							>
-								<span class="c-inner" tabindex="-2">
-									<svg
-										class="lexicon-icon lexicon-icon-ellipsis-v"
-										focusable="false"
-										role="presentation"
-									>
-										<use
-											xlink:href="/images/icons/icons.svg#ellipsis-v"
-										/>
-									</svg>
-								</span>
-							</button>
-						</div>
+						</span>
+					</div>
+					<div class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle-full"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle-full"
+									/>
+								</svg>
+							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-ellipsis-v"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#ellipsis-v"
+									/>
+								</svg>
+							</span>
+						</button>
 					</div>
 				</div>
 			</div>
-			<div class="collapse" id="treeviewLightCollapseCheckbox04">
-				<ul class="treeview-group" role="group">
-					<li class="treeview-item" role="none">
+		</div>
+		<div class="collapse" id="treeviewLightCollapseCheckbox03">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
 						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
 						>
-							<div
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div
-											class="custom-control custom-checkbox"
-										>
-											<label>
-												<input
-													class="custom-control-input"
-													tabindex="-1"
-													type="checkbox"
-												/>
-												<span
-													class="custom-control-label"
-												></span>
-											</label>
-										</div>
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input
+												class="custom-control-input"
+												tabindex="-1"
+												type="checkbox"
+											/>
+											<span
+												class="custom-control-label"
+											></span>
+										</label>
 									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Default User Associations"
-												><span class="text-truncate"
-													>Default User
-													Associations</span
-												></span
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Sitemap"
+											><span class="text-truncate"
+												>Sitemap</span
 											></span
-										>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
+										></span
+									>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-					</li>
-					<li class="treeview-item" role="none">
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
 						<div
-							class="treeview-link"
-							role="treeitem"
-							tabindex="-1"
-							style="padding-left:24px;"
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
 						>
-							<div
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div
-											class="custom-control custom-checkbox"
-										>
-											<label>
-												<input
-													class="custom-control-input"
-													tabindex="-1"
-													type="checkbox"
-												/>
-												<span
-													class="custom-control-label"
-												></span>
-											</label>
-										</div>
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input
+												class="custom-control-input"
+												tabindex="-1"
+												type="checkbox"
+											/>
+											<span
+												class="custom-control-label"
+											></span>
+										</label>
 									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Staging"
-												><span class="text-truncate"
-													>Staging</span
-												></span
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Robots"
+											><span class="text-truncate"
+												>Robots</span
 											></span
-										>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
+										></span
+									>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
 								</div>
 							</div>
 						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewLightCollapseCheckbox04"
+			aria-expanded="false"
+			class="collapsed treeview-link"
+			data-target="#treeviewLightCollapseCheckbox04"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="-1"
+		>
+			<div class="c-inner" tabindex="-2">
+				<div class="autofit-row">
+					<div class="autofit-col">
+						<button
+							aria-controls="treeviewLightCollapseCheckbox04"
+							aria-expanded="false"
+							class="btn btn-monospaced component-expander"
+							data-target="#treeviewLightCollapseCheckbox04"
+							data-toggle="collapse"
 							tabindex="-1"
-							style="padding-left:24px;"
+							type="button"
 						>
-							<div
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div
-											class="custom-control custom-checkbox"
-										>
-											<label>
-												<input
-													class="custom-control-input"
-													tabindex="-1"
-													type="checkbox"
-												/>
-												<span
-													class="custom-control-label"
-												></span>
-											</label>
-										</div>
-									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Analytics"
-												><span class="text-truncate"
-													>Analytics</span
-												></span
-											></span
-										>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-								</div>
-							</div>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-angle-down"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-down"
+									/>
+								</svg>
+								<svg
+									class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#angle-right"
+									/>
+								</svg>
+							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<div class="custom-control custom-checkbox">
+							<label>
+								<input
+									class="custom-control-input"
+									tabindex="-1"
+									type="checkbox"
+								/>
+								<span class="custom-control-label"></span>
+							</label>
 						</div>
-					</li>
-					<li class="treeview-item" role="none">
-						<div
-							class="treeview-link"
-							role="treeitem"
+					</div>
+					<div class="autofit-col">
+						<div class="component-icon">
+							<svg
+								class="lexicon-icon lexicon-icon-folder"
+								focusable="false"
+								role="presentation"
+							>
+								<use
+									xlink:href="/images/icons/icons.svg#folder"
+								/>
+							</svg>
+						</div>
+					</div>
+					<div class="autofit-col autofit-col-expand">
+						<span class="component-text">
+							<span
+								class="text-truncate-inline"
+								title="Documents and Media"
+								><span class="text-truncate"
+									>Documents and Media</span
+								></span
+							>
+						</span>
+					</div>
+					<div class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
 							tabindex="-1"
-							style="padding-left:24px;"
+							type="button"
 						>
-							<div
-								class="c-inner"
-								tabindex="-2"
-								style="margin-left:-24px;"
-							>
-								<div class="autofit-row">
-									<div class="autofit-col">
-										<div
-											class="custom-control custom-checkbox"
-										>
-											<label>
-												<input
-													class="custom-control-input"
-													tabindex="-1"
-													type="checkbox"
-												/>
-												<span
-													class="custom-control-label"
-												></span>
-											</label>
-										</div>
-									</div>
-									<div class="autofit-col autofit-col-expand">
-										<span class="component-text"
-											><span
-												class="text-truncate-inline"
-												title="Maps"
-												><span class="text-truncate"
-													>Maps</span
-												></span
-											></span
-										>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-times-circle-full"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#times-circle-full"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-									<div class="autofit-col">
-										<button
-											class="btn btn-monospaced component-action"
-											tabindex="-1"
-											type="button"
-										>
-											<span class="c-inner" tabindex="-2">
-												<svg
-													class="lexicon-icon lexicon-icon-ellipsis-v"
-													focusable="false"
-													role="presentation"
-												>
-													<use
-														xlink:href="/images/icons/icons.svg#ellipsis-v"
-													/>
-												</svg>
-											</span>
-										</button>
-									</div>
-								</div>
-							</div>
-						</div>
-					</li>
-				</ul>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-times-circle-full"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#times-circle-full"
+									/>
+								</svg>
+							</span>
+						</button>
+					</div>
+					<div class="autofit-col">
+						<button
+							class="btn btn-monospaced component-action"
+							tabindex="-1"
+							type="button"
+						>
+							<span class="c-inner" tabindex="-2">
+								<svg
+									class="lexicon-icon lexicon-icon-ellipsis-v"
+									focusable="false"
+									role="presentation"
+								>
+									<use
+										xlink:href="/images/icons/icons.svg#ellipsis-v"
+									/>
+								</svg>
+							</span>
+						</button>
+					</div>
+				</div>
 			</div>
-		</li>
-	</ul>
-</div>
+		</div>
+		<div class="collapse" id="treeviewLightCollapseCheckbox04">
+			<ul class="treeview-group" role="group">
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<div
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input
+												class="custom-control-input"
+												tabindex="-1"
+												type="checkbox"
+											/>
+											<span
+												class="custom-control-label"
+											></span>
+										</label>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Default User Associations"
+											><span class="text-truncate"
+												>Default User Associations</span
+											></span
+										></span
+									>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<div
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input
+												class="custom-control-input"
+												tabindex="-1"
+												type="checkbox"
+											/>
+											<span
+												class="custom-control-label"
+											></span>
+										</label>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Staging"
+											><span class="text-truncate"
+												>Staging</span
+											></span
+										></span
+									>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<div
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input
+												class="custom-control-input"
+												tabindex="-1"
+												type="checkbox"
+											/>
+											<span
+												class="custom-control-label"
+											></span>
+										</label>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Analytics"
+											><span class="text-truncate"
+												>Analytics</span
+											></span
+										></span
+									>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</li>
+				<li class="treeview-item" role="none">
+					<div
+						class="treeview-link"
+						role="treeitem"
+						tabindex="-1"
+						style="padding-left:24px;"
+					>
+						<div
+							class="c-inner"
+							tabindex="-2"
+							style="margin-left:-24px;"
+						>
+							<div class="autofit-row">
+								<div class="autofit-col">
+									<div class="custom-control custom-checkbox">
+										<label>
+											<input
+												class="custom-control-input"
+												tabindex="-1"
+												type="checkbox"
+											/>
+											<span
+												class="custom-control-label"
+											></span>
+										</label>
+									</div>
+								</div>
+								<div class="autofit-col autofit-col-expand">
+									<span class="component-text"
+										><span
+											class="text-truncate-inline"
+											title="Maps"
+											><span class="text-truncate"
+												>Maps</span
+											></span
+										></span
+									>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-times-circle-full"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#times-circle-full"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+								<div class="autofit-col">
+									<button
+										class="btn btn-monospaced component-action"
+										tabindex="-1"
+										type="button"
+									>
+										<span class="c-inner" tabindex="-2">
+											<svg
+												class="lexicon-icon lexicon-icon-ellipsis-v"
+												focusable="false"
+												role="presentation"
+											>
+												<use
+													xlink:href="/images/icons/icons.svg#ellipsis-v"
+												/>
+											</svg>
+										</span>
+									</button>
+								</div>
+							</div>
+						</div>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</li>
+</ul>
 ```
 
 ### Treeview Dark(#css-treeview-dark)
 
 A `treeview` variation for dark colored backgrounds.
 
-<div class="bg-dark cadmin">
+<div class="bg-dark">
 	<ul class="treeview treeview-dark treeview-nested" role="tree">
 		<li class="treeview-item" role="none">
 			<div aria-controls="treeviewDarkCollapseCheckbox01" aria-expanded="true" class="treeview-link" data-target="#treeviewDarkCollapseCheckbox01" data-toggle="collapse" role="treeitem" tabindex="0">
@@ -6369,7 +6625,7 @@ A `treeview` variation for dark colored backgrounds.
 </div>
 
 ```html
-<div class="bg-dark cadmin">
+<div class="bg-dark">
 	<ul class="treeview treeview-dark treeview-nested" role="tree">
 		<li class="treeview-item" role="none">
 			<div

--- a/packages/clay-core/docs/treeview.js
+++ b/packages/clay-core/docs/treeview.js
@@ -90,7 +90,7 @@ const exampleCode = `const FileExplorer = () => {
 	};
 	
 	return (
-		<Provider spritemap={spritemap} theme="cadmin">
+		<Provider spritemap={spritemap}>
 			<TreeView
 				dragAndDrop
 				items={items}
@@ -152,7 +152,7 @@ const multipleSelectionImports = `import {Provider, TreeView} from '@clayui/core
 import {ClayCheckbox as Checkbox} from '@clayui/form';`;
 
 const multipleSelectionCode = `const MultipleSelection = () => (
-	<Provider spritemap={spritemap} theme="cadmin">
+	<Provider spritemap={spritemap}>
 		<TreeView>
 			<TreeView.Item>
 				<TreeView.ItemStack>

--- a/packages/clay-css/src/scss/_components.scss
+++ b/packages/clay-css/src/scss/_components.scss
@@ -77,6 +77,7 @@
 @import 'components/_timelines';
 @import 'components/_toggle-switch';
 @import 'components/_tooltip';
+@import 'components/_treeview';
 
 @import 'components/_utilities';
 @import 'components/_utilities-functional-important';

--- a/packages/clay-css/src/scss/_variables.scss
+++ b/packages/clay-css/src/scss/_variables.scss
@@ -61,6 +61,7 @@
 @import 'variables/_timelines';
 @import 'variables/_toggle-switch';
 @import 'variables/_tooltip';
+@import 'variables/_treeview';
 @import 'variables/_type';
 
 @import 'variables/_utilities';

--- a/packages/clay-css/src/scss/cadmin/components/_links.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_links.scss
@@ -74,11 +74,6 @@ button.link-outline {
 	@include clay-css($cadmin-component-icon);
 
 	.lexicon-icon {
-		$lexicon-icon: setter(
-			map-get($cadmin-component-icon, lexicon-icon),
-			()
-		);
-
-		@include clay-css($lexicon-icon);
+		@include clay-css(map-get($cadmin-component-icon, lexicon-icon));
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -2,30 +2,21 @@
 	@include clay-css($cadmin-treeview);
 
 	.btn {
-		$btn: setter(map-get($cadmin-treeview, btn), ());
-
-		@include clay-button-variant($btn);
+		@include clay-button-variant(map-get($cadmin-treeview, btn));
 	}
 
 	.btn-monospaced {
-		$btn-monospaced: setter(map-get($cadmin-treeview, btn-monospaced), ());
-
-		@include clay-button-variant($btn-monospaced);
+		@include clay-button-variant(map-get($cadmin-treeview, btn-monospaced));
 	}
 
 	.custom-control {
-		$custom-control: setter(map-get($cadmin-treeview, custom-control), ());
-
-		@include clay-css($custom-control);
+		@include clay-css(map-get($cadmin-treeview, custom-control));
 	}
 
 	.component-expander {
-		$component-expander: setter(
-			map-get($cadmin-treeview, component-expander),
-			()
+		@include clay-button-variant(
+			map-get($cadmin-treeview, component-expander)
 		);
-
-		@include clay-button-variant($component-expander);
 
 		.lexicon-icon:not(.component-expanded-d-none) {
 			display: none;
@@ -33,30 +24,23 @@
 	}
 
 	.component-action {
-		$component-action: setter(
-			map-get($cadmin-treeview, component-action),
-			()
+		@include clay-button-variant(
+			map-get($cadmin-treeview, component-action)
 		);
-
-		@include clay-button-variant($component-action);
 	}
 
 	.component-icon {
-		$component-icon: setter(map-get($cadmin-treeview, component-icon), ());
-
-		@include clay-css($component-icon);
+		@include clay-css(map-get($cadmin-treeview, component-icon));
 
 		.lexicon-icon {
-			$lexicon-icon: setter(map-get($component-icon, lexicon-icon), ());
-
-			@include clay-css($lexicon-icon);
+			@include clay-css(
+				map-deep-get($cadmin-treeview, component-icon, lexicon-icon)
+			);
 		}
 	}
 
 	.component-text {
-		$component-text: setter(map-get($cadmin-treeview, component-text), ());
-
-		@include clay-css($component-text);
+		@include clay-css(map-get($cadmin-treeview, component-text));
 	}
 
 	&.show-component-expander-on-hover {
@@ -64,82 +48,77 @@
 
 		&:hover,
 		&.hover {
-			$hover: setter(
+			@include clay-css(
 				map-get(
 					$cadmin-treeview-show-component-expander-on-hover,
 					hover
-				),
-				()
+				)
 			);
 
-			@include clay-css($hover);
-
 			.component-expander {
-				$component-expander: setter(
-					map-get($hover, component-expander),
-					()
+				@include clay-css(
+					map-deep-get(
+						$cadmin-treeview-show-component-expander-on-hover,
+						hover,
+						component-expander
+					)
 				);
-
-				@include clay-css($component-expander);
 			}
 		}
 
 		.treeview-link {
-			$treeview-link: setter(
+			@include clay-css(
 				map-get(
 					$cadmin-treeview-show-component-expander-on-hover,
 					treeview-link
-				),
-				()
+				)
 			);
-
-			@include clay-css($treeview-link);
 
 			&:focus,
 			&.focus {
-				$focus: setter(map-get($treeview-link, focus), ());
-
-				@include clay-css($focus);
+				@include clay-css(
+					map-deep-get(
+						$cadmin-treeview-show-component-expander-on-hover,
+						treeview-link,
+						focus
+					)
+				);
 
 				.component-expander {
-					$component-expander: setter(
-						map-get($focus, component-expander)
+					@include clay-css(
+						map-deep-get(
+							$cadmin-treeview-show-component-expander-on-hover,
+							treeview-link,
+							focus,
+							component-expander
+						)
 					);
-
-					@include clay-css($component-expander);
 				}
 			}
 		}
 
 		.component-expander {
-			$component-expander: setter(
+			@include clay-css(
 				map-get(
 					$cadmin-treeview-show-component-expander-on-hover,
 					component-expander
-				),
-				()
+				)
 			);
-
-			@include clay-css($component-expander);
 		}
 	}
 }
 
 .treeview-group {
-	$group: setter(map-get($cadmin-treeview, treeview-group), ());
-
-	@include clay-css($group);
+	@include clay-css(map-get($cadmin-treeview, treeview-group));
 }
 
 .treeview-item {
-	$item: setter(map-get($cadmin-treeview, treeview-item), ());
-
-	@include clay-css($item);
+	@include clay-css(map-get($cadmin-treeview, treeview-item));
 
 	&:last-child {
-		$last-child: setter(map-get($item, last-child), ());
-
-		@include clay-css($last-child);
+		@include clay-css(
+			map-deep-get($cadmin-treeview, treeview-item, last-child)
+		);
 	}
 
 	&.disabled {
@@ -158,30 +137,24 @@
 }
 
 .treeview-link {
-	$link: setter(map-get($cadmin-treeview, link), ());
+	@include clay-link(map-get($cadmin-treeview, link));
 
-	@include clay-link($link);
+	&.treeview-dropping-bottom {
+		@include clay-css(
+			map-deep-get($cadmin-treeview, link, treeview-dropping-bottom)
+		);
+	}
 
-	&.treeview-dropping {
-		$dropping: setter(map-get($link, dropping), ());
+	&.treeview-dropping-middle {
+		@include clay-css(
+			map-deep-get($cadmin-treeview, link, treeview-dropping-middle)
+		);
+	}
 
-		&-bottom {
-			$dropping-bottom: setter(map-get($dropping, bottom), ());
-
-			@include clay-css($dropping-bottom);
-		}
-
-		&-middle {
-			$dropping-middle: setter(map-get($dropping, middle), ());
-
-			@include clay-css($dropping-middle);
-		}
-
-		&-top {
-			$dropping-top: setter(map-get($dropping, top), ());
-
-			@include clay-css($dropping-top);
-		}
+	&.treeview-dropping-top {
+		@include clay-css(
+			map-deep-get($cadmin-treeview, link, treeview-dropping-top)
+		);
 	}
 
 	&.hover,
@@ -211,25 +184,24 @@
 	@include clay-css($cadmin-treeview-nested-margins);
 
 	.treeview-group {
-		$group: setter(
-			map-get($cadmin-treeview-nested-margins, treeview-group),
-			()
+		@include clay-css(
+			map-get($cadmin-treeview-nested-margins, treeview-group)
 		);
 
-		@include clay-css($group);
-
 		.treeview-item {
-			$item: setter(map-get($group, treeview-item), ());
-
-			@include clay-css($item);
+			@include clay-css(
+				map-deep-get(
+					$cadmin-treeview-nested-margins,
+					treeview-group,
+					treeview-item
+				)
+			);
 		}
 	}
 }
 
 .treeview-dragging {
-	$dragging: setter(map-get($cadmin-treeview, treeview-dragging), ());
-
-	@include clay-css($dragging);
+	@include clay-css(map-get($cadmin-treeview, treeview-dragging));
 }
 
 // Treeview Variants
@@ -238,90 +210,65 @@
 	@include clay-css($cadmin-treeview-light);
 
 	.btn {
-		$btn: setter(map-get($cadmin-treeview-light, btn), ());
-
-		@include clay-button-variant($btn);
+		@include clay-button-variant(map-get($cadmin-treeview-light, btn));
 	}
 
 	.btn-monospaced {
-		$btn-monospaced: setter(
-			map-get($cadmin-treeview-light, btn-monospaced),
-			()
+		@include clay-button-variant(
+			map-get($cadmin-treeview-light, btn-monospaced)
 		);
-
-		@include clay-button-variant($btn-monospaced);
 	}
 
 	.component-expander {
-		$component-expander: setter(
-			map-get($cadmin-treeview-light, component-expander),
-			()
+		@include clay-button-variant(
+			map-get($cadmin-treeview-light, component-expander)
 		);
 
-		@include clay-button-variant($component-expander);
-
 		&.btn-secondary {
-			$btn-secondary: setter(
-				map-get($component-expander, btn-secondary),
-				()
+			@include clay-button-variant(
+				map-deep-get(
+					$cadmin-treeview-light,
+					component-expander,
+					btn-secondary
+				)
 			);
-
-			@include clay-button-variant($btn-secondary);
 		}
 	}
 
 	.custom-control {
-		$custom-control: setter(
-			map-get($cadmin-treeview-light, custom-control),
-			()
-		);
-
-		@include clay-css($custom-control);
+		@include clay-css(map-get($cadmin-treeview-light, custom-control));
 	}
 
 	.treeview-group {
-		$group: setter(map-get($cadmin-treeview-light, treeview-group), ());
-
-		@include clay-css($group);
+		@include clay-css(map-get($cadmin-treeview-light, treeview-group));
 	}
 
 	.treeview-item {
-		$item: setter(map-get($cadmin-treeview-light, treeview-item), ());
-
-		@include clay-css($item);
+		@include clay-css(map-get($cadmin-treeview-light, treeview-item));
 
 		&:last-child {
-			$last-child: setter(map-get($item, last-child), ());
-
-			@include clay-css($last-child);
+			@include clay-css(
+				map-deep-get($cadmin-treeview-light, treeview-item, last-child)
+			);
 		}
 	}
 
 	.treeview-link {
-		$link: setter(map-get($cadmin-treeview-light, link), ());
-
-		@include clay-link($link);
+		@include clay-link(map-get($cadmin-treeview-light, link));
 	}
 
 	.component-action {
-		$component-action: setter(
-			map-get($cadmin-treeview-light, component-action),
-			()
+		@include clay-button-variant(
+			map-get($cadmin-treeview-light, component-action)
 		);
-
-		@include clay-button-variant($component-action);
 	}
 
 	.component-icon {
-		$component: setter(map-get($cadmin-treeview-light, component), ());
-
-		@include clay-css($component);
+		@include clay-css(map-get($cadmin-treeview-light, component));
 	}
 
 	.component-text {
-		$component: setter(map-get($cadmin-treeview-light, component), ());
-
-		@include clay-css($component);
+		@include clay-css(map-get($cadmin-treeview-light, component));
 	}
 }
 
@@ -329,95 +276,64 @@
 	@include clay-css($cadmin-treeview-dark);
 
 	.btn {
-		$btn: setter(map-get($cadmin-treeview-dark, btn), ());
-
-		@include clay-button-variant($btn);
+		@include clay-button-variant(map-get($cadmin-treeview-dark, btn));
 	}
 
 	.btn-monospaced {
-		$btn-monospaced: setter(
-			map-get($cadmin-treeview-dark, btn-monospaced),
-			()
+		@include clay-button-variant(
+			map-get($cadmin-treeview-dark, btn-monospaced)
 		);
-
-		@include clay-button-variant($btn-monospaced);
 	}
 
 	.component-expander {
-		$component-expander: setter(
-			map-get($cadmin-treeview-dark, component-expander),
-			()
+		@include clay-button-variant(
+			map-get($cadmin-treeview-dark, component-expander)
 		);
 
-		@include clay-button-variant($component-expander);
-
 		&.btn-secondary {
-			$btn-secondary: setter(
-				map-get($component-expander, btn-secondary),
-				()
+			@include clay-button-variant(
+				map-deep-get(
+					$cadmin-treeview-dark,
+					component-expander,
+					btn-secondary
+				)
 			);
-
-			@include clay-button-variant($btn-secondary);
 		}
 	}
 
 	.custom-control {
-		$custom-control: setter(
-			map-get($cadmin-treeview-dark, custom-control),
-			()
-		);
-
-		@include clay-css($custom-control);
+		@include clay-css(map-get($cadmin-treeview-dark, custom-control));
 	}
 
 	.treeview-group {
-		$group: setter(map-get($cadmin-treeview-dark, treeview-group), ());
-
-		@include clay-css($group);
+		@include clay-css(map-get($cadmin-treeview-dark, treeview-group));
 	}
 
 	.treeview-item {
-		$item: setter(map-get($cadmin-treeview-dark, treeview-item), ());
-
-		@include clay-css($item);
+		@include clay-css(map-get($cadmin-treeview-dark, treeview-item));
 
 		&:last-child {
-			$last-child: setter(map-get($item, last-child), ());
-
-			@include clay-css($last-child);
+			@include clay-css(
+				map-deep-get($cadmin-treeview-dark, treeview-item, last-child)
+			);
 		}
 	}
 
 	.treeview-link {
-		$link: setter(map-get($cadmin-treeview-dark, link), ());
-
-		@include clay-link($link);
+		@include clay-link(map-get($cadmin-treeview-dark, link));
 	}
 
 	.component-action {
-		$component-action: setter(
-			map-get($cadmin-treeview-dark, component-action),
-			()
+		@include clay-button-variant(
+			map-get($cadmin-treeview-dark, component-action)
 		);
-
-		@include clay-button-variant($component-action);
 	}
 
 	.component-icon {
-		$component-icon: setter(
-			map-get($cadmin-treeview-dark, component-icon),
-			()
-		);
-
-		@include clay-css($component-icon);
+		@include clay-css(map-get($cadmin-treeview-dark, component-icon));
 	}
 
 	.component-text {
-		$component-text: setter(
-			map-get($cadmin-treeview-dark, component-text),
-			()
-		);
-
-		@include clay-css($component-text);
+		@include clay-css(map-get($cadmin-treeview-dark, component-text));
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -54,19 +54,17 @@ $cadmin-treeview: map-merge(
 			padding: 0,
 			position: relative,
 			user-select: none,
-			dropping: (
-				bottom: (
-					border-bottom-width: 2px,
-					border-bottom-color: $cadmin-primary-l1,
-				),
-				middle: (
-					background-color: $cadmin-primary-l3,
-					border-color: $cadmin-primary-l1,
-				),
-				top: (
-					border-top-color: $cadmin-primary-l1,
-					border-top-width: 2px,
-				),
+			treeview-dropping-bottom: (
+				border-bottom-width: 2px,
+				border-bottom-color: $cadmin-primary-l1,
+			),
+			treeview-dropping-middle: (
+				background-color: $cadmin-primary-l3,
+				border-color: $cadmin-primary-l1,
+			),
+			treeview-dropping-top: (
+				border-top-color: $cadmin-primary-l1,
+				border-top-width: 2px,
 			),
 			hover: (
 				text-decoration: none,

--- a/packages/clay-css/src/scss/components/_links.scss
+++ b/packages/clay-css/src/scss/components/_links.scss
@@ -65,3 +65,15 @@ button.link-outline {
 .component-action {
 	@include clay-link($component-action);
 }
+
+.component-text {
+	@include clay-css($component-text);
+}
+
+.component-icon {
+	@include clay-css($component-icon);
+
+	.lexicon-icon {
+		@include clay-css(map-get($component-icon, lexicon-icon));
+	}
+}

--- a/packages/clay-css/src/scss/components/_treeview.scss
+++ b/packages/clay-css/src/scss/components/_treeview.scss
@@ -1,0 +1,312 @@
+.treeview {
+	@include clay-css($treeview);
+
+	.btn {
+		@include clay-button-variant(map-get($treeview, btn));
+	}
+
+	.btn-monospaced {
+		@include clay-button-variant(map-get($treeview, btn-monospaced));
+	}
+
+	.custom-control {
+		@include clay-css(map-get($treeview, custom-control));
+	}
+
+	.component-expander {
+		@include clay-button-variant(map-get($treeview, component-expander));
+
+		.lexicon-icon:not(.component-expanded-d-none) {
+			display: none;
+		}
+	}
+
+	.component-action {
+		@include clay-button-variant(map-get($treeview, component-action));
+	}
+
+	.component-icon {
+		@include clay-css(map-get($treeview, component-icon));
+
+		.lexicon-icon {
+			@include clay-css(
+				map-deep-get($treeview, component-icon, lexicon-icon)
+			);
+		}
+	}
+
+	.component-text {
+		@include clay-css(map-get($treeview, component-text));
+	}
+
+	&.show-component-expander-on-hover {
+		@include clay-css($treeview-show-component-expander-on-hover);
+
+		&:hover,
+		&.hover {
+			@include clay-css(
+				map-get($treeview-show-component-expander-on-hover, hover)
+			);
+
+			.component-expander {
+				@include clay-css(
+					map-deep-get(
+						$treeview-show-component-expander-on-hover,
+						hover,
+						component-expander
+					)
+				);
+			}
+		}
+
+		.treeview-link {
+			@include clay-css(
+				map-get(
+					$treeview-show-component-expander-on-hover,
+					treeview-link
+				)
+			);
+
+			&:focus,
+			&.focus {
+				@include clay-css(
+					map-deep-get(
+						$treeview-show-component-expander-on-hover,
+						treeview-link,
+						focus
+					)
+				);
+
+				.component-expander {
+					@include clay-css(
+						map-deep-get(
+							$treeview-show-component-expander-on-hover,
+							treeview-link,
+							focus,
+							component-expander
+						)
+					);
+				}
+			}
+		}
+
+		.component-expander {
+			@include clay-css(
+				map-get(
+					$treeview-show-component-expander-on-hover,
+					component-expander
+				)
+			);
+		}
+	}
+}
+
+.treeview-group {
+	@include clay-css(map-get($treeview, treeview-group));
+}
+
+.treeview-item {
+	@include clay-css(map-get($treeview, treeview-item));
+
+	&:last-child {
+		@include clay-css(map-deep-get($treeview, treeview-item, last-child));
+	}
+
+	&.disabled {
+		cursor: $disabled-cursor;
+		opacity: 0.4;
+
+		.treeview-dropping {
+			&-bottom,
+			&-middle,
+			&-top {
+				border-color: transparent;
+				background-color: transparent;
+			}
+		}
+	}
+}
+
+.treeview-link {
+	@include clay-link(map-get($treeview, link));
+
+	&.treeview-dropping-bottom {
+		@include clay-css(
+			map-deep-get($treeview, link, treeview-dropping-bottom)
+		);
+	}
+
+	&.treeview-dropping-middle {
+		@include clay-css(
+			map-deep-get($treeview, link, treeview-dropping-middle)
+		);
+	}
+
+	&.treeview-dropping-top {
+		@include clay-css(map-deep-get($treeview, link, treeview-dropping-top));
+	}
+
+	&.hover,
+	&:hover,
+	&.focus,
+	&:focus {
+		.component-action {
+			display: block;
+		}
+	}
+
+	&.show,
+	&[aria-expanded='true'] {
+		.component-expander {
+			.component-expanded-d-none {
+				display: none;
+			}
+
+			.lexicon-icon:not(.component-expanded-d-none) {
+				display: inline-block;
+			}
+		}
+	}
+}
+
+.treeview-nested-margins {
+	@include clay-css($treeview-nested-margins);
+
+	.treeview-group {
+		@include clay-css(map-get($treeview-nested-margins, treeview-group));
+
+		.treeview-item {
+			@include clay-css(
+				map-deep-get(
+					$treeview-nested-margins,
+					treeview-group,
+					treeview-item
+				)
+			);
+		}
+	}
+}
+
+.treeview-dragging {
+	@include clay-css(map-get($treeview, treeview-dragging));
+}
+
+// Treeview Variants
+
+.treeview-light {
+	@include clay-css($treeview-light);
+
+	.btn {
+		@include clay-button-variant(map-get($treeview-light, btn));
+	}
+
+	.btn-monospaced {
+		@include clay-button-variant(map-get($treeview-light, btn-monospaced));
+	}
+
+	.component-expander {
+		@include clay-button-variant(
+			map-get($treeview-light, component-expander)
+		);
+
+		&.btn-secondary {
+			@include clay-button-variant(
+				map-deep-get($treeview-light, component-expander, btn-secondary)
+			);
+		}
+	}
+
+	.custom-control {
+		@include clay-css(map-get($treeview-light, custom-control));
+	}
+
+	.treeview-group {
+		@include clay-css(map-get($treeview-light, treeview-group));
+	}
+
+	.treeview-item {
+		@include clay-css(map-get($treeview-light, treeview-item));
+
+		&:last-child {
+			@include clay-css(
+				map-deep-get($treeview-light, treeview-item, last-child)
+			);
+		}
+	}
+
+	.treeview-link {
+		@include clay-link(map-get($treeview-light, link));
+	}
+
+	.component-action {
+		@include clay-button-variant(
+			map-get($treeview-light, component-action)
+		);
+	}
+
+	.component-icon {
+		@include clay-css(map-get($treeview-light, component));
+	}
+
+	.component-text {
+		@include clay-css(map-get($treeview-light, component));
+	}
+}
+
+.treeview-dark {
+	@include clay-css($treeview-dark);
+
+	.btn {
+		@include clay-button-variant(map-get($treeview-dark, btn));
+	}
+
+	.btn-monospaced {
+		@include clay-button-variant(map-get($treeview-dark, btn-monospaced));
+	}
+
+	.component-expander {
+		@include clay-button-variant(
+			map-get($treeview-dark, component-expander)
+		);
+
+		&.btn-secondary {
+			@include clay-button-variant(
+				map-deep-get($treeview-dark, component-expander, btn-secondary)
+			);
+		}
+	}
+
+	.custom-control {
+		@include clay-css(map-get($treeview-dark, custom-control));
+	}
+
+	.treeview-group {
+		@include clay-css(map-get($treeview-dark, treeview-group));
+	}
+
+	.treeview-item {
+		@include clay-css(map-get($treeview-dark, treeview-item));
+
+		&:last-child {
+			@include clay-css(
+				map-deep-get($treeview-dark, treeview-item, last-child)
+			);
+		}
+	}
+
+	.treeview-link {
+		@include clay-link(map-get($treeview-dark, link));
+	}
+
+	.component-action {
+		@include clay-button-variant(map-get($treeview-dark, component-action));
+	}
+
+	.component-icon {
+		@include clay-css(map-get($treeview-dark, component-icon));
+	}
+
+	.component-text {
+		@include clay-css(map-get($treeview-dark, component-text));
+	}
+}

--- a/packages/clay-css/src/scss/variables/_links.scss
+++ b/packages/clay-css/src/scss/variables/_links.scss
@@ -285,3 +285,20 @@ $component-action: map-deep-merge(
 	),
 	$component-action
 );
+
+$component-text: () !default;
+
+$component-icon: () !default;
+$component-icon: map-deep-merge(
+	(
+		align-items: center,
+		display: inline-flex,
+		height: 32px,
+		justify-content: center,
+		width: 32px,
+		lexicon-icon: (
+			margin-top: 0,
+		),
+	),
+	$component-icon
+);

--- a/packages/clay-css/src/scss/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/variables/_treeview.scss
@@ -1,0 +1,215 @@
+$treeview: () !default;
+$treeview: map-merge(
+	(
+		display: flex,
+		flex-direction: column,
+		font-size: 14px,
+		list-style: none,
+		margin-bottom: 0,
+		padding: 2px 0,
+		btn-monospaced: (
+			font-size: 14px,
+			height: 24px,
+			width: 24px,
+			focus: (
+				box-shadow: $component-focus-inset-box-shadow,
+			),
+		),
+		custom-control: (
+			margin-left: 4px,
+			margin-right: 4px,
+			margin-top: 1.5px,
+		),
+		treeview-dragging: (
+			background-color: $white,
+			border-color: $primary-l1,
+			border-radius: $border-radius-sm,
+			border-style: solid,
+			border-width: 1px,
+			display: inline-block,
+			font-size: 10px,
+			font-weight: $font-weight-semi-bold,
+			padding: 4px 12px,
+			text-transform: uppercase,
+		),
+		treeview-group: (
+			display: flex,
+			flex-direction: column,
+			list-style: none,
+			margin-bottom: 0,
+			padding-left: 0,
+		),
+		treeview-item: (
+			word-wrap: break-word,
+		),
+		link: (
+			cursor: pointer,
+			display: block,
+			border-color: transparent,
+			border-style: solid,
+			border-width: 1px,
+			margin-bottom: 2px,
+			margin-top: 2px,
+			min-width: 100%,
+			padding: 0,
+			position: relative,
+			user-select: none,
+			treeview-dropping-bottom: (
+				border-bottom-width: 2px,
+				border-bottom-color: $primary-l1,
+			),
+			treeview-dropping-middle: (
+				background-color: $primary-l3,
+				border-color: $primary-l1,
+			),
+			treeview-dropping-top: (
+				border-top-color: $primary-l1,
+				border-top-width: 2px,
+			),
+			hover: (
+				text-decoration: none,
+			),
+			focus: (
+				box-shadow: $component-focus-inset-box-shadow,
+				outline: 0,
+			),
+		),
+		component-action: (
+			display: none,
+			margin-left: 2px,
+			margin-right: 2px,
+			hover: (
+				background-color: transparent,
+				color: $secondary,
+			),
+			focus: (
+				color: $secondary,
+			),
+			active: (
+				background-color: transparent,
+			),
+		),
+		component-icon: (
+			display: inline,
+			height: auto,
+			margin-left: 4px,
+			margin-right: 4px,
+			width: auto,
+		),
+		component-text: (
+			padding-bottom: 1.5px,
+			padding-left: 4px,
+			padding-top: 1.5px,
+			user-select: auto,
+		),
+	),
+	$treeview
+);
+
+$treeview-nested-margins: () !default;
+$treeview-nested-margins: map-deep-merge(
+	(
+		treeview-group: (
+			treeview-item: (
+				margin-left: 24px,
+			),
+		),
+	),
+	$treeview-nested-margins
+);
+
+$treeview-show-component-expander-on-hover: () !default;
+$treeview-show-component-expander-on-hover: map-deep-merge(
+	(
+		hover: (
+			component-expander: (
+				opacity: 1,
+				transition: opacity ease-in-out 600ms,
+			),
+		),
+		component-expander: (
+			opacity: 0,
+			transition: opacity ease-in-out 450ms,
+		),
+		treeview-link: (
+			focus: (
+				component-expander: (
+					opacity: 1,
+					transition: none,
+				),
+			),
+		),
+	),
+	$treeview-show-component-expander-on-hover
+);
+
+// Variants
+
+$treeview-light: () !default;
+$treeview-light: map-deep-merge(
+	(
+		component-expander: (
+			color: $secondary,
+			hover: (
+				color: $primary,
+			),
+			btn-secondary: (
+				background-color: $white,
+			),
+		),
+		link: (
+			color: $gray-600,
+			hover: (
+				background-color: $gray-100,
+				color: $gray-900,
+			),
+			active: (
+				background-color: $gray-200,
+				color: $gray-900,
+			),
+			active-class: (
+				background-color: $gray-200,
+				color: $gray-900,
+			),
+			show: (
+				background-color: null,
+				color: null,
+			),
+		),
+	),
+	$treeview-light
+);
+
+$treeview-dark: () !default;
+$treeview-dark: map-deep-merge(
+	(
+		component-expander: (
+			color: $secondary-l1,
+			hover: (
+				color: $primary-l1,
+			),
+		),
+		link: (
+			color: $secondary-l1,
+			hover: (
+				background-color: rgba($white, 0.04),
+			),
+			active-class: (
+				background-color: rgba($white, 0.06),
+				color: $white,
+			),
+			disabled: (
+				background-color: transparent,
+				color: rgba($secondary-l1, 0.04),
+			),
+			show: (
+				background-color: null,
+				color: null,
+			),
+		),
+		component-action: (
+			color: $secondary-l1,
+		),
+	),
+	$treeview-dark
+);


### PR DESCRIPTION
fixes #4588

- removed unnecessary `setter()`'s from code
- added docs for `.treeview-item.disabled`, `.treeview-dropping`, `.treeview-dragging-*`
- removed cadmin from examples in the docs