### PR TITLE
feat(@clayui/drop-down): make it possible to render the menu lazily

### DIFF
--- a/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
@@ -38,6 +38,7 @@ exports[`ClayBreadcrumb calls callback when an item is clicked 1`] = `
       <button
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
+        style=""
         type="button"
       >
         <svg
@@ -116,6 +117,7 @@ exports[`ClayBreadcrumb renders 1`] = `
       <button
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
+        style=""
         type="button"
       >
         <svg
@@ -195,6 +197,7 @@ exports[`ClayBreadcrumb renders with properties passed by \`ellipsisProps\` 1`] 
       <button
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
+        style=""
         type="button"
       >
         <svg

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -1502,6 +1502,7 @@ exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
           >
             <button
               class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+              style=""
               type="button"
             >
               <svg
@@ -2240,6 +2241,7 @@ exports[`ClayCardWithInfo renders as not selectable 1`] = `
           >
             <button
               class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+              style=""
               type="button"
             >
               <svg
@@ -2870,6 +2872,7 @@ exports[`ClayCardWithUser renders as selectable 1`] = `
             >
               <button
                 class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
+                style=""
                 type="button"
               >
                 <svg

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -289,6 +289,7 @@ exports[`TreeView basic rendering render with actions 1`] = `
               >
                 <button
                   class="dropdown-toggle component-action btn btn-monospaced"
+                  style=""
                   tabindex="-1"
                   type="button"
                 >

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -77,6 +77,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement | HTMLLIElement> {
 	offsetFn?: React.ComponentProps<typeof Menu>['offsetFn'];
 
 	/**
+	 * Flag indicating if the menu should be rendered lazily
+	 */
+	renderMenuOnClick?: boolean;
+
+	/**
 	 * Element that is used as the trigger which will activate the dropdown on click.
 	 */
 	trigger: React.ReactElement & {
@@ -109,13 +114,14 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 	menuWidth,
 	offsetFn,
 	onActiveChange,
+	renderMenuOnClick = false,
 	trigger,
 	...otherProps
 }: IProps) => {
 	const triggerElementRef = React.useRef<HTMLButtonElement | null>(null);
 	const menuElementRef = React.useRef<HTMLDivElement>(null);
 
-	const [initialized, setInitialized] = React.useState(false);
+	const [initialized, setInitialized] = React.useState(!renderMenuOnClick);
 
 	const handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {
 		if (event.key === Keys.Esc) {

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -70,6 +70,13 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	spritemap?: string;
 
 	/**
+	 * Flag indicating if the menu should be rendered lazily
+	 */
+	renderMenuOnClick?: React.ComponentProps<
+		typeof ClayDropDown
+	>['renderMenuOnClick'];
+
+	/**
 	 * Element that is used as the trigger which will activate the dropdown on click.
 	 */
 	trigger: React.ReactElement;
@@ -92,6 +99,7 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	menus,
 	offsetFn,
 	onActiveChange,
+	renderMenuOnClick,
 	spritemap,
 	trigger,
 }: IProps) => {
@@ -120,6 +128,7 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 			menuWidth={menuWidth}
 			offsetFn={offsetFn}
 			onActiveChange={setInternalActive}
+			renderMenuOnClick={renderMenuOnClick}
 			trigger={trigger}
 		>
 			<Drilldown.Inner>

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -125,6 +125,13 @@ export interface IProps extends IDropDownContentProps {
 	onSearchValueChange?: (newValue: string) => void;
 
 	/**
+	 * Flag indicating if the menu should be rendered lazily
+	 */
+	renderMenuOnClick?: React.ComponentProps<
+		typeof ClayDropDown
+	>['renderMenuOnClick'];
+
+	/**
 	 * Flag to show search at the top of the DropDown.
 	 */
 	searchable?: boolean;
@@ -392,6 +399,7 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 	offsetFn,
 	onActiveChange,
 	onSearchValueChange = () => {},
+	renderMenuOnClick,
 	searchable,
 	searchProps,
 	searchValue = '',
@@ -429,6 +437,7 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 			menuWidth={menuWidth}
 			offsetFn={offsetFn}
 			onActiveChange={setInternalActive}
+			renderMenuOnClick={renderMenuOnClick}
 			trigger={trigger}
 		>
 			<ClayDropDownContext.Provider

--- a/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
@@ -40,6 +40,7 @@ describe('ClayDropDownWithDrilldown', () => {
 					],
 					x0a5: [{title: 'The'}, {title: 'End'}],
 				}}
+				renderMenuOnClick
 				spritemap="#"
 				trigger={<button data-testid="trigger" />}
 			/>
@@ -69,6 +70,7 @@ describe('ClayDropDownWithDrilldown', () => {
 					],
 					x0a5: [{title: 'The'}, {type: 'divider'}, {title: 'End'}],
 				}}
+				renderMenuOnClick
 				spritemap="#"
 				trigger={<button data-testid="trigger" />}
 			/>
@@ -90,6 +92,7 @@ describe('ClayDropDownWithDrilldown', () => {
 					],
 					x0a4: [{href: '#', title: '2nd hash link'}],
 				}}
+				renderMenuOnClick
 				spritemap="#"
 				trigger={<button data-testid="trigger" />}
 			/>
@@ -117,6 +120,7 @@ describe('ClayDropDownWithDrilldown', () => {
 					],
 					x0a4: [{href: '#', title: '2nd hash link'}],
 				}}
+				renderMenuOnClick
 				spritemap="#"
 				trigger={<button data-testid="trigger" />}
 			/>
@@ -147,6 +151,7 @@ describe('ClayDropDownWithDrilldown', () => {
 					],
 					x0a4: [{href: '#', title: '2nd hash link'}],
 				}}
+				renderMenuOnClick
 				spritemap="#"
 				trigger={<button data-testid="trigger" />}
 			/>
@@ -169,6 +174,7 @@ describe('ClayDropDownWithDrilldown', () => {
 					x0a4: [{href: '#', title: '2nd hash link'}],
 				}}
 				onActiveChange={onActiveChange}
+				renderMenuOnClick
 				spritemap="#"
 				trigger={<button data-testid="trigger" />}
 			/>

--- a/packages/clay-drop-down/src/__tests__/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/__tests__/DropDownWithItems.tsx
@@ -31,6 +31,7 @@ describe('ClayDropDownWithItems', () => {
 						label: 'linkable',
 					},
 				]}
+				renderMenuOnClick
 				spritemap={spritemap}
 				trigger={<ClayButton>Click Me</ClayButton>}
 			/>
@@ -61,6 +62,7 @@ describe('ClayDropDownWithItems', () => {
 						type: 'radiogroup' as const,
 					},
 				]}
+				renderMenuOnClick
 				spritemap={spritemap}
 				trigger={<ClayButton>Click Me</ClayButton>}
 			/>
@@ -90,6 +92,7 @@ describe('ClayDropDownWithItems', () => {
 						type: 'group' as const,
 					},
 				]}
+				renderMenuOnClick
 				spritemap={spritemap}
 				trigger={<ClayButton>Click Me</ClayButton>}
 			/>
@@ -108,6 +111,7 @@ describe('ClayDropDownWithItems', () => {
 						label: 'linkable',
 					},
 				]}
+				renderMenuOnClick
 				spritemap={spritemap}
 				trigger={<ClayButton>Click Me</ClayButton>}
 			/>
@@ -126,6 +130,7 @@ describe('ClayDropDownWithItems', () => {
 						label: 'linkable',
 					},
 				]}
+				renderMenuOnClick
 				spritemap={spritemap}
 				trigger={<ClayButton>Click Me</ClayButton>}
 			/>
@@ -144,6 +149,7 @@ describe('ClayDropDownWithItems', () => {
 						label: 'linkable',
 					},
 				]}
+				renderMenuOnClick
 				spritemap={spritemap}
 				trigger={<ClayButton>Click Me</ClayButton>}
 			/>
@@ -162,6 +168,7 @@ describe('ClayDropDownWithItems', () => {
 					},
 				]}
 				onSearchValueChange={() => {}}
+				renderMenuOnClick
 				searchValue="Search"
 				searchable
 				spritemap={spritemap}

--- a/packages/clay-drop-down/src/__tests__/index.tsx
+++ b/packages/clay-drop-down/src/__tests__/index.tsx
@@ -20,6 +20,7 @@ const DropDownWithState: React.FunctionComponent<any> = ({
 			{...others}
 			active={active}
 			onActiveChange={(val) => setActive(val)}
+			renderMenuOnClick
 			trigger={<button>Click Me</button>}
 		>
 			{children}
@@ -289,6 +290,7 @@ describe('ClayDropDown', () => {
 						onClick: onClickFn,
 					},
 				]}
+				renderMenuOnClick
 				trigger={<button>Click Me</button>}
 			/>
 		);

--- a/packages/clay-drop-down/stories/index.tsx
+++ b/packages/clay-drop-down/stories/index.tsx
@@ -88,6 +88,7 @@ const DropDownWithState: React.FunctionComponent<any> = ({
 			menuHeight={select('Height', ['', 'auto'], '')}
 			menuWidth={select('Width', ['', 'sm', 'full'], '')}
 			onActiveChange={(newVal) => setActive(newVal)}
+			renderMenuOnClick={boolean('Render Menu On Click', true)}
 			trigger={<ClayButton>Click Me</ClayButton>}
 		>
 			{children}
@@ -296,6 +297,7 @@ storiesOf('Components|ClayDropDown', module)
 				],
 				x0a5: [{title: 'The'}, {type: 'divider'}, {title: 'End'}],
 			}}
+			renderMenuOnClick={boolean('Render Menu On Click', true)}
 			spritemap={spritemap}
 			trigger={<ClayButton>Click Me</ClayButton>}
 		/>
@@ -350,6 +352,7 @@ storiesOf('Components|ClayDropDown', module)
 				helpText="You can customize this menu or see all you have by pressing 'more'."
 				items={ITEMS}
 				onSearchValueChange={setValue}
+				renderMenuOnClick={boolean('Render Menu On Click', true)}
 				searchProps={{
 					formProps: {
 						onSubmit: (event) => {

--- a/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
@@ -32,6 +32,7 @@ exports[`ClayLocalizedInput renders 1`] = `
         >
           <button
             class="dropdown-toggle btn btn-monospaced btn-secondary"
+            style=""
             title="Open Localizations"
             type="button"
           >
@@ -106,6 +107,7 @@ exports[`ClayLocalizedInput renders with prepend content and result formatter 1`
         >
           <button
             class="dropdown-toggle btn btn-monospaced btn-secondary"
+            style=""
             title="Open Localizations"
             type="button"
           >

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -11,6 +11,7 @@ exports[`ClayPaginationBar renders 1`] = `
       <button
         class="dropdown-toggle btn btn-unstyled"
         data-testid="selectPaginationBar"
+        style=""
         type="button"
       >
         10 items
@@ -88,6 +89,7 @@ exports[`ClayPaginationBar renders 1`] = `
       >
         <button
           class="dropdown-toggle page-link btn btn-unstyled"
+          style=""
           type="button"
         >
           ...
@@ -196,6 +198,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
       >
         <button
           class="dropdown-toggle page-link btn btn-unstyled"
+          style=""
           type="button"
         >
           ...

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -39,6 +39,7 @@ exports[`ClayPagination renders 1`] = `
     >
       <button
         class="dropdown-toggle page-link btn btn-unstyled"
+        style=""
         type="button"
       >
         ...
@@ -100,6 +101,7 @@ exports[`ClayPagination renders 1`] = `
     >
       <button
         class="dropdown-toggle page-link btn btn-unstyled"
+        style=""
         type="button"
       >
         ...

--- a/packages/clay-upper-toolbar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-upper-toolbar/src/__tests__/__snapshots__/index.tsx.snap
@@ -123,6 +123,7 @@ exports[`ClayUpperToolbar renders 1`] = `
             >
               <button
                 class="dropdown-toggle btn btn-monospaced btn-sm btn-unstyled"
+                style=""
                 type="button"
               >
                 <svg


### PR DESCRIPTION
This is an improvement on top of [1d90d45].(https://github.com/liferay/clay/commit/1d90d454d9b2d242dd2d491e4525e815553e9fa3)
By default the behaviour of the component is unchanged, but by passing
the `renderMenuOnClick` prop, the menu will be rendered only when
the trigger is clicked.