### PR TITLE
feat: Allow disabling ellipsis button in pagination

### DIFF
--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -11,6 +11,7 @@ export interface IPaginationEllipsisProps {
 	alignmentPosition?: React.ComponentProps<
 		typeof ClayDropDownWithItems
 	>['alignmentPosition'];
+	disabled?: boolean;
 	disabledPages?: Array<number>;
 	hrefConstructor?: (page?: number) => string;
 	items?: Array<number>;
@@ -20,17 +21,20 @@ export interface IPaginationEllipsisProps {
 const ClayPaginationEllipsis: React.FunctionComponent<IPaginationEllipsisProps> =
 	({
 		alignmentPosition,
+		disabled = false,
 		disabledPages = [],
 		hrefConstructor,
 		items = [],
 		onPageChange,
 	}: IPaginationEllipsisProps) => {
-		const pages = items.map((page) => ({
-			disabled: disabledPages.includes(page),
-			href: hrefConstructor ? hrefConstructor(page) : undefined,
-			label: String(page),
-			onClick: () => onPageChange && onPageChange(page),
-		}));
+		const pages = disabled
+			? []
+			: items.map((page) => ({
+					disabled: disabledPages.includes(page),
+					href: hrefConstructor ? hrefConstructor(page) : undefined,
+					label: String(page),
+					onClick: () => onPageChange && onPageChange(page),
+			  }));
 
 		return (
 			<ClayDropDownWithItems
@@ -39,7 +43,11 @@ const ClayPaginationEllipsis: React.FunctionComponent<IPaginationEllipsisProps> 
 				containerElement="li"
 				items={pages}
 				trigger={
-					<ClayButton className="page-link" displayType="unstyled">
+					<ClayButton
+						className="page-link"
+						disabled={disabled}
+						displayType="unstyled"
+					>
 						...
 					</ClayButton>
 				}

--- a/packages/clay-pagination/src/PaginationWithBasicItems.tsx
+++ b/packages/clay-pagination/src/PaginationWithBasicItems.tsx
@@ -40,6 +40,11 @@ interface IProps extends React.ComponentProps<typeof Pagination> {
 	ellipsisBuffer?: number;
 
 	/**
+	 * Flag to disable ellipsis button
+	 */
+	disableEllipsis?: boolean;
+
+	/**
 	 * The page numbers that should be disabled. For example, `[2,5,6]`.
 	 */
 	disabledPages?: Array<number>;
@@ -75,6 +80,7 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 				next: 'Next',
 				previous: 'Previous',
 			},
+			disableEllipsis = false,
 			disabledPages = [],
 			ellipsisBuffer = ELLIPSIS_BUFFER,
 			hrefConstructor,
@@ -113,6 +119,7 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 								EllipsisComponent: Pagination.Ellipsis,
 								ellipsisProps: {
 									alignmentPosition,
+									disabled: disableEllipsis,
 									disabledPages,
 									hrefConstructor,
 									onPageChange,

--- a/packages/clay-pagination/src/__tests__/index.tsx
+++ b/packages/clay-pagination/src/__tests__/index.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import '@testing-library/jest-dom/extend-expect';
 import {ClayPaginationWithBasicItems} from '..';
 import {cleanup, fireEvent, getByText, render} from '@testing-library/react';
 import React from 'react';
@@ -74,6 +75,21 @@ describe('ClayPagination', () => {
 		fireEvent.click(getByText('25'), {});
 
 		expect(changeMock).toHaveBeenLastCalledWith(25);
+	});
+
+	it('disable ellipsis when disableEllipsis prop is passed', () => {
+		const {getAllByText} = render(
+			<ClayPaginationWithBasicItems
+				activePage={12}
+				disableEllipsis
+				spritemap={spritemap}
+				totalPages={25}
+			/>
+		);
+
+		getAllByText('...').forEach((ellipsisButton) =>
+			expect(ellipsisButton).toBeDisabled()
+		);
 	});
 
 	it('shows dropdown when ellipsis is clicked', () => {


### PR DESCRIPTION
This is potential quick fix for https://github.com/liferay/clay/issues/4605 until lexicon revise this pattern

Here we simply allow disabling the ellipsis button to avoid having a dropdown with a huge number of items (for bigger pagination)

Let me know what do you think :) 