### PR TITLE
chore(release): prepare new `@clayui/core` release 3.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.45.1](https://github.com/liferay/clay/compare/v3.45.0...v3.45.1) (2022-02-02)
+
+### Bug Fixes
+
+-   **@clayui/core:** avoid converting key type to string when using public method of selection.has() ([7c9413a](https://github.com/liferay/clay/commit/7c9413a9e8da28709107648823c96c21fc4f8989))
+-   **@clayui/core:** fix error when converting key to string when it is of type number ([201d72f](https://github.com/liferay/clay/commit/201d72f84023324297cf0a7eb4f6e66ef72a1a09))
+-   **@clayui/core:** fix error when propagating event when clicking expander ([56f56d6](https://github.com/liferay/clay/commit/56f56d60a0a3a2a032d479b16d5230d9b8c268e7))
+-   **@clayui/core:** fixes error when not showing expander with static content ([e96ffb0](https://github.com/liferay/clay/commit/e96ffb0cf87c86d0bb345d6df146a7ba61e7a28c))
+-   **@clayui/core:** fixes error when the child of `TreeView.ItemStack` is of type number ([7b3531f](https://github.com/liferay/clay/commit/7b3531fc5466c2a08d1e923f8d0158d6b185d51a))
+
 # [3.45.0](https://github.com/liferay/clay/compare/v3.44.2...v3.45.0) (2022-02-01)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"lerna": "3.4.0",
-	"version": "3.45.0",
+	"version": "3.45.1",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/packages/clay-core/CHANGELOG.md
+++ b/packages/clay-core/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.45.1](https://github.com/liferay/clay/compare/v3.45.0...v3.45.1) (2022-02-02)
+
+### Bug Fixes
+
+-   **@clayui/core:** avoid converting key type to string when using public method of selection.has() ([7c9413a](https://github.com/liferay/clay/commit/7c9413a9e8da28709107648823c96c21fc4f8989))
+-   **@clayui/core:** fix error when converting key to string when it is of type number ([201d72f](https://github.com/liferay/clay/commit/201d72f84023324297cf0a7eb4f6e66ef72a1a09))
+-   **@clayui/core:** fix error when propagating event when clicking expander ([56f56d6](https://github.com/liferay/clay/commit/56f56d60a0a3a2a032d479b16d5230d9b8c268e7))
+-   **@clayui/core:** fixes error when not showing expander with static content ([e96ffb0](https://github.com/liferay/clay/commit/e96ffb0cf87c86d0bb345d6df146a7ba61e7a28c))
+-   **@clayui/core:** fixes error when the child of `TreeView.ItemStack` is of type number ([7b3531f](https://github.com/liferay/clay/commit/7b3531fc5466c2a08d1e923f8d0158d6b185d51a))
+
 # [3.45.0](https://github.com/liferay/clay/compare/v3.44.2...v3.45.0) (2022-02-01)
 
 ### Bug Fixes

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@clayui/core",
-	"version": "3.45.0",
+	"version": "3.45.1",
 	"description": "Clay UI components in React",
 	"license": "BSD-3-Clause",
 	"repository": "https://github.com/liferay/clay",

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -59,10 +59,11 @@ interface ITreeViewProps<T>
 
 	/**
 	 * Flag changes the Node selection behavior when a checkbox is rendered on the Node.
-	 * - multiple: selects child nodes recursively.
-	 * - single: select only node, ignoring children.
+	 * - single: select only node.
+	 * - multiple: select multiple nodes.
+	 * - multiple-recursive: selects multiple nodes and recursively.
 	 */
-	selectionMode?: 'multiple' | 'single';
+	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
 
 	/**
 	 * Flag to indicate if the TreeView will show the expander in the hover in the Node.
@@ -93,7 +94,7 @@ export function TreeView<T>({
 	onRenameItem,
 	onSelectionChange,
 	selectedKeys,
-	selectionMode = 'multiple',
+	selectionMode = 'single',
 	showExpanderOnHover = true,
 	...otherProps
 }: ITreeViewProps<T>) {
@@ -126,6 +127,7 @@ export function TreeView<T>({
 		onLoadMore,
 		onRenameItem,
 		rootRef,
+		selectionMode,
 		showExpanderOnHover,
 		...state,
 	};

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -23,6 +23,7 @@ export interface ITreeViewContext<T> extends ITreeState<T> {
 	onLoadMore?: (item: any) => Promise<unknown>;
 	onRenameItem?: (item: T) => Promise<any>;
 	rootRef: React.RefObject<HTMLUListElement>;
+	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
 	showExpanderOnHover?: boolean;
 }
 

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -37,7 +37,7 @@ type Position = ValueOf<typeof TARGET_POSITION>;
 const DISTANCE = 0.2;
 
 function getKey(key: React.Key) {
-	return `${key}`.replace('.$', '');
+	return typeof key === 'string' ? `${key}`.replace('.$', '') : key;
 }
 
 function isMovingIntoItself(from: Array<number>, path: Array<number>) {

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -41,7 +41,7 @@ export interface ITreeProps<T>
 	 * A callback which is called when the property of items is changed.
 	 */
 	onItemsChange?: (items: ICollectionProps<T>['items']) => void;
-	selectionMode?: 'multiple' | 'single';
+	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
 }
 
 export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -14,6 +14,7 @@ import {ClayCheckbox as Checkbox, ClayInput as Input} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {Provider} from '@clayui/provider';
 import Sticker from '@clayui/sticker';
+import {select} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React, {useMemo, useState} from 'react';
 
@@ -33,14 +34,17 @@ const ITEMS_DRIVE = [
 			{
 				children: [
 					{
-						children: [{name: 'Research 1'}],
+						children: [{id: 17, name: 'Research 1'}],
+						id: 3,
 						name: 'Research',
 					},
 					{
-						children: [{name: 'News 1'}],
+						children: [{id: 16, name: 'News 1'}],
+						id: 4,
 						name: 'News',
 					},
 				],
+				id: 2,
 				name: 'Blogs',
 			},
 			{
@@ -48,42 +52,57 @@ const ITEMS_DRIVE = [
 					{
 						children: [
 							{
+								id: 16,
 								name: 'Instructions.pdf',
 								status: 'success',
 								type: 'pdf',
 							},
 						],
+						id: 15,
 						name: 'PDF',
 					},
 					{
 						children: [
 							{
+								id: 6,
 								name: 'Treeview review.docx',
 								status: 'success',
 								type: 'document',
 							},
 							{
+								id: 7,
 								name: 'Heuristics Evaluation.docx',
 								status: 'success',
 								type: 'document',
 							},
 						],
+						id: 8,
 						name: 'Word',
 					},
 				],
+				id: 5,
 				name: 'Documents and Media',
 			},
 		],
+		id: 1,
 		name: 'Liferay Drive',
 		type: 'cloud',
 	},
 	{
-		children: [{name: 'Blogs'}, {name: 'Documents and Media'}],
+		children: [
+			{id: 10, name: 'Blogs'},
+			{id: 11, name: 'Documents and Media'},
+		],
+		id: 9,
 		name: 'Repositories',
 		type: 'repository',
 	},
 	{
-		children: [{name: 'PDF'}, {name: 'Word'}],
+		children: [
+			{id: 13, name: 'PDF'},
+			{id: 14, name: 'Word'},
+		],
+		id: 12,
 		name: 'Documents and Media',
 		status: 'warning',
 	},
@@ -606,6 +625,7 @@ storiesOf('Components|ClayTreeView', module)
 					items={items}
 					nestedKey="children"
 					onExpandedChange={(keys) => setExpandedKeys(keys)}
+					selectionMode={null}
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -632,7 +652,7 @@ storiesOf('Components|ClayTreeView', module)
 			</Provider>
 		);
 	})
-	.add('selection', () => {
+	.add('multiple-selection', () => {
 		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
 			new Set()
 		);
@@ -650,6 +670,7 @@ storiesOf('Components|ClayTreeView', module)
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
+					selectionMode="multiple-recursive"
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -674,7 +695,7 @@ storiesOf('Components|ClayTreeView', module)
 			</Provider>
 		);
 	})
-	.add('selection w/async load', () => {
+	.add('multiple-selection w/async load', () => {
 		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
 			new Set()
 		);
@@ -712,6 +733,7 @@ storiesOf('Components|ClayTreeView', module)
 					}}
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
+					selectionMode="multiple-recursive"
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -727,6 +749,51 @@ storiesOf('Components|ClayTreeView', module)
 										<OptionalCheckbox />
 										<Icon symbol="folder" />
 										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
+	.add('manually trigger multiple-selection', () => {
+		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
+			new Set()
+		);
+
+		return (
+			<Provider spritemap={spritemap}>
+				<p>Selected items: {Array.from(selectedKeys).join(', ')}</p>
+
+				<TreeView
+					items={ITEMS_DRIVE}
+					nestedKey="children"
+					onSelectionChange={(keys) => setSelectionChange(keys)}
+					selectedKeys={selectedKeys}
+					selectionMode="multiple-recursive"
+					showExpanderOnHover={false}
+				>
+					{(item, selection) => (
+						<TreeView.Item>
+							<TreeView.ItemStack
+								onClick={() => selection.toggle(item.id)}
+							>
+								<Icon symbol="folder" />
+								{item.name}
+								{item.id}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item
+										onClick={() =>
+											selection.toggle(item.id)
+										}
+									>
+										<Icon symbol="folder" />
+										{item.name}
+										{item.id}
 									</TreeView.Item>
 								)}
 							</TreeView.Group>
@@ -755,50 +822,17 @@ storiesOf('Components|ClayTreeView', module)
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
-					showExpanderOnHover={false}
-				>
-					{(item) => (
-						<TreeView.Item>
-							<TreeView.ItemStack>
-								<OptionalCheckbox />
-								<Icon symbol="folder" />
-								{item.name}
-							</TreeView.ItemStack>
-							<TreeView.Group items={item.children}>
-								{(item) => (
-									<TreeView.Item>
-										<OptionalCheckbox />
-										<Icon symbol="folder" />
-										{item.name}
-									</TreeView.Item>
-								)}
-							</TreeView.Group>
-						</TreeView.Item>
-					)}
-				</TreeView>
-			</Provider>
-		);
-	})
-	.add('expand on check w/single selection', () => {
-		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
-			new Set()
-		);
-
-		// Just to avoid TypeScript error with required props
-		const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
-
-		OptionalCheckbox.displayName = 'ClayCheckbox';
-
-		return (
-			<Provider spritemap={spritemap} theme="cadmin">
-				<TreeView
-					dragAndDrop
-					expandOnCheck
-					items={ITEMS_DRIVE}
-					nestedKey="children"
-					onSelectionChange={(keys) => setSelectionChange(keys)}
-					selectedKeys={selectedKeys}
-					selectionMode="single"
+					selectionMode={
+						select(
+							'Selection mode',
+							{
+								multiple: 'multiple',
+								'multiple-recursive': 'multiple-recursive',
+								single: 'single',
+							},
+							'multiple-recursive'
+						) as 'multiple-recursive'
+					}
 					showExpanderOnHover={false}
 				>
 					{(item) => (
@@ -828,11 +862,6 @@ storiesOf('Components|ClayTreeView', module)
 			new Set()
 		);
 
-		// Just to avoid TypeScript error with required props
-		const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
-
-		OptionalCheckbox.displayName = 'ClayCheckbox';
-
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
@@ -846,14 +875,91 @@ storiesOf('Components|ClayTreeView', module)
 					{(item) => (
 						<TreeView.Item>
 							<TreeView.ItemStack>
-								<OptionalCheckbox />
 								<Icon symbol="folder" />
 								{item.name}
 							</TreeView.ItemStack>
 							<TreeView.Group items={item.children}>
 								{(item) => (
 									<TreeView.Item>
-										<OptionalCheckbox />
+										<Icon symbol="folder" />
+										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
+	.add('manually trigger single selection', () => {
+		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
+			new Set()
+		);
+
+		const [selected, setSelected] = useState({});
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<p>Selected items: {Array.from(selectedKeys).join(', ')}</p>
+				<pre
+					style={{
+						backgroundColor: '#f7f8f9',
+						border: '1px solid #e7e7ed',
+						color: '#393a4a',
+						height: '60px',
+						overflowY: 'auto',
+						padding: '10px',
+					}}
+				>
+					{JSON.stringify(selected)}
+				</pre>
+
+				<TreeView
+					items={ITEMS_DRIVE}
+					nestedKey="children"
+					onSelectionChange={(keys) => setSelectionChange(keys)}
+					selectedKeys={selectedKeys}
+					selectionMode="single"
+					showExpanderOnHover={false}
+				>
+					{(item, selection) => (
+						<TreeView.Item>
+							<TreeView.ItemStack
+								onClick={() => {
+									if (!selection.has(item.id)) {
+										setSelected(item);
+									}
+
+									selection.toggle(item.id);
+								}}
+								style={{
+									backgroundColor: selection.has(item.id)
+										? '#ffb46e'
+										: '',
+								}}
+							>
+								<Icon symbol="folder" />
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item
+										onClick={() => {
+											if (!selection.has(item.id)) {
+												setSelected(item);
+											}
+
+											selection.toggle(item.id);
+										}}
+										style={{
+											backgroundColor: selection.has(
+												item.id
+											)
+												? '#ffb46e'
+												: '',
+										}}
+									>
 										<Icon symbol="folder" />
 										{item.name}
 									</TreeView.Item>
@@ -1039,6 +1145,7 @@ storiesOf('Components|ClayTreeView', module)
 					}}
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
+					selectionMode="multiple-recursive"
 					showExpanderOnHover={false}
 				>
 					{(item) => (

--- a/packages/clay-css/README.md
+++ b/packages/clay-css/README.md
@@ -1,89 +1,43 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-### Jump to Section
+## Jump to Section
 
 - [About](#about)
-- [Building](#building)
-    - [Clone the repo](#clone-the-repo)
-    - [Install Node.js and NPM](#install-nodejs-and-npm)
-    - [Install the NPM modules](#install-the-npm-modules)
-    - [Modify files in src/](#modify-files-in-src)
-    - [Build the static files](#build-the-static-files)
-    - [View the files](#view-the-files)
-    - [File Heading Options](#file-heading-options)
-    - [Available Build Tasks](#available-build-tasks)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+- [Adding New SVG Icons](#adding-new-svg-icons)
 
 ## About
+
 Clay is Liferay's web implementation of the Lexicon Design Language. It is built with HTML, CSS, and Javascript with [Bootstrap](https://getbootstrap.com/docs/4.1/getting-started/introduction/) as a foundation.
 
 You can view the various components on [the Clay site](http://clayui.com).
 
-<!-- TODO: provide link to Lexicon site for documentation on design patterns -->
+## Adding New SVG Icons
 
-## Building
-If you would like to contribute, or make changes on your system you need to do the following:
+1) The copyright license should be added at the top of the new SVG icon file using the format:
 
-### Clone the repo
-Clone the repo to your computer
+```
+<!--
+* SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+* SPDX-FileCopyrightText: © 2022 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>
+*
+* SPDX-License-Identifier: BSD-3-Clause
+-->
+```
 
-### Install Node.js (v4.6.0 LTS) and NPM
-If you don't already have it installed. You can find more info here: http://nodejs.org/
-Node and NPM come bundled together, so you only need to install one package.
+See https://liferay.dev/blogs/-/blogs/how-and-why-to-properly-write-copyright-statements-in-your-code#tldr for more details.
 
-### Install the NPM modules
-Run `npm install` inside of the `packages/clay-css` directory
+2) The `<svg></svg>` element should only have the attributes `xmlns` and `viewBox`.
 
-### Modify files in src/
-The files are generated from the `src/` directory, however, most of the files you'd be interested in changing are in `src/content/`. Files can be either HTML (`.html`) or Markdown (`.md`).
-Every file in `src/content/` has a heading at the top in YAML format that looks something like:
+3) Remove any `fill` and `id` attributes from the SVG elements.
 
+4) Remove any `<style></style>` tags and the classes / ids that are referenced by it.
 
-    ---
-    title: Title of the Page
-    ---
+5) The class `lexicon-icon-body` is deprecated and is no longer being included in newer icons. This class allowed the background color of an icon to be modified using the property `fill`. We shouldn't use this class.
 
-This section has a couple of options that can be leveraged for different purposes. Those will be covered below.
+6) The class `lexicon-icon-outline` is a marker on each SVG element (e.g., `path`, `circle`, `rect`). It provides another class to use as a selector to apply CSS changes to an icon. This class should be included on all SVG elements.
 
-### Build the static files
-Run `gulp build` to generate the static files.
+7) Run `yarn compile` and include the auto generated file `src/scss/functions/_lx-icons-generated.scss` in your commit.
 
-### View the files
-The generated files are placed into the `build/` directory.
-Sass files in the `.scss` format are generated to CSS, Markdown files with the extension of `.md` are generated to HTML, and HTML files have one bit of processing applied, which is that HTML inside of triple ticks is escaped, like so:
+8) In the file, `clay/clayui.com/plugins/gatsby-plugin-clay-css-tasks/clay-icon-aliases.js`, find `iconsData` and add the icon aliases if needed.
 
-    ```
-	<div>Foo</div>
-    ```
+9) In the `clayui.com` directory run `yarn develop` and check to see if the icon shows up in the icon section.
 
-### File Heading Options
-There are a couple of properties you can add to the headings of files, only one of which is required:
-
-`title:`: **(Required)** This is used for the title of the page in the heading and in the navigation sidebar
-
-`navIndex:`:  The navigation is sorted alphabetically by default, but if you pass a `navIndex:` property, it will manually sort the item into that position.
-The property is any number, with `0` as the first position, but you can also pass in a keyword of `last` to force an item to the end.
-
-`section:`: If you want to group multiple files into sections, in each of those files, pass the same title to the `section:` property. That title will be used for the section heading, and the files will be sorted in there. The `navIndex:` property works inside of sections as well.
-
-### Available Build Tasks
-You can pass these options when running `gulp`.
-
-`build`: This is the default task, so running just `gulp` will fire off the build task.
-This will generate all of the HTML/CSS/etc into the `build/` directory.
-
-`watch`: Because running a script after every change can get tedious, run `gulp watch` to rebuild the files automatically as you change files.
-
-`serve`: Starts a local server on port 3000 and also runs the watch task.
-
-### Updating Bootstrap Version and Dependencies
-Bootstrap can be updated or downgraded by using the command:
-
-`npm install --save-dev --save-exact bootstrap@the_version`
-
-Popper.js can be updated or downgraded by using:
-
-`npm install --save-dev --save-exact popper.js@the_version`
-
-Then run `gulp build` or `gulp-serve` to compile Clay CSS with the new version
+10) Include the files `static/images/icons/icons.svg`, `static/js/icons-autogenerated.json`, and `static/js/flags-autogenerated.json` to the commit. Some of these files might not show up in git's "Changes not staged for commit:" if aliases or flags have not been added.


### PR DESCRIPTION
## [3.45.1](https://github.com/liferay/clay/compare/v3.45.0...v3.45.1) (2022-02-02)

### Bug Fixes

-   **@clayui/core:** avoid converting key type to string when using public method of selection.has() ([7c9413a](https://github.com/liferay/clay/commit/7c9413a9e8da28709107648823c96c21fc4f8989))
-   **@clayui/core:** fix error when converting key to string when it is of type number ([201d72f](https://github.com/liferay/clay/commit/201d72f84023324297cf0a7eb4f6e66ef72a1a09))
-   **@clayui/core:** fix error when propagating event when clicking expander ([56f56d6](https://github.com/liferay/clay/commit/56f56d60a0a3a2a032d479b16d5230d9b8c268e7))
-   **@clayui/core:** fixes error when not showing expander with static content ([e96ffb0](https://github.com/liferay/clay/commit/e96ffb0cf87c86d0bb345d6df146a7ba61e7a28c))
-   **@clayui/core:** fixes error when the child of `TreeView.ItemStack` is of type number ([7b3531f](https://github.com/liferay/clay/commit/7b3531fc5466c2a08d1e923f8d0158d6b185d51a))