### PR TITLE
chore(release): remove the step of sync master with stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,6 @@ jobs:
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-      - run: git push origin stable
       - run: lerna publish from-git --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
For some reason, it is not possible to sync with master with stable by Github Action, for now, I will do it manually and send another PR to test another option. Submitting this so we can see if we can automate the end-to-end release today.