### PR TITLE
feat(@clayui/modal): When using ClayModalProvider, `footer`,`header` properties now are optional

### DIFF
--- a/packages/clay-modal/src/Provider.tsx
+++ b/packages/clay-modal/src/Provider.tsx
@@ -38,7 +38,7 @@ type TState = {
 	 * - middle
 	 * - last
 	 */
-	footer: Array<React.ReactElement | undefined>;
+	footer?: Array<React.ReactElement | undefined>;
 
 	/**
 	 * Renders an element in the modal header.
@@ -99,7 +99,7 @@ const ClayModalProvider: React.FunctionComponent<IProps> = ({
 	const {observer, onClose} = useModal({
 		onClose: () => dispatch({type: Action.Close}),
 	});
-	const {body, center, footer, header, size, status, url} = otherState;
+	const {body, center, footer = [], header, size, status, url} = otherState;
 	const [first, middle, last] = footer;
 	const state = {
 		...otherState,
@@ -116,13 +116,15 @@ const ClayModalProvider: React.FunctionComponent<IProps> = ({
 					spritemap={spritemap}
 					status={status}
 				>
-					<ClayModal.Header>{header}</ClayModal.Header>
+					{header && <ClayModal.Header>{header}</ClayModal.Header>}
 					<ClayModal.Body url={url}>{body}</ClayModal.Body>
-					<ClayModal.Footer
-						first={first}
-						last={last}
-						middle={middle}
-					/>
+					{!!footer.length && (
+						<ClayModal.Footer
+							first={first}
+							last={last}
+							middle={middle}
+						/>
+					)}
 				</ClayModal>
 			)}
 			<Context.Provider value={[state, dispatch]}>

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -255,6 +255,47 @@ describe('ModalProvider -> IncrementalInteractions', () => {
 		jest.useRealTimers();
 	});
 
+	it('will not render modal title and footer when not providing it', () => {
+		const ModalWithProvider = () => {
+			const [, dispatch] = React.useContext(Context);
+
+			return (
+				<Button
+					data-testid="button"
+					displayType="primary"
+					onClick={() =>
+						dispatch({
+							payload: {
+								body: <h1>Hello world!</h1>,
+								size: 'lg',
+							},
+							type: 1,
+						})
+					}
+				>
+					Open modal
+				</Button>
+			);
+		};
+
+		const {getByTestId} = render(
+			<ClayModalProvider spritemap={spritemap}>
+				<ModalWithProvider />
+			</ClayModalProvider>
+		);
+
+		const button = getByTestId('button');
+
+		fireEvent.click(button, {});
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(document.querySelector('modal-header')).toBeNull();
+		expect(document.querySelector('modal-footer')).toBeNull();
+	});
+
 	it('renders a modal when dispatching Open by provider', () => {
 		const ModalWithProvider = () => {
 			const [state, dispatch] = React.useContext(Context);

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -29,7 +29,7 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-7"
+        aria-labelledby="clay-modal-label-8"
         class="modal-dialog modal-lg"
         role="dialog"
         tabindex="-1"
@@ -42,7 +42,7 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
           >
             <div
               class="modal-title"
-              id="clay-modal-label-7"
+              id="clay-modal-label-8"
             >
               Title
             </div>

--- a/packages/clay-modal/stories/index.tsx
+++ b/packages/clay-modal/stories/index.tsx
@@ -91,6 +91,27 @@ const MyApp: React.FunctionComponent<any> = () => {
 	);
 };
 
+const MyAppWithoutFooterAndHeader: React.FunctionComponent<any> = () => {
+	const [, dispatch] = React.useContext(Context);
+
+	return (
+		<ClayButton
+			displayType="primary"
+			onClick={() =>
+				dispatch({
+					payload: {
+						body: <h1>Hello world!</h1>,
+						size: 'lg',
+					},
+					type: 1,
+				})
+			}
+		>
+			Open modal without Footer and Header
+		</ClayButton>
+	);
+};
+
 const size = {
 	'full-screen': 'full-screen',
 	lg: 'lg',
@@ -427,5 +448,7 @@ storiesOf('Components|ClayModal', module)
 	.add('w/ Provider', () => (
 		<ClayModalProvider spritemap={spritemap}>
 			<MyApp />
+
+			<MyAppWithoutFooterAndHeader />
 		</ClayModalProvider>
 	));


### PR DESCRIPTION
## What it does

When not providing footer and header properties on ModalProvider's dispatch, it will not render footer and header sections.

## How to test

0. Fetch my changes
1. Run `yarn storybook`
2. Go to Clay Modal > w/ Provider
3. Click on Button with the following title: "Open modal without Footer and Header"
4. To close the modal, hit ESC or click outside the modal


Fixes #4778