### PR TITLE
feat(@clayui/modal): improves ClayModal component accessibility

### DIFF
--- a/packages/clay-modal/src/Context.ts
+++ b/packages/clay-modal/src/Context.ts
@@ -8,6 +8,8 @@ import React from 'react';
 import {Status} from './types';
 
 export interface IContext {
+	ariaLabelledby?: string;
+
 	/**
 	 * Callback called to close the modal.
 	 */

--- a/packages/clay-modal/src/Header.tsx
+++ b/packages/clay-modal/src/Header.tsx
@@ -54,11 +54,19 @@ export const TitleSection: React.FunctionComponent<
 
 export const Title: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => (
-	<div className={classNames('modal-title', className)} {...otherProps}>
-		{children}
-	</div>
-);
+> = ({children, className, ...otherProps}) => {
+	const {ariaLabelledby} = React.useContext(Context);
+
+	return (
+		<div
+			className={classNames('modal-title', className)}
+			{...otherProps}
+			id={ariaLabelledby}
+		>
+			{children}
+		</div>
+	);
+};
 
 export const TitleIndicator: React.FunctionComponent<
 	React.HTMLAttributes<HTMLDivElement>

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -22,13 +22,16 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
 >
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade show"
     />
     <div
       class="fade modal d-block show"
     >
       <div
+        aria-labelledby="clay-modal-label-7"
         class="modal-dialog modal-lg"
+        role="dialog"
         tabindex="-1"
       >
         <div
@@ -39,6 +42,7 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
           >
             <div
               class="modal-title"
+              id="clay-modal-label-7"
             >
               Title
             </div>

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -6,13 +6,16 @@ exports[`ClayModal renders 1`] = `
 >
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade show"
     />
     <div
       class="fade modal d-block show"
     >
       <div
+        aria-labelledby="clay-modal-label-1"
         class="modal-dialog"
+        role="dialog"
         tabindex="-1"
       >
         <div
@@ -23,6 +26,7 @@ exports[`ClayModal renders 1`] = `
           >
             <div
               class="modal-title"
+              id="clay-modal-label-1"
             >
               Foo
             </div>
@@ -82,13 +86,16 @@ exports[`ClayModal renders Header w/ low-level API 1`] = `
 >
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade show"
     />
     <div
       class="fade modal d-block show"
     >
       <div
+        aria-labelledby="clay-modal-label-3"
         class="modal-dialog"
+        role="dialog"
         tabindex="-1"
       >
         <div
@@ -108,6 +115,7 @@ exports[`ClayModal renders Header w/ low-level API 1`] = `
                 >
                   <div
                     class="modal-title"
+                    id="clay-modal-label-3"
                   >
                     Modal Title
                   </div>
@@ -142,13 +150,16 @@ exports[`ClayModal renders a body component with url 1`] = `
 >
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade show"
     />
     <div
       class="fade modal d-block show"
     >
       <div
+        aria-labelledby="clay-modal-label-7"
         class="modal-dialog"
+        role="dialog"
         tabindex="-1"
       >
         <div
@@ -176,13 +187,16 @@ exports[`ClayModal renders a footer component with buttons 1`] = `
 >
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade show"
     />
     <div
       class="fade modal d-block show"
     >
       <div
+        aria-labelledby="clay-modal-label-8"
         class="modal-dialog"
+        role="dialog"
         tabindex="-1"
       >
         <div
@@ -236,13 +250,16 @@ exports[`ClayModal renders with Header 1`] = `
 >
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade show"
     />
     <div
       class="fade modal d-block show"
     >
       <div
+        aria-labelledby="clay-modal-label-2"
         class="modal-dialog"
+        role="dialog"
         tabindex="-1"
       >
         <div
@@ -253,6 +270,7 @@ exports[`ClayModal renders with Header 1`] = `
           >
             <div
               class="modal-title"
+              id="clay-modal-label-2"
             >
               Foo
             </div>
@@ -285,13 +303,16 @@ exports[`ClayModal renders with center 1`] = `
 >
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade show"
     />
     <div
       class="fade modal d-block show"
     >
       <div
+        aria-labelledby="clay-modal-label-6"
         class="modal-dialog modal-dialog-centered"
+        role="dialog"
         tabindex="-1"
       >
         <div
@@ -310,13 +331,16 @@ exports[`ClayModal renders with size 1`] = `
 >
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade show"
     />
     <div
       class="fade modal d-block show"
     >
       <div
+        aria-labelledby="clay-modal-label-4"
         class="modal-dialog modal-lg"
+        role="dialog"
         tabindex="-1"
       >
         <div
@@ -335,13 +359,16 @@ exports[`ClayModal renders with status 1`] = `
 >
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade show"
     />
     <div
       class="fade modal d-block show"
     >
       <div
+        aria-labelledby="clay-modal-label-5"
         class="modal-dialog modal-success"
+        role="dialog"
         tabindex="-1"
       >
         <div

--- a/packages/clay-modal/src/__tests__/__snapshots__/modal.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/modal.tsx.snap
@@ -7,13 +7,16 @@ exports[`ClayModal custom opener does not close automatically with disableAutoCl
   <div />
   <div>
     <div
+      aria-hidden="true"
       class="modal-backdrop fade"
     />
     <div
       class="fade modal d-block"
     >
       <div
+        aria-labelledby="clay-modal-label-2"
         class="modal-dialog"
+        role="dialog"
         tabindex="-1"
       >
         <div
@@ -36,13 +39,16 @@ exports[`ClayModal custom opener renders inside a container element 1`] = `
       container
       <div>
         <div
+          aria-hidden="true"
           class="modal-backdrop fade"
         />
         <div
           class="fade modal d-block"
         >
           <div
+            aria-labelledby="clay-modal-label-1"
             class="modal-dialog"
+            role="dialog"
             tabindex="-1"
           >
             <div

--- a/packages/clay-modal/stories/index.tsx
+++ b/packages/clay-modal/stories/index.tsx
@@ -31,6 +31,7 @@ const Autocomplete = () => {
 		<ClayAutocomplete>
 			<ClayAutocomplete.Input
 				aria-label="Numbers: Enter a number from One to Five"
+				autoFocus
 				onBlur={() => {
 					setActive(false);
 				}}
@@ -259,7 +260,7 @@ storiesOf('Components|ClayModal', module)
 							scrollable={boolean('scrollable', false)}
 							url={text('Url', '')}
 						>
-							<h1>Hello world!</h1>
+							<h2>Hello world!</h2>
 							<div>
 								Lorem ipsum dolor sit amet, consectetur
 								adipiscing elit. Curabitur dignissim eu ante


### PR DESCRIPTION
Fixes #4736

It basically adds attributes that we haven't added for accessibility like `role="dialog"` and others.

We are also moving the focus to the `role="dialog"` which has `aria-labelledby` which can help the screen reader read the dialog title, this avoids escaping the Modal focus control along with `aria- hidden="true"`, this implementation does not break `autoFocus` if used.

If you want to test these scenarios, use a screen reader and see the Modal examples in the Storybook. [Remember that the link is generated in the CI checks](https://github.com/liferay/clay/blob/master/docs/netlify_deploy.md#deploy-previews).