### PR TITLE
fix(@clayui/css): Dropdown removes `pointer-events: none` from `.drop…

### DIFF
--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -199,7 +199,6 @@ $dropdown-item-base: map-deep-merge(
 		),
 		active-class: (
 			font-weight: $dropdown-link-active-font-weight,
-			pointer-events: none,
 		),
 		disabled: (
 			background-color: transparent,


### PR DESCRIPTION
…down-item.active`

We have to remember to remove the styles from `frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss`.
fixes #4690