### PR TITLE
feat(@clayui/color-picker): add color validation in input

### DIFF
--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -353,6 +353,23 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 								])}
 								disabled={disabled}
 								insetBefore
+								onBlur={(event) => {
+									const value = event.target.value;
+
+									const newColor = tinycolor(value);
+
+									if (newColor.isValid()) {
+										if (newColor.getFormat() === 'hex') {
+											onValueChange(newColor.toHex());
+										} else if (
+											newColor.toString() !== value
+										) {
+											onValueChange(newColor.toString());
+										}
+									} else if (!value.includes('var(')) {
+										onValueChange('');
+									}
+								}}
 								onChange={(event) => {
 									onValueChange(event.target.value);
 								}}


### PR DESCRIPTION
Fixes #4694

This validation does not prevent how much the user is typing at the moment, only after the user leaves the input the validation is done, either by converting the hex, if the color is not valid it is set to an empty value, this allows people to type different types of colors besides hexadecimal.

For example set the color using CSS Variable, color name, hsl, hsv, rgb. I think the Lexicon document is not covering these cases that came more from the stylebook, so some rules that exist in the specification are very related to the use of hexadecimal but in this case, we can't imply some rules or for example, define the maximum size of the input length instead we leave it free and update the input in `onBlur` that has a better DX to cover all these cases.