### PR TITLE
fix(@clayui/css): Atlas .btn.active:focus should have outline

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -10,7 +10,7 @@ $btn-focus-box-shadow: $component-focus-box-shadow !default;
 
 $btn-disabled-opacity: 0.4 !default;
 
-$btn-active-box-shadow: none !default;
+$btn-active-box-shadow: $c-unset !default;
 
 $btn-inline-item-font-size: 1rem !default; // 16px
 

--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -284,9 +284,9 @@ $embed-responsive-aspect-ratios: join(
 	$embed-responsive-aspect-ratios
 );
 
-$component-focus-box-shadow: 0 0 0 0.125rem $white#{','} 0 0 0 0.25rem $primary-l1 !default;
-$component-focus-inset-box-shadow: inset 0 0 0 0.125rem $primary-l1#{','} inset 0
-	0 0 0.25rem $white !default;
+$component-focus-box-shadow: #{0 0 0 0.125rem $white, 0 0 0 0.25rem $primary-l1} !default;
+$component-focus-inset-box-shadow: #{inset 0 0 0 0.125rem $primary-l1,
+	inset 0 0 0 0.25rem $white} !default;
 
 $component-active-color: #fff !default;
 $component-active-bg: #0b5fff !default;

--- a/packages/clay-css/src/scss/atlas/variables/_navs.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navs.scss
@@ -23,7 +23,7 @@ $nav-link-btn-unstyled: () !default;
 $nav-link-btn-unstyled: map-deep-merge(
 	(
 		focus: (
-			box-shadow: 0 0 0 0.125rem $white#{','} 0 0 0 0.25rem $primary-l1,
+			box-shadow: $component-focus-box-shadow,
 		),
 	),
 	$nav-link-btn-unstyled

--- a/packages/clay-css/src/scss/atlas/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sheets.scss
@@ -37,7 +37,8 @@ $sheet-subtitle-link: map-deep-merge(
 		border-radius: 1px,
 		transition: box-shadow 0.15s ease-in-out,
 		focus: (
-			box-shadow: 0 0 0 0.25rem $white#{','} 0 0 0 0.375rem $primary-l1,
+			box-shadow: #{0 0 0 0.25rem $white,
+			0 0 0 0.375rem $primary-l1},
 			outline: 0,
 		),
 	),

--- a/packages/clay-css/src/scss/atlas/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sidebar.scss
@@ -63,7 +63,8 @@ $sidebar-light: map-deep-merge(
 		),
 		panel-unstyled: (
 			header-link: (
-				focus-box-shadow: 0 0 0 0.25rem $white#{','} 0 0 0 0.375rem $primary-l1,
+				focus-box-shadow: #{0 0 0 0.25rem $white,
+				0 0 0 0.375rem $primary-l1},
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -735,6 +735,10 @@
 					@include clay-css($active-class-after);
 				}
 
+				&:focus {
+					@include clay-css(map-deep-get($map, active-class, focus));
+				}
+
 				.inline-item {
 					@include clay-css(map-get($active-class, inline-item));
 				}

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -1,6 +1,7 @@
 $btn-border-width: $input-btn-border-width !default;
 $btn-border-radius: $border-radius !default;
-$btn-box-shadow: inset 0 1px 0 rgba($white, 0.15), 0 1px 1px rgba($black, 0.075) !default;
+$btn-box-shadow: #{inset 0 1px 0 rgba($white, 0.15),
+	0 1px 1px rgba($black, 0.075)} !default;
 $btn-cursor: $link-cursor !default;
 $btn-font-family: $input-btn-font-family !default;
 $btn-font-size: $input-btn-font-size !default;
@@ -38,7 +39,7 @@ $btn: map-deep-merge(
 		border-style: solid,
 		border-width: $btn-border-width,
 		border-radius: clay-enable-rounded($btn-border-radius),
-		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		box-shadow: clay-enable-shadows($btn-box-shadow),
 		color: $body-color,
 		cursor: $btn-cursor,
 		display: inline-block,
@@ -72,13 +73,13 @@ $btn: map-deep-merge(
 			outline: 0,
 		),
 		active: (
-			box-shadow: clay-enable-shadows([$btn-active-box-shadow]),
+			box-shadow: clay-enable-shadows($btn-active-box-shadow),
 			focus: (
-				box-shadow: clay-enable-shadows([$btn-focus-box-shadow]),
+				box-shadow: clay-enable-shadows($btn-focus-box-shadow),
 			),
 		),
 		active-class: (
-			box-shadow: clay-enable-shadows([$btn-active-box-shadow]),
+			box-shadow: clay-enable-shadows($btn-active-box-shadow),
 		),
 		disabled: (
 			cursor: $btn-disabled-cursor,
@@ -352,7 +353,7 @@ $btn-primary: map-deep-merge(
 		background-color: $primary,
 		background-image: clay-enable-gradients($primary),
 		border-color: $primary,
-		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		box-shadow: clay-enable-shadows($btn-box-shadow),
 		color: color-yiq($primary),
 		hover: (
 			background-color: clay-darken($primary, 7.5%),
@@ -366,10 +367,11 @@ $btn-primary: map-deep-merge(
 			border-color: clay-darken($primary, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					[ $btn-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5),
+					#{$btn-box-shadow,
+					0 0 0 $btn-focus-width
+						rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5)},
 					0 0 0 $btn-focus-width
 						rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5)
-						]
 				),
 			color: color-yiq(clay-darken($primary, 7.5%)),
 		),
@@ -381,13 +383,17 @@ $btn-primary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($primary), $primary, 15%), 0.5),
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($primary), $primary, 15%),
+								0.5
+							)},
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($primary), $primary, 15%),
 								0.5
 							)
-							]
 					),
 			),
 		),
@@ -408,7 +414,7 @@ $btn-secondary: map-deep-merge(
 		background-color: $secondary,
 		background-image: clay-enable-gradients($secondary),
 		border-color: $secondary,
-		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		box-shadow: clay-enable-shadows($btn-box-shadow),
 		color: color-yiq($secondary),
 		hover: (
 			background-color: clay-darken($secondary, 7.5%),
@@ -424,13 +430,17 @@ $btn-secondary: map-deep-merge(
 			border-color: clay-darken($secondary, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					[ $btn-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($secondary), $secondary, 15%), 0.5),
+					#{$btn-box-shadow,
 					0 0 0 $btn-focus-width
 						rgba(
 							clay-mix(color-yiq($secondary), $secondary, 15%),
 							0.5
-						),
-					]
+						)},
+					0 0 0 $btn-focus-width
+						rgba(
+							clay-mix(color-yiq($secondary), $secondary, 15%),
+							0.5
+						)
 				),
 			color: color-yiq(clay-darken($secondary, 7.5%)),
 		),
@@ -442,7 +452,16 @@ $btn-secondary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($secondary), $secondary, 15%), 0.5),
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(
+									color-yiq($secondary),
+									$secondary,
+									15%
+								),
+								0.5
+							)},
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(
@@ -452,7 +471,6 @@ $btn-secondary: map-deep-merge(
 								),
 								0.5
 							)
-							]
 					),
 			),
 		),
@@ -473,7 +491,7 @@ $btn-success: map-deep-merge(
 		background-color: $success,
 		background-image: clay-enable-gradients($success),
 		border-color: $success,
-		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		box-shadow: clay-enable-shadows($btn-box-shadow),
 		color: color-yiq($success),
 		hover: (
 			background-color: clay-darken($success, 7.5%),
@@ -487,10 +505,11 @@ $btn-success: map-deep-merge(
 			border-color: clay-darken($success, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					[ $btn-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($success), $success, 15%), 0.5),
+					#{$btn-box-shadow,
+					0 0 0 $btn-focus-width
+						rgba(clay-mix(color-yiq($success), $success, 15%), 0.5)},
 					0 0 0 $btn-focus-width
 						rgba(clay-mix(color-yiq($success), $success, 15%), 0.5)
-						]
 				),
 			color: color-yiq(clay-darken($success, 7.5%)),
 		),
@@ -502,13 +521,17 @@ $btn-success: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($success), $success, 15%), 0.5),
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($success), $success, 15%),
+								0.5
+							)},
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($success), $success, 15%),
 								0.5
 							)
-							]
 					),
 			),
 		),
@@ -529,7 +552,7 @@ $btn-info: map-deep-merge(
 		background-color: $info,
 		background-image: clay-enable-gradients($info),
 		border-color: $info,
-		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		box-shadow: clay-enable-shadows($btn-box-shadow),
 		color: color-yiq($info),
 		hover: (
 			background-color: clay-darken($info, 7.5%),
@@ -543,9 +566,11 @@ $btn-info: map-deep-merge(
 			border-color: clay-darken($info, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					[ $btn-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($info), $info, 15%), 0.5),
+					#{$btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($info), $info, 15%), 0.5) ]
+						rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)},
+					0 0 0 $btn-focus-width
+						rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)
 				),
 			color: color-yiq(clay-darken($info, 7.5%)),
 		),
@@ -557,9 +582,11 @@ $btn-info: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($info), $info, 15%), 0.5),
+						#{$btn-active-box-shadow,
 						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5) ]
+							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)},
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)
 					),
 			),
 		),
@@ -580,7 +607,7 @@ $btn-warning: map-deep-merge(
 		background-color: $warning,
 		background-image: clay-enable-gradients($warning),
 		border-color: $warning,
-		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		box-shadow: clay-enable-shadows($btn-box-shadow),
 		color: color-yiq($warning),
 		hover: (
 			background-color: clay-darken($warning, 7.5%),
@@ -594,10 +621,11 @@ $btn-warning: map-deep-merge(
 			border-color: clay-darken($warning, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					[ $btn-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5),
+					#{$btn-box-shadow,
+					0 0 0 $btn-focus-width
+						rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5)},
 					0 0 0 $btn-focus-width
 						rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5)
-						]
 				),
 			color: color-yiq(clay-darken($warning, 7.5%)),
 		),
@@ -609,13 +637,17 @@ $btn-warning: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($warning), $warning, 15%), 0.5),
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($warning), $warning, 15%),
+								0.5
+							)},
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($warning), $warning, 15%),
 								0.5
 							)
-							]
 					),
 			),
 		),
@@ -635,7 +667,7 @@ $btn-danger: map-deep-merge(
 		background-color: $danger,
 		background-image: clay-enable-gradients($danger),
 		border-color: $danger,
-		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		box-shadow: clay-enable-shadows($btn-box-shadow),
 		color: color-yiq($danger),
 		hover: (
 			background-color: clay-darken($danger, 7.5%),
@@ -649,9 +681,11 @@ $btn-danger: map-deep-merge(
 			border-color: clay-darken($danger, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					[ $btn-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5),
+					#{$btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5) ]
+						rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5)},
+					0 0 0 $btn-focus-width
+						rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5)
 				),
 			color: color-yiq(clay-darken($danger, 7.5%)),
 		),
@@ -663,13 +697,17 @@ $btn-danger: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($danger), $danger, 15%), 0.5),
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($danger), $danger, 15%),
+								0.5
+							)},
 						0 0 0 $btn-focus-width
 							rgba(
 								clay-mix(color-yiq($danger), $danger, 15%),
 								0.5
 							)
-							]
 					),
 			),
 		),
@@ -690,7 +728,7 @@ $btn-light: map-deep-merge(
 		background-color: $light,
 		background-image: clay-enable-gradients($light),
 		border-color: $light,
-		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		box-shadow: clay-enable-shadows($btn-box-shadow),
 		color: color-yiq($light),
 		hover: (
 			background-color: clay-darken($light, 7.5%),
@@ -704,9 +742,11 @@ $btn-light: map-deep-merge(
 			border-color: clay-darken($light, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					[ $btn-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($light), $light, 15%), 0.5),
+					#{$btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($light), $light, 15%), 0.5) ]
+						rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)},
+					0 0 0 $btn-focus-width
+						rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)
 				),
 			color: color-yiq(clay-darken($light, 7.5%)),
 		),
@@ -718,10 +758,11 @@ $btn-light: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($light), $light, 15%), 0.5),
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)},
 						0 0 0 $btn-focus-width
 							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)
-							]
 					),
 			),
 		),
@@ -741,7 +782,7 @@ $btn-dark: map-deep-merge(
 		background-color: $dark,
 		background-image: clay-enable-gradients($dark),
 		border-color: $dark,
-		box-shadow: clay-enable-shadows([$btn-box-shadow]),
+		box-shadow: clay-enable-shadows($btn-box-shadow),
 		color: color-yiq($dark),
 		hover: (
 			background-color: clay-darken($dark, 7.5%),
@@ -755,9 +796,11 @@ $btn-dark: map-deep-merge(
 			border-color: clay-darken($dark, 10%),
 			box-shadow:
 				clay-enable-shadows(
-					[ $btn-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5),
+					#{$btn-box-shadow,
 					0 0 0 $btn-focus-width
-						rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5) ]
+						rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)},
+					0 0 0 $btn-focus-width
+						rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)
 				),
 			color: color-yiq(clay-darken($dark, 7.5%)),
 		),
@@ -769,9 +812,11 @@ $btn-dark: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5),
+						#{$btn-active-box-shadow,
 						0 0 0 $btn-focus-width
-							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5) ]
+							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)},
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)
 					),
 			),
 		),
@@ -792,7 +837,7 @@ $btn-link: () !default;
 $btn-link: map-deep-merge(
 	(
 		border-radius: 1px,
-		box-shadow: clay-enable-shadows([none]),
+		box-shadow: clay-enable-shadows(none),
 		color: $link-color,
 		font-weight: $font-weight-normal,
 		text-decoration: $link-decoration,
@@ -805,7 +850,7 @@ $btn-link: map-deep-merge(
 			text-decoration: $link-decoration,
 		),
 		active: (
-			box-shadow: clay-enable-shadows([none]),
+			box-shadow: clay-enable-shadows(none),
 		),
 		disabled: (
 			box-shadow: none,
@@ -854,8 +899,9 @@ $btn-outline-primary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba($primary, 0.5),
-						$c-unset ]
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($primary, 0.5)},
+						$c-unset
 					),
 			),
 		),
@@ -887,8 +933,9 @@ $btn-outline-secondary: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba($secondary, 0.5),
-						0 0 0 $btn-focus-width rgba($secondary, 0.5) ]
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($secondary, 0.5)},
+						0 0 0 $btn-focus-width rgba($secondary, 0.5)
 					),
 			),
 		),
@@ -920,8 +967,9 @@ $btn-outline-success: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba($success, 0.5),
-						0 0 0 $btn-focus-width rgba($success, 0.5) ]
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($success, 0.5)},
+						0 0 0 $btn-focus-width rgba($success, 0.5)
 					),
 			),
 		),
@@ -953,8 +1001,9 @@ $btn-outline-info: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba($info, 0.5),
-						0 0 0 $btn-focus-width rgba($info, 0.5) ]
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($info, 0.5)},
+						0 0 0 $btn-focus-width rgba($info, 0.5)
 					),
 			),
 		),
@@ -986,8 +1035,9 @@ $btn-outline-warning: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba($warning, 0.5),
-						0 0 0 $btn-focus-width rgba($warning, 0.5) ]
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($warning, 0.5)},
+						0 0 0 $btn-focus-width rgba($warning, 0.5)
 					),
 			),
 		),
@@ -1019,8 +1069,9 @@ $btn-outline-danger: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba($danger, 0.5),
-						0 0 0 $btn-focus-width rgba($danger, 0.5) ]
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($danger, 0.5)},
+						0 0 0 $btn-focus-width rgba($danger, 0.5)
 					),
 			),
 		),
@@ -1052,8 +1103,9 @@ $btn-outline-light: map-deep-merge(
 			focus: (
 				box-shadow:
 					clay-enable-shadows(
-						[ $btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba($light, 0.5),
-						0 0 0 $btn-focus-width rgba($light, 0.5) ]
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($light, 0.5)},
+						0 0 0 $btn-focus-width rgba($light, 0.5)
 					),
 			),
 		),
@@ -1084,9 +1136,9 @@ $btn-outline-dark: map-deep-merge(
 			color: color-yiq($dark),
 			focus: (
 				box-shadow:
-					if(
-						$enable-shadows and $btn-active-box-shadow != none,
-						$btn-active-box-shadow#{','} 0 0 0 $btn-focus-width rgba($dark, 0.5),
+					clay-enable-shadows(
+						#{$btn-active-box-shadow,
+						0 0 0 $btn-focus-width rgba($dark, 0.5)},
 						0 0 0 $btn-focus-width rgba($dark, 0.5)
 					),
 			),

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -849,9 +849,6 @@ $btn-link: map-deep-merge(
 			box-shadow: $btn-focus-box-shadow,
 			text-decoration: $link-decoration,
 		),
-		active: (
-			box-shadow: clay-enable-shadows(none),
-		),
 		disabled: (
 			box-shadow: none,
 			color: $btn-link-disabled-color,

--- a/packages/clay-css/src/scss/variables/_panels.scss
+++ b/packages/clay-css/src/scss/variables/_panels.scss
@@ -47,7 +47,8 @@ $panel-header-link: map-deep-merge(
 		color: inherit,
 		display: block,
 		text-decoration: $panel-header-link-text-decoration,
-		transition: border-color 0.1s ease#{','} border-radius 0.5s ease,
+		transition: #{border-color 0.1s ease,
+		border-radius 0.5s ease},
 		hover: (
 			color: inherit,
 			text-decoration: $panel-header-link-hover-text-decoration,

--- a/packages/clay-css/src/scss/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/variables/_tbar.scss
@@ -58,12 +58,12 @@ $tbar-stacked: map-deep-merge(
 			position: relative,
 			width: 2.5rem,
 			focus: (
-				box-shadow: inset 0 0 0 0.125rem $primary-l1#{','} inset 0 0 0 0.25rem
-					$white,
+				box-shadow: #{inset 0 0 0 0.125rem $primary-l1,
+				inset 0 0 0 0.25rem $white},
 			),
 			active-focus: (
-				box-shadow: inset 0 0 0 0.125rem $primary-l1#{','} inset 0 0 0 0.25rem
-					$white,
+				box-shadow: #{inset 0 0 0 0.125rem $primary-l1,
+				inset 0 0 0 0.25rem $white},
 			),
 		),
 	),
@@ -136,7 +136,8 @@ $tbar-light: () !default;
 $tbar-light: map-deep-merge(
 	(
 		background-color: $white,
-		box-shadow: inset 1px 0 0 0 $gray-200#{','} inset -1px 0 0 0 $gray-200,
+		box-shadow: #{inset 1px 0 0 0 $gray-200,
+		inset -1px 0 0 0 $gray-200},
 		color: $secondary,
 		divider-before: (
 			background-color: $gray-200,
@@ -167,8 +168,8 @@ $tbar-dark-d1: () !default;
 $tbar-dark-d1: map-deep-merge(
 	(
 		background-color: $dark-d1,
-		box-shadow: inset 1px 0 0 0 rgba($white, 0.06) #{','} inset -1px 0 0 0
-			rgba($white, 0.06),
+		box-shadow: #{inset 1px 0 0 0 rgba($white, 0.06),
+		inset -1px 0 0 0 rgba($white, 0.06)},
 		color: $gray-500,
 		divider-before: (
 			background-color: rgba($white, 0.06),
@@ -209,8 +210,8 @@ $tbar-dark-l2: () !default;
 $tbar-dark-l2: map-deep-merge(
 	(
 		background-color: $dark-l2,
-		box-shadow: inset 1px 0 0 0 rgba($white, 0.06) #{','} inset -1px 0 0 0
-			rgba($white, 0.06),
+		box-shadow: #{inset 1px 0 0 0 rgba($white, 0.06),
+		inset -1px 0 0 0 rgba($white, 0.06)},
 		border-color: rgba($white, 0.06),
 		color: $gray-500,
 		divider-before: (


### PR DESCRIPTION
- interpolate multiple box-shadows and transitions
- use the global $component-focus-box-shadow where applicable
- Mixins clay-button-variant should be able to style .active:focus

fixes #4804