### PR TITLE
chore(@clayui/core): updates the OverlayMask example with popover to use the new properties

### DIFF
--- a/packages/clay-core/stories/OverlayMask.stories.tsx
+++ b/packages/clay-core/stories/OverlayMask.stories.tsx
@@ -70,6 +70,7 @@ storiesOf('Components|OverlayMask', module)
 							<ClayPopover
 								alignPosition="right-top"
 								closeOnClickOutside
+								displayType="secondary"
 								header={
 									<ClayLayout.ContentRow
 										noGutters
@@ -83,6 +84,7 @@ storiesOf('Components|OverlayMask', module)
 										<ClayLayout.ContentCol>
 											<ClayButtonWithIcon
 												aria-label="close"
+												className="close"
 												displayType="unstyled"
 												onClick={() =>
 													setVisible(false)
@@ -95,7 +97,7 @@ storiesOf('Components|OverlayMask', module)
 								}
 								onShowChange={setVisible}
 								show={visible}
-								style={{maxWidth: '26rem'}}
+								size="lg"
 								trigger={
 									<ClayButton ref={ref}>Logo</ClayButton>
 								}


### PR DESCRIPTION
After PR #4801 entered the master new properties were added to the popover which are used in compositing with the OverlayMask, this PR just updates the example in the storybook to use the new properties.