### PR TITLE
chore: adds workflow to generate automated release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,10 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                 node-version: '16'
-            - name: Clean yarn cache
-              run: yarn cache clean
+            - uses: actions/cache@v2
+              with:
+                path: '**/node_modules'
+                key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
             - name: Install Dependencies
               run: yarn install
             - name: Lint
@@ -24,8 +26,6 @@ jobs:
               run: yarn format:check
             - name: Verify Dependencies
               run: yarn checkDeps
-            - name: Clear jest cache
-              run: yarn test --clearCache
             - name: Run Jest
               env:
                   BROWSERSLIST_CONFIG: './packages/browserslist-config-clay/config'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Clay Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Install Dependencies
+        run: yarn install
+      - name: Lint
+        run: yarn lint
+      - name: Format
+        run: yarn format:check
+      - name: Verify Dependencies
+        run: yarn checkDeps
+      - name: Run Jest
+        env:
+            BROWSERSLIST_CONFIG: './packages/browserslist-config-clay/config'
+            BROWSERSLIST_DISABLE_CACHE: 1
+            CI: true
+        run: yarn test
+
+  version:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          lerna version --conventional-commits --no-push --yes
+      - run: git push origin master --follow-tags
+
+  publish:
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@clayui'
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - run: git push origin master:stable
+      - run: lerna publish from-package --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Related #3683

I spent a little bit of the day today trying to bring our manual Clay releases workflow into an automated workflow with Github Actions.

This implementation has some implications that not being able to reproduce the `git push $REMOTE master:stable` step was failing in the CI, I think if I do more tests I can get it working too.

Some considerations, this workflow is [triggered manually via the Github CLI or via the UI in the Actions tab](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow), so whenever we need to cut a new release we just run the workflow manually and it will take care of everything, run tests, cut package versions using semantic version, add the changelog and publish to NPM.

> Apparently, we don't have access to configure secrets so we will have to open a ticket to add the `NPM_TOKEN` token.

I made tests in my fork not to pollute the repository, see an Action in action https://github.com/matuzalemsteles/clay/actions/runs/1890172564. Also, the running average is about 9m to 10m, I didn't test the publish step because I didn't really want to publish the packages in NPM.

Leave your concerns and feel free to suggest any improvement.