### PR TITLE
feat(@clayui/core): adds the new OverlayMask component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -50,10 +50,10 @@ module.exports = {
 			statements: 91,
 		},
 		'./packages/clay-core/src/overlay-mask/': {
-			branches: 82,
+			branches: 77,
 			functions: 100,
-			lines: 94,
-			statements: 94,
+			lines: 92,
+			statements: 92,
 		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 69,

--- a/jest.config.js
+++ b/jest.config.js
@@ -49,6 +49,12 @@ module.exports = {
 			lines: 90,
 			statements: 91,
 		},
+		'./packages/clay-core/src/overlay-mask/': {
+			branches: 82,
+			functions: 100,
+			lines: 94,
+			statements: 94,
+		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 69,
 			functions: 73,

--- a/packages/clay-core/docs/api-overlay-mask.mdx
+++ b/packages/clay-core/docs/api-overlay-mask.mdx
@@ -1,0 +1,9 @@
+---
+title: 'OverlayMask'
+description: 'OverlayMask create a highlight area on some DOM element with overlay.'
+mainTabURL: 'docs/components/overlay-mask.html'
+---
+
+## OverlayMask
+
+<div>[APITable "clay-core/src/overlay-mask/OverlayMask.tsx"]</div>

--- a/packages/clay-core/docs/overlay-mask.js
+++ b/packages/clay-core/docs/overlay-mask.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Editor from '$clayui.com/src/components/Editor';
+import {Button, OverlayMask} from '@clayui/core';
+import React, {useState} from 'react';
+
+const exampleImports = `import {Button, OverlayMask} from '@clayui/core';
+import React, {useState} from 'react';`;
+
+const exampleCode = `const OverlayTrigger = () => {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <Button.Group spaced>
+      <Button displayType="secondary" borderless onClick={() => setVisible(!visible)}>
+        Open overlay
+      </Button>
+      <OverlayMask onClick={() => setVisible(false)} visible={visible}>
+        <Button>Button</Button>
+      </OverlayMask>
+    </Button.Group>
+  );
+};
+
+render(<OverlayTrigger />)`;
+
+const OverlayMaskExample = () => {
+	const scope = {Button, OverlayMask, useState};
+
+	return <Editor code={exampleCode} imports={exampleImports} scope={scope} />;
+};
+
+export {OverlayMaskExample};

--- a/packages/clay-core/docs/overlay-mask.mdx
+++ b/packages/clay-core/docs/overlay-mask.mdx
@@ -1,0 +1,89 @@
+---
+title: 'OverlayMask'
+description: 'OverlayMask create a highlight area on some DOM element with overlay.'
+packageNpm: '@clayui/core'
+packageStatus: 'Beta'
+---
+
+import {OverlayMaskExample} from '$packages/clay-core/docs/overlay-mask';
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Example](#example)
+-   [Introduction](#introduction)
+-   [Area highlight](#area-highlight)
+    -   [React component](#react-component)
+    -   [Non-React component](#non-react-component)
+
+</div>
+</div>
+
+## Example
+
+<OverlayMaskExample />
+
+## Introduction
+
+Create a highlight area for some element in the DOM. The component can place the highlight automatically when passing a component with [`forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref) support as `children`, it is also possible to set the highlighted area if there is no `children` component.
+
+## Area highlight
+
+## React component
+
+There are two different ways to create the highlighted area for a component, this allows the component to determine the highlight area and keep updating when there is scroll on the page. The first, set the component as the component's `children`.
+
+```jsx
+<OverlayMask>
+	<ClayButton>Button</ClayButton>
+</OverlayMask>
+```
+
+Another option is for cases where it is not possible to define the component as the only child of the `<OverlayMask />`, define the children as a function and the `ref` object is passed via render props to add to the element that should get the highlight.
+
+```jsx
+<OverlayMask>
+	{(ref) => (
+		<>
+			<ClayButton>Button A</ClayButton>
+			<ClayButton ref={ref}>Button B</ClayButton>
+		</>
+	)}
+</OverlayMask>
+```
+
+## Non-React component
+
+The component can be controlled ie define a highlight area for a non-React element that is not managed by React, the difference is that you need to keep the area (bounds) updated if the page exists scroll.
+
+```jsx
+const logo = document.body.querySelector('.logo');
+const {height, width, x, y} = logo.getBoundingClientRect();
+
+<OverlayMask
+  defaultBounds={{
+    height,
+    width,
+    x,
+    y,
+  }}
+  visible
+/>
+
+// or
+
+const [bounds, setBounds] = useState({
+	height: 0,
+	width: 0,
+	x: 0,
+	y: 0,
+});
+
+useEffect(() => {...}, []);
+
+<OverlayMask
+  bounds={bounds}
+  onBoundsChange={setBounds}
+  visible
+/>
+```

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -20,4 +20,5 @@ export {
 } from '@clayui/modal';
 export {Provider, useProvider} from '@clayui/provider';
 
+export {OverlayMask} from './overlay-mask';
 export {TreeView} from './tree-view';

--- a/packages/clay-core/src/overlay-mask/OverlayMask.tsx
+++ b/packages/clay-core/src/overlay-mask/OverlayMask.tsx
@@ -17,9 +17,10 @@ type Bounds = {
 	y: number;
 };
 
-const M = (x: number, y: number) => `M ${x} ${y}`;
-const L = (x: number, y: number) => `L ${x} ${y}`;
-const arc = (toX: number, toY: number) => `A 0,0 0 0 0 ${toX},${toY}`;
+const MoveTo = (x: number, y: number) => `M ${x} ${y}`;
+const LineTo = (x: number, y: number) => `L ${x} ${y}`;
+const EllipticalArcCurve = (toX: number, toY: number) =>
+	`A 0,0 0 0 0 ${toX},${toY}`;
 
 const createClipPath = (
 	bounds: Bounds,
@@ -39,20 +40,20 @@ const createClipPath = (
 	const endY = startY + bounds.height + padding * 2;
 
 	return [
-		M(parentBounds.startX, parentBounds.startY),
-		L(parentBounds.startX, parentBounds.endY),
-		L(parentBounds.endX, parentBounds.endY),
-		L(parentBounds.endX, parentBounds.startY),
+		MoveTo(parentBounds.startX, parentBounds.startY),
+		LineTo(parentBounds.startX, parentBounds.endY),
+		LineTo(parentBounds.endX, parentBounds.endY),
+		LineTo(parentBounds.endX, parentBounds.startY),
 		'z',
-		M(startX, startY),
-		L(startX, endY),
-		arc(startX, endY),
-		L(endX, endY),
-		arc(endX, endY),
-		L(endX, startY),
-		arc(endX, startY),
-		L(startX, startY),
-		arc(startX, startY),
+		MoveTo(startX, startY),
+		LineTo(startX, endY),
+		EllipticalArcCurve(startX, endY),
+		LineTo(endX, endY),
+		EllipticalArcCurve(endX, endY),
+		LineTo(endX, startY),
+		EllipticalArcCurve(endX, startY),
+		LineTo(startX, startY),
+		EllipticalArcCurve(startX, startY),
 	].join(' ');
 };
 

--- a/packages/clay-core/src/overlay-mask/OverlayMask.tsx
+++ b/packages/clay-core/src/overlay-mask/OverlayMask.tsx
@@ -1,0 +1,218 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {TInternalStateOnChange, useInternalState} from '@clayui/shared';
+import React, {useEffect, useLayoutEffect, useRef, useState} from 'react';
+
+type Bounds = {
+	height: number;
+	width: number;
+	x: number;
+	y: number;
+};
+
+const M = (x: number, y: number) => `M ${x} ${y}`;
+const L = (x: number, y: number) => `L ${x} ${y}`;
+const arc = (toX: number, toY: number) => `A 0,0 0 0 0 ${toX},${toY}`;
+
+const createClipPath = (
+	bounds: Bounds,
+	containerBounds: Bounds,
+	padding: number
+) => {
+	const parentBounds = {
+		endX: containerBounds.width,
+		endY: containerBounds.height,
+		startX: 0,
+		startY: 0,
+	};
+
+	const startX = bounds.x - padding;
+	const endX = startX + bounds.width + padding * 2;
+	const startY = bounds.y - padding;
+	const endY = startY + bounds.height + padding * 2;
+
+	return [
+		M(parentBounds.startX, parentBounds.startY),
+		L(parentBounds.startX, parentBounds.endY),
+		L(parentBounds.endX, parentBounds.endY),
+		L(parentBounds.endX, parentBounds.startY),
+		'z',
+		M(startX, startY),
+		L(startX, endY),
+		arc(startX, endY),
+		L(endX, endY),
+		arc(endX, endY),
+		L(endX, startY),
+		arc(endX, startY),
+		L(startX, startY),
+		arc(startX, startY),
+	].join(' ');
+};
+
+type Props<T> = {
+	/**
+	 * Sets the current value of bounds to define the highlight area (controlled).
+	 */
+	bounds?: Bounds;
+
+	/**
+	 * Sets the element that will receive the highlight.
+	 */
+	children?: React.ReactNode | ((ref: React.RefObject<T>) => React.ReactNode);
+
+	/**
+	 * Callback is called when the overlay is clicked.
+	 */
+	onClick?: (event: React.MouseEvent<SVGRectElement>) => void;
+
+	/**
+	 * Set the highlight padding.
+	 */
+	padding?: number;
+
+	/**
+	 * Sets the current visibility of the overlay.
+	 */
+	visible?: boolean;
+
+	/**
+	 * Sets the default value of bounds (uncontrolled).
+	 */
+	defaultBounds?: Bounds;
+
+	/**
+	 * Callback is called when the bounds changes (controlled).
+	 */
+	onBoundsChange?: TInternalStateOnChange<Bounds>;
+};
+
+const initialBounds = {
+	height: 0,
+	width: 0,
+	x: 0,
+	y: 0,
+};
+
+const useIsomorphicLayoutEffect =
+	typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+export function OverlayMask<T>({
+	defaultBounds = initialBounds,
+	bounds,
+	children,
+	onClick,
+	onBoundsChange,
+	padding = 10,
+	visible = false,
+}: Props<T>) {
+	const [internalBounds, setBounds] = useInternalState({
+		defaultName: 'defaultBounds',
+		handleName: 'onBoundsChange',
+		initialValue: defaultBounds,
+		name: 'bounds',
+		onChange: onBoundsChange,
+		value: bounds,
+	});
+
+	const [containerBounds, setContainerBounds] =
+		useState<Bounds>(defaultBounds);
+
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const childrenRef = useRef<HTMLElement | null>(null);
+
+	useIsomorphicLayoutEffect(() => {
+		if (childrenRef.current) {
+			const {height, width, x, y} =
+				childrenRef.current.getBoundingClientRect();
+
+			setBounds({height, width, x, y});
+		}
+	}, [visible]);
+
+	useIsomorphicLayoutEffect(() => {
+		if (containerRef.current) {
+			const {height, width, x, y} =
+				containerRef.current.getBoundingClientRect();
+
+			setContainerBounds({height, width, x, y});
+		}
+	}, [visible]);
+
+	return (
+		<>
+			{children &&
+				typeof children !== 'function' &&
+				React.cloneElement(children as React.ReactElement, {
+					ref: (node: HTMLElement) => {
+						childrenRef.current = node;
+
+						// @ts-ignore
+						const {ref} = children;
+
+						if (typeof ref === 'function') {
+							ref(node);
+						} else if (ref !== null) {
+							(ref as React.MutableRefObject<any>).current = node;
+						}
+					},
+				})}
+
+			{typeof children === 'function' && children(childrenRef)}
+
+			{visible && (
+				<div
+					ref={containerRef}
+					style={{
+						bottom: 0,
+						left: 0,
+						position: 'absolute',
+						right: 0,
+						top: 0,
+					}}
+				>
+					<svg
+						height={containerBounds.height}
+						width={containerBounds.width}
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<g>
+							<defs>
+								<clipPath id="overlayMask">
+									<path
+										clipRule="evenodd"
+										d={createClipPath(
+											internalBounds,
+											containerBounds,
+											padding
+										)}
+									/>
+								</clipPath>
+							</defs>
+
+							<rect
+								clipPath="url(#overlayMask)"
+								fill="#393a4a"
+								fillOpacity={0.8}
+								height="100%"
+								onClick={onClick}
+								width="100%"
+								x={0}
+								y={0}
+							>
+								<animate
+									attributeName="opacity"
+									dur="0.3s"
+									repeatCount={1}
+									values="0;1"
+								/>
+							</rect>
+						</g>
+					</svg>
+				</div>
+			)}
+		</>
+	);
+}

--- a/packages/clay-core/src/overlay-mask/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/overlay-mask/__tests__/BasicRendering.tsx
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import {Button, OverlayMask} from '../../';
+
+describe('OverlayMask basic rendering', () => {
+	afterEach(cleanup);
+
+	it('render highlight for the component', () => {
+		const {container} = render(
+			<OverlayMask visible>
+				<Button>Button</Button>
+			</OverlayMask>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render highlight for component via render props', () => {
+		const {container} = render(
+			<OverlayMask<HTMLButtonElement> visible>
+				{(ref) => <Button ref={ref}>Button</Button>}
+			</OverlayMask>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it("don't render highlighting for component when not visible", () => {
+		const {container} = render(
+			<OverlayMask>
+				<Button>Button</Button>
+			</OverlayMask>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render highlight to a specific area', () => {
+		const {container} = render(
+			<OverlayMask
+				defaultBounds={{
+					height: 100,
+					width: 100,
+					x: 50,
+					y: 50,
+				}}
+				visible
+			/>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render highlight for component with a custom padding', () => {
+		const {container} = render(
+			<OverlayMask padding={50} visible>
+				<Button>Button</Button>
+			</OverlayMask>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+});

--- a/packages/clay-core/src/overlay-mask/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/overlay-mask/__tests__/IncrementalInteractions.tsx
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import React, {useState} from 'react';
+
+import {Button, OverlayMask} from '../../';
+
+describe('OverlayMask incremental interactions', () => {
+	afterEach(cleanup);
+
+	it('render highlight for component when clicking a button', () => {
+		function OverlayTrigger() {
+			const [visible, setVisible] = useState(false);
+
+			return (
+				<>
+					<Button monospaced onClick={() => setVisible(!visible)}>
+						Dot
+					</Button>
+					<OverlayMask visible={visible}>
+						<Button>Button</Button>
+					</OverlayMask>
+				</>
+			);
+		}
+
+		const {container, getByText} = render(<OverlayTrigger />);
+
+		expect(container.querySelector('svg')).not.toBeTruthy();
+
+		const dot = getByText('Dot') as HTMLButtonElement;
+
+		fireEvent.click(dot);
+
+		expect(container.querySelector('svg')).toBeTruthy();
+
+		fireEvent.click(dot);
+
+		expect(container.querySelector('svg')).not.toBeTruthy();
+	});
+
+	it('render highlight for non reactjs component', () => {
+		const button = document.createElement('button');
+		button.setAttribute('id', 'button');
+		button.setAttribute('type', 'button');
+		button.setAttribute('style', 'margin-top: 100px;margin-left: 100px;');
+
+		document.body.appendChild(button);
+
+		const {container} = render(
+			<OverlayMask
+				defaultBounds={{
+					height: 100,
+					width: 100,
+					x: 0,
+					y: 0,
+				}}
+				visible
+			/>
+		);
+
+		const mask = container.querySelector('path') as SVGPathElement;
+
+		expect(mask.getAttribute('d')).toBe(
+			'M 0 0 L 0 0 L 0 0 L 0 0 z M -10 -10 L -10 110 A 0,0 0 0 0 -10,110 L 110 110 A 0,0 0 0 0 110,110 L 110 -10 A 0,0 0 0 0 110,-10 L -10 -10 A 0,0 0 0 0 -10,-10'
+		);
+
+		document.body.removeChild(button);
+	});
+
+	it('changing the visibility of the highlight area must be consistent', () => {
+		function OverlayTrigger() {
+			const [visible, setVisible] = useState(false);
+
+			return (
+				<>
+					<Button monospaced onClick={() => setVisible(!visible)}>
+						Dot
+					</Button>
+					<OverlayMask visible={visible}>
+						<Button>Button</Button>
+					</OverlayMask>
+				</>
+			);
+		}
+
+		const {container, getByText} = render(<OverlayTrigger />);
+
+		const dot = getByText('Dot') as HTMLButtonElement;
+
+		fireEvent.click(dot);
+
+		const mask = container.querySelector('path') as SVGPathElement;
+
+		expect(mask.getAttribute('d')).toBe(
+			'M 0 0 L 0 0 L 0 0 L 0 0 z M -10 -10 L -10 10 A 0,0 0 0 0 -10,10 L 10 10 A 0,0 0 0 0 10,10 L 10 -10 A 0,0 0 0 0 10,-10 L -10 -10 A 0,0 0 0 0 -10,-10'
+		);
+
+		fireEvent.click(dot);
+
+		expect(container.querySelector('path')).not.toBeTruthy();
+
+		fireEvent.click(dot);
+
+		expect(mask.getAttribute('d')).toBe(
+			'M 0 0 L 0 0 L 0 0 L 0 0 z M -10 -10 L -10 10 A 0,0 0 0 0 -10,10 L 10 10 A 0,0 0 0 0 10,10 L 10 -10 A 0,0 0 0 0 10,-10 L -10 -10 A 0,0 0 0 0 -10,-10'
+		);
+	});
+});

--- a/packages/clay-core/src/overlay-mask/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/overlay-mask/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -1,0 +1,202 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OverlayMask basic rendering don't render highlighting for component when not visible 1`] = `
+<div>
+  <button
+    class="btn btn-primary"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`OverlayMask basic rendering render highlight for component via render props 1`] = `
+<div>
+  <button
+    class="btn btn-primary"
+    type="button"
+  >
+    Button
+  </button>
+  <div
+    style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px;"
+  >
+    <svg
+      height="0"
+      width="0"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <defs>
+          <clippath
+            id="overlayMask"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M 0 0 L 0 0 L 0 0 L 0 0 z M -10 -10 L -10 10 A 0,0 0 0 0 -10,10 L 10 10 A 0,0 0 0 0 10,10 L 10 -10 A 0,0 0 0 0 10,-10 L -10 -10 A 0,0 0 0 0 -10,-10"
+            />
+          </clippath>
+        </defs>
+        <rect
+          clip-path="url(#overlayMask)"
+          fill="#393a4a"
+          fill-opacity="0.8"
+          height="100%"
+          width="100%"
+          x="0"
+          y="0"
+        >
+          <animate
+            attributeName="opacity"
+            dur="0.3s"
+            repeatCount="1"
+            values="0;1"
+          />
+        </rect>
+      </g>
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`OverlayMask basic rendering render highlight for component with a custom padding 1`] = `
+<div>
+  <button
+    class="btn btn-primary"
+    type="button"
+  >
+    Button
+  </button>
+  <div
+    style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px;"
+  >
+    <svg
+      height="0"
+      width="0"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <defs>
+          <clippath
+            id="overlayMask"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M 0 0 L 0 0 L 0 0 L 0 0 z M -50 -50 L -50 50 A 0,0 0 0 0 -50,50 L 50 50 A 0,0 0 0 0 50,50 L 50 -50 A 0,0 0 0 0 50,-50 L -50 -50 A 0,0 0 0 0 -50,-50"
+            />
+          </clippath>
+        </defs>
+        <rect
+          clip-path="url(#overlayMask)"
+          fill="#393a4a"
+          fill-opacity="0.8"
+          height="100%"
+          width="100%"
+          x="0"
+          y="0"
+        >
+          <animate
+            attributeName="opacity"
+            dur="0.3s"
+            repeatCount="1"
+            values="0;1"
+          />
+        </rect>
+      </g>
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`OverlayMask basic rendering render highlight for the component 1`] = `
+<div>
+  <button
+    class="btn btn-primary"
+    type="button"
+  >
+    Button
+  </button>
+  <div
+    style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px;"
+  >
+    <svg
+      height="0"
+      width="0"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <defs>
+          <clippath
+            id="overlayMask"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M 0 0 L 0 0 L 0 0 L 0 0 z M -10 -10 L -10 10 A 0,0 0 0 0 -10,10 L 10 10 A 0,0 0 0 0 10,10 L 10 -10 A 0,0 0 0 0 10,-10 L -10 -10 A 0,0 0 0 0 -10,-10"
+            />
+          </clippath>
+        </defs>
+        <rect
+          clip-path="url(#overlayMask)"
+          fill="#393a4a"
+          fill-opacity="0.8"
+          height="100%"
+          width="100%"
+          x="0"
+          y="0"
+        >
+          <animate
+            attributeName="opacity"
+            dur="0.3s"
+            repeatCount="1"
+            values="0;1"
+          />
+        </rect>
+      </g>
+    </svg>
+  </div>
+</div>
+`;
+
+exports[`OverlayMask basic rendering render highlight to a specific area 1`] = `
+<div>
+  <div
+    style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px;"
+  >
+    <svg
+      height="0"
+      width="0"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <defs>
+          <clippath
+            id="overlayMask"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M 0 0 L 0 0 L 0 0 L 0 0 z M 40 40 L 40 160 A 0,0 0 0 0 40,160 L 160 160 A 0,0 0 0 0 160,160 L 160 40 A 0,0 0 0 0 160,40 L 40 40 A 0,0 0 0 0 40,40"
+            />
+          </clippath>
+        </defs>
+        <rect
+          clip-path="url(#overlayMask)"
+          fill="#393a4a"
+          fill-opacity="0.8"
+          height="100%"
+          width="100%"
+          x="0"
+          y="0"
+        >
+          <animate
+            attributeName="opacity"
+            dur="0.3s"
+            repeatCount="1"
+            values="0;1"
+          />
+        </rect>
+      </g>
+    </svg>
+  </div>
+</div>
+`;

--- a/packages/clay-core/src/overlay-mask/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/overlay-mask/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -20,7 +20,7 @@ exports[`OverlayMask basic rendering render highlight for component via render p
     Button
   </button>
   <div
-    style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px;"
+    style="bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; z-index: 1040;"
   >
     <svg
       height="0"
@@ -69,7 +69,7 @@ exports[`OverlayMask basic rendering render highlight for component with a custo
     Button
   </button>
   <div
-    style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px;"
+    style="bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; z-index: 1040;"
   >
     <svg
       height="0"
@@ -118,7 +118,7 @@ exports[`OverlayMask basic rendering render highlight for the component 1`] = `
     Button
   </button>
   <div
-    style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px;"
+    style="bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; z-index: 1040;"
   >
     <svg
       height="0"
@@ -161,7 +161,7 @@ exports[`OverlayMask basic rendering render highlight for the component 1`] = `
 exports[`OverlayMask basic rendering render highlight to a specific area 1`] = `
 <div>
   <div
-    style="bottom: 0px; left: 0px; position: absolute; right: 0px; top: 0px;"
+    style="bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; z-index: 1040;"
   >
     <svg
       height="0"

--- a/packages/clay-core/src/overlay-mask/index.ts
+++ b/packages/clay-core/src/overlay-mask/index.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export * from './OverlayMask';

--- a/packages/clay-core/stories/OverlayMask.stories.tsx
+++ b/packages/clay-core/stories/OverlayMask.stories.tsx
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import '@clayui/css/lib/css/atlas.css';
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
+import {ClayCheckbox} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
+import ClayPopover from '@clayui/popover';
+import {storiesOf} from '@storybook/react';
+import React, {useState} from 'react';
+
+import {Provider} from '../src';
+import {OverlayMask} from '../src/overlay-mask';
+
+type Props = {
+	onClick: () => void;
+};
+
+// Use only for demo.
+const Dot = ({onClick}: Props) => (
+	<div
+		onClick={onClick}
+		style={{
+			alignItems: 'center',
+			backgroundColor: '#ffffff',
+			border: '2px solid #0053F0',
+			borderRadius: '100%',
+			cursor: 'pointer',
+			display: 'flex',
+			height: '32px',
+			justifyContent: 'center',
+			marginLeft: '-10px',
+			marginTop: '-10px',
+			position: 'absolute',
+			width: '32px',
+		}}
+	>
+		<div
+			style={{
+				backgroundColor: '#004AD7',
+				borderRadius: '100%',
+				height: '24px',
+				width: '24px',
+			}}
+		/>
+	</div>
+);
+
+storiesOf('Components|OverlayMask', module)
+	.add('default', () => (
+		<div style={{marginLeft: '200px', marginTop: '200px'}}>
+			<OverlayMask visible>
+				<ClayButton>Button</ClayButton>
+			</OverlayMask>
+		</div>
+	))
+	.add('with popover', () => {
+		const [visible, setVisible] = useState(false);
+
+		return (
+			<Provider spritemap={spritemap}>
+				<div style={{marginLeft: '200px', marginTop: '200px'}}>
+					{!visible && <Dot onClick={() => setVisible(true)} />}
+
+					<OverlayMask<HTMLButtonElement> visible={visible}>
+						{(ref) => (
+							<ClayPopover
+								alignPosition="right-top"
+								closeOnClickOutside
+								header={
+									<ClayLayout.ContentRow
+										noGutters
+										verticalAlign="center"
+									>
+										<ClayLayout.ContentCol expand>
+											<span>
+												Step 1 of 3: Customize logo
+											</span>
+										</ClayLayout.ContentCol>
+										<ClayLayout.ContentCol>
+											<ClayButtonWithIcon
+												aria-label="close"
+												displayType="unstyled"
+												onClick={() =>
+													setVisible(false)
+												}
+												small
+												symbol="times"
+											/>
+										</ClayLayout.ContentCol>
+									</ClayLayout.ContentRow>
+								}
+								onShowChange={setVisible}
+								show={visible}
+								style={{maxWidth: '26rem'}}
+								trigger={
+									<ClayButton ref={ref}>Logo</ClayButton>
+								}
+							>
+								<p>
+									Place your name and logo using this widget
+									and make then a link the Homepage.
+								</p>
+
+								<ClayLayout.ContentRow
+									noGutters
+									verticalAlign="center"
+								>
+									<ClayLayout.ContentCol expand>
+										<ClayCheckbox
+											checked={false}
+											label="Don't show this again"
+											onChange={() => {}}
+										/>
+									</ClayLayout.ContentCol>
+									<ClayLayout.ContentCol>
+										<ClayButton.Group spaced>
+											<ClayButton
+												displayType="secondary"
+												small
+											>
+												Previous
+											</ClayButton>
+											<ClayButton
+												onClick={() =>
+													setVisible(false)
+												}
+												small
+											>
+												Got it
+											</ClayButton>
+										</ClayButton.Group>
+									</ClayLayout.ContentCol>
+								</ClayLayout.ContentRow>
+							</ClayPopover>
+						)}
+					</OverlayMask>
+				</div>
+			</Provider>
+		);
+	});

--- a/packages/clay-popover/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-popover/src/__tests__/__snapshots__/index.tsx.snap
@@ -58,6 +58,16 @@ exports[`ClayPopover renders with \`show\` 1`] = `
 </div>
 `;
 
+exports[`ClayPopover renders with trigger 1`] = `
+<div>
+  <button
+    type="button"
+  >
+    Logo
+  </button>
+</div>
+`;
+
 exports[`ClayPopover renders without scroll 1`] = `
 <div>
   <div

--- a/packages/clay-popover/src/__tests__/index.tsx
+++ b/packages/clay-popover/src/__tests__/index.tsx
@@ -45,4 +45,19 @@ describe('ClayPopover', () => {
 
 		expect(container).toMatchSnapshot();
 	});
+
+	it('renders with trigger', () => {
+		const {container} = render(
+			<ClayPopover
+				header="Popover"
+				trigger={<button type="button">Logo</button>}
+			>
+				{`Viennese flavour cup eu, percolator froth ristretto mazagran
+					caffeine. White roast seasonal, mocha trifecta, dripper caffeine
+					spoon acerbic to go macchiato strong.`}
+			</ClayPopover>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
 });

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -94,7 +94,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Callback for setting the offset of the popover from the trigger.
 	 */
-	offset?: (points: Point) => [number, number];
+	onOffset?: (points: Point) => [number, number];
 
 	/**
 	 * Callback for when the `show` prop changes.
@@ -123,7 +123,7 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 			containerProps = {},
 			disableScroll = false,
 			header,
-			offset = (points) =>
+			onOffset = (points) =>
 				OFFSET_MAP[points.join('') as keyof typeof OFFSET_MAP] as [
 					number,
 					number
@@ -157,7 +157,7 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 				const points = ALIGNMENTS_MAP[alignPosition];
 
 				doAlign({
-					offset: offset(points),
+					offset: onOffset(points),
 					points,
 					sourceElement: (ref as React.RefObject<HTMLElement>)
 						.current!,

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -42,6 +42,28 @@ const ALIGNMENTS_MAP = {
 	'top-right': ['br', 'tr'],
 } as const;
 
+type Point = typeof ALIGNMENTS_MAP[keyof typeof ALIGNMENTS_MAP];
+
+const BOTTOM_OFFSET = [0, 4] as const;
+const LEFT_OFFSET = [-4, 0] as const;
+const RIGHT_OFFSET = [4, 0] as const;
+const TOP_OFFSET = [0, -4] as const;
+
+const OFFSET_MAP = {
+	bctc: TOP_OFFSET,
+	blbr: RIGHT_OFFSET,
+	bltl: TOP_OFFSET,
+	brbl: LEFT_OFFSET,
+	brtr: TOP_OFFSET,
+	clcr: RIGHT_OFFSET,
+	crcl: LEFT_OFFSET,
+	tcbc: BOTTOM_OFFSET,
+	tlbl: BOTTOM_OFFSET,
+	tltr: RIGHT_OFFSET,
+	trbr: BOTTOM_OFFSET,
+	trtl: LEFT_OFFSET,
+};
+
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Position in which the tooltip will be aligned to the element.
@@ -70,6 +92,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	show?: boolean;
 
 	/**
+	 * Callback for setting the offset of the popover from the trigger.
+	 */
+	offset?: (points: Point) => [number, number];
+
+	/**
 	 * Callback for when the `show` prop changes.
 	 */
 	onShowChange?: (val: boolean) => void;
@@ -77,9 +104,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * React element that the popover will align to when clicked.
 	 */
-	trigger?: React.ReactElement & {
-		ref?: (node: HTMLButtonElement | null) => void;
-	};
+	trigger?: React.ReactElement & React.RefAttributes<HTMLButtonElement>;
 
 	/**
 	 * Content to display in the header of the popover.
@@ -97,6 +122,11 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 			containerProps = {},
 			disableScroll = false,
 			header,
+			offset = (points) =>
+				OFFSET_MAP[points.join('') as keyof typeof OFFSET_MAP] as [
+					number,
+					number
+				],
 			onShowChange,
 			show: externalShow = false,
 			trigger,
@@ -114,7 +144,8 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 			ref = popoverRef as React.Ref<HTMLDivElement>;
 		}
 
-		const show = externalShow ? externalShow : internalShow;
+		const show =
+			typeof externalShow === 'boolean' ? externalShow : internalShow;
 		const setShow = onShowChange ? onShowChange : internalSetShow;
 
 		const align = useCallback(() => {
@@ -122,12 +153,10 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 				(ref as React.RefObject<HTMLElement>).current &&
 				triggerRef.current
 			) {
-				const points = ALIGNMENTS_MAP[alignPosition] as [
-					string,
-					string
-				];
+				const points = ALIGNMENTS_MAP[alignPosition];
 
 				doAlign({
+					offset: offset(points),
 					points,
 					sourceElement: (ref as React.RefObject<HTMLElement>)
 						.current!,
@@ -245,6 +274,10 @@ const ClayPopover = React.forwardRef<HTMLDivElement, IProps>(
 								const {ref} = trigger;
 								if (typeof ref === 'function') {
 									ref(node);
+								} else if (ref) {
+									(
+										ref as React.MutableRefObject<HTMLButtonElement>
+									).current = node;
 								}
 							}
 						},

--- a/packages/clay-popover/src/index.tsx
+++ b/packages/clay-popover/src/index.tsx
@@ -104,7 +104,8 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * React element that the popover will align to when clicked.
 	 */
-	trigger?: React.ReactElement & React.RefAttributes<HTMLButtonElement>;
+	trigger?: React.ReactElement &
+		Omit<React.RefAttributes<HTMLButtonElement>, 'key'>;
 
 	/**
 	 * Content to display in the header of the popover.


### PR DESCRIPTION
Fixes #4791

Well, this is a new component to handle element highlighting and overlay, I wanted to try using it in Modal but it's a bit overkill for Modal. Also still not sure about that name, I thought `<HighlightOverlay />` seems like a good option.

This component allows [controlling and uncontrolled](https://github.com/liferay/clay/blob/0ac74bb7b16322be916a0dbcc74646c810037aef/docs/proposals/0002-controlled-and-uncontrolled.md) the `bounds` state that defines the highlight aria, otherwise, it will be automatically detected if `children` is defined.

```jsx
// Create the highlight for the Button component
<OverlayMask visible>
  <ClayButton>Button</ClayButton>
</OverlayMask>
```

Another option is to define the children as a function and the `ref` is passed via render props to allow you to define which element should be highlighted if there are too many components being rendered in the `OverlayMask`. See a use case in the storybook using.

```jsx
<OverlayMask visible>
  {(ref) => (
    <>
      <ClayButton>Button A</ClayButton>
      <ClayButton ref={ref}>Button B</ClayButton>
    </>
  )}
</OverlayMask>
```

It is also possible to set the highlight for non-React elements, so you can pass these values to the `bounds` property.

```jsx
const logo = document.body.querySelector('.logo');
const {height, width, x, y} = logo.getBoundingClientRect();

<OverlayMask
  defaultBounds={{
    height,
    width,
    x,
    y,
  }}
  visible
/>
```

### ToDo

- [x] Create documentation
- [x] Create tests