### PR TITLE
fix(@clayui/tooltip): cancel scheduled tooltip before scheduling new one

### DIFF
--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -290,6 +290,8 @@ const TooltipProvider: React.FunctionComponent<
 				'data-title-set-as-html'
 			);
 
+			clearTimeout(timeoutIdRef.current);
+
 			timeoutIdRef.current = setTimeout(
 				() => {
 					dispatch({


### PR DESCRIPTION
### References

- [LPS-149687](https://issues.liferay.com/browse/LPS-149687)

### What is the goal?

* Fix tooltip misalignment when hovering and clicking on trigger

### What does it look like?

#### Before fix: 
Tooltip shows but isn't in the right position

https://user-images.githubusercontent.com/6642927/167459355-814f0d5f-2348-442a-8113-e288adf6a196.mov

#### After fix: 
Tooltip doesn't show until you after you hover over the trigger again

https://user-images.githubusercontent.com/6642927/167459404-1b44b27c-4824-46eb-bcac-e7e19b33ecbc.mov


### How to replicate
* Go to DXP Forms
* Add a new form
* Add any field
* Hover over the field, hover over the actions button, quickly click on it
* See that a tooltip appears on the bottom left of the screen

### Notes
The cause of this is that in scoped mode, we are subscribing to [all these events](https://github.com/liferay/clay/blob/master/packages/clay-tooltip/src/TooltipProvider.tsx#L71-L84) to show/hide the tooltip:
```js
var TRIGGER_HIDE_EVENTS = ['dragstart', 'mouseout', 'mouseup', 'pointerup', 'touchend'];
var TRIGGER_SHOW_EVENTS = ['mouseover', 'mouseup', 'pointerdown', 'touchstart'];
```
When we hover and click on an element that triggers a tooltip, the following event chain happens:
- mouseover: shows tooltip
- pointerdown: shows tooltip
- pointerup: hides tooltip
- mouseup: shows, then hides tooltip (it's in both arrays, I think this is another bug 🤔)

The problem is that the tooltip is delayed using a `setTimeout` that gets canceled on hide, and since we have two shows in a row, the first timeout is never cleared, it runs and sets `show` to true. But by then [the reference to the trigger has been removed on the last hide](https://github.com/liferay/clay/blob/master/packages/clay-tooltip/src/TooltipProvider.tsx#L246) so when [the effect that aligns the tooltip](https://github.com/liferay/clay/blob/master/packages/clay-tooltip/src/TooltipProvider.tsx#L338-L341) runs, the condition for alignment is false and it doesn't get aligned.

I don't really know why all these events are necessary, especially considering that in the [non-scoped version of the tooltip](https://github.com/liferay/clay/blob/master/packages/clay-tooltip/src/TooltipProvider.tsx#L417-L421) we just use `mouseover` and `mouseout`. But that's beyond the scope of this bug.