### PR TITLE
fix(@clayui/date-picker): fix error when formatting time using 12 hours

### DIFF
--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -60,7 +60,7 @@ export const useWeeks = (
 /**
  * Sets the current time
  */
-export const useCurrentTime = () => {
+export const useCurrentTime = (use12Hours: boolean) => {
 	const [currentTime, set] = useState<string>('--:--');
 
 	const setCurrentTime = useCallback(
@@ -73,6 +73,10 @@ export const useCurrentTime = () => {
 
 			if (typeof hours !== 'string') {
 				hours = formatDate(date, 'HH');
+
+				if (use12Hours) {
+					hours = formatDate(setDate(new Date(), {hours}), 'hh');
+				}
 			}
 
 			if (typeof minutes !== 'string') {

--- a/packages/clay-date-picker/src/TimePicker.tsx
+++ b/packages/clay-date-picker/src/TimePicker.tsx
@@ -6,8 +6,6 @@
 import ClayTimePicker, {Input} from '@clayui/time-picker';
 import React from 'react';
 
-import {formatDate, setDate} from './Helpers';
-
 interface IProps {
 	currentTime: string;
 	disabled?: boolean;
@@ -68,10 +66,7 @@ const ClayDatePickerTimePicker: React.FunctionComponent<IProps> = ({
 		setValues((prevValues) => ({
 			...prevValues,
 			ampm: ampm as Input['ampm'],
-			hours:
-				use12Hours && hours !== DEFAULT_VALUE
-					? formatDate(setDate(new Date(), {hours}), 'hh')
-					: String(hours),
+			hours: String(hours),
 			minutes: String(minutes),
 		}));
 	}, [currentTime, use12Hours]);

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -419,6 +419,69 @@ describe('IncrementalInteractions', () => {
 			expect(hoursEl.value).toBe('01');
 			expect(minutesEl.value).toBe('20');
 		});
+
+		it('value added in the input with 12 hours must be reflected in the time picker', () => {
+			const {getByLabelText, getByTestId} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					initialExpanded
+					placeholder="YYYY-MM-DD"
+					spritemap={spritemap}
+					time
+					use12Hours
+				/>
+			);
+
+			const input: any = getByLabelText(ariaLabels.input);
+			const hoursEl = getByTestId('hours') as HTMLInputElement;
+			const minutesEl = getByTestId('minutes') as HTMLInputElement;
+			const ampmEl = getByTestId('ampm') as HTMLInputElement;
+
+			fireEvent.change(input, {
+				target: {
+					value: '2019-04-18 10:20 PM',
+				},
+			});
+
+			expect(hoursEl.value).toBe('10');
+			expect(minutesEl.value).toBe('20');
+			expect(ampmEl.value).toBe('PM');
+		});
+
+		it('change date with time 12 hours must be persisted am/pm', () => {
+			const {getByLabelText, getByTestId} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					initialExpanded
+					placeholder="YYYY-MM-DD"
+					spritemap={spritemap}
+					time
+					use12Hours
+				/>
+			);
+
+			const input: any = getByLabelText(ariaLabels.input);
+			const dayNumber = getByLabelText(
+				new Date('2019 05 01').toDateString()
+			);
+			const hoursEl = getByTestId('hours') as HTMLInputElement;
+			const minutesEl = getByTestId('minutes') as HTMLInputElement;
+			const ampmEl = getByTestId('ampm') as HTMLInputElement;
+
+			fireEvent.change(input, {
+				target: {
+					value: '2019-04-18 10:20 PM',
+				},
+			});
+
+			fireEvent.click(dayNumber);
+
+			expect(input.value).toBe('2019-05-01 10:20 PM');
+
+			expect(hoursEl.value).toBe('10');
+			expect(minutesEl.value).toBe('20');
+			expect(ampmEl.value).toBe('PM');
+		});
 	});
 
 	describe('Range', () => {

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -383,7 +383,9 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 						setCurrentTime(
 							startDate.getHours(),
 							startDate.getMinutes(),
-							formatDate(startDate, 'a') as Input['ampm']
+							use12Hours
+								? (formatDate(startDate, 'a') as Input['ampm'])
+								: undefined
 						);
 					}
 				}

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -248,7 +248,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		/**
 		 * Indicates the time selected by the user.
 		 */
-		const [currentTime, setCurrentTime] = useCurrentTime();
+		const [currentTime, setCurrentTime] = useCurrentTime(use12Hours);
 
 		/**
 		 * An array of the weeks and days list for the current month


### PR DESCRIPTION
Fixes #4638

The time formatting was only being done when it was passed to the TimePicker component but not being formatted correctly when it is saved in the internal state, this caused other actions to change the value to the wrong time when changing the date for example.

The second case was always saving the ampm in the time state, just checking that `use12Hours` is enabled before saving.

### ToDo

- [x] Add tests for this use case