### PR TITLE
fix(@clayui/date-picker): Reset actual date when input string is empty

### DIFF
--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -350,7 +350,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				setDaysSelected([initialMonth, initialMonth]);
 
 				if (time) {
-					setCurrentTime(0, 0, undefined);
+					setCurrentTime('--', '--', undefined);
 				}
 			} else {
 				const format = time

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -345,23 +345,12 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			const {value} = event.target;
 
 			if (!value) {
-				const newDaysSelected: [Date, Date] = [NEW_DATE, NEW_DATE];
-
-				const initialTime = {
-					hours: 0,
-					minutes: 0,
-				};
-
 				changeMonth(initialMonth);
 
-				setDaysSelected(newDaysSelected);
+				setDaysSelected([initialMonth, initialMonth]);
 
 				if (time) {
-					setCurrentTime(
-						initialTime.hours,
-						initialTime.minutes,
-						undefined
-					);
+					setCurrentTime(0, 0, undefined);
 				}
 			} else {
 				const format = time

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -346,33 +346,23 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 
 			if (!value) {
 				const newDaysSelected: [Date, Date] = [NEW_DATE, NEW_DATE];
-				let dateFormatted;
 
-				changeMonth(NEW_DATE);
+				const initialTime = {
+					hours: 0,
+					minutes: 0,
+				};
 
-				if (range) {
-					dateFormatted = fromRangeToString(
-						newDaysSelected,
-						dateFormat
-					);
-				} else if (time) {
-					dateFormatted = formatDate(
-						parseDate(
-							currentTime,
-							use12Hours ? TIME_FORMAT_12H : TIME_FORMAT,
-							NEW_DATE
-						),
-						`${dateFormat} ${
-							use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
-						}`
-					);
-				} else {
-					dateFormatted = formatDate(NEW_DATE, dateFormat);
-				}
+				changeMonth(initialMonth);
 
 				setDaysSelected(newDaysSelected);
 
-				onValueChange(dateFormatted, 'time');
+				if (time) {
+					setCurrentTime(
+						initialTime.hours,
+						initialTime.minutes,
+						undefined
+					);
+				}
 			} else {
 				const format = time
 					? `${dateFormat} ${

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -344,35 +344,68 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		const inputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 			const {value} = event.target;
 
-			const format = time
-				? `${dateFormat} ${use12Hours ? TIME_FORMAT_12H : TIME_FORMAT}`
-				: dateFormat;
+			if (!value) {
+				const newDaysSelected: [Date, Date] = [NEW_DATE, NEW_DATE];
+				let dateFormatted;
 
-			const [startDate, endDate] = fromStringToRange(
-				value,
-				format,
-				NEW_DATE
-			);
+				changeMonth(NEW_DATE);
 
-			const yearFrom = startDate.getFullYear();
-			const yearTo = endDate.getFullYear();
-
-			if (
-				isValid(startDate) &&
-				isValid(endDate) &&
-				isYearWithinYears(yearFrom, years) &&
-				isYearWithinYears(yearTo, years)
-			) {
-				changeMonth(startDate);
-
-				setDaysSelected([startDate, endDate]);
-
-				if (time) {
-					setCurrentTime(
-						startDate.getHours(),
-						startDate.getMinutes(),
-						formatDate(startDate, 'a') as Input['ampm']
+				if (range) {
+					dateFormatted = fromRangeToString(
+						newDaysSelected,
+						dateFormat
 					);
+				} else if (time) {
+					dateFormatted = formatDate(
+						parseDate(
+							currentTime,
+							use12Hours ? TIME_FORMAT_12H : TIME_FORMAT,
+							NEW_DATE
+						),
+						`${dateFormat} ${
+							use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
+						}`
+					);
+				} else {
+					dateFormatted = formatDate(NEW_DATE, dateFormat);
+				}
+
+				setDaysSelected(newDaysSelected);
+
+				onValueChange(dateFormatted, 'time');
+			} else {
+				const format = time
+					? `${dateFormat} ${
+							use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
+					  }`
+					: dateFormat;
+
+				const [startDate, endDate] = fromStringToRange(
+					value,
+					format,
+					NEW_DATE
+				);
+
+				const yearFrom = startDate.getFullYear();
+				const yearTo = endDate.getFullYear();
+
+				if (
+					isValid(startDate) &&
+					isValid(endDate) &&
+					isYearWithinYears(yearFrom, years) &&
+					isYearWithinYears(yearTo, years)
+				) {
+					changeMonth(startDate);
+
+					setDaysSelected([startDate, endDate]);
+
+					if (time) {
+						setCurrentTime(
+							startDate.getHours(),
+							startDate.getMinutes(),
+							formatDate(startDate, 'a') as Input['ampm']
+						);
+					}
 				}
 			}
 


### PR DESCRIPTION
**@clayui/date-picker:** Reset to actual date when input of the date picker is empty

Fixes #4470 