### PR TITLE
 fix(@clayui/css): Forms `label` inside `form-control` should use `min-height`

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -426,10 +426,11 @@ $form-control-label-size: map-deep-merge(
 	(
 		border-width: 0.0625rem,
 		font-size: map-get($label-lg, font-size),
-		height: 1.5rem,
+		height: auto,
 		margin-bottom: 0.3125rem,
 		margin-right: 0.625rem,
 		margin-top: 0.3125rem,
+		min-height: 1.5rem,
 		padding-x: map-get($label-lg, padding-x),
 		padding-y: map-get($label-lg, padding-y),
 		text-transform: none,

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -125,7 +125,7 @@ fieldset[disabled] label {
 	}
 
 	.label {
-		@include clay-label-size($cadmin-form-control-label-size);
+		@include clay-label-variant($cadmin-form-control-label-size);
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -341,7 +341,7 @@ $cadmin-form-control-label-size: map-deep-merge(
 $cadmin-form-control-tag-group-padding-y: (
 		$cadmin-input-height - $cadmin-input-border-bottom-width -
 			$cadmin-input-border-top-width -
-			map-get($cadmin-form-control-label-size, height) -
+			map-get($cadmin-form-control-label-size, min-height) -
 			(map-get($cadmin-form-control-label-size, margin-bottom)) -
 			(map-get($cadmin-form-control-label-size, margin-top))
 	) * 0.5 !default;

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -319,10 +319,11 @@ $cadmin-form-control-label-size: map-deep-merge(
 	(
 		border-width: 1px,
 		font-size: map-get($cadmin-label-lg, font-size),
-		height: 24px,
+		height: auto,
 		margin-bottom: 5px,
 		margin-right: 10px,
 		margin-top: 5px,
+		min-height: 24px,
 		padding-x: map-get($cadmin-label-lg, padding-x),
 		padding-y: map-get($cadmin-label-lg, padding-y),
 		text-transform: none,

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -118,7 +118,7 @@ fieldset[disabled] label {
 	}
 
 	.label {
-		@include clay-label-size($form-control-label-size);
+		@include clay-label-variant($form-control-label-size);
 	}
 }
 

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -323,7 +323,7 @@ $form-control-label-size: map-deep-merge(
 
 $form-control-tag-group-padding-y: (
 		$input-height - $input-border-bottom-width - $input-border-top-width -
-			map-get($form-control-label-size, height) -
+			map-get($form-control-label-size, min-height) -
 			(map-get($form-control-label-size, margin-bottom)) -
 			(map-get($form-control-label-size, margin-top))
 	) * 0.5 !default;

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -310,10 +310,11 @@ $form-control-label-size: () !default;
 $form-control-label-size: map-deep-merge(
 	(
 		border-width: 0.0625rem,
-		height: 1.25rem,
+		height: auto,
 		margin-bottom: 0.25rem,
 		margin-right: 0.5rem,
 		margin-top: 0.25rem,
+		min-height: 1.25rem,
 	),
 	$form-control-label-size
 );


### PR DESCRIPTION
fixes #4606