### PR TITLE
feat: standardizes behaviors and APIs for controlled and uncontrolled components

### DIFF
--- a/clayui.com/content/blog/2022-05-02-api-consistency-improvements-for-controlled-and-uncontrolled-components.md
+++ b/clayui.com/content/blog/2022-05-02-api-consistency-improvements-for-controlled-and-uncontrolled-components.md
@@ -1,0 +1,84 @@
+---
+title: 'API consistency improvements for controlled and uncontrolled components'
+author: [matuzalemsteles]
+---
+
+In the last few months, we have been working on identifying points for improvement in Clay components with the mindset of decreasing the learning curve and improving the DX (developer experience) of the components. This requires a lot of research about our components and using existing patterns within the community so we don't reinvent new patterns that can increase the learning curve for the developers but we also want to abstract certain complexities for the component to avoid the developer not having to worry about implementing it on its own.
+
+There are many areas of work that we want to tackle and improve in Clay and we will be making improvements on top of the v3 with compatibility so that current applications continue to work but many APIs are being deprecated which will be removed in v4. In overview, we hope to improve Clay in different arias:
+
+-   [API Consistency](https://github.com/liferay/clay/milestone/47)
+    -   [Standardizing collection components](https://github.com/liferay/clay/issues/4112)
+    -   [Standardizing form-related components](https://github.com/liferay/clay/issues/4741)
+    -   [Improves consistency of controlled and uncontrolled component APIs](https://github.com/liferay/clay/issues/4766) (Current work)
+-   [Solid components foundation](https://github.com/liferay/clay/milestone/50)
+-   [Develop a new structure for documentation](https://github.com/liferay/clay/milestone/48)
+-   Accessibility
+
+These improvements will be progressively implemented in v3 and some may only come in v4 if we are unable to implement compatibility. Now we want to present significant improvements for the consistency of the APIs of the components to the behavior of controlled and uncontrolled.
+
+> The term [controlled](https://reactjs.org/docs/forms.html#controlled-components) and [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html) components are not new and was [introduced by React.js](https://reactjs.org/docs/glossary.html#controlled-vs-uncontrolled-components), they are essentially used for form-related elements such as `<input />`. Elements like input have user interactions when typing in the input, this value can be managed without a state or with, but both cannot be changed during the component's lifecycle, this allows it to have a single source of truth that can be controlled without losing data on what the user is typing and what the component is changing.
+>
+> -- <cite>Excerpt from proposal [RFC 0002 Controlled and uncontrolled components](https://github.com/liferay/clay/blob/fef377e64b473090470a0f2446f184e81a957260/docs/proposals/0002-controlled-and-uncontrolled.md)</cite>
+
+These changes decrease the learning curve, meaning what you learned to do in a component like `<ColorPicker />` will do the same in `<DatePicker />`. This does not affect all components but only those components that fall into the category of Forms based and Presentation based if have a state.
+
+We separate them into two categories because the controlling and [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html) components are when the user is interacting with the component that the action triggers some state change, this for the form there is a common pattern and for presentation components like `<DropDown />` or ` <TreeView />` can be different, we'll delve deeper into that below. This change does not affect all components but they are standards that we will follow for existing components that meet these criteria and for future components.
+
+> We recommend reading the [Changelog](https://github.com/liferay/clay/releases/tag/v3.55.0) which describes all components that have had these changes.
+
+## Form based
+
+Form based components such as `<ColorPicker />`, `<DatePicker />`, `<MultiSelect />`... follow the same pattern to control the value state of the component which is what the user is typing. Setting the `value` and `onChange` properties makes the component [controlled](https://reactjs.org/docs/forms.html#controlled-components), if no properties are defined the component goes into an [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html) state. Setting just `value` will throw an error in the console because the component will not have any source of truth to trigger changes when the user is typing, in this scenario you can set the initial state of the value using the `defaultValue` property for this purpose.
+
+```tsx{expanded}
+const [value, setValue] = useState<string>('');
+
+<ColorPicker
+  onChange={setValue}
+  value={value}
+/>
+```
+
+Not all components had changed like `Checkbox`, `Toggle`, and `Select` because we would not be able to maintain backward compatibility and would cause a breaking change in v3, but we will be enforcing this pattern in v4.
+
+## Presentation based
+
+Presentation based components are a little different because depending on their context and properties like `value` doesn't make sense, for example for `<Modal />` or `<Pagination />`, but they follow the same concept, both can change the state of a component being triggered by user interaction and in some components, this can come from various user actions in different places in the component.
+
+We keep the same behavior of the [controlled](https://reactjs.org/docs/forms.html#controlled-components) and [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html) state, the only difference is the names of the properties that can change according to the context of the component, for example:
+
+```jsx{expanded}
+// Controlled
+<TreeView
+  items={...}
+  onItemsChange={...}
+/>
+
+<Panel
+  expanded={...}
+  onExpandedChange={...}
+/>
+
+<DropDown
+  active={...}
+  onActiveChange={...}
+/>
+
+// Uncontrolled
+<TreeView
+  defaultItems={...}
+/>
+
+<Panel
+  defaultExpanded={...}
+/>
+
+<DropDown
+  defaultActive={...}
+/>
+```
+
+## What's next
+
+We will continue to improve and research ways to improve the consistency of component APIs and improve compositing with great DX. Keep an eye out for the respective milestones as we're working on them, we'll also be publishing more blog posts about changes that have a lot of impact on the components.

--- a/clayui.com/src/styles/_blog.scss
+++ b/clayui.com/src/styles/_blog.scss
@@ -1,7 +1,13 @@
 .blog {
+	header {
+		padding: 20px 0;
+	}
+
 	.blog-title {
-		line-height: 1.2 !important;
 		font-weight: 700 !important;
+		line-height: 1.2 !important;
+		margin-bottom: 15px !important;
+		margin-top: 0 !important;
 
 		@media (max-width: $grid-float-breakpoint - 1) {
 			margin-top: 30px !important;
@@ -14,6 +20,14 @@
 
 	article {
 		margin-bottom: 100px;
+
+		ul {
+			padding-left: 18px;
+		}
+
+		p {
+			color: #000000 !important;
+		}
 	}
 
 	.clay-site-container {

--- a/clayui.com/src/styles/_prismjs.scss
+++ b/clayui.com/src/styles/_prismjs.scss
@@ -1,7 +1,7 @@
 $prismDark: #f5f5f8; // 282a36
 $prismWhite: #30313f; // ffffff
 
-$char: #d8dee9;
+$char: #005cc5;
 $comment: #999;
 $keyword: #2f6f9f;
 $attribute: #4f9fcf;

--- a/clayui.com/src/templates/blog.js
+++ b/clayui.com/src/templates/blog.js
@@ -43,9 +43,9 @@ export default function Blog({data, location}) {
 						<div className="col-xl sidebar-offset">
 							<LayoutNav pathname={location.pathname} />
 							<div className="clay-blog-content">
-								<header>
-									<div className="clay-site-container container-fluid">
-										<h1 className="blog-title">
+								<div className="clay-site-container container-fluid">
+									<header>
+										<h1 className="blog-title text-10">
 											{frontmatter.title}
 										</h1>
 										<span className="blog-date">
@@ -72,20 +72,12 @@ export default function Blog({data, location}) {
 												)
 											)}
 										</span>
-									</div>
-								</header>
-								<div className="clay-site-container container-fluid">
-									<div className="row">
-										<div className="col-md-12">
-											<article>
-												<div
-													dangerouslySetInnerHTML={{
-														__html: html,
-													}}
-												/>
-											</article>
-										</div>
-									</div>
+									</header>
+									<article
+										dangerouslySetInnerHTML={{
+											__html: html,
+										}}
+									/>
 								</div>
 							</div>
 						</div>

--- a/docs/proposals/0002-controlled-and-uncontrolled.md
+++ b/docs/proposals/0002-controlled-and-uncontrolled.md
@@ -2,9 +2,9 @@
 
 -   Start Date: 2022-03-28
 -   Author: [Matuzalém Teles](https://github.com/matuzalemsteles)
--   RFC PR: (leave this empty)
+-   RFC PR: [#4786](https://github.com/liferay/clay/pull/4786)
 -   Clay Issue: [#4766](https://github.com/liferay/clay/issues/4766)
--   Status: **Awaiting final implementation**
+-   Status: **Implemented**
 
 ## Introduction
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -130,14 +130,14 @@ module.exports = {
 		'./packages/clay-modal/src/': {
 			branches: 55,
 			functions: 81,
-			lines: 86,
-			statements: 86,
+			lines: 85,
+			statements: 85,
 		},
 		'./packages/clay-multi-select/src/': {
 			branches: 85,
 			functions: 80,
-			lines: 88,
-			statements: 87,
+			lines: 87,
+			statements: 86,
 		},
 		'./packages/clay-multi-step-nav/src/': {
 			branches: 94,

--- a/packages/clay-breadcrumb/src/Ellipsis.tsx
+++ b/packages/clay-breadcrumb/src/Ellipsis.tsx
@@ -26,41 +26,35 @@ const Ellipsis: React.FunctionComponent<IEllipsisProps> = ({
 	items,
 	spritemap,
 	...otherProps
-}) => {
-	const [active, setActive] = React.useState(false);
-
-	return (
-		<ClayDropDown
-			active={active}
-			className="breadcrumb-item"
-			containerElement="li"
-			onActiveChange={(newVal) => setActive(newVal)}
-			trigger={
-				<ClayButton
-					className="breadcrumb-link"
-					data-testid="breadcrumbDropdownTrigger"
-					displayType="unstyled"
+}) => (
+	<ClayDropDown
+		className="breadcrumb-item"
+		containerElement="li"
+		trigger={
+			<ClayButton
+				className="breadcrumb-link"
+				data-testid="breadcrumbDropdownTrigger"
+				displayType="unstyled"
+			>
+				<ClayIcon spritemap={spritemap} symbol="ellipsis-h" />
+				<ClayIcon spritemap={spritemap} symbol="caret-bottom" />
+			</ClayButton>
+		}
+		{...otherProps}
+	>
+		<ClayDropDown.ItemList>
+			{items.map(({href, label, onClick}, i) => (
+				<ClayDropDown.Item
+					href={href}
+					key={`breadcrumbEllipsisItem${i}`}
+					onClick={onClick}
+					title={label}
 				>
-					<ClayIcon spritemap={spritemap} symbol="ellipsis-h" />
-					<ClayIcon spritemap={spritemap} symbol="caret-bottom" />
-				</ClayButton>
-			}
-			{...otherProps}
-		>
-			<ClayDropDown.ItemList>
-				{items.map(({href, label, onClick}, i) => (
-					<ClayDropDown.Item
-						href={href}
-						key={`breadcrumbEllipsisItem${i}`}
-						onClick={onClick}
-						title={label}
-					>
-						{label}
-					</ClayDropDown.Item>
-				))}
-			</ClayDropDown.ItemList>
-		</ClayDropDown>
-	);
-};
+					{label}
+				</ClayDropDown.Item>
+			))}
+		</ClayDropDown.ItemList>
+	</ClayDropDown>
+);
 
 export default Ellipsis;

--- a/packages/clay-color-picker/docs/index.js
+++ b/packages/clay-color-picker/docs/index.js
@@ -19,8 +19,8 @@ const colorPickerCode = `const Component = () => {
 			colors={customColors}
 			label="Custom Colors"
 			name="colorPicker2"
+			onChange={setColor}
 			onColorsChange={setCustoms}
-			onValueChange={setColor}
 			showHex={true}
 			spritemap={spritemap}
 			title="Custom Colors"

--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -5,7 +5,7 @@
 
 import ClayForm, {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
-import {TInternalStateOnChange, useInternalState} from '@clayui/shared';
+import {InternalDispatch, useInternalState} from '@clayui/shared';
 import React from 'react';
 import tinycolor from 'tinycolor2';
 
@@ -151,7 +151,7 @@ interface IProps {
 
 	editorActive?: boolean;
 
-	onEditorActiveChange?: TInternalStateOnChange<boolean>;
+	onEditorActiveChange?: InternalDispatch<boolean>;
 
 	value?: string;
 }
@@ -185,8 +185,8 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 
 	const [internalEditorActive, setInternalEditorActive] = useInternalState({
 		defaultName: '',
+		defaultValue: !showPalette,
 		handleName: 'onEditorActiveChange',
-		initialValue: !showPalette,
 		name: 'editorActive',
 		onChange: onEditorActiveChange,
 		value: editorActive,

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -32,7 +32,7 @@ const ClayColorPickerWithState = (
 		<ClayColorPicker
 			label="Default Colors"
 			name="colorPicker1"
-			onValueChange={setValue}
+			onChange={setValue}
 			spritemap="/test/path"
 			title="Default"
 			value={value}
@@ -51,14 +51,14 @@ const ClayColorPickerWithCustomColors = (props: any) => {
 		'var(--blue)',
 	]);
 
-	const [color, setColor] = React.useState();
+	const [color, setColor] = React.useState('');
 
 	return (
 		<ClayColorPickerWithState
 			{...props}
 			colors={customColors}
+			onChange={setColor}
 			onColorsChange={setCustoms}
-			onValueChange={setColor}
 			value={color}
 		/>
 	);
@@ -70,12 +70,11 @@ describe('Rendering', () => {
 	it('default', () => {
 		render(
 			<ClayColorPicker
+				defaultValue="FFF"
 				label="Default Colors"
 				name="colorPicker1"
-				onValueChange={() => {}}
 				spritemap="/test/path"
 				title="Default"
-				value="FFF"
 			/>
 		);
 
@@ -85,12 +84,11 @@ describe('Rendering', () => {
 	it('renders w/ var()', () => {
 		render(
 			<ClayColorPicker
+				defaultValue="var(--blue)"
 				label="Default Colors"
 				name="colorPicker1"
-				onValueChange={() => {}}
 				spritemap="/test/path"
 				title="Default"
-				value="var(--blue)"
 			/>
 		);
 
@@ -100,12 +98,11 @@ describe('Rendering', () => {
 	it('renders with a hash for the value', () => {
 		render(
 			<ClayColorPicker
+				defaultValue="#FFF"
 				label="Default Colors"
 				name="colorPicker1"
-				onValueChange={() => {}}
 				spritemap="/test/path"
 				title="Default"
-				value="#FFF"
 			/>
 		);
 
@@ -115,12 +112,11 @@ describe('Rendering', () => {
 	it('renders with a named color for the value', () => {
 		render(
 			<ClayColorPicker
+				defaultValue="red"
 				label="Default Colors"
 				name="colorPicker1"
-				onValueChange={() => {}}
 				spritemap="/test/path"
 				title="Default"
-				value="red"
 			/>
 		);
 
@@ -130,13 +126,12 @@ describe('Rendering', () => {
 	it('small color-picker', () => {
 		render(
 			<ClayColorPicker
+				defaultValue="FFF"
 				label="Default Colors"
 				name="colorPicker1"
-				onValueChange={() => {}}
 				small
 				spritemap="/test/path"
 				title="Small"
-				value="FFF"
 			/>
 		);
 
@@ -146,13 +141,12 @@ describe('Rendering', () => {
 	it('disabled state', () => {
 		render(
 			<ClayColorPicker
+				defaultValue="FFF"
 				disabled
 				label="Default Colors"
 				name="colorPicker1"
-				onValueChange={() => {}}
 				spritemap="/test/path"
 				title="Default"
-				value="FFF"
 			/>
 		);
 
@@ -162,13 +156,12 @@ describe('Rendering', () => {
 	it('disabled palette', () => {
 		render(
 			<ClayColorPicker
+				defaultValue="FFF"
 				label="Default Colors"
 				name="colorPicker1"
-				onValueChange={() => {}}
 				showPalette={false}
 				spritemap="/test/path"
 				title="Default"
-				value="FFF"
 			/>
 		);
 
@@ -227,7 +220,7 @@ describe('Interactions', () => {
 			<ClayColorPicker
 				label="Default Colors"
 				name="colorPicker1"
-				onValueChange={() => {}}
+				onChange={() => {}}
 				spritemap="/test/path"
 				title="Default"
 				value="FFF"
@@ -249,8 +242,8 @@ describe('Interactions', () => {
 				colors={['000000', '00FFFF', '0000FF']}
 				label="Custom Colors"
 				name="colorPicker2"
+				onChange={() => {}}
 				onColorsChange={() => {}}
-				onValueChange={() => {}}
 				spritemap="/test/path"
 				title="Custom Colors"
 				value="008000"
@@ -293,10 +286,11 @@ describe('Interactions', () => {
 					colors={['5BB0A5', '00FFFF', '0000FF']}
 					label="Custom Colors"
 					name="colorPicker2"
+					onChange={handleValueChange}
 					onColorsChange={handleColorsChange}
-					onValueChange={handleValueChange}
 					spritemap="/test/path"
 					title="Custom Colors"
+					value="FFFFFF"
 				/>
 			);
 

--- a/packages/clay-color-picker/stories/ColorPicker.stories.tsx
+++ b/packages/clay-color-picker/stories/ColorPicker.stories.tsx
@@ -54,8 +54,8 @@ export const CustomColors = (args: any) => {
 			disabled={args.disabled}
 			label={args.label}
 			name="colorPicker2"
+			onChange={setColor}
 			onColorsChange={setCustoms}
-			onValueChange={setColor}
 			showHex={args.showHex}
 			title={args.title}
 			value={color}
@@ -88,8 +88,8 @@ export const CustomAndPredefinedColors = (args: any) => {
 			disabled={args.disabled}
 			label={args.label}
 			name="colorPicker2"
+			onChange={setColor}
 			onColorsChange={setCustoms}
-			onValueChange={setColor}
 			showHex
 			showPredefinedColorsWithCustom
 			title={args.title}
@@ -122,8 +122,8 @@ export const CustomPalette = (args: any) => {
 			disabled={args.disabled}
 			label={args.label}
 			name="colorPicker2"
+			onChange={setColor}
 			onColorsChange={setCustoms}
-			onValueChange={setColor}
 			showHex={args.showHex}
 			showPalette={false}
 			title={args.title}
@@ -169,7 +169,7 @@ export const Small = (args: any) => {
 		<ClayColorPicker
 			disabled={args.disabled}
 			label={args.label}
-			onValueChange={setColor}
+			onChange={setColor}
 			showHex={args.showHex}
 			small
 			title={args.title}
@@ -192,7 +192,7 @@ export const Validation = () => {
 
 	return (
 		<ClayForm.Group className={!valid ? 'has-error' : ''}>
-			<ClayColorPicker onValueChange={setColor} value={color} />
+			<ClayColorPicker onChange={setColor} value={color} />
 
 			{!valid && (
 				<ClayForm.FeedbackGroup>

--- a/packages/clay-core/src/overlay-mask/OverlayMask.tsx
+++ b/packages/clay-core/src/overlay-mask/OverlayMask.tsx
@@ -3,11 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {
-	TInternalStateOnChange,
-	observeRect,
-	useInternalState,
-} from '@clayui/shared';
+import {InternalDispatch, observeRect, useInternalState} from '@clayui/shared';
 import React, {useEffect, useLayoutEffect, useRef, useState} from 'react';
 
 type Bounds = {
@@ -91,7 +87,7 @@ type Props<T> = {
 	/**
 	 * Callback is called when the bounds changes (controlled).
 	 */
-	onBoundsChange?: TInternalStateOnChange<Bounds>;
+	onBoundsChange?: InternalDispatch<Bounds>;
 };
 
 const initialBounds = {
@@ -115,8 +111,8 @@ export function OverlayMask<T>({
 }: Props<T>) {
 	const [internalBounds, setBounds] = useInternalState({
 		defaultName: 'defaultBounds',
+		defaultValue: defaultBounds,
 		handleName: 'onBoundsChange',
-		initialValue: defaultBounds,
 		name: 'bounds',
 		onChange: onBoundsChange,
 		value: bounds,

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -122,8 +122,8 @@ export function useMultipleSelection<T>(
 
 	const [selectedKeys, setSelectionKeys] = useInternalState<Set<Key>>({
 		defaultName: 'defaultSelectedKeys',
+		defaultValue: props.defaultSelectedKeys ?? new Set(),
 		handleName: 'onSelectionChange',
-		initialValue: props.defaultSelectedKeys ?? new Set(),
 		name: 'selectedKeys',
 		onChange: props.onSelectionChange,
 		value: props.selectedKeys,

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -90,8 +90,8 @@ export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {
 export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 	const [items, setItems] = useInternalState({
 		defaultName: 'defaultItems',
+		defaultValue: props.defaultItems ?? [],
 		handleName: 'onItemsChange',
-		initialValue: props.defaultItems ?? [],
 		name: 'items',
 		onChange: props.onItemsChange,
 		value: props.items,
@@ -108,8 +108,7 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 
 	const [expandedKeys, setExpandedKeys] = useInternalState<Set<Key>>({
 		defaultName: 'defaultExpandedKeys',
-		handleName: 'onExpandedChange',
-		initialValue: () => {
+		defaultValue: () => {
 			const {
 				defaultExpandedKeys,
 				nestedKey,
@@ -147,6 +146,7 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 
 			return defaultExpandedKeys ?? new Set();
 		},
+		handleName: 'onExpandedChange',
 		name: 'expandedKeys',
 		onChange: props.onExpandedChange,
 		value: props.expandedKeys,

--- a/packages/clay-date-picker/docs/index.js
+++ b/packages/clay-date-picker/docs/index.js
@@ -17,7 +17,7 @@ const DatePickerWithState = () => {
 
 	return (
 		<ClayDatePicker
-			onValueChange={setValue}
+			onChange={setValue}
 			placeholder="YYYY-MM-DD"
 			spritemap={spritemap}
 			value={value}
@@ -66,7 +66,7 @@ const DatePickerLocale = () => {
 				'Ноябрь',
 				'Декабрь',
 			]}
-			onValueChange={setValue}
+			onChange={setValue}
 			placeholder="DD.MM.YYYY"
 			spritemap={spritemap}
 			value={value}
@@ -101,11 +101,11 @@ const DatePickerCustomFooter = () => {
 
 	return (
 		<ClayDatePicker
-			onValueChange={setValue}
+			footerElement={() => <span>Footer Content</span>}
+			onChange={setValue}
 			placeholder="YYYY-MM-DD"
 			spritemap={spritemap}
 			value={value}
-			footerElement={() => <span>Footer Content</span>}
 			years={{
 				end: 2024,
 				start: 2008,
@@ -136,12 +136,12 @@ const DatePickerWithTime = () => {
 
 	return (
 		<ClayDatePicker
-			onValueChange={setValue}
+			onChange={setValue}
 			placeholder="YYYY-MM-DD HH:mm"
 			spritemap={spritemap}
-			value={value}
 			time
 			timezone="GMT+01:00"
+			value={value}
 			years={{
 				end: 2024,
 				start: 2008,
@@ -172,7 +172,7 @@ const DatePickerWithRange = () => {
 
 	return (
 		<ClayDatePicker
-			onValueChange={setValue}
+			onChange={setValue}
 			placeholder="YYYY-MM-DD - YYYY-MM-DD"
 			range
 			spritemap={spritemap}

--- a/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
+++ b/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
@@ -15,11 +15,9 @@ describe('BasicRendering', () => {
 	it('renders by default', () => {
 		render(
 			<ClayDatePicker
-				initialMonth={new Date(2019, 3, 18)}
-				onValueChange={() => {}}
+				defaultMonth={new Date(2019, 3, 18)}
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
-				value=""
 				years={{end: 2019, start: 2019}}
 			/>
 		);
@@ -27,14 +25,12 @@ describe('BasicRendering', () => {
 		expect(document.body).toMatchSnapshot();
 	});
 
-	it('renders the date picker with the selected day using the initialMonth', () => {
+	it('renders the date picker with the selected day using the defaultMonth', () => {
 		const {getByLabelText} = render(
 			<ClayDatePicker
-				initialMonth={new Date(2019, 3, 18)}
-				onValueChange={() => {}}
+				defaultMonth={new Date(2019, 3, 18)}
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
-				value=""
 				years={{end: 2019, start: 2019}}
 			/>
 		);
@@ -47,12 +43,10 @@ describe('BasicRendering', () => {
 	it('renders date picker with dropdown open', () => {
 		render(
 			<ClayDatePicker
-				initialExpanded
-				initialMonth={new Date(2019, 3, 18)}
-				onValueChange={() => {}}
+				defaultExpanded
+				defaultMonth={new Date(2019, 3, 18)}
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
-				value=""
 				years={{end: 2019, start: 2019}}
 			/>
 		);
@@ -63,14 +57,12 @@ describe('BasicRendering', () => {
 	it('renders date picker with time', () => {
 		render(
 			<ClayDatePicker
-				initialExpanded
-				initialMonth={new Date(2019, 3, 18)}
-				onValueChange={() => {}}
+				defaultExpanded
+				defaultMonth={new Date(2019, 3, 18)}
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 				time
 				timezone="GMT+01:00"
-				value=""
 				years={{end: 2019, start: 2019}}
 			/>
 		);
@@ -81,13 +73,11 @@ describe('BasicRendering', () => {
 	it('renders date picker with native picker', () => {
 		render(
 			<ClayDatePicker
-				initialExpanded
-				initialMonth={new Date(2019, 3, 18)}
-				onValueChange={() => {}}
+				defaultExpanded
+				defaultMonth={new Date(2019, 3, 18)}
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 				useNative
-				value=""
 				years={{end: 2019, start: 2019}}
 			/>
 		);
@@ -98,12 +88,10 @@ describe('BasicRendering', () => {
 	it('renders the date picker with years range', () => {
 		render(
 			<ClayDatePicker
-				initialExpanded
-				initialMonth={new Date(2019, 3, 18)}
-				onValueChange={() => {}}
+				defaultExpanded
+				defaultMonth={new Date(2019, 3, 18)}
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
-				value=""
 				years={{
 					end: 2024,
 					start: 1997,

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -19,17 +19,17 @@ const ariaLabels = {
 };
 
 const DatePickerWithState = ({
-	initialMonth = new Date(2019, 3, 18),
+	defaultMonth = new Date(2019, 3, 18),
 	years = {end: 2019, start: 2019},
 	...props
 }: any) => {
-	const [value, setValue] = React.useState();
+	const [value, setValue] = React.useState('');
 
 	return (
 		<ClayDatePicker
 			{...props}
-			initialMonth={initialMonth}
-			onValueChange={setValue}
+			defaultMonth={defaultMonth}
+			onChange={setValue}
 			value={value}
 			years={years}
 		/>
@@ -49,7 +49,7 @@ describe('IncrementalInteractions', () => {
 		const {getByLabelText, getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
+				defaultExpanded
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 			/>
@@ -90,7 +90,7 @@ describe('IncrementalInteractions', () => {
 		const {getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
+				defaultExpanded
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 			/>
@@ -109,7 +109,7 @@ describe('IncrementalInteractions', () => {
 			<>
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
-					initialExpanded
+					defaultExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 				/>
@@ -130,7 +130,7 @@ describe('IncrementalInteractions', () => {
 		const {getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
+				defaultExpanded
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 			/>
@@ -152,7 +152,7 @@ describe('IncrementalInteractions', () => {
 		const {getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
+				defaultExpanded
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 				years={{
@@ -178,7 +178,7 @@ describe('IncrementalInteractions', () => {
 		const {getByLabelText, getByTestId, queryAllByLabelText} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
+				defaultExpanded
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 			/>
@@ -203,7 +203,7 @@ describe('IncrementalInteractions', () => {
 		const {getByLabelText} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
+				defaultExpanded
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 			/>
@@ -226,7 +226,7 @@ describe('IncrementalInteractions', () => {
 		const {getByLabelText, getByTestId, queryAllByLabelText} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
+				defaultExpanded
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 			/>
@@ -249,8 +249,8 @@ describe('IncrementalInteractions', () => {
 		const {getByLabelText, getByTestId, queryAllByLabelText} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
-				initialMonth={new Date(2019, 0, 18)}
+				defaultExpanded
+				defaultMonth={new Date(2019, 0, 18)}
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 				years={{
@@ -279,8 +279,8 @@ describe('IncrementalInteractions', () => {
 		const {getByLabelText, getByTestId, queryAllByLabelText} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
-				initialMonth={new Date(2019, 11, 18)}
+				defaultExpanded
+				defaultMonth={new Date(2019, 11, 18)}
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 				years={{
@@ -307,7 +307,7 @@ describe('IncrementalInteractions', () => {
 		const {getByLabelText, getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
+				defaultExpanded
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 			/>
@@ -330,7 +330,7 @@ describe('IncrementalInteractions', () => {
 		const {getByLabelText, getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
-				initialExpanded
+				defaultExpanded
 				placeholder="YYYY-MM-DD"
 				spritemap={spritemap}
 			/>
@@ -354,7 +354,7 @@ describe('IncrementalInteractions', () => {
 			const {getByLabelText, getByTestId} = render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
-					initialExpanded
+					defaultExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 					time
@@ -373,7 +373,7 @@ describe('IncrementalInteractions', () => {
 			const {getByLabelText, getByTestId} = render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
-					initialExpanded
+					defaultExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 					time
@@ -399,7 +399,7 @@ describe('IncrementalInteractions', () => {
 			const {getByLabelText, getByTestId} = render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
-					initialExpanded
+					defaultExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 					time
@@ -424,7 +424,7 @@ describe('IncrementalInteractions', () => {
 			const {getByLabelText, getByTestId} = render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
-					initialExpanded
+					defaultExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 					time
@@ -452,7 +452,7 @@ describe('IncrementalInteractions', () => {
 			const {getByLabelText, getByTestId} = render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
-					initialExpanded
+					defaultExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 					time
@@ -489,7 +489,7 @@ describe('IncrementalInteractions', () => {
 			const {getByLabelText} = render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
-					initialExpanded
+					defaultExpanded
 					placeholder="YYYY-MM-DD"
 					range
 					spritemap={spritemap}
@@ -513,7 +513,7 @@ describe('IncrementalInteractions', () => {
 			const {getByLabelText} = render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
-					initialExpanded
+					defaultExpanded
 					placeholder="YYYY-MM-DD"
 					range
 					spritemap={spritemap}
@@ -539,7 +539,7 @@ describe('IncrementalInteractions', () => {
 				const {getByLabelText} = render(
 					<DatePickerWithState
 						ariaLabels={ariaLabels}
-						initialExpanded
+						defaultExpanded
 						placeholder="YYYY-MM-DD"
 						range
 						spritemap={spritemap}

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -568,4 +568,110 @@ describe('IncrementalInteractions', () => {
 			}
 		);
 	});
+
+	describe('Backward compatibility', () => {
+		it('define the initial state of expanded', () => {
+			render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					initialExpanded
+					placeholder="YYYY-MM-DD"
+					spritemap={spritemap}
+				/>
+			);
+
+			expect(
+				(
+					document.body.querySelector(
+						'.dropdown-menu'
+					) as HTMLDivElement
+				).classList
+			).toContain('show');
+		});
+
+		it('define the initial state of month', () => {
+			const DatePickerWithOldProp = ({
+				initialMonth = new Date(2019, 3, 18),
+				years = {end: 2019, start: 2019},
+				...props
+			}: any) => {
+				const [value, setValue] = React.useState('');
+
+				return (
+					<ClayDatePicker
+						{...props}
+						initialMonth={initialMonth}
+						onValueChange={setValue}
+						value={value}
+						years={years}
+					/>
+				);
+			};
+
+			const {getByTestId} = render(
+				<DatePickerWithOldProp
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					initialMonth={new Date(2019, 0, 18)}
+					placeholder="YYYY-MM-DD"
+					spritemap={spritemap}
+					years={{
+						end: 2020,
+						start: 2017,
+					}}
+				/>
+			);
+
+			const monthSelect: any = getByTestId('month-select');
+			const yearSelect: any = getByTestId('year-select');
+			const daySelected = document.querySelector(
+				'[aria-label="Fri Jan 18 2019"]'
+			) as HTMLDivElement;
+
+			expect(yearSelect.value).toBe('2019');
+			expect(monthSelect.value).toBe('0');
+			expect(daySelected.innerHTML).toBe('18');
+		});
+	});
+
+	it('clicking the dot button should select the current date using the deprecated properties', () => {
+		const DatePickerWithOldProp = ({
+			defaultMonth = new Date(2019, 3, 18),
+			years = {end: 2019, start: 2019},
+			...props
+		}: any) => {
+			const [value, setValue] = React.useState('');
+
+			return (
+				<ClayDatePicker
+					{...props}
+					defaultMonth={defaultMonth}
+					onValueChange={setValue}
+					value={value}
+					years={years}
+				/>
+			);
+		};
+
+		const {getByLabelText} = render(
+			<DatePickerWithOldProp
+				ariaLabels={ariaLabels}
+				defaultExpanded
+				placeholder="YYYY-MM-DD"
+				spritemap={spritemap}
+			/>
+		);
+
+		const input: any = getByLabelText(ariaLabels.input);
+		const dotButtonEl = getByLabelText(ariaLabels.buttonDot);
+
+		fireEvent.click(dotButtonEl);
+
+		const currentDate = new Date(2019, 3, 18);
+
+		expect(input.value).toBe(formatDate(currentDate, 'yyyy-MM-dd'));
+
+		const dayNumber = getByLabelText(currentDate.toDateString());
+		expect(dayNumber.classList).toContain('active');
+	});
 });

--- a/packages/clay-date-picker/src/__tests__/Internationalization.tsx
+++ b/packages/clay-date-picker/src/__tests__/Internationalization.tsx
@@ -20,17 +20,17 @@ const ariaLabels = {
 };
 
 const DatePickerWithState = ({
-	initialMonth = new Date(2019, 3, 18),
+	defaultMonth = new Date(2019, 3, 18),
 	years = {end: 2019, start: 2019},
 	...props
 }: any) => {
-	const [value, setValue] = React.useState();
+	const [value, setValue] = React.useState('');
 
 	return (
 		<ClayDatePicker
 			{...props}
-			initialMonth={initialMonth}
-			onValueChange={setValue}
+			defaultMonth={defaultMonth}
+			onChange={setValue}
 			value={value}
 			years={years}
 		/>
@@ -45,8 +45,8 @@ describe('Internationalization', () => {
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
 				dateFormat="DD.MM.YYYY"
+				defaultExpanded
 				firstDayOfWeek={FirstDayOfWeek.Monday}
-				initialExpanded
 				months={[
 					'Январь',
 					'Февраль',
@@ -80,8 +80,8 @@ describe('Internationalization', () => {
 			render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
+					defaultExpanded
 					firstDayOfWeek={FirstDayOfWeek.Sunday}
-					initialExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 				/>
@@ -94,7 +94,7 @@ describe('Internationalization', () => {
 			render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
-					initialExpanded
+					defaultExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 				/>
@@ -107,8 +107,8 @@ describe('Internationalization', () => {
 			render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
+					defaultExpanded
 					firstDayOfWeek={FirstDayOfWeek.Tuesday}
-					initialExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 				/>
@@ -121,8 +121,8 @@ describe('Internationalization', () => {
 			render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
+					defaultExpanded
 					firstDayOfWeek={FirstDayOfWeek.Wednesday}
-					initialExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 				/>
@@ -135,8 +135,8 @@ describe('Internationalization', () => {
 			render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
+					defaultExpanded
 					firstDayOfWeek={FirstDayOfWeek.Thursday}
-					initialExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 				/>
@@ -149,8 +149,8 @@ describe('Internationalization', () => {
 			render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
+					defaultExpanded
 					firstDayOfWeek={FirstDayOfWeek.Friday}
-					initialExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 				/>
@@ -163,8 +163,8 @@ describe('Internationalization', () => {
 			render(
 				<DatePickerWithState
 					ariaLabels={ariaLabels}
+					defaultExpanded
 					firstDayOfWeek={FirstDayOfWeek.Saturday}
-					initialExpanded
 					placeholder="YYYY-MM-DD"
 					spritemap={spritemap}
 				/>

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -7,11 +7,7 @@ import Button from '@clayui/button';
 import DropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
-import {
-	FocusScope,
-	TInternalStateOnChange,
-	useInternalState,
-} from '@clayui/shared';
+import {FocusScope, InternalDispatch, useInternalState} from '@clayui/shared';
 import React from 'react';
 
 import DateNavigation from './DateNavigation';
@@ -27,7 +23,8 @@ import {FirstDayOfWeek, IAriaLabels, IYears} from './types';
 
 import type {Input} from '@clayui/time-picker';
 
-interface IProps extends React.HTMLAttributes<HTMLInputElement> {
+interface IProps
+	extends Omit<React.HTMLAttributes<HTMLInputElement>, 'onChange'> {
 	/**
 	 * Labels for the aria attributes
 	 */
@@ -40,9 +37,30 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	dateFormat?: string;
 
 	/**
+	 * Property to set if expanded by default (uncontrolled).
+	 */
+	defaultExpanded?: boolean;
+
+	/**
+	 * The start date to be displayed on the calendar as "Today". Used to mark
+	 * the start date of the day and when resetting.
+	 */
+	defaultMonth?: Date;
+
+	/**
+	 * Property to set the default value (uncontrolled).
+	 */
+	defaultValue?: string;
+
+	/**
 	 * Flag to disable the component, buttons, open the datepicker, etc...
 	 */
 	disabled?: boolean;
+
+	/**
+	 * Determines if menu is expanded or not (controlled).
+	 */
+	expanded?: boolean;
 
 	/**
 	 * Set the first day of the week, starting from
@@ -64,12 +82,14 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	/**
 	 * Flag to indicate if date is initially expanded when
 	 * `expand` and `onExpandChange` are not being used.
+	 * @deprecated since v3.51.0 - use `defaultExpanded` instead.
 	 */
 	initialExpanded?: boolean;
 
 	/**
 	 * The start date to be displayed on the calendar as "Today". Used to mark
 	 * the start date of the day and when resetting.
+	 * @deprecated since v3.51.0 - use `defaultMonth` instead.
 	 */
 	initialMonth?: Date;
 
@@ -84,6 +104,16 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	months?: Array<string>;
 
 	/**
+	 * Callback that is called when the value changes (controlled).
+	 */
+	onChange?: InternalDispatch<string>;
+
+	/**
+	 * Callback for when dropdown changes its expanded state (controlled).
+	 */
+	onExpandedChange?: InternalDispatch<boolean>;
+
+	/**
 	 * Called when the user is browsing the date picker, changing the
 	 * month, year and navigating with arrows.
 	 */
@@ -93,8 +123,9 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	 * Called when the input change.
 	 *
 	 * Second argument gives the type that caused the value change
+	 * @deprecated since v3.51.0 - use `onChange` instead.
 	 */
-	onValueChange: (value: string, type?: 'click' | 'input' | 'time') => void;
+	onValueChange?: (value: string, type?: 'click' | 'input' | 'time') => void;
 
 	/**
 	 * Describe a brief tip to help users interact.
@@ -132,9 +163,9 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	useNative?: boolean;
 
 	/**
-	 * Set the value of the input.
+	 * The value property sets the current value (controlled).
 	 */
-	value: string;
+	value?: string;
 
 	/**
 	 * Short names of days of the week to use in the header
@@ -152,16 +183,6 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	 * is included in the range of years. Disable only if your range is dynamic.
 	 */
 	yearsCheck?: boolean;
-
-	/**
-	 * Determines if menu is expanded or not
-	 */
-	expanded?: boolean;
-
-	/**
-	 * Callback for when dropdown changes its active state
-	 */
-	onExpandedChange?: TInternalStateOnChange<boolean>;
 }
 
 const DEFAULT_DATE_TIME = {
@@ -193,6 +214,9 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				buttonPreviousMonth: 'Select the previous month',
 			},
 			dateFormat = 'yyyy-MM-dd',
+			defaultExpanded,
+			defaultMonth = NEW_DATE,
+			defaultValue,
 			disabled,
 			expanded,
 			firstDayOfWeek = FirstDayOfWeek.Sunday,
@@ -215,9 +239,10 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				'November',
 				'December',
 			],
+			onChange,
 			onExpandedChange,
 			onNavigation = () => {},
-			onValueChange = () => {},
+			onValueChange,
 			placeholder,
 			range,
 			spritemap,
@@ -236,6 +261,10 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		}: IProps,
 		ref
 	) => {
+		// For backward compatibility `defaultMonth` is just an alias for
+		// `initialMonth`.
+		initialMonth = defaultMonth ?? initialMonth;
+
 		/**
 		 * Indicates the current month rendered on the screen.
 		 */
@@ -262,14 +291,26 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		 */
 		const [weeks, setWeeks] = useWeeks(currentMonth, firstDayOfWeek);
 
+		const [internalValue, setValue] = useInternalState({
+			defaultName: 'defaultValue',
+			defaultValue,
+			handleName: 'onChange',
+			name: 'value',
+			onChange: onChange ?? onValueChange,
+			value,
+		});
+
 		/**
 		 * Flag to indicate if date is expanded. Uses an internal state value
 		 * if component is not controlled by props.
 		 */
 		const [expandedValue, setExpandedValue] = useInternalState({
-			defaultName: 'initialExpanded',
+			defaultName: 'defaultExpanded',
+			defaultValue:
+				defaultExpanded === undefined
+					? initialExpanded
+					: defaultExpanded,
 			handleName: 'onExpandedChange',
-			initialValue: initialExpanded,
 			name: 'expanded',
 			onChange: onExpandedChange,
 			value: expanded,
@@ -344,12 +385,12 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			}
 
 			setDaysSelected(newDaysSelected);
-			onValueChange(daysSelectedToString, 'click');
+			setValue(daysSelectedToString);
 		};
 
 		/**
 		 * Control the value of the input propagating with the call
-		 * of `onValueChange` but does not change what the user types,
+		 * of `onChange` but does not change what the user types,
 		 * if a date is valid the month of the Date Picker is changed.
 		 */
 		const inputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -401,7 +442,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				}
 			}
 
-			onValueChange(value, 'input');
+			setValue(value);
 		};
 
 		/**
@@ -438,7 +479,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			}
 
 			setDaysSelected(newDaysSelected);
-			onValueChange(dateFormatted);
+			setValue(dateFormatted);
 		};
 
 		const handleTimeChange = (
@@ -456,7 +497,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 				minutes = 0;
 			}
 
-			if (value) {
+			if (internalValue) {
 				let date =
 					typeof hours === 'string' && typeof minutes === 'string'
 						? `${formatDate(day, dateFormat)} ${hours}:${minutes}`
@@ -469,7 +510,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 					date += ` ${ampm}`;
 				}
 
-				onValueChange(date, 'time');
+				setValue(date);
 			}
 
 			setCurrentTime(hours, minutes, use12Hours ? ampm : undefined);
@@ -518,7 +559,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 								placeholder={placeholder}
 								ref={ref}
 								useNative={useNative}
-								value={value}
+								value={internalValue}
 							/>
 							{!useNative && (
 								<ClayInput.GroupInsetItem after>

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -215,7 +215,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			},
 			dateFormat = 'yyyy-MM-dd',
 			defaultExpanded,
-			defaultMonth = NEW_DATE,
+			defaultMonth,
 			defaultValue,
 			disabled,
 			expanded,

--- a/packages/clay-date-picker/stories/DatePicker.stories.tsx
+++ b/packages/clay-date-picker/stories/DatePicker.stories.tsx
@@ -29,7 +29,7 @@ const ClayDatePickerWithState = (props: {[key: string]: any}) => {
 					buttonPreviousMonth: 'Previous month',
 					input: value.toLocaleString(),
 				}}
-				onValueChange={setValue}
+				onChange={setValue}
 				value={value}
 			/>
 		</>
@@ -116,14 +116,8 @@ export const CustomExpand = () => {
 
 			<ClayDatePicker
 				expanded={expanded}
+				onChange={setValue}
 				onExpandedChange={setExpanded}
-				onValueChange={(val, type) => {
-					setValue(val);
-
-					if (type === 'click') {
-						setExpanded(false);
-					}
-				}}
 				placeholder="YYYY-MM-DD"
 				value={value}
 				years={{
@@ -176,15 +170,7 @@ export const DynamicYears = () => {
 				buttonPreviousMonth: 'Previous month',
 				input: value.toLocaleString(),
 			}}
-			onNavigation={(date: Date) => {
-				const year = date.getFullYear();
-
-				setYears({
-					end: year + 10,
-					start: year - 10,
-				});
-			}}
-			onValueChange={(value) => {
+			onChange={(value) => {
 				if (value) {
 					const year = parseDate(
 						value,
@@ -201,6 +187,14 @@ export const DynamicYears = () => {
 				}
 
 				setValue(value);
+			}}
+			onNavigation={(date: Date) => {
+				const year = date.getFullYear();
+
+				setYears({
+					end: year + 10,
+					start: year - 10,
+				});
 			}}
 			placeholder="YYYY-MM-DD"
 			value={value}

--- a/packages/clay-drop-down/docs/drop-down.mdx
+++ b/packages/clay-drop-down/docs/drop-down.mdx
@@ -80,7 +80,7 @@ const Menu = ({children, hasLeftSymbols, hasRightSymbols}) => {
 				alignElementRef={triggerElementRef}
 				hasLeftSymbols={hasLeftSymbols}
 				hasRightSymbols={hasRightSymbols}
-				onSetActive={() => setExpand(!expand)}
+				onActiveChange={() => setExpand(!expand)}
 				ref={menuElementRef}
 			>
 				{children}

--- a/packages/clay-drop-down/docs/index.js
+++ b/packages/clay-drop-down/docs/index.js
@@ -14,13 +14,9 @@ import React from 'react';
 const dropDownImportsCode = `import ClayDropDown from '@clayui/drop-down';`;
 
 const dropDownCode = `const Component = () => {
-	const [active, setActive] = useState(false);
-
 	return (
 		<ClayDropDown
 			trigger={<button className="btn btn-primary">Click here!</button>}
-			active={active}
-			onActiveChange={setActive}
 			menuElementAttrs={{
 				className: 'my-custom-dropdown-menu',
 				containerProps: {
@@ -90,57 +86,57 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';`;
 
 const dropDownWithItemsCode = `const Component = () => {
 	const [value, setValue] = useState();
-    const items = [
-      {
-        label: 'clickable',
-        onClick: () => {
-          alert('you clicked!');
-        },
-      },
-      {
-        type: 'divider',
-      },
-      {
-        items: [
-          {
-            label: 'one',
-            type: 'radio',
-            value: 'one',
-          },
-          {
-            label: 'two',
-            type: 'radio',
-            value: 'two',
-          },
-        ],
-        label: 'radio',
-        name: 'radio',
-        onChange: (value) => alert('New Radio checked'),
-        type: 'radiogroup',
-      },
-      {
-        items: [
-          {
-            checked: true,
-            label: 'checkbox',
-            onChange: () => alert('checkbox changed'),
-            type: 'checkbox',
-          },
-          {
-            checked: true,
-            label: 'checkbox 1',
-            onChange: () => alert('checkbox changed'),
-            type: 'checkbox',
-          },
-        ],
-        label: 'checkbox',
-        type: 'group',
-      },
-      {
-        href: '#',
-        label: 'linkable',
-      },
-    ];
+	const items = [
+		{
+			label: 'clickable',
+			onClick: () => {
+				alert('you clicked!');
+			},
+		},
+		{
+			type: 'divider',
+		},
+		{
+			items: [
+				{
+					label: 'one',
+					type: 'radio',
+					value: 'one',
+				},
+				{
+					label: 'two',
+					type: 'radio',
+					value: 'two',
+				},
+			],
+			label: 'radio',
+			name: 'radio',
+			onChange: (value) => alert('New Radio checked'),
+			type: 'radiogroup',
+		},
+		{
+			items: [
+				{
+					checked: true,
+					label: 'checkbox',
+					onChange: () => alert('checkbox changed'),
+					type: 'checkbox',
+				},
+				{
+					checked: true,
+					label: 'checkbox 1',
+					onChange: () => alert('checkbox changed'),
+					type: 'checkbox',
+				},
+			],
+			label: 'checkbox',
+			type: 'group',
+		},
+		{
+			href: '#',
+			label: 'linkable',
+		},
+	];
 
 	return (
 		<ClayDropDownWithItems
@@ -182,7 +178,7 @@ import {ClayDropDownWithDrilldown} from '@clayui/drop-down';`;
 const dropDownWithDrilldownCode = `const Component = () => {
 	return (
 		<ClayDropDownWithDrilldown
-			initialActiveMenu="x0a3"
+			defaultActiveMenu="x0a3"
 			menus={{
 				x0a3: [
 					{href: '#', title: 'Hash Link'},

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -52,7 +52,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * The unique identifier of the menu that should be active on mount.
 	 * @deprecated since v3.51.0 - use `defaultActiveMenu` instead.
 	 */
-	initialActiveMenu: string;
+	initialActiveMenu?: string;
 
 	/**
 	 * Prop to pass DOM element attributes to <DropDown.Menu />.

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {TInternalStateOnChange, useInternalState} from '@clayui/shared';
+import {InternalDispatch} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -13,7 +13,7 @@ import Drilldown from './drilldown';
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
-	 * Flag to indicate if the menu should be initially active (open).
+	 * Flag to indicate if the menu should be initially open (controlled).
 	 */
 	active?: boolean;
 
@@ -39,12 +39,18 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	>['containerElement'];
 
 	/**
-	 * Property to set the initial value of `active`.
+	 * Property to set the initial value of `active` (uncontrolled).
 	 */
 	defaultActive?: boolean;
 
 	/**
 	 * The unique identifier of the menu that should be active on mount.
+	 */
+	defaultActiveMenu?: string;
+
+	/**
+	 * The unique identifier of the menu that should be active on mount.
+	 * @deprecated since v3.51.0 - use `defaultActiveMenu` instead.
 	 */
 	initialActiveMenu: string;
 
@@ -72,9 +78,9 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	offsetFn?: React.ComponentProps<typeof ClayDropDown>['offsetFn'];
 
 	/**
-	 * Callback the will be invoked when the active prop is changed.
+	 * Callback the will be invoked when the active prop is changed (controlled).
 	 */
-	onActiveChange?: TInternalStateOnChange<boolean>;
+	onActiveChange?: InternalDispatch<boolean>;
 
 	/**
 	 * Path to spritemap
@@ -106,6 +112,7 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	className,
 	containerElement,
 	defaultActive,
+	defaultActiveMenu,
 	initialActiveMenu,
 	menuElementAttrs,
 	menuHeight,
@@ -117,28 +124,22 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	spritemap,
 	trigger,
 }: IProps) => {
-	const [activeMenu, setActiveMenu] = React.useState(initialActiveMenu);
+	const [activeMenu, setActiveMenu] = React.useState(
+		defaultActiveMenu ?? initialActiveMenu
+	);
 	const [direction, setDirection] = React.useState<'prev' | 'next'>();
 	const [history, setHistory] = React.useState<Array<IHistory>>([]);
-
-	const [internalActive, setInternalActive] = useInternalState({
-		defaultName: 'defaultActive',
-		handleName: 'onActiveChange',
-		initialValue: defaultActive,
-		name: 'active',
-		onChange: onActiveChange,
-		value: active,
-	});
 
 	const menuIds = Object.keys(menus);
 
 	return (
 		<ClayDropDown
-			active={internalActive}
+			active={active}
 			alignmentByViewport={alignmentByViewport}
 			alignmentPosition={alignmentPosition}
 			className={className}
 			containerElement={containerElement}
+			defaultActive={defaultActive}
 			hasRightSymbols
 			menuElementAttrs={{
 				...menuElementAttrs,
@@ -147,7 +148,7 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 			menuHeight={menuHeight}
 			menuWidth={menuWidth}
 			offsetFn={offsetFn}
-			onActiveChange={setInternalActive}
+			onActiveChange={onActiveChange}
 			renderMenuOnClick={renderMenuOnClick}
 			trigger={trigger}
 		>

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -100,10 +100,10 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	trigger: React.ReactElement;
 }
 
-interface IHistory {
+type History = {
 	id: string;
 	title: string;
-}
+};
 
 export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 	active,
@@ -128,7 +128,7 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 		defaultActiveMenu ?? initialActiveMenu
 	);
 	const [direction, setDirection] = React.useState<'prev' | 'next'>();
-	const [history, setHistory] = React.useState<Array<IHistory>>([]);
+	const [history, setHistory] = React.useState<Array<History>>([]);
 
 	const menuIds = Object.keys(menus);
 
@@ -179,7 +179,7 @@ export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
 							onForward={(title, childId) => {
 								setHistory([
 									...history,
-									{id: activeMenu, title},
+									{id: activeMenu, title} as History,
 								]);
 
 								setDirection('next');

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -5,8 +5,8 @@
 
 import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import {
+	InternalDispatch,
 	MouseSafeArea,
-	TInternalStateOnChange,
 	useInternalState,
 } from '@clayui/shared';
 import React, {useContext, useRef, useState} from 'react';
@@ -58,7 +58,10 @@ interface IDropDownContentProps {
 }
 
 export interface IProps extends IDropDownContentProps {
-	active?: React.ComponentProps<typeof ClayDropDown>['active'];
+	/**
+	 * Flag to indicate if the DropDown menu is active or not (controlled).
+	 */
+	active?: boolean;
 
 	/**
 	 * Flag to align the DropDown menu within the viewport.
@@ -93,7 +96,7 @@ export interface IProps extends IDropDownContentProps {
 	>['containerElement'];
 
 	/**
-	 * Property to set the initial value of `active`.
+	 * Property to set the initial value of `active` (uncontrolled).
 	 */
 	defaultActive?: boolean;
 
@@ -129,7 +132,10 @@ export interface IProps extends IDropDownContentProps {
 	 */
 	offsetFn?: React.ComponentProps<typeof ClayDropDown>['offsetFn'];
 
-	onActiveChange?: TInternalStateOnChange<boolean>;
+	/**
+	 * Callback for when the active state changes (controlled).
+	 */
+	onActiveChange?: InternalDispatch<boolean>;
 
 	/**
 	 * Callback will always be called when the user is interacting with search.
@@ -418,7 +424,7 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 	className,
 	closeOnClickOutside,
 	containerElement,
-	defaultActive,
+	defaultActive = false,
 	footerContent,
 	helpText,
 	items,
@@ -437,8 +443,8 @@ export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
 }: IProps) => {
 	const [internalActive, setInternalActive] = useInternalState({
 		defaultName: 'defaultActive',
+		defaultValue: defaultActive,
 		handleName: 'onActiveChange',
-		initialValue: defaultActive,
 		name: 'active',
 		onChange: onActiveChange,
 		value: active,

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -168,7 +168,13 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Callback function for when active state changes.
 	 */
-	onSetActive: (val: boolean) => void;
+	onActiveChange?: (value: boolean) => void;
+
+	/**
+	 * Callback function for when active state changes.
+	 * @deprecated since v3.52.0 - use `onActiveChange` instead.
+	 */
+	onSetActive?: (value: boolean) => void;
 
 	/**
 	 * The modifier class `dropdown-menu-width-${width}` makes the menu expand
@@ -205,6 +211,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 					number,
 					number
 				],
+			onActiveChange,
 			onSetActive,
 			width,
 			...otherProps
@@ -214,6 +221,8 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 		// See https://github.com/microsoft/TypeScript/issues/30748#issuecomment-480197036
 		ref
 	) => {
+		const setActive = onActiveChange ?? onSetActive;
+
 		const subPortalRef = useRef<HTMLDivElement | null>(null);
 
 		useEffect(() => {
@@ -232,7 +241,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 							element.contains(event.target as Node)
 						)
 					) {
-						onSetActive(false);
+						setActive!(false);
 					}
 				};
 
@@ -253,7 +262,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 						focusRefOnEsc.current.focus();
 					}
 
-					onSetActive(false);
+					setActive!(false);
 				}
 			};
 

--- a/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
@@ -27,7 +27,7 @@ describe('ClayDropDownWithDrilldown', () => {
 	it('renders', () => {
 		const {getByTestId} = render(
 			<ClayDropDownWithDrilldown
-				initialActiveMenu="x0a3"
+				defaultActiveMenu="x0a3"
 				menus={{
 					x0a3: [
 						{href: '#', title: 'Hash Link'},

--- a/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
@@ -142,7 +142,7 @@ describe('ClayDropDownWithDrilldown', () => {
 	it('renders with the menu initially active', () => {
 		render(
 			<ClayDropDownWithDrilldown
-				active
+				defaultActive
 				initialActiveMenu="x0a3"
 				menus={{
 					x0a3: [
@@ -165,6 +165,7 @@ describe('ClayDropDownWithDrilldown', () => {
 
 		const {getByTestId} = render(
 			<ClayDropDownWithDrilldown
+				active={false}
 				initialActiveMenu="x0a3"
 				menus={{
 					x0a3: [
@@ -185,7 +186,7 @@ describe('ClayDropDownWithDrilldown', () => {
 		fireEvent.click(getByTestId('menu-item-Toggle'));
 		fireEvent.click(getByTestId('menu-item-Toggle'));
 
-		expect(onActiveChange).toHaveBeenCalledTimes(3);
+		expect(onActiveChange).toHaveBeenCalledTimes(4);
 
 		expect(document.body).toMatchSnapshot();
 	});

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -387,7 +387,7 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
   <div>
     <div>
       <div
-        class="dropdown-menu drilldown dropdown-menu-indicator-end show"
+        class="dropdown-menu drilldown dropdown-menu-indicator-end"
         style="left: -999px; top: -995px;"
       >
         <div

--- a/packages/clay-drop-down/src/__tests__/index.tsx
+++ b/packages/clay-drop-down/src/__tests__/index.tsx
@@ -19,7 +19,7 @@ const DropDownWithState: React.FunctionComponent<any> = ({
 		<ClayDropDown
 			{...others}
 			active={active}
-			onActiveChange={(val) => setActive(val)}
+			onActiveChange={setActive}
 			renderMenuOnClick
 			trigger={<button>Click Me</button>}
 		>

--- a/packages/clay-drop-down/stories/DropDown.stories.tsx
+++ b/packages/clay-drop-down/stories/DropDown.stories.tsx
@@ -66,23 +66,6 @@ const ITEMS = [
 	},
 ];
 
-const DropDownWithState = ({children, ...others}: any) => {
-	const [active, setActive] = useState(false);
-
-	return (
-		<ClayDropDown
-			{...others}
-			active={active}
-			alignmentPosition={Align.BottomLeft}
-			onActiveChange={(newVal) => setActive(newVal)}
-			renderMenuOnClick
-			trigger={<ClayButton>Click Me</ClayButton>}
-		>
-			{children}
-		</ClayDropDown>
-	);
-};
-
 export default {
 	argTypes: {
 		alignmentPosition: {
@@ -101,34 +84,28 @@ export default {
 	title: 'Design System/Components/DropDown',
 };
 
-export const Default = (args: any) => {
-	const [active, setActive] = useState(false);
-
-	return (
-		<ClayDropDown
-			active={active}
-			alignmentPosition={args.alignmentPosition}
-			menuHeight={args.height}
-			menuWidth={args.width}
-			onActiveChange={(newVal) => setActive(newVal)}
-			renderMenuOnClick={args.renderMenuOnClick}
-			trigger={<ClayButton>Click Me</ClayButton>}
-		>
-			<ClayDropDown.ItemList>
-				{[
-					{href: '#one', label: 'one'},
-					{href: '#two', label: 'two'},
-					{disabled: true, href: '#three', label: 'three'},
-					{href: '#four', label: 'four'},
-				].map(({href, label, ...otherProps}, i) => (
-					<ClayDropDown.Item href={href} key={i} {...otherProps}>
-						{label}
-					</ClayDropDown.Item>
-				))}
-			</ClayDropDown.ItemList>
-		</ClayDropDown>
-	);
-};
+export const Default = (args: any) => (
+	<ClayDropDown
+		alignmentPosition={args.alignmentPosition}
+		menuHeight={args.height}
+		menuWidth={args.width}
+		renderMenuOnClick={args.renderMenuOnClick}
+		trigger={<ClayButton>Click Me</ClayButton>}
+	>
+		<ClayDropDown.ItemList>
+			{[
+				{href: '#one', label: 'one'},
+				{href: '#two', label: 'two'},
+				{disabled: true, href: '#three', label: 'three'},
+				{href: '#four', label: 'four'},
+			].map(({href, label, ...otherProps}, i) => (
+				<ClayDropDown.Item href={href} key={i} {...otherProps}>
+					{label}
+				</ClayDropDown.Item>
+			))}
+		</ClayDropDown.ItemList>
+	</ClayDropDown>
+);
 
 Default.args = {
 	alignmentPosition: 5,
@@ -138,7 +115,11 @@ Default.args = {
 };
 
 export const Groups = () => (
-	<DropDownWithState>
+	<ClayDropDown
+		alignmentPosition={Align.BottomLeft}
+		renderMenuOnClick
+		trigger={<ClayButton>Click Me</ClayButton>}
+	>
 		<ClayDropDown.ItemList>
 			<ClayDropDown.Group header="Group #1">
 				{[
@@ -164,11 +145,15 @@ export const Groups = () => (
 				))}
 			</ClayDropDown.Group>
 		</ClayDropDown.ItemList>
-	</DropDownWithState>
+	</ClayDropDown>
 );
 
 export const Checkbox = () => (
-	<DropDownWithState>
+	<ClayDropDown
+		alignmentPosition={Align.BottomLeft}
+		renderMenuOnClick
+		trigger={<ClayButton>Click Me</ClayButton>}
+	>
 		<ClayDropDown.ItemList>
 			<ClayDropDown.Section>
 				<ClayCheckbox
@@ -178,14 +163,18 @@ export const Checkbox = () => (
 				/>
 			</ClayDropDown.Section>
 		</ClayDropDown.ItemList>
-	</DropDownWithState>
+	</ClayDropDown>
 );
 
 export const Search = () => {
 	const [query, setQuery] = useState('');
 
 	return (
-		<DropDownWithState>
+		<ClayDropDown
+			alignmentPosition={Align.BottomLeft}
+			renderMenuOnClick
+			trigger={<ClayButton>Click Me</ClayButton>}
+		>
 			<ClayDropDown.Search
 				onChange={(event) => setQuery(event.target.value)}
 				value={query}
@@ -205,12 +194,16 @@ export const Search = () => {
 						</ClayDropDown.Item>
 					))}
 			</ClayDropDown.ItemList>
-		</DropDownWithState>
+		</ClayDropDown>
 	);
 };
 
 export const Radio = () => (
-	<DropDownWithState>
+	<ClayDropDown
+		alignmentPosition={Align.BottomLeft}
+		renderMenuOnClick
+		trigger={<ClayButton>Click Me</ClayButton>}
+	>
 		<ClayDropDown.ItemList>
 			<ClayDropDown.Group header="Order">
 				<ClayDropDown.Section>
@@ -221,11 +214,15 @@ export const Radio = () => (
 				</ClayDropDown.Section>
 			</ClayDropDown.Group>
 		</ClayDropDown.ItemList>
-	</DropDownWithState>
+	</ClayDropDown>
 );
 
 export const CaptionAndHelp = () => (
-	<DropDownWithState>
+	<ClayDropDown
+		alignmentPosition={Align.BottomLeft}
+		renderMenuOnClick
+		trigger={<ClayButton>Click Me</ClayButton>}
+	>
 		<ClayDropDown.Help>Can I help you?</ClayDropDown.Help>
 
 		<ClayDropDown.ItemList>
@@ -241,11 +238,17 @@ export const CaptionAndHelp = () => (
 		</ClayDropDown.ItemList>
 
 		<ClayDropDown.Caption>... or maybe not.</ClayDropDown.Caption>
-	</DropDownWithState>
+	</ClayDropDown>
 );
 
 export const ItemsWithIcons = () => (
-	<DropDownWithState hasLeftSymbols hasRightSymbols>
+	<ClayDropDown
+		alignmentPosition={Align.BottomLeft}
+		hasLeftSymbols
+		hasRightSymbols
+		renderMenuOnClick
+		trigger={<ClayButton>Click Me</ClayButton>}
+	>
 		<ClayDropDown.ItemList>
 			{[
 				{label: 'Left', left: 'trash'},
@@ -261,11 +264,16 @@ export const ItemsWithIcons = () => (
 				</ClayDropDown.Item>
 			))}
 		</ClayDropDown.ItemList>
-	</DropDownWithState>
+	</ClayDropDown>
 );
 
 export const CustomOffset = () => (
-	<DropDownWithState offsetFn={() => [20, 20]}>
+	<ClayDropDown
+		alignmentPosition={Align.BottomLeft}
+		offsetFn={() => [20, 20]}
+		renderMenuOnClick
+		trigger={<ClayButton>Click Me</ClayButton>}
+	>
 		<ClayDropDown.ItemList>
 			{[
 				{href: '#one', label: 'one'},
@@ -278,7 +286,7 @@ export const CustomOffset = () => (
 				</ClayDropDown.Item>
 			))}
 		</ClayDropDown.ItemList>
-	</DropDownWithState>
+	</ClayDropDown>
 );
 
 export const AlignmentPositions = () => (

--- a/packages/clay-form/BREAKING.md
+++ b/packages/clay-form/BREAKING.md
@@ -1,1 +1,3 @@
 # List of Breaking Changes for 4.x
+
+-   `onChange` will return only the value instead of the event.

--- a/packages/clay-form/docs/radiogroup.js
+++ b/packages/clay-form/docs/radiogroup.js
@@ -10,13 +10,10 @@ import React from 'react';
 const radioGroupImportsCode = `import {ClayRadio, ClayRadioGroup} from '@clayui/form';`;
 
 const radioGroupCode = `const Component = () => {
-	const [value, setValue] = useState('one');
-
 	return (
 		<ClayRadioGroup
+			defaultValue="one"
 			inline
-			onSelectedValueChange={val => setValue(val)}
-			selectedValue={value}
 		>
 			<ClayRadio label="One" value="one" />
 			<ClayRadio label="Two" value="two" />

--- a/packages/clay-form/src/RadioGroup.tsx
+++ b/packages/clay-form/src/RadioGroup.tsx
@@ -3,19 +3,26 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {InternalDispatch, useInternalState} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
 import {IRadioProps} from './Radio';
 import {IToggleProps} from './Toggle';
 
-interface IGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+interface IGroupProps
+	extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
 	/**
 	 * Takes either Radio or Toggle as a child.
 	 */
 	children: Array<
 		React.ReactElement<IRadioProps> | React.ReactElement<IToggleProps>
 	>;
+
+	/**
+	 * Property to set the default value (uncontrolled).
+	 */
+	defaultValue?: React.ReactText;
 
 	/**
 	 * Flag to indicate if radio elements should display inline.
@@ -28,26 +35,50 @@ interface IGroupProps extends React.HTMLAttributes<HTMLDivElement> {
 	name?: string;
 
 	/**
-	 * Callback function for whenever a radio element is selected.
+	 * Callback function for whenever a radio element is selected (controlled).
 	 */
-	onSelectedValueChange: (val: React.ReactText) => void;
+	onChange?: InternalDispatch<React.ReactText>;
+
+	/**
+	 * Callback function for whenever a radio element is selected.
+	 * @deprecated since v3.51.0 - use `onChange` instead.
+	 */
+	onSelectedValueChange?: InternalDispatch<React.ReactText>;
 
 	/**
 	 * The value that corresponds to the selected radio element. Leave
 	 * undefined if no option is selected.
+	 * @deprecated since v3.51.0 - use `value` instead.
 	 */
 	selectedValue?: React.ReactText;
+
+	/**
+	 * The value property sets the current value (controlled).
+	 */
+	value?: React.ReactText;
 }
 
 const ClayRadioGroup: React.FunctionComponent<IGroupProps> = ({
 	children,
 	className,
+	defaultValue,
 	inline,
 	name,
+	onChange,
 	onSelectedValueChange,
 	selectedValue,
+	value,
 	...otherProps
 }: IGroupProps) => {
+	const [internalValue, setValue] = useInternalState({
+		defaultName: 'defaultValue',
+		defaultValue,
+		handleName: 'onChange',
+		name: 'value',
+		onChange: onChange ?? onSelectedValueChange,
+		value: value ?? selectedValue,
+	});
+
 	return (
 		<div {...otherProps} className={classNames(className)}>
 			{React.Children.map(
@@ -55,12 +86,11 @@ const ClayRadioGroup: React.FunctionComponent<IGroupProps> = ({
 				(child: React.ReactElement<IToggleProps | IRadioProps>, i) => {
 					return React.cloneElement(child, {
 						...child.props,
-						checked: selectedValue === child.props.value,
+						checked: internalValue === child.props.value,
 						inline,
 						key: i,
 						name,
-						onChange: () =>
-							onSelectedValueChange(child.props.value!),
+						onChange: () => setValue(child.props.value!),
 						type: 'radio',
 					});
 				}

--- a/packages/clay-form/src/__tests__/RadioGroup.tsx
+++ b/packages/clay-form/src/__tests__/RadioGroup.tsx
@@ -27,11 +27,14 @@ describe('Rendering', () => {
 describe('Interactions', () => {
 	afterEach(cleanup);
 
-	it('selecting a radio element should fire the onChange prop with the new value', () => {
+	it('selecting a radio element should fire the onSelectedValueChange prop with the new value', () => {
 		const handleSelectedChange = jest.fn();
 
 		const {getByLabelText} = render(
-			<ClayRadioGroup onChange={handleSelectedChange} value="one">
+			<ClayRadioGroup
+				onSelectedValueChange={handleSelectedChange}
+				selectedValue="one"
+			>
 				<ClayRadio label="One" value="one" />
 				<ClayRadio label="Two" value="two" />
 				<ClayRadio label="Three" value="three" />
@@ -44,6 +47,25 @@ describe('Interactions', () => {
 
 		expect(handleSelectedChange).toHaveBeenCalledTimes(1);
 		expect(handleSelectedChange).toHaveBeenCalledWith('three');
+	});
+
+	it('selecting a radio element should fire the onChange prop with the new value', () => {
+		const onChange = jest.fn();
+
+		const {getByLabelText} = render(
+			<ClayRadioGroup onChange={onChange} value="one">
+				<ClayRadio label="One" value="one" />
+				<ClayRadio label="Two" value="two" />
+				<ClayRadio label="Three" value="three" />
+			</ClayRadioGroup>
+		);
+
+		const radioThree = getByLabelText('Three');
+
+		fireEvent.click(radioThree as HTMLButtonElement, {});
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange).toHaveBeenCalledWith('three');
 	});
 
 	it('select a radio element with the uncontrolled component', () => {

--- a/packages/clay-form/src/__tests__/RadioGroup.tsx
+++ b/packages/clay-form/src/__tests__/RadioGroup.tsx
@@ -13,10 +13,7 @@ import ClayRadioGroup from '../RadioGroup';
 describe('Rendering', () => {
 	it('default', () => {
 		const testRenderer = TestRenderer.create(
-			<ClayRadioGroup
-				onSelectedValueChange={() => {}}
-				selectedValue="one"
-			>
+			<ClayRadioGroup defaultValue="one">
 				<ClayRadio label="One" value="one" />
 				<ClayRadio label="Two" value="two" />
 				<ClayRadio label="Three" value="three" />
@@ -30,14 +27,11 @@ describe('Rendering', () => {
 describe('Interactions', () => {
 	afterEach(cleanup);
 
-	it('selecting a radio element should fire the onSelectedValueChange prop with the new value', () => {
+	it('selecting a radio element should fire the onChange prop with the new value', () => {
 		const handleSelectedChange = jest.fn();
 
 		const {getByLabelText} = render(
-			<ClayRadioGroup
-				onSelectedValueChange={handleSelectedChange}
-				selectedValue="one"
-			>
+			<ClayRadioGroup onChange={handleSelectedChange} value="one">
 				<ClayRadio label="One" value="one" />
 				<ClayRadio label="Two" value="two" />
 				<ClayRadio label="Three" value="three" />
@@ -50,5 +44,25 @@ describe('Interactions', () => {
 
 		expect(handleSelectedChange).toHaveBeenCalledTimes(1);
 		expect(handleSelectedChange).toHaveBeenCalledWith('three');
+	});
+
+	it('select a radio element with the uncontrolled component', () => {
+		const {getByLabelText} = render(
+			<ClayRadioGroup defaultValue="one">
+				<ClayRadio label="One" value="one" />
+				<ClayRadio label="Two" value="two" />
+				<ClayRadio label="Three" value="three" />
+			</ClayRadioGroup>
+		);
+
+		const radioOne = getByLabelText('One') as HTMLInputElement;
+
+		expect(radioOne.checked).toBe(true);
+
+		const radioThree = getByLabelText('Three') as HTMLInputElement;
+
+		fireEvent.click(radioThree as HTMLButtonElement, {});
+
+		expect(radioThree.checked).toBe(true);
 	});
 });

--- a/packages/clay-modal/docs/index.js
+++ b/packages/clay-modal/docs/index.js
@@ -14,14 +14,11 @@ import ClayModal, {useModal} from '@clayui/modal';
 `;
 
 const modalCode = `const Component = () => {
-	const [visible, setVisible] = useState(false);
-	const {observer, onClose} = useModal({
-		onClose: () => setVisible(false),
-	});
+	const {observer, onOpenChange, open} = useModal();
 
 	return (
 		<>
-			{visible && (
+			{open && (
 				<ClayModal
 					observer={observer}
 					size="lg"
@@ -44,12 +41,12 @@ const modalCode = `const Component = () => {
 							</ClayButton.Group>
 						}
 						last={
-							<ClayButton onClick={onClose}>{'Primary'}</ClayButton>
+							<ClayButton onClick={() => onOpenChange(false)}>{'Primary'}</ClayButton>
 						}
 					/>
 				</ClayModal>
 			)}
-			<ClayButton displayType="primary" onClick={() => setVisible(true)}>
+			<ClayButton onClick={() => onOpenChange(true)}>
 				{'Open modal'}
 			</ClayButton>
 		</>

--- a/packages/clay-modal/docs/modal.mdx
+++ b/packages/clay-modal/docs/modal.mdx
@@ -10,8 +10,8 @@ import {ClayModalHeaderExamples, Modal} from '$packages/clay-modal/docs/index';
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [useModal hook](#usemodal-hook)
-    -   [Usage](#usage)
+-   [Usage](#usage)
+    -   [useModal hook](#usemodal-hook)
 -   [Header](#header)
 -   [Provider](#provider)
 
@@ -22,83 +22,55 @@ You may want to compose your content and customize with your use cases or add yo
 
 <Modal />
 
-### useModal hook
+### Usage
+
+Modal can be controlled using the `useModal` hook without the need for additional state, it handles the animations for you.
+
+```jsx
+const Dialog = () => {
+	const {observer, onOpenChange, open} = useModal();
+
+	return (
+		<>
+			{open && (
+				<ClayModal observer={observer} spritemap={spritemap}>
+					<ClayModal.Header>Title</ClayModal.Header>
+					<ClayModal.Body>Body</ClayModal.Body>
+					<ClayModal.Footer
+						last={
+							<ClayButton onClick={() => onOpenChange(false)}>
+								Close
+							</ClayButton>
+						}
+					/>
+				</ClayModal>
+			)}
+			<ClayButton onClick={() => onOpenChange(true)}>
+				Open modal
+			</ClayButton>
+		</>
+	);
+};
+```
+
+#### useModal hook
 
 The `useModal` [hook](https://reactjs.org/docs/hooks-intro.html) is required to create a Modal component in Clay, it is responsible for communicating with ClayModal and controlling states to make animations, this is necessary because Modal needs animation when opening and closing so we need to delay calls of the `onClose` so you can safely control Modal's visibility or do other things.
 
 `useModal` returns a signature with `observer` and `onClose`:
 
 -   **observer** - Observer is the communication channel that connects ClayModal with `useModal`.
--   **onClose** - Callback is called after Modal's close animation.
+-   **onOpenChange** - Callback to change open state.
+-   **open** - Flag to indicate the open state of the modal.
 
 ```jsx
-const {observer, onClose} = useModal({
-	onClose: () => setVisible(false),
-});
+const {observer, onOpenChange, open} = useModal();
 ```
 
 <div class="clay-site-alert alert alert-warning">
 	To avoid future problems, do not use the information or change the values
 	​​of `observer`, it is considered a bad practice.
 </div>
-
-To prevent Modal from closing before animation always use the `onClose` method returned by `useModal`.
-
-```diff
-<ClayModal.Footer
--   last={<ClayButton onClick={() => setVisible(false)}>{"Primary"}</ClayButton>}
-+   last={<ClayButton onClick={onClose}>{"Primary"}</ClayButton>}
-/>
-```
-
-#### Usage
-
-`useModal` is a hook so it implies that you cannot use ClayModal directly in a class component. If you'd like to use it in a class component, try the recommended strategy below.
-
--   Wrap ClayModal and `useModal` in a function component.
-
-```jsx
-const ModalWithDialog = ({visible, onClose, title, body}) => {
-    const { observer, onClose: close } = useModal({
-        onClose: onVisible,
-    });
-
-    if (!visible) {
-        return;
-    }
-
-    return (
-        <ClayModal
-            observer={observer}
-            spritemap={spritemap}
-        >
-            <ClayModal.Header>{title}</ClayModal.Header>
-            <ClayModal.Body>
-                {body}
-            </ClayModal.Body>
-            <ClayModal.Footer
-                last={<ClayButton onClick={close}>{"Close"}</ClayButton>}
-            />
-        </ClayModal>
-    );
-};
-
-// This is pseudocode
-class Page extends Component {
-    render() {
-        return (
-            <>
-                <ModalWithDialog visible={this.state.visible} onClose={() => this.setVisible(false)} title={...} body={...} />
-                <ClayButton displayType="primary" onClick={() => this.setVisible(true)}>
-                    {"Open modal"}
-                </ClayButton>
-            <>
-        );
-    }
-}
-```
-
-`useModal` may be lost if you raise the visible condition above the hook, if Modal happens to be unmounted at the same time as the component. Ideally the hook is not unmounted every time Modal is opened and closed.
 
 ### Header
 
@@ -158,15 +130,15 @@ const MyApp = () => {
 
 Provider contains two different states that you can control:
 
--   **Close** - 0
--   **Open** - 1
+-   **Close** - CLOSE
+-   **Open** - OPEN
 
 The context signature is similar to a [`useReducer`](https://reactjs.org/docs/hooks-reference.html#usereducer), contains `state` and `dispatch`.
 
 ```js
 const [state, dispatch] = useContext(Context);
 
-dispatch({payload: {...}, type: 1});
+dispatch({payload: {...}, type: 'OPEN'});
 ```
 
 `state` returns all values that are passed to dispatch payload and you can pass `body`, `footer`, `header`, `size`, `status` and `url` to payload.

--- a/packages/clay-modal/src/Provider.tsx
+++ b/packages/clay-modal/src/Provider.tsx
@@ -10,8 +10,8 @@ import {Size, Status} from './types';
 import {useModal} from './useModal';
 
 enum Action {
-	Close = 0,
-	Open = 1,
+	Close = 'CLOSE',
+	Open = 'OPEN',
 }
 
 interface IProps {
@@ -61,7 +61,9 @@ type TState = {
 	url?: string;
 };
 
-type TAction = {type: Action.Open; payload: TState} | {type: Action.Close};
+type TAction =
+	| {type: Action.Open | 1; payload: TState}
+	| {type: Action.Close | 0};
 
 type TProvider = [TState & {onClose: () => void}, React.Dispatch<TAction>];
 
@@ -77,8 +79,10 @@ const reducer = (
 	action: TAction
 ): TState & {visible: boolean} => {
 	switch (action.type) {
+		case 1:
 		case Action.Open:
 			return {...action.payload, visible: true};
+		case 0:
 		case Action.Close:
 			return initialState;
 		default:

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -40,6 +40,19 @@ const ModalWithState: React.FunctionComponent<IProps> = ({
 	);
 };
 
+const ModalWithHookState = () => {
+	const {observer, onOpenChange, open} = useModal();
+
+	return (
+		<>
+			{open && <ClayModal observer={observer} spritemap={spritemap} />}
+			<Button aria-label="button" onClick={() => onOpenChange(true)}>
+				Foo
+			</Button>
+		</>
+	);
+};
+
 describe('Modal -> IncrementalInteractions', () => {
 	afterEach(() => {
 		jest.clearAllTimers();
@@ -62,6 +75,22 @@ describe('Modal -> IncrementalInteractions', () => {
 
 	it('open the modal', () => {
 		const {container, getByLabelText} = render(<ModalWithState />);
+
+		expect(document.body.classList).not.toContain('modal-open');
+
+		fireEvent.click(getByLabelText('button'), {});
+
+		expect(document.body.classList).toContain('modal-open');
+		expect(
+			container.querySelector('.modal-backdrop.fade.show')
+		).toBeDefined();
+		expect(
+			container.querySelector('.fade.modal.d-block.show')
+		).toBeDefined();
+	});
+
+	it('open the modal with useModal state', () => {
+		const {container, getByLabelText} = render(<ModalWithHookState />);
 
 		expect(document.body.classList).not.toContain('modal-open');
 

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -29,7 +29,7 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
       class="fade modal d-block show"
     >
       <div
-        aria-labelledby="clay-modal-label-8"
+        aria-labelledby="clay-modal-label-9"
         class="modal-dialog modal-lg"
         role="dialog"
         tabindex="-1"
@@ -42,7 +42,7 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
           >
             <div
               class="modal-title"
-              id="clay-modal-label-8"
+              id="clay-modal-label-9"
             >
               Title
             </div>

--- a/packages/clay-modal/src/useModal.tsx
+++ b/packages/clay-modal/src/useModal.tsx
@@ -3,16 +3,45 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 
-import {ObserverType} from './types';
+import {Observer, ObserverType} from './types';
 
-interface IProps {
+type Props = {
+	/**
+	 * Set the default value of the state of the modal dialog.
+	 */
+	defaultOpen?: boolean;
+
 	/**
 	 * Callback called to close the modal.
+	 * @deprecated since v3.52.0 - use the `open` and `onOpenChange` properties
+	 * of the hook return and remove its state.
 	 */
 	onClose?: () => void;
-}
+};
+
+type Return = {
+	/**
+	 * Observer is an internal property that must be connected to the <ClayModal /> component.
+	 */
+	observer: Observer;
+
+	/**
+	 * Callback to close the modal, aliased to `onOpenChange` callback.
+	 */
+	onClose: () => void;
+
+	/**
+	 * Callback to change open state.
+	 */
+	onOpenChange: (value: boolean) => void;
+
+	/**
+	 * Sets the open state of the modal.
+	 */
+	open: boolean;
+};
 
 const delay = (fn: Function) => {
 	return setTimeout(() => {
@@ -22,12 +51,14 @@ const delay = (fn: Function) => {
 
 const modalOpenClassName = 'modal-open';
 
-export const useModal = ({onClose = () => {}}: IProps) => {
-	const [visible, setVisible] = React.useState<[boolean, boolean]>([
-		false,
-		false,
-	]);
-	const timerIdRef = React.useRef<NodeJS.Timeout | null>(null);
+export const useModal = ({
+	defaultOpen = false,
+	onClose,
+}: Props = {}): Return => {
+	const [open, setOpen] = useState(defaultOpen);
+
+	const [visible, setVisible] = useState<[boolean, boolean]>([false, false]);
+	const timerIdRef = useRef<NodeJS.Timeout | null>(null);
 
 	/**
 	 * Control the close of the modal to create the component's "unmount"
@@ -36,14 +67,20 @@ export const useModal = ({onClose = () => {}}: IProps) => {
 	const handleCloseModal = () => {
 		document.body.classList.remove(modalOpenClassName);
 		setVisible([false, true]);
+
 		timerIdRef.current = delay(() => {
-			onClose();
+			if (onClose) {
+				onClose();
+			}
+
+			setOpen(false);
 			setVisible([false, false]);
 		});
 	};
 
 	const handleOpenModal = () => {
 		document.body.classList.add(modalOpenClassName);
+		setOpen(true);
 		timerIdRef.current = delay(() => setVisible([true, true]));
 	};
 
@@ -60,8 +97,18 @@ export const useModal = ({onClose = () => {}}: IProps) => {
 		}
 	};
 
-	React.useEffect(() => {
+	const onOpenChange = useCallback((value: boolean) => {
+		if (value) {
+			handleOpenModal();
+		} else {
+			handleCloseModal();
+		}
+	}, []);
+
+	useEffect(() => {
 		return () => {
+			document.body.classList.remove(modalOpenClassName);
+
 			if (timerIdRef.current) {
 				clearTimeout(timerIdRef.current);
 			}
@@ -74,5 +121,7 @@ export const useModal = ({onClose = () => {}}: IProps) => {
 			mutation: visible,
 		},
 		onClose: handleCloseModal,
+		onOpenChange,
+		open,
 	};
 };

--- a/packages/clay-modal/stories/Modal.stories.tsx
+++ b/packages/clay-modal/stories/Modal.stories.tsx
@@ -27,14 +27,11 @@ export default {
 };
 
 export const Default = (args: any) => {
-	const [visibleModal, setVisibleModal] = useState<boolean>(false);
-	const {observer, onClose} = useModal({
-		onClose: () => setVisibleModal(false),
-	});
+	const {observer, onOpenChange, open} = useModal();
 
 	return (
 		<>
-			{visibleModal && (
+			{open && (
 				<ClayModal
 					center={args.center}
 					disableAutoClose={args.autoClose}
@@ -81,14 +78,16 @@ export const Default = (args: any) => {
 							</ClayButton.Group>
 						}
 						last={
-							<ClayButton onClick={onClose}>Primary</ClayButton>
+							<ClayButton onClick={() => onOpenChange(false)}>
+								Primary
+							</ClayButton>
 						}
 					/>
 				</ClayModal>
 			)}
 			<ClayButton
 				displayType="primary"
-				onClick={() => setVisibleModal(true)}
+				onClick={() => onOpenChange(true)}
 			>
 				Open modal
 			</ClayButton>
@@ -107,14 +106,11 @@ Default.args = {
 };
 
 export const CustomHeader = () => {
-	const [visibleModal, setVisibleModal] = useState<boolean>(false);
-	const {observer, onClose} = useModal({
-		onClose: () => setVisibleModal(false),
-	});
+	const {observer, onOpenChange, open} = useModal();
 
 	return (
 		<>
-			{visibleModal && (
+			{open && (
 				<ClayModal observer={observer} size="lg">
 					<ClayModal.Header withTitle={false}>
 						<ClayModal.ItemGroup>
@@ -141,7 +137,7 @@ export const CustomHeader = () => {
 							aria-label="close"
 							className="close"
 							displayType="unstyled"
-							onClick={onClose}
+							onClick={() => onOpenChange(false)}
 						>
 							<ClayIcon symbol="times" />
 						</ClayButton>
@@ -152,7 +148,7 @@ export const CustomHeader = () => {
 
 			<ClayButton
 				displayType="primary"
-				onClick={() => setVisibleModal(true)}
+				onClick={() => onOpenChange(true)}
 			>
 				Open modal
 			</ClayButton>
@@ -257,14 +253,11 @@ const Autocomplete = () => {
 };
 
 export const AutocompleteAndDropDown = () => {
-	const [visibleModal, setVisibleModal] = useState<boolean>(false);
-	const {observer} = useModal({
-		onClose: () => setVisibleModal(false),
-	});
+	const {observer, onOpenChange, open} = useModal();
 
 	return (
 		<>
-			{visibleModal && (
+			{open && (
 				<ClayModal observer={observer} size="lg">
 					<ClayModal.Header>Title</ClayModal.Header>
 					<ClayModal.Body
@@ -288,7 +281,7 @@ export const AutocompleteAndDropDown = () => {
 			)}
 			<ClayButton
 				displayType="primary"
-				onClick={() => setVisibleModal(true)}
+				onClick={() => onOpenChange(true)}
 			>
 				Open modal
 			</ClayButton>

--- a/packages/clay-multi-select/docs/index.js
+++ b/packages/clay-multi-select/docs/index.js
@@ -27,11 +27,11 @@ const multiSelectCode = `const Component = () => {
 	return (
 		<ClayMultiSelect
 			inputName="myInput"
-			inputValue={value}
 			items={items}
 			onChange={setValue}
 			onItemsChange={setItems}
 			spritemap={spritemap}
+			value={value}
 		/>
 	);
 }
@@ -87,12 +87,12 @@ const multiSelectWithAutocompleteCode = `const Component = (props) => {
 		<ClayMultiSelect
 			{...props}
 			inputName="myInput"
-			inputValue={value}
 			items={items}
 			onChange={setValue}
 			onItemsChange={setItems}
 			sourceItems={sourceItems}
 			spritemap={spritemap}
+			value={value}
 		/>
 	);
 }
@@ -152,12 +152,12 @@ const multiSelectWithSelectButtonCode = `const Component = () => {
 				<ClayInput.GroupItem>
 					<ClayMultiSelect
 						inputName="myInput"
-						inputValue={value}
 						items={items}
 						onChange={setValue}
 						onItemsChange={setItems}
 						sourceItems={sourceItems}
 						spritemap={spritemap}
+						value={value}
 					/>
 				</ClayInput.GroupItem>
 				<ClayInput.GroupItem shrink>
@@ -228,12 +228,12 @@ const multiSelectWithValidationCode = `const Component = () => {
 				<ClayInput.GroupItem>
 					<ClayMultiSelect
 						inputName="myInput"
-						inputValue={value}
 						items={items}
 						onChange={setValue}
 						onItemsChange={setItems}
 						sourceItems={sourceItems}
 						spritemap={spritemap}
+						value={value}
 					/>
 
 					<ClayForm.FeedbackGroup>
@@ -338,13 +338,13 @@ const Component = () => {
 	return (
 		<ClayMultiSelect
 			inputName="myInput"
-			inputValue={value}
 			items={items}
 			menuRenderer={MenuCustom}
 			onChange={setValue}
 			onItemsChange={setItems}
 			sourceItems={sourceItems}
 			spritemap={spritemap}
+			value={value}
 		/>
 	);
 }

--- a/packages/clay-multi-select/src/__tests__/index.tsx
+++ b/packages/clay-multi-select/src/__tests__/index.tsx
@@ -368,10 +368,10 @@ describe('Interactions', () => {
 					inputValue={value}
 					isLoading={isLoading}
 					items={selectedItems}
-					onChange={(newInputVal) => {
-						setValue(newInputVal);
+					onChange={(value: string) => {
+						setValue(value);
 
-						asyncData(newInputVal);
+						asyncData(value);
 					}}
 					onItemsChange={setSelectedItems}
 					sourceItems={items}

--- a/packages/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/packages/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -50,18 +50,17 @@ const ClayMultiSelectWithAutocomplete = (props: any) => {
 	return (
 		<ClayMultiSelect
 			inputName="myInput"
-			inputValue={value}
 			items={items}
 			onChange={setValue}
 			onItemsChange={setItems}
 			sourceItems={itemLabelFilter(sourceItems, value)}
+			value={value}
 			{...props}
 		/>
 	);
 };
 
 export const Default = (args: any) => {
-	const [value, setValue] = useState('');
 	const [items, setItems] = useState([
 		{
 			label: 'one',
@@ -78,11 +77,9 @@ export const Default = (args: any) => {
 				disabledClearAll={args.disabledClearAll}
 				id="multiSelect"
 				inputName="myInput"
-				inputValue={value}
 				isValid={args.isValid}
 				items={items}
-				onChange={setValue}
-				onItemsChange={(val) => setItems(val as any)}
+				onItemsChange={setItems}
 			/>
 		</>
 	);
@@ -95,7 +92,6 @@ Default.args = {
 };
 
 export const ComparingItems = () => {
-	const [value, setValue] = useState('');
 	const [items, setItems] = useState<
 		React.ComponentProps<typeof ClayMultiSelect>['items']
 	>([
@@ -112,9 +108,7 @@ export const ComparingItems = () => {
 			<ClayMultiSelect
 				id="multiSelect"
 				inputName="myInput"
-				inputValue={value}
 				items={items}
-				onChange={setValue}
 				onItemsChange={(itemsChanged) => {
 					const removedItems = items.filter(
 						(value) => !itemsChanged.includes(value)
@@ -152,11 +146,11 @@ export const SourceItems = () => {
 
 			<ClayMultiSelect
 				inputName="myInput"
-				inputValue={value}
 				items={items}
 				onChange={setValue}
 				onItemsChange={(val) => setItems(val as any)}
 				sourceItems={itemLabelFilter(sourceItems, value)}
+				value={value}
 			/>
 		</>
 	);
@@ -195,7 +189,6 @@ const MenuCustom: React.ComponentProps<typeof ClayMultiSelect>['menuRenderer'] =
 	);
 
 export const CustomMenu = () => {
-	const [value, setValue] = React.useState('');
 	const [items, setItems] = React.useState([
 		{
 			email: 'one@example.com',
@@ -211,10 +204,8 @@ export const CustomMenu = () => {
 			<ClayMultiSelectWithAutocomplete
 				id="multiSelect"
 				inputName="myInput"
-				inputValue={value}
 				items={items}
 				menuRenderer={MenuCustom}
-				onChange={setValue}
 				onItemsChange={setItems}
 				sourceItems={[
 					{
@@ -239,11 +230,11 @@ export const CustomFilter = () => {
 
 	return (
 		<ClayMultiSelect
-			inputValue={value}
 			items={items}
 			onChange={setValue}
 			onItemsChange={setItems}
 			sourceItems={sourceItems.filter((item) => item.label.match(value))}
+			value={value}
 		/>
 	);
 };
@@ -271,7 +262,6 @@ export const Async = () => {
 
 	return (
 		<ClayMultiSelect
-			inputValue={value}
 			isLoading={isLoading}
 			items={items}
 			onChange={(newInputVal) => {
@@ -281,6 +271,7 @@ export const Async = () => {
 			}}
 			onItemsChange={setItems}
 			sourceItems={dropdownItems}
+			value={value}
 		/>
 	);
 };

--- a/packages/clay-multi-step-nav/docs/index.js
+++ b/packages/clay-multi-step-nav/docs/index.js
@@ -120,9 +120,9 @@ const multiStepNavWithBasicItemsCode = `const Component = (props) => {
 
 	return (
 		<ClayMultiStepNavWithBasicItems
-			activeIndex={active}
+			active={active}
 			maxStepsShown={2}
-			onIndexChange={setActive}
+			onActiveChange={setActive}
 			spritemap={spritemap}
 			steps={steps}
 		/>

--- a/packages/clay-multi-step-nav/package.json
+++ b/packages/clay-multi-step-nav/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@clayui/drop-down": "^3.52.0",
 		"@clayui/icon": "^3.40.0",
+		"@clayui/shared": "^3.52.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
+++ b/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
@@ -4,6 +4,7 @@
  */
 
 import {ClayDropDownWithItems} from '@clayui/drop-down';
+import {InternalDispatch, useInternalState} from '@clayui/shared';
 import React from 'react';
 
 import ClayMultiStepNav from './MultiStepNav';
@@ -22,9 +23,20 @@ interface ISteps {
 
 interface IProps extends React.ComponentProps<typeof ClayMultiStepNav> {
 	/**
-	 * Value for which step index is active
+	 * Value for which step index is active (controlled).
 	 */
-	activeIndex: number;
+	active?: number;
+
+	/**
+	 * Value for which step index is active
+	 * @deprecated since v3.52.0 - use `active` instead.
+	 */
+	activeIndex?: number;
+
+	/**
+	 * Set the default value of active state (uncontrolled).
+	 */
+	defaultActive?: number;
 
 	/**
 	 * Determines at what point a dropdown is show. The dropdown will
@@ -35,7 +47,13 @@ interface IProps extends React.ComponentProps<typeof ClayMultiStepNav> {
 	/**
 	 * Callback for when step is clicked
 	 */
-	onIndexChange: (val: number) => void;
+	onActiveChange?: InternalDispatch<number>;
+
+	/**
+	 * Callback for when step is clicked
+	 * @deprecated since v3.52.0 - use `onActiveChange` instead.
+	 */
+	onIndexChange?: InternalDispatch<number>;
 
 	/**
 	 * Path to spritemap for icon symbol.
@@ -65,13 +83,25 @@ IndicatorWithInnerRef.displayName = 'ClayIndicatorWithInnerRef';
 
 export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<IProps> =
 	({
+		active,
 		activeIndex,
+		defaultActive,
 		maxStepsShown = MAX_STEPS_SHOWN,
+		onActiveChange,
 		onIndexChange,
 		spritemap,
 		steps,
 		...otherProps
 	}: IProps) => {
+		const [internalActive, setActive] = useInternalState({
+			defaultName: 'defaultActive',
+			defaultValue: defaultActive,
+			handleName: 'onActiveChange',
+			name: 'value',
+			onChange: onActiveChange ?? onIndexChange,
+			value: typeof active === 'undefined' ? activeIndex : active,
+		});
+
 		let dropdownItems;
 		let showSteps = steps;
 		const indexEnd = steps.length - 1;
@@ -87,10 +117,11 @@ export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<IProps> =
 					const index = indexBeforeDropdown + i;
 
 					return {
-						active: activeIndex === index,
+						active: internalActive === index,
 						label: `${index + 1}. ${step.title}`,
-						onClick: () => onIndexChange(index),
-						symbolRight: activeIndex > index ? 'check' : undefined,
+						onClick: () => setActive(index),
+						symbolRight:
+							internalActive > index ? 'check' : undefined,
 					};
 				});
 
@@ -98,16 +129,16 @@ export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<IProps> =
 		}
 
 		const activeInDropDown =
-			activeIndex > showSteps.length - 1 && activeIndex < indexEnd;
+			internalActive > showSteps.length - 1 && internalActive < indexEnd;
 
 		return (
 			<ClayMultiStepNav {...otherProps}>
 				{showSteps.map(({subTitle, title}, i: number) => {
-					const complete = activeIndex > i;
+					const complete = internalActive > i;
 
 					return (
 						<ClayMultiStepNav.Item
-							active={activeIndex === i}
+							active={internalActive === i}
 							complete={complete}
 							expand={i + 1 !== steps.length}
 							key={i}
@@ -119,7 +150,7 @@ export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<IProps> =
 							<ClayMultiStepNav.Indicator
 								complete={complete}
 								label={1 + i}
-								onClick={() => onIndexChange(i)}
+								onClick={() => setActive(i)}
 								spritemap={spritemap}
 								subTitle={subTitle}
 							/>
@@ -131,12 +162,12 @@ export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<IProps> =
 					<>
 						<ClayMultiStepNav.Item
 							active={activeInDropDown}
-							complete={activeIndex === indexEnd}
+							complete={internalActive === indexEnd}
 							expand
 						>
 							<ClayMultiStepNav.Title>
 								{activeInDropDown
-									? steps[activeIndex].title
+									? steps[internalActive].title
 									: steps[showSteps.length].title}
 							</ClayMultiStepNav.Title>
 							<ClayMultiStepNav.Divider />
@@ -149,7 +180,7 @@ export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<IProps> =
 						</ClayMultiStepNav.Item>
 
 						<ClayMultiStepNav.Item
-							active={activeIndex === indexEnd}
+							active={internalActive === indexEnd}
 						>
 							<ClayMultiStepNav.Title>
 								{lastStep.title}
@@ -157,7 +188,7 @@ export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<IProps> =
 							<ClayMultiStepNav.Divider />
 							<ClayMultiStepNav.Indicator
 								label={steps.length}
-								onClick={() => onIndexChange(indexEnd)}
+								onClick={() => setActive(indexEnd)}
 								spritemap={spritemap}
 								subTitle={lastStep.subTitle}
 							/>

--- a/packages/clay-multi-step-nav/src/__tests__/index.tsx
+++ b/packages/clay-multi-step-nav/src/__tests__/index.tsx
@@ -148,6 +148,40 @@ describe('ClayMultiStepNavWithBasicItems', () => {
 		expect(getByText('2').parentNode!.parentNode!).toHaveClass('active');
 	});
 
+	it('click on step change active state (using new properties)', () => {
+		const MultiStepNavWithBasicItems = () => {
+			const [active, setActive] = React.useState(0);
+
+			return (
+				<ClayMultiStepNavWithBasicItems
+					active={active}
+					onActiveChange={setActive}
+					spritemap={spritemap}
+					steps={[
+						{
+							subTitle: 'SubOne',
+							title: 'One',
+						},
+						{
+							subTitle: 'SubTwo',
+							title: 'Two',
+						},
+					]}
+				/>
+			);
+		};
+
+		const {getByText} = render(<MultiStepNavWithBasicItems />);
+
+		expect(getByText('2').parentNode!.parentNode!).not.toHaveClass(
+			'active'
+		);
+
+		fireEvent.click(getByText('2'));
+
+		expect(getByText('2').parentNode!.parentNode!).toHaveClass('active');
+	});
+
 	it('clicking on dropdown item activates that step', () => {
 		const {getByText} = render(
 			<ClayMultiStepNavWithBasicItemsWithState

--- a/packages/clay-multi-step-nav/stories/MultiStepNav.stories.tsx
+++ b/packages/clay-multi-step-nav/stories/MultiStepNav.stories.tsx
@@ -79,8 +79,6 @@ export const Default = () => {
 };
 
 export const MultiStepNavWithBasicItems = (args: any) => {
-	const [active, setActive] = useState(0);
-
 	const steps = [
 		{
 			subTitle: 'SubOne',
@@ -123,9 +121,7 @@ export const MultiStepNavWithBasicItems = (args: any) => {
 	return (
 		<div className="sheet">
 			<ClayMultiStepNavWithBasicItems
-				activeIndex={active}
 				maxStepsShown={args.maxStepsShown}
-				onIndexChange={setActive}
 				steps={steps}
 			/>
 		</div>

--- a/packages/clay-pagination-bar/docs/index.js
+++ b/packages/clay-pagination-bar/docs/index.js
@@ -44,8 +44,7 @@ const PaginationBarCode = `const Component = () => {
 			</ClayPaginationBar.Results>
 
 			<ClayPaginationWithBasicItems
-				activePage={1}
-				onPageChange={() => {}}
+				defaultActive={1}
 				spritemap={spritemap}
 				totalPages={10}
 			/>
@@ -70,7 +69,6 @@ const paginationWithBasicItemsImportsCode = `import {ClayPaginationBarWithBasicI
 `;
 
 const PaginationBarWithBasicItemsCode = `const Component = () => {
-	const [activePage, setActivePage] = useState(1);
 	const [delta, setDelta] = useState(5);
 
 	const deltas = [
@@ -92,12 +90,11 @@ const PaginationBarWithBasicItemsCode = `const Component = () => {
 
 	return (
 		<ClayPaginationBarWithBasicItems
+			defaultActive={1}
 			activeDelta={delta}
-			activePage={activePage}
 			deltas={deltas}
 			ellipsisBuffer={3}
 			onDeltaChange={setDelta}
-			onPageChange={setActivePage}
 			spritemap={spritemap}
 			totalItems={21}
 		/>
@@ -122,16 +119,14 @@ const paginationWithBasicItemsWithoutDropDownImportsCode = `import {ClayPaginati
 `;
 
 const PaginationBarWithBasicItemsWithoutDropDownCode = `const Component = () => {
-	const [activePage, setActivePage] = useState(1);
 	const [delta, setDelta] = useState(5);
 
 	return (
 		<ClayPaginationBarWithBasicItems
 			activeDelta={delta}
-			activePage={activePage}
+			defaultActive={1}
 			ellipsisBuffer={3}
 			onDeltaChange={setDelta}
-			onPageChange={setActivePage}
 			showDeltasDropDown={false}
 			spritemap={spritemap}
 			totalItems={21}

--- a/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
+++ b/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
@@ -6,7 +6,7 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import {ClayPaginationWithBasicItems} from '@clayui/pagination';
-import {sub} from '@clayui/shared';
+import {InternalDispatch, sub, useInternalState} from '@clayui/shared';
 import React from 'react';
 
 import PaginationBar from './PaginationBar';
@@ -42,12 +42,18 @@ interface IDelta {
 
 interface IProps extends React.ComponentProps<typeof PaginationBar> {
 	/**
+	 * Sets the currently active page (controlled).
+	 */
+	active?: number;
+
+	/**
 	 * The value of delta that is currently selected
 	 */
 	activeDelta?: number;
 
 	/**
 	 * Initialize the page that is currently active. The first page is `1`.
+	 * @deprecated since v3.52.0 - use `active` instead.
 	 */
 	activePage?: number;
 
@@ -63,6 +69,11 @@ interface IProps extends React.ComponentProps<typeof PaginationBar> {
 	 * Possible values of items per page.
 	 */
 	deltas?: Array<IDelta>;
+
+	/**
+	 * Sets the default active page (uncontrolled).
+	 */
+	defaultActive?: number;
 
 	/**
 	 * The page numbers that should be disabled. For example, `[2,5,6]`.
@@ -93,6 +104,12 @@ interface IProps extends React.ComponentProps<typeof PaginationBar> {
 	};
 
 	/**
+	 * Callback called when the state of the active page changes (controlled).
+	 * This is only used if an href is not provided.
+	 */
+	onActiveChange?: InternalDispatch<number>;
+
+	/**
 	 * Callback for when the number of elements per page changes. This is only used if
 	 * an href is not provided.
 	 */
@@ -101,6 +118,7 @@ interface IProps extends React.ComponentProps<typeof PaginationBar> {
 	/**
 	 * Callback for when the active page changes. This is only used if
 	 * an href is not provided.
+	 * @deprecated since v3.52.0 - use `onActiveChange` instead.
 	 */
 	onPageChange?: (page: number) => void;
 
@@ -128,14 +146,17 @@ const DEFAULT_LABELS = {
 
 export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> =
 	({
+		active,
 		activeDelta,
-		activePage = 1,
+		activePage,
 		alignmentPosition,
+		defaultActive = 1,
 		deltas = defaultDeltas,
 		disabledPages,
 		ellipsisBuffer,
 		hrefConstructor,
 		labels = DEFAULT_LABELS,
+		onActiveChange,
 		onDeltaChange,
 		onPageChange,
 		showDeltasDropDown = true,
@@ -143,6 +164,15 @@ export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> =
 		totalItems,
 		...otherProps
 	}: IProps) => {
+		const [internalActive, setActive] = useInternalState({
+			defaultName: 'defaultActive',
+			defaultValue: defaultActive,
+			handleName: 'onActiveChange',
+			name: 'value',
+			onChange: onActiveChange ?? onPageChange,
+			value: typeof active === 'undefined' ? activePage : active,
+		});
+
 		if (!activeDelta) {
 			activeDelta = deltas[0].label;
 		}
@@ -171,8 +201,8 @@ export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> =
 		const totalPages = Math.ceil(totalItems / activeDelta);
 
 		React.useEffect(() => {
-			if (onPageChange && activePage > totalPages) {
-				onPageChange(1);
+			if (internalActive > totalPages) {
+				setActive(1);
 			}
 		}, [totalPages]);
 
@@ -200,25 +230,21 @@ export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> =
 
 				<PaginationBar.Results>
 					{sub(labels.paginationResults, [
-						(activePage - 1) * activeDelta + 1,
-						activePage * activeDelta < totalItems
-							? activePage * activeDelta
+						(internalActive - 1) * activeDelta + 1,
+						internalActive * activeDelta < totalItems
+							? internalActive * activeDelta
 							: totalItems,
 						totalItems,
 					])}
 				</PaginationBar.Results>
 
 				<ClayPaginationWithBasicItems
-					activePage={activePage}
+					active={internalActive}
 					alignmentPosition={alignmentPosition}
 					disabledPages={disabledPages}
 					ellipsisBuffer={ellipsisBuffer}
 					hrefConstructor={hrefConstructor}
-					onPageChange={(page) => {
-						if (page && onPageChange) {
-							onPageChange(page);
-						}
-					}}
+					onActiveChange={setActive}
 					spritemap={spritemap}
 					totalPages={totalPages}
 				/>

--- a/packages/clay-pagination-bar/src/__tests__/index.tsx
+++ b/packages/clay-pagination-bar/src/__tests__/index.tsx
@@ -56,12 +56,33 @@ describe('ClayPaginationBar', () => {
 		expect(changeMock).toHaveBeenLastCalledWith(13);
 	});
 
+	it('calls onActiveChange when arrow is clicked', () => {
+		const changeMock = jest.fn();
+
+		const {getByTestId} = render(
+			<ClayPaginationBarWithBasicItems
+				active={12}
+				onActiveChange={changeMock}
+				spritemap={spritemap}
+				totalItems={100}
+			/>
+		);
+
+		fireEvent.click(getByTestId('prevArrow'), {});
+
+		expect(changeMock).toHaveBeenLastCalledWith(11);
+
+		fireEvent.click(getByTestId('nextArrow'), {});
+
+		expect(changeMock).toHaveBeenLastCalledWith(13);
+	});
+
 	it('calls onDeltaChange when select is expanded', () => {
 		const deltaChangeMock = jest.fn();
 
 		const {getByTestId} = render(
 			<ClayPaginationBarWithBasicItems
-				activePage={12}
+				defaultActive={12}
 				onDeltaChange={deltaChangeMock}
 				spritemap={spritemap}
 				totalItems={100}
@@ -78,7 +99,7 @@ describe('ClayPaginationBar', () => {
 	it('shows dropdown when pagination dropdown is clicked', () => {
 		const {getByTestId} = render(
 			<ClayPaginationBarWithBasicItems
-				activePage={12}
+				defaultActive={12}
 				spritemap={spritemap}
 				totalItems={100}
 			/>

--- a/packages/clay-pagination-bar/stories/PaginationBar.stories.tsx
+++ b/packages/clay-pagination-bar/stories/PaginationBar.stories.tsx
@@ -45,7 +45,6 @@ export const Default = () => (
 );
 
 export const WithItems = (args: any) => {
-	const [activePage, setActivePage] = useState<number>(1);
 	const [delta, setDelta] = useState<number>(5);
 
 	const deltas = [
@@ -68,11 +67,9 @@ export const WithItems = (args: any) => {
 	return (
 		<ClayPaginationBarWithBasicItems
 			activeDelta={delta}
-			activePage={activePage}
 			deltas={deltas}
 			ellipsisBuffer={args.ellipsisBuffer}
 			onDeltaChange={setDelta}
-			onPageChange={setActivePage}
 			totalItems={args.totalItems}
 		/>
 	);
@@ -84,16 +81,14 @@ WithItems.args = {
 };
 
 export const WithoutDropdown = () => {
-	const [activePage, setActivePage] = useState<number>(3);
 	const [delta, setDelta] = useState<number>(5);
 
 	return (
 		<ClayPaginationBarWithBasicItems
 			activeDelta={delta}
-			activePage={activePage}
+			defaultActive={3}
 			ellipsisBuffer={3}
 			onDeltaChange={setDelta}
-			onPageChange={setActivePage}
 			showDeltasDropDown={false}
 			totalItems={21}
 		/>

--- a/packages/clay-pagination/docs/index.js
+++ b/packages/clay-pagination/docs/index.js
@@ -36,9 +36,9 @@ const PaginationWithBasicItemsCode = `const Component = () => {
 
 	return (
 		<ClayPaginationWithBasicItems
-			activePage={active}
+			active={active}
 			ellipsisBuffer={2}
-			onPageChange={setActive}
+			onActiveChange={setActive}
 			spritemap={spritemap}
 			totalPages={25}
 		/>

--- a/packages/clay-pagination/src/__tests__/index.tsx
+++ b/packages/clay-pagination/src/__tests__/index.tsx
@@ -16,7 +16,7 @@ describe('ClayPagination', () => {
 	it('renders', () => {
 		const {container} = render(
 			<ClayPaginationWithBasicItems
-				activePage={12}
+				defaultActive={12}
 				size="lg"
 				spritemap={spritemap}
 				totalPages={25}
@@ -29,7 +29,7 @@ describe('ClayPagination', () => {
 	it('renders with only one page', () => {
 		const {container} = render(
 			<ClayPaginationWithBasicItems
-				activePage={1}
+				defaultActive={1}
 				ellipsisBuffer={1}
 				spritemap={spritemap}
 				totalPages={1}
@@ -77,10 +77,27 @@ describe('ClayPagination', () => {
 		expect(changeMock).toHaveBeenLastCalledWith(25);
 	});
 
+	it('calls onPageChange when individual page is (using new properties)', () => {
+		const changeMock = jest.fn();
+
+		const {getByText} = render(
+			<ClayPaginationWithBasicItems
+				active={12}
+				onActiveChange={changeMock}
+				spritemap={spritemap}
+				totalPages={25}
+			/>
+		);
+
+		fireEvent.click(getByText('25'), {});
+
+		expect(changeMock).toHaveBeenLastCalledWith(25);
+	});
+
 	it('disable ellipsis when disableEllipsis prop is passed', () => {
 		const {getAllByText} = render(
 			<ClayPaginationWithBasicItems
-				activePage={12}
+				defaultActive={12}
 				disableEllipsis
 				spritemap={spritemap}
 				totalPages={25}
@@ -95,7 +112,7 @@ describe('ClayPagination', () => {
 	it('render pagination with links and active item without link', () => {
 		const {getByText} = render(
 			<ClayPaginationWithBasicItems
-				activePage={12}
+				defaultActive={12}
 				ellipsisBuffer={2}
 				hrefConstructor={(page) => `/#${page}`}
 				spritemap={spritemap}
@@ -115,7 +132,7 @@ describe('ClayPagination', () => {
 	it('shows dropdown when ellipsis is clicked', () => {
 		const {getAllByText} = render(
 			<ClayPaginationWithBasicItems
-				activePage={12}
+				defaultActive={12}
 				spritemap={spritemap}
 				totalPages={25}
 			/>

--- a/packages/clay-pagination/stories/Pagination.stories.tsx
+++ b/packages/clay-pagination/stories/Pagination.stories.tsx
@@ -4,7 +4,7 @@
  */
 
 import {number} from '@storybook/addon-knobs';
-import React, {useState} from 'react';
+import React from 'react';
 
 import ClayPagination, {ClayPaginationWithBasicItems} from '../src';
 
@@ -35,18 +35,13 @@ WithLinks.args = {
 	totalPages: 25,
 };
 
-export const WithButtons = (args: any) => {
-	const [active, setActive] = useState<number>(8);
-
-	return (
-		<ClayPaginationWithBasicItems
-			activePage={active}
-			ellipsisBuffer={args.ellipsisBuffer}
-			onPageChange={(value) => setActive(value as number)}
-			totalPages={args.totalPages}
-		/>
-	);
-};
+export const WithButtons = (args: any) => (
+	<ClayPaginationWithBasicItems
+		defaultActive={8}
+		ellipsisBuffer={args.ellipsisBuffer}
+		totalPages={args.totalPages}
+	/>
+);
 
 WithButtons.args = {
 	ellipsisBuffer: 2,
@@ -56,20 +51,20 @@ WithButtons.args = {
 export const Sizes = () => (
 	<>
 		<ClayPaginationWithBasicItems
-			activePage={number('Active Page', 8)}
+			defaultActive={number('Active Page', 8)}
 			ellipsisBuffer={number('Ellipsis Buffer', 2)}
 			hrefConstructor={(page) => `/#${page}`}
 			size="sm"
 			totalPages={25}
 		/>
 		<ClayPaginationWithBasicItems
-			activePage={number('Active Page', 8)}
+			defaultActive={number('Active Page', 8)}
 			ellipsisBuffer={number('Ellipsis Buffer', 2)}
 			hrefConstructor={(page) => `/#${page}`}
 			totalPages={25}
 		/>
 		<ClayPaginationWithBasicItems
-			activePage={number('Active Page', 8)}
+			defaultActive={number('Active Page', 8)}
 			ellipsisBuffer={number('Ellipsis Buffer', 2)}
 			hrefConstructor={(page) => `/#${page}`}
 			size="lg"
@@ -78,16 +73,11 @@ export const Sizes = () => (
 	</>
 );
 
-export const DisabledPages = () => {
-	const [active, setActive] = useState(8);
-
-	return (
-		<ClayPaginationWithBasicItems
-			activePage={active}
-			disabledPages={[4, 5]}
-			ellipsisBuffer={2}
-			onPageChange={(value) => setActive(value as number)}
-			totalPages={5}
-		/>
-	);
-};
+export const DisabledPages = () => (
+	<ClayPaginationWithBasicItems
+		defaultActive={8}
+		disabledPages={[4, 5]}
+		ellipsisBuffer={2}
+		totalPages={5}
+	/>
+);

--- a/packages/clay-panel/src/index.tsx
+++ b/packages/clay-panel/src/index.tsx
@@ -6,7 +6,7 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import {
-	TInternalStateOnChange,
+	InternalDispatch,
 	setElementFullHeight,
 	useInternalState,
 } from '@clayui/shared';
@@ -32,7 +32,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	collapseClassNames?: string;
 
 	/**
-	 * Flag to indicate the initial value of expanded.
+	 * Flag to indicate the initial value of expanded (uncontrolled).
 	 */
 	defaultExpanded?: boolean;
 
@@ -47,14 +47,14 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	displayType?: 'unstyled' | 'secondary';
 
 	/**
-	 * Determines if menu is expanded or not
+	 * Determines if menu is expanded or not (controlled).
 	 */
 	expanded?: boolean;
 
 	/**
-	 * Callback for when dropdown changes its active state
+	 * Callback for when dropdown changes its active state (controlled).
 	 */
-	onExpandedChange?: TInternalStateOnChange<boolean>;
+	onExpandedChange?: InternalDispatch<boolean>;
 
 	/**
 	 * Flag to toggle collapse icon visibility when `collapsable` is true.
@@ -89,8 +89,8 @@ const ClayPanel: React.FunctionComponent<IProps> & {
 }: IProps) => {
 	const [internalExpanded, setInternalExpanded] = useInternalState({
 		defaultName: 'defaultExpanded',
+		defaultValue: defaultExpanded,
 		handleName: 'onExpandedChange',
-		initialValue: defaultExpanded,
 		name: 'expanded',
 		onChange: onExpandedChange,
 		value: expanded,

--- a/packages/clay-popover/src/__tests__/index.tsx
+++ b/packages/clay-popover/src/__tests__/index.tsx
@@ -36,7 +36,7 @@ describe('ClayPopover', () => {
 
 	it('renders with `show`', () => {
 		const {container} = render(
-			<ClayPopover header="Popover" show>
+			<ClayPopover defaultShow header="Popover">
 				{`Viennese flavour cup eu, percolator froth ristretto mazagran
 					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
 					spoon acerbic to go macchiato strong.`}

--- a/packages/clay-popover/stories/Popover.stories.tsx
+++ b/packages/clay-popover/stories/Popover.stories.tsx
@@ -118,14 +118,11 @@ export const ManualShow = () => {
 };
 
 export const RecalculatePosition = () => {
-	const [visible, setVisible] = useState(false);
-	const {observer, onClose} = useModal({
-		onClose: () => setVisible(false),
-	});
+	const {observer, onOpenChange, open} = useModal();
 
 	return (
 		<>
-			{visible && (
+			{open && (
 				<ClayModal observer={observer} size="lg" status="info">
 					<ClayModal.Header>Title</ClayModal.Header>
 					<ClayModal.Body scrollable>
@@ -171,13 +168,18 @@ export const RecalculatePosition = () => {
 							</ClayButton.Group>
 						}
 						last={
-							<ClayButton onClick={onClose}>Primary</ClayButton>
+							<ClayButton onClick={() => onOpenChange(false)}>
+								Primary
+							</ClayButton>
 						}
 					/>
 				</ClayModal>
 			)}
 
-			<ClayButton displayType="primary" onClick={() => setVisible(true)}>
+			<ClayButton
+				displayType="primary"
+				onClick={() => onOpenChange(true)}
+			>
 				Open modal
 			</ClayButton>
 		</>

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -20,4 +20,4 @@ export {useInternalState} from './useInternalState';
 export {useMousePosition} from './useMousePosition';
 export {MouseSafeArea} from './MouseSafeArea';
 export type {IBaseProps as IPortalBaseProps} from './Portal';
-export type {TInternalStateOnChange} from './useInternalState';
+export type {InternalDispatch} from './useInternalState';

--- a/packages/clay-shared/src/useInternalState.ts
+++ b/packages/clay-shared/src/useInternalState.ts
@@ -3,34 +3,32 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import * as React from 'react';
+import {useState} from 'react';
 import warning from 'warning';
 
-export type TInternalStateOnChange<T> =
-	| ((val: T) => void)
-	| ((val?: T) => void)
-	| React.Dispatch<React.SetStateAction<T>>;
+export type InternalDispatch<Value> =
+	| ((value: Value) => void)
+	| ((value?: Value) => void)
+	| React.Dispatch<React.SetStateAction<Value>>;
 
-interface IArgs<T> {
+type Props<Value> = {
 	defaultName: string;
 	handleName: string;
-	initialValue?: T | (() => T);
 	name: string;
-	onChange?: TInternalStateOnChange<T>;
-	value?: T;
-}
+	defaultValue?: Value | (() => Value);
+	onChange?: InternalDispatch<Value>;
+	value?: Value;
+};
 
-export function useInternalState<TValue>({
+export function useInternalState<Value>({
 	defaultName,
+	defaultValue,
 	handleName,
-	initialValue,
 	name,
 	onChange,
 	value,
-}: IArgs<TValue>) {
-	const [internalValue, setInternalValue] = React.useState(
-		initialValue ?? value
-	);
+}: Props<Value>) {
+	const [internalValue, setInternalValue] = useState(defaultValue ?? value);
 
 	warning(
 		!(typeof value === 'undefined' && typeof onChange !== 'undefined'),
@@ -47,5 +45,5 @@ export function useInternalState<TValue>({
 		onChange = setInternalValue;
 	}
 
-	return [value, onChange] as [TValue, TInternalStateOnChange<TValue>];
+	return [value, onChange] as [Value, InternalDispatch<Value>];
 }

--- a/packages/clay-slider/docs/index.js
+++ b/packages/clay-slider/docs/index.js
@@ -10,17 +10,14 @@ import React from 'react';
 const sliderImportsCode = `import ClaySlider from '@clayui/slider';`;
 
 const SliderCode = `const Component = () => {
-	const [value, setValue] = useState(10);
-
 	return (
 		<div className="form-group">
 			<label htmlFor="slider">{'With Tooltip'}</label>
 			<ClaySlider
+				defaultValue={10}
 				id="slider"
-				onValueChange={setValue}
-				value={value}
 			/>
-        </div>
+    </div>
 	);
 }
 
@@ -35,18 +32,15 @@ export const Slider = () => {
 };
 
 const DecadeSliderCode = `const Component = () => {
-	const [decade, setDecade] = useState(10);
-
 	return (
 		<div className="form-group">
 			<label htmlFor="decadeSlider">{'Decades'}</label>
 
 			<ClaySlider
+				defaultValue={10}
 				id="decadeSlider"
 				max={2020}
-				onValueChange={setDecade}
 				step={10}
-				value={decade}
 			/>
 		</div>
 	);

--- a/packages/clay-slider/docs/slider.mdx
+++ b/packages/clay-slider/docs/slider.mdx
@@ -15,7 +15,7 @@ import {DecadeSlider, Slider} from '$packages/clay-slider/docs/index';
 </div>
 </div>
 
-Slider is a controlled component and needs just 2 props for its basic use, `value` and `onValueChange`.
+Slider is a controlled component and needs just 2 props for its basic use, `value` and `onChange`.
 
 <Slider />
 

--- a/packages/clay-slider/package.json
+++ b/packages/clay-slider/package.json
@@ -26,6 +26,7 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/shared": "^3.52.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-slider/src/__tests__/index.tsx
+++ b/packages/clay-slider/src/__tests__/index.tsx
@@ -12,7 +12,7 @@ describe('ClaySlider', () => {
 
 	it('renders', () => {
 		const {container} = render(
-			<ClaySlider onValueChange={() => {}} value={10} />
+			<ClaySlider onChange={() => {}} value={10} />
 		);
 
 		expect(container).toMatchSnapshot();
@@ -20,7 +20,7 @@ describe('ClaySlider', () => {
 
 	it('renders a Slider disabled', () => {
 		const {container} = render(
-			<ClaySlider disabled onValueChange={() => {}} value={10} />
+			<ClaySlider disabled onChange={() => {}} value={10} />
 		);
 
 		const input = container.querySelector(
@@ -34,11 +34,7 @@ describe('ClaySlider', () => {
 
 	it('renders a Slider with the tooltip position bottom', () => {
 		const {container} = render(
-			<ClaySlider
-				onValueChange={() => {}}
-				tooltipPosition="bottom"
-				value={10}
-			/>
+			<ClaySlider defaultValue={10} tooltipPosition="bottom" />
 		);
 
 		expect(

--- a/packages/clay-slider/stories/Slider.stories.tsx
+++ b/packages/clay-slider/stories/Slider.stories.tsx
@@ -19,27 +19,21 @@ export default {
 	title: 'Design System/Components/Slider',
 };
 
-export const Default = (args: any) => {
-	const [value, setValue] = useState<number>(10);
-
-	return (
-		<div className="sheet">
-			<div className="form-group">
-				<label htmlFor="slider">With Tooltip</label>
-				<ClaySlider
-					disabled={args.disabled}
-					id="slider"
-					max={args.max}
-					min={args.min}
-					onValueChange={setValue}
-					step={args.step}
-					tooltipPosition={args.tooltipPosition}
-					value={value}
-				/>
-			</div>
+export const Default = (args: any) => (
+	<div className="sheet">
+		<div className="form-group">
+			<label htmlFor="slider">With Tooltip</label>
+			<ClaySlider
+				disabled={args.disabled}
+				id="slider"
+				max={args.max}
+				min={args.min}
+				step={args.step}
+				tooltipPosition={args.tooltipPosition}
+			/>
 		</div>
-	);
-};
+	</div>
+);
 
 Default.args = {
 	disabled: false,
@@ -50,7 +44,7 @@ Default.args = {
 };
 
 export const MultipleSliders = () => {
-	const [value, setValue] = React.useState<number>(10);
+	const [value, setValue] = useState<number>(10);
 
 	return (
 		<div className="sheet">
@@ -60,7 +54,7 @@ export const MultipleSliders = () => {
 					id={`sliderOne${value}`}
 					max={10}
 					min={0}
-					onValueChange={setValue}
+					onChange={setValue}
 					step={1}
 					tooltipPosition="top"
 					value={value}
@@ -74,7 +68,7 @@ export const MultipleSliders = () => {
 					id={`sliderTwo${value}`}
 					max={100}
 					min={0}
-					onValueChange={(n) => setValue(100 - n)}
+					onChange={(n) => setValue(100 - n)}
 					step={1}
 					tooltipPosition="top"
 					value={100 - value}

--- a/packages/clay-time-picker/docs/index.js
+++ b/packages/clay-time-picker/docs/index.js
@@ -18,11 +18,11 @@ const timePickerCode = `const Component = () => {
 
 	return (
 		<ClayTimePicker
+			onChange={setState}
 			spritemap={spritemap}
-			onInputChange={setState}
-			values={state}
 			timezone="GMT+01:00"
 			use12Hours
+			value={state}
 		/>
 	);
 }

--- a/packages/clay-time-picker/stories/TimePicker.stories.tsx
+++ b/packages/clay-time-picker/stories/TimePicker.stories.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {useState} from 'react';
+import React from 'react';
 
 import ClayTimePicker from '../src';
 
@@ -12,29 +12,20 @@ export default {
 	title: 'Design System/Components/TimePicker',
 };
 
-export const Default = (args: any) => {
-	const [state, setState] = useState({
-		hours: '--',
-		minutes: '--',
-	});
-
-	return (
-		<div className="sheet">
-			<div className="form-group">
-				<label>Time Picker</label>
-				<ClayTimePicker
-					disabled={args.disabled}
-					icon={args.showIcon}
-					name={args.name}
-					onInputChange={setState}
-					timezone={args.timezone}
-					use12Hours={args.use12Hours}
-					values={state}
-				/>
-			</div>
+export const Default = (args: any) => (
+	<div className="sheet">
+		<div className="form-group">
+			<label>Time Picker</label>
+			<ClayTimePicker
+				disabled={args.disabled}
+				icon={args.showIcon}
+				name={args.name}
+				timezone={args.timezone}
+				use12Hours={args.use12Hours}
+			/>
 		</div>
-	);
-};
+	</div>
+);
 
 Default.args = {
 	disabled: false,


### PR DESCRIPTION
Fixes #4766

This PR is applying the [RFC 0002 Controlled and uncontrolled components](https://github.com/liferay/clay/blob/4bad9532a7ee689b6add7ba8fa1dbda1fe8b37b3/docs/proposals/0002-controlled-and-uncontrolled.md), with this change we are deprecating some public APIs of the components but still maintaining backward compatibility, also adding the behavior of controlled and uncontrolled for the components that had only the behavior of controlled.

Some components mainly for the `@clayui/form` package, like Checkbox, Toggle, and Select don't allow us to make these changes now because the `onChange` prop has the event argument, we will have to do it in v4.

This PR is still a WIP, still need to add this for other components and also make changes to the documentation. I'm also thinking about adding backward compatibility tests to make sure we don't break anything.

### Discussions

The RFC does not cover this naming part for some edge cases because they are more preferred and optional things, most of the components have the `active` or `open` state of the content, for example: open the DropDown/DatePicker/ColorPicker menu; open the Modal; show the autocomplete menu, we are using the nomenclature of `active` in the vast majority and others like `expanded`, well the idea here is also to define a unique nomenclature for cases like opening/showing a suspended content.

- `active` seems to be a bit confusing that you use for example in a Modal or DropDown, it doesn't seem very predictable to link with the menu.
- `visible` is probably more predictable when content was hidden and is being shown/opened.
- `open` is very similar to `visible`, seems predictable, and perhaps more common for these scenarios.
- `expanded` is less predictable, normally linked to collapse actions like Panel and TreeView, seems to be more aligned for this scenario if you look at the accessibility nomenclature for these `aria-expanded` scenarios.

I don't have a very strong choice on the name of these properties but I'm bringing them here so others can add their opinions as I work on this PR. Probably `open` fits well within these scenarios that are linked to suspended content.

### ToDo

- [x] Update documentation
  - [x] ColorPicker
  - [x] DatePicker
  - [x] DropDown
  - [x] ClayRadioGroup
  - [x] Modal
  - [x] MultiSelect
  - [x] MultiStepNavWithBasicItems
  - [x] ~~VerticalNav~~
  - [x] PaginationWithBasicItems
  - [x] PaginationBarWithBasicItems
  - [x] Panel
  - [x] Popover
  - [x] Slider
  - [x] TimePicker
- [x] Add backward compatibility tests
  - [x] ColorPicker
  - [x] DatePicker
  - [x] DropDown
  - [x] ClayRadioGroup
  - [x] Modal
  - [x] MultiSelect
  - [x] MultiStepNavWithBasicItems
  - [x] ~~VerticalNav~~
  - [x] PaginationWithBasicItems
  - [x] PaginationBarWithBasicItems
  - [x] Panel
  - [x] Popover
  - [x] Slider
  - [x] TimePicker
- [x] Standardize controlled and uncontrolled components
  - [x] ColorPicker
  - [x] DatePicker
  - [x] DropDown
  - [x] ClayRadioGroup
  - [x] Modal
  - [x] MultiSelect
  - [x] MultiStepNavWithBasicItems
  - [x] ~~VerticalNav~~
  - [x] PaginationWithBasicItems
  - [x] PaginationBarWithBasicItems
  - [x] Panel
  - [x] Popover
  - [x] Slider
  - [x] TimePicker