### PR TITLE
fix(@clayui/core): the Heading tag follows the level definition

### DIFF
--- a/packages/clay-core/src/typography/Heading.tsx
+++ b/packages/clay-core/src/typography/Heading.tsx
@@ -33,14 +33,18 @@ type Props = {
 	weight?: WeightFont;
 };
 
-export const Heading = ({children, level = 1, weight = 'bold'}: Props) => (
-	<h1
-		className={classNames([`text-${11 - level}`], {
-			[`font-weight-${weight}`]: weight,
-		})}
-	>
-		{children}
-	</h1>
-);
+export const Heading = ({children, level = 1, weight = 'bold'}: Props) => {
+	const HeadingTag = `h${level}` as React.ElementType;
+
+	return (
+		<HeadingTag
+			className={classNames([`text-${11 - level}`], {
+				[`font-weight-${weight}`]: weight,
+			})}
+		>
+			{children}
+		</HeadingTag>
+	);
+};
 
 Heading.displayName = 'Heading';

--- a/packages/clay-core/src/typography/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-core/src/typography/__tests__/__snapshots__/index.tsx.snap
@@ -15,11 +15,11 @@ exports[`Heading renders as h1 without style defined 1`] = `
 exports[`Heading renders as h3 with semi-bold style 1`] = `
 <body>
   <div>
-    <h1
+    <h3
       class="text-8 font-weight-semi-bold"
     >
       This is a Heading
-    </h1>
+    </h3>
   </div>
 </body>
 `;


### PR DESCRIPTION
Following up #4659

I ended up not noticing in the implementation's PR that we weren't updating the tag according to the `level` definition, in this case, we need to make the tag follow the definition to keep the markup semantics adequate for each level. Maybe it got confused when I explained that the sizes must follow the mapping of the classes.