### PR TITLE
fix(@clayui/drop-down): fix contextual menu error not rendering icons without spaces

### DIFF
--- a/packages/clay-drop-down/stories/index.tsx
+++ b/packages/clay-drop-down/stories/index.tsx
@@ -509,7 +509,11 @@ storiesOf('Components|ClayDropDown', module)
 					{type: 'divider'},
 					{
 						items: [
-							{label: 'Basic Document'},
+							{
+								label: 'Basic Document',
+								symbolLeft: 'document',
+								symbolRight: 'check',
+							},
 							{label: 'Contract'},
 							{label: 'Marketing Banner'},
 							{label: 'Spreadsheet'},


### PR DESCRIPTION
Fixes #4775

The contextual menu is rendered in a submenu next to the current menu, so the properties of `hasRightSymbols` and `hasLeftSymbols` were not defined, in this case, I am checking if within the items of the current contextual menu there is any icon, the search for this property on `findNested` ignores continuing fetching if there is a sub-menu because it should be fetching only when the element is rendered and with the data of the current contextual menu being rendered, this avoids the case, for example, exists icons in the sub-menu and not in the current menu, this would render extra whitespace unnecessarily.