### PR TITLE
feat(@clayui/management-toolbar): Deprecate ClayManagementToolbar

### DIFF
--- a/packages/clay-management-toolbar/README.md
+++ b/packages/clay-management-toolbar/README.md
@@ -1,5 +1,7 @@
 # `@clayui/management-toolbar`
 
+> 🚨 This component has been deprecated since version 3.54.x.
+
 Management toolbar is an extension of Toolbar. It is a combination of different components, including filters, orders, search, visualization select, and other actions that let users manage a dataset.
 
 -   [Documentation](https://clayui.com/docs/components/management-toolbar.html)

--- a/packages/clay-management-toolbar/docs/management-toolbar.mdx
+++ b/packages/clay-management-toolbar/docs/management-toolbar.mdx
@@ -3,6 +3,7 @@ title: 'Management Toolbar'
 description: 'Management toolbar is an extension of Toolbar. It is a combination of different components, including filters, orders, search, visualization select, and other actions that let users manage a dataset.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/toolbars/management-bar/'
 packageNpm: '@clayui/management-toolbar'
+packageStatus: 'Deprecated'
 ---
 
 import {
@@ -10,6 +11,11 @@ import {
 	MinimalManagementToolbar,
 	ResultsBar,
 } from '$packages/clay-management-toolbar/docs/index';
+
+<div class="clay-site-alert alert alert-warning">
+	<strong class="lead">Warning</strong>
+	Deprecated since version 3.54.x
+</div>
 
 ## Composing
 

--- a/packages/clay-management-toolbar/src/index.tsx
+++ b/packages/clay-management-toolbar/src/index.tsx
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+/**
+ * @deprecated since version 3.54.x.
+ */
+
 import ClayManagementToolbar from './ManagementToolbar';
 import ClayResultsBar from './ResultsBar';
 


### PR DESCRIPTION
**What is new?**
The main goal of this issue is deprecating `ClayManagementToolbar`. 

Changes made in:
- Main file marked as deprecated.
- Add a message to the `README.md` to mark it as deprecated.
- Add a message to the documentation to mark it as deprecated.

**Issues:**
#4819 
[LPS-147979](https://issues.liferay.com/browse/LPS-147979) 