### PR TITLE
feat(@clayui/clay-shared): Add more test cases to FocusScope

### DIFF
--- a/packages/clay-shared/src/__tests__/FocusScope.tsx
+++ b/packages/clay-shared/src/__tests__/FocusScope.tsx
@@ -3,31 +3,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayDropDown from '@clayui/drop-down';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 import {ClayPortal, FocusScope} from '..';
-
-const DropDownWithState: React.FunctionComponent<any> = ({
-	children,
-	...others
-}) => {
-	const [active, setActive] = React.useState(false);
-
-	return (
-		<ClayDropDown
-			{...others}
-			active={active}
-			onActiveChange={(val) => setActive(val)}
-			trigger={<button>Click Me</button>}
-		>
-			{children}
-		</ClayDropDown>
-	);
-};
 
 describe('FocusScope', () => {
 	afterEach(() => {
@@ -252,7 +233,7 @@ describe('FocusScope', () => {
 			document.body.innerHTML = '';
 		});
 
-		it('interacts with React.Portal', () => {
+		it('interacts with React.Portal', async () => {
 			const {getByText} = render(
 				<FocusScope>
 					<div>
@@ -264,50 +245,36 @@ describe('FocusScope', () => {
 							</div>
 						</ClayPortal>
 
-						<DropDownWithState>
-							<ClayDropDown.ItemList>
-								{[
-									{href: '#one', label: 'one'},
-									{href: '#two', label: 'two'},
-								].map((item, i) => (
-									<ClayDropDown.Item
-										href={item.href}
-										key={i}
-										spritemap="/foo/bar"
-									>
-										{item.label}
-									</ClayDropDown.Item>
-								))}
-							</ClayDropDown.ItemList>
-						</DropDownWithState>
+						<ClayPortal>
+							<FocusScope>
+								<div id="content">
+									<button>one</button>
+									<button>two</button>
+								</div>
+							</FocusScope>
+						</ClayPortal>
 					</div>
 				</FocusScope>
 			);
 
 			const button1El = getByText('Button 1');
 			const button2El = getByText('Button 2');
-			const clickMeEl = getByText('Click Me');
 
-			userEvent.tab();
+			await userEvent.tab();
 
 			expect(button1El).toHaveFocus();
 
-			userEvent.tab();
+			await userEvent.tab();
 
 			expect(button2El).toHaveFocus();
 
-			userEvent.tab();
-			fireEvent.click(clickMeEl);
-
-			expect(clickMeEl).toHaveFocus();
-
-			userEvent.tab();
+			await userEvent.tab();
 
 			const oneEl = getByText('one');
 
 			expect(oneEl).toHaveFocus();
 
-			userEvent.tab();
+			await userEvent.tab();
 
 			const twoEl = getByText('two');
 
@@ -322,37 +289,23 @@ describe('FocusScope', () => {
 							<button>Button 1</button>
 						</div>
 
-						<DropDownWithState>
-							<ClayDropDown.ItemList>
-								{[
-									{href: '#one', label: 'one'},
-									{href: '#two', label: 'two'},
-								].map((item, i) => (
-									<ClayDropDown.Item
-										href={item.href}
-										key={i}
-										spritemap="/foo/bar"
-									>
-										{item.label}
-									</ClayDropDown.Item>
-								))}
-							</ClayDropDown.ItemList>
-						</DropDownWithState>
+						<ClayPortal>
+							<FocusScope>
+								<div id="content">
+									<button>one</button>
+									<button>two</button>
+								</div>
+							</FocusScope>
+						</ClayPortal>
 					</div>
 				</FocusScope>
 			);
 
 			const button1El = getByText('Button 1');
-			const clickMeEl = getByText('Click Me');
 
 			userEvent.tab();
 
 			expect(button1El).toHaveFocus();
-
-			userEvent.tab();
-			fireEvent.click(clickMeEl);
-
-			expect(clickMeEl).toHaveFocus();
 
 			userEvent.tab();
 

--- a/packages/clay-shared/src/__tests__/FocusScope.tsx
+++ b/packages/clay-shared/src/__tests__/FocusScope.tsx
@@ -3,22 +3,48 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 import {ClayPortal, FocusScope} from '..';
 
+import ClayDropDown from '../../../clay-drop-down/src';
+
+const DropDownWithState: React.FunctionComponent<any> = ({
+	children,
+	...others
+}) => {
+	const [active, setActive] = React.useState(false);
+
+	return (
+		<ClayDropDown
+			{...others}
+			active={active}
+			className="dropdown-test"
+			onActiveChange={(val) => setActive(val)}
+			renderMenuOnClick
+			trigger={<button>Click Me</button>}
+		>
+			{children}
+		</ClayDropDown>
+	);
+};
+
 describe('FocusScope', () => {
 	afterEach(() => {
 		jest.clearAllTimers();
-
+		document.body.innerHTML = '';
 		cleanup();
 	});
 
-	it('manages focus order when using portals', () => {
-		// Create non-react based html nodes
+	afterAll(() => {
+		document.body.innerHTML = '';
+		cleanup();
+	});
+
+	beforeEach(() => {
 		if (document) {
 			const buttonNode = document.createElement('button');
 			buttonNode.id = 'button1';
@@ -41,8 +67,18 @@ describe('FocusScope', () => {
 					<ClayPortal>
 						<ul>
 							<li>
-								<a href="#" id="linkInPortal">
+								<a href="#" id="linkInPortal1">
 									link 1
+								</a>
+							</li>
+							<li>
+								<a href="#" id="linkInPortal2">
+									link 2
+								</a>
+							</li>
+							<li>
+								<a href="#" id="linkInPortal3">
+									link 3
 								</a>
 							</li>
 						</ul>
@@ -51,7 +87,9 @@ describe('FocusScope', () => {
 			</FocusScope>,
 			{container: document.getElementById('reactRoot') as HTMLElement}
 		);
+	});
 
+	it('manages focus order when using portals', () => {
 		// Putting this snapshot inline to reference the structure of the DOM
 		expect(document.body).toMatchInlineSnapshot(`
 		<body>
@@ -79,9 +117,25 @@ describe('FocusScope', () => {
 		      <li>
 		        <a
 		          href="#"
-		          id="linkInPortal"
+		          id="linkInPortal1"
 		        >
 		          link 1
+		        </a>
+		      </li>
+		      <li>
+		        <a
+		          href="#"
+		          id="linkInPortal2"
+		        >
+		          link 2
+		        </a>
+		      </li>
+		      <li>
+		        <a
+		          href="#"
+		          id="linkInPortal3"
+		        >
+		          link 3
 		        </a>
 		      </li>
 		    </ul>
@@ -94,8 +148,14 @@ describe('FocusScope', () => {
 		const reactButton = document.getElementById(
 			'reactButton'
 		) as HTMLElement;
-		const linkInPortal = document.getElementById(
-			'linkInPortal'
+		const linkInPortalOne = document.getElementById(
+			'linkInPortal1'
+		) as HTMLElement;
+		const linkInPortalTwo = document.getElementById(
+			'linkInPortal2'
+		) as HTMLElement;
+		const linkInPortalThree = document.getElementById(
+			'linkInPortal3'
 		) as HTMLElement;
 
 		userEvent.tab();
@@ -108,10 +168,185 @@ describe('FocusScope', () => {
 
 		userEvent.tab();
 
-		expect(linkInPortal).toHaveFocus();
+		expect(linkInPortalOne).toHaveFocus();
+
+		userEvent.tab();
+
+		expect(linkInPortalTwo).toHaveFocus();
+
+		userEvent.tab();
+
+		expect(linkInPortalThree).toHaveFocus();
 
 		userEvent.tab();
 
 		expect(htmlButton2).toHaveFocus();
+	});
+
+	it('interacts with shift + tab', () => {
+		const htmlButton1 = document.getElementById('button1') as HTMLElement;
+		const htmlButton2 = document.getElementById('button2') as HTMLElement;
+
+		const reactButton = document.getElementById(
+			'reactButton'
+		) as HTMLElement;
+
+		htmlButton2.focus();
+
+		expect(htmlButton2).toHaveFocus();
+
+		userEvent.tab({shift: true});
+
+		expect(reactButton).toHaveFocus();
+
+		userEvent.tab({shift: true});
+
+		expect(htmlButton1).toHaveFocus();
+	});
+
+	it('interacts with down arrow key', () => {
+		const linkInPortalOne = document.getElementById(
+			'linkInPortal1'
+		) as HTMLElement;
+		const linkInPortalTwo = document.getElementById(
+			'linkInPortal2'
+		) as HTMLElement;
+		const linkInPortalThree = document.getElementById(
+			'linkInPortal3'
+		) as HTMLElement;
+
+		linkInPortalOne.focus();
+
+		expect(linkInPortalOne).toHaveFocus();
+
+		fireEvent.keyDown(linkInPortalOne, {key: 'ArrowDown'});
+
+		expect(linkInPortalTwo).toHaveFocus();
+
+		fireEvent.keyDown(linkInPortalTwo, {key: 'ArrowDown'});
+
+		expect(linkInPortalThree).toHaveFocus();
+
+		fireEvent.keyDown(linkInPortalThree, {key: 'ArrowDown'});
+	});
+
+	it('interacts with up arrow key', () => {
+		const linkInPortalOne = document.getElementById(
+			'linkInPortal1'
+		) as HTMLElement;
+		const linkInPortalTwo = document.getElementById(
+			'linkInPortal2'
+		) as HTMLElement;
+		const linkInPortalThree = document.getElementById(
+			'linkInPortal3'
+		) as HTMLElement;
+
+		linkInPortalThree.focus();
+
+		expect(linkInPortalThree).toHaveFocus();
+
+		fireEvent.keyDown(linkInPortalThree, {key: 'ArrowUp'});
+
+		expect(linkInPortalTwo).toHaveFocus();
+
+		fireEvent.keyDown(linkInPortalTwo, {key: 'ArrowUp'});
+
+		expect(linkInPortalOne).toHaveFocus();
+
+		fireEvent.keyDown(linkInPortalOne, {key: 'ArrowUp'});
+	});
+
+	describe('FocusScope outside the React Tree', () => {
+		beforeEach(() => {
+			jest.clearAllTimers();
+			document.body.innerHTML = '';
+			cleanup();
+		});
+
+		it('interacts with React.Portal', () => {
+			render(
+				<>
+					<ClayPortal>
+						<div id="content">
+							<button id="button1" />
+						</div>
+					</ClayPortal>
+
+					<DropDownWithState>
+						<ClayDropDown.ItemList>
+							{[
+								{href: '#one', label: 'one'},
+								{href: '#two', label: 'two'},
+								{href: '#three', label: 'three'},
+							].map((item, i) => (
+								<ClayDropDown.Item
+									href={item.href}
+									key={i}
+									spritemap="/foo/bar"
+								>
+									{item.label}
+								</ClayDropDown.Item>
+							))}
+						</ClayDropDown.ItemList>
+					</DropDownWithState>
+				</>
+			);
+			const dropdownButton = document.querySelector(
+				'.dropdown-toggle'
+			) as HTMLElement;
+			const htmlButton1 = document.getElementById(
+				'button1'
+			) as HTMLElement;
+
+			dropdownButton.click();
+
+			userEvent.tab();
+
+			expect(dropdownButton).toHaveFocus();
+
+			userEvent.tab();
+
+			expect(htmlButton1).toHaveFocus();
+		});
+
+		it('interacts without React.Portal', () => {
+			render(
+				<>
+					<div id="content">
+						<button id="button1" />
+					</div>
+
+					<DropDownWithState>
+						<ClayDropDown.ItemList>
+							{[
+								{href: '#one', label: 'one'},
+								{href: '#two', label: 'two'},
+							].map((item, i) => (
+								<ClayDropDown.Item
+									href={item.href}
+									key={i}
+									spritemap="/foo/bar"
+								>
+									{item.label}
+								</ClayDropDown.Item>
+							))}
+						</ClayDropDown.ItemList>
+					</DropDownWithState>
+				</>
+			);
+
+			const dropdownButton = document.querySelector(
+				'.dropdown-toggle'
+			) as HTMLElement;
+			const htmlButton1 = document.getElementById(
+				'button1'
+			) as HTMLElement;
+
+			dropdownButton.click();
+
+			userEvent.tab();
+
+			expect(htmlButton1).toHaveFocus();
+		});
 	});
 });

--- a/packages/clay-shared/src/__tests__/FocusScope.tsx
+++ b/packages/clay-shared/src/__tests__/FocusScope.tsx
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import ClayDropDown from '@clayui/drop-down';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 import {ClayPortal, FocusScope} from '..';
-
-import ClayDropDown from '../../../clay-drop-down/src';
 
 const DropDownWithState: React.FunctionComponent<any> = ({
 	children,
@@ -22,9 +21,7 @@ const DropDownWithState: React.FunctionComponent<any> = ({
 		<ClayDropDown
 			{...others}
 			active={active}
-			className="dropdown-test"
 			onActiveChange={(val) => setActive(val)}
-			renderMenuOnClick
 			trigger={<button>Click Me</button>}
 		>
 			{children}
@@ -34,12 +31,6 @@ const DropDownWithState: React.FunctionComponent<any> = ({
 
 describe('FocusScope', () => {
 	afterEach(() => {
-		jest.clearAllTimers();
-		document.body.innerHTML = '';
-		cleanup();
-	});
-
-	afterAll(() => {
 		document.body.innerHTML = '';
 		cleanup();
 	});
@@ -258,124 +249,122 @@ describe('FocusScope', () => {
 
 	describe('FocusScope outside the React Tree', () => {
 		beforeEach(() => {
-			jest.clearAllTimers();
 			document.body.innerHTML = '';
-			cleanup();
 		});
 
 		it('interacts with React.Portal', () => {
-			render(
-				<>
-					<ClayPortal>
-						<div id="content">
-							<button id="button1" />
-						</div>
-					</ClayPortal>
+			const {getByText} = render(
+				<FocusScope>
+					<div>
+						<button>Button 1</button>
 
-					<DropDownWithState>
-						<ClayDropDown.ItemList>
-							{[
-								{href: '#one', label: 'one'},
-								{href: '#two', label: 'two'},
-							].map((item, i) => (
-								<ClayDropDown.Item
-									href={item.href}
-									key={i}
-									spritemap="/foo/bar"
-								>
-									{item.label}
-								</ClayDropDown.Item>
-							))}
-						</ClayDropDown.ItemList>
-					</DropDownWithState>
-				</>
-			);
-			const dropdownButton = document.querySelector(
-				'.dropdown-toggle'
-			) as HTMLElement;
-			const htmlButton1 = document.getElementById(
-				'button1'
-			) as HTMLElement;
+						<ClayPortal>
+							<div id="content">
+								<button>Button 2</button>
+							</div>
+						</ClayPortal>
 
-			fireEvent.click(dropdownButton);
-
-			const itemOne = (document.body as HTMLElement).querySelector(
-				'a[href="#one"]'
+						<DropDownWithState>
+							<ClayDropDown.ItemList>
+								{[
+									{href: '#one', label: 'one'},
+									{href: '#two', label: 'two'},
+								].map((item, i) => (
+									<ClayDropDown.Item
+										href={item.href}
+										key={i}
+										spritemap="/foo/bar"
+									>
+										{item.label}
+									</ClayDropDown.Item>
+								))}
+							</ClayDropDown.ItemList>
+						</DropDownWithState>
+					</div>
+				</FocusScope>
 			);
 
-			userEvent.tab();
-
-			expect(dropdownButton).toHaveFocus();
-
-			const itemTwo = (document.body as HTMLElement).querySelector(
-				'a[href="#two"]'
-			);
+			const button1El = getByText('Button 1');
+			const button2El = getByText('Button 2');
+			const clickMeEl = getByText('Click Me');
 
 			userEvent.tab();
 
-			expect(htmlButton1).toHaveFocus();
+			expect(button1El).toHaveFocus();
 
 			userEvent.tab();
 
-			expect(itemOne).toHaveFocus();
+			expect(button2El).toHaveFocus();
+
+			userEvent.tab();
+			fireEvent.click(clickMeEl);
+
+			expect(clickMeEl).toHaveFocus();
 
 			userEvent.tab();
 
-			expect(itemTwo).toHaveFocus();
+			const oneEl = getByText('one');
+
+			expect(oneEl).toHaveFocus();
+
+			userEvent.tab();
+
+			const twoEl = getByText('two');
+
+			expect(twoEl).toHaveFocus();
 		});
 
 		it('interacts without React.Portal', () => {
-			render(
-				<>
-					<div id="content">
-						<button id="button1" />
+			const {getByText} = render(
+				<FocusScope>
+					<div>
+						<div id="content">
+							<button>Button 1</button>
+						</div>
+
+						<DropDownWithState>
+							<ClayDropDown.ItemList>
+								{[
+									{href: '#one', label: 'one'},
+									{href: '#two', label: 'two'},
+								].map((item, i) => (
+									<ClayDropDown.Item
+										href={item.href}
+										key={i}
+										spritemap="/foo/bar"
+									>
+										{item.label}
+									</ClayDropDown.Item>
+								))}
+							</ClayDropDown.ItemList>
+						</DropDownWithState>
 					</div>
-
-					<DropDownWithState>
-						<ClayDropDown.ItemList>
-							{[
-								{href: '#one', label: 'one'},
-								{href: '#two', label: 'two'},
-							].map((item, i) => (
-								<ClayDropDown.Item
-									href={item.href}
-									key={i}
-									spritemap="/foo/bar"
-								>
-									{item.label}
-								</ClayDropDown.Item>
-							))}
-						</ClayDropDown.ItemList>
-					</DropDownWithState>
-				</>
+				</FocusScope>
 			);
 
-			const dropdownButton = document.querySelector(
-				'.dropdown-toggle'
-			) as HTMLElement;
-			const htmlButton1 = document.getElementById(
-				'button1'
-			) as HTMLElement;
-
-			dropdownButton.focus();
-
-			fireEvent.click(dropdownButton);
-
-			const itemOne = (document.body as HTMLElement).querySelector(
-				'a[href="#one"]'
-			);
+			const button1El = getByText('Button 1');
+			const clickMeEl = getByText('Click Me');
 
 			userEvent.tab();
 
-			expect(itemOne).toHaveFocus();
+			expect(button1El).toHaveFocus();
 
-			const itemTwo = (document.body as HTMLElement).querySelector(
-				'a[href="#two"]'
-			);
+			userEvent.tab();
+			fireEvent.click(clickMeEl);
+
+			expect(clickMeEl).toHaveFocus();
 
 			userEvent.tab();
 
-			expect(itemTwo).toHaveFocus();
+			const oneEl = getByText('one');
+
+			expect(oneEl).toHaveFocus();
+
+			userEvent.tab();
+
+			const twoEl = getByText('two');
+
+			expect(twoEl).toHaveFocus();
 
 			userEvent.tab();
 
@@ -383,7 +372,7 @@ describe('FocusScope', () => {
 
 			userEvent.tab();
 
-			expect(htmlButton1).toHaveFocus();
+			expect(button1El).toHaveFocus();
 		});
 	});
 });

--- a/packages/clay-shared/src/__tests__/FocusScope.tsx
+++ b/packages/clay-shared/src/__tests__/FocusScope.tsx
@@ -277,7 +277,6 @@ describe('FocusScope', () => {
 							{[
 								{href: '#one', label: 'one'},
 								{href: '#two', label: 'two'},
-								{href: '#three', label: 'three'},
 							].map((item, i) => (
 								<ClayDropDown.Item
 									href={item.href}
@@ -298,15 +297,31 @@ describe('FocusScope', () => {
 				'button1'
 			) as HTMLElement;
 
-			dropdownButton.click();
+			fireEvent.click(dropdownButton);
+
+			const itemOne = (document.body as HTMLElement).querySelector(
+				'a[href="#one"]'
+			);
 
 			userEvent.tab();
 
 			expect(dropdownButton).toHaveFocus();
 
+			const itemTwo = (document.body as HTMLElement).querySelector(
+				'a[href="#two"]'
+			);
+
 			userEvent.tab();
 
 			expect(htmlButton1).toHaveFocus();
+
+			userEvent.tab();
+
+			expect(itemOne).toHaveFocus();
+
+			userEvent.tab();
+
+			expect(itemTwo).toHaveFocus();
 		});
 
 		it('interacts without React.Portal', () => {
@@ -342,7 +357,29 @@ describe('FocusScope', () => {
 				'button1'
 			) as HTMLElement;
 
-			dropdownButton.click();
+			dropdownButton.focus();
+
+			fireEvent.click(dropdownButton);
+
+			const itemOne = (document.body as HTMLElement).querySelector(
+				'a[href="#one"]'
+			);
+
+			userEvent.tab();
+
+			expect(itemOne).toHaveFocus();
+
+			const itemTwo = (document.body as HTMLElement).querySelector(
+				'a[href="#two"]'
+			);
+
+			userEvent.tab();
+
+			expect(itemTwo).toHaveFocus();
+
+			userEvent.tab();
+
+			expect(document.body).toHaveFocus();
 
 			userEvent.tab();
 


### PR DESCRIPTION
**What is new?**
Adding more test cases to FocusScope:
1. Some interactions using `tab + shift`.
2. Some interactions using `Arrow Up` and `Arrow Down`
3. Some interactions using `ClayPortal` to move the focus outside the React Tree

**Issues:**
#4621 