### PR TITLE
feat(@clayui/date-picker): adds a new `yearsCheck` prop to be able to disable the check if the year is within the years range

### DIFF
--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -148,9 +148,8 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	years?: IYears;
 
 	/**
-	 * Flag to indicate whether the DatePicker should validate whether the year
-	 * entered in the input is included in the range of years. Disable only
-	 * if your range is dynamic.
+	 * Flag to indicate whether the DatePicker should validate if the year
+	 * is included in the range of years. Disable only if your range is dynamic.
 	 */
 	yearsCheck?: boolean;
 

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -148,6 +148,13 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	years?: IYears;
 
 	/**
+	 * Flag to indicate whether the DatePicker should validate whether the year
+	 * entered in the input is included in the range of years. Disable only
+	 * if your range is dynamic.
+	 */
+	yearsCheck?: boolean;
+
+	/**
 	 * Determines if menu is expanded or not
 	 */
 	expanded?: boolean;
@@ -225,6 +232,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				end: NEW_DATE.getFullYear(),
 				start: NEW_DATE.getFullYear(),
 			},
+			yearsCheck = true,
 			...otherProps
 		}: IProps,
 		ref
@@ -369,12 +377,12 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				const yearFrom = startDate.getFullYear();
 				const yearTo = endDate.getFullYear();
 
-				if (
-					isValid(startDate) &&
-					isValid(endDate) &&
-					isYearWithinYears(yearFrom, years) &&
-					isYearWithinYears(yearTo, years)
-				) {
+				const isValidYear = yearsCheck
+					? isYearWithinYears(yearFrom, years) &&
+					  isYearWithinYears(yearTo, years)
+					: true;
+
+				if (isValid(startDate) && isValid(endDate) && isValidYear) {
 					changeMonth(startDate);
 
 					setDaysSelected([startDate, endDate]);

--- a/packages/clay-date-picker/stories/index.tsx
+++ b/packages/clay-date-picker/stories/index.tsx
@@ -10,6 +10,7 @@ import {storiesOf} from '@storybook/react';
 import React from 'react';
 
 import ClayDatePicker, {FirstDayOfWeek} from '../src';
+import {parseDate} from '../src/Helpers';
 
 const ClayDatePickerWithState = (props: {[key: string]: any}) => {
 	const [value, setValue] = React.useState<string | Date>('');
@@ -157,4 +158,63 @@ storiesOf('Components|ClayDatePicker', module)
 				start: 1997,
 			}}
 		/>
-	));
+	))
+	.add('dynamic years', () => {
+		const [value, setValue] = React.useState<string>('');
+
+		const initialMonthRef = React.useRef(new Date());
+
+		const [years, setYears] = React.useState(() => {
+			const year = initialMonthRef.current.getFullYear();
+
+			return {
+				end: year + 10,
+				start: year - 10,
+			};
+		});
+
+		return (
+			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: `Choose Date, selected date is ${
+						value.toLocaleString() ?? value
+					}`,
+					buttonDot: 'Go to today',
+					buttonNextMonth: 'Next month',
+					buttonPreviousMonth: 'Previous month',
+					input: value.toLocaleString(),
+				}}
+				onNavigation={(date: Date) => {
+					const year = date.getFullYear();
+
+					setYears({
+						end: year + 10,
+						start: year - 10,
+					});
+				}}
+				onValueChange={(value) => {
+					if (value) {
+						const year = parseDate(
+							value,
+							'yyyy-MM-dd',
+							initialMonthRef.current
+						).getFullYear();
+
+						if (typeof year === 'number' && year > 1000) {
+							setYears({
+								end: year + 10,
+								start: year - 10,
+							});
+						}
+					}
+
+					setValue(value);
+				}}
+				placeholder="YYYY-MM-DD"
+				spritemap={spritemap}
+				value={value}
+				years={years}
+				yearsCheck={false}
+			/>
+		);
+	});


### PR DESCRIPTION
Fixes #4624

This API simplifies the use case of issue #4624, but I added it in the API description to only disable it when the year range is dynamic, otherwise, there will be a visual bug in the year selector.