### PR TITLE
fix(@clayui/core): TreeView: fix error when selecting parent nodes and controlling intermediate state in multiple selection

### DIFF
--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -31,6 +31,13 @@ interface ITreeViewProps<T>
 	dragAndDrop?: boolean;
 
 	/**
+	 * Optional drag and drop context: this is to avoid
+	 * errors when using various drag and drop contexts
+	 * on the same page.
+	 */
+	dragAndDropContext?: Window & typeof globalThis;
+
+	/**
 	 * Flag to expand child nodes when a parent node is checked.
 	 */
 	expandOnCheck?: boolean;
@@ -82,6 +89,7 @@ export function TreeView<T>({
 	className,
 	displayType = 'light',
 	dragAndDrop = false,
+	dragAndDropContext = window,
 	expandOnCheck = false,
 	expandedKeys,
 	expanderClassName,
@@ -143,7 +151,10 @@ export function TreeView<T>({
 				ref={rootRef}
 				role="tree"
 			>
-				<DndProvider backend={HTML5Backend}>
+				<DndProvider
+					backend={HTML5Backend}
+					context={dragAndDropContext}
+				>
 					<TreeViewContext.Provider value={context}>
 						<Collection<T> items={state.items}>
 							{children}

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -266,7 +266,18 @@ export function useMultipleSelection<T>(
 	const toggleSelection = useCallback(
 		(key: Key) => {
 			switch (selectionMode) {
-				case 'multiple':
+				case 'multiple': {
+					const selecteds = new Set(selectedKeys);
+
+					if (selecteds.has(key)) {
+						selecteds.delete(key);
+					} else {
+						selecteds.add(key);
+					}
+
+					setSelectionKeys(selecteds);
+					break;
+				}
 				case 'multiple-recursive': {
 					const selecteds = new Set(selectedKeys);
 
@@ -283,14 +294,12 @@ export function useMultipleSelection<T>(
 						selecteds.add(key);
 					}
 
-					if (selectionMode === 'multiple-recursive') {
-						toggleChildrenSelection(
-							keyMap,
-							key,
-							selecteds,
-							selecteds.has(key)
-						);
-					}
+					toggleChildrenSelection(
+						keyMap,
+						key,
+						selecteds,
+						selecteds.has(key)
+					);
 
 					toggleParentSelection(keyMap, selecteds);
 

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -670,7 +670,16 @@ storiesOf('Components|ClayTreeView', module)
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
-					selectionMode="multiple-recursive"
+					selectionMode={
+						select(
+							'Selection mode',
+							{
+								multiple: 'multiple',
+								'multiple-recursive': 'multiple-recursive',
+							},
+							'multiple-recursive'
+						) as 'multiple-recursive'
+					}
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -733,7 +742,16 @@ storiesOf('Components|ClayTreeView', module)
 					}}
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
-					selectionMode="multiple-recursive"
+					selectionMode={
+						select(
+							'Selection mode',
+							{
+								multiple: 'multiple',
+								'multiple-recursive': 'multiple-recursive',
+							},
+							'multiple-recursive'
+						) as 'multiple-recursive'
+					}
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -772,7 +790,16 @@ storiesOf('Components|ClayTreeView', module)
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
-					selectionMode="multiple-recursive"
+					selectionMode={
+						select(
+							'Selection mode',
+							{
+								multiple: 'multiple',
+								'multiple-recursive': 'multiple-recursive',
+							},
+							'multiple-recursive'
+						) as 'multiple-recursive'
+					}
 					showExpanderOnHover={false}
 				>
 					{(item, selection) => (


### PR DESCRIPTION
Fixes #4623

I'm just removing the option to select parent nodes when the `selectionMode` is multiple only, in the code I'm just separating and repeating a bit to avoid the multiple conditions if the `selectionMode` is `multiple-recursive`.