### PR TITLE
fix(@clayui/css): Replace `$spacer * 0.5` with fixed values, it plays…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -426,7 +426,7 @@ $h6-font-size-mobile: null !default;
 
 // Headings h1-h6
 
-$headings-margin-bottom: $spacer * 0.5 !default;
+$headings-margin-bottom: 0.5rem !default;
 $headings-font-family: null !default;
 $headings-font-weight: $font-weight-bold !default;
 $headings-line-height: 1.2 !default;

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -405,7 +405,7 @@ $dropdown-divider-bg: $gray-200 !default;
 
 /// @deprecated as of v3.x use map $dropdown-divider instead
 
-$dropdown-divider-margin-y: $spacer * 0.5 !default;
+$dropdown-divider-margin-y: 0.5rem !default;
 
 $dropdown-divider: () !default;
 $dropdown-divider: map-merge(
@@ -884,7 +884,7 @@ $dropdown-action: map-deep-merge(
 
 $dropdown-alert-font-size: null !default;
 $dropdown-alert-line-height: normal !default;
-$dropdown-alert-margin: $spacer * 0.5 !default;
+$dropdown-alert-margin: 0.5rem !default;
 $dropdown-alert-padding-x: $dropdown-header-padding-x !default;
 $dropdown-alert-padding-y: $dropdown-header-padding-y !default;
 

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -496,7 +496,7 @@ $h6: map-deep-merge(
 
 // Headings h1-h6
 
-$headings-margin-bottom: $spacer * 0.5 !default;
+$headings-margin-bottom: 0.5rem !default;
 $headings-font-family: null !default;
 $headings-font-weight: 500 !default;
 $headings-line-height: 1.2 !default;

--- a/packages/clay-css/src/scss/variables/_navbar.scss
+++ b/packages/clay-css/src/scss/variables/_navbar.scss
@@ -2,8 +2,8 @@ $enable-scaling-navbar: $enable-scaling-components !default;
 
 $navbar-border-radius: null !default;
 $navbar-font-size: null !default;
-$navbar-padding-x: $spacer !default;
-$navbar-padding-y: $spacer * 0.5 !default;
+$navbar-padding-x: 1rem !default;
+$navbar-padding-y: 0.5rem !default;
 
 $navbar-nav-link-padding-x: 0.5rem !default;
 

--- a/packages/clay-css/src/scss/variables/_navs.scss
+++ b/packages/clay-css/src/scss/variables/_navs.scss
@@ -157,7 +157,7 @@ $nav-item: map-deep-merge(
 // .nav-divider
 
 $nav-divider-color: $gray-600 !default;
-$nav-divider-margin-y: $spacer * 0.5 !default;
+$nav-divider-margin-y: 0.5rem !default;
 
 $nav-divider: () !default;
 $nav-divider: map-deep-merge(


### PR DESCRIPTION
… better with calc()

I didn't change the `$spacers` map due to it being directly related to the `$spacer` variable. I'm not sure if anyone is depending on the relationship and is easy to find.

fixes #4811 