### PR TITLE
fix(@clayui/css): Forms .form-control-tag-group .label (Multiselect) …

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -425,20 +425,21 @@ $form-control-label-size: () !default;
 $form-control-label-size: map-deep-merge(
 	(
 		border-width: 0.0625rem,
-		font-size: map-get($label-lg, font-size),
+		font-size: 0.75rem,
 		height: auto,
 		margin-bottom: 0.3125rem,
 		margin-right: 0.625rem,
 		margin-top: 0.3125rem,
 		min-height: 1.5rem,
-		padding-x: map-get($label-lg, padding-x),
-		padding-y: map-get($label-lg, padding-y),
+		padding-bottom: 0.3125rem,
+		padding-left: 0.5rem,
+		padding-right: 0.5rem,
+		padding-top: 0.3125rem,
 		text-transform: none,
-		item-spacer-y: map-get($label-lg, item-spacer-y),
-		lexicon-icon-height: map-get($label-lg, lexicon-icon-height),
-		lexicon-icon-width: map-get($label-lg, lexicon-icon-width),
-		sticker-size: map-get($label-lg, sticker-size),
-		close: map-get($label-lg, close),
+		label-item: (
+			margin-bottom: -0.0625rem,
+			margin-top: -0.0625rem,
+		),
 	),
 	$form-control-label-size
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -318,20 +318,21 @@ $cadmin-form-control-label-size: () !default;
 $cadmin-form-control-label-size: map-deep-merge(
 	(
 		border-width: 1px,
-		font-size: map-get($cadmin-label-lg, font-size),
+		font-size: 12px,
 		height: auto,
 		margin-bottom: 5px,
 		margin-right: 10px,
 		margin-top: 5px,
 		min-height: 24px,
-		padding-x: map-get($cadmin-label-lg, padding-x),
-		padding-y: map-get($cadmin-label-lg, padding-y),
+		padding-bottom: 5px,
+		padding-left: 8px,
+		padding-right: 8px,
+		padding-top: 5px,
 		text-transform: none,
-		item-spacer-y: map-get($cadmin-label-lg, item-spacer-y),
-		lexicon-icon-height: map-get($cadmin-label-lg, lexicon-icon-height),
-		lexicon-icon-width: map-get($cadmin-label-lg, lexicon-icon-width),
-		sticker-size: map-get($cadmin-label-lg, sticker-size),
-		close: map-get($cadmin-label-lg, close),
+		label-item: (
+			margin-bottom: -1px,
+			margin-top: -1px,
+		),
 	),
 	$cadmin-form-control-label-size
 );


### PR DESCRIPTION
…remove references to deprecated keys

    - Define the values for `.label` inside `.form-control` instead of inheriting them from `.label-lg`

fixes #4712