### PR TITLE
feat(clayui.com): add deprecated prop badge to doc

### DIFF
--- a/clayui.com/plugins/gatsby-remark-api-table/index.js
+++ b/clayui.com/plugins/gatsby-remark-api-table/index.js
@@ -12,6 +12,15 @@ const generateTr = (item, key) => `<tr id="api-${key}">
 	<td>
 		<div class="table-title">
 			${key}
+			${
+				item.description?.includes('@deprecated')
+					? `
+				<span class="badge badge-danger badge-pill">
+					<span class="badge-item badge-item-expand">Deprecated</span>
+				</span>
+			`
+					: ''
+			}
 		</div>
 	</td>
 	<td class="table-cell-expand table-cell-minw-150">{${


### PR DESCRIPTION
Fixes #4835

I'm adding a deprecated badge along with the property name in the API table in the documentation. This is a step so that people can see that some properties have been deprecated, I think that in the improvements later in the documentation and in the more adjusted visual, we will put a better interaction like showing the information of which alternative to the property if exist (this information is currently in the description).