### PR TITLE
 fix(@clayui/css): Forms input sizes should be generated using the Clay Mixin pattern

### DIFF
--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -305,8 +305,7 @@ select.form-control[multiple] {
 textarea.form-control,
 textarea.form-control-plaintext,
 .form-control.form-control-textarea {
-	height: $input-textarea-height;
-	resize: vertical;
+	@include clay-form-control-variant($input-textarea);
 }
 
 // File
@@ -445,23 +444,14 @@ textarea.form-control-plaintext,
 // Bootstrap 4 @extend .form-control-lg; work around
 
 %clay-form-control-lg {
-	@include border-radius($input-border-radius-lg);
-
-	font-size: $input-font-size-lg;
-	height: $input-height-lg;
-	padding-bottom: $input-padding-y-lg;
-	padding-left: $input-padding-x-lg;
-	padding-right: $input-padding-x-lg;
-	padding-top: $input-padding-y-lg;
-
-	@include clay-scale-component {
-		height: $input-height-lg-mobile;
-	}
+	@include clay-form-control-variant($input-lg);
 }
 
 .form-control-lg {
 	@extend %clay-form-control-lg;
 }
+
+// Select Lg
 
 %clay-select-form-control-lg {
 	height: $input-height-lg;
@@ -471,66 +461,34 @@ textarea.form-control-plaintext,
 	}
 }
 
+// Textarea Lg
+
 %clay-textarea-form-control-lg {
-	height: $input-textarea-height-lg;
+	@include clay-form-control-variant($input-textarea-lg);
 }
 
 textarea.form-control-lg,
 .form-control-lg.form-control-textarea {
-	height: $input-textarea-height-lg;
-}
-
-// Form control sizing
-// Build on `.form-control` with modifier classes to decrease or increase the
-// height and font-size of form controls.
-// Repeated in `_input_group.scss` to avoid Sass extend issues.
-
-.form-control-sm {
-	@include border-radius($input-border-radius-sm);
-
-	font-size: $input-font-size-sm;
-	height: $input-height-sm;
-	line-height: $input-line-height-sm;
-	padding: $input-padding-y-sm $input-padding-x-sm;
-}
-
-.form-control-lg {
-	@include border-radius($input-border-radius-lg);
-
-	font-size: $input-font-size-lg;
-	height: $input-height-lg;
-	line-height: $input-line-height-lg;
-	padding: $input-padding-y-lg $input-padding-x-lg;
+	@extend %clay-textarea-form-control-lg !optional;
 }
 
 // Bootstrap 4 @extend .form-control-sm; work around
 
 %clay-form-control-sm {
-	@include border-radius($input-border-radius-sm);
-
-	font-size: $input-font-size-sm;
-	height: $input-height-sm;
-	padding-bottom: $input-padding-y-sm;
-	padding-left: $input-padding-x-sm;
-	padding-right: $input-padding-x-sm;
-	padding-top: $input-padding-y-sm;
-
-	@include clay-scale-component {
-		height: $input-height-sm-mobile;
-	}
+	@include clay-form-control-variant($input-sm);
 }
 
 .form-control-sm {
-	@extend %clay-form-control-sm;
+	@extend %clay-form-control-sm !optional;
 }
 
+// Select Sm
+
 %clay-select-form-control-sm {
-	@include clay-css(setter($form-control-select-sm, ()));
+	@include clay-form-control-variant($form-control-select-sm);
 
 	@include clay-scale-component {
-		$mobile: setter(map-get($form-control-select-sm, mobile));
-
-		@include clay-css($mobile);
+		@include clay-css(map-get($form-control-select-sm, mobile));
 	}
 }
 
@@ -538,13 +496,15 @@ textarea.form-control-lg,
 	@extend %clay-select-form-control-sm !optional;
 }
 
+// Textarea Sm
+
 %clay-textarea-form-control-sm {
-	height: $input-textarea-height-sm;
+	@include clay-form-control-variant($input-textarea-sm);
 }
 
 textarea.form-control-sm,
 .form-control-sm.form-control-textarea {
-	height: $input-textarea-height-sm;
+	@extend %clay-textarea-form-control-sm !optional;
 }
 
 // Fieldset

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -601,6 +601,8 @@
 					);
 				}
 			}
+
+			@include clay-generate-media-breakpoints($map);
 		}
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_grid.scss
+++ b/packages/clay-css/src/scss/mixins/_grid.scss
@@ -184,7 +184,7 @@
 		$media-breakpoint-up: map-get($map, media-breakpoint-up);
 
 		@each $breakpoint in map-keys($media-breakpoint-up) {
-			$breakpoint-up: map-get($map, $breakpoint);
+			$breakpoint-up: map-get($media-breakpoint-up, $breakpoint);
 
 			@include media-breakpoint-up($breakpoint) {
 				@include clay-css($breakpoint-up);
@@ -195,8 +195,8 @@
 	@if (map-get($map, media-breakpoint-down)) {
 		$media-breakpoint-down: map-get($map, media-breakpoint-down);
 
-		@each $breakpoint in map-keys($map) {
-			$breakpoint-down: map-get($map, $breakpoint);
+		@each $breakpoint in map-keys($media-breakpoint-down) {
+			$breakpoint-down: map-get($media-breakpoint-down, $breakpoint);
 
 			@include media-breakpoint-down($breakpoint) {
 				@include clay-css($breakpoint-down);

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -142,6 +142,27 @@ $input-padding-y-lg: $input-btn-padding-y-lg !default;
 $input-font-size-lg-mobile: null !default;
 $input-height-lg-mobile: null !default;
 
+$input-lg: () !default;
+$input-lg: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($input-border-radius-lg),
+		font-size: $input-font-size-lg,
+		height: $input-height-lg,
+		line-height: $input-line-height-lg,
+		padding-bottom: $input-padding-y-lg,
+		padding-left: $input-padding-x-lg,
+		padding-right: $input-padding-x-lg,
+		padding-top: $input-padding-y-lg,
+		media-breakpoint-down: (
+			sm: (
+				font-size: $input-font-size-lg-mobile,
+				height: $input-height-lg-mobile,
+			),
+		),
+	),
+	$input-lg
+);
+
 // Input Sm (.form-control-sm)
 
 $input-border-radius-sm: $border-radius-sm !default;
@@ -153,6 +174,26 @@ $input-padding-y-sm: $input-btn-padding-y-sm !default;
 
 $input-font-size-sm-mobile: null !default;
 $input-height-sm-mobile: null !default;
+
+$input-sm: () !default;
+$input-sm: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($input-border-radius-sm),
+		font-size: $input-font-size-sm,
+		height: $input-height-sm,
+		line-height: $input-line-height-sm,
+		padding-bottom: $input-padding-y-sm,
+		padding-left: $input-padding-x-sm,
+		padding-right: $input-padding-x-sm,
+		padding-top: $input-padding-y-sm,
+		media-breakpoint-down: (
+			sm: (
+				height: $input-height-sm-mobile,
+			),
+		),
+	),
+	$input-sm
+);
 
 // Input Label (<label>)
 
@@ -300,9 +341,42 @@ $input-plaintext-readonly: map-deep-merge(
 	$input-plaintext-readonly
 );
 
+// textarea.form-control, textarea.form-control-plaintext, .form-control.form-control-textarea
+
 $input-textarea-height: 150px !default;
+
+$input-textarea: () !default;
+$input-textarea: map-merge(
+	(
+		height: $input-textarea-height,
+		resize: vertical,
+	),
+	$input-textarea
+);
+
+// textarea.form-control-lg, .form-control-lg.form-control-textarea
+
 $input-textarea-height-lg: 190px !default;
+
+$input-textarea-lg: () !default;
+$input-textarea-lg: map-deep-merge(
+	(
+		height: $input-textarea-height-lg,
+	),
+	$input-textarea-lg
+);
+
+// textarea.form-control-sm, .form-control-sm.form-control-textarea
+
 $input-textarea-height-sm: 120px !default;
+
+$input-textarea-sm: () !default;
+$input-textarea-sm: map-deep-merge(
+	(
+		height: $input-textarea-height-sm,
+	),
+	$input-textarea-sm
+);
 
 // Form Control Label (Labels inside Form Control Tag Group)
 


### PR DESCRIPTION
fixes #4711

This converts `form-control` sizes to use the Clay Mixin pattern.

textarea, textarea.form-control-lg, textarea.form-control-sm, .form-control-lg, .form-control-sm, .form-control-select.form-control-sm