### PR TITLE
feat(@clayui/localized-input): turn label and resultFormatter into optional properties

### DIFF
--- a/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
@@ -5,11 +5,6 @@ exports[`ClayLocalizedInput renders 1`] = `
   <div
     class="form-group"
   >
-    <label
-      for="locale1"
-    >
-      Check for translations
-    </label>
     <div
       class="input-group"
     >
@@ -56,11 +51,6 @@ exports[`ClayLocalizedInput renders 1`] = `
           </button>
         </div>
       </div>
-    </div>
-    <div
-      class="form-text"
-    >
-      Apple
     </div>
   </div>
 </div>

--- a/packages/clay-localized-input/src/__tests__/index.tsx
+++ b/packages/clay-localized-input/src/__tests__/index.tsx
@@ -60,6 +60,7 @@ describe('ClayLocalizedInput', () => {
 		const {container} = render(
 			<ClayLocalizedInput
 				id="locale1"
+				label="Check for translations"
 				locales={locales}
 				onSelectedLocaleChange={() => {}}
 				onTranslationsChange={() => {}}

--- a/packages/clay-localized-input/src/index.tsx
+++ b/packages/clay-localized-input/src/index.tsx
@@ -93,13 +93,13 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 			},
 			helpText,
 			id,
-			label = 'Check for translations',
+			label,
 			locales,
 			onSelectedLocaleChange,
 			onTranslationsChange,
 			placeholder = 'Text to translate...',
 			prependContent,
-			resultFormatter = (val) => val,
+			resultFormatter,
 			selectedLocale,
 			spritemap,
 			translations,
@@ -226,9 +226,11 @@ const ClayLocalizedInput = React.forwardRef<HTMLInputElement, IProps>(
 					</ClayInput.GroupItem>
 				</ClayInput.Group>
 
-				<ClayForm.Text>
-					{resultFormatter(translations[defaultLanguage.label])}
-				</ClayForm.Text>
+				{resultFormatter && (
+					<ClayForm.Text>
+						{resultFormatter(translations[defaultLanguage.label])}
+					</ClayForm.Text>
+				)}
 			</ClayForm.Group>
 		);
 	}


### PR DESCRIPTION
The goal of this changes is to give more flexibility for developers in order to display or not the label or formatted result.

### Some context
I'm currently working on Objects, the only app that's already using this component into DXP, and I've found out that they are hiding the label in order to add a new one supporting the required mark (*).
https://github.com/liferay/liferay-portal/blob/0876c4ff2e20691df829d192039047f26cf63508/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Form/InputLocalized/InputLocalized.tsx#L51-L60

We are also using the taglib `<aui:input />` that does the same as this component, but to port this code to React I need to hide the formated result.
https://github.com/liferay/liferay-portal/blob/0876c4ff2e20691df829d192039047f26cf63508/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_field.jsp#L38

IMHO the proper place to do that is here and once we don't have already other modules relying on this component I've set those properties as optional.