### PR TITLE
chore: changes the way to sync the master branch with stable in the release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-      - run: git push origin master:stable
+      - run: git push origin stable
       - run: lerna publish from-git --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The release process of cutting the version generates a new commit that we need to send to the master, this happens in the `version` step, and in the `publish` step we get the SHA so that we can work on top of the last change.

The problem with this is that even though we run `git push origin master` it doesn't immediately sync with the upstream, it's probably done after the job finishes.

In the `publish` step we are trying to sync `master:stable` but it is [causing an error](https://github.com/liferay/clay/runs/5819769892?check_suite_focus=true):

```
error: src refspec master does not match any
error: failed to push some refs to 'https://github.com/liferay/clay'
Error: Process completed with exit code 1.
```

That's because there seems to be a difference in refs between the master in clay and the master in the job that in theory we updated in the previous step. To avoid this I'm changing the way to update the stable branch as an attempt to resolve this.