### PR TITLE
fix(@clayui/shared): fix error when controlling focus in React 17.x

### DIFF
--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -135,7 +135,9 @@ const getFiber = (scope: React.RefObject<HTMLElement | null>) => {
 	}
 
 	const internalKey = Object.keys(scope.current).find(
-		(key) => key.indexOf('__reactInternalInstance') === 0
+		(key) =>
+			key.indexOf('__reactInternalInstance') === 0 ||
+			key.indexOf('__reactFiber') === 0
 	);
 
 	if (internalKey) {


### PR DESCRIPTION
Fixes #4787

React 17.x had no internal changes to the Fiber API so the implementation is safe here but only changed the API name for fiber access, previously `__reactInternalInstance` and now in 17.x `__reactFiber`.