### PR TITLE
fix(@clayui/navigator-bar): Long text in Item is truncated

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_navbar.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_navbar.scss
@@ -65,6 +65,7 @@
 		align-items: center;
 		display: flex;
 		word-wrap: normal;
+		max-width: 100%;
 	}
 
 	.nav-item {

--- a/packages/clay-css/src/scss/components/_navbar.scss
+++ b/packages/clay-css/src/scss/components/_navbar.scss
@@ -63,6 +63,7 @@
 		align-items: center;
 		display: flex;
 		word-wrap: normal;
+		max-width: 100%;
 	}
 
 	.nav-item {

--- a/packages/clay-navigation-bar/docs/index.js
+++ b/packages/clay-navigation-bar/docs/index.js
@@ -4,29 +4,47 @@
  */
 
 import Editor from '$clayui.com/src/components/Editor';
+import ClayButton from '@clayui/button';
 import ClayLink from '@clayui/link';
 import ClayNavigationBar from '@clayui/navigation-bar';
-import React from 'react';
+import React, {useState} from 'react';
 
-const navigationBarImportsCode = `import ClayLink from '@clayui/link';
-import ClayNavigationBar from '@clayui/navigation-bar';`;
+const navigationBarImportsCode = `import ClayButton from '@clayui/button';
+import ClayLink from '@clayui/link';
+import ClayNavigationBar from '@clayui/navigation-bar';
+import React, {useState} from 'react';`;
 
 const NavigationBarCode = `const Component = () => {
+	const [active, setActive] = useState('Item 1');
 
 	return (
-		<ClayNavigationBar triggerLabel="Item 1" spritemap={spritemap}>
-			<ClayNavigationBar.Item active>
-				<ClayLink className="nav-link" displayType="unstyled">
+		<ClayNavigationBar triggerLabel={active} spritemap={spritemap}>
+			<ClayNavigationBar.Item active={active === 'Item 1'}>
+				<ClayLink
+					href="#"
+					onClick={(event) => {
+						event.preventDefault();
+						setActive('Item 1');
+					}}
+				>
 					Item 1
 				</ClayLink>
 			</ClayNavigationBar.Item>
-			<ClayNavigationBar.Item>
-				<ClayLink className="nav-link" displayType="unstyled">
+			<ClayNavigationBar.Item active={active === 'Item 2'}>
+				<ClayButton
+					onClick={() => setActive('Item 2')}
+				>
 					Item 2
-				</ClayLink>
+				</ClayButton>
 			</ClayNavigationBar.Item>
-			<ClayNavigationBar.Item>
-				<ClayLink className="nav-link" displayType="unstyled">
+			<ClayNavigationBar.Item active={active === 'Item 3'}>
+				<ClayLink
+					href="#"
+					onClick={(event) => {
+						event.preventDefault();
+						setActive('Item 3');
+					}}
+				>
 					Item 3
 				</ClayLink>
 			</ClayNavigationBar.Item>
@@ -37,13 +55,23 @@ const NavigationBarCode = `const Component = () => {
 render(<Component />);`;
 
 const NavigationBar = () => {
-	const scope = {ClayLink, ClayNavigationBar};
+	const scope = {ClayButton, ClayLink, ClayNavigationBar, useState};
 
-	const code = NavigationBarCode;
+	const codeSnippets = [
+		{
+			imports: navigationBarImportsCode,
+			name: 'React',
+			value: NavigationBarCode,
+		},
+		{
+			disabled: true,
+			imports: navigationBarJSPImportsCode,
+			name: 'JSP',
+			value: NavigationBarJSPCode,
+		},
+	];
 
-	return (
-		<Editor code={code} imports={navigationBarImportsCode} scope={scope} />
-	);
+	return <Editor code={codeSnippets} scope={scope} />;
 };
 
 const navigationBarWithStyledItemImportsCode = `import ClayNavigationBar from '@clayui/navigation-bar';`;
@@ -58,13 +86,13 @@ const NavigationBarWithStyledItemCode = `const Component = () => {
 	return (
 		<ClayNavigationBar triggerLabel="Item 1" spritemap={spritemap}>
 			<ClayNavigationBar.Item active>
-					<button className="btn btn-unstyled btn-block btn-sm" style={btnStyle} type="button">Item 1</button>
+					<button className="btn btn-unstyled" style={btnStyle} type="button">Item 1</button>
 			</ClayNavigationBar.Item>
 			<ClayNavigationBar.Item>
-					<button className="btn btn-unstyled btn-block btn-sm" style={btnStyle} type="button">Item 2</button>
+					<button className="btn btn-unstyled" style={btnStyle} type="button">Item 2</button>
 			</ClayNavigationBar.Item>
 			<ClayNavigationBar.Item>
-					<button className="btn btn-unstyled btn-block btn-sm" style={btnStyle} type="button">Item 3</button>
+					<button className="btn btn-unstyled" style={btnStyle} type="button">Item 3</button>
 			</ClayNavigationBar.Item>
 		</ClayNavigationBar>
 	);
@@ -102,21 +130,13 @@ const NavigationBarJSPCode = `<clay:navigation-bar
 const NavigationBarWithStyledItem = () => {
 	const scope = {ClayNavigationBar};
 
-	const codeSnippets = [
-		{
-			imports: navigationBarWithStyledItemImportsCode,
-			name: 'React',
-			value: NavigationBarWithStyledItemCode,
-		},
-		{
-			disabled: true,
-			imports: navigationBarJSPImportsCode,
-			name: 'JSP',
-			value: NavigationBarJSPCode,
-		},
-	];
-
-	return <Editor code={codeSnippets} scope={scope} />;
+	return (
+		<Editor
+			code={NavigationBarWithStyledItemCode}
+			imports={navigationBarWithStyledItemImportsCode}
+			scope={scope}
+		/>
+	);
 };
 
 export {NavigationBar, NavigationBarWithStyledItem};

--- a/packages/clay-navigation-bar/docs/navigation-bar.mdx
+++ b/packages/clay-navigation-bar/docs/navigation-bar.mdx
@@ -12,6 +12,10 @@ import {
 
 As described on Lexicon, a NavigationBar can be styled with an inverted theme. It displays navigation items in a dark background with light text. It is always placed right below the header. Use [`inverted`](#api-inverted) property for this.
 
+<NavigationBar />
+
+Use the property `active` to specify which element is currently active on the navigation.
+
 <div class="clay-site-alert alert alert-warning">
 	<code class="language-text">triggerLabel</code> property is mandatory
 	because it specifies the name of the trigger of the dropdown that will be
@@ -20,12 +24,6 @@ As described on Lexicon, a NavigationBar can be styled with an inverted theme. I
 
 ## Item
 
-For enabling more personalization on NavigationBar items, you can pass `<ClayNavigationBar.Item>` component to specify the element that will be rendered as an item.
-
-Use the property [`active`](#api-active) to specify which element is currently active on the navigation.
+For enabling more personalization on NavigationBar items, you can pass `<ClayNavigationBar.Item>` component to specify the element that will be rendered as an item. Components like `<ClayButton />` and `<ClayLink />` when added as children of the component item are not required to add unique classes like `nav-link` or set the `displayType` to `unstyled` this is set OOTB.
 
 <NavigationBarWithStyledItem />
-
-`nav-link` class is mandatory for styling the children of ClayNavigationBar.Item as Lexicon describes but if you don't prefer to follow Lexicon, you can style with whatever you want.
-
-<NavigationBar />

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -28,14 +28,38 @@ const ClayNavigationBarIcon: React.FunctionComponent<IItemProps> = ({
 		<li {...otherProps} className={classNames('nav-item', className)}>
 			{React.Children.map(
 				children,
-				(child: React.ReactElement<IItemProps>, index) =>
-					React.cloneElement(child, {
+				(child: React.ReactElement<IItemProps>, index) => {
+					if (
+						// @ts-ignore
+						child?.type.displayName === 'ClayLink' ||
+						// @ts-ignore
+						child?.type.displayName === 'ClayButton'
+					) {
+						return React.cloneElement(child, {
+							...child.props,
+							children: (
+								<span className="navbar-text-truncate">
+									{child.props.children}
+								</span>
+							),
+							className: classNames(
+								child.props.className,
+								{
+									active,
+								}
+							),
+							key: index,
+						});
+					}
+
+					return React.cloneElement(child, {
 						...child.props,
 						className: classNames(child.props.className, {
 							active,
 						}),
 						key: index,
-					})
+					});
+				}
 			)}
 		</li>
 	);

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -43,11 +43,14 @@ const ClayNavigationBarIcon: React.FunctionComponent<IItemProps> = ({
 								</span>
 							),
 							className: classNames(
-								child.props.className,
+								'nav-link',
+								child.props.className?.replace('nav-link', ''),
 								{
 									active,
 								}
 							),
+							// @ts-ignore
+							displayType: 'unstyled',
 							key: index,
 						});
 					}

--- a/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -9,13 +9,13 @@ exports[`ClayNavigationBar collapses the previously expanded dropdown when trigg
     class="container-fluid container-fluid-max-xl"
   >
     <ul
-      class="navbar-nav text-truncate"
+      class="navbar-nav"
     >
       <li
         class="nav-item"
       >
         <a
-          class="nav-link active link-secondary"
+          class="nav-link active link-unstyled"
           href="#1"
         >
           <span
@@ -29,7 +29,7 @@ exports[`ClayNavigationBar collapses the previously expanded dropdown when trigg
         class="nav-item"
       >
         <button
-          class="nav-link btn btn-block btn-sm btn-unstyled"
+          class="nav-link btn btn-unstyled"
           type="button"
         >
           <span
@@ -79,13 +79,13 @@ exports[`ClayNavigationBar renders 1`] = `
           class="container-fluid container-fluid-max-xl"
         >
           <ul
-            class="navbar-nav text-truncate"
+            class="navbar-nav"
           >
             <li
               class="nav-item"
             >
               <a
-                class="nav-link active link-secondary"
+                class="nav-link active link-unstyled"
                 href="#1"
               >
                 <span
@@ -99,7 +99,7 @@ exports[`ClayNavigationBar renders 1`] = `
               class="nav-item"
             >
               <button
-                class="nav-link btn btn-block btn-sm btn-unstyled"
+                class="nav-link btn btn-unstyled"
                 type="button"
               >
                 <span
@@ -113,7 +113,7 @@ exports[`ClayNavigationBar renders 1`] = `
               class="nav-item"
             >
               <a
-                class="nav-link link-secondary"
+                class="nav-link link-unstyled"
                 href="#3"
               >
                 <span
@@ -121,6 +121,61 @@ exports[`ClayNavigationBar renders 1`] = `
                 >
                   Item 3
                 </span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`ClayNavigationBar renders a custom item 1`] = `
+<div>
+  <nav
+    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
+  >
+    <div
+      class="container-fluid container-fluid-max-xl"
+    >
+      <button
+        aria-expanded="false"
+        class="navbar-toggler navbar-toggler-link collapsed btn btn-unstyled"
+        data-testid="navbarToggler"
+        type="button"
+      >
+        <span
+          class="navbar-text-truncate"
+        >
+          Item 1
+        </span>
+        <svg
+          class="lexicon-icon lexicon-icon-caret-bottom"
+          role="presentation"
+        >
+          <use
+            xlink:href="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
+          />
+        </svg>
+      </button>
+      <div
+        class="navbar-collapse collapse"
+      >
+        <div
+          class="container-fluid container-fluid-max-xl"
+        >
+          <ul
+            class="navbar-nav"
+          >
+            <li
+              class="nav-item"
+            >
+              <a
+                class="my-custom-class active"
+                href="#1"
+              >
+                Item 1
               </a>
             </li>
           </ul>
@@ -140,13 +195,13 @@ exports[`ClayNavigationBar renders a dropdown when clicking the trigger element 
     class="container-fluid container-fluid-max-xl"
   >
     <ul
-      class="navbar-nav text-truncate"
+      class="navbar-nav"
     >
       <li
         class="nav-item"
       >
         <a
-          class="nav-link active link-secondary"
+          class="nav-link active link-unstyled"
           href="#1"
         >
           <span
@@ -160,7 +215,7 @@ exports[`ClayNavigationBar renders a dropdown when clicking the trigger element 
         class="nav-item"
       >
         <button
-          class="nav-link btn btn-block btn-sm btn-unstyled"
+          class="nav-link btn btn-unstyled"
           type="button"
         >
           <span
@@ -210,13 +265,13 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
           class="container-fluid container-fluid-max-xl"
         >
           <ul
-            class="navbar-nav text-truncate"
+            class="navbar-nav"
           >
             <li
               class="nav-item"
             >
               <a
-                class="nav-link link-secondary"
+                class="nav-link link-unstyled"
                 href="#1"
               >
                 <span
@@ -230,7 +285,7 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
               class="nav-item"
             >
               <button
-                class="nav-link active btn btn-block btn-sm btn-unstyled"
+                class="nav-link active btn btn-unstyled"
                 type="button"
               >
                 <span
@@ -244,7 +299,7 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
               class="nav-item"
             >
               <a
-                class="nav-link link-secondary"
+                class="nav-link link-unstyled"
                 href="#3"
               >
                 <span
@@ -297,13 +352,13 @@ exports[`ClayNavigationBar renders with a single item 1`] = `
           class="container-fluid container-fluid-max-xl"
         >
           <ul
-            class="navbar-nav text-truncate"
+            class="navbar-nav"
           >
             <li
               class="nav-item"
             >
               <a
-                class="nav-link active link-secondary"
+                class="nav-link active link-unstyled"
                 href="#1"
               >
                 <span
@@ -356,13 +411,13 @@ exports[`ClayNavigationBar throws a warning when passing more than one active pr
           class="container-fluid container-fluid-max-xl"
         >
           <ul
-            class="navbar-nav text-truncate"
+            class="navbar-nav"
           >
             <li
               class="nav-item"
             >
               <a
-                class="nav-link active link-secondary"
+                class="nav-link active link-unstyled"
                 href="#1"
               >
                 <span
@@ -376,7 +431,7 @@ exports[`ClayNavigationBar throws a warning when passing more than one active pr
               class="nav-item"
             >
               <button
-                class="nav-link active btn btn-block btn-sm btn-unstyled"
+                class="nav-link active btn btn-unstyled"
                 type="button"
               >
                 <span

--- a/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -9,7 +9,7 @@ exports[`ClayNavigationBar collapses the previously expanded dropdown when trigg
     class="container-fluid container-fluid-max-xl"
   >
     <ul
-      class="navbar-nav"
+      class="navbar-nav text-truncate"
     >
       <li
         class="nav-item"
@@ -79,7 +79,7 @@ exports[`ClayNavigationBar renders 1`] = `
           class="container-fluid container-fluid-max-xl"
         >
           <ul
-            class="navbar-nav"
+            class="navbar-nav text-truncate"
           >
             <li
               class="nav-item"
@@ -140,7 +140,7 @@ exports[`ClayNavigationBar renders a dropdown when clicking the trigger element 
     class="container-fluid container-fluid-max-xl"
   >
     <ul
-      class="navbar-nav"
+      class="navbar-nav text-truncate"
     >
       <li
         class="nav-item"
@@ -210,7 +210,7 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
           class="container-fluid container-fluid-max-xl"
         >
           <ul
-            class="navbar-nav"
+            class="navbar-nav text-truncate"
           >
             <li
               class="nav-item"
@@ -297,7 +297,7 @@ exports[`ClayNavigationBar renders with a single item 1`] = `
           class="container-fluid container-fluid-max-xl"
         >
           <ul
-            class="navbar-nav"
+            class="navbar-nav text-truncate"
           >
             <li
               class="nav-item"
@@ -356,7 +356,7 @@ exports[`ClayNavigationBar throws a warning when passing more than one active pr
           class="container-fluid container-fluid-max-xl"
         >
           <ul
-            class="navbar-nav"
+            class="navbar-nav text-truncate"
           >
             <li
               class="nav-item"

--- a/packages/clay-navigation-bar/src/__tests__/index.tsx
+++ b/packages/clay-navigation-bar/src/__tests__/index.tsx
@@ -25,34 +25,35 @@ describe('ClayNavigationBar', () => {
 				triggerLabel={label}
 			>
 				<ClayNavigationBar.Item active>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#1"
-					>
-						<span className="navbar-text-truncate">{label}</span>
-					</ClayLink>
+					<ClayLink href="#1">{label}</ClayLink>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item>
-					<ClayButton
-						block
-						className="nav-link"
-						displayType="unstyled"
-						small
-					>
-						<span className="navbar-text-truncate">Item 2</span>
-					</ClayButton>
+					<ClayButton>Item 2</ClayButton>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#3"
-					>
-						<span className="navbar-text-truncate">Item 3</span>
-					</ClayLink>
+					<ClayLink href="#3">Item 3</ClayLink>
+				</ClayNavigationBar.Item>
+			</ClayNavigationBar>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders a custom item', () => {
+		const label = 'Item 1';
+
+		const {container} = render(
+			<ClayNavigationBar
+				inverted
+				spritemap={spritemap}
+				triggerLabel={label}
+			>
+				<ClayNavigationBar.Item active>
+					<a className="my-custom-class" href="#1">
+						{label}
+					</a>
 				</ClayNavigationBar.Item>
 			</ClayNavigationBar>
 		);
@@ -70,24 +71,11 @@ describe('ClayNavigationBar', () => {
 				triggerLabel="Trigger Label"
 			>
 				<ClayNavigationBar.Item active>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#1"
-					>
-						<span className="navbar-text-truncate">Item 1</span>
-					</ClayLink>
+					<ClayLink href="#1">Item 1</ClayLink>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item>
-					<ClayButton
-						block
-						className="nav-link"
-						displayType="unstyled"
-						small
-					>
-						<span className="navbar-text-truncate">Item 2</span>
-					</ClayButton>
+					<ClayButton>Item 2</ClayButton>
 				</ClayNavigationBar.Item>
 			</ClayNavigationBar>
 		);
@@ -119,24 +107,11 @@ describe('ClayNavigationBar', () => {
 				triggerLabel="Trigger Label"
 			>
 				<ClayNavigationBar.Item active>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#1"
-					>
-						<span className="navbar-text-truncate">Item 1</span>
-					</ClayLink>
+					<ClayLink href="#1">Item 1</ClayLink>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item>
-					<ClayButton
-						block
-						className="nav-link"
-						displayType="unstyled"
-						small
-					>
-						<span className="navbar-text-truncate">Item 2</span>
-					</ClayButton>
+					<ClayButton>Item 2</ClayButton>
 				</ClayNavigationBar.Item>
 			</ClayNavigationBar>
 		);
@@ -178,34 +153,15 @@ describe('ClayNavigationBar', () => {
 				triggerLabel={label}
 			>
 				<ClayNavigationBar.Item>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#1"
-					>
-						<span className="navbar-text-truncate">{label}</span>
-					</ClayLink>
+					<ClayLink href="#1">{label}</ClayLink>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item active>
-					<ClayButton
-						block
-						className="nav-link"
-						displayType="unstyled"
-						small
-					>
-						<span className="navbar-text-truncate">Item 2</span>
-					</ClayButton>
+					<ClayButton>Item 2</ClayButton>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#3"
-					>
-						<span className="navbar-text-truncate">Item 3</span>
-					</ClayLink>
+					<ClayLink href="#3">Item 3</ClayLink>
 				</ClayNavigationBar.Item>
 			</ClayNavigationBar>
 		);
@@ -227,24 +183,11 @@ describe('ClayNavigationBar', () => {
 				triggerLabel={label}
 			>
 				<ClayNavigationBar.Item active>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#1"
-					>
-						<span className="navbar-text-truncate">{label}</span>
-					</ClayLink>
+					<ClayLink href="#1">{label}</ClayLink>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item active>
-					<ClayButton
-						block
-						className="nav-link"
-						displayType="unstyled"
-						small
-					>
-						<span className="navbar-text-truncate">Item 2</span>
-					</ClayButton>
+					<ClayButton>Item 2</ClayButton>
 				</ClayNavigationBar.Item>
 			</ClayNavigationBar>
 		);
@@ -267,13 +210,7 @@ describe('ClayNavigationBar', () => {
 				triggerLabel={label}
 			>
 				<ClayNavigationBar.Item active>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#1"
-					>
-						<span className="navbar-text-truncate">{label}</span>
-					</ClayLink>
+					<ClayLink href="#1">{label}</ClayLink>
 				</ClayNavigationBar.Item>
 			</ClayNavigationBar>
 		);

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -121,7 +121,9 @@ const ClayNavigationBar: React.FunctionComponent<IProps> & {
 				>
 					<div>
 						<ClayLayout.ContainerFluid>
-							<ul className="navbar-nav">{children}</ul>
+							<ul className="navbar-nav text-truncate">
+								{children}
+							</ul>
 						</ClayLayout.ContainerFluid>
 					</div>
 				</CSSTransition>

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -121,9 +121,7 @@ const ClayNavigationBar: React.FunctionComponent<IProps> & {
 				>
 					<div>
 						<ClayLayout.ContainerFluid>
-							<ul className="navbar-nav text-truncate">
-								{children}
-							</ul>
+							<ul className="navbar-nav">{children}</ul>
 						</ClayLayout.ContainerFluid>
 					</div>
 				</CSSTransition>

--- a/packages/clay-navigation-bar/stories/index.tsx
+++ b/packages/clay-navigation-bar/stories/index.tsx
@@ -29,7 +29,7 @@ storiesOf('Components|ClayNavigationBar', module)
 						displayType="secondary"
 						href="#"
 					>
-						<span className="navbar-text-truncate">Item 1</span>
+						Item 1
 					</ClayLink>
 				</ClayNavigationBar.Item>
 
@@ -41,24 +41,28 @@ storiesOf('Components|ClayNavigationBar', module)
 						onClick={() => setTriggerName('Item 2')}
 						small
 					>
-						<span className="navbar-text-truncate">Item 2</span>
+						Item 2
 					</ClayButton>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item active={boolean('Active 3: ', false)}>
-					<a className="link-secondary nav-link" href="#">
-						<span className="navbar-text-truncate">Item 3</span>
-					</a>
+					<ClayLink
+						displayType="secondary"
+						href="#"
+					>
+						Item 3
+					</ClayLink>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item active={boolean('Active 4: ', false)}>
-					<button
-						className="btn btn-block btn-sm btn-unstyled nav-link"
+					<ClayButton
+						block
+						displayType="unstyled"
 						onClick={() => setTriggerName('Item 4')}
-						type="button"
+						small
 					>
-						<span className="navbar-text-truncate">Item 4</span>
-					</button>
+						Item 4
+					</ClayButton>
 				</ClayNavigationBar.Item>
 			</ClayNavigationBar>
 		);
@@ -78,7 +82,7 @@ storiesOf('Components|ClayNavigationBar', module)
 						displayType="secondary"
 						href="#"
 					>
-						<span className="navbar-text-truncate">Item 1</span>
+						Item 1
 					</ClayLink>
 				</ClayNavigationBar.Item>
 			</ClayNavigationBar>

--- a/packages/clay-navigation-bar/stories/index.tsx
+++ b/packages/clay-navigation-bar/stories/index.tsx
@@ -24,43 +24,21 @@ storiesOf('Components|ClayNavigationBar', module)
 				triggerLabel={text('triggerLabel: ', triggerName)}
 			>
 				<ClayNavigationBar.Item active={boolean('Active 1: ', true)}>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#"
-					>
-						Item 1
-					</ClayLink>
+					<ClayLink href="#">Item 1</ClayLink>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item active={boolean('Active 2: ', false)}>
-					<ClayButton
-						block
-						className="nav-link"
-						displayType="unstyled"
-						onClick={() => setTriggerName('Item 2')}
-						small
-					>
+					<ClayButton onClick={() => setTriggerName('Item 2')}>
 						Item 2
 					</ClayButton>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item active={boolean('Active 3: ', false)}>
-					<ClayLink
-						displayType="secondary"
-						href="#"
-					>
-						Item 3
-					</ClayLink>
+					<ClayLink href="#">Item 3</ClayLink>
 				</ClayNavigationBar.Item>
 
 				<ClayNavigationBar.Item active={boolean('Active 4: ', false)}>
-					<ClayButton
-						block
-						displayType="unstyled"
-						onClick={() => setTriggerName('Item 4')}
-						small
-					>
+					<ClayButton onClick={() => setTriggerName('Item 4')}>
 						Item 4
 					</ClayButton>
 				</ClayNavigationBar.Item>
@@ -77,13 +55,7 @@ storiesOf('Components|ClayNavigationBar', module)
 				triggerLabel={text('triggerLabel: ', triggerName)}
 			>
 				<ClayNavigationBar.Item active={boolean('Active 1: ', true)}>
-					<ClayLink
-						className="nav-link"
-						displayType="secondary"
-						href="#"
-					>
-						Item 1
-					</ClayLink>
+					<ClayLink href="#">Item 1</ClayLink>
 				</ClayNavigationBar.Item>
 			</ClayNavigationBar>
 		);


### PR DESCRIPTION
**What is new?**
- Adding `text-truncate` in `ClayNavigationBar`.
- Updates snapshots for test cases.

 **Before changes:**

https://user-images.githubusercontent.com/44723449/160881502-82ea1313-08b4-467f-b7ad-88e946ab37ef.mov

**After changes:**

<img width="721" alt="After Changes" src="https://user-images.githubusercontent.com/44723449/160882005-2e810adc-122d-48db-9bb1-8282394c4a55.png">

**Reproduce in portal:**
Using the Dev tools and applying `text-truncate` in the component, the result is:


https://user-images.githubusercontent.com/44723449/160883404-39f39f3f-b0a5-43e9-8904-2afd793407f0.mov

**Issues:**
#4773 
