### PR TITLE
docs: adds Tests coverage document with testing recommendations and strategies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ There are two types of documents, repository infrastructure documents, release c
 -   [Clay CSS Version History](clay_css_version_history.md)
 -   [TreeView Performance Analysis](treeview_performance.md)
 -   [Netlify deploy process](netlify_deploy.md)
+-   [Tests coverage](tests.md)
 
 ## RFCs
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,36 +1,34 @@
-# Tests coverage
+# Test coverage
 
-This document describes how we approach Clay testing strategies, recommendations, and best practices for testing components. The tests are very focused on unit tests rather than E2E tests, firstly because unit tests are very cheap and we can mirror most component behavior with unit tests, some are covered with poshi tests in the DXP itself and secondly because it is only components and not a complete React application we don't see a need to implement E2E tests like using [cypress](https://www.cypress.io/) for example.
+This document describes how we approach testing components. We focus on unit tests rather than E2E tests, mainly because unit tests are cheap and enough to test most of our components behaviour and use cases. In [DXP](https://github.com/liferay/liferay-portal), [Poshi](https://qa-compendium.readthedocs.io/en/latest/poshi/index-poshi.html) is used for E2E and integration tests.
 
 ## Approach
 
-The vast majority of components in Clay are oriented to UI composition, very much related to markup and more complex ones such as TreeView, DropDown, DatePicker, TimePicker, ColorPicker... which have more usage behaviors, whether dealing with accessibility issues, shortcuts, focus control and more complex interactions.
+Most components in Clay are oriented to UI composition (related to markup) or can be more complex in terms of interaction (e.g. focus control, accessibility issues, etc...).
 
-All components have detailed behavior and UI specifications written by the [Lexicon](https://liferay.design/lexicon/) design team, we use this as a basis for creating test suites.
+All components have a detailed behavior and UI specifications written by the [Lexicon](https://liferay.design/lexicon/) design team, which we use as a basis for creating our test suites.
 
-The components in Clay use strategies based on the definition of suites, that is, each suite has a purpose.
+Components in Clay use strategies based on the definition of the test suites, where each suite has a purpose.
 
--   `BasicRendering` Suite only covers cases of component compositing and customization, e.g different compositing of the component, the tests here may be more markup related than interaction.
--   `IncrementalInteractions` The suite covers the behaviors that are expected using Lexicon as a basis and simulates an "end-to-end" interaction within the component.
--   `Internationalization` Optional but dedicated suite to test components for internationalization cases, such as DatePicker.
-
-Basically `BasicRendering` suites can have more use of markup snapshot to cover different component settings and variations if any.
+-   The `BasicRendering` suite only covers cases of component composition and customization (e.g. different composition of the component). These tests are more related to markup than interaction.
+-   The `IncrementalInteractions` suite covers the expected behavior using Lexicon as a basis and simulates an "end-to-end" interaction.
+-   The `Internationalization` suite is optional and used to test components for internationalization cases (e.g. `DatePicker`).
 
 ## Threshold
 
-Achieving healthy test coverage that is not just numbers is quite challenging, so Clay is taking an organic coverage growth approach instead of setting a fixed value to always stay above that value, which would create some pitfalls.
+Achieving healthy test coverage is quite challenging, so Clay tries to follow an organic coverage growth approach instead of setting a fixed value, to avoid pitfalls such as:
 
--   Create a false sense of security when being over the limit and we don't care about testing as long as we are over the limit.
--   Create the opposite feeling when it's below and want to add more tests, regardless of test quality, to hit the threshold.
--   We could stop adding tests when we hit the threshold.
+-   Creating a false sense of security by being over the limit and not caring about the test itself as long as we are over the limit.
+-   Creating the opposite feeling when it's below and adding more tests (regardless of their quality) to hit the threshold.
+-   Stop adding tests when we hit the threshold.
 
 In order to avoid these pitfalls, we can set the threshold as close as possible to our current code coverage, then organically adjust the threshold when finishing a story/epic, new behaviors or features.
 
 Some examples of scenarios that could be used to adjust code coverage:
 
--   "I realize changes are failing the threshold but another test would be unreasonable." Adjust threshold down.
+-   "I realize changes are failing to reach the threshold but another test would be unreasonable." Adjust threshold down.
 -   "My changes have increased the overall coverage." Adjust threshold up so we can still be notified if future coverage decreases.
 
-The scenarios allow us to keep the threshold as close to actual coverage as possible so we have a reminder to check if another test is necessary when we’re ready to deliver the code to production.
+Theses scenarios allow us to keep the threshold as close as possible to actual coverage so we have a reminder to check if another test is necessary when we’re ready to deliver the code to production.
 
-Consider keeping a minimum threshold of 50% for packages with low coverage with the exception of some packages that are being deprecated for example and the other packages add the organic threshold.
+Consider keeping a minimum threshold of 50% for packages with low coverage with the exception of packages that are being deprecated.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,36 @@
+# Tests coverage
+
+This document describes how we approach Clay testing strategies, recommendations, and best practices for testing components. The tests are very focused on unit tests rather than E2E tests, firstly because unit tests are very cheap and we can mirror most component behavior with unit tests, some are covered with poshi tests in the DXP itself and secondly because it is only components and not a complete React application we don't see a need to implement E2E tests like using [cypress](https://www.cypress.io/) for example.
+
+## Approach
+
+The vast majority of components in Clay are oriented to UI composition, very much related to markup and more complex ones such as TreeView, DropDown, DatePicker, TimePicker, ColorPicker... which have more usage behaviors, whether dealing with accessibility issues, shortcuts, focus control and more complex interactions.
+
+All components have detailed behavior and UI specifications written by the [Lexicon](https://liferay.design/lexicon/) design team, we use this as a basis for creating test suites.
+
+The components in Clay use strategies based on the definition of suites, that is, each suite has a purpose.
+
+-   `BasicRendering` Suite only covers cases of component compositing and customization, e.g different compositing of the component, the tests here may be more markup related than interaction.
+-   `IncrementalInteractions` The suite covers the behaviors that are expected using Lexicon as a basis and simulates an "end-to-end" interaction within the component.
+-   `Internationalization` Optional but dedicated suite to test components for internationalization cases, such as DatePicker.
+
+Basically `BasicRendering` suites can have more use of markup snapshot to cover different component settings and variations if any.
+
+## Threshold
+
+Achieving healthy test coverage that is not just numbers is quite challenging, so Clay is taking an organic coverage growth approach instead of setting a fixed value to always stay above that value, which would create some pitfalls.
+
+-   Create a false sense of security when being over the limit and we don't care about testing as long as we are over the limit.
+-   Create the opposite feeling when it's below and want to add more tests, regardless of test quality, to hit the threshold.
+-   We could stop adding tests when we hit the threshold.
+
+In order to avoid these pitfalls, we can set the threshold as close as possible to our current code coverage, then organically adjust the threshold when finishing a story/epic, new behaviors or features.
+
+Some examples of scenarios that could be used to adjust code coverage:
+
+-   "I realize changes are failing the threshold but another test would be unreasonable." Adjust threshold down.
+-   "My changes have increased the overall coverage." Adjust threshold up so we can still be notified if future coverage decreases.
+
+The scenarios allow us to keep the threshold as close to actual coverage as possible so we have a reminder to check if another test is necessary when we’re ready to deliver the code to production.
+
+Consider keeping a minimum threshold of 50% for packages with low coverage with the exception of some packages that are being deprecated for example and the other packages add the organic threshold.


### PR DESCRIPTION
Well, this document describes most of the recommendations that @john-co reported in his review and recommendations on covering unit tests with organic limits. I've also added the test building approach to the suites that we're already using on most of the more complex components.

Leave your opinion and suggestions on how we can better handle the tests.

### [View Rendered Text](https://github.com/matuzalemsteles/clay/blob/coverage-docs/docs/tests.md)