### PR TITLE
fix(@clayui/date-picker): fix date picker error not starting with default values using controlled or uncontrolled

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -68,10 +68,10 @@ module.exports = {
 			statements: 96,
 		},
 		'./packages/clay-date-picker/src/': {
-			branches: 72,
-			functions: 92,
-			lines: 94,
-			statements: 94,
+			branches: 76,
+			functions: 94,
+			lines: 95,
+			statements: 95,
 		},
 		'./packages/clay-drop-down/src/': {
 			branches: 70,

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -17,12 +17,8 @@ const normalizeTime = (date: Date) =>
  * Handles selected days and stabilize date time when set to avoid problems
  * when the range is used to check intervals.
  */
-export const useDaysSelected = (initialMonth: Date) => {
-	const [daysSelected, set] = useState(() => {
-		const date = normalizeTime(initialMonth);
-
-		return [date, date] as const;
-	});
+export const useDaysSelected = (defaultDays: () => readonly [Date, Date]) => {
+	const [daysSelected, set] = useState(defaultDays);
 
 	const setDaysSelected = useCallback(([start, end]: [Date, Date]) => {
 		// Preserves the reference of dates
@@ -60,8 +56,11 @@ export const useWeeks = (
 /**
  * Sets the current time
  */
-export const useCurrentTime = (use12Hours: boolean) => {
-	const [currentTime, set] = useState<string>('--:--');
+export const useCurrentTime = (
+	defaultTime: () => string,
+	use12Hours: boolean
+) => {
+	const [currentTime, set] = useState<string>(defaultTime);
 
 	const setCurrentTime = useCallback(
 		(
@@ -75,7 +74,9 @@ export const useCurrentTime = (use12Hours: boolean) => {
 				hours = formatDate(date, 'HH');
 
 				if (use12Hours) {
+					console.log(hours);
 					hours = formatDate(setDate(new Date(), {hours}), 'hh');
+					console.log(hours);
 				}
 			}
 

--- a/packages/clay-date-picker/src/Hooks.ts
+++ b/packages/clay-date-picker/src/Hooks.ts
@@ -74,9 +74,7 @@ export const useCurrentTime = (
 				hours = formatDate(date, 'HH');
 
 				if (use12Hours) {
-					console.log(hours);
 					hours = formatDate(setDate(new Date(), {hours}), 'hh');
-					console.log(hours);
 				}
 			}
 

--- a/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
+++ b/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
@@ -101,4 +101,189 @@ describe('BasicRendering', () => {
 
 		expect(document.body).toMatchSnapshot();
 	});
+
+	it('render date picker with default value', () => {
+		const {getByLabelText, getByTestId} = render(
+			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: 'Choose your desired date',
+					buttonDot: 'Select current date',
+					buttonNextMonth: 'Select the next month',
+					buttonPreviousMonth: 'Select the previous month',
+					input: 'input-test',
+				}}
+				defaultMonth={new Date(2019, 3, 18)}
+				defaultValue="2019-04-10"
+				years={{end: 2019, start: 2019}}
+			/>
+		);
+
+		const input: any = getByLabelText('input-test');
+		const dayNumber = getByLabelText(new Date('2019 04 10').toDateString());
+		const monthSelect: any = getByTestId('month-select');
+		const yearSelect: any = getByTestId('year-select');
+
+		expect(input.value).toBe('2019-04-10');
+		expect(dayNumber.classList).toContain('active');
+		expect(monthSelect.value).toBe('3');
+		expect(yearSelect.value).toBe('2019');
+	});
+
+	it('render date picker with value controlled', () => {
+		const {getByLabelText, getByTestId} = render(
+			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: 'Choose your desired date',
+					buttonDot: 'Select current date',
+					buttonNextMonth: 'Select the next month',
+					buttonPreviousMonth: 'Select the previous month',
+					input: 'input-test',
+				}}
+				defaultMonth={new Date(2019, 3, 18)}
+				onChange={() => {}}
+				value="2019-04-10"
+				years={{end: 2019, start: 2019}}
+			/>
+		);
+
+		const input: any = getByLabelText('input-test');
+		const dayNumber = getByLabelText(new Date('2019 04 10').toDateString());
+		const monthSelect: any = getByTestId('month-select');
+		const yearSelect: any = getByTestId('year-select');
+
+		expect(input.value).toBe('2019-04-10');
+		expect(dayNumber.classList).toContain('active');
+		expect(monthSelect.value).toBe('3');
+		expect(yearSelect.value).toBe('2019');
+	});
+
+	it('render date picker with value controlled with range', () => {
+		const {getByLabelText, getByTestId} = render(
+			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: 'Choose your desired date',
+					buttonDot: 'Select current date',
+					buttonNextMonth: 'Select the next month',
+					buttonPreviousMonth: 'Select the previous month',
+					input: 'input-test',
+				}}
+				defaultMonth={new Date(2019, 3, 18)}
+				onChange={() => {}}
+				range
+				value="2019-04-10 - 2019-04-15"
+				years={{end: 2019, start: 2019}}
+			/>
+		);
+
+		const input: any = getByLabelText('input-test');
+		const dayNumber = getByLabelText(new Date('2019 04 10').toDateString());
+		const endDate = getByLabelText(new Date('2019 04 15').toDateString());
+		const monthSelect: any = getByTestId('month-select');
+		const yearSelect: any = getByTestId('year-select');
+
+		expect(input.value).toBe('2019-04-10 - 2019-04-15');
+		expect(dayNumber.classList).toContain('active');
+		expect(endDate.classList).toContain('active');
+		expect(monthSelect.value).toBe('3');
+		expect(yearSelect.value).toBe('2019');
+	});
+
+	it('render date picker with default value with range', () => {
+		const {getByLabelText, getByTestId} = render(
+			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: 'Choose your desired date',
+					buttonDot: 'Select current date',
+					buttonNextMonth: 'Select the next month',
+					buttonPreviousMonth: 'Select the previous month',
+					input: 'input-test',
+				}}
+				defaultMonth={new Date(2019, 3, 18)}
+				defaultValue="2019-04-10 - 2019-04-15"
+				range
+				years={{end: 2019, start: 2019}}
+			/>
+		);
+
+		const input: any = getByLabelText('input-test');
+		const dayNumber = getByLabelText(new Date('2019 04 10').toDateString());
+		const endDate = getByLabelText(new Date('2019 04 15').toDateString());
+		const monthSelect: any = getByTestId('month-select');
+		const yearSelect: any = getByTestId('year-select');
+
+		expect(input.value).toBe('2019-04-10 - 2019-04-15');
+		expect(dayNumber.classList).toContain('active');
+		expect(endDate.classList).toContain('active');
+		expect(monthSelect.value).toBe('3');
+		expect(yearSelect.value).toBe('2019');
+	});
+
+	it('render date picker with value controlled with time', () => {
+		const {getByLabelText, getByTestId} = render(
+			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: 'Choose your desired date',
+					buttonDot: 'Select current date',
+					buttonNextMonth: 'Select the next month',
+					buttonPreviousMonth: 'Select the previous month',
+					input: 'input-test',
+				}}
+				defaultMonth={new Date(2019, 3, 18)}
+				onChange={() => {}}
+				time
+				value="2019-04-10 05:00"
+				years={{end: 2019, start: 2019}}
+			/>
+		);
+
+		const input: any = getByLabelText('input-test');
+		const dayNumber = getByLabelText(new Date('2019 04 10').toDateString());
+
+		const monthSelect: any = getByTestId('month-select');
+		const yearSelect: any = getByTestId('year-select');
+
+		const hours = getByTestId('hours') as HTMLInputElement;
+		const minutes = getByTestId('minutes') as HTMLInputElement;
+
+		expect(input.value).toBe('2019-04-10 05:00');
+		expect(dayNumber.classList).toContain('active');
+		expect(monthSelect.value).toBe('3');
+		expect(yearSelect.value).toBe('2019');
+		expect(hours.value).toBe('05');
+		expect(minutes.value).toBe('00');
+	});
+
+	it('render date picker with default value with time', () => {
+		const {getByLabelText, getByTestId} = render(
+			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: 'Choose your desired date',
+					buttonDot: 'Select current date',
+					buttonNextMonth: 'Select the next month',
+					buttonPreviousMonth: 'Select the previous month',
+					input: 'input-test',
+				}}
+				defaultMonth={new Date(2019, 3, 18)}
+				defaultValue="2019-04-10 05:00"
+				time
+				years={{end: 2019, start: 2019}}
+			/>
+		);
+
+		const input: any = getByLabelText('input-test');
+		const dayNumber = getByLabelText(new Date('2019 04 10').toDateString());
+
+		const monthSelect: any = getByTestId('month-select');
+		const yearSelect: any = getByTestId('year-select');
+
+		const hours = getByTestId('hours') as HTMLInputElement;
+		const minutes = getByTestId('minutes') as HTMLInputElement;
+
+		expect(input.value).toBe('2019-04-10 05:00');
+		expect(dayNumber.classList).toContain('active');
+		expect(monthSelect.value).toBe('3');
+		expect(yearSelect.value).toBe('2019');
+		expect(hours.value).toBe('05');
+		expect(minutes.value).toBe('00');
+	});
 });

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -284,23 +284,17 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		 */
 		const [daysSelected, setDaysSelected] = useDaysSelected(() => {
 			if (internalValue) {
-				const [startDate, endDate] = fromStringToRange(
-					internalValue,
-					time
-						? `${dateFormat} ${
-								use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
-						  }`
-						: dateFormat,
-					NEW_DATE
-				);
+				const days = hasDaysSelected({
+					checkRangeYears: yearsCheck,
+					dateFormat,
+					is12Hours: use12Hours,
+					isTime: time,
+					value: internalValue,
+					years,
+				});
 
-				const isValidYear = yearsCheck
-					? isYearWithinYears(startDate.getFullYear(), years) &&
-					  isYearWithinYears(endDate.getFullYear(), years)
-					: true;
-
-				if (isValid(startDate) && isValid(endDate) && isValidYear) {
-					return [normalizeTime(startDate), normalizeTime(endDate)];
+				if (days) {
+					return [normalizeTime(days[0]), normalizeTime(days[1])];
 				}
 			}
 
@@ -457,25 +451,18 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 					setCurrentTime('--', '--', undefined);
 				}
 			} else {
-				const [startDate, endDate] = fromStringToRange(
+				const days = hasDaysSelected({
+					checkRangeYears: yearsCheck,
+					dateFormat,
+					is12Hours: use12Hours,
+					isTime: time,
 					value,
-					time
-						? `${dateFormat} ${
-								use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
-						  }`
-						: dateFormat,
-					NEW_DATE
-				);
+					years,
+				});
 
-				const yearFrom = startDate.getFullYear();
-				const yearTo = endDate.getFullYear();
+				if (days) {
+					const [startDate, endDate] = days;
 
-				const isValidYear = yearsCheck
-					? isYearWithinYears(yearFrom, years) &&
-					  isYearWithinYears(yearTo, years)
-					: true;
-
-				if (isValid(startDate) && isValid(endDate) && isValidYear) {
 					changeMonth(startDate);
 
 					setDaysSelected([startDate, endDate]);
@@ -729,6 +716,41 @@ function fromStringToRange(
 			? parseDate(endDateString, dateFormat, referenceDate)
 			: startDate,
 	];
+}
+
+type Options = {
+	checkRangeYears: boolean;
+	dateFormat: string;
+	is12Hours: boolean;
+	isTime: boolean;
+	value: string;
+	years: IYears;
+};
+
+function hasDaysSelected({
+	checkRangeYears,
+	dateFormat,
+	is12Hours,
+	isTime,
+	value,
+	years,
+}: Options) {
+	const [startDate, endDate] = fromStringToRange(
+		value,
+		isTime
+			? `${dateFormat} ${is12Hours ? TIME_FORMAT_12H : TIME_FORMAT}`
+			: dateFormat,
+		NEW_DATE
+	);
+
+	const isValidYear = checkRangeYears
+		? isYearWithinYears(startDate.getFullYear(), years) &&
+		  isYearWithinYears(endDate.getFullYear(), years)
+		: true;
+
+	if (isValid(startDate) && isValid(endDate) && isValidYear) {
+		return [startDate, endDate];
+	}
 }
 
 function fromRangeToString(range: [Date, Date], dateFormat: string) {

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -467,8 +467,6 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 					NEW_DATE
 				);
 
-				console.log(startDate);
-
 				const yearFrom = startDate.getFullYear();
 				const yearTo = endDate.getFullYear();
 

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -8,7 +8,7 @@ import DropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {FocusScope, InternalDispatch, useInternalState} from '@clayui/shared';
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import DateNavigation from './DateNavigation';
 import DayNumber from './DayNumber';
@@ -125,7 +125,7 @@ interface IProps
 	 * Second argument gives the type that caused the value change
 	 * @deprecated since v3.51.0 - use `onChange` instead.
 	 */
-	onValueChange?: (value: string, type?: 'click' | 'input' | 'time') => void;
+	onValueChange?: InternalDispatch<string>;
 
 	/**
 	 * Describe a brief tip to help users interact.
@@ -198,6 +198,9 @@ const TIME_FORMAT = 'HH:mm';
 
 const TIME_FORMAT_12H = 'hh:mm aa';
 
+const normalizeTime = (date: Date) =>
+	setDate(date, {hours: 12, milliseconds: 0, minutes: 0, seconds: 0});
+
 /**
  * ClayDatePicker component.
  */
@@ -265,32 +268,6 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		// `initialMonth`.
 		initialMonth = defaultMonth ?? initialMonth;
 
-		/**
-		 * Indicates the current month rendered on the screen.
-		 */
-		const [currentMonth, setCurrentMonth] = React.useState(() =>
-			// Normalize the date to always set noon to avoid time zone problems
-			// and to the 1st of the month.
-			setDate(initialMonth, {date: 1, ...DEFAULT_DATE_TIME})
-		);
-
-		/**
-		 * DaysSelected is a tuple that represents [startDate, endDate]
-		 * in the cases where We have a date range and when `range` property
-		 * is disabled we will just use the first element of the tuple(startDate)
-		 */
-		const [daysSelected, setDaysSelected] = useDaysSelected(initialMonth);
-
-		/**
-		 * Indicates the time selected by the user.
-		 */
-		const [currentTime, setCurrentTime] = useCurrentTime(use12Hours);
-
-		/**
-		 * An array of the weeks and days list for the current month
-		 */
-		const [weeks, setWeeks] = useWeeks(currentMonth, firstDayOfWeek);
-
 		const [internalValue, setValue] = useInternalState({
 			defaultName: 'defaultValue',
 			defaultValue,
@@ -299,6 +276,81 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			onChange: onChange ?? onValueChange,
 			value,
 		});
+
+		/**
+		 * DaysSelected is a tuple that represents [startDate, endDate]
+		 * in the cases where We have a date range and when `range` property
+		 * is disabled we will just use the first element of the tuple(startDate)
+		 */
+		const [daysSelected, setDaysSelected] = useDaysSelected(() => {
+			if (internalValue) {
+				const [startDate, endDate] = fromStringToRange(
+					internalValue,
+					time
+						? `${dateFormat} ${
+								use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
+						  }`
+						: dateFormat,
+					NEW_DATE
+				);
+
+				const isValidYear = yearsCheck
+					? isYearWithinYears(startDate.getFullYear(), years) &&
+					  isYearWithinYears(endDate.getFullYear(), years)
+					: true;
+
+				if (isValid(startDate) && isValid(endDate) && isValidYear) {
+					return [normalizeTime(startDate), normalizeTime(endDate)];
+				}
+			}
+
+			const date = normalizeTime(initialMonth);
+
+			return [date, date] as const;
+		});
+
+		/**
+		 * Indicates the current month rendered on the screen.
+		 */
+		const [currentMonth, setCurrentMonth] = useState(() =>
+			// Normalize the date to always set noon to avoid time zone problems
+			// and to the 1st of the month.
+			setDate(daysSelected[0], {date: 1, ...DEFAULT_DATE_TIME})
+		);
+
+		/**
+		 * Indicates the time selected by the user.
+		 */
+		const [currentTime, setCurrentTime] = useCurrentTime(() => {
+			if (time && internalValue) {
+				const [startDate] = fromStringToRange(
+					internalValue,
+					`${dateFormat} ${
+						use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
+					}`,
+					NEW_DATE
+				);
+
+				if (startDate.toString() !== 'Invalid Date') {
+					const hours = use12Hours
+						? formatDate(startDate, 'HH')
+						: formatDate(startDate, 'hh');
+
+					const minutes = formatDate(startDate, 'mm');
+
+					return use12Hours
+						? `${hours}:${minutes} ${formatDate(startDate, 'a')}`
+						: `${hours}:${minutes}`;
+				}
+			}
+
+			return '--:--';
+		}, use12Hours);
+
+		/**
+		 * An array of the weeks and days list for the current month
+		 */
+		const [weeks, setWeeks] = useWeeks(currentMonth, firstDayOfWeek);
 
 		/**
 		 * Flag to indicate if date is expanded. Uses an internal state value
@@ -319,12 +371,12 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		/**
 		 * Create a ref to store the datepicker DOM element
 		 */
-		const dropdownContainerRef = React.useRef<HTMLDivElement | null>(null);
+		const dropdownContainerRef = useRef<HTMLDivElement | null>(null);
 
 		/**
 		 * Create a ref to store the datepicker DOM element
 		 */
-		const triggerElementRef = React.useRef<HTMLDivElement | null>(null);
+		const triggerElementRef = useRef<HTMLDivElement | null>(null);
 
 		/**
 		 * Handles the change of the current month of the Date Picker
@@ -405,17 +457,17 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 					setCurrentTime('--', '--', undefined);
 				}
 			} else {
-				const format = time
-					? `${dateFormat} ${
-							use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
-					  }`
-					: dateFormat;
-
 				const [startDate, endDate] = fromStringToRange(
 					value,
-					format,
+					time
+						? `${dateFormat} ${
+								use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
+						  }`
+						: dateFormat,
 					NEW_DATE
 				);
+
+				console.log(startDate);
 
 				const yearFrom = startDate.getFullYear();
 				const yearTo = endDate.getFullYear();
@@ -537,7 +589,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			}
 		};
 
-		React.useEffect(() => {
+		useEffect(() => {
 			document.addEventListener('focus', handleFocus, true);
 
 			return () => {


### PR DESCRIPTION
Fixes #4856

Well, this is not a specific bug of the implementation of controlled or uncontrolled, actually, we were not covering this use case, we just consider the value of the `initialMonth` property instead of considering the value of `value` or `defaultValue`.

Considering that this is a behavior that was from the beginning of the component construction, probably people always used the `initialMonth` to start the default value, maybe this was misinterpreted the use of this property that ended up covering a wrong behavior of the component, with the introduction of more solid controlled and uncontrolled components got more clearer for developers.