### PR TITLE
chore: increases storybook memory usage and split files more into chunks

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -42,6 +42,14 @@ module.exports = {
 			})
 		);
 
+		config.optimization = {
+			splitChunks: {
+				chunks: 'all',
+				minSize: 30 * 1024,
+				maxSize: 1024 * 1024,
+			},
+		};
+
 		return config;
 	},
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"lint": "eslint \".*.js\" \"**/*.{js,ts,tsx}\"",
 		"site": "cd next.clayui.com && yarn build && yarn serve",
 		"sizeLimit": "size-limit",
-		"storybook:build": "NODE_OPTIONS=--max_old_space_size=4096 build-storybook -c .storybook -o .storybook-static",
+		"storybook:build": "NODE_OPTIONS=--max_old_space_size=8192 build-storybook -c .storybook -o .storybook-static",
 		"storybook": "start-storybook -p 8888",
 		"test": "jest",
 		"version": "prettier --write -- \"**/CHANGELOG.md\" \"lerna.json\" && git add -- \"packages/clay-css/src/scss/_license-text.scss\""


### PR DESCRIPTION
This is just a test PR, apparently, Storybook is consuming too much memory and maxing out, not sure if it's related to the Node.js limit set before 4GB now to 8GB because the process is being killed with `exit code 137`, so it is more related to the operating system in this case Linux, maybe the container in our plan has a limit of 4GB or less, I will look more at the documentations.