### PR TITLE
fix(@clayui/css): Removes duplicate mixins _assert-ascending and _ass…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -266,39 +266,3 @@
 		}
 	}
 }
-
-/// A Bootstrap 4 function that warns the user if values in key value pairs are not in ascending order. Used to evaluate Sass maps `$grid-breakpoints` and `$container-max-widths`.
-/// @param {Map} $map - The map to evaluate
-/// @param {String} $map-name - The name of the map
-
-@mixin _assert-ascending($map, $map-name) {
-	$prev-key: null;
-	$prev-num: null;
-
-	@each $key, $num in $map {
-		@if $prev-num == null or unit($num) == '%' or unit($prev-num) == '%' {
-			// Do nothing
-		} @else if not comparable($prev-num, $num) {
-			@warn "Potentially invalid value for #{$map-name}: This map must be in ascending order, but key '#{$key}' has value #{$num} whose unit makes it incomparable to #{$prev-num}, the value of the previous key '#{$prev-key}' !";
-		} @else if $prev-num >= $num {
-			@warn "Invalid value for #{$map-name}: This map must be in ascending order, but key '#{$key}' has value #{$num} which isn't greater than #{$prev-num}, the value of the previous key '#{$prev-key}' !";
-		}
-
-		$prev-key: $key;
-		$prev-num: $num;
-	}
-}
-
-/// A Bootstrap 4 function that warns the user if the first value in a Sass map is not 0. Used to evalute the Sass map `$grid-breakpoints`.
-/// @param {Map} $map - The map to evaluate
-/// @param {String} $map-name['$grid-breakpoints'] - The name of the map
-
-@mixin _assert-starts-at-zero($map, $map-name: '$grid-breakpoints') {
-	$values: map-values($map);
-
-	$first-value: nth($values, 1);
-
-	@if $first-value != 0 {
-		@warn "First breakpoint in #{$map-name} must start at 0, but starts at #{$first-value}.";
-	}
-}


### PR DESCRIPTION
…ert-starts-at-zero

- Removed from `mixins/_globals.scss`, these were never updated to accept CSS Custom Properties with default values
- These mixins should exist in `_global-functions.scss`

fixes #4756 

https://issues.liferay.com/browse/LPS-149682