### PR TITLE
fix(@clayui/date-picker): fix bug when not changing time to current time when clicking on dot button

### DIFF
--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -79,7 +79,13 @@ export const useCurrentTime = () => {
 				minutes = formatDate(date, 'mm');
 			}
 
-			set(ampm ? `${hours}:${minutes} ${ampm}` : `${hours}:${minutes}`);
+			const value = ampm
+				? `${hours}:${minutes} ${ampm}`
+				: `${hours}:${minutes}`;
+
+			set(value);
+
+			return value;
 		},
 		[]
 	);

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -214,7 +214,7 @@ describe('IncrementalInteractions', () => {
 
 		fireEvent.click(dotButtonEl);
 
-		const currentDate = new Date();
+		const currentDate = new Date(2019, 3, 18);
 
 		expect(input.value).toBe(formatDate(currentDate, 'yyyy-MM-dd'));
 

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -68,7 +68,8 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	initialExpanded?: boolean;
 
 	/**
-	 * The month to display in the calendar on the first render.
+	 * The start date to be displayed on the calendar as "Today". Used to mark
+	 * the start date of the day and when resetting.
 	 */
 	initialMonth?: Date;
 
@@ -386,30 +387,30 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		const handleDotClicked = () => {
 			const [, endDate] = daysSelected;
 
-			changeMonth(NEW_DATE);
+			changeMonth(initialMonth);
 
 			const newDaysSelected: [Date, Date] =
-				range && endDate < NEW_DATE
-					? [endDate, NEW_DATE]
-					: [NEW_DATE, endDate];
+				range && endDate < initialMonth
+					? [endDate, initialMonth]
+					: [initialMonth, endDate];
 
 			let dateFormatted;
 
 			if (range) {
 				dateFormatted = fromRangeToString(newDaysSelected, dateFormat);
 			} else if (time) {
-				dateFormatted = formatDate(
-					parseDate(
-						currentTime,
-						use12Hours ? TIME_FORMAT_12H : TIME_FORMAT,
-						NEW_DATE
-					),
-					`${dateFormat} ${
-						use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
-					}`
-				);
+				dateFormatted = `${formatDate(
+					initialMonth,
+					dateFormat
+				)} ${setCurrentTime(
+					initialMonth.getHours(),
+					initialMonth.getMinutes(),
+					use12Hours
+						? (formatDate(initialMonth, 'a') as Input['ampm'])
+						: undefined
+				)}`;
 			} else {
-				dateFormatted = formatDate(NEW_DATE, dateFormat);
+				dateFormatted = formatDate(initialMonth, dateFormat);
 			}
 
 			setDaysSelected(newDaysSelected);


### PR DESCRIPTION
Fixes #4645

I noticed that we are directly using `NEW_DATE` instead of `initialMonth` (I was probably the one who did it 😄), I changed it because this can generate some conflicts if the property is set.

You can test by checking the example in Storybook using the time example with the date picker. This PR fixes for when the time is 12 hours as well. This PR is related to #4647 which fixes the formatting to 12 hours.