### PR TITLE
chore(@clayui/core): call `onChange` if declared in Checkbox

### DIFF
--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -462,7 +462,20 @@ export function TreeViewItemStack({
 						checked: selection.selectedKeys.has(item.key),
 						disabled: loading,
 						indeterminate: selection.isIntermediate(item.key),
-						onChange: () => {
+						onChange: (
+							event: React.ChangeEvent<HTMLInputElement>
+						) => {
+							const {onChange} = (child as React.ReactElement)
+								.props;
+
+							if (onChange) {
+								onChange(event);
+							}
+
+							if (event.defaultPrevented) {
+								return;
+							}
+
 							selection.toggleSelection(item.key);
 
 							if (expandOnCheck) {


### PR DESCRIPTION
Fixes #4652

This PR is adding the possibility to call the `onChange` method if it is declared in the `Checkbox`, ideally, the TreeView abstracts the need to control the Checkbox but some need to listen for the `onChange` event to do other operations.

I'm also adding the same behavior as in `onClick` to be able to prevent the default behavior.