### PR TITLE
fix(@clayui/css): Rename `.treeview-item.disabled` to `treeview-item-dragging`

### DIFF
--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -87,7 +87,7 @@ export const TreeViewItem = React.forwardRef<
 			<li
 				{...otherProps}
 				className={classNames('treeview-item', className, {
-					disabled: isDragging,
+					'treeview-item-dragging': isDragging,
 				})}
 				role="none"
 			>

--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -120,20 +120,6 @@
 			map-deep-get($cadmin-treeview, treeview-item, last-child)
 		);
 	}
-
-	&.disabled {
-		cursor: $cadmin-disabled-cursor;
-		opacity: 0.4;
-
-		.treeview-dropping {
-			&-bottom,
-			&-middle,
-			&-top {
-				border-color: transparent;
-				background-color: transparent;
-			}
-		}
-	}
 }
 
 .treeview-link {
@@ -197,6 +183,20 @@
 				)
 			);
 		}
+	}
+}
+
+.treeview-item-dragging {
+	@include clay-css(map-get($cadmin-treeview, treeview-item-dragging));
+
+	.treeview-link {
+		@include clay-link(
+			map-deep-get(
+				$cadmin-treeview,
+				treeview-item-dragging,
+				treeview-link
+			)
+		);
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -123,23 +123,31 @@
 }
 
 .treeview-link {
-	@include clay-link(map-get($cadmin-treeview, link));
+	@include clay-link(map-get($cadmin-treeview, treeview-link));
 
 	&.treeview-dropping-bottom {
 		@include clay-link(
-			map-deep-get($cadmin-treeview, link, treeview-dropping-bottom)
+			map-deep-get(
+				$cadmin-treeview,
+				treeview-link,
+				treeview-dropping-bottom
+			)
 		);
 	}
 
 	&.treeview-dropping-middle {
 		@include clay-link(
-			map-deep-get($cadmin-treeview, link, treeview-dropping-middle)
+			map-deep-get(
+				$cadmin-treeview,
+				treeview-link,
+				treeview-dropping-middle
+			)
 		);
 	}
 
 	&.treeview-dropping-top {
 		@include clay-link(
-			map-deep-get($cadmin-treeview, link, treeview-dropping-top)
+			map-deep-get($cadmin-treeview, treeview-link, treeview-dropping-top)
 		);
 	}
 
@@ -254,7 +262,7 @@
 	}
 
 	.treeview-link {
-		@include clay-link(map-get($cadmin-treeview-light, link));
+		@include clay-link(map-get($cadmin-treeview-light, treeview-link));
 	}
 
 	.component-action {
@@ -320,7 +328,7 @@
 	}
 
 	.treeview-link {
-		@include clay-link(map-get($cadmin-treeview-dark, link));
+		@include clay-link(map-get($cadmin-treeview-dark, treeview-link));
 	}
 
 	.component-action {

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -42,6 +42,15 @@ $cadmin-treeview: map-merge(
 		treeview-item: (
 			word-wrap: break-word,
 		),
+		treeview-item-dragging: (
+			cursor: $cadmin-disabled-cursor,
+			opacity: 0.4,
+			treeview-link: (
+				background-color: transparent,
+				border-color: transparent,
+				box-shadow: none,
+			),
+		),
 		link: (
 			cursor: pointer,
 			display: block,

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -51,7 +51,7 @@ $cadmin-treeview: map-merge(
 				box-shadow: none,
 			),
 		),
-		link: (
+		treeview-link: (
 			cursor: pointer,
 			display: block,
 			border-color: transparent,
@@ -164,7 +164,7 @@ $cadmin-treeview-light: map-deep-merge(
 				background-color: $cadmin-white,
 			),
 		),
-		link: (
+		treeview-link: (
 			color: $cadmin-gray-600,
 			hover: (
 				background-color: $cadmin-gray-100,
@@ -196,7 +196,7 @@ $cadmin-treeview-dark: map-deep-merge(
 				color: $cadmin-primary-l1,
 			),
 		),
-		link: (
+		treeview-link: (
 			color: $cadmin-secondary-l1,
 			hover: (
 				background-color: rgba($cadmin-white, 0.04),

--- a/packages/clay-css/src/scss/components/_treeview.scss
+++ b/packages/clay-css/src/scss/components/_treeview.scss
@@ -111,20 +111,6 @@
 	&:last-child {
 		@include clay-css(map-deep-get($treeview, treeview-item, last-child));
 	}
-
-	&.disabled {
-		cursor: $disabled-cursor;
-		opacity: 0.4;
-
-		.treeview-dropping {
-			&-bottom,
-			&-middle,
-			&-top {
-				border-color: transparent;
-				background-color: transparent;
-			}
-		}
-	}
 }
 
 .treeview-link {
@@ -186,6 +172,16 @@
 				)
 			);
 		}
+	}
+}
+
+.treeview-item-dragging {
+	@include clay-css(map-get($treeview, treeview-item-dragging));
+
+	.treeview-link {
+		@include clay-link(
+			map-deep-get($treeview, treeview-item-dragging, treeview-link)
+		);
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_treeview.scss
+++ b/packages/clay-css/src/scss/components/_treeview.scss
@@ -114,23 +114,23 @@
 }
 
 .treeview-link {
-	@include clay-link(map-get($treeview, link));
+	@include clay-link(map-get($treeview, treeview-link));
 
 	&.treeview-dropping-bottom {
 		@include clay-link(
-			map-deep-get($treeview, link, treeview-dropping-bottom)
+			map-deep-get($treeview, treeview-link, treeview-dropping-bottom)
 		);
 	}
 
 	&.treeview-dropping-middle {
 		@include clay-link(
-			map-deep-get($treeview, link, treeview-dropping-middle)
+			map-deep-get($treeview, treeview-link, treeview-dropping-middle)
 		);
 	}
 
 	&.treeview-dropping-top {
 		@include clay-link(
-			map-deep-get($treeview, link, treeview-dropping-top)
+			map-deep-get($treeview, treeview-link, treeview-dropping-top)
 		);
 	}
 
@@ -233,7 +233,7 @@
 	}
 
 	.treeview-link {
-		@include clay-link(map-get($treeview-light, link));
+		@include clay-link(map-get($treeview-light, treeview-link));
 	}
 
 	.component-action {
@@ -293,7 +293,7 @@
 	}
 
 	.treeview-link {
-		@include clay-link(map-get($treeview-dark, link));
+		@include clay-link(map-get($treeview-dark, treeview-link));
 	}
 
 	.component-action {

--- a/packages/clay-css/src/scss/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/variables/_treeview.scss
@@ -42,6 +42,15 @@ $treeview: map-merge(
 		treeview-item: (
 			word-wrap: break-word,
 		),
+		treeview-item-dragging: (
+			cursor: $disabled-cursor,
+			opacity: 0.4,
+			treeview-link: (
+				background-color: transparent,
+				border-color: transparent,
+				box-shadow: none,
+			),
+		),
 		link: (
 			cursor: pointer,
 			display: block,

--- a/packages/clay-css/src/scss/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/variables/_treeview.scss
@@ -51,7 +51,7 @@ $treeview: map-merge(
 				box-shadow: none,
 			),
 		),
-		link: (
+		treeview-link: (
 			cursor: pointer,
 			display: block,
 			border-color: transparent,
@@ -164,7 +164,7 @@ $treeview-light: map-deep-merge(
 				background-color: $white,
 			),
 		),
-		link: (
+		treeview-link: (
 			color: $gray-600,
 			hover: (
 				background-color: $gray-100,
@@ -196,7 +196,7 @@ $treeview-dark: map-deep-merge(
 				color: $primary-l1,
 			),
 		),
-		link: (
+		treeview-link: (
 			color: $secondary-l1,
 			hover: (
 				background-color: rgba($white, 0.04),


### PR DESCRIPTION
- Removes dropping styles and style `treeview-link` directly

@matuzalemsteles I wasn't able to make the disable links when dragging happen since it requires pointer events on the item being dragged. This just frees up the `disabled` class for future use. I think it will come in handy.

fixes #4593