### PR TITLE
feat(@clayui/core): add API to disable item and expander disable optionally

### DIFF
--- a/clayui.com/src/components/Typography/Typography.js
+++ b/clayui.com/src/components/Typography/Typography.js
@@ -6,35 +6,38 @@
 import React from 'react';
 
 const getId = (children) => {
-	return (
-		typeof children === 'string' &&
-		children.toLowerCase().split(' ').join('-')
-	);
+	if (typeof children !== 'string') {
+		return;
+	}
+
+	if (children.match(/\(#/)) {
+		return children.match(/\(#(.*?)\)$/)[1];
+	}
+
+	return children.toLowerCase().split(' ').join('-');
 };
 
-export const H1 = (props) => (
-	<h1 className="clay-h1" id={getId(props.children)}>
-		{props.children}
-	</h1>
+const getChildren = (children) => {
+	if (typeof children !== 'string' || !children.match(/\(#/)) {
+		return children;
+	}
+
+	return children.match(/(.*?)\(#/)[1];
+};
+
+const Heading = ({as: As = 'h1', children}) => (
+	<As className={`clay-${As}`} id={getId(children)}>
+		{getChildren(children)}
+	</As>
 );
 
-export const H2 = (props) => (
-	<h2 className="clay-h2" id={getId(props.children)}>
-		{props.children}
-	</h2>
-);
+export const H1 = (props) => <Heading as="h1" {...props} />;
 
-export const H3 = (props) => (
-	<h3 className="clay-h3" id={getId(props.children)}>
-		{props.children}
-	</h3>
-);
+export const H2 = (props) => <Heading as="h2" {...props} />;
 
-export const H4 = (props) => (
-	<h4 className="clay-h4" id={getId(props.children)}>
-		{props.children}
-	</h4>
-);
+export const H3 = (props) => <Heading as="h3" {...props} />;
+
+export const H4 = (props) => <Heading as="h4" {...props} />;
 
 export const P = (props) => (
 	<p className={props.className ? props.className : 'clay-p'}>

--- a/packages/clay-core/docs/treeview.mdx
+++ b/packages/clay-core/docs/treeview.mdx
@@ -23,8 +23,10 @@ import {Example, MultipleSelection} from '$packages/clay-core/docs/treeview';
         -   [Single Level](#single-level)
         -   [Nested](#nested)
         -   [Actions](#actions)
+        -   [Disabled](#item-disabled)
 -   [Expander](#expander)
     -   [Custom expander](#custom-expander)
+    -   [Disabled](#expander-disabled)
 -   [Selection](#selection)
     -   [Single Selection](#single-selection)
     -   [Multiple Selection](#multiple-selection)
@@ -262,6 +264,27 @@ Actions are added using the `actions` property on each item. The component abstr
 </TreeView>
 ```
 
+#### Disabled(#item-disabled)
+
+The item can be disabled by setting the `disabled` prop in `<TreeView.ItemStack />` and `<TreeView.Item />`. By default, the Expander and Checkbox are also disabled OOTB, any other clickable elements other than these need to be set to disable in the composition.
+
+```jsx
+<TreeView.Item>
+	<TreeView.ItemStack disabled={true}>
+		<Checkbox />
+		<Icon symbol="folder" />
+		Drive
+	</TreeView.ItemStack>
+	<TreeView.Group>
+		<TreeView.Item disabled={true}>
+			<Checkbox />
+			<Icon symbol="folder" />
+			Documents
+		</TreeView.Item>
+	</TreeView.Group>
+</TreeView.Item>
+```
+
 ## Expander
 
 The expansion of an item in the TreeView is controlled internally. It's also possible to control the state and set an initial value with the keys of the items that are initially expanded.
@@ -299,6 +322,29 @@ Customizing the expander is possible using the `expanderIcons` property. Changin
 	{...}
 </TreeView>
 ```
+
+### Disabled(#expander-disabled)
+
+The Expander is disabled when the item is also disabled but you can optionally control the state of the expander.
+
+```jsx
+<TreeView.Item>
+	<TreeView.ItemStack disabled={true} expanderDisabled={false}>
+		<Checkbox />
+		<Icon symbol="folder" />
+		Drive
+	</TreeView.ItemStack>
+	<TreeView.Group>
+		<TreeView.Item disabled={true}>
+			<Checkbox />
+			<Icon symbol="folder" />
+			Documents
+		</TreeView.Item>
+	</TreeView.Group>
+</TreeView.Item>
+```
+
+The `expanderDisabled` property is only available in the `<TreeView.ItemStack />` component where the expander is visible when it has children.
 
 ## Selection
 

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -21,9 +21,27 @@ export interface ITreeViewItemProps
 	 * Property for rendering actions on a Node.
 	 */
 	actions?: React.ReactElement;
+
 	children: React.ReactNode;
+
+	/**
+	 * Flag indicates that the component is disabled.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Internal property.
+	 */
 	isDragging?: boolean;
+
+	/**
+	 * Internal property.
+	 */
 	overPosition?: string;
+
+	/**
+	 * Internal property.
+	 */
 	overTarget?: boolean;
 }
 
@@ -135,6 +153,8 @@ export const TreeViewItem = React.forwardRef<
 								selectionMode === 'single' &&
 								selection.selectedKeys.has(item.key),
 							collapsed: group && expandedKeys.has(item.key),
+							disabled:
+								itemStackProps.disabled || nodeProps.disabled,
 							focus,
 							'treeview-dropping-bottom':
 								overTarget && overPosition === 'bottom',
@@ -144,6 +164,7 @@ export const TreeViewItem = React.forwardRef<
 								overTarget && overPosition === 'top',
 						}
 					)}
+					disabled={itemStackProps.disabled || nodeProps.disabled}
 					onBlur={({currentTarget, relatedTarget}) => {
 						if (
 							actions &&
@@ -154,6 +175,10 @@ export const TreeViewItem = React.forwardRef<
 						}
 					}}
 					onClick={(event) => {
+						if (itemStackProps.disabled || nodeProps.disabled) {
+							return;
+						}
+
 						if (hasItemStack && itemStackProps.onClick) {
 							itemStackProps.onClick(event);
 						}
@@ -201,6 +226,10 @@ export const TreeViewItem = React.forwardRef<
 					onKeyDown={(event) => {
 						event.preventDefault();
 
+						if (itemStackProps.disabled || nodeProps.disabled) {
+							return;
+						}
+
 						const {key} = event;
 
 						if (key === Keys.Left) {
@@ -240,7 +269,7 @@ export const TreeViewItem = React.forwardRef<
 									);
 								const firstItemElement =
 									group?.querySelector<HTMLDivElement>(
-										'.treeview-link'
+										'.treeview-link:not(.disabled)'
 									);
 								firstItemElement?.focus();
 							} else {
@@ -305,7 +334,9 @@ export const TreeViewItem = React.forwardRef<
 							spacing + (group || onLoadMore ? 0 : 24)
 						}px`,
 					}}
-					tabIndex={0}
+					tabIndex={
+						itemStackProps.disabled || nodeProps.disabled ? -1 : 0
+					}
 				>
 					<span
 						className="c-inner"
@@ -332,6 +363,7 @@ export const TreeViewItem = React.forwardRef<
 						) : (
 							<TreeViewItemStack
 								actions={actions}
+								disabled={nodeProps.disabled}
 								expandable={!!onLoadMore}
 								loading={loading}
 							>
@@ -351,6 +383,18 @@ TreeViewItem.displayName = 'ClayTreeViewItem';
 interface ITreeViewItemStackProps extends React.HTMLAttributes<HTMLDivElement> {
 	actions?: React.ReactElement;
 	children: React.ReactNode;
+
+	/**
+	 * Flag indicates that the component is disabled.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Flag indicates if Expander is disabled, by default it follows the
+	 * behavior of the disabled prop.
+	 */
+	expanderDisabled?: boolean;
+
 	expandable?: boolean;
 	loading?: boolean;
 }
@@ -384,7 +428,9 @@ function Expander({expanderIcons}: ExpanderProps) {
 export function TreeViewItemStack({
 	actions,
 	children,
+	disabled,
 	expandable = true,
+	expanderDisabled,
 	loading = false,
 	...otherProps
 }: ITreeViewItemStackProps) {
@@ -423,6 +469,11 @@ export function TreeViewItemStack({
 								collapsed: expandedKeys.has(item.key),
 							}
 						)}
+						disabled={
+							typeof expanderDisabled === 'undefined'
+								? disabled
+								: expanderDisabled
+						}
 						displayType={null}
 						monospaced
 						onClick={(event) => {
@@ -463,7 +514,7 @@ export function TreeViewItemStack({
 				} else if (child?.type.displayName === 'ClayCheckbox') {
 					content = React.cloneElement(child as React.ReactElement, {
 						checked: selection.selectedKeys.has(item.key),
-						disabled: loading,
+						disabled: loading || disabled,
 						indeterminate: selection.isIntermediate(item.key),
 						onChange: (
 							event: React.ChangeEvent<HTMLInputElement>

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -76,6 +76,7 @@ const ITEMS_DRIVE = [
 								type: 'document',
 							},
 						],
+						disabled: true,
 						id: 8,
 						name: 'Word',
 					},
@@ -84,13 +85,14 @@ const ITEMS_DRIVE = [
 				name: 'Documents and Media',
 			},
 		],
+		disabled: true,
 		id: 1,
 		name: 'Liferay Drive',
 		type: 'cloud',
 	},
 	{
 		children: [
-			{id: 10, name: 'Blogs'},
+			{disabled: true, id: 10, name: 'Blogs'},
 			{id: 11, name: 'Documents and Media'},
 		],
 		id: 9,
@@ -689,6 +691,42 @@ storiesOf('Components|ClayTreeView', module)
 							<TreeView.Group items={item.children}>
 								{(item) => (
 									<TreeView.Item>
+										<OptionalCheckbox />
+										<Icon symbol="folder" />
+										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+	})
+	.add('disabled', () => {
+		// Just to avoid TypeScript error with required props
+		const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
+
+		OptionalCheckbox.displayName = 'ClayCheckbox';
+
+		return (
+			<Provider spritemap={spritemap} theme="cadmin">
+				<TreeView
+					dragAndDrop
+					items={ITEMS_DRIVE}
+					selectionMode="multiple-recursive"
+					showExpanderOnHover={false}
+				>
+					{(item) => (
+						<TreeView.Item>
+							<TreeView.ItemStack disabled={item.disabled}>
+								<OptionalCheckbox />
+								<Icon symbol="folder" />
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item: any) => (
+									<TreeView.Item disabled={item.disabled}>
 										<OptionalCheckbox />
 										<Icon symbol="folder" />
 										{item.name}


### PR DESCRIPTION
Fixes #4676

This PR is adding the two behaviors of disabling the item, disabling all clickable elements inside the item, or making the Expander clickable. By default adding `disabled` to `<Item />` and `<ItemStack />` disables all elements, to always make the expander clickable adds the `expanderDisabled` property to `<ItemStack />`.

I added this information to the documentation as well. I tried to avoid adding an auxiliary prop but without that, we couldn't support both cases by doing inference for example.