### PR TITLE
fix(@clayui/css): Treeview dropping an item above or below causes items to shift

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -140,19 +140,19 @@
 	@include clay-link(map-get($cadmin-treeview, link));
 
 	&.treeview-dropping-bottom {
-		@include clay-css(
+		@include clay-link(
 			map-deep-get($cadmin-treeview, link, treeview-dropping-bottom)
 		);
 	}
 
 	&.treeview-dropping-middle {
-		@include clay-css(
+		@include clay-link(
 			map-deep-get($cadmin-treeview, link, treeview-dropping-middle)
 		);
 	}
 
 	&.treeview-dropping-top {
-		@include clay-css(
+		@include clay-link(
 			map-deep-get($cadmin-treeview, link, treeview-dropping-top)
 		);
 	}

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -55,16 +55,14 @@ $cadmin-treeview: map-merge(
 			position: relative,
 			user-select: none,
 			treeview-dropping-bottom: (
-				border-bottom-width: 2px,
-				border-bottom-color: $cadmin-primary-l1,
+				box-shadow: 0 2px 0 0 $cadmin-primary-l1,
 			),
 			treeview-dropping-middle: (
 				background-color: $cadmin-primary-l3,
 				border-color: $cadmin-primary-l1,
 			),
 			treeview-dropping-top: (
-				border-top-color: $cadmin-primary-l1,
-				border-top-width: 2px,
+				box-shadow: 0 -2px 0 0 $cadmin-primary-l1,
 			),
 			hover: (
 				text-decoration: none,

--- a/packages/clay-css/src/scss/components/_treeview.scss
+++ b/packages/clay-css/src/scss/components/_treeview.scss
@@ -131,19 +131,21 @@
 	@include clay-link(map-get($treeview, link));
 
 	&.treeview-dropping-bottom {
-		@include clay-css(
+		@include clay-link(
 			map-deep-get($treeview, link, treeview-dropping-bottom)
 		);
 	}
 
 	&.treeview-dropping-middle {
-		@include clay-css(
+		@include clay-link(
 			map-deep-get($treeview, link, treeview-dropping-middle)
 		);
 	}
 
 	&.treeview-dropping-top {
-		@include clay-css(map-deep-get($treeview, link, treeview-dropping-top));
+		@include clay-link(
+			map-deep-get($treeview, link, treeview-dropping-top)
+		);
 	}
 
 	&.hover,

--- a/packages/clay-css/src/scss/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/variables/_treeview.scss
@@ -55,16 +55,14 @@ $treeview: map-merge(
 			position: relative,
 			user-select: none,
 			treeview-dropping-bottom: (
-				border-bottom-width: 2px,
-				border-bottom-color: $primary-l1,
+				box-shadow: 0 2px 0 0 $primary-l1,
 			),
 			treeview-dropping-middle: (
 				background-color: $primary-l3,
 				border-color: $primary-l1,
 			),
 			treeview-dropping-top: (
-				border-top-color: $primary-l1,
-				border-top-width: 2px,
+				box-shadow: 0 -2px 0 0 $primary-l1,
 			),
 			hover: (
 				text-decoration: none,


### PR DESCRIPTION
fix(@clayui/css): Treeview use `box-shadow` instead of border to indicate drop zone
    
fix(@clayui/css): Treeview use `clay-link` mixin for `treeview-dropping-*` it gives more styling options like hover, focus, active, disabled and pseudo elements

fixes #4592