### PR TITLE
feat(@clay/empty-state): Enable users to not render title related markup on empty-state

### DIFF
--- a/packages/clay-empty-state/src/__tests__/index.tsx
+++ b/packages/clay-empty-state/src/__tests__/index.tsx
@@ -24,6 +24,12 @@ describe('ClayEmptyState', () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it('when passing `title` property with null, it will not render title section', () => {
+		const {queryByText} = render(<ClayEmptyState title={null} />);
+
+		expect(queryByText('No results found')).toBeNull();
+	});
+
 	it('renders with a children content', () => {
 		const {container} = render(
 			<ClayEmptyState>My Empty State</ClayEmptyState>

--- a/packages/clay-empty-state/src/index.tsx
+++ b/packages/clay-empty-state/src/index.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+interface IProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
 	/**
 	 * Message the user will see describing what they can do when on this screen
 	 */
@@ -30,7 +30,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Title of the message highlighting the description
 	 */
-	title?: string;
+	title?: string | null;
 }
 
 const ClayEmptyState: React.FunctionComponent<IProps> = ({
@@ -69,11 +69,13 @@ const ClayEmptyState: React.FunctionComponent<IProps> = ({
 				</div>
 			)}
 
-			<div className="c-empty-state-title">
-				<span className="text-truncate-inline">
-					<span className="text-truncate">{title}</span>
-				</span>
-			</div>
+			{title && (
+				<div className="c-empty-state-title">
+					<span className="text-truncate-inline">
+						<span className="text-truncate">{title}</span>
+					</span>
+				</div>
+			)}
 
 			<div className="c-empty-state-text">{description}</div>
 

--- a/packages/clay-empty-state/stories/index.tsx
+++ b/packages/clay-empty-state/stories/index.tsx
@@ -20,6 +20,11 @@ storiesOf('Components|ClayEmptyState', module)
 			<ClayButton displayType="primary">Button</ClayButton>
 		</ClayEmptyState>
 	))
+	.add('no title', () => (
+		<ClayEmptyState title={null}>
+			<ClayButton displayType="primary">Button</ClayButton>
+		</ClayEmptyState>
+	))
 	.add('empty state', () => (
 		<ClayEmptyState imgSrc={emptyImage} small={boolean('Small', false)}>
 			<ClayButton displayType="secondary">Button</ClayButton>


### PR DESCRIPTION
## What It Does

When passing `title={null}` it will not render title related markup.

## Worries

Ideally we should:

1. Stop naming props as native DOM attrs 
2. Don't provide default values, turning `title` and `description` properties mandatory and not optional anymore, since they should be i18n with `Liferay.Language.get`.

Can I create tickets for it? Maybe to be updated on v4? /cc @matuzalemsteles @bryceosterhaus 

## How to test 

1. Fetch my changes
2. Run `yarn storybook` on Clay repo
3. Go to ClayEmptyState > no title on Storybook :)

Fixes #4776