### PR TITLE
feat: add chromatic for visual testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
             BROWSERSLIST_DISABLE_CACHE: 1
             CI: true
         run: yarn test
+      - name: UI Tests
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        run: yarn chromatic
 
   version:
     needs: test

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"storybook:build": "NODE_OPTIONS=--max_old_space_size=8192 build-storybook -c .storybook -o .storybook-static",
 		"storybook": "start-storybook -p 8888",
 		"test": "jest",
-		"version": "prettier --write -- \"**/CHANGELOG.md\" \"lerna.json\" && git add -- \"packages/clay-css/src/scss/_license-text.scss\""
+		"version": "prettier --write -- \"**/CHANGELOG.md\" \"lerna.json\" && git add -- \"packages/clay-css/src/scss/_license-text.scss\"",
+		"chromatic": "chromatic --exit-zero-on-changes --build-script-name=storybook:build"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.15.7",
@@ -78,6 +79,7 @@
 		"babel-plugin-dev-expression": "^0.2.2",
 		"babel-plugin-react-remove-properties": "^0.3.0",
 		"babel-plugin-transform-inline-environment-variables": "^0.4.3",
+		"chromatic": "^6.5.4",
 		"coveralls": "^3.1.1",
 		"cross-env": "^7.0.3",
 		"css-loader": "^2.1.1",

--- a/packages/clay-charts/stories/Chart.stories.tsx
+++ b/packages/clay-charts/stories/Chart.stories.tsx
@@ -20,6 +20,9 @@ const COLUMNS_2 = [
 ];
 
 export default {
+	parameters: {
+		chromatic: {disableSnapshot: true},
+	},
 	title: 'Design System/Charts/React Billboard',
 };
 

--- a/packages/clay-data-provider/stories/DataProvider.stories.tsx
+++ b/packages/clay-data-provider/stories/DataProvider.stories.tsx
@@ -9,6 +9,9 @@ import ClayDataProvider, {useResource} from '../src';
 import {FetchPolicy} from '../src/types';
 
 export default {
+	parameters: {
+		chromatic: {disableSnapshot: true},
+	},
 	title: 'Design System/Components/DataProvider',
 };
 

--- a/packages/clay-empty-state/stories/EmptyState.stories.tsx
+++ b/packages/clay-empty-state/stories/EmptyState.stories.tsx
@@ -29,7 +29,11 @@ export const Title = () => (
 );
 
 export const EmptyState = (args: any) => (
-	<ClayEmptyState imgSrc={emptyImage} small={args.small}>
+	<ClayEmptyState
+		imgProps={{className: 'chromatic-ignore'}}
+		imgSrc={emptyImage}
+		small={args.small}
+	>
 		<ClayButton displayType="secondary">Button</ClayButton>
 	</ClayEmptyState>
 );
@@ -41,6 +45,7 @@ EmptyState.args = {
 export const SearchState = () => (
 	<ClayEmptyState
 		description="This is a description of what the button will allow you to do"
+		imgProps={{className: 'chromatic-ignore'}}
 		imgSrc={searchImage}
 		title="No content yet"
 	/>
@@ -49,6 +54,7 @@ export const SearchState = () => (
 export const SuccessState = () => (
 	<ClayEmptyState
 		description="You don't have more notifications to review"
+		imgProps={{className: 'chromatic-ignore'}}
 		imgSrc={successImage}
 		title="Hurray"
 	/>
@@ -57,7 +63,11 @@ export const SuccessState = () => (
 export const WithImage = () => (
 	<ClayEmptyState
 		description="You don't have more notifications to review"
-		imgProps={{alt: 'test test', title: 'hello world'}}
+		imgProps={{
+			alt: 'test test',
+			className: 'chromatic-ignore',
+			title: 'hello world',
+		}}
 		imgSrc={successImage}
 		title="Hurray"
 	/>

--- a/packages/clay-shared/stories/FocusScope.stories.tsx
+++ b/packages/clay-shared/stories/FocusScope.stories.tsx
@@ -9,6 +9,9 @@ import {ClayPortal, FocusScope} from '../src';
 
 export default {
 	component: FocusScope,
+	parameters: {
+		chromatic: {disableSnapshot: false},
+	},
 	title: 'Design System/Internal Use Only/FocusScope',
 };
 

--- a/packages/demos/stories/Recharts.stories.tsx
+++ b/packages/demos/stories/Recharts.stories.tsx
@@ -83,6 +83,9 @@ const DATA = [
 ];
 
 export default {
+	parameters: {
+		chromatic: {disableSnapshot: true},
+	},
 	title: 'Demos/Recharts',
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7531,6 +7531,11 @@ chroma-js@^1.2.2:
   resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-1.4.1.tgz#eb2d9c4d1ff24616be84b35119f4d26f8205f134"
   integrity sha512-jTwQiT859RTFN/vIf7s+Vl/Z2LcMrvMv3WUFmd/4u76AdlFC0NTNgqEEFPcRiHmAswPsMiQEDZLM8vX8qXpZNQ==
 
+chromatic@^6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-6.5.4.tgz#2e1beb7a8f6b84e7575456fe484201a3b4327ee1"
+  integrity sha512-/yunI/+rdc56C6x0IhpPmdfK/DRMOvQ2hoNyAe6uuU9rdWRoAH72lYatr2NcpdsOdHGOcV5DKgIaKgVdPfUk1w==
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"


### PR DESCRIPTION
Closes #4802

Well I did some exploring with [Chromatic](https://www.chromatic.com/) and we don't really need to do any configuration, this is [very simple and OOTB with storybook](https://storybook.js.org/docs/react/writing-tests/visual-testing) is pretty cool.

The problem is that you need a Cloud service from [Chromatic](https://www.chromatic.com/) itself, you can't run something locally as far as I know but there is a [free plan that offers 5,000 snapshots per month](https://www.chromatic.com/pricing), this is good because so far we have 192 snapshots.

One way to not hit this limit is to run this UI test only on every workflow release instead of running it on every pull request.

I already made an account and it syncs the `liferay/clay` collaborators in [Chromatic](https://www.chromatic.com/) to have access to the build and validate the changes to update the baseline if necessary, you just need to create an account with your GitHub account that collaborates with Clay.

Another point is that I ignored some stories from the storybook so as not to generate visual tests, some are related to the charts and the data provider which is not necessary. I think for better results we need to improve some stories to show for example open menus and dropdowns for DropDown, ColorPicker, and Datepicker, and better examples to show use cases for example typography.

> To run the test in Clay's release automation workflow it is necessary to add the token in the secrets of GitHub as `CHROMATIC_PROJECT_TOKEN`, I will open a ticket for that.