### PR TITLE
fix(@clayui/core): fixes the error of not revalidating the intermediate state of the selected item's parents in the first render and expands the items

### DIFF
--- a/packages/clay-core/docs/treeview.mdx
+++ b/packages/clay-core/docs/treeview.mdx
@@ -34,6 +34,8 @@ import {Example, MultipleSelection} from '$packages/clay-core/docs/treeview';
 -   [Shortcuts](#shortcuts)
     -   [Rename Item](#rename-item)
     -   [Remove Item](#remove-item)
+-   [Performance](#performance)
+    -   [Selection hydration](#selection-hydration)
 
 </div>
 </div>
@@ -308,6 +310,33 @@ The selection allows the user to select one or more items in the TreeView, there
 
 The selection can be configured and composed in different ways depending on each use case. Setting the selectionMode and using a `<Checkbox />` in the item will respect the configuration of the selection. It is also possible to configure the selection manually to customize what will trigger the selection or modify the look of the selected state. For more information check the [manual selection](#manual-selection) section.
 
+Selection can be controlled and uncontrolled, this means you can keep the state of `selectedKeys` at the implementation level or let the TreeView keep the state controlled internally.
+
+```jsx
+const [selectedKeys, setSelectionChange] = useState(new Set());
+
+return (
+	<TreeView
+		onSelectionChange={(keys) => setSelectionChange(keys)}
+		selectedKeys={selectedKeys}
+	>
+		...
+	</TreeView>
+);
+```
+
+Rendering the TreeView with some pre-selected items will cause the parent items of the selected items to be expanded so that the selected item is visible on the first render. In recursive multiple selection, the state of the parents of the selected items is marked as intermediate if they are valid.
+
+<div class="clay-site-alert alert alert-info">
+	<strong class="lead">Info</strong>
+	Expanding selected items in the first render implies performance degradation
+	if the TreeView has too many items and too many items selected but there are
+	some possibilities to work around depending on the use case, read the <a href="#selection-hydration">
+		Selection hydration
+	</a> section for more information to mitigate this when viewing a noticeable
+	slowdown on the first render.
+</div>
+
 ### Single Selection
 
 The single selection state works independently of adding the `<Checkbox />` and this state is set by default.
@@ -464,3 +493,32 @@ The `onRenameItem` property receives the `item` object corresponding to the curr
 ### Remove Item
 
 If the user presses the `Backspace` or `Delete` key the TreeView removes the item from the `items` structure. In which case `onItemsChange` is called with the tree is updated.
+
+## Performance
+
+The TreeView component was designed with performance in mind, so many of the APIs and behavior were designed aligned with that in mind. The component handles a lot of OOTB stuff without the developer having to worry about making implementation adjustments but in some scenarios, it may be necessary for the developer to follow some good practices to avoid performance degradation.
+
+This section helps with some good practices that help TreeView remain responsive.
+
+### Selection hydration
+
+Selection hydration is the ability for the TreeView to expand the parent items of the selected items when the component performs the first rendering.
+
+The possibility of doing this implies some performance problems because the component will only have the visibility of `selectedKeys` and the `items` itself, to take care of expanding the items the component will traverse the tree in search of the selected items and the path to the item and then expand.
+
+This can lead to a performance problem on the first render if you have too many items and too many items selected because the component will traverse the tree, there is a possibility to mitigate this on the first render by setting the `selectionHydrationMode` flag.
+
+It supports two rendering phases, render-first and hydrate after or hydrate before rendering, both have trade-offs that depend on the number of items being rendered.
+
+Both cases traverse the tree looking for the selected items to know which items should be expanded and which should be in the intermediate state, this is done only the first time the component is rendered and if it has selected items.
+
+-   `render-first` will render first and then hydrate. It doesn't block the initial rendering but after rendering it is possible to see the items being expanded.
+-   `hydrate-first` will hydrate first and then render. This blocks rendering first until it traverses the tree, when rendered the items are already expanded.
+
+<div class="clay-site-alert alert alert-info">
+	<strong class="lead">Info</strong>
+	The tree traversal implementation internally has some performance optimizations,
+	depending on the number of selected items the TreeView stops traversing the tree
+	when it finds all the selected items, in most scenarios the TreeView will almost
+	never traverse the entire tree.
+</div>

--- a/packages/clay-core/docs/treeview.mdx
+++ b/packages/clay-core/docs/treeview.mdx
@@ -325,13 +325,13 @@ return (
 );
 ```
 
-Rendering the TreeView with some pre-selected items will cause the parent items of the selected items to be expanded so that the selected item is visible on the first render. In recursive multiple selection, the state of the parents of the selected items is marked as intermediate if they are valid.
+Rendering the TreeView with pre-selected items will cause their parent items to be expanded so that the selected item is visible on the first render. In recursive multiple selection, the parents items will marked as intermediate.
 
 <div class="clay-site-alert alert alert-info">
 	<strong class="lead">Info</strong>
 	Expanding selected items in the first render implies performance degradation
-	if the TreeView has too many items and too many items selected but there are
-	some possibilities to work around depending on the use case, read the <a href="#selection-hydration">
+	if the TreeView has too many items; but there are some possibilities to work
+	around depending on the use case, read the <a href="#selection-hydration">
 		Selection hydration
 	</a> section for more information to mitigate this when viewing a noticeable
 	slowdown on the first render.
@@ -496,29 +496,25 @@ If the user presses the `Backspace` or `Delete` key the TreeView removes the ite
 
 ## Performance
 
-The TreeView component was designed with performance in mind, so many of the APIs and behavior were designed aligned with that in mind. The component handles a lot of OOTB stuff without the developer having to worry about making implementation adjustments but in some scenarios, it may be necessary for the developer to follow some good practices to avoid performance degradation.
+The TreeView component was designed with performance in mind. Internally, the component handles everything without the developer having to worry about making implementation adjustments, but in some scenarios, it may be necessary for the developer to follow good practices to avoid a performance degradation.
 
-This section helps with some good practices that help TreeView remain responsive.
+This section helps with some good practices that help the TreeView remain responsive.
 
 ### Selection hydration
 
-Selection hydration is the ability for the TreeView to expand the parent items of the selected items when the component performs the first rendering.
+Selection hydration is the ability for the TreeView to expand the parent items of the selected items when the component performs the first render.
 
-The possibility of doing this implies some performance problems because the component will only have the visibility of `selectedKeys` and the `items` itself, to take care of expanding the items the component will traverse the tree in search of the selected items and the path to the item and then expand.
+This implies some performance problems because the component only knows about the `selectedKeys` and the `items`, and will have to traverse the entire tree to find the selected items and the path to the parent item to expand it.
 
-This can lead to a performance problem on the first render if you have too many items and too many items selected because the component will traverse the tree, there is a possibility to mitigate this on the first render by setting the `selectionHydrationMode` flag.
+This can lead to a performance problem on the first render if you have too many items or too many selected items. It's possible to mitigate this on the first render by setting the `selectionHydrationMode` prop: it supports two rendering phases, `render-first` and `hydrate-first`, both have trade-offs that depend on the number of items being rendered:
 
-It supports two rendering phases, render-first and hydrate after or hydrate before rendering, both have trade-offs that depend on the number of items being rendered.
-
-Both cases traverse the tree looking for the selected items to know which items should be expanded and which should be in the intermediate state, this is done only the first time the component is rendered and if it has selected items.
-
--   `render-first` will render first and then hydrate. It doesn't block the initial rendering but after rendering it is possible to see the items being expanded.
+-   `render-first` will render first and then hydrate. It doesn't block the initial rendering but it is possible to see the items being expanded.
 -   `hydrate-first` will hydrate first and then render. This blocks rendering first until it traverses the tree, when rendered the items are already expanded.
 
 <div class="clay-site-alert alert alert-info">
 	<strong class="lead">Info</strong>
-	The tree traversal implementation internally has some performance optimizations,
-	depending on the number of selected items the TreeView stops traversing the tree
-	when it finds all the selected items, in most scenarios the TreeView will almost
-	never traverse the entire tree.
+	The tree traversal implementation internally has some performance optimizations.
+	Depending on the number of selected items, the TreeView stops traversing the
+	tree when it finds all the selected items. In most scenarios, the TreeView will
+	almost never traverse the entire tree.
 </div>

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -90,10 +90,10 @@ export function TreeView<T>({
 	displayType = 'light',
 	dragAndDrop = false,
 	dragAndDropContext = window,
-	expandOnCheck = false,
 	expandedKeys,
 	expanderClassName,
 	expanderIcons,
+	expandOnCheck = false,
 	items,
 	nestedKey = 'children',
 	onExpandedChange,
@@ -102,6 +102,7 @@ export function TreeView<T>({
 	onRenameItem,
 	onSelectionChange,
 	selectedKeys,
+	selectionHydrationMode = 'hydrate-first',
 	selectionMode = 'single',
 	showExpanderOnHover = true,
 	...otherProps
@@ -116,6 +117,7 @@ export function TreeView<T>({
 		onItemsChange,
 		onSelectionChange,
 		selectedKeys,
+		selectionHydrationMode,
 		selectionMode,
 	});
 

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -52,7 +52,7 @@ const ITEMS_DRIVE = [
 					{
 						children: [
 							{
-								id: 16,
+								id: 18,
 								name: 'Instructions.pdf',
 								status: 'success',
 								type: 'pdf',
@@ -643,6 +643,55 @@ storiesOf('Components|ClayTreeView', module)
 									<TreeView.Item>
 										<Icon symbol={TYPES_TO_SYMBOLS[type]} />
 										{name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
+	.add('pre-selected items', () => {
+		const [selectedKeys, setSelectionChange] = useState<Set<React.Key>>(
+			new Set([3, 15, 17, 18])
+		);
+
+		// Just to avoid TypeScript error with required props
+		const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
+
+		OptionalCheckbox.displayName = 'ClayCheckbox';
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView
+					items={ITEMS_DRIVE}
+					onSelectionChange={(keys) => setSelectionChange(keys)}
+					selectedKeys={selectedKeys}
+					selectionHydrationMode={select(
+						'Selection hydration mode',
+						{
+							'hydrate-first': 'hydrate-first',
+							'render-first': 'render-first',
+						},
+						'hydrate-first'
+					)}
+					selectionMode="multiple-recursive"
+					showExpanderOnHover={false}
+				>
+					{(item) => (
+						<TreeView.Item>
+							<TreeView.ItemStack>
+								<OptionalCheckbox />
+								<Icon symbol="folder" />
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item>
+										<OptionalCheckbox />
+										<Icon symbol="folder" />
+										{item.name}
 									</TreeView.Item>
 								)}
 							</TreeView.Group>

--- a/packages/clay-shared/src/useInternalState.ts
+++ b/packages/clay-shared/src/useInternalState.ts
@@ -11,7 +11,7 @@ export type TInternalStateOnChange<T> =
 	| React.Dispatch<React.SetStateAction<T>>;
 
 interface IArgs<T> {
-	initialValue?: T;
+	initialValue?: T | (() => T);
 	onChange?: TInternalStateOnChange<T>;
 	value?: T;
 }


### PR DESCRIPTION
Fixes #4660 #4661

This PR fixes the error that when starting the rendering of the TreeView with selected items, it was not keeping the state of intermediate, that's because this data is not saved in the backend and just for visual effect, so we need to check which items should have the state of intermediate.

Also with items selected in depth were not visible, we need to expand their parent items to make them visible.

Correcting this implied having to traverse the items tree to know which items should be expanded, we have some conditions that can optimize this so that it does not traverse the entire tree, first, we traverse the tree in search of the selected items and stop traversing until we find all the items, depending on the data and where the selected items are, this can be very fast but this is just an inference that there is no way to predict.

The problem with this is that it can block initial rendering until this operation is finished if it is called at `expandedKeys` initialization so that the TreeView component renders first with all items expanded and with the intermediate state will degrade performance to the first startup, this, when you have a lot of data, can become a problem, with little data it might not be a very noticeable problem.

We also have the option of doing this operation after the TreeView is rendered, so it does not block the first rendering but it will be noticeable for the user to see two changes in the TreeView, first, the TreeView being rendered and then the items being expanded and marked with the state of intermediate.

That's why we're introducing the `selectionHydrationMode` prop here so that developers can choose which behavior they want, for cases where very large data is rendered, the `render-first` option is recommended to avoid blocking the first render. By default, we are leaving `hydrate-first` as it doesn't have the effect of seeing items expand.

### ToDo

- [x] Adds TreeView performance recommendations in the documentation