### PR TITLE
fix(@clayui/pagination): The current page button must be disabled to avoid screen readers to read it as this is confusing for the final user

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"lint:fix": "eslint --fix \".*.js\" \"**/*.{js,ts,tsx}\"",
 		"lint:quiet": "eslint --quiet \".*.js\" \"**/*.{js,ts,tsx}\"",
 		"lint": "eslint \".*.js\" \"**/*.{js,ts,tsx}\"",
-		"site": "cd next.clayui.com && yarn build && yarn serve",
+		"site": "cd clayui.com && yarn build && yarn serve",
 		"sizeLimit": "size-limit",
 		"storybook:build": "NODE_OPTIONS=--max_old_space_size=8192 build-storybook -c .storybook -o .storybook-static",
 		"storybook": "start-storybook -p 8888",

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -58,6 +58,7 @@ exports[`ClayPaginationBar renders 1`] = `
       >
         <button
           class="page-link"
+          disabled=""
           type="button"
         >
           1
@@ -166,6 +167,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
       >
         <button
           class="page-link"
+          disabled=""
           type="button"
         >
           1

--- a/packages/clay-pagination/src/Item.tsx
+++ b/packages/clay-pagination/src/Item.tsx
@@ -21,18 +21,17 @@ const ClayPaginationItem: React.FunctionComponent<IPaginationItemProps> = ({
 	href,
 	...otherProps
 }: IPaginationItemProps) => {
-	const classes = classNames('page-item', {active, disabled});
-
 	const ElementTag = href ? ClayLink : 'button';
 
 	return (
-		<li className={classes}>
+		<li className={classNames('page-item', {active, disabled})}>
 			<ElementTag
-				type={!href ? 'button' : undefined}
+				type={href ? undefined : 'button'}
 				{...otherProps}
+				aria-current={active && href ? 'page' : undefined}
 				className="page-link"
-				disabled={disabled || active}
-				href={href}
+				disabled={href ? undefined : disabled || active}
+				href={disabled || active ? undefined : href}
 			>
 				{children}
 			</ElementTag>

--- a/packages/clay-pagination/src/Item.tsx
+++ b/packages/clay-pagination/src/Item.tsx
@@ -31,7 +31,7 @@ const ClayPaginationItem: React.FunctionComponent<IPaginationItemProps> = ({
 				type={!href ? 'button' : undefined}
 				{...otherProps}
 				className="page-link"
-				disabled={disabled}
+				disabled={disabled || active}
 				href={href}
 			>
 				{children}

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -70,6 +70,7 @@ exports[`ClayPagination renders 1`] = `
     >
       <button
         class="page-link"
+        disabled=""
         type="button"
       >
         12
@@ -169,6 +170,7 @@ exports[`ClayPagination renders with only one page 1`] = `
     >
       <button
         class="page-link"
+        disabled=""
         type="button"
       >
         1

--- a/packages/clay-pagination/src/__tests__/index.tsx
+++ b/packages/clay-pagination/src/__tests__/index.tsx
@@ -92,6 +92,26 @@ describe('ClayPagination', () => {
 		);
 	});
 
+	it('render pagination with links and active item without link', () => {
+		const {getByText} = render(
+			<ClayPaginationWithBasicItems
+				activePage={12}
+				ellipsisBuffer={2}
+				hrefConstructor={(page) => `/#${page}`}
+				spritemap={spritemap}
+				totalPages={25}
+			/>
+		);
+
+		const currentActivePage = getByText('12');
+
+		expect(
+			(currentActivePage.parentElement as HTMLElement).classList
+		).toContain('active');
+		expect(currentActivePage.getAttribute('href')).toBe(null);
+		expect(currentActivePage.getAttribute('aria-current')).toBe('page');
+	});
+
 	it('shows dropdown when ellipsis is clicked', () => {
 		const {getAllByText} = render(
 			<ClayPaginationWithBasicItems


### PR DESCRIPTION
This issue is linked to https://github.com/liferay-frontend/liferay-portal/pull/1950 and https://issues.liferay.com/browse/LPS-148048


_This issue has been reported by a blind association that is a Liferay customer, for more information see: https://issues.liferay.com/browse/LPS-148048?focusedCommentId=2626115&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2626115_

The pagination button to the current page should be disabled to avoid screen readers read it, as this is confusing for the final users.

After a quick research with several search engines:

- Google: https://www.google.com/search?q=search
- Bing: https://www.bing.com/search?q=search
- Yahoo: https://search.yahoo.com/search?p=search
- Amazon: https://www.amazon.com/s?k=search

All of them are not linking the current page, so it seems we should also disable the button.

For more information see the discussion in PR https://github.com/liferay-frontend/liferay-portal/pull/1950
