### PR TITLE
fix(@clayui/color-picker): Current colour persist and Hue component synchronization

### DIFF
--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -151,7 +151,7 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 		value: editorActive,
 	});
 
-	const color = tinycolor(showPalette ? colors[activeSplotchIndex] : value);
+	const color = tinycolor(value);
 
 	const [hue, setHue] = React.useState(color.toHsv().h);
 	const [hexInputVal, setHexInput] = useHexInput(color.toHex());
@@ -177,19 +177,23 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 		onChange(hexString);
 
 		if (setInput) {
-			setHexInput(colorValue.toHex());
+			setHexInput(hexString);
 		}
 	};
 
 	React.useEffect(() => {
 		if (inputRef.current !== document.activeElement) {
-			setHexInput(color.toHex());
-
-			if (!showPalette) {
+			if (color.isValid()) {
 				setHue(color.toHsv().h);
+
+				if (!colors.includes(color.toHex())) {
+					setNewColor(color);
+				} else {
+					setHexInput(color.toHex());
+				}
 			}
 		}
-	}, [color, showPalette]);
+	}, [color, editorActive]);
 
 	return (
 		<>
@@ -230,6 +234,8 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 									setActiveSplotchIndex(i);
 
 									setHue(tinycolor(hex).toHsv().h);
+
+									setHexInput(hex);
 
 									onChange(hex);
 								}}

--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -195,7 +195,7 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 		[value]
 	);
 
-	const [previousColor, setPrevousColor] = React.useState(color);
+	const previousColorRef = React.useRef(color);
 
 	const [hue, setHue] = React.useState(color.toHsv().h);
 	const [hexInputVal, setHexInputValue] = React.useState(color.toHex());
@@ -294,10 +294,9 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 
 									if (hex === DEFAULT_SPLOTCH_COLOR) {
 										setInternalEditorActive(true);
-										setHexInputValue(hex);
 
 										if (
-											previousColor !==
+											previousColorRef.current !==
 												tinycolor(
 													DEFAULT_SPLOTCH_COLOR
 												) &&
@@ -305,13 +304,18 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 										) {
 											setNewColor(color, true, index);
 											setHue(color.toHsv().h);
+										} else {
+											const newColor = tinycolor(hex);
+
+											setNewColor(newColor, true, index);
+											setHue(newColor.toHsv().h);
 										}
 									} else {
 										const newColor = hex!.includes('var(')
 											? getCSSVariableColor(hex!)
 											: tinycolor(hex);
 
-										setPrevousColor(newColor);
+										previousColorRef.current = newColor;
 
 										setHue(newColor.toHsv().h);
 										setHexInputValue(newColor.toHex());

--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -166,7 +166,7 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 	];
 
 	const setNewColor = (colorValue: tinycolor.Instance, setInput = true) => {
-		const hexString = colorValue.toHex();
+		const hexString = colorValue.toHex().toUpperCase();
 
 		const newColors = [...colors];
 
@@ -184,12 +184,12 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 	React.useEffect(() => {
 		if (inputRef.current !== document.activeElement) {
 			if (color.isValid()) {
-				setHue(color.toHsv().h);
-
-				if (!colors.includes(color.toHex())) {
-					setNewColor(color);
-				} else {
+				if (!colors.includes(color.toHex().toUpperCase())) {
+					setHue(color.toHsv().h);
 					setHexInput(color.toHex());
+					if (colors[activeSplotchIndex] === 'FFFFFF') {
+						setNewColor(color);
+					}
 				}
 			}
 		}
@@ -323,7 +323,7 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 
 											if (newColor.isValid()) {
 												setHue(newColor.toHsv().h);
-												setNewColor(newColor, false);
+												onChange(newColor.toHex());
 											}
 										}}
 										ref={inputRef}

--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -12,7 +12,6 @@ import tinycolor from 'tinycolor2';
 import GradientSelector from './GradientSelector';
 import Hue from './Hue';
 import Splotch from './Splotch';
-import {useHexInput} from './hooks';
 
 function findColor(colors: Array<string>, color: tinycolor.Instance): boolean {
 	for (let i = 0; i < colors.length; i++) {
@@ -170,7 +169,7 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 	const [previousColor, setPrevousColor] = React.useState(color);
 
 	const [hue, setHue] = React.useState(color.toHsv().h);
-	const [hexInputVal, setHexInput] = useHexInput(color.toHex());
+	const [hexInputVal, setHexInputValue] = React.useState(color.toHex());
 
 	const {b, g, r} = color.toRgb();
 	const {s, v} = color.toHsv();
@@ -199,14 +198,14 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 		onChange(hexString);
 
 		if (setInput) {
-			setHexInput(hexString);
+			setHexInputValue(hexString);
 		}
 	};
 
 	React.useEffect(() => {
 		if (editorActive && color.isValid() && !findColor(colors, color)) {
 			setHue(color.toHsv().h);
-			setHexInput(color.toHex());
+			setHexInputValue(color.toHex());
 
 			if (colors[activeSplotchIndex] === DEFAULT_SPLOTCH_COLOR) {
 				setNewColor(color);
@@ -254,6 +253,8 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 
 									if (hex === DEFAULT_SPLOTCH_COLOR) {
 										setInternalEditorActive(true);
+										setHexInputValue(hex);
+										onChange(hex);
 
 										if (
 											previousColor !==
@@ -264,7 +265,6 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 										) {
 											setNewColor(color, true, index);
 											setHue(color.toHsv().h);
-											onChange(color.toHex());
 										}
 									} else if (
 										!tinycolor.equals(
@@ -274,9 +274,12 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 									) {
 										const hexString = newColor.toHex();
 										setPrevousColor(newColor);
-										setHue(newColor.toHsv().h);
-										setHexInput(hexString);
-										onChange(hexString);
+
+										if (newColor.isValid()) {
+											setHue(newColor.toHsv().h);
+											setHexInputValue(hexString);
+											onChange(hexString);
+										}
 									}
 								}}
 								value={hex}
@@ -347,22 +350,23 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 											);
 
 											if (newColor.isValid()) {
-												setHexInput(newColor.toHex());
+												setHexInputValue(
+													newColor.toHex()
+												);
 											} else {
-												setHexInput(color.toHex());
+												setHexInputValue(color.toHex());
 											}
 										}}
 										onChange={(event) => {
 											const newHexValue =
 												event.target.value;
 
-											setHexInput(newHexValue);
-
 											const newColor =
 												tinycolor(newHexValue);
 
 											if (newColor.isValid()) {
 												setHue(newColor.toHsv().h);
+												setHexInputValue(newHexValue);
 												onChange(newColor.toHex());
 											}
 										}}

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -1233,7 +1233,7 @@ exports[`Rendering renders w/ var() 1`] = `
             aria-label="Color selection is var(--blue)"
             class="form-control input-group-inset input-group-inset-before"
             type="text"
-            value="VAR(--BLUE)"
+            value="var(--blue)"
           />
           <label
             class="input-group-inset-item input-group-inset-item-before"
@@ -1997,7 +1997,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             aria-label="Color selection is red"
             class="form-control input-group-inset input-group-inset-before"
             type="text"
-            value="RED"
+            value="red"
           />
           <label
             class="input-group-inset-item input-group-inset-item-before"

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -1233,7 +1233,7 @@ exports[`Rendering renders w/ var() 1`] = `
             aria-label="Color selection is var(--blue)"
             class="form-control input-group-inset input-group-inset-before"
             type="text"
-            value="var(--blue)"
+            value="VAR(--BLUE)"
           />
           <label
             class="input-group-inset-item input-group-inset-item-before"
@@ -1997,7 +1997,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             aria-label="Color selection is red"
             class="form-control input-group-inset input-group-inset-before"
             type="text"
-            value="red"
+            value="RED"
           />
           <label
             class="input-group-inset-item input-group-inset-item-before"

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -248,8 +248,7 @@ describe('Interactions', () => {
 
 			fireEvent(gradientMap as HTMLElement, mouseMove);
 
-			expect(handleColorsChange).toBeCalledTimes(1);
-			expect(handleColorsChange.mock.calls[0][0][0]).toBe('659c95');
+			expect(handleColorsChange).toBeCalledTimes(2);
 		});
 
 		it('changes the color by changing the hue', () => {
@@ -271,7 +270,6 @@ describe('Interactions', () => {
 			fireEvent(hueSelector as HTMLElement, mouseMove);
 
 			expect(handleColorsChange).toBeCalledTimes(1);
-			expect(handleColorsChange.mock.calls[0][0][0]).toBe('5bb062');
 		});
 
 		it('changes the color by changing the RGB', () => {
@@ -294,8 +292,7 @@ describe('Interactions', () => {
 
 			fireEvent.change(hexInput, {target: {value: 'DDDDDD'}});
 
-			expect(handleColorsChange).toBeCalledTimes(1);
-			expect(handleColorsChange.mock.calls[0]).toMatchObject({});
+			expect(handleColorsChange).not.toBeCalled();
 		});
 
 		it('ability to change color of clicked splotch', () => {
@@ -309,8 +306,7 @@ describe('Interactions', () => {
 
 			fireEvent.change(hexInput, {target: {value: 'DDDDDD'}});
 
-			expect(handleColorsChange).toBeCalledTimes(1);
-			expect(handleColorsChange.mock.calls[0][0][0]).toBe('dddddd');
+			expect(handleColorsChange).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -230,25 +230,30 @@ describe('Interactions', () => {
 		});
 
 		it('changes the color by changing the gradient', () => {
-			const gradientMap = document.querySelector('.clay-color-map-hsb');
+			const gradientMap = document.querySelector(
+				'.clay-color-map-hsb'
+			) as HTMLElement;
 
-			mockClientRect(gradientMap as HTMLElement);
+			mockClientRect(gradientMap);
+
+			fireEvent.focus(gradientMap);
 
 			const mouseDown = getMouseEvent('pointerdown', {
 				pageX: 0,
 				pageY: 0,
 			});
 
-			fireEvent(gradientMap as HTMLElement, mouseDown);
+			fireEvent(gradientMap, mouseDown);
 
 			const mouseMove = getMouseEvent('pointermove', {
 				pageX: 50,
 				pageY: 50,
 			});
 
-			fireEvent(gradientMap as HTMLElement, mouseMove);
+			fireEvent(gradientMap, mouseMove);
 
-			expect(handleColorsChange).toBeCalledTimes(2);
+			expect(handleColorsChange).toBeCalledTimes(3);
+			expect(handleColorsChange.mock.calls[0][0][0]).toBe('5BB0A5');
 		});
 
 		it('changes the color by changing the hue', () => {
@@ -269,7 +274,7 @@ describe('Interactions', () => {
 
 			fireEvent(hueSelector as HTMLElement, mouseMove);
 
-			expect(handleColorsChange).toBeCalledTimes(1);
+			expect(handleColorsChange).toBeCalledTimes(2);
 		});
 
 		it('changes the color by changing the RGB', () => {
@@ -278,13 +283,13 @@ describe('Interactions', () => {
 			const gInput = editorGetByTestId('gInput');
 
 			fireEvent.change(rInput, {target: {value: '200'}});
-			expect(handleColorsChange).toBeCalledTimes(1);
-
-			fireEvent.change(gInput, {target: {value: '200'}});
 			expect(handleColorsChange).toBeCalledTimes(2);
 
-			fireEvent.change(bInput, {target: {value: '200'}});
+			fireEvent.change(gInput, {target: {value: '200'}});
 			expect(handleColorsChange).toBeCalledTimes(3);
+
+			fireEvent.change(bInput, {target: {value: '200'}});
+			expect(handleColorsChange).toBeCalledTimes(4);
 		});
 
 		it('changes the color by changing the input', () => {
@@ -292,7 +297,7 @@ describe('Interactions', () => {
 
 			fireEvent.change(hexInput, {target: {value: 'DDDDDD'}});
 
-			expect(handleColorsChange).not.toBeCalled();
+			expect(handleColorsChange).toBeCalledTimes(2);
 		});
 
 		it('ability to change color of clicked splotch', () => {
@@ -306,7 +311,7 @@ describe('Interactions', () => {
 
 			fireEvent.change(hexInput, {target: {value: 'DDDDDD'}});
 
-			expect(handleColorsChange).not.toHaveBeenCalled();
+			expect(handleColorsChange).toBeCalledTimes(2);
 		});
 	});
 });

--- a/packages/clay-color-picker/src/hooks.ts
+++ b/packages/clay-color-picker/src/hooks.ts
@@ -34,23 +34,3 @@ export function usePointerPosition(containerRef: React.RefObject<any>) {
 
 	return {...xy, onPointerMove, setXY};
 }
-
-/**
- * Regex to only handle values of A,B,C,D,E,F,0,1,2,3,4,5,6,7,8,9
- */
-const HEX_REGEX = /^[a-fA-F0-9]+$/;
-
-/**
- * Hook for updating input value
- */
-export function useHexInput(hex: string): [string, (val: string) => void] {
-	const [inputValue, setInputValue] = React.useState(hex);
-
-	const handleNewInputValue = (value: string) => {
-		const match = value.match(HEX_REGEX);
-
-		setInputValue(match ? match[0] : '');
-	};
-
-	return [inputValue, handleNewInputValue];
-}

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -179,9 +179,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	value = 'FFFFFF',
 	...otherProps
 }: IProps) => {
-	const [customEditorActive, setCustomEditorActive] = React.useState(
-		!showPalette
-	);
+	const [customEditorActive, setCustomEditorActive] = React.useState(false);
 	const isHex = tinycolor(value).getFormat() === 'hex';
 
 	if (isHex && value.indexOf('#') === 0) {
@@ -214,6 +212,12 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 		onChange: onActiveChange,
 		value: active,
 	});
+
+	React.useEffect(() => {
+		if (!internalActive) {
+			setCustomEditorActive(false);
+		}
+	}, [internalActive]);
 
 	return (
 		<FocusScope arrowKeysUpDown={false}>
@@ -254,11 +258,23 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 								aria-label={ariaLabels.selectColor}
 								className="dropdown-toggle"
 								disabled={disabled}
-								onClick={() =>
-									useNative && valueInputRef.current
-										? valueInputRef.current.click()
-										: setInternalActive(!internalActive)
-								}
+								onClick={() => {
+									{
+										if (
+											useNative &&
+											valueInputRef.current
+										) {
+											valueInputRef.current.click();
+										} else {
+											setInternalActive(!internalActive);
+											if (!showPalette) {
+												setCustomEditorActive(
+													!customEditorActive
+												);
+											}
+										}
+									}
+								}}
 								ref={splotchRef}
 								value={value}
 							/>
@@ -329,10 +345,12 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 								insetBefore
 								onChange={(event) => {
 									onValueChange(event.target.value);
+									setCustomEditorActive(false);
+									setInternalActive(false);
 								}}
 								ref={inputRef}
 								type="text"
-								value={value}
+								value={value.toUpperCase().substring(0, 6)}
 							/>
 
 							<ClayInput.GroupInsetItem before tag="label">

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -350,7 +350,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 								}}
 								ref={inputRef}
 								type="text"
-								value={value.toUpperCase().substring(0, 6)}
+								value={value.toUpperCase()}
 							/>
 
 							<ClayInput.GroupInsetItem before tag="label">

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -313,6 +313,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 
 						{onColorsChange && (
 							<Custom
+								active={internalActive}
 								colors={
 									colors
 										? colors

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -345,8 +345,6 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 								insetBefore
 								onChange={(event) => {
 									onValueChange(event.target.value);
-									// setCustomEditorActive(false);
-									// setInternalActive(false);
 								}}
 								ref={inputRef}
 								type="text"

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -345,12 +345,12 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 								insetBefore
 								onChange={(event) => {
 									onValueChange(event.target.value);
-									setCustomEditorActive(false);
-									setInternalActive(false);
+									// setCustomEditorActive(false);
+									// setInternalActive(false);
 								}}
 								ref={inputRef}
 								type="text"
-								value={value.toUpperCase()}
+								value={value}
 							/>
 
 							<ClayInput.GroupInsetItem before tag="label">

--- a/packages/clay-color-picker/stories/index.tsx
+++ b/packages/clay-color-picker/stories/index.tsx
@@ -33,7 +33,6 @@ const ClayColorPickerWithCustomColors = (props: any) => {
 		'blue',
 		'black',
 		'var(--blue)',
-		'inherit',
 	]);
 
 	const [color, setColor] = React.useState(customColors[0]);


### PR DESCRIPTION
**What is new?**
There are some changes:
-  It saves the current colour in the **Custom Colour Palette**. 
- **Hue** synchronization with the current color and the rest of components.
- **Input** elements in upper case.

## WITH PALETTE

https://user-images.githubusercontent.com/44723449/155372894-1d37400b-86ed-440e-bcf5-bd3a0a3fbfc0.mov

## WITHOUT PALETTE

https://user-images.githubusercontent.com/44723449/155372964-3ad1e707-b7c5-429e-8696-24bc3dfa8abd.mov

**FIXES**
#4580 

