### PR TITLE
fix(@clayui/css): Tables use calc() to make fatter border widths in t…

### DIFF
--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -107,7 +107,7 @@ caption {
 	}
 
 	tbody + tbody {
-		border-top: (2 * $table-border-width) solid $table-border-color;
+		border-top: calc(2 * #{$table-border-width}) solid $table-border-color;
 	}
 
 	tfoot {
@@ -170,7 +170,7 @@ caption {
 	thead {
 		td,
 		th {
-			border-bottom-width: 2 * $table-border-width;
+			border-bottom-width: calc(2 * #{$table-border-width});
 
 			@if (
 				$table-head-border-top-width ==

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -68,7 +68,7 @@ $table-cell-expand-smallest-width: 10% !default;
 // TH
 
 $table-head-bg: $white !default;
-$table-head-border-bottom-width: 2 * $table-border-width !default;
+$table-head-border-bottom-width: calc(2 * #{$table-border-width}) !default;
 $table-head-border-top-width: 0px !default;
 $table-head-color: $gray-700 !default;
 $table-head-font-size: null !default;


### PR DESCRIPTION
…head and tbody

Tables still need a revamp, but custom properties should work now.

/cc @ethib137 

fixes #4818