### PR TITLE
fix(@clayui/core): fixes error when removing parent's intermediate state when item's sibling is intermediate

### DIFF
--- a/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
@@ -87,6 +87,77 @@ describe('TreeView incremental interactions', () => {
 
 	describe('selection', () => {
 		describe('checkbox', () => {
+			it("uncheck the checkbox when a sibling item is indeterminate preserve the parent's indeterminate state", () => {
+				const {container} = render(
+					<Provider spritemap={spritemap}>
+						<TreeView
+							defaultItems={[
+								{
+									children: [
+										{id: 2, name: 'Item 0'},
+										{
+											children: [
+												{id: 4, name: 'Item 2'},
+												{id: 5, name: 'Item 3'},
+											],
+											id: 3,
+											name: 'Item 1',
+										},
+									],
+									id: 1,
+									name: 'Root',
+								},
+							]}
+							defaultSelectedKeys={new Set([2, 4])}
+							selectionMode="multiple-recursive"
+						>
+							{(item) => (
+								<TreeView.Item>
+									<TreeView.ItemStack>
+										<OptionalCheckbox />
+										{item.name}
+									</TreeView.ItemStack>
+									<TreeView.Group items={item.children}>
+										{(item) => (
+											<TreeView.Item>
+												<OptionalCheckbox />
+												{item.name}
+											</TreeView.Item>
+										)}
+									</TreeView.Group>
+								</TreeView.Item>
+							)}
+						</TreeView>
+					</Provider>
+				);
+
+				const checkboxsChecked =
+					container.querySelectorAll<HTMLInputElement>(
+						'input.custom-control-input[type=checkbox]:checked'
+					);
+
+				const checkboxsIndeterminate =
+					container.querySelectorAll<HTMLInputElement>(
+						'input.custom-control-input[type=checkbox]:indeterminate'
+					);
+
+				expect(checkboxsChecked.length).toBe(2);
+				expect(checkboxsIndeterminate.length).toBe(2);
+
+				const [, item0] = container.querySelectorAll<HTMLInputElement>(
+					'input.custom-control-input[type=checkbox]'
+				);
+
+				fireEvent.click(item0);
+
+				expect(item0.checked).toBeFalsy();
+				expect(
+					container.querySelectorAll<HTMLInputElement>(
+						'input.custom-control-input[type=checkbox]:indeterminate'
+					).length
+				).toBe(2);
+			});
+
 			it('select only one item using single selection', () => {
 				const {container} = render(
 					<Provider spritemap={spritemap}>

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -245,9 +245,15 @@ export function useMultipleSelection<T>(
 
 				if (unselected) {
 					// An item can only be intermediate when there is at least
-					// one item selected in its tree. We don't need to sweep
-					// the tree because we have the recursive effect.
-					if (children.some((key) => selecteds.has(key))) {
+					// one selected or intermediate item in its tree. We don't need
+					// to sweep the tree because we have the recursive effect.
+					if (
+						children.some(
+							(key) =>
+								selecteds.has(key) ||
+								intermediateKeys.current.has(key)
+						)
+					) {
 						intermediateKeys.current.add(keyMap.parentKey);
 					} else {
 						intermediateKeys.current.delete(keyMap.parentKey);


### PR DESCRIPTION
Fixes #4742

Basically, this PR fixes an edge case that was not being considered, considering that in a recursive flow to add or remove the item from the `intermediate` state it was just checking if the children of the parent were selected would decide but exist a case of a tree in-depth than any of the parent's children can have other children and is set to `intermediate`, in which case the recursive multiple selection must preserve the `intermediate` state of the parent if there is any child selected or `intermediate`.

This ASCII represents an illustration of a tree with this edge case:

```
Root (Intermediate)
├─ Item 0 (Checked) <- Click to uncheck
├─ Item 1 (Intermediate)
│  ├─ Item 2 (Checked)
│  ├─ Item 3
```

I'm also adding a test for this selection edge case.