### PR TITLE
chore: add comments to types outputs

### DIFF
--- a/tsconfig.declarations.json
+++ b/tsconfig.declarations.json
@@ -4,7 +4,8 @@
 		"allowJs": false,
 		"declaration": true,
 		"emitDeclarationOnly": true,
-		"noEmit": false
+		"noEmit": false,
+		"removeComments": false
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
Fixes #4836

I'm setting the `removeComments` property to `false` because this TypeScript config is an extension of the build config that omits comments in the output.