### PR TITLE
fix(@clayui/color-picker): fixes error when not syncing the field state with the editor when there are no palettes

### DIFF
--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -125,6 +125,8 @@ interface IProps {
 	editorActive?: boolean;
 
 	onEditorActiveChange?: TInternalStateOnChange<boolean>;
+
+	value?: string;
 }
 
 /**
@@ -139,6 +141,7 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 	onEditorActiveChange,
 	showPalette,
 	spritemap,
+	value,
 }) => {
 	const inputRef = React.useRef(null);
 	const [activeSplotchIndex, setActiveSplotchIndex] = React.useState(0);
@@ -148,7 +151,7 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 		value: editorActive,
 	});
 
-	const color = tinycolor(colors[activeSplotchIndex]);
+	const color = tinycolor(showPalette ? colors[activeSplotchIndex] : value);
 
 	const [hue, setHue] = React.useState(color.toHsv().h);
 	const [hexInputVal, setHexInput] = useHexInput(color.toHex());
@@ -181,8 +184,12 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 	React.useEffect(() => {
 		if (inputRef.current !== document.activeElement) {
 			setHexInput(color.toHex());
+
+			if (!showPalette) {
+				setHue(color.toHsv().h);
+			}
 		}
-	}, [color]);
+	}, [color, showPalette]);
 
 	return (
 		<>

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -313,6 +313,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 								onEditorActiveChange={setCustomEditorActive}
 								showPalette={showPalette}
 								spritemap={spritemap}
+								value={value}
 							/>
 						)}
 					</ClayDropDown.Menu>


### PR DESCRIPTION
Fixes #4580

When there are no custom colors but the editor is enabled it was not synchronizing what the user was typing in the Field with the editor just the inverse path, this commit corrects this behavior for this scenario.