### PR TITLE
chore(clayui.com): update CNAME

### DIFF
--- a/clayui.com/static/CNAME
+++ b/clayui.com/static/CNAME
@@ -1,1 +1,1 @@
-clayui.com
+v2.clayui.com


### PR DESCRIPTION
Just updating the CNAME of the Clay v2 site that is pointing to the Clay v3 site, it is not affecting production because it was updated directly in the `gh-pages` branch.