### PR TITLE
chore(@clayui/core): adds TreeView tests

### DIFF
--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -87,7 +87,7 @@ export function Collection<T extends Record<any, any>>({
 							</ItemContextProvider>
 						);
 				  })
-				: React.Children.toArray(children).map((child, index) => {
+				: React.Children.map(children, (child, index) => {
 						if (!React.isValidElement(child)) {
 							return null;
 						}

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -347,7 +347,7 @@ export const TreeViewItem = React.forwardRef<
 						}}
 						tabIndex={-2}
 					>
-						{typeof left === 'string' ? (
+						{typeof left === 'string' && !right ? (
 							<Layout.ContentRow>
 								<Layout.ContentCol expand>
 									<div className="component-text">{left}</div>

--- a/packages/clay-core/src/tree-view/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/BasicRendering.tsx
@@ -1,0 +1,361 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ClayDropDownWithItems as DropDownWithItems} from '@clayui/drop-down';
+import {ClayCheckbox as Checkbox} from '@clayui/form';
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import {Button, Icon, Provider, TreeView} from '../..';
+
+const spritemap = 'icons.svg';
+
+// Just to avoid TypeScript error with required props
+const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
+
+OptionalCheckbox.displayName = 'ClayCheckbox';
+
+describe('TreeView basic rendering', () => {
+	afterEach(cleanup);
+
+	it('render static content', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView>
+					<TreeView.Item>
+						<TreeView.ItemStack>Root</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item>Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render dynamic content', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView
+					items={[
+						{
+							children: [{name: 'Item'}],
+							name: 'Root',
+						},
+					]}
+				>
+					{(item) => (
+						<TreeView.Item key={item.name}>
+							<TreeView.ItemStack>{item.name}</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item key={item.name}>
+										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render nested dynamic content', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView
+					items={[
+						{
+							children: [
+								{
+									children: [
+										{
+											children: [{name: 'Foo'}],
+											name: 'Baz',
+										},
+									],
+									name: 'Bar',
+								},
+							],
+							name: 'Foo',
+						},
+					]}
+				>
+					{(item) => (
+						<TreeView.Item key={item.name}>
+							<TreeView.ItemStack>{item.name}</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item key={item.name}>
+										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render light theme', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView displayType="light">
+					<TreeView.Item>
+						<TreeView.ItemStack>Root</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item>Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container.querySelector('.treeview-light')).toBeTruthy();
+	});
+
+	it('render dark theme', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView displayType="dark">
+					<TreeView.Item>
+						<TreeView.ItemStack>Root</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item>Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container.querySelector('.treeview-dark')).toBeTruthy();
+	});
+
+	it('render with custom expander', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView
+					expanderIcons={{
+						close: <Icon symbol="hr" />,
+						open: <Icon symbol="plus" />,
+					}}
+				>
+					<TreeView.Item>
+						<TreeView.ItemStack>Root</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item>Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container.querySelectorAll('svg.lexicon-icon-hr').length).toBe(
+			1
+		);
+		expect(container.querySelectorAll('svg.lexicon-icon-plus').length).toBe(
+			1
+		);
+	});
+
+	it('render with actions', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView>
+					<TreeView.Item
+						actions={
+							<>
+								<Button displayType={null} monospaced>
+									<Icon symbol="times" />
+								</Button>
+								<DropDownWithItems
+									items={[
+										{label: 'One'},
+										{label: 'Two'},
+										{label: 'Three'},
+									]}
+									trigger={
+										<Button displayType={null} monospaced>
+											<Icon symbol="ellipsis-v" />
+										</Button>
+									}
+								/>
+							</>
+						}
+					>
+						Root
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render with item disabled', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView>
+					<TreeView.Item>
+						<TreeView.ItemStack disabled>Root</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item disabled>Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(
+			container.querySelectorAll('.treeview-link.disabled').length
+		).toBe(1);
+		expect(
+			container.querySelectorAll('.btn.component-expander[disabled]')
+				.length
+		).toBe(1);
+	});
+
+	it('render with item disabled except expander', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView>
+					<TreeView.Item>
+						<TreeView.ItemStack disabled expanderDisabled={false}>
+							Root
+						</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item disabled>Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(
+			container.querySelectorAll('.treeview-link.disabled').length
+		).toBe(1);
+		expect(
+			container.querySelector('.btn.component-expander[disabled]')
+		).toBeFalsy();
+	});
+
+	it('render with checkbox', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView>
+					<TreeView.Item>
+						<TreeView.ItemStack>
+							<OptionalCheckbox />
+							Root
+						</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item>
+								<OptionalCheckbox />
+								Item
+							</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render with pre-selected items', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView selectedKeys={new Set(['Root', 'Item'])}>
+					<TreeView.Item key="Root">
+						<TreeView.ItemStack>
+							<OptionalCheckbox />
+							Root
+						</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item key="Item">
+								<OptionalCheckbox />
+								Item
+							</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(
+			container.querySelectorAll(
+				'input.custom-control-input[type=checkbox]:checked'
+			).length
+		).toBe(1);
+	});
+
+	it('render with pre-selected items with dynamic content', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView
+					items={[
+						{
+							children: [{id: 2, name: 'Item'}],
+							id: 1,
+							name: 'Root',
+						},
+					]}
+					selectedKeys={new Set([1, 2])}
+				>
+					{(item) => (
+						<TreeView.Item>
+							<TreeView.ItemStack>
+								<OptionalCheckbox />
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								{(item) => (
+									<TreeView.Item>
+										<OptionalCheckbox />
+										{item.name}
+									</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+
+		expect(
+			container.querySelectorAll(
+				'input.custom-control-input[type=checkbox]:checked'
+			).length
+		).toBe(2);
+	});
+
+	it('render with pre-expanded items', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView expandedKeys={new Set(['Root', 'Item'])}>
+					<TreeView.Item key="Root">
+						<TreeView.ItemStack>Root</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item key="Item">Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(
+			container.querySelector('.treeview-link.collapsed')
+		).toBeTruthy();
+		expect(container.querySelector('.collapse.show')).toBeTruthy();
+	});
+});

--- a/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
@@ -1,0 +1,929 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Button from '@clayui/button';
+import {ClayCheckbox as Checkbox} from '@clayui/form';
+import {cleanup, fireEvent, render, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import {Provider, TreeView} from '../..';
+
+const spritemap = 'icons.svg';
+
+// Just to avoid TypeScript error with required props
+const OptionalCheckbox = (props: any) => <Checkbox {...props} />;
+
+OptionalCheckbox.displayName = 'ClayCheckbox';
+
+describe('TreeView incremental interactions', () => {
+	afterEach(cleanup);
+
+	it('expand item when click on the expander', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView>
+					<TreeView.Item key="Root">
+						<TreeView.ItemStack>Root</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item key="Item">Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		const expanderButton = container.querySelector(
+			'.component-expander'
+		) as HTMLButtonElement;
+
+		fireEvent.click(expanderButton);
+
+		const linkItem = container.querySelector(
+			'.treeview-link'
+		) as HTMLDivElement;
+
+		expect(linkItem.getAttribute('aria-expanded')).toBe('true');
+		expect(container.querySelector('.collapse.show')).toBeTruthy();
+	});
+
+	it('hide item by clicking expander', async () => {
+		jest.useFakeTimers();
+
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView>
+					<TreeView.Item key="Root">
+						<TreeView.ItemStack>Root</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item key="Item">Item</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		const expanderButton = container.querySelector(
+			'.component-expander'
+		) as HTMLButtonElement;
+
+		fireEvent.click(expanderButton);
+
+		const linkItem = container.querySelector(
+			'.treeview-link'
+		) as HTMLDivElement;
+
+		expect(linkItem.getAttribute('aria-expanded')).toBe('true');
+		expect(container.querySelector('.collapse.show')).toBeTruthy();
+
+		fireEvent.click(expanderButton);
+
+		jest.runAllTimers();
+
+		expect(linkItem.getAttribute('aria-expanded')).toBe('false');
+		expect(container.querySelector('.collapse')).toBeFalsy();
+	});
+
+	describe('selection', () => {
+		describe('checkbox', () => {
+			it('select only one item using single selection', () => {
+				const {container} = render(
+					<Provider spritemap={spritemap}>
+						<TreeView expandedKeys={new Set(['Root'])}>
+							<TreeView.Item key="Root">
+								<TreeView.ItemStack>
+									<OptionalCheckbox />
+									Root
+								</TreeView.ItemStack>
+								<TreeView.Group>
+									<TreeView.Item key="Item">
+										<OptionalCheckbox />
+										Item
+									</TreeView.Item>
+								</TreeView.Group>
+							</TreeView.Item>
+						</TreeView>
+					</Provider>
+				);
+
+				const [root, item] =
+					container.querySelectorAll<HTMLInputElement>(
+						'input.custom-control-input[type=checkbox]'
+					);
+
+				fireEvent.click(root);
+
+				expect(root.checked).toBeTruthy();
+
+				fireEvent.click(item);
+
+				expect(item.checked).toBeTruthy();
+				expect(root.checked).toBeFalsy();
+			});
+
+			it('select multiple item using multiple selection', () => {
+				const {container} = render(
+					<Provider spritemap={spritemap}>
+						<TreeView
+							expandedKeys={new Set(['Root'])}
+							selectionMode="multiple"
+						>
+							<TreeView.Item key="Root">
+								<TreeView.ItemStack>
+									<OptionalCheckbox />
+									Root
+								</TreeView.ItemStack>
+								<TreeView.Group>
+									<TreeView.Item key="Item">
+										<OptionalCheckbox />
+										Item
+									</TreeView.Item>
+								</TreeView.Group>
+							</TreeView.Item>
+						</TreeView>
+					</Provider>
+				);
+
+				const [root, item] =
+					container.querySelectorAll<HTMLInputElement>(
+						'input.custom-control-input[type=checkbox]'
+					);
+
+				fireEvent.click(root);
+				fireEvent.click(item);
+
+				expect(item.checked).toBeTruthy();
+				expect(root.checked).toBeTruthy();
+			});
+
+			it('select children and parent recursively using recursive multiple selection', () => {
+				const {container} = render(
+					<Provider spritemap={spritemap}>
+						<TreeView
+							items={[
+								{
+									children: [{id: 2, name: 'Item'}],
+									id: 1,
+									name: 'Root',
+								},
+							]}
+							selectionMode="multiple-recursive"
+						>
+							{(item) => (
+								<TreeView.Item>
+									<TreeView.ItemStack>
+										<OptionalCheckbox />
+										{item.name}
+									</TreeView.ItemStack>
+									<TreeView.Group items={item.children}>
+										{(item) => (
+											<TreeView.Item>
+												<OptionalCheckbox />
+												{item.name}
+											</TreeView.Item>
+										)}
+									</TreeView.Group>
+								</TreeView.Item>
+							)}
+						</TreeView>
+					</Provider>
+				);
+
+				const rootExpander = container.querySelector(
+					'.component-expander'
+				) as HTMLButtonElement;
+
+				const root = container.querySelector(
+					'input.custom-control-input[type=checkbox]'
+				) as HTMLInputElement;
+
+				fireEvent.click(root);
+				fireEvent.click(rootExpander);
+
+				expect(root.checked).toBeTruthy();
+
+				const [, item] = container.querySelectorAll<HTMLInputElement>(
+					'input.custom-control-input[type=checkbox]'
+				);
+
+				expect(item.checked).toBeTruthy();
+			});
+
+			it('pressing space selects item', () => {
+				const {container, getByRole} = render(
+					<Provider spritemap={spritemap}>
+						<TreeView>
+							<TreeView.Item key="Root">
+								<TreeView.ItemStack>
+									<OptionalCheckbox />
+									Root
+								</TreeView.ItemStack>
+								<TreeView.Group>
+									<TreeView.Item key="Item">
+										<OptionalCheckbox />
+										Item
+									</TreeView.Item>
+								</TreeView.Group>
+							</TreeView.Item>
+						</TreeView>
+					</Provider>
+				);
+
+				const root = getByRole('treeitem');
+
+				const rootCheckbox = container.querySelector(
+					'input.custom-control-input[type=checkbox]'
+				) as HTMLInputElement;
+
+				fireEvent.keyDown(root, {key: ' '});
+
+				expect(rootCheckbox.checked).toBeTruthy();
+			});
+		});
+
+		it('clicking the item link selects the item in the single selection', () => {
+			const {getAllByRole} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const [root, item] = getAllByRole('treeitem');
+
+			fireEvent.click(root);
+
+			expect(root.classList).toContain('active');
+
+			fireEvent.click(item);
+
+			expect(item.classList).toContain('active');
+			expect(root.classList).not.toContain('active');
+		});
+
+		it('trigger selection manually using single selection', () => {
+			jest.useFakeTimers();
+
+			const {getAllByRole, getByTestId} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+					>
+						{(item, selection) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+									<Button
+										data-testid="root"
+										onClick={() =>
+											selection.toggle(item.id)
+										}
+									>
+										Select
+									</Button>
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+											<Button
+												data-testid="item"
+												onClick={() =>
+													selection.toggle(item.id)
+												}
+											>
+												Select
+											</Button>
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			jest.runAllTimers();
+
+			const [root, item] = getAllByRole('treeitem');
+
+			fireEvent.click(getByTestId('root'));
+
+			expect(root.classList).toContain('active');
+
+			fireEvent.click(getByTestId('item'));
+
+			expect(item.classList).toContain('active');
+			expect(root.classList).not.toContain('active');
+		});
+
+		it('trigger selection manually using multiple selection', () => {
+			jest.useFakeTimers();
+
+			const {getAllByRole, getByTestId} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+						selectionMode="multiple"
+					>
+						{(item, selection) => (
+							<TreeView.Item>
+								<TreeView.ItemStack
+									className={
+										selection.has(item.id)
+											? 'active'
+											: undefined
+									}
+								>
+									{item.name}
+									<Button
+										data-testid="root"
+										onClick={(event) => {
+											event.stopPropagation();
+
+											selection.toggle(item.id);
+										}}
+									>
+										Select
+									</Button>
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item
+											className={
+												selection.has(item.id)
+													? 'active'
+													: undefined
+											}
+										>
+											{item.name}
+											<Button
+												data-testid="item"
+												onClick={(event) => {
+													event.stopPropagation();
+
+													selection.toggle(item.id);
+												}}
+											>
+												Select
+											</Button>
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			jest.runAllTimers();
+
+			const [root, item] = getAllByRole('treeitem');
+
+			fireEvent.click(getByTestId('root'));
+			fireEvent.click(getByTestId('item'));
+
+			expect(item.classList).toContain('active');
+			expect(root.classList).toContain('active');
+		});
+
+		it('trigger selection manually using recursive multiple selection', () => {
+			const {getAllByRole, getByTestId} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+						selectionMode="multiple-recursive"
+					>
+						{(item, selection) => (
+							<TreeView.Item>
+								<TreeView.ItemStack
+									className={
+										selection.has(item.id)
+											? 'active'
+											: undefined
+									}
+								>
+									{item.name}
+									<Button
+										data-testid="root"
+										onClick={(event) => {
+											event.stopPropagation();
+
+											selection.toggle(item.id);
+										}}
+									>
+										Select
+									</Button>
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item
+											className={
+												selection.has(item.id)
+													? 'active'
+													: undefined
+											}
+										>
+											{item.name}
+											<Button
+												data-testid="item"
+												onClick={(event) => {
+													event.stopPropagation();
+
+													selection.toggle(item.id);
+												}}
+											>
+												Select
+											</Button>
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const [root, item] = getAllByRole('treeitem');
+
+			fireEvent.click(getByTestId('root'));
+
+			expect(item.classList).toContain('active');
+			expect(root.classList).toContain('active');
+		});
+	});
+
+	describe('focus', () => {
+		it('pressing the right arrow key expands the item', () => {
+			const {container, getByRole} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const root = getByRole('treeitem');
+
+			fireEvent.keyDown(root, {key: 'ArrowRight'});
+
+			expect(document.activeElement).toBe(root);
+			expect(root.getAttribute('aria-expanded')).toBe('true');
+			expect(container.querySelector('.collapse.show')).toBeTruthy();
+		});
+
+		it('pressing the right arrow key with the expanded item moves focus to the nearest down item', () => {
+			const {getAllByRole} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const [root, item] = getAllByRole('treeitem');
+
+			fireEvent.keyDown(root, {key: 'ArrowRight'});
+
+			expect(document.activeElement).toBe(item);
+		});
+
+		it('pressing the left arrow key hides the item', () => {
+			jest.useFakeTimers();
+
+			const {container, getByRole} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const root = getByRole('treeitem');
+
+			fireEvent.keyDown(root, {key: 'ArrowRight'});
+
+			expect(root.getAttribute('aria-expanded')).toBe('true');
+			expect(container.querySelector('.collapse.show')).toBeTruthy();
+
+			fireEvent.keyDown(root, {key: 'ArrowLeft'});
+
+			jest.runAllTimers();
+
+			expect(root.getAttribute('aria-expanded')).toBe('false');
+			expect(container.querySelector('.collapse.show')).toBeFalsy();
+		});
+
+		it('pressing the left arrow key with the item hidden moves the focus to the next item above', () => {
+			const {getAllByRole} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [
+									{
+										children: [{id: 3, name: 'Item 2'}],
+										id: 2,
+										name: 'Item',
+									},
+								],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const [root, item] = getAllByRole('treeitem');
+
+			fireEvent.keyDown(item, {key: 'ArrowLeft'});
+
+			expect(document.activeElement).toBe(root);
+		});
+
+		it('pressing the down key moves focus to the nearest item', () => {
+			const {container, getByRole} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const root = getByRole('treeitem');
+
+			fireEvent.keyDown(root, {key: 'ArrowRight'});
+
+			expect(root.getAttribute('aria-expanded')).toBe('true');
+			expect(container.querySelector('.collapse.show')).toBeTruthy();
+
+			fireEvent.keyDown(root, {key: 'ArrowDown'});
+
+			const group = getByRole('group');
+
+			expect(document.activeElement).toBe(
+				group.querySelector('.treeview-link')
+			);
+		});
+
+		it('pressing the up key moves focus to the nearest item', () => {
+			jest.useFakeTimers();
+
+			const {getAllByRole} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [
+									{id: 2, name: 'Bar'},
+									{id: 3, name: 'Baz'},
+								],
+								id: 1,
+								name: 'Foo',
+							},
+						]}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			jest.runAllTimers();
+
+			const [foo, bar, baz] = getAllByRole('treeitem');
+
+			fireEvent.keyDown(foo, {key: 'ArrowRight'});
+
+			fireEvent.keyDown(foo, {key: 'ArrowDown'});
+
+			fireEvent.keyDown(baz, {key: 'ArrowUp'});
+
+			expect(document.activeElement).toBe(bar);
+
+			fireEvent.keyDown(bar, {key: 'ArrowUp'});
+
+			expect(document.activeElement).toBe(foo);
+		});
+	});
+
+	describe('load more', () => {
+		it('clicking on the item should load the children asynchronously', async () => {
+			const {getAllByRole, getByText} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+						onLoadMore={async () => {
+							return [
+								{
+									id: 3,
+									name: 'Item 2',
+								},
+							];
+						}}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const [, item] = getAllByRole('treeitem');
+
+			fireEvent.click(item);
+
+			await waitFor(() => getByText('Item 2'));
+
+			const [, , random] = getAllByRole('treeitem');
+
+			expect(random).toBeTruthy();
+		});
+
+		it('pressing the right arrow key loads the item asynchronously', async () => {
+			const {getAllByRole, getByText} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+						onLoadMore={async () => {
+							return [
+								{
+									id: 3,
+									name: 'Item 2',
+								},
+							];
+						}}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const [, item] = getAllByRole('treeitem');
+
+			fireEvent.keyDown(item, {key: 'ArrowRight'});
+
+			await waitFor(() => getByText('Item 2'));
+
+			const [, , random] = getAllByRole('treeitem');
+
+			expect(random).toBeTruthy();
+		});
+
+		it('loading item dynamically disable checkbox selection', async () => {
+			const {container, getAllByRole, getByText} = render(
+				<Provider spritemap={spritemap}>
+					<TreeView
+						expandedKeys={new Set([1])}
+						items={[
+							{
+								children: [{id: 2, name: 'Item'}],
+								id: 1,
+								name: 'Root',
+							},
+						]}
+						onLoadMore={async () => {
+							return [
+								{
+									id: 3,
+									name: 'Item 2',
+								},
+							];
+						}}
+					>
+						{(item) => (
+							<TreeView.Item>
+								<TreeView.ItemStack>
+									{item.name}
+								</TreeView.ItemStack>
+								<TreeView.Group items={item.children}>
+									{(item) => (
+										<TreeView.Item>
+											<OptionalCheckbox />
+											{item.name}
+										</TreeView.Item>
+									)}
+								</TreeView.Group>
+							</TreeView.Item>
+						)}
+					</TreeView>
+				</Provider>
+			);
+
+			const [, item] = getAllByRole('treeitem');
+
+			fireEvent.click(item);
+
+			expect(
+				container.querySelectorAll(
+					'input.custom-control-input[type=checkbox]:disabled'
+				).length
+			).toBe(1);
+			expect(container.querySelector('.loading-animation')).toBeTruthy();
+
+			await waitFor(() => getByText('Item 2'));
+
+			const [, , random] = getAllByRole('treeitem');
+
+			expect(random).toBeTruthy();
+		});
+	});
+});

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -1,0 +1,410 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TreeView basic rendering render dynamic content 1`] = `
+<div>
+  <ul
+    class="treeview treeview-light show-component-expander-on-hover"
+    role="tree"
+  >
+    <li
+      class="treeview-item"
+      role="none"
+    >
+      <div
+        aria-expanded="false"
+        class="treeview-link"
+        role="treeitem"
+        style="padding-left: 0px;"
+        tabindex="0"
+      >
+        <span
+          class="c-inner"
+          style="margin-left: -0px;"
+          tabindex="-2"
+        >
+          <div
+            class="autofit-row"
+          >
+            <div
+              class="autofit-col"
+            >
+              <button
+                aria-controls="Root"
+                aria-expanded="false"
+                class="component-expander btn btn-monospaced"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="c-inner"
+                  tabindex="-2"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-down"
+                    />
+                  </svg>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="autofit-col autofit-col-expand"
+            >
+              <div
+                class="component-text"
+              >
+                Root
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TreeView basic rendering render nested dynamic content 1`] = `
+<div>
+  <ul
+    class="treeview treeview-light show-component-expander-on-hover"
+    role="tree"
+  >
+    <li
+      class="treeview-item"
+      role="none"
+    >
+      <div
+        aria-expanded="false"
+        class="treeview-link"
+        role="treeitem"
+        style="padding-left: 0px;"
+        tabindex="0"
+      >
+        <span
+          class="c-inner"
+          style="margin-left: -0px;"
+          tabindex="-2"
+        >
+          <div
+            class="autofit-row"
+          >
+            <div
+              class="autofit-col"
+            >
+              <button
+                aria-controls="Foo"
+                aria-expanded="false"
+                class="component-expander btn btn-monospaced"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="c-inner"
+                  tabindex="-2"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-down"
+                    />
+                  </svg>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="autofit-col autofit-col-expand"
+            >
+              <div
+                class="component-text"
+              >
+                Foo
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TreeView basic rendering render static content 1`] = `
+<div>
+  <ul
+    class="treeview treeview-light show-component-expander-on-hover"
+    role="tree"
+  >
+    <li
+      class="treeview-item"
+      role="none"
+    >
+      <div
+        aria-expanded="false"
+        class="treeview-link"
+        role="treeitem"
+        style="padding-left: 0px;"
+        tabindex="0"
+      >
+        <span
+          class="c-inner"
+          style="margin-left: -0px;"
+          tabindex="-2"
+        >
+          <div
+            class="autofit-row"
+          >
+            <div
+              class="autofit-col"
+            >
+              <button
+                aria-controls="$.0"
+                aria-expanded="false"
+                class="component-expander btn btn-monospaced"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="c-inner"
+                  tabindex="-2"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-down"
+                    />
+                  </svg>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="autofit-col autofit-col-expand"
+            >
+              <div
+                class="component-text"
+              >
+                Root
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TreeView basic rendering render with actions 1`] = `
+<div>
+  <ul
+    class="treeview treeview-light show-component-expander-on-hover"
+    role="tree"
+  >
+    <li
+      class="treeview-item"
+      role="none"
+    >
+      <div
+        class="treeview-link"
+        role="treeitem"
+        style="padding-left: 24px;"
+        tabindex="0"
+      >
+        <span
+          class="c-inner"
+          style="margin-left: -24px;"
+          tabindex="-2"
+        >
+          <div
+            class="autofit-row"
+          >
+            <div
+              class="autofit-col autofit-col-expand"
+            >
+              <div
+                class="component-text"
+              >
+                Root
+              </div>
+            </div>
+            <div
+              class="autofit-col"
+            >
+              <button
+                class="component-action btn btn-monospaced"
+                tabindex="-1"
+                type="button"
+              >
+                <div
+                  class="c-inner"
+                  tabindex="-2"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#times"
+                    />
+                  </svg>
+                </div>
+              </button>
+            </div>
+            <div
+              class="autofit-col"
+            >
+              <div
+                class="dropdown"
+              >
+                <button
+                  class="dropdown-toggle component-action btn btn-monospaced"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c-inner"
+                    tabindex="-2"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-ellipsis-v"
+                      role="presentation"
+                    >
+                      <use
+                        xlink:href="icons.svg#ellipsis-v"
+                      />
+                    </svg>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TreeView basic rendering render with checkbox 1`] = `
+<div>
+  <ul
+    class="treeview treeview-light show-component-expander-on-hover"
+    role="tree"
+  >
+    <li
+      class="treeview-item"
+      role="none"
+    >
+      <div
+        aria-expanded="false"
+        class="treeview-link"
+        role="treeitem"
+        style="padding-left: 0px;"
+        tabindex="0"
+      >
+        <span
+          class="c-inner"
+          style="margin-left: -0px;"
+          tabindex="-2"
+        >
+          <div
+            class="autofit-row"
+          >
+            <div
+              class="autofit-col"
+            >
+              <button
+                aria-controls="$.0"
+                aria-expanded="false"
+                class="component-expander btn btn-monospaced"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="c-inner"
+                  tabindex="-2"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-down"
+                    />
+                  </svg>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="autofit-col"
+            >
+              <div
+                class="custom-control custom-checkbox"
+              >
+                <label>
+                  <input
+                    class="custom-control-input"
+                    type="checkbox"
+                  />
+                  <span
+                    class="custom-control-label"
+                  />
+                </label>
+              </div>
+            </div>
+            <div
+              class="autofit-col autofit-col-expand"
+            >
+              <div
+                class="component-text"
+              >
+                Root
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </li>
+  </ul>
+</div>
+`;

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -289,7 +289,6 @@ exports[`TreeView basic rendering render with actions 1`] = `
               >
                 <button
                   class="dropdown-toggle component-action btn btn-monospaced"
-                  style=""
                   tabindex="-1"
                   type="button"
                 >

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -304,7 +304,7 @@ function expandSelectedItems<T extends Array<Record<string, any>>>(
 		nestedKey as string,
 		key,
 		(item: Record<string, any>, path: Array<React.Key>) => {
-			if (selectedKeys.has(item.id)) {
+			if (selectedKeys.has(item[key])) {
 				currentSelected++;
 
 				expand.push(...path);


### PR DESCRIPTION
Fixes #4658

This PR is just a draft, but it already includes the `BasicRendering` suite for the TreeView component, I'm still working on the incremental interactions suite, it has good coverage of the TreeView cases, I should probably finish it tomorrow.

It also includes a fix for when the content is static setting the key it was getting lost because it was using the [`React.Children.toArray`](https://reactjs.org/docs/react-api.html#reactchildrentoarray) API which does this intentionally 🤦‍♂️.

Any suggestion is welcome!