### PR TITLE
feat(@clayui/core): adds new properties to set the initial value of properties that can be controlled

### DIFF
--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -146,7 +146,10 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 	const inputRef = React.useRef(null);
 	const [activeSplotchIndex, setActiveSplotchIndex] = React.useState(0);
 	const [internalEditorActive, setInternalEditorActive] = useInternalState({
+		defaultName: '',
+		handleName: 'onEditorActiveChange',
 		initialValue: !showPalette,
+		name: 'editorActive',
 		onChange: onEditorActiveChange,
 		value: editorActive,
 	});

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -79,6 +79,11 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	colors?: Array<string>;
 
 	/**
+	 * Property to set the initial value of `active`.
+	 */
+	defaultActive?: boolean;
+
+	/**
 	 * Flag for adding ColorPicker in disabled state
 	 */
 	disabled?: boolean;
@@ -161,6 +166,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	active,
 	ariaLabels = DEFAULT_ARIA_LABELS,
 	colors,
+	defaultActive = false,
 	disabled,
 	dropDownContainerProps,
 	label,
@@ -210,7 +216,10 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 	const splotchRef = React.useRef<HTMLButtonElement>(null);
 
 	const [internalActive, setInternalActive] = useInternalState({
-		initialValue: false,
+		defaultName: 'defaultActive',
+		handleName: 'onActiveChange',
+		initialValue: defaultActive,
+		name: 'active',
 		onChange: onActiveChange,
 		value: active,
 	});

--- a/packages/clay-core/docs/treeview.js
+++ b/packages/clay-core/docs/treeview.js
@@ -92,8 +92,8 @@ const exampleCode = `const FileExplorer = ({selectionMode}) => {
 	return (
 		<Provider spritemap={spritemap}>
 			<TreeView
+				defaultItems={items}
 				dragAndDrop
-				items={items}
 				nestedKey="children"
 				selectionMode={selectionMode}
 			>

--- a/packages/clay-core/docs/treeview.mdx
+++ b/packages/clay-core/docs/treeview.mdx
@@ -135,7 +135,7 @@ function Example() {
 	];
 
 	return (
-		<TreeView items={items} nestedKey="children">
+		<TreeView defaultItems={items} nestedKey="children">
 			{(item) => (
 				<TreeView.Item key={item.name}>
 					{item.name}

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -22,6 +22,11 @@ export interface ICollectionProps<T> {
 	children: React.ReactNode | ChildrenFunction<T>;
 
 	/**
+	 * Property to set the initial value of `items`.
+	 */
+	defaultItems?: Array<T>;
+
+	/**
 	 * Property to inform the dynamic data of the tree.
 	 */
 	items?: Array<T>;

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -87,6 +87,9 @@ export function TreeView<T>(props: ITreeViewProps<T>): JSX.Element & {
 export function TreeView<T>({
 	children,
 	className,
+	defaultExpandedKeys,
+	defaultItems,
+	defaultSelectedKeys,
 	displayType = 'light',
 	dragAndDrop = false,
 	dragAndDropContext = window,
@@ -110,6 +113,9 @@ export function TreeView<T>({
 	const rootRef = React.useRef(null);
 
 	const state = useTree<T>({
+		defaultExpandedKeys,
+		defaultItems,
+		defaultSelectedKeys,
 		expandedKeys,
 		items,
 		nestedKey,

--- a/packages/clay-core/src/tree-view/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/BasicRendering.tsx
@@ -41,7 +41,7 @@ describe('TreeView basic rendering', () => {
 		const {container} = render(
 			<Provider spritemap={spritemap}>
 				<TreeView
-					items={[
+					defaultItems={[
 						{
 							children: [{name: 'Item'}],
 							name: 'Root',
@@ -71,7 +71,7 @@ describe('TreeView basic rendering', () => {
 		const {container} = render(
 			<Provider spritemap={spritemap}>
 				<TreeView
-					items={[
+					defaultItems={[
 						{
 							children: [
 								{
@@ -275,7 +275,7 @@ describe('TreeView basic rendering', () => {
 	it('render with pre-selected items', () => {
 		const {container} = render(
 			<Provider spritemap={spritemap}>
-				<TreeView selectedKeys={new Set(['Root', 'Item'])}>
+				<TreeView defaultSelectedKeys={new Set(['Root', 'Item'])}>
 					<TreeView.Item key="Root">
 						<TreeView.ItemStack>
 							<OptionalCheckbox />
@@ -303,14 +303,14 @@ describe('TreeView basic rendering', () => {
 		const {container} = render(
 			<Provider spritemap={spritemap}>
 				<TreeView
-					items={[
+					defaultItems={[
 						{
 							children: [{id: 2, name: 'Item'}],
 							id: 1,
 							name: 'Root',
 						},
 					]}
-					selectedKeys={new Set([1, 2])}
+					defaultSelectedKeys={new Set([1, 2])}
 				>
 					{(item) => (
 						<TreeView.Item>
@@ -342,7 +342,7 @@ describe('TreeView basic rendering', () => {
 	it('render with pre-expanded items', () => {
 		const {container} = render(
 			<Provider spritemap={spritemap}>
-				<TreeView expandedKeys={new Set(['Root', 'Item'])}>
+				<TreeView defaultExpandedKeys={new Set(['Root', 'Item'])}>
 					<TreeView.Item key="Root">
 						<TreeView.ItemStack>Root</TreeView.ItemStack>
 						<TreeView.Group>

--- a/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
@@ -90,7 +90,7 @@ describe('TreeView incremental interactions', () => {
 			it('select only one item using single selection', () => {
 				const {container} = render(
 					<Provider spritemap={spritemap}>
-						<TreeView expandedKeys={new Set(['Root'])}>
+						<TreeView defaultExpandedKeys={new Set(['Root'])}>
 							<TreeView.Item key="Root">
 								<TreeView.ItemStack>
 									<OptionalCheckbox />
@@ -126,7 +126,7 @@ describe('TreeView incremental interactions', () => {
 				const {container} = render(
 					<Provider spritemap={spritemap}>
 						<TreeView
-							expandedKeys={new Set(['Root'])}
+							defaultExpandedKeys={new Set(['Root'])}
 							selectionMode="multiple"
 						>
 							<TreeView.Item key="Root">
@@ -161,7 +161,7 @@ describe('TreeView incremental interactions', () => {
 				const {container} = render(
 					<Provider spritemap={spritemap}>
 						<TreeView
-							items={[
+							defaultItems={[
 								{
 									children: [{id: 2, name: 'Item'}],
 									id: 1,
@@ -246,8 +246,8 @@ describe('TreeView incremental interactions', () => {
 			const {getAllByRole} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -291,8 +291,8 @@ describe('TreeView incremental interactions', () => {
 			const {getAllByRole, getByTestId} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -354,8 +354,8 @@ describe('TreeView incremental interactions', () => {
 			const {getAllByRole, getByTestId} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -429,8 +429,8 @@ describe('TreeView incremental interactions', () => {
 			const {getAllByRole, getByTestId} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -503,7 +503,7 @@ describe('TreeView incremental interactions', () => {
 			const {container, getByRole} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						items={[
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -542,8 +542,8 @@ describe('TreeView incremental interactions', () => {
 			const {getAllByRole} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -582,7 +582,7 @@ describe('TreeView incremental interactions', () => {
 			const {container, getByRole} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						items={[
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -627,8 +627,8 @@ describe('TreeView incremental interactions', () => {
 			const {getAllByRole} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [
 									{
@@ -671,7 +671,7 @@ describe('TreeView incremental interactions', () => {
 			const {container, getByRole} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						items={[
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -719,8 +719,8 @@ describe('TreeView incremental interactions', () => {
 			const {getAllByRole} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [
 									{id: 2, name: 'Bar'},
@@ -772,8 +772,8 @@ describe('TreeView incremental interactions', () => {
 			const {getAllByRole, getByText} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -822,8 +822,8 @@ describe('TreeView incremental interactions', () => {
 			const {getAllByRole, getByText} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,
@@ -872,8 +872,8 @@ describe('TreeView incremental interactions', () => {
 			const {container, getAllByRole, getByText} = render(
 				<Provider spritemap={spritemap}>
 					<TreeView
-						expandedKeys={new Set([1])}
-						items={[
+						defaultExpandedKeys={new Set([1])}
+						defaultItems={[
 							{
 								children: [{id: 2, name: 'Item'}],
 								id: 1,

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -13,6 +13,11 @@ import type {ICollectionProps} from './Collection';
 
 export interface IMultipleSelection {
 	/**
+	 * Property to set the initial value of `selectedKeys`.
+	 */
+	defaultSelectedKeys?: Set<Key>;
+
+	/**
 	 * Handler that is called when the selection changes.
 	 */
 	onSelectionChange?: (keys: Set<Key>) => void;
@@ -116,7 +121,10 @@ export function useMultipleSelection<T>(
 	const intermediateKeys = useRef(new Set<Key>());
 
 	const [selectedKeys, setSelectionKeys] = useInternalState<Set<Key>>({
-		initialValue: props.selectedKeys ?? new Set(),
+		defaultName: 'defaultSelectedKeys',
+		handleName: 'onSelectionChange',
+		initialValue: props.defaultSelectedKeys ?? new Set(),
+		name: 'selectedKeys',
 		onChange: props.onSelectionChange,
 		value: props.selectedKeys,
 	});

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -298,8 +298,7 @@ storiesOf('Components|ClayTreeView', module)
 	.add('dynamic', () => (
 		<Provider spritemap={spritemap} theme="cadmin">
 			<TreeView
-				dragAndDrop
-				items={[
+				defaultItems={[
 					{
 						children: [
 							{name: 'Blogs'},
@@ -328,6 +327,7 @@ storiesOf('Components|ClayTreeView', module)
 						name: 'Empty directory',
 					},
 				]}
+				dragAndDrop
 				nestedKey="children"
 				onRenameItem={(item) => {
 					return new Promise((resolve) => {
@@ -358,8 +358,7 @@ storiesOf('Components|ClayTreeView', module)
 	.add('w/styling', () => (
 		<Provider spritemap={spritemap} theme="cadmin">
 			<TreeView
-				expanderClassName="expander-css-class-1"
-				items={[
+				defaultItems={[
 					{
 						children: [
 							{name: 'Blogs'},
@@ -372,6 +371,7 @@ storiesOf('Components|ClayTreeView', module)
 						name: 'Documents and Media',
 					},
 				]}
+				expanderClassName="expander-css-class-1"
 				nestedKey="children"
 				showExpanderOnHover={false}
 			>
@@ -411,8 +411,8 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
+					defaultItems={ITEMS_DRIVE}
 					dragAndDrop
-					items={ITEMS_DRIVE}
 					onRenameItem={(item) => {
 						return new Promise((resolve) => {
 							setTimeout(() => {
@@ -619,12 +619,12 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
+					defaultItems={items}
 					expandedKeys={expandedKeys}
 					expanderIcons={{
 						close: <Icon symbol="hr" />,
 						open: <Icon symbol="plus" />,
 					}}
-					items={items}
 					nestedKey="children"
 					onExpandedChange={(keys) => setExpandedKeys(keys)}
 					selectionMode={null}
@@ -667,7 +667,7 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
-					items={ITEMS_DRIVE}
+					defaultItems={ITEMS_DRIVE}
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
 					selectionHydrationMode={select(
@@ -712,8 +712,8 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
+					defaultItems={ITEMS_DRIVE}
 					dragAndDrop
-					items={ITEMS_DRIVE}
 					selectionMode="multiple-recursive"
 					showExpanderOnHover={false}
 				>
@@ -752,8 +752,8 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
+					defaultItems={ITEMS_DRIVE}
 					dragAndDrop
-					items={ITEMS_DRIVE}
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
@@ -804,7 +804,7 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
-					items={ITEMS_DRIVE}
+					defaultItems={ITEMS_DRIVE}
 					nestedKey="children"
 					onLoadMore={async (item) => {
 						// Delay to simulate loading of new data
@@ -873,7 +873,7 @@ storiesOf('Components|ClayTreeView', module)
 				<p>Selected items: {Array.from(selectedKeys).join(', ')}</p>
 
 				<TreeView
-					items={ITEMS_DRIVE}
+					defaultItems={ITEMS_DRIVE}
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
@@ -930,9 +930,9 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
+					defaultItems={ITEMS_DRIVE}
 					dragAndDrop
 					expandOnCheck
-					items={ITEMS_DRIVE}
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
@@ -979,7 +979,7 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
-					items={ITEMS_DRIVE}
+					defaultItems={ITEMS_DRIVE}
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
@@ -1030,7 +1030,7 @@ storiesOf('Components|ClayTreeView', module)
 				</pre>
 
 				<TreeView
-					items={ITEMS_DRIVE}
+					defaultItems={ITEMS_DRIVE}
 					nestedKey="children"
 					onSelectionChange={(keys) => setSelectionChange(keys)}
 					selectedKeys={selectedKeys}
@@ -1091,7 +1091,7 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
-					items={[rootNode]}
+					defaultItems={[rootNode]}
 					nestedKey="children"
 					showExpanderOnHover={false}
 				>
@@ -1113,7 +1113,7 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
-					items={ITEMS_DRIVE}
+					defaultItems={ITEMS_DRIVE}
 					nestedKey="children"
 					onLoadMore={async (item) => {
 						// Delay to simulate loading of new data
@@ -1173,7 +1173,7 @@ storiesOf('Components|ClayTreeView', module)
 		return (
 			<Provider spritemap={spritemap} theme="cadmin">
 				<TreeView
-					items={ITEMS_DRIVE}
+					defaultItems={ITEMS_DRIVE}
 					nestedKey="children"
 					onLoadMore={onLoadMore}
 				>
@@ -1323,7 +1323,11 @@ storiesOf('Components|ClayTreeView', module)
 						overflow: 'auto',
 					}}
 				>
-					<TreeView dragAndDrop items={items} nestedKey="children">
+					<TreeView
+						defaultItems={items}
+						dragAndDrop
+						nestedKey="children"
+					>
 						{(item) => (
 							<TreeView.Item>
 								<TreeView.ItemStack>

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -267,7 +267,10 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		 * if component is not controlled by props.
 		 */
 		const [expandedValue, setExpandedValue] = useInternalState({
+			defaultName: 'initialExpanded',
+			handleName: 'onExpandedChange',
 			initialValue: initialExpanded,
+			name: 'expanded',
 			onChange: onExpandedChange,
 			value: expanded,
 		});

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -32,6 +32,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	>['containerElement'];
 
 	/**
+	 * Property to set the initial value of `active`.
+	 */
+	defaultActive?: boolean;
+
+	/**
 	 * The unique identifier of the menu that should be active on mount.
 	 */
 	initialActiveMenu: string;
@@ -85,6 +90,7 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	alignmentPosition,
 	className,
 	containerElement,
+	defaultActive,
 	initialActiveMenu,
 	menuElementAttrs,
 	menuHeight,
@@ -98,7 +104,12 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	const [activeMenu, setActiveMenu] = React.useState(initialActiveMenu);
 	const [direction, setDirection] = React.useState<'prev' | 'next'>();
 	const [history, setHistory] = React.useState<Array<IHistory>>([]);
+
 	const [internalActive, setInternalActive] = useInternalState({
+		defaultName: 'defaultActive',
+		handleName: 'onActiveChange',
+		initialValue: defaultActive,
+		name: 'active',
 		onChange: onActiveChange,
 		value: active,
 	});

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -86,6 +86,11 @@ export interface IProps extends IDropDownContentProps {
 	>['containerElement'];
 
 	/**
+	 * Property to set the initial value of `active`.
+	 */
+	defaultActive?: boolean;
+
+	/**
 	 * Add an action button or any other element you want to be fixed position to the
 	 * footer from the DropDown.
 	 */
@@ -383,6 +388,7 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 	className,
 	closeOnClickOutside,
 	containerElement,
+	defaultActive,
 	footerContent,
 	helpText,
 	items,
@@ -399,7 +405,10 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 	trigger,
 }: IProps) => {
 	const [internalActive, setInternalActive] = useInternalState({
-		initialValue: false,
+		defaultName: 'defaultActive',
+		handleName: 'onActiveChange',
+		initialValue: defaultActive,
+		name: 'active',
 		onChange: onActiveChange,
 		value: active,
 	});

--- a/packages/clay-panel/src/index.tsx
+++ b/packages/clay-panel/src/index.tsx
@@ -88,7 +88,10 @@ const ClayPanel: React.FunctionComponent<IProps> & {
 	...otherProps
 }: IProps) => {
 	const [internalExpanded, setInternalExpanded] = useInternalState({
+		defaultName: 'defaultExpanded',
+		handleName: 'onExpandedChange',
 		initialValue: defaultExpanded,
+		name: 'expanded',
 		onChange: onExpandedChange,
 		value: expanded,
 	});

--- a/packages/clay-shared/package.json
+++ b/packages/clay-shared/package.json
@@ -30,7 +30,8 @@
 		"@clayui/link": "^3.45.0",
 		"@clayui/provider": "^3.40.0",
 		"classnames": "^2.2.6",
-		"dom-align": "^1.10.2"
+		"dom-align": "^1.10.2",
+		"warning": "^4.0.3"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-shared/src/useInternalState.ts
+++ b/packages/clay-shared/src/useInternalState.ts
@@ -4,6 +4,7 @@
  */
 
 import * as React from 'react';
+import warning from 'warning';
 
 export type TInternalStateOnChange<T> =
 	| ((val: T) => void)
@@ -11,18 +12,34 @@ export type TInternalStateOnChange<T> =
 	| React.Dispatch<React.SetStateAction<T>>;
 
 interface IArgs<T> {
+	defaultName: string;
+	handleName: string;
 	initialValue?: T | (() => T);
+	name: string;
 	onChange?: TInternalStateOnChange<T>;
 	value?: T;
 }
 
 export function useInternalState<TValue>({
+	defaultName,
+	handleName,
 	initialValue,
+	name,
 	onChange,
 	value,
 }: IArgs<TValue>) {
 	const [internalValue, setInternalValue] = React.useState(
 		initialValue ?? value
+	);
+
+	warning(
+		!(typeof value === 'undefined' && typeof onChange !== 'undefined'),
+		`A component is changing a controlled ${name} to be uncontrolled. This is likely caused by the value changing from a defined to undefined, which should not happen. Decide between using a controlled or uncontrolled '${name}' prop for the lifetime of the component.`
+	);
+
+	warning(
+		!(typeof onChange === 'undefined' && typeof value !== 'undefined'),
+		`You provided a '${name}' prop for a component without a handler '${handleName}'. This will render the component with an internal state, if the component is to be uncontrolled, use '${defaultName}'. Otherwise, set the '${handleName}' handler.`
 	);
 
 	if (typeof value === 'undefined' || typeof onChange === 'undefined') {


### PR DESCRIPTION
Fixes #4662

Well, following with the feedbacks, we are adding properties in the TreeView that define the initial value of controlled props, also adding the warning message when the properties are used incorrectly, the warning message is practically the same as what React.js throws when doing this in the input elements.

This change removes the behavior of `items`, `expandedKeys` and `selectedKeys` from also having the initial state behavior when they are only defined without the handler properties, in the next release we will have to update the use cases in DXP.