### PR TITLE
fix(@clayui/css): Treeview adds disabled styles to `treeview-link`

### DIFF
--- a/clayui.com/content/docs/components/markup-treeview.md
+++ b/clayui.com/content/docs/components/markup-treeview.md
@@ -12,8 +12,8 @@ mainTabURL: 'docs/components/treeview.html'
 
     -   [Group](#css-treeview-group)
     -   [Item](#css-treeview-item)
-    -   [Item](#css-treeview-item-disabled)
     -   [Link](#css-treeview-link)
+    -   [Link Disabled](#css-treeview-link-disabled)
     -   [Component Expander](#css-treeview-component-expander)
     -   [Component Action](#css-treeview-component-action)
     -   [Dragging](#css-treeview-dragging)
@@ -1777,28 +1777,6 @@ The class `treeview-item` must be applied to all `li` elements. This class helps
 </ul>
 ```
 
-### Treeview Item Disabled(#css-treeview-item-disabled)
-
-The modifier class `disabled` on `treeview-item` items nested inside when dragging an item.
-
-```html
-<ul class="treeview treeview-light treeview-nested" role="tree">
-	<li class="disabled treeview-item" role="none">
-		<div
-			aria-controls="treeviewExpanderCollapse01"
-			aria-expanded="false"
-			class="treeview-link"
-			data-target="#treeviewExpanderCollapse01"
-			data-toggle="collapse"
-			role="treeitem"
-			tabindex="0"
-		>
-			...
-		</div>
-	</li>
-</ul>
-```
-
 ### Treeview Link(#css-treeview-link)
 
 This is the container for all nodes inside `treeview`. If there are auxiliary controls inside the `treeview-link` (e.g., `a` or `button`) it is recommended to use a `div` element with the `tabindex` attribute.
@@ -1819,6 +1797,213 @@ This is the container for all nodes inside `treeview`. If there are auxiliary co
 		</div>
 	</li>
 </ul>
+```
+
+### Treeview Link Disabled(#css-treeview-link-disabled)
+
+The modifier class `disabled` adds disabled styles to `treeview-link`. The class does not add disabled styles to form elements, links, or buttons inside. Those must be disabled individually.
+
+<div class="row">
+	<div class="col-md-4">
+		<ul class="treeview treeview-light treeview-nested" role="tree">
+			<li class="treeview-item" role="none">
+				<div aria-controls="treeviewItemDisabledCollapse02" aria-expanded="true" class="treeview-link disabled hover" data-target="#treeviewItemDisabledCollapse02" data-toggle="collapse" role="treeitem" tabindex="-1">
+					<span class="c-inner" tabindex="-2">
+						<span class="autofit-row">
+							<span class="autofit-col">
+								<button aria-controls="treeviewItemDisabledCollapse02" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewItemDisabledCollapse02" data-toggle="collapse" type="button">
+									<span class="c-inner" tabindex="-2">
+										<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-down" />
+										</svg>
+										<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#angle-right" />
+										</svg>
+									</span>
+								</button>
+							</span>
+							<span class="autofit-col">
+								<span class="custom-control custom-checkbox">
+									<label>
+										<input class="custom-control-input" disabled tabindex="-1" type="checkbox">
+										<span class="custom-control-label"></span>
+									</label>
+								</span>
+							</span>
+							<span class="autofit-col">
+								<span class="component-icon">
+									<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+										<use xlink:href="/images/icons/icons.svg#folder" />
+									</svg>
+								</span>
+							</span>
+							<span class="autofit-col autofit-col-expand">
+								<span class="component-text">
+									<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+								</span>
+							</span>
+							<span class="autofit-col">
+								<button class="btn btn-monospaced component-action" disabled tabindex="-1" type="button">
+									<span class="c-inner" tabindex="-2">
+										<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+										</svg>
+									</span>
+								</button>
+							</span>
+							<span class="autofit-col">
+								<button class="btn btn-monospaced component-action" disabled tabindex="-1" type="button">
+									<span class="c-inner" tabindex="-2">
+										<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+										</svg>
+									</span>
+								</button>
+							</span>
+						</span>
+					</span>
+				</div>
+				<div class="collapse show" id="treeviewItemDisabledCollapse02">
+					<ul class="treeview-group" role="group">
+						<li class="treeview-item" role="none">
+							<a class="treeview-link disabled" href="#1" role="treeitem" tabindex="-1" style="padding-left:24px;">
+								<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Anchor 1</span></span>
+							</a>
+						</li>
+						<li class="treeview-item" role="none">
+							<a class="treeview-link disabled" href="#1" role="treeitem" tabindex="-1" style="padding-left:24px;">
+								<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Anchor 2</span></span>
+							</a>
+						</li>
+						<li class="treeview-item" role="none">
+							<a class="treeview-link disabled" href="#1" role="treeitem" tabindex="-1" style="padding-left:24px;">
+								<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Anchor 3</span></span>
+							</a>
+						</li>
+					</ul>
+				</div>
+			</li>
+		</ul>
+	</div>
+	<div class="col-md-4">
+		<div class="bg-dark">
+			<ul class="treeview treeview-dark treeview-nested" role="tree">
+				<li class="treeview-item" role="none">
+					<div aria-controls="treeviewItemDisabledDarkCollapse01" aria-expanded="true" class="treeview-link disabled hover" data-target="#treeviewItemDisabledDarkCollapse01" data-toggle="collapse" role="treeitem" tabindex="-1">
+						<span class="c-inner" tabindex="-2">
+							<span class="autofit-row">
+								<span class="autofit-col">
+									<button aria-controls="treeviewItemDisabledDarkCollapse01" aria-expanded="true" class="btn btn-monospaced component-expander" data-target="#treeviewItemDisabledDarkCollapse01" data-toggle="collapse" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-angle-down" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#angle-down" />
+											</svg>
+											<svg class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#angle-right" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<span class="custom-control custom-checkbox">
+										<label>
+											<input class="custom-control-input" disabled tabindex="-1" type="checkbox">
+											<span class="custom-control-label"></span>
+										</label>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<span class="component-icon">
+										<svg class="lexicon-icon lexicon-icon-folder" focusable="false" role="presentation">
+											<use xlink:href="/images/icons/icons.svg#folder" />
+										</svg>
+									</span>
+								</span>
+								<span class="autofit-col autofit-col-expand">
+									<span class="component-text">
+										<span class="text-truncate-inline" title="Liferay Drive"><span class="text-truncate">Liferay Drive</span></span>
+									</span>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" disabled tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-times-circle-full" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#times-circle-full" />
+											</svg>
+										</span>
+									</button>
+								</span>
+								<span class="autofit-col">
+									<button class="btn btn-monospaced component-action" disabled tabindex="-1" type="button">
+										<span class="c-inner" tabindex="-2">
+											<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
+												<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
+											</svg>
+										</span>
+									</button>
+								</span>
+							</span>
+						</span>
+					</div>
+					<div class="collapse show" id="treeviewItemDisabledDarkCollapse01">
+						<ul class="treeview-group" role="group">
+							<li class="treeview-item" role="none">
+								<button class="treeview-link" disabled role="treeitem" tabindex="-1" type="button" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Button 1</span></span>
+								</button>
+							</li>
+							<li class="treeview-item" role="none">
+								<button class="treeview-link" disabled role="treeitem" tabindex="-1"  type="button" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Button 2</span></span>
+								</button>
+							</li>
+							<li class="treeview-item" role="none">
+								<button class="treeview-link" disabled role="treeitem" tabindex="-1"  type="button" style="padding-left:24px;">
+									<span class="c-inner" tabindex="-2" style="margin-left:-24px;"><span class="component-text">Button 3</span></span>
+								</button>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</div>
+</div>
+
+```html
+<ul class="treeview treeview-light treeview-nested" role="tree">
+	<li class="treeview-item" role="none">
+		<div
+			aria-controls="treeviewItemDisabledCollapse02"
+			aria-expanded="true"
+			class="treeview-link disabled hover"
+			data-target="#treeviewItemDisabledCollapse02"
+			data-toggle="collapse"
+			role="treeitem"
+			tabindex="-1"
+		>
+			...
+		</div>
+	</li>
+</ul>
+
+<div class="bg-dark">
+	<ul class="treeview treeview-dark treeview-nested" role="tree">
+		<li class="treeview-item" role="none">
+			<div
+				aria-controls="treeviewItemDisabledDarkCollapse01"
+				aria-expanded="true"
+				class="treeview-link disabled hover"
+				data-target="#treeviewItemDisabledDarkCollapse01"
+				data-toggle="collapse"
+				role="treeitem"
+				tabindex="-1"
+			>
+				...
+			</div>
+		</li>
+	</ul>
+</div>
 ```
 
 ### Component Expander(#css-treeview-component-expander)

--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -156,7 +156,14 @@
 	&.focus,
 	&:focus {
 		.component-action {
-			display: block;
+			display: flex;
+		}
+	}
+
+	&:disabled,
+	&.disabled {
+		.component-action {
+			display: none;
 		}
 	}
 
@@ -263,6 +270,31 @@
 
 	.treeview-link {
 		@include clay-link(map-get($cadmin-treeview-light, treeview-link));
+
+		&:disabled,
+		&.disabled {
+			.component-expander {
+				@include clay-css(
+					map-deep-get(
+						$cadmin-treeview-light,
+						treeview-link,
+						disabled,
+						component-expander
+					)
+				);
+			}
+
+			.component-action {
+				@include clay-css(
+					map-deep-get(
+						$cadmin-treeview-light,
+						treeview-link,
+						disabled,
+						component-action
+					)
+				);
+			}
+		}
 	}
 
 	.component-action {
@@ -329,6 +361,31 @@
 
 	.treeview-link {
 		@include clay-link(map-get($cadmin-treeview-dark, treeview-link));
+
+		&:disabled,
+		&.disabled {
+			.component-expander {
+				@include clay-css(
+					map-deep-get(
+						$cadmin-treeview-dark,
+						treeview-link,
+						disabled,
+						component-expander
+					)
+				);
+			}
+
+			.component-action {
+				@include clay-css(
+					map-deep-get(
+						$cadmin-treeview-dark,
+						treeview-link,
+						disabled,
+						component-action
+					)
+				);
+			}
+		}
 	}
 
 	.component-action {

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -52,6 +52,7 @@ $cadmin-treeview: map-merge(
 			),
 		),
 		treeview-link: (
+			background-color: transparent,
 			cursor: pointer,
 			display: block,
 			border-color: transparent,
@@ -62,6 +63,7 @@ $cadmin-treeview: map-merge(
 			min-width: 100%,
 			padding: 0,
 			position: relative,
+			text-align: left,
 			user-select: none,
 			treeview-dropping-bottom: (
 				box-shadow: 0 2px 0 0 $cadmin-primary-l1,
@@ -79,6 +81,9 @@ $cadmin-treeview: map-merge(
 			focus: (
 				box-shadow: $cadmin-component-focus-inset-box-shadow,
 				outline: 0,
+			),
+			disabled: (
+				cursor: $cadmin-disabled-cursor,
 			),
 		),
 		component-action: (
@@ -160,6 +165,10 @@ $cadmin-treeview-light: map-deep-merge(
 			hover: (
 				color: $cadmin-primary,
 			),
+			disabled: (
+				color: $cadmin-secondary,
+				opacity: 0.5,
+			),
 			btn-secondary: (
 				background-color: $cadmin-white,
 			),
@@ -177,6 +186,10 @@ $cadmin-treeview-light: map-deep-merge(
 			active-class: (
 				background-color: $cadmin-gray-200,
 				color: $cadmin-gray-900,
+			),
+			disabled: (
+				background-color: transparent,
+				color: rgba($cadmin-gray-600, 0.5),
 			),
 			show: (
 				background-color: null,
@@ -207,7 +220,7 @@ $cadmin-treeview-dark: map-deep-merge(
 			),
 			disabled: (
 				background-color: transparent,
-				color: rgba($cadmin-secondary-l1, 0.04),
+				color: rgba($cadmin-secondary-l1, 0.5),
 			),
 			show: (
 				background-color: null,
@@ -216,6 +229,9 @@ $cadmin-treeview-dark: map-deep-merge(
 		),
 		component-action: (
 			color: $cadmin-secondary-l1,
+			disabled: (
+				color: $cadmin-secondary-l1,
+			),
 		),
 	),
 	$cadmin-treeview-dark

--- a/packages/clay-css/src/scss/components/_treeview.scss
+++ b/packages/clay-css/src/scss/components/_treeview.scss
@@ -139,7 +139,14 @@
 	&.focus,
 	&:focus {
 		.component-action {
-			display: block;
+			display: flex;
+		}
+	}
+
+	&:disabled,
+	&.disabled {
+		.component-action {
+			display: none;
 		}
 	}
 
@@ -234,6 +241,31 @@
 
 	.treeview-link {
 		@include clay-link(map-get($treeview-light, treeview-link));
+
+		&:disabled,
+		&.disabled {
+			.component-expander {
+				@include clay-css(
+					map-deep-get(
+						$treeview-light,
+						treeview-link,
+						disabled,
+						component-expander
+					)
+				);
+			}
+
+			.component-action {
+				@include clay-css(
+					map-deep-get(
+						$treeview-light,
+						treeview-link,
+						disabled,
+						component-action
+					)
+				);
+			}
+		}
 	}
 
 	.component-action {
@@ -294,6 +326,31 @@
 
 	.treeview-link {
 		@include clay-link(map-get($treeview-dark, treeview-link));
+
+		&:disabled,
+		&.disabled {
+			.component-expander {
+				@include clay-css(
+					map-deep-get(
+						$treeview-dark,
+						treeview-link,
+						disabled,
+						component-expander
+					)
+				);
+			}
+
+			.component-action {
+				@include clay-css(
+					map-deep-get(
+						$treeview-dark,
+						treeview-link,
+						disabled,
+						component-action
+					)
+				);
+			}
+		}
 	}
 
 	.component-action {

--- a/packages/clay-css/src/scss/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/variables/_treeview.scss
@@ -52,6 +52,7 @@ $treeview: map-merge(
 			),
 		),
 		treeview-link: (
+			background-color: transparent,
 			cursor: pointer,
 			display: block,
 			border-color: transparent,
@@ -62,6 +63,7 @@ $treeview: map-merge(
 			min-width: 100%,
 			padding: 0,
 			position: relative,
+			text-align: left,
 			user-select: none,
 			treeview-dropping-bottom: (
 				box-shadow: 0 2px 0 0 $primary-l1,
@@ -79,6 +81,9 @@ $treeview: map-merge(
 			focus: (
 				box-shadow: $component-focus-inset-box-shadow,
 				outline: 0,
+			),
+			disabled: (
+				cursor: $disabled-cursor,
 			),
 		),
 		component-action: (
@@ -160,6 +165,10 @@ $treeview-light: map-deep-merge(
 			hover: (
 				color: $primary,
 			),
+			disabled: (
+				color: $secondary,
+				opacity: 0.5,
+			),
 			btn-secondary: (
 				background-color: $white,
 			),
@@ -178,6 +187,10 @@ $treeview-light: map-deep-merge(
 				background-color: $gray-200,
 				color: $gray-900,
 			),
+			disabled: (
+				background-color: transparent,
+				color: rgba($gray-600, 0.5),
+			),
 			show: (
 				background-color: null,
 				color: null,
@@ -195,6 +208,10 @@ $treeview-dark: map-deep-merge(
 			hover: (
 				color: $primary-l1,
 			),
+			disabled: (
+				color: $secondary-l1,
+				opacity: 0.5,
+			),
 		),
 		treeview-link: (
 			color: $secondary-l1,
@@ -207,7 +224,7 @@ $treeview-dark: map-deep-merge(
 			),
 			disabled: (
 				background-color: transparent,
-				color: rgba($secondary-l1, 0.04),
+				color: rgba($secondary-l1, 0.5),
 			),
 			show: (
 				background-color: null,
@@ -216,6 +233,9 @@ $treeview-dark: map-deep-merge(
 		),
 		component-action: (
 			color: $secondary-l1,
+			disabled: (
+				color: $secondary-l1,
+			),
 		),
 	),
 	$treeview-dark


### PR DESCRIPTION
issue #4676 

@matuzalemsteles This should cover the disabled styles. We need to disable each clickable element inside a disabled link unfortunately. This mostly applies to a checkbox if it's present. The hover controls won't be shown if disabled.