### PR TITLE
fix(@clayui/css): Alerts/Table deprecate `$alert-*-level` and `$table-*-level` variables

### DIFF
--- a/packages/clay-css/src/scss/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/variables/_alerts.scss
@@ -410,8 +410,16 @@ $alert-autofit-row: map-deep-merge(
 
 // Alert Color Levels
 
+/// @deprecated as of v3.x with no replacement, this color modifier is too specific to support a variety of colors
+
 $alert-bg-level: -10 !default;
+
+/// @deprecated as of v3.x with no replacement, this color modifier is too specific to support a variety of colors
+
 $alert-border-level: -9 !default;
+
+/// @deprecated as of v3.x with no replacement, this color modifier is too specific to support a variety of colors
+
 $alert-color-level: 6 !default;
 
 // Alert Feedback

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -234,7 +234,12 @@ $table-dark-accent-bg: rgba($white, 0.05) !default;
 
 $table-bordered-border-width: $table-border-width !default;
 
+/// @deprecated as of v3.x with no replacement, this color modifier is too specific to support a variety of colors
+
 $table-bg-level: -9 !default;
+
+/// @deprecated as of v3.x with no replacement, this color modifier is too specific to support a variety of colors
+
 $table-border-level: -6 !default;
 
 // Table List


### PR DESCRIPTION
I wanted to remove all uses of Bootstrap's `theme-color-level` function, but might be too breaking.

fixes #4281