### PR TITLE
fix(@clayui/css): Mixin `clay-navbar-variant` get `focus, color` inst…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -1250,7 +1250,8 @@
 								$map,
 								navbar-nav,
 								nav-link,
-								focus-color
+								focus,
+								color
 							)
 						),
 				),


### PR DESCRIPTION
…ead of `focus-color`

fixes #4726