### PR TITLE
chore(clayui.com): add the new icons in the documentation

### DIFF
--- a/clayui.com/static/images/icons/icons.svg
+++ b/clayui.com/static/images/icons/icons.svg
@@ -104,6 +104,15 @@
 	<path class="lexicon-icon-outline books-3-spine-top" d="M359.2,35.2l-31,8.1c-17.1,4.5-27.4,21.9-22.9,39l8.1,31l92.9-24.2l-8.1-31C393.7,41,376.3,30.7,359.2,35.2z"/>
 	<rect class="lexicon-icon-outline books-3-spine" x="352.1" y="128" transform="matrix(0.9678 -0.2518 0.2518 0.9678 -51.571 108.9927)" width="96" height="256"/>
 	<path class="lexicon-icon-outline books-3-spine-bottom" d="M402,453.9c4.5,17.1,21.9,27.4,39,22.9l31-8.1c17.1-4.5,27.4-21.9,22.9-39l-8.1-31l-92.9,24.2L402,453.9z"/>
+</symbol><symbol id="border-style" viewBox="0 0 512 512">  <path class="lexicon-icon-outline border-style-rectangle-1" d="M64.0015 96C46.3284 96 32.0015 110.327 32.0015 128C32.0015 145.673 46.3284 160 64.0015 160H448.001C465.675 160 480.001 145.673 480.001 128C480.001 110.327 465.675 96 448.001 96H64.0015Z" />
+  <path class="lexicon-icon-outline border-style-rectangle-2" d="M64.0015 224C46.3284 224 32.0015 238.327 32.0015 256C32.0015 273.673 46.3284 288 64.0015 288H192.001C209.675 288 224.001 273.673 224.001 256C224.001 238.327 209.675 224 192.001 224H64.0015Z" />
+  <path class="lexicon-icon-outline border-style-rectangle-3" d="M32.0015 384C32.0015 366.327 46.3284 352 64.0015 352H128.001C145.675 352 160.001 366.327 160.001 384C160.001 401.673 145.675 416 128.001 416H64.0015C46.3284 416 32.0015 401.673 32.0015 384Z" />
+  <path class="lexicon-icon-outline border-style-rectangle-4" d="M320.001 224C302.328 224 288.001 238.327 288.001 256C288.001 273.673 302.328 288 320.001 288H448.001C465.675 288 480.001 273.673 480.001 256C480.001 238.327 465.675 224 448.001 224H320.001Z" />
+  <path class="lexicon-icon-outline border-style-rectangle-5" d="M192.001 384C192.001 366.327 206.328 352 224.001 352H288.001C305.675 352 320.001 366.327 320.001 384C320.001 401.673 305.675 416 288.001 416H224.001C206.328 416 192.001 401.673 192.001 384Z" />
+  <path class="lexicon-icon-outline border-style-rectangle-6" d="M384.001 352C366.328 352 352.001 366.327 352.001 384C352.001 401.673 366.328 416 384.001 416H448.001C465.675 416 480.001 401.673 480.001 384C480.001 366.327 465.675 352 448.001 352H384.001Z" />
+</symbol><symbol id="border-width" viewBox="0 0 512 512">  <path class="lexicon-icon-outline lx-border-width-line-1" d="M32 352h448v96H32z"/>
+  <path class="lexicon-icon-outline lx-border-width-line-2" d="M32 192h448v64H32z"/>
+  <path class="lexicon-icon-outline lx-border-width-line-3" d="M32 64h448v32H32z"/>
 </symbol><symbol id="box-container" viewBox="0 0 512 512">	<path class="lexicon-icon-outline box-container-border" d="M448,64v384H64V64H448 M448,0H64C28.7,0,0,28.7,0,64v384c0,35.3,28.7,64,64,64h384c35.3,0,64-28.7,64-64V64C512,28.7,483.3,0,448,0L448,0z"></path>
 	<path class="lexicon-icon-outline box-container-square1" d="M384,256h-64c-17.7,0-32-14.3-32-32v-64c0-17.7,14.3-32,32-32h64c17.7,0,32,14.3,32,32v64C416,241.7,401.7,256,384,256z"></path>
 	<path class="lexicon-icon-outline box-container-square2" d="M384,416h-64c-17.7,0-32-14.3-32-32v-64c0-17.7,14.3-32,32-32h64c17.7,0,32,14.3,32,32v64C416,401.7,401.7,416,384,416z"></path>
@@ -857,6 +866,14 @@
 	<path class="lexicon-icon-outline number-ones" d="M369.9,314.1C382,326,416,354,452.8,329.8c29.7-27.3,6.7-68.8-54.4-62.8v-29.6c11,0,58.6,0.6,58.4-35.9c-2.3-43.5-54.8-34-78.1-8.8l-20.7-25c9.6-8.5,43-38.7,96.8-24.3c67.2,23.1,46.2,98.1,3.8,106.6c47.4,9,77.4,88-1.6,117.4c-44,11.6-86-2.4-106.5-27.3L369.9,314.1z"></path>
 </symbol><symbol id="oauth" viewBox="0 0 512 512">	<path class="lexicon-icon-outline oauth-2-border" d="M256.4,64c254.8,13,256.7,370.5,0,384C-0.5,436.4,0.2,76.4,256.4,64 M256.4,0c-342,15.6-341.7,497.6,0,512C596.9,499.9,597.5,14.2,256.4,0L256.4,0z"></path>
 	<path class="lexicon-icon-outline oauth-2-a" d="M350.6,310.3L303.9,164c-7.2-17.7-16-36-47.8-36c-32.1,0-40.5,18.2-48,36l-46.7,146.4c-10.9,40.4,45.8,59.7,61.2,19.3l9.2-29h48.3l9.2,29C304.7,370,361.6,351,350.6,310.3z"></path>
+</symbol><symbol id="opacity" viewBox="0 0 512 512">  <path class="lexicon-icon-outline lx-opacity-square-1" d="M0 256h128v128H0z"/>
+  <path class="lexicon-icon-outline lx-opacity-square-2" d="M128 128h128v128H128z"/>
+  <path class="lexicon-icon-outline lx-opacity-square-3" d="M0 64C0 28.654 28.654 0 64 0h64v128H0V64Z"/>
+  <path class="lexicon-icon-outline lx-opacity-square-4" d="M128 384h128v128H128z"/>
+  <path class="lexicon-icon-outline lx-opacity-square-5" d="M256 0h128v128H256z"/>
+  <path class="lexicon-icon-outline lx-opacity-square-6" d="M256 256h128v128H256z"/>
+  <path class="lexicon-icon-outline lx-opacity-square-7" d="M384 384h128v64c0 35.346-28.654 64-64 64h-64V384Z"/>
+  <path class="lexicon-icon-outline lx-opacity-square-8" d="M384 128h128v128H384z"/>
 </symbol><symbol id="open-id" viewBox="0 0 512 512">	<path class="lexicon-icon-outline open-id-tail" d="M224,64v382.2C128.3,436.4,64,383.8,64,336c0-42.3,50.3-88.3,128-105.2v-65C81.6,185.3,0,254,0,336c0,89.7,97.8,165.2,224,176l96-64V0L224,64z"></path>
 	<path class="lexicon-icon-outline open-id-head" d="M512,320l-32-128l-35.2,26.4c-25.6-19.5-56.7-35.5-92.8-45.5v66.9c7.2,2.6,26.3,7.5,41.8,16.8L352,288L512,320z"></path>
 </symbol><symbol id="order-arrow-down" viewBox="0 0 512 512">	<path class="lexicon-icon-outline" d="M161.5,367.9l71.6,71.6c11.9,10.8,32.9,11.2,45.8,0l71.6-71.6c29.8-33.6-15.8-74.9-45.8-45.8L288,338.8V96c0-42.5-64-42.5-64,0v242.8l-16.7-16.7C175.5,292.2,131.8,337,161.5,367.9z"></path>

--- a/clayui.com/static/js/icons-autogenerated.json
+++ b/clayui.com/static/js/icons-autogenerated.json
@@ -200,6 +200,14 @@
         "aliases": [""]
     },
     {
+        "name": "border-style",
+        "aliases": ["line", "stroke", "dashed", "solid"]
+    },
+    {
+        "name": "border-width",
+        "aliases": ["line", "stroke", "weight", "thickness"]
+    },
+    {
         "name": "box-container",
         "aliases": ["chest", "collection", "package"]
     },
@@ -906,6 +914,10 @@
     {
         "name": "oauth",
         "aliases": [""]
+    },
+    {
+        "name": "opacity",
+        "aliases": ["transparent", "checker", "opaque"]
     },
     {
         "name": "open-id",


### PR DESCRIPTION
We recently added new icons but they were not updated in the documentation, I just added the generated files here. Maybe one way to avoid generating these files every time and being tracked by git is bypassing git and letting it run at build time, probably build time for production is already done and we don't update in git.