### PR TITLE
fix(@clayui/css): Sidebar long text with no white space should break …

### DIFF
--- a/packages/clay-css/src/scss/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/variables/_sidebar.scss
@@ -10,6 +10,7 @@ $sidebar-header-component-title: map-deep-merge(
 	(
 		font-size: 1.5rem,
 		font-weight: $font-weight-semi-bold,
+		overflow-wrap: break-word,
 		href: (
 			color: $gray-900,
 		),
@@ -25,6 +26,7 @@ $sidebar-header-component-subtitle: map-deep-merge(
 		font-size: 1.125rem,
 		font-weight: $font-weight-semi-bold,
 		margin-bottom: 0,
+		overflow-wrap: break-word,
 	),
 	$sidebar-header-component-subtitle
 );


### PR DESCRIPTION
…to new line in component-title and subtitle

fixes #3805