### PR TITLE
feat(@clayui/css): Utilities adds `font-size` utilities `fs-*`

### DIFF
--- a/clayui.com/content/docs/css/utilities/markup-text.md
+++ b/clayui.com/content/docs/css/utilities/markup-text.md
@@ -1,0 +1,211 @@
+---
+title: 'Text'
+lexiconDefinition: 'https://liferay.design/lexicon/foundations/typography/'
+---
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Sizes](#css-text-sizes)
+-   [Weights](#css-text-weights)
+-   [Styles](#css-text-styles)
+
+</div>
+</div>
+
+## Sizes(#css-text-sizes)
+
+Utility classes for changing the `font-size` of text.
+
+<div class="sheet-example">
+	<table class="table table-autofit">
+		<thead>
+			<th class="table-cell-ws-nowrap">Utility</th>
+			<th>Rem</th>
+			<th>Px</th>
+			<th class="table-cell-expand">Example</th>
+		</thead>
+		<tbody>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-11</td>
+				<td>2.5rem</td>
+				<td>40px</td>
+				<td class="table-cell-expand"><span class="text-11">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-10</td>
+				<td>2.25rem</td>
+				<td>36px</td>
+				<td class="table-cell-expand"><span class="text-10">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-9</td>
+				<td>2rem</td>
+				<td>32px</td>
+				<td class="table-cell-expand"><span class="text-9">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-8</td>
+				<td>1.75rem</td>
+				<td>28px</td>
+				<td class="table-cell-expand"><span class="text-8">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-7</td>
+				<td>1.5rem</td>
+				<td>24px</td>
+				<td class="table-cell-expand"><span class="text-7">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-6</td>
+				<td>1.25rem</td>
+				<td>20px</td>
+				<td class="table-cell-expand"><span class="text-6">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-5</td>
+				<td>1.125rem</td>
+				<td>18px</td>
+				<td class="table-cell-expand"><span class="text-5">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-4</td>
+				<td>1rem</td>
+				<td>16px</td>
+				<td class="table-cell-expand"><span class="text-4">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-3</td>
+				<td>0.875rem</td>
+				<td>14px</td>
+				<td class="table-cell-expand"><span class="text-3">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-2</td>
+				<td>0.75rem</td>
+				<td>12px</td>
+				<td class="table-cell-expand"><span class="text-2">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-1</td>
+				<td>0.625rem</td>
+				<td>10px</td>
+				<td class="table-cell-expand"><span class="text-1">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+```html
+<span class="text-11">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-10">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-9">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-8">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-7">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-6">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-5">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-4">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-3">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-2">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-1">The quick brown fox jumped over the lazy dog.</span>
+```
+
+## Weights(#css-text-weights)
+
+Utility classes for changing the `font-weight` of text.
+
+<div class="sheet-example">
+	<table class="table table-autofit">
+		<thead>
+			<th class="table-cell-ws-nowrap">Utility</th>
+			<th>Value</th>
+			<th class="table-cell-expand">Example</th>
+		</thead>
+		<tbody>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-weight-lighter</td>
+				<td>lighter</td>
+				<td class="table-cell-expand"><span class="text-weight-lighter">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-weight-light</td>
+				<td>300</td>
+				<td class="table-cell-expand"><span class="text-weight-light">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-weight-normal</td>
+				<td>400</td>
+				<td class="table-cell-expand"><span class="text-weight-normal">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-weight-semi-bold</td>
+				<td>500</td>
+				<td class="table-cell-expand"><span class="text-weight-semi-bold">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-weight-bold</td>
+				<td>700</td>
+				<td class="table-cell-expand"><span class="text-weight-bold">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-weight-bolder</td>
+				<td>900</td>
+				<td class="table-cell-expand"><span class="text-weight-bolder">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+```html
+<span class="text-weight-lighter"
+	>The quick brown fox jumped over the lazy dog.</span
+>
+<span class="text-weight-light"
+	>The quick brown fox jumped over the lazy dog.</span
+>
+<span class="text-weight-normal"
+	>The quick brown fox jumped over the lazy dog.</span
+>
+<span class="text-weight-semi-bold"
+	>The quick brown fox jumped over the lazy dog.</span
+>
+<span class="text-weight-bold"
+	>The quick brown fox jumped over the lazy dog.</span
+>
+<span class="text-weight-bolder"
+	>The quick brown fox jumped over the lazy dog.</span
+>
+```
+
+## Styles(#css-text-styles)
+
+Utility classes for changing the `font-style` of text.
+
+<div class="sheet-example">
+	<table class="table table-autofit">
+		<thead>
+			<th class="table-cell-ws-nowrap">Utility</th>
+			<th class="table-cell-minw-200">Value</th>
+			<th class="table-cell-expand">Example</th>
+		</thead>
+		<tbody>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-italic</td>
+				<td class="table-cell-minw-200">italic</td>
+				<td class="table-cell-expand"><span class="text-italic">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+			<tr>
+				<td class="table-cell-ws-nowrap">text-monospace</td>
+				<td class="table-cell-minw-200">SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace</td>
+				<td class="table-cell-expand"><span class="text-monospace">The quick brown fox jumped over the lazy dog.</span></td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+
+```html
+<span class="text-italic">The quick brown fox jumped over the lazy dog.</span>
+<span class="text-monospace"
+	>The quick brown fox jumped over the lazy dog.</span
+>
+```

--- a/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
@@ -656,12 +656,6 @@
 	}
 }
 
-// Text
-
-.text-monospace {
-	font-family: $cadmin-font-family-monospace !important;
-}
-
 // Text Alignment
 
 .text-justify {
@@ -721,32 +715,58 @@
 
 // Font Weight and Italics
 
-.font-weight-light {
-	font-weight: $cadmin-font-weight-light !important;
-}
-
-.font-weight-lighter {
+.font-weight-lighter,
+.text-weight-lighter {
 	font-weight: $cadmin-font-weight-lighter !important;
 }
 
-.font-weight-normal {
+.font-weight-light,
+.text-weight-light {
+	font-weight: $cadmin-font-weight-light !important;
+}
+
+.font-weight-normal,
+.text-weight-normal {
 	font-weight: $cadmin-font-weight-normal !important;
 }
 
-.font-weight-semi-bold {
+.font-weight-semi-bold,
+.text-weight-semi-bold {
 	font-weight: $cadmin-font-weight-semi-bold !important;
 }
 
-.font-weight-bold {
+.font-weight-bold,
+.text-weight-bold {
 	font-weight: $cadmin-font-weight-bold !important;
 }
 
-.font-weight-bolder {
+.font-weight-bolder,
+.text-weight-bolder {
 	font-weight: $cadmin-font-weight-bolder !important;
 }
 
-.font-italic {
+.font-italic,
+.text-italic {
 	font-style: italic !important;
+}
+
+.font-monospace,
+.text-monospace {
+	font-family: $cadmin-font-family-monospace !important;
+}
+
+// Font Sizes
+
+@each $selector, $value in $cadmin-font-sizes {
+	$selector: if(
+		starts-with($selector, '.') or starts-with($selector, '#'),
+		$selector,
+		str-insert($selector, '.', 1)
+	);
+
+	#{$selector} {
+		@include clay-css($value);
+	}
 }
 
 // Contextual Colors

--- a/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
@@ -141,3 +141,45 @@ $cadmin-overflows: auto, hidden !default;
 // Position
 
 $cadmin-positions: static, relative, absolute, fixed, sticky !default;
+
+// Font Sizes
+
+$cadmin-font-sizes: () !default;
+$cadmin-font-sizes: map-deep-merge(
+	(
+		text-1: (
+			font-size: 0.625rem,
+		),
+		text-2: (
+			font-size: 0.75rem,
+		),
+		text-3: (
+			font-size: 0.875rem,
+		),
+		text-4: (
+			font-size: 1rem,
+		),
+		text-5: (
+			font-size: 1.125rem,
+		),
+		text-6: (
+			font-size: 1.25rem,
+		),
+		text-7: (
+			font-size: 1.5rem,
+		),
+		text-8: (
+			font-size: 1.75rem,
+		),
+		text-9: (
+			font-size: 2rem,
+		),
+		text-10: (
+			font-size: 2.25rem,
+		),
+		text-11: (
+			font-size: 2.5rem,
+		),
+	),
+	$cadmin-font-sizes
+);

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -619,12 +619,6 @@
 	}
 }
 
-// Text
-
-.text-monospace {
-	font-family: $font-family-monospace !important;
-}
-
 // Text Alignment
 
 .text-justify {
@@ -681,32 +675,58 @@
 
 // Font Weight and Italics
 
-.font-weight-light {
-	font-weight: $font-weight-light !important;
-}
-
-.font-weight-lighter {
+.font-weight-lighter,
+.text-weight-lighter {
 	font-weight: $font-weight-lighter !important;
 }
 
-.font-weight-normal {
+.font-weight-light,
+.text-weight-light {
+	font-weight: $font-weight-light !important;
+}
+
+.font-weight-normal,
+.text-weight-normal {
 	font-weight: $font-weight-normal !important;
 }
 
-.font-weight-semi-bold {
+.font-weight-semi-bold,
+.text-weight-semi-bold {
 	font-weight: $font-weight-semi-bold !important;
 }
 
-.font-weight-bold {
+.font-weight-bold,
+.text-weight-bold {
 	font-weight: $font-weight-bold !important;
 }
 
-.font-weight-bolder {
+.font-weight-bolder,
+.text-weight-bolder {
 	font-weight: $font-weight-bolder !important;
 }
 
-.font-italic {
+.font-italic,
+.text-italic {
 	font-style: italic !important;
+}
+
+.font-monospace,
+.text-monospace {
+	font-family: $font-family-monospace !important;
+}
+
+// Font Sizes
+
+@each $selector, $value in $font-sizes {
+	$selector: if(
+		starts-with($selector, '.') or starts-with($selector, '#'),
+		$selector,
+		str-insert($selector, '.', 1)
+	);
+
+	#{$selector} {
+		@include clay-css($value);
+	}
 }
 
 // Contextual Colors

--- a/packages/clay-css/src/scss/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/variables/_utilities.scss
@@ -305,6 +305,48 @@ $overflows: auto, hidden !default;
 
 $positions: static, relative, absolute, fixed, sticky !default;
 
+// Font Sizes
+
+$font-sizes: () !default;
+$font-sizes: map-deep-merge(
+	(
+		text-1: (
+			font-size: 0.625rem,
+		),
+		text-2: (
+			font-size: 0.75rem,
+		),
+		text-3: (
+			font-size: 0.875rem,
+		),
+		text-4: (
+			font-size: 1rem,
+		),
+		text-5: (
+			font-size: 1.125rem,
+		),
+		text-6: (
+			font-size: 1.25rem,
+		),
+		text-7: (
+			font-size: 1.5rem,
+		),
+		text-8: (
+			font-size: 1.75rem,
+		),
+		text-9: (
+			font-size: 2rem,
+		),
+		text-10: (
+			font-size: 2.25rem,
+		),
+		text-11: (
+			font-size: 2.5rem,
+		),
+	),
+	$font-sizes
+);
+
 // Text
 
 $text-theme-colors: () !default;


### PR DESCRIPTION
Quoting Emiliano (can't find gh user name):

> I just want to add that even if programmatically it would make sense to add more steps from both sizes, from the design point of view I wouldn’t recommend going under 10px in any case. Thus, there shouldn’t be a way to scale it downwards, at least from our side.

> I also think a common scenario for this would be a request to extend between steps (like adding one number between XL and XXL) and that’s difficult to provide, but not impossible.

> I think T-Shirt sizes are a good idea if we adapt it for the web, and for this I would recommend aligning the text sizes with the measures the same way we did with colors and is by adding steps, here’s my idea:

> 16px is the base so it should be an unique Medium size (fs-M).
then we can decrease size: 14px (fs-S), 12px (fs-S2), 10px (fs-S3)
we can also Increase size: 18px (fs-L), 20px (fs-L1), 24px (fs-L3)

> AND we can provide extra measures included in the 11 sizes for bigger content: 28px (fs-XL1), 32px (fs-XL2), 36px (fs-XL3), 40px (fs-XL4) (this is actually the only one with 4 text sizes, we can adapt it to be 3 since this scaling system has not been used yet)

> So, in the end each measure would have 3 associated text sizes, it can scale easily and could also extendable by adding more numbers such as fs-L4 or fs-XL5. :smile:
I think we can start with something similar, keep an eye on how people use it, request feedback and iterate.

I modeled the utility classes after this suggestion. Does this provide the space to expand font sizing anywhere along the scale? Is it confusing? If it's good I can send a proper pr for this.

/cc @liferay-lexicon @ethib137 @claraizquierdo @matuzalemsteles @julien 