### PR TITLE
fix(@clayui/core): fixes error when having condition in the children of `TreeView.Item` and `TreeView.ItemStack` the last element is positioned to the right

### DIFF
--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -389,6 +389,7 @@ export function TreeViewItemStack({
 	...otherProps
 }: ITreeViewItemStackProps) {
 	const {
+		childrenRoot,
 		expandOnCheck,
 		expandedKeys,
 		expanderClassName,
@@ -435,7 +436,7 @@ export function TreeViewItemStack({
 							{loading ? (
 								<ClayLoadingIndicator small />
 							) : (
-								(hasChildren || !nestedChildren) && (
+								(hasChildren || !childrenRoot.current) && (
 									<Expander expanderIcons={expanderIcons} />
 								)
 							)}

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -401,7 +401,7 @@ export function TreeViewItemStack({
 
 	const item = useItem();
 
-	const childrenArray = React.Children.toArray(children);
+	const childrenCount = React.Children.count(children);
 
 	const nestedChildren =
 		nestedKey && (item[nestedKey] as Array<Record<string, any>>);
@@ -503,9 +503,7 @@ export function TreeViewItemStack({
 				}
 
 				return (
-					<Layout.ContentCol
-						expand={index === childrenArray.length - 1}
-					>
+					<Layout.ContentCol expand={index === childrenCount - 1}>
 						{content}
 					</Layout.ContentCol>
 				);


### PR DESCRIPTION
Fixes #4668

Using `React.Children.toArray` brings the result different from `React.Children.map`, apparently when you have conditionals, some elements are `Array<Array<any>>` while `React.Children.map` brings a flat array, we use `React.Children.count` because it is safer here and brings the exact count of elements as children.