### PR TITLE
chore: add the outputs variable in the release workflow to be exposed in the job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
   version:
     needs: test
     runs-on: ubuntu-latest
+    outputs:
+      new_sha: ${{ steps.sha.outputs.SHA }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
In PR #4749 I added some workflow changes to use newer SHA so it can be used in the next publish job so that lerna has visibility of the created commit that updates the package versions and can publish correctly but I didn't configure it correctly because the `new_sha` variable was not being exposed so that the `publish` job could have ref visibility.