### PR TITLE
chore: add npm token via CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,9 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-      - run: lerna publish from-git --yes
+      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: lerna publish from-package --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This is an attempt to correct #4822.

This is a solution so that Lerna can publish the packages through CI using NPM tokens, unfortunately, lerna has no other option to get the token via env.