### PR TITLE
feat(@clayui/drop-down): add new prop to align Menu in viewport

### DIFF
--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -29,6 +29,13 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement | HTMLLIElement> {
 	active: boolean;
 
 	/**
+	 * Flag to align the DropDown menu within the viewport.
+	 */
+	alignmentByViewport?: React.ComponentProps<
+		typeof Menu
+	>['alignmentByViewport'];
+
+	/**
 	 * Default position of menu element. Values come from `./Menu`.
 	 */
 	alignmentPosition?: React.ComponentProps<typeof Menu>['alignmentPosition'];
@@ -97,6 +104,7 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 	Section: typeof Section;
 } = ({
 	active = false,
+	alignmentByViewport,
 	alignmentPosition,
 	children,
 	className,
@@ -178,6 +186,7 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 						{...menuElementAttrs}
 						active={active}
 						alignElementRef={triggerElementRef}
+						alignmentByViewport={alignmentByViewport}
 						alignmentPosition={alignmentPosition}
 						closeOnClickOutside={closeOnClickOutside}
 						hasLeftSymbols={hasLeftSymbols}

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -18,6 +18,13 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	active?: boolean;
 
 	/**
+	 * Flag to align the DropDown menu within the viewport.
+	 */
+	alignmentByViewport?: React.ComponentProps<
+		typeof ClayDropDownMenu
+	>['alignmentByViewport'];
+
+	/**
 	 * Default position of menu element. Values come from `./Menu`.
 	 */
 	alignmentPosition?: React.ComponentProps<
@@ -87,6 +94,7 @@ interface IHistory {
 
 export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	active,
+	alignmentByViewport,
 	alignmentPosition,
 	className,
 	containerElement,
@@ -119,6 +127,7 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	return (
 		<ClayDropDown
 			active={internalActive}
+			alignmentByViewport={alignmentByViewport}
 			alignmentPosition={alignmentPosition}
 			className={className}
 			containerElement={containerElement}

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -61,6 +61,13 @@ export interface IProps extends IDropDownContentProps {
 	active?: React.ComponentProps<typeof ClayDropDown>['active'];
 
 	/**
+	 * Flag to align the DropDown menu within the viewport.
+	 */
+	alignmentByViewport?: React.ComponentProps<
+		typeof ClayDropDownMenu
+	>['alignmentByViewport'];
+
+	/**
 	 * Default position of menu element. Values come from `./Menu`.
 	 */
 	alignmentPosition?: React.ComponentProps<
@@ -383,6 +390,7 @@ const findNested = <
 
 export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 	active,
+	alignmentByViewport,
 	alignmentPosition,
 	caption,
 	className,
@@ -427,6 +435,7 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 	return (
 		<ClayDropDown
 			active={internalActive}
+			alignmentByViewport={alignmentByViewport}
 			alignmentPosition={alignmentPosition}
 			className={className}
 			closeOnClickOutside={closeOnClickOutside}

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -99,6 +99,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	alignElementRef: React.RefObject<HTMLElement>;
 
 	/**
+	 * Flag to align the DropDown menu within the viewport.
+	 */
+	alignmentByViewport?: boolean;
+
+	/**
 	 * Flag to suggest or not the best region to align menu element.
 	 */
 	autoBestAlign?: boolean;
@@ -184,6 +189,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 		{
 			active,
 			alignElementRef,
+			alignmentByViewport = false,
 			alignmentPosition = Align.BottomLeft,
 			autoBestAlign = true,
 			children,
@@ -276,6 +282,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 						overflow: {
 							adjustX: autoBestAlign,
 							adjustY: autoBestAlign,
+							alwaysByViewport: alignmentByViewport,
 						},
 						points,
 						sourceElement: (ref as React.RefObject<HTMLElement>)

--- a/packages/clay-shared/package.json
+++ b/packages/clay-shared/package.json
@@ -30,7 +30,7 @@
 		"@clayui/link": "^3.45.0",
 		"@clayui/provider": "^3.40.0",
 		"classnames": "^2.2.6",
-		"dom-align": "^1.10.2",
+		"dom-align": "^1.12.2",
 		"warning": "^4.0.3"
 	},
 	"peerDependencies": {

--- a/packages/clay-shared/src/doAlign.ts
+++ b/packages/clay-shared/src/doAlign.ts
@@ -7,7 +7,7 @@ import domAlign from 'dom-align';
 
 type AlignBase = {
 	offset?: readonly [number, number];
-	overflow?: {adjustX: boolean; adjustY: boolean};
+	overflow?: {adjustX: boolean; adjustY: boolean; alwaysByViewport?: boolean};
 	points?: readonly [string, string];
 	targetOffset?: readonly [string, string];
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8686,9 +8686,9 @@ core-js-pure@^3.0.1, core-js-pure@^3.16.0, core-js-pure@^3.8.2:
   integrity sha512-UEQk8AxyCYvNAs6baNoPqDADv7BX0AmBLGxVsrAifPPx/C8EAzV4Q+2ZUJqVzfI2TQQEZITnwUkWcHpgc/IubQ==
 
 core-js-pure@^3.8.1:
-  version "3.20.2"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.20.2.tgz#5d263565f0e34ceeeccdc4422fae3e84ca6b8c0f"
-  integrity sha512-CmWHvSKn2vNL6p6StNp1EmMIfVY/pqn3JLAjfZQ8WZGPOlGoO92EkX9/Mk81i6GxvoPXjUqEQnpM3rJ5QxxIOg==
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.21.1.tgz#8c4d1e78839f5f46208de7230cebfb72bc3bdb51"
+  integrity sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==
 
 core-js@^2.4.0, core-js@^2.6.10, core-js@^2.6.5:
   version "2.6.12"
@@ -10214,7 +10214,7 @@ dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.9.tgz#915f8531ba29a50e5c29389dbfb87a9642fef0d6"
   integrity sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw==
 
-dom-align@^1.10.2:
+dom-align@^1.12.2:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.12.2.tgz#0f8164ebd0c9c21b0c790310493cd855892acd4b"
   integrity sha512-pHuazgqrsTFrGU2WLDdXxCFabkdQDx72ddkraZNih1KsMcN5qsRSTR9O4VJRlwTPCPb5COYg3LOfiMHHcPInHg==


### PR DESCRIPTION
Fixes #4720

This PR adds a new `alignmentByViewport` prop which is passed to `dom-align` to align the element considering the viewport.

I didn't set it as the default because in most scenarios it doesn't make sense because the user can scroll to view the DropDown content and if considering the viewport it can cause strange behavior and not very smooth alignment, in the case of the issue it does feeling because it is inside another container with scroll and fixed on the screen.