### PR TITLE
fix(@clayui/css): Mixin clay-nav-nested use css calc() to calculate l…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_nav-nested.scss
+++ b/packages/clay-css/src/scss/mixins/_nav-nested.scss
@@ -20,11 +20,11 @@
 	@for $i from (1) through $nest-level {
 		#{$nav-class} > li {
 			> a {
-				padding-left: $indent * ($i + 1);
+				padding-left: calc(#{$indent} * #{$i + 1});
 			}
 
 			> .nav-equal-height-heading {
-				padding-left: $indent * $i;
+				padding-left: calc(#{$indent} * #{$i});
 			}
 		}
 


### PR DESCRIPTION
…eft padding

    - We can use CSS Custom Properties instead of number values

fixes #4721