### PR TITLE
chore(@clayui/core): track svg container position in OverlayMask

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -50,10 +50,10 @@ module.exports = {
 			statements: 91,
 		},
 		'./packages/clay-core/src/overlay-mask/': {
-			branches: 77,
+			branches: 73,
 			functions: 100,
-			lines: 92,
-			statements: 92,
+			lines: 91,
+			statements: 91,
 		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 69,


### PR DESCRIPTION
Fixes #4851

This is an improvement to the `<OverlayMask />` component that tracks the position of the container when the window is scrolled or resized. I tried to make it not need the `observeRect` but it's not working very well when I use the window resize listener I also wanted to do it via CSS it didn't work very well either. I need to set the value to the element size. Maybe I'm missing something here, any suggestions are welcome.