### PR TITLE
chore: add the version step sha reference in the publish step of the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,14 @@ jobs:
           git config user.email github-actions@github.com
           lerna version --conventional-commits --no-push --yes
       - run: git push origin master --follow-tags
+      - name: Get SHA
+        id: sha
+        run: |
+          sha_new=$(git rev-parse HEAD)
+          echo $sha_new
+          echo "::set-output name=SHA::$sha_new"
+      - run:
+          echo ${{ steps.sha.outputs.SHA }}
 
   publish:
     needs: version
@@ -57,6 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: ${{ needs.version.outputs.new_sha }}
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
[I managed to make the release using the automated workflow](https://github.com/liferay/clay/actions/runs/2018503223) but without the publish step, apparently when running the publish step in NPM I was not having visibility of the commit made in the previous step that cuts the new version, so the command says it has none version to be published.

```
Run lerna publish from-git --yes
info cli using local version of lerna
lerna notice cli v4.0.0
lerna info ci enabled
lerna notice from-git No tagged release found
lerna success No changed packages to publish 
```

I made the change to get the Git SHA reference from the version step and use it in the publish step at checkout, now the job can have visibility of recent changes.