### PR TITLE
feat(@clayui/core): adds new API to expand node via double click in TreeView

### DIFF
--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -38,6 +38,11 @@ interface ITreeViewProps<T>
 	dragAndDropContext?: Window & typeof globalThis;
 
 	/**
+	 * Flag to expand the node's children when double-clicking the node.
+	 */
+	expandDoubleClick?: boolean;
+
+	/**
 	 * Flag to expand child nodes when a parent node is checked.
 	 */
 	expandOnCheck?: boolean;
@@ -93,6 +98,7 @@ export function TreeView<T>({
 	displayType = 'light',
 	dragAndDrop = false,
 	dragAndDropContext = window,
+	expandDoubleClick = false,
 	expandedKeys,
 	expanderClassName,
 	expanderIcons,
@@ -136,6 +142,7 @@ export function TreeView<T>({
 	const context = {
 		childrenRoot: childrenRootRef,
 		dragAndDrop,
+		expandDoubleClick,
 		expandOnCheck,
 		expanderClassName,
 		expanderIcons,

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -65,6 +65,7 @@ export const TreeViewItem = React.forwardRef<
 	const {
 		childrenRoot,
 		close,
+		expandDoubleClick,
 		expandedKeys,
 		insert,
 		nestedKey,
@@ -202,7 +203,7 @@ export const TreeViewItem = React.forwardRef<
 							selection.toggleSelection(item.key);
 						}
 
-						if (group) {
+						if (group && !expandDoubleClick) {
 							toggle(item.key);
 						} else {
 							if (onLoadMore) {
@@ -220,6 +221,38 @@ export const TreeViewItem = React.forwardRef<
 										console.error(error);
 									});
 							}
+						}
+					}}
+					onDoubleClick={(event) => {
+						if (!expandDoubleClick) {
+							return;
+						}
+
+						if (itemStackProps.disabled || nodeProps.disabled) {
+							return;
+						}
+
+						if (hasItemStack && itemStackProps.onDoubleClick) {
+							itemStackProps.onDoubleClick(event);
+						}
+
+						if (nodeProps.onDoubleClick) {
+							(
+								nodeProps.onDoubleClick as unknown as (
+									event: React.MouseEvent<
+										HTMLDivElement,
+										MouseEvent
+									>
+								) => void
+							)(event);
+						}
+
+						if (event.defaultPrevented) {
+							return;
+						}
+
+						if (group) {
+							toggle(item.key);
 						}
 					}}
 					onFocus={() => actions && setFocus(true)}

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -199,11 +199,19 @@ export const TreeViewItem = React.forwardRef<
 							return;
 						}
 
+						// event.detail it has no type but is an existing property of the
+						// element to know how many clicks were triggered.
+						// https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
+						// @ts-ignore
+						if (expandDoubleClick && event.detail !== 2) {
+							return;
+						}
+
 						if (selectionMode === 'single') {
 							selection.toggleSelection(item.key);
 						}
 
-						if (group && !expandDoubleClick) {
+						if (group) {
 							toggle(item.key);
 						} else {
 							if (onLoadMore) {
@@ -221,38 +229,6 @@ export const TreeViewItem = React.forwardRef<
 										console.error(error);
 									});
 							}
-						}
-					}}
-					onDoubleClick={(event) => {
-						if (!expandDoubleClick) {
-							return;
-						}
-
-						if (itemStackProps.disabled || nodeProps.disabled) {
-							return;
-						}
-
-						if (hasItemStack && itemStackProps.onDoubleClick) {
-							itemStackProps.onDoubleClick(event);
-						}
-
-						if (nodeProps.onDoubleClick) {
-							(
-								nodeProps.onDoubleClick as unknown as (
-									event: React.MouseEvent<
-										HTMLDivElement,
-										MouseEvent
-									>
-								) => void
-							)(event);
-						}
-
-						if (event.defaultPrevented) {
-							return;
-						}
-
-						if (group) {
-							toggle(item.key);
 						}
 					}}
 					onFocus={() => actions && setFocus(true)}

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -16,6 +16,7 @@ export type Icons = {
 export interface ITreeViewContext<T> extends ITreeState<T> {
 	childrenRoot: React.MutableRefObject<ChildrenFunction<Object> | null>;
 	dragAndDrop?: boolean;
+	expandDoubleClick?: boolean;
 	expandOnCheck?: boolean;
 	expanderClassName?: string;
 	expanderIcons?: Icons;


### PR DESCRIPTION
Closes #4863

There is another way to provide this like we do for selection but I think the expander is not needed now, we can see if there are use cases in the future and we can think about adding that possibility.

I'm adding the `expandDoubleClick` API that expanding by clicking on the node will only be done by double-click on the node, it is also possible to avoid this behavior but I think it is something that may not even make sense to be added because to have this behavior is enabled via props but I'm adding to keep the same behavior we have for `onClick`.