### PR TITLE
chore: fixes error when not getting git history to cut a new version in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
@@ -69,6 +71,6 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
       - run: git push origin master:stable
-      - run: lerna publish from-package --yes
+      - run: lerna publish from-git --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I did a test using the automated release workflow but the version being cut is a patch version, because `actions/checkout@v2` is only fetching the first commit instead of fetching all commits for the conventional commit to working well.

Also, the publishing part of the packages doesn't seem to work for some reason, I think because we are using `lerna publish from-package` instead of `lerna publish from-git` to test this.