### PR TITLE
fix(@clayui/date-picker): fix time picker default value and error when not formatting time in 12hours when passing to time picker

### DIFF
--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -60,7 +60,7 @@ export const useWeeks = (
 /**
  * Sets the current time
  */
-export const useCurrentTime = (format: string) => {
+export const useCurrentTime = () => {
 	const [currentTime, set] = useState<string>('--:--');
 
 	const setCurrentTime = useCallback(

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -61,9 +61,7 @@ export const useWeeks = (
  * Sets the current time
  */
 export const useCurrentTime = (format: string) => {
-	const [currentTime, set] = useState<string>(() =>
-		formatDate(setDate(new Date(), {hours: 0, minutes: 0}), format)
-	);
+	const [currentTime, set] = useState<string>('--:--');
 
 	const setCurrentTime = useCallback(
 		(

--- a/packages/clay-date-picker/src/TimePicker.tsx
+++ b/packages/clay-date-picker/src/TimePicker.tsx
@@ -6,6 +6,8 @@
 import ClayTimePicker, {Input} from '@clayui/time-picker';
 import React from 'react';
 
+import {formatDate, setDate} from './Helpers';
+
 interface IProps {
 	currentTime: string;
 	disabled?: boolean;
@@ -66,10 +68,13 @@ const ClayDatePickerTimePicker: React.FunctionComponent<IProps> = ({
 		setValues((prevValues) => ({
 			...prevValues,
 			ampm: ampm as Input['ampm'],
-			hours: String(hours),
+			hours:
+				use12Hours && hours !== DEFAULT_VALUE
+					? formatDate(setDate(new Date(), {hours}), 'hh')
+					: String(hours),
 			minutes: String(minutes),
 		}));
-	}, [currentTime]);
+	}, [currentTime, use12Hours]);
 
 	return (
 		<div className="time-picker">

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -2153,7 +2153,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                           maxlength="2"
                           readonly=""
                           type="text"
-                          value="00"
+                          value="--"
                         />
                         <span
                           class="clay-time-divider"
@@ -2167,7 +2167,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
                           maxlength="2"
                           readonly=""
                           type="text"
-                          value="00"
+                          value="--"
                         />
                       </div>
                       <div

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -5822,7 +5822,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                           maxlength="2"
                           readonly=""
                           type="text"
-                          value="00"
+                          value="--"
                         />
                         <span
                           class="clay-time-divider"
@@ -5836,7 +5836,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                           maxlength="2"
                           readonly=""
                           type="text"
-                          value="00"
+                          value="--"
                         />
                       </div>
                       <div

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -423,6 +423,14 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		) => {
 			const [day] = daysSelected;
 
+			if (hours === '--' && typeof minutes === 'number') {
+				hours = 0;
+			}
+
+			if (minutes === '--' && typeof hours === 'number') {
+				minutes = 0;
+			}
+
 			if (value) {
 				let date =
 					typeof hours === 'string' && typeof minutes === 'string'

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -247,7 +247,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		/**
 		 * Indicates the time selected by the user.
 		 */
-		const [currentTime, setCurrentTime] = useCurrentTime(TIME_FORMAT);
+		const [currentTime, setCurrentTime] = useCurrentTime();
 
 		/**
 		 * An array of the weeks and days list for the current month


### PR DESCRIPTION
Fixes #4608

Just small fixes related to Date Picker with Time Picker. Some changes are more related to the Time Picker default value which was always starting with the value.