### PR TITLE
feat(@clayui/core): adds support to trigger selection manually and change the behavior of single selection to select only one Node in the whole TreeView

### DIFF
--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -3,11 +3,20 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React from 'react';
+import React, {Key, useCallback} from 'react';
 
 import {ItemContextProvider, useItem} from './useItem';
+import {useTreeViewContext} from './context';
 
-export type ChildrenFunction<T> = (item: T) => React.ReactElement;
+export type Selection = {
+	toggle: (key: Key) => void;
+	has: (key: Key) => boolean;
+};
+
+export type ChildrenFunction<T> = (
+	item: T,
+	selection: Selection
+) => React.ReactElement;
 
 export interface ICollectionProps<T> {
 	children: React.ReactNode | ChildrenFunction<T>;
@@ -37,13 +46,24 @@ export function Collection<T extends Record<any, any>>({
 	children,
 	items,
 }: ICollectionProps<T>) {
+	const {selection} = useTreeViewContext();
 	const {key: parentKey} = useItem();
+
+	const hasKey = useCallback(
+		(key: Key) => {
+			return selection.selectedKeys.has(String(key));
+		},
+		[selection.selectedKeys]
+	);
 
 	return (
 		<>
 			{typeof children === 'function' && items
 				? items.map((item, index) => {
-						const child = children(item);
+						const child = children(item, {
+							has: hasKey,
+							toggle: selection.toggleSelection,
+						});
 
 						const key = getKey(
 							index,

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -14,7 +14,7 @@ export type Selection = {
 };
 
 export type ChildrenFunction<T> = (
-	item: T,
+	item: Omit<T, 'indexes' | 'itemRef' | 'key' | 'parentItemRef'>,
 	selection: Selection
 ) => React.ReactElement;
 
@@ -42,6 +42,13 @@ export function getKey(
 	return parentKey ? `${parentKey}.${index}` : `$.${index}`;
 }
 
+export function removeItemInternalProps<T extends Record<any, any>>(props: T) {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const {indexes, itemRef, key, parentItemRef, ...item} = props;
+
+	return item;
+}
+
 export function Collection<T extends Record<any, any>>({
 	children,
 	items,
@@ -60,7 +67,7 @@ export function Collection<T extends Record<any, any>>({
 		<>
 			{typeof children === 'function' && items
 				? items.map((item, index) => {
-						const child = children(item, {
+						const child = children(removeItemInternalProps(item), {
 							has: hasKey,
 							toggle: selection.toggleSelection,
 						});

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -5,8 +5,8 @@
 
 import React, {Key, useCallback} from 'react';
 
-import {ItemContextProvider, useItem} from './useItem';
 import {useTreeViewContext} from './context';
+import {ItemContextProvider, useItem} from './useItem';
 
 export type Selection = {
 	toggle: (key: Key) => void;

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -51,7 +51,7 @@ export function Collection<T extends Record<any, any>>({
 
 	const hasKey = useCallback(
 		(key: Key) => {
-			return selection.selectedKeys.has(String(key));
+			return selection.selectedKeys.has(key);
 		},
 		[selection.selectedKeys]
 	);

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -59,10 +59,11 @@ interface ITreeViewProps<T>
 
 	/**
 	 * Flag changes the Node selection behavior when a checkbox is rendered on the Node.
-	 * - multiple: selects child nodes recursively.
-	 * - single: select only node, ignoring children.
+	 * - single: select only node.
+	 * - multiple: select multiple nodes.
+	 * - multiple-recursive: selects multiple nodes and recursively.
 	 */
-	selectionMode?: 'multiple' | 'single';
+	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
 
 	/**
 	 * Flag to indicate if the TreeView will show the expander in the hover in the Node.
@@ -93,7 +94,7 @@ export function TreeView<T>({
 	onRenameItem,
 	onSelectionChange,
 	selectedKeys,
-	selectionMode = 'multiple',
+	selectionMode = 'single',
 	showExpanderOnHover = true,
 	...otherProps
 }: ITreeViewProps<T>) {
@@ -126,6 +127,7 @@ export function TreeView<T>({
 		onLoadMore,
 		onRenameItem,
 		rootRef,
+		selectionMode,
 		showExpanderOnHover,
 		...state,
 	};

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -419,7 +419,7 @@ export function TreeViewItemStack({
 					return null;
 				}
 
-				if (typeof child === 'string') {
+				if (typeof child === 'string' || typeof child === 'number') {
 					content = <div className="component-text">{child}</div>;
 
 					// @ts-ignore

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -76,7 +76,7 @@ export const TreeViewItem = React.forwardRef<
 
 	const hasKey = useCallback(
 		(key: Key) => {
-			return selection.selectedKeys.has(String(key));
+			return selection.selectedKeys.has(key);
 		},
 		[selection.selectedKeys]
 	);

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -11,6 +11,7 @@ import {Keys} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {Key, useCallback, useContext, useState} from 'react';
 
+import {removeItemInternalProps} from './Collection';
 import {Icons, useTreeViewContext} from './context';
 import {useItem} from './useItem';
 
@@ -81,7 +82,7 @@ export const TreeViewItem = React.forwardRef<
 
 	if (!group && nestedKey && item[nestedKey] && childrenRoot.current) {
 		return React.cloneElement(
-			childrenRoot.current(item, {
+			childrenRoot.current(removeItemInternalProps(item), {
 				has: hasKey,
 				toggle: selection.toggleSelection,
 			}),

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -9,7 +9,7 @@ import Layout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {Keys} from '@clayui/shared';
 import classNames from 'classnames';
-import React, {useContext, useState} from 'react';
+import React, {useContext, useCallback, useState, Key} from 'react';
 
 import {Icons, useTreeViewContext} from './context';
 import {useItem} from './useItem';
@@ -72,14 +72,27 @@ export const TreeViewItem = React.forwardRef<
 		// @ts-ignore
 		right?.type?.displayName === 'ClayTreeViewGroup' ? right : null;
 
+	const hasKey = useCallback(
+		(key: Key) => {
+			return selection.selectedKeys.has(String(key));
+		},
+		[selection.selectedKeys]
+	);
+
 	if (!group && nestedKey && item[nestedKey] && childrenRoot.current) {
-		return React.cloneElement(childrenRoot.current(item), {
-			actions,
-			isDragging,
-			overPosition,
-			overTarget,
-			ref,
-		});
+		return React.cloneElement(
+			childrenRoot.current(item, {
+				has: hasKey,
+				toggle: selection.toggleSelection,
+			}),
+			{
+				actions,
+				isDragging,
+				overPosition,
+				overTarget,
+				ref,
+			}
+		);
 	}
 
 	return (

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -37,6 +37,7 @@ export const TreeViewItem = React.forwardRef<
 		children,
 		className,
 		isDragging,
+		onClick,
 		overPosition,
 		overTarget,
 		...otherProps
@@ -99,6 +100,7 @@ export const TreeViewItem = React.forwardRef<
 		<SpacingContext.Provider value={spacing + 24}>
 			<li
 				{...otherProps}
+				onClick={group ? onClick : undefined}
 				className={classNames('treeview-item', className, {
 					'treeview-item-dragging': isDragging,
 				})}
@@ -127,7 +129,30 @@ export const TreeViewItem = React.forwardRef<
 							setFocus(false);
 						}
 					}}
-					onClick={() => {
+					onClick={(event) => {
+						if (
+							typeof left !== 'string' &&
+							group &&
+							(left as React.ReactElement)?.props.onClick
+						) {
+							(left as React.ReactElement).props.onClick(event);
+						}
+
+						if (!group && onClick) {
+							(
+								onClick as unknown as (
+									event: React.MouseEvent<
+										HTMLDivElement,
+										MouseEvent
+									>
+								) => void
+							)(event);
+						}
+
+						if (event.defaultPrevented) {
+							return;
+						}
+
 						if (group) {
 							toggle(item.key);
 						} else {
@@ -274,6 +299,7 @@ export const TreeViewItem = React.forwardRef<
 						) : group ? (
 							React.cloneElement(left as React.ReactElement, {
 								actions,
+								onClick: undefined,
 							})
 						) : (
 							<TreeViewItemStack

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -9,7 +9,7 @@ import Layout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {Keys} from '@clayui/shared';
 import classNames from 'classnames';
-import React, {useContext, useCallback, useState, Key} from 'react';
+import React, {Key, useCallback, useContext, useState} from 'react';
 
 import {Icons, useTreeViewContext} from './context';
 import {useItem} from './useItem';
@@ -101,10 +101,10 @@ export const TreeViewItem = React.forwardRef<
 		<SpacingContext.Provider value={spacing + 24}>
 			<li
 				{...otherProps}
-				onClick={group ? onClick : undefined}
 				className={classNames('treeview-item', className, {
 					'treeview-item-dragging': isDragging,
 				})}
+				onClick={group ? onClick : undefined}
 				role="none"
 			>
 				<div

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -422,7 +422,11 @@ export function TreeViewItemStack({
 						)}
 						displayType={null}
 						monospaced
-						onClick={() => toggle(item.key)}
+						onClick={(event) => {
+							event.stopPropagation();
+
+							toggle(item.key);
+						}}
 						tabIndex={-1}
 					>
 						<span className="c-inner" tabIndex={-2}>

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -411,7 +411,7 @@ export function TreeViewItemStack({
 							{loading ? (
 								<ClayLoadingIndicator small />
 							) : (
-								hasChildren && (
+								(hasChildren || !nestedChildren) && (
 									<Expander expanderIcons={expanderIcons} />
 								)
 							)}

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -58,6 +58,7 @@ export const TreeViewItem = React.forwardRef<
 		replace,
 		rootRef,
 		selection,
+		selectionMode,
 		toggle,
 	} = useTreeViewContext();
 
@@ -111,6 +112,9 @@ export const TreeViewItem = React.forwardRef<
 						group ? expandedKeys.has(item.key) : undefined
 					}
 					className={classNames('treeview-link', {
+						active:
+							selectionMode === 'single' &&
+							selection.selectedKeys.has(item.key),
 						collapsed: group && expandedKeys.has(item.key),
 						focus,
 						'treeview-dropping-bottom':
@@ -151,6 +155,10 @@ export const TreeViewItem = React.forwardRef<
 
 						if (event.defaultPrevented) {
 							return;
+						}
+
+						if (selectionMode === 'single') {
+							selection.toggleSelection(item.key);
 						}
 
 						if (group) {

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -23,6 +23,7 @@ export interface ITreeViewContext<T> extends ITreeState<T> {
 	onLoadMore?: (item: any) => Promise<unknown>;
 	onRenameItem?: (item: T) => Promise<any>;
 	rootRef: React.RefObject<HTMLUListElement>;
+	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
 	showExpanderOnHover?: boolean;
 }
 

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -37,7 +37,7 @@ type Position = ValueOf<typeof TARGET_POSITION>;
 const DISTANCE = 0.2;
 
 function getKey(key: React.Key) {
-	return `${key}`.replace('.$', '');
+	return typeof key === 'string' ? `${key}`.replace('.$', '') : key;
 }
 
 function isMovingIntoItself(from: Array<number>, path: Array<number>) {

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -297,7 +297,7 @@ export function useMultipleSelection<T>(
 					setSelectionKeys(selecteds);
 					break;
 				}
-				case 'single': {
+				default: {
 					if (selectedKeys.has(key)) {
 						setSelectionKeys(new Set<Key>());
 					} else {

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -39,7 +39,7 @@ export interface IMultipleSelectionProps<T>
 	extends IMultipleSelection,
 		Pick<ITreeProps<T>, 'nestedKey'>,
 		Pick<ICollectionProps<T>, 'items'> {
-	selectionMode?: 'multiple' | 'single';
+	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
 }
 
 type LayoutInfo = {
@@ -265,37 +265,52 @@ export function useMultipleSelection<T>(
 
 	const toggleSelection = useCallback(
 		(key: Key) => {
-			const keyMap = layoutKeys.current.get(key) as LayoutInfo;
+			switch (selectionMode) {
+				case 'multiple':
+				case 'multiple-recursive': {
+					const selecteds = new Set(selectedKeys);
 
-			const selecteds = new Set(selectedKeys);
+					const keyMap = layoutKeys.current.get(key) as LayoutInfo;
 
-			// Resets the intermediate state because the element will be selected
-			// or otherwise the state must be false because it will be unchecking
-			// all its children.
-			keyMap.intermediate = false;
+					// Resets the intermediate state because the element will be selected
+					// or otherwise the state must be false because it will be unchecking
+					// all its children.
+					keyMap.intermediate = false;
 
-			if (selecteds.has(key)) {
-				selecteds.delete(key);
-			} else {
-				selecteds.add(key);
+					if (selecteds.has(key)) {
+						selecteds.delete(key);
+					} else {
+						selecteds.add(key);
+					}
+
+					if (selectionMode === 'multiple-recursive') {
+						toggleChildrenSelection(
+							keyMap,
+							key,
+							selecteds,
+							selecteds.has(key)
+						);
+					}
+
+					toggleParentSelection(keyMap, selecteds);
+
+					setSelectionKeys(selecteds);
+					break;
+				}
+				case 'single': {
+					if (selectedKeys.has(key)) {
+						setSelectionKeys(new Set<Key>());
+					} else {
+						setSelectionKeys(new Set<Key>([key]));
+					}
+					break;
+				}
 			}
-
-			if (selectionMode === 'multiple') {
-				toggleChildrenSelection(
-					keyMap,
-					key,
-					selecteds,
-					selecteds.has(key)
-				);
-			}
-
-			toggleParentSelection(keyMap, selecteds);
-
-			setSelectionKeys(selecteds);
 		},
 		[
 			layoutKeys,
 			selectedKeys,
+			selectionMode,
 			toggleChildrenSelection,
 			toggleParentSelection,
 		]

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -41,7 +41,7 @@ export interface ITreeProps<T>
 	 * A callback which is called when the property of items is changed.
 	 */
 	onItemsChange?: (items: ICollectionProps<T>['items']) => void;
-	selectionMode?: 'multiple' | 'single';
+	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
 }
 
 export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -892,6 +892,85 @@ storiesOf('Components|ClayTreeView', module)
 			</Provider>
 		);
 	})
+	.add('manually trigger single selection', () => {
+		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
+			new Set()
+		);
+
+		const [selected, setSelected] = useState({});
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<p>Selected items: {Array.from(selectedKeys).join(', ')}</p>
+				<pre
+					style={{
+						backgroundColor: '#f7f8f9',
+						border: '1px solid #e7e7ed',
+						color: '#393a4a',
+						height: '60px',
+						overflowY: 'auto',
+						padding: '10px',
+					}}
+				>
+					{JSON.stringify(selected)}
+				</pre>
+
+				<TreeView
+					items={ITEMS_DRIVE}
+					nestedKey="children"
+					onSelectionChange={(keys) => setSelectionChange(keys)}
+					selectedKeys={selectedKeys}
+					selectionMode="single"
+					showExpanderOnHover={false}
+				>
+					{(item, selection) => (
+						<TreeView.Item>
+							<TreeView.ItemStack
+								onClick={() => {
+									if (!selection.has(item.id)) {
+										setSelected(item);
+									}
+
+									selection.toggle(item.id);
+								}}
+								style={{
+									backgroundColor: selection.has(item.id)
+										? '#ffb46e'
+										: '',
+								}}
+							>
+								<Icon symbol="folder" />
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item
+										onClick={() => {
+											if (!selection.has(item.id)) {
+												setSelected(item);
+											}
+
+											selection.toggle(item.id);
+										}}
+										style={{
+											backgroundColor: selection.has(
+												item.id
+											)
+												? '#ffb46e'
+												: '',
+										}}
+									>
+										<Icon symbol="folder" />
+										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
 	.add('large data', () => {
 		const rootNode = createNode(10, 5);
 

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -14,7 +14,7 @@ import {ClayCheckbox as Checkbox, ClayInput as Input} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {Provider} from '@clayui/provider';
 import Sticker from '@clayui/sticker';
-import {boolean, select} from '@storybook/addon-knobs';
+import {select} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React, {useMemo, useState} from 'react';
 
@@ -826,8 +826,8 @@ storiesOf('Components|ClayTreeView', module)
 						select(
 							'Selection mode',
 							{
-								'multiple-recursive': 'multiple-recursive',
 								multiple: 'multiple',
+								'multiple-recursive': 'multiple-recursive',
 								single: 'single',
 							},
 							'multiple-recursive'

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -14,6 +14,7 @@ import {ClayCheckbox as Checkbox, ClayInput as Input} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {Provider} from '@clayui/provider';
 import Sticker from '@clayui/sticker';
+import {boolean, select} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React, {useMemo, useState} from 'react';
 
@@ -33,14 +34,17 @@ const ITEMS_DRIVE = [
 			{
 				children: [
 					{
-						children: [{name: 'Research 1'}],
+						children: [{id: 17, name: 'Research 1'}],
+						id: 3,
 						name: 'Research',
 					},
 					{
-						children: [{name: 'News 1'}],
+						children: [{id: 16, name: 'News 1'}],
+						id: 4,
 						name: 'News',
 					},
 				],
+				id: 2,
 				name: 'Blogs',
 			},
 			{
@@ -48,42 +52,57 @@ const ITEMS_DRIVE = [
 					{
 						children: [
 							{
+								id: 16,
 								name: 'Instructions.pdf',
 								status: 'success',
 								type: 'pdf',
 							},
 						],
+						id: 15,
 						name: 'PDF',
 					},
 					{
 						children: [
 							{
+								id: 6,
 								name: 'Treeview review.docx',
 								status: 'success',
 								type: 'document',
 							},
 							{
+								id: 7,
 								name: 'Heuristics Evaluation.docx',
 								status: 'success',
 								type: 'document',
 							},
 						],
+						id: 8,
 						name: 'Word',
 					},
 				],
+				id: 5,
 				name: 'Documents and Media',
 			},
 		],
+		id: 1,
 		name: 'Liferay Drive',
 		type: 'cloud',
 	},
 	{
-		children: [{name: 'Blogs'}, {name: 'Documents and Media'}],
+		children: [
+			{id: 10, name: 'Blogs'},
+			{id: 11, name: 'Documents and Media'},
+		],
+		id: 9,
 		name: 'Repositories',
 		type: 'repository',
 	},
 	{
-		children: [{name: 'PDF'}, {name: 'Word'}],
+		children: [
+			{id: 13, name: 'PDF'},
+			{id: 14, name: 'Word'},
+		],
+		id: 12,
 		name: 'Documents and Media',
 		status: 'warning',
 	},
@@ -606,6 +625,7 @@ storiesOf('Components|ClayTreeView', module)
 					items={items}
 					nestedKey="children"
 					onExpandedChange={(keys) => setExpandedKeys(keys)}
+					selectionMode={null}
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -632,7 +652,7 @@ storiesOf('Components|ClayTreeView', module)
 			</Provider>
 		);
 	})
-	.add('selection', () => {
+	.add('multiple-selection', () => {
 		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
 			new Set()
 		);
@@ -650,6 +670,7 @@ storiesOf('Components|ClayTreeView', module)
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
+					selectionMode="multiple-recursive"
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -674,7 +695,7 @@ storiesOf('Components|ClayTreeView', module)
 			</Provider>
 		);
 	})
-	.add('selection w/async load', () => {
+	.add('multiple-selection w/async load', () => {
 		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
 			new Set()
 		);
@@ -712,6 +733,7 @@ storiesOf('Components|ClayTreeView', module)
 					}}
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
+					selectionMode="multiple-recursive"
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -727,6 +749,51 @@ storiesOf('Components|ClayTreeView', module)
 										<OptionalCheckbox />
 										<Icon symbol="folder" />
 										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
+	.add('manually trigger multiple-selection', () => {
+		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
+			new Set()
+		);
+
+		return (
+			<Provider spritemap={spritemap}>
+				<p>Selected items: {Array.from(selectedKeys).join(', ')}</p>
+
+				<TreeView
+					items={ITEMS_DRIVE}
+					nestedKey="children"
+					onSelectionChange={(keys) => setSelectionChange(keys)}
+					selectedKeys={selectedKeys}
+					selectionMode="multiple-recursive"
+					showExpanderOnHover={false}
+				>
+					{(item, selection) => (
+						<TreeView.Item>
+							<TreeView.ItemStack
+								onClick={() => selection.toggle(item.id)}
+							>
+								<Icon symbol="folder" />
+								{item.name}
+								{item.id}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item
+										onClick={() =>
+											selection.toggle(item.id)
+										}
+									>
+										<Icon symbol="folder" />
+										{item.name}
+										{item.id}
 									</TreeView.Item>
 								)}
 							</TreeView.Group>
@@ -755,50 +822,17 @@ storiesOf('Components|ClayTreeView', module)
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
-					showExpanderOnHover={false}
-				>
-					{(item) => (
-						<TreeView.Item>
-							<TreeView.ItemStack>
-								<OptionalCheckbox />
-								<Icon symbol="folder" />
-								{item.name}
-							</TreeView.ItemStack>
-							<TreeView.Group items={item.children}>
-								{(item) => (
-									<TreeView.Item>
-										<OptionalCheckbox />
-										<Icon symbol="folder" />
-										{item.name}
-									</TreeView.Item>
-								)}
-							</TreeView.Group>
-						</TreeView.Item>
-					)}
-				</TreeView>
-			</Provider>
-		);
-	})
-	.add('expand on check w/single selection', () => {
-		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
-			new Set()
-		);
-
-		// Just to avoid TypeScript error with required props
-		const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
-
-		OptionalCheckbox.displayName = 'ClayCheckbox';
-
-		return (
-			<Provider spritemap={spritemap} theme="cadmin">
-				<TreeView
-					dragAndDrop
-					expandOnCheck
-					items={ITEMS_DRIVE}
-					nestedKey="children"
-					onSelectionChange={(keys) => setSelectionChange(keys)}
-					selectedKeys={selectedKeys}
-					selectionMode="single"
+					selectionMode={
+						select(
+							'Selection mode',
+							{
+								'multiple-recursive': 'multiple-recursive',
+								multiple: 'multiple',
+								single: 'single',
+							},
+							'multiple-recursive'
+						) as 'multiple-recursive'
+					}
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -828,11 +862,6 @@ storiesOf('Components|ClayTreeView', module)
 			new Set()
 		);
 
-		// Just to avoid TypeScript error with required props
-		const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
-
-		OptionalCheckbox.displayName = 'ClayCheckbox';
-
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
@@ -846,14 +875,12 @@ storiesOf('Components|ClayTreeView', module)
 					{(item) => (
 						<TreeView.Item>
 							<TreeView.ItemStack>
-								<OptionalCheckbox />
 								<Icon symbol="folder" />
 								{item.name}
 							</TreeView.ItemStack>
 							<TreeView.Group items={item.children}>
 								{(item) => (
 									<TreeView.Item>
-										<OptionalCheckbox />
 										<Icon symbol="folder" />
 										{item.name}
 									</TreeView.Item>
@@ -1039,6 +1066,7 @@ storiesOf('Components|ClayTreeView', module)
 					}}
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
+					selectionMode="multiple-recursive"
 					showExpanderOnHover={false}
 				>
 					{(item) => (


### PR DESCRIPTION
Fixes #4602

This PR first implements the proposal to trigger the selection manually using render props like in this example https://github.com/liferay/clay/issues/4568#issuecomment-1022375634, also see the demo in Storybook. The idea here is to use render props and expose a safe API that has a certain barrier in the internal methods so that the selection feature can be used manually without having to add the `<Checkbox />` explicitly in Node.

For the manual selection behavior, I also made some intuitive changes to the `onClick` methods so they can respect the design intuition, see my comment in the commit message which I describe with more information the reason to add it this way https://github.com/liferay/clay/commit/8e03f43d8ad030b6da7695d332d581a2650cb62f.

Also adds the single selection behavior, as I commented in the issue I am changing the behaviors to take the confusion out of the `selectionMode` API and adding the single selection as defined by default according to the [Lexicon spec](https://docs.google.com/document/d/1fggZBRGAIkGPbnkRrGEUOT0hHpkF-YjFmREee0XCoI0/edit#heading=h.e2tswp5i0wxo).

For cases where the TreeView is in a Modal and you select a Node and you need to close it, instead of using a single selection just add an `onClick` method on `TreeView.ItemStack` or `TreeView.Item` to know when you clicked on the node and if you need to prevent the default behavior of expanding, You can use `event.preventDefault()`, something like this:

```jsx
<TreeView
  selectionMode={null}
>
  {(item) => (
    <TreeView.Item>
      <TreeView.ItemStack onClick={() => closeModal(item)}>
        <Icon symbol="folder" />
        {item.name}
      </TreeView.ItemStack>
      <TreeView.Group items={item.children}>
        {(item) => (
          <TreeView.Item onClick={() => closeModal(item)}>
            <Icon symbol="folder" />
            {item.name}
          </TreeView.Item>
        )}
      </TreeView.Group>
    </TreeView.Item>
  )}
</TreeView>
```

I'm still in doubt with the single selection of how the unselected state would work, right now, clicking again on the selected Node will uncheck it. @drakonux could you look at [this example](https://deploy-preview-4603--next-storybook-clayui.netlify.app/?path=/story/components-claytreeview--single-selection) and check if it should be like this?

### ToDo

- [ ] Update the documentation