### PR TITLE
chore: updates broken links to examples in storybook

### DIFF
--- a/clayui.com/content/docs/examples.mdx
+++ b/clayui.com/content/docs/examples.mdx
@@ -53,7 +53,7 @@ Here are our demos we have in Storybook that utilize Clay components showcasing 
 	</li>
 	<li>
 		<a
-			href="https://storybook.clayui.com/?path=/story/demos-templates--table-rows-drag-drop"
+			href="https://storybook.clayui.com/?path=/story/demos-templates--table-rows-with-drag-and-drop"
 			rel="noreferrer noopener"
 			target="_blank"
 		>
@@ -62,7 +62,7 @@ Here are our demos we have in Storybook that utilize Clay components showcasing 
 	</li>
 	<li>
 		<a
-			href="https://storybook.clayui.com/?path=/story/demos-templates--table-columns-drag-drop"
+			href="https://storybook.clayui.com/?path=/story/demos-templates--table-columns-with-drag-and-drop"
 			rel="noreferrer noopener"
 			target="_blank"
 		>
@@ -71,7 +71,7 @@ Here are our demos we have in Storybook that utilize Clay components showcasing 
 	</li>
 	<li>
 		<a
-			href="https://storybook.clayui.com/?path=/story/demos-templates--drag-drop"
+			href="https://storybook.clayui.com/?path=/story/demos-templates--drag-and-drop"
 			rel="noreferrer noopener"
 			target="_blank"
 		>

--- a/clayui.com/gatsby/onCreateNode.js
+++ b/clayui.com/gatsby/onCreateNode.js
@@ -41,6 +41,7 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 			path: permalink,
 			redirect,
 			redirectFrom,
+			storybookPath,
 			title,
 			version,
 		} = node.frontmatter;
@@ -185,6 +186,12 @@ module.exports = exports.onCreateNode = ({actions, getNode, node}) => {
 			name: 'packageNpm',
 			node,
 			value: packageNpm || '',
+		});
+
+		createNodeField({
+			name: 'storybookPath',
+			node,
+			value: storybookPath || '',
 		});
 
 		createNodeField({

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -35,6 +35,18 @@ const mapStatus = {
 	stable: 'success',
 };
 
+const getStorybookUrl = (packageNpm, path) => {
+	const url = 'https://storybook.clayui.com/?path=/story/';
+
+	if (path) {
+		return url + path;
+	}
+
+	return `${url}design-system-components-${packageNpm
+		.replace('@clayui/', '')
+		.replace('-', '')}`;
+};
+
 const PackageInfo = ({fields = {}, frontmatter = {}}) => (
 	<p className="clay-site-label">
 		{fields.packageStatus && (
@@ -94,9 +106,10 @@ const PackageInfo = ({fields = {}, frontmatter = {}}) => (
 
 				<a
 					className="align-middle d-inline-block link-primary"
-					href={`https://storybook.clayui.com/?path=/story/components-${frontmatter.packageNpm
-						.replace('@clayui/', 'clay')
-						.replace('-', '')}`}
+					href={getStorybookUrl(
+						frontmatter.packageNpm,
+						frontmatter.storybookPath
+					)}
 					rel="noopener noreferrer"
 					target="_blank"
 				>
@@ -376,6 +389,7 @@ export const pageQuery = graphql`
 				navigationParent
 				lexiconDefinition
 				packageNpm
+				storybookPath
 				title
 			}
 			fields {

--- a/packages/clay-alert/docs/alert.mdx
+++ b/packages/clay-alert/docs/alert.mdx
@@ -29,7 +29,7 @@ You can use alert with the following variants:
 
 <Alert />
 
-We recommend that you review the use cases in the <a href="https://storybook-clayui.netlify.com/?path=/story/clayalert--default">Storybook</a>.
+We recommend that you review the use cases in the <a href="https://storybook.clayui.com/?path=/story/design-system-components-alert--default">Storybook</a>.
 
 ## Using with ClayButton
 

--- a/packages/clay-badge/docs/badge.mdx
+++ b/packages/clay-badge/docs/badge.mdx
@@ -12,4 +12,4 @@ For numbers greater than 999, use K to indicate Thousands (5K for 5.231) and M t
 
 <Badge />
 
-We recommend that you review the use cases in the <a href="https://storybook-clayui.netlify.com/?path=/story/claybadge--default">Storybook</a>.
+We recommend that you review the use cases in the <a href="https://storybook.clayui.com/?path=/story/design-system-components-badge--default">Storybook</a>.

--- a/packages/clay-charts/docs/charts.mdx
+++ b/packages/clay-charts/docs/charts.mdx
@@ -3,6 +3,7 @@ title: 'Chart'
 description: 'Charts is a React wrapper around the Billboard.js library with a few additional charts provided.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/charts/'
 packageNpm: '@clayui/charts'
+storybookPath: 'design-system-charts-react-billboard'
 ---
 
 import {Chart, GeoMap, Predictive} from '$packages/clay-charts/docs/index';
@@ -21,7 +22,7 @@ import {Chart, GeoMap, Predictive} from '$packages/clay-charts/docs/index';
 	Charts in its current state will be deprecated soon in favor of a wrapper
 	around <a href="https://recharts.org/">Recharts</a>. See examples of charts
 	built with recharts on&nbsp;
-	<a href="https://storybook.clayui.com/?path=/story/demos-recharts--line">
+	<a href="https://storybook.clayui.com/?path=/story/design-system-charts-react-billboard--bar">
 		Storybook
 	</a>.
 </div>

--- a/packages/clay-color-picker/docs/color-picker.mdx
+++ b/packages/clay-color-picker/docs/color-picker.mdx
@@ -18,4 +18,4 @@ Color Picker is delivered in 4 different ways: default colors, custom colors, na
 
 <ColorPicker />
 
-We recommend that you review the [use cases in the Storybook](https://storybook.clayui.com/?path=/story/claycolorpicker--default).
+We recommend that you review the [use cases in the Storybook](https://storybook.clayui.com/?path=/story/design-system-components-colorpicker--default).

--- a/packages/clay-core/docs/overlay-mask.mdx
+++ b/packages/clay-core/docs/overlay-mask.mdx
@@ -3,6 +3,7 @@ title: 'OverlayMask'
 description: 'OverlayMask create a highlight area on some DOM element with overlay.'
 packageNpm: '@clayui/core'
 packageStatus: 'Beta'
+storybookPath: 'design-system-components-overlaymask'
 ---
 
 import {OverlayMaskExample} from '$packages/clay-core/docs/overlay-mask';

--- a/packages/clay-core/docs/treeview.mdx
+++ b/packages/clay-core/docs/treeview.mdx
@@ -4,6 +4,7 @@ description: 'A tree view is a component based on nodes that are shown in a hier
 packageNpm: '@clayui/core'
 packageStatus: 'Beta'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/tree-view/'
+storybookPath: 'design-system-components-treeview'
 ---
 
 import {Example, MultipleSelection} from '$packages/clay-core/docs/treeview';

--- a/packages/clay-form/docs/checkbox.mdx
+++ b/packages/clay-form/docs/checkbox.mdx
@@ -4,6 +4,7 @@ description: 'A checkbox is a component that lets the user select the value that
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/'
 packageNpm: '@clayui/form'
 navigationParent: 'docs/components/form.html'
+storybookPath: 'design-system-application-checkbox'
 ---
 
 import {

--- a/packages/clay-form/docs/dual-list-box.mdx
+++ b/packages/clay-form/docs/dual-list-box.mdx
@@ -4,6 +4,7 @@ description: 'Dual List Box provides users with two Select Boxes with the abilit
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
 navigationParent: 'docs/components/form.html'
+storybookPath: 'design-system-application-duallistbox'
 ---
 
 import {DualListBox} from '$packages/clay-form/docs/duallistbox';
@@ -12,6 +13,6 @@ ClayDualListBox consists of low-level utilities that provides the ability to cre
 Users are allowed to multi-select different items from a list and sometimes, options in use can be re-order.
 It's a high level component using `ClaySelectBox` under the hood.
 
-> Note: The actual select functionality will not work here due to a pending issue at [FormidableLabs/react-live#196](https://github.com/FormidableLabs/react-live/issues/196). To see it in action, check out the [storybook demo](https://storybook.clayui.com/?path=/story/components-clayduallistbox--default).
+> Note: The actual select functionality will not work here due to a pending issue at [FormidableLabs/react-live#196](https://github.com/FormidableLabs/react-live/issues/196). To see it in action, check out the [storybook demo](https://storybook.clayui.com/?path=/story/design-system-components-duallistbox--default).
 
 <DualListBox />

--- a/packages/clay-form/docs/form.mdx
+++ b/packages/clay-form/docs/form.mdx
@@ -3,6 +3,7 @@ title: 'Form'
 description: 'Forms obtain user data and transmit it to the system to either store the data, produce an action, or both.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/'
 packageNpm: '@clayui/form'
+storybookPath: 'design-system-application-input'
 alwaysActive: true
 ---
 

--- a/packages/clay-form/docs/input.mdx
+++ b/packages/clay-form/docs/input.mdx
@@ -4,6 +4,7 @@ description: 'This section demonstrates the different text input types.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/text-input/'
 packageNpm: '@clayui/form'
 navigationParent: 'docs/components/form.html'
+storybookPath: 'design-system-application-input'
 ---
 
 import {

--- a/packages/clay-form/docs/radio-group.mdx
+++ b/packages/clay-form/docs/radio-group.mdx
@@ -3,6 +3,7 @@ title: 'Radio Group'
 description: 'Radios provide users with different selection and activation tools.'
 packageNpm: '@clayui/form'
 navigationParent: 'docs/components/form.html'
+storybookPath: 'design-system-application-radio'
 ---
 
 import {RadioGroup} from '$packages/clay-form/docs/radiogroup';

--- a/packages/clay-form/docs/select-box.mdx
+++ b/packages/clay-form/docs/select-box.mdx
@@ -4,6 +4,7 @@ description: 'Select Box allows users to select multiple options and if needed t
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dual-listbox/'
 packageNpm: '@clayui/form'
 navigationParent: 'docs/components/form.html'
+storybookPath: 'design-system-application-selectbox'
 ---
 
 import {SelectBox} from '$packages/clay-form/docs/selectbox';
@@ -20,6 +21,6 @@ import {SelectBox} from '$packages/clay-form/docs/selectbox';
 
 Select Box is exported from the `@clayui/form` package, consisting of some low-level utilities that provides the ability to create a Select element with multiple options selectable.
 
-> Note: The actual select functionality will not work here due to a pending issue at [FormidableLabs/react-live#196](https://github.com/FormidableLabs/react-live/issues/196). To see it in action, check out the [storybook demo](https://storybook.clayui.com/?path=/story/components-clayselectbox--default).
+> Note: The actual select functionality will not work here due to a pending issue at [FormidableLabs/react-live#196](https://github.com/FormidableLabs/react-live/issues/196). To see it in action, check out the [storybook demo](https://storybook.clayui.com/?path=/story/design-system-components-selectbox--default).
 
 <SelectBox />

--- a/packages/clay-form/docs/select.mdx
+++ b/packages/clay-form/docs/select.mdx
@@ -4,6 +4,7 @@ description: 'A form control element used to select from several provided option
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/selector/'
 packageNpm: '@clayui/form'
 navigationParent: 'docs/components/form.html'
+storybookPath: 'design-system-application-select'
 ---
 
 import {Select, SelectWithOption} from '$packages/clay-form/docs/select';

--- a/packages/clay-form/docs/toggle-switch.mdx
+++ b/packages/clay-form/docs/toggle-switch.mdx
@@ -4,6 +4,7 @@ description: 'Toggle provide users with different selection and activation tools
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/radio-check-toggle/#toggle'
 packageNpm: '@clayui/form'
 navigationParent: 'docs/components/form.html'
+storybookPath: 'design-system-application-toggle'
 ---
 
 import {RadioToggle, Toggle} from '$packages/clay-form/docs/toggle';

--- a/packages/clay-label/docs/label.mdx
+++ b/packages/clay-label/docs/label.mdx
@@ -24,7 +24,7 @@ import {
 
 `ClayLabel` offers two different APIs for use by toggling the prop `withClose`. By default(`withClose={true}`), `ClayLabel` behaves like a high-level component. If you want to use the lower-level components and compose multiple parts to your label, all you need to do is set `withClose={false}`.
 
-Check out [this storybook example](storybook.clayui.com/?path=/story/components-claylabel--w-content-before) for a demo.
+Check out [this storybook example](https://storybook.clayui.com/?path=/story/design-system-components-label--content-before) for a demo.
 
 ## Display Types
 

--- a/packages/clay-management-toolbar/docs/management-toolbar.mdx
+++ b/packages/clay-management-toolbar/docs/management-toolbar.mdx
@@ -15,7 +15,7 @@ import {
 
 With ClayManagementToolbar you can create a variety of [Management Toolbar variations](https://liferay.design/lexicon/core-components/toolbars/management-bar/#layout-variations), use `ClayManagementToolbar` component as the outside container, `ClayManagementToolbar.ItemList` for creating groups of items and `ClayManagementToolbar.Item` for create items inside groups. Use `expand` property on `ClayManagementToolbar.ItemList` for expanding the item list.
 
-We recommend that you review the use cases in the <a href="https://storybook.clayui.com/?path=/story/components-claymanagementtoolbar--w-low-level">Storybook</a>. Also, check our <a href="https://storybook.clayui.com/?path=/story/demos-templates--list-page">List Page Template</a> on Storybook.
+We recommend that you review the use cases in the <a href="https://storybook.clayui.com/?path=/story/design-system-components-managementtoolbar--default">Storybook</a>. Also, check our <a href="https://storybook.clayui.com/?path=/story/demos-templates--list-page">List Page Template</a> on Storybook.
 
 Use `ClayManagementToolbar.Search` for creating a Search input inside the management toolbar.
 

--- a/packages/clay-multi-step-nav/docs/multi-step-nav.mdx
+++ b/packages/clay-multi-step-nav/docs/multi-step-nav.mdx
@@ -3,6 +3,7 @@ title: 'Multi Step Nav'
 description: 'A multi step nav, also known as a wizard, is a determinate progress bar used in long processes that divides the main task into subtasks. The wizard lets the user quickly identify their current progress in completing the task and navigate forwards and backwards between steps if needed.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/forms/multi-step-form/'
 packageNpm: '@clayui/multi-step-nav'
+storybookPath: 'design-system-application-multistepnav'
 ---
 
 import {

--- a/packages/clay-panel/docs/panel.mdx
+++ b/packages/clay-panel/docs/panel.mdx
@@ -15,7 +15,7 @@ import {Panel, PanelWithCustomTitle} from '$packages/clay-panel/docs/index';
 </div>
 </div>
 
-The Panel is a replacement for the old ClayCollapse in version 2.x, has the same effect but written in React using composition, try it. We recommend that you review the [use cases in the Storybook](https://storybook.clayui.com/?path=/story/claypanel--default).
+The Panel is a replacement for the old ClayCollapse in version 2.x, has the same effect but written in React using composition, try it. We recommend that you review the [use cases in the Storybook](https://storybook.clayui.com/?path=/story/design-system-components-panel--default).
 
 ## Basic Usage
 

--- a/packages/clay-provider/docs/provider.mdx
+++ b/packages/clay-provider/docs/provider.mdx
@@ -2,6 +2,7 @@
 title: 'Provider'
 description: 'Provider component which aggregates the main Clay, Icon, and Modal.'
 packageNpm: '@clayui/core'
+storybookPath: 'design-system-application-provider'
 ---
 
 <div class="nav-toc-absolute">

--- a/packages/clay-sticker/docs/sticker.mdx
+++ b/packages/clay-sticker/docs/sticker.mdx
@@ -38,4 +38,4 @@ Use a ClaySticker as User Icon just adding `sticker-user-icon` on className of t
 
 You can set a desired alignment of sticker according to a parent element, just setting up the [`position`](#api-position) property. If you want to set the position of the sticker on the outside corners, use [`outside`](#api-outside) property in conjunction with [`position`](#api-position) property.
 
-Overlay content over stickers by nesting `sticker-overlay` elements as children of ClaySticker. Check our example on [Storybook](https://storybook-clayui.netlify.com/?path=/story/claysticker--overlay)
+Overlay content over stickers by nesting `sticker-overlay` elements as children of ClaySticker. Check our example on [Storybook](https://storybook.clayui.com/?path=/story/design-system-components-sticker--overlay)

--- a/packages/clay-table/docs/table.mdx
+++ b/packages/clay-table/docs/table.mdx
@@ -9,6 +9,6 @@ import {Table} from '$packages/clay-table/docs/index';
 
 ## Composing
 
-You compose the table with the main components to assemble a table with your use cases, use `ClayButton`, `ClayDropDown`... in the cells and try it out. We recommend that you review the [use cases in the Storybook](https://storybook.clayui.com/?path=/story/claytable--default).
+You compose the table with the main components to assemble a table with your use cases, use `ClayButton`, `ClayDropDown`... in the cells and try it out. We recommend that you review the [use cases in the Storybook](https://storybook.clayui.com/?path=/story/design-system-components-table--default).
 
 <Table />

--- a/packages/clay-upper-toolbar/README.md
+++ b/packages/clay-upper-toolbar/README.md
@@ -1,6 +1,6 @@
 # `@clayui/upper-toolbar`
 
-> 🚨 This component has been discontinued in favor of ClayToolbar, you can get the [same result](http://storybook.clayui.com/?path=/story/components-claytoolbar--upper-toolbar).
+> 🚨 This component has been discontinued in favor of ClayToolbar, you can get the [same result](https://storybook.clayui.com/?path=/story/design-system-components-toolbar--upper-toolbar).
 
 Upper toolbar is a guidance pattern to allow designers create their own toolbars for edition with preview pages.
 

--- a/packages/clay-upper-toolbar/docs/upper-toolbar.mdx
+++ b/packages/clay-upper-toolbar/docs/upper-toolbar.mdx
@@ -21,7 +21,7 @@ import {UpperToolbarExample} from '$packages/clay-upper-toolbar/docs/index';
 <div class="clay-site-alert alert alert-warning">
 	<strong class="lead">Warning</strong>
 	This component has been discontinued in favor of ClayToolbar, you can get the{' '}
-	<a href="http://storybook.clayui.com/?path=/story/components-claytoolbar--upper-toolbar">
+	<a href="https://storybook.clayui.com/?path=/story/design-system-components-toolbar--upper-toolbar">
 		same result
 	</a>.
 </div>


### PR DESCRIPTION
Fixes #4821

This PR just updates the examples links to Storybook, after we updated the Storybook version we rearranged the content to be clearer and that changed the paths so we are updating here.