### PR TITLE
fix(@clayui/localized-input): fix typo

### DIFF
--- a/packages/clay-localized-input/src/index.tsx
+++ b/packages/clay-localized-input/src/index.tsx
@@ -89,7 +89,7 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 				default: 'Default',
 				openLocalizations: 'Open Localizations',
 				translated: 'Translated',
-				untranslated: 'Unstranslated',
+				untranslated: 'Untranslated',
 			},
 			helpText,
 			id,


### PR DESCRIPTION
Fix a small typo on the label `UNTRANSLATED`

### Before
![Screenshot from 2022-02-15 19-18-00](https://user-images.githubusercontent.com/10508566/154159105-52423fa8-25ec-480b-89ff-174a082fdfd7.png)

### After
![Screenshot from 2022-02-15 19-17-01](https://user-images.githubusercontent.com/10508566/154159133-752ee39f-32ee-43c1-9860-206e47091e14.png)

