### PR TITLE
chore: updates test threshold for ColorPicker

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -44,10 +44,10 @@ module.exports = {
 			statements: 95,
 		},
 		'./packages/clay-color-picker/src/': {
-			branches: 67,
-			functions: 80,
-			lines: 80,
-			statements: 84,
+			branches: 74,
+			functions: 87,
+			lines: 90,
+			statements: 91,
 		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 69,


### PR DESCRIPTION
We recently added new behaviors to ColorPicker, #4691 and #4738, and new tests were created to cover these new scenarios in #4746 and #4781. This increases our current coverage and to continue with our strategy of organic growth and safe testing, we raised the threshold closer to the current one to prevent us from losing coverage or failing to test the new behaviors.