### PR TITLE
feat(@clayui/css): Adds placeholder comments that can be replaced wit…

### DIFF
--- a/packages/clay-css/src/scss/_cadmin-variables.scss
+++ b/packages/clay-css/src/scss/_cadmin-variables.scss
@@ -1,3 +1,5 @@
+// INSERT @use rules
+
 @import '_license-text';
 
 @import 'functions/_global-functions';

--- a/packages/clay-css/src/scss/atlas-variables.scss
+++ b/packages/clay-css/src/scss/atlas-variables.scss
@@ -1,3 +1,5 @@
+// INSERT @use rules
+
 @import '_license-text';
 
 @import 'functions/_global-functions';

--- a/packages/clay-css/src/scss/atlas.scss
+++ b/packages/clay-css/src/scss/atlas.scss
@@ -1,3 +1,5 @@
+// INSERT @use rules
+
 @import '_license-text';
 
 @import 'functions/_global-functions';

--- a/packages/clay-css/src/scss/base-variables.scss
+++ b/packages/clay-css/src/scss/base-variables.scss
@@ -1,3 +1,5 @@
+// INSERT @use rules
+
 @import '_license-text';
 
 @import 'functions/_global-functions';

--- a/packages/clay-css/src/scss/base.scss
+++ b/packages/clay-css/src/scss/base.scss
@@ -1,3 +1,5 @@
+// INSERT @use rules
+
 @import '_license-text';
 
 @import 'functions/_global-functions';

--- a/packages/clay-css/src/scss/cadmin.scss
+++ b/packages/clay-css/src/scss/cadmin.scss
@@ -1,3 +1,5 @@
+// INSERT @use rules
+
 @import '_license-text';
 
 // Don't forget easy to include variable overwrites


### PR DESCRIPTION
…h Sass @use rules

fixes #4713

Edit: ~This one is a little weird, not from our end but from Portal's end. According to the `yarn.lock` file, we're either on Sass [1.29.0](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/yarn.lock#L1716) or [1.30.0](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/yarn.lock#L10068). The slash as division deprecation wasn't implemented until Sass [1.33.0](https://sass-lang.com/documentation/breaking-changes/slash-div).~

Nevermind, I'm going to leave this for future reference. The Sass math module was introduced in Sass [1.23.0](https://sass-lang.com/documentation/modules/math), so we are still good. I was just wondering why I wasn't seeing deprecation warnings when I deployed in Portal.