### PR TITLE
feat(@clayui/core): calls onKeyDown on Item and ItemStack if defined

### DIFF
--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -17,7 +17,10 @@ import {Icons, TreeViewContext} from './context';
 import {ITreeProps, useTree} from './useTree';
 
 interface ITreeViewProps<T>
-	extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'>,
+	extends Omit<
+			React.HTMLAttributes<HTMLUListElement>,
+			'children' | 'onSelect'
+		>,
 		ITreeProps<T>,
 		ICollectionProps<T> {
 	/**
@@ -65,6 +68,13 @@ interface ITreeViewProps<T>
 	onLoadMore?: (item: T) => Promise<unknown>;
 
 	/**
+	 * Callback called whenever an item is selected. Similar to the `onSelectionChange`
+	 * callback but instead of passing the selected keys it is called with the current
+	 * item being selected.
+	 */
+	onSelect?: (item: T) => void;
+
+	/**
 	 * Calback is called when the user presses the R or F2 hotkey.
 	 */
 	onRenameItem?: (item: T) => Promise<T>;
@@ -109,6 +119,7 @@ export function TreeView<T>({
 	onItemsChange,
 	onLoadMore,
 	onRenameItem,
+	onSelect,
 	onSelectionChange,
 	selectedKeys,
 	selectionHydrationMode = 'hydrate-first',
@@ -149,6 +160,7 @@ export function TreeView<T>({
 		nestedKey,
 		onLoadMore,
 		onRenameItem,
+		onSelect,
 		rootRef,
 		selectionMode,
 		showExpanderOnHover,

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -233,11 +233,32 @@ export const TreeViewItem = React.forwardRef<
 					}}
 					onFocus={() => actions && setFocus(true)}
 					onKeyDown={(event) => {
-						event.preventDefault();
-
 						if (itemStackProps.disabled || nodeProps.disabled) {
 							return;
 						}
+
+						if (hasItemStack && itemStackProps.onKeyDown) {
+							itemStackProps.onKeyDown(event);
+						}
+
+						if (nodeProps.onKeyDown) {
+							(
+								nodeProps.onKeyDown as unknown as (
+									event: React.KeyboardEvent<HTMLDivElement>
+								) => void
+							)(event);
+						}
+
+						if (event.defaultPrevented) {
+							return;
+						}
+
+						// We call `preventDefault` after checking if it was ignored
+						// because the behavior is different when the developer sets
+						// `onKeyDown` it can ignore the default behavior of the browser
+						// and the default behavior of the TreeView when this is not done
+						// by default we ignore the default browser behavior by default.
+						event.preventDefault();
 
 						const {key} = event;
 

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -71,6 +71,7 @@ export const TreeViewItem = React.forwardRef<
 		nestedKey,
 		onLoadMore,
 		onRenameItem,
+		onSelect,
 		open,
 		remove,
 		replace,
@@ -209,6 +210,10 @@ export const TreeViewItem = React.forwardRef<
 
 						if (selectionMode === 'single') {
 							selection.toggleSelection(item.key);
+
+							if (onSelect) {
+								onSelect(removeItemInternalProps(item));
+							}
 						}
 
 						if (group) {
@@ -353,6 +358,10 @@ export const TreeViewItem = React.forwardRef<
 
 						if (key === Keys.Spacebar) {
 							selection.toggleSelection(item.key);
+
+							if (onSelect) {
+								onSelect(removeItemInternalProps(item));
+							}
 						}
 					}}
 					ref={ref}
@@ -471,6 +480,7 @@ export function TreeViewItemStack({
 		expanderClassName,
 		expanderIcons,
 		nestedKey,
+		onSelect,
 		open,
 		selection,
 		toggle,
@@ -561,6 +571,10 @@ export function TreeViewItemStack({
 							}
 
 							selection.toggleSelection(item.key);
+
+							if (onSelect) {
+								onSelect(removeItemInternalProps(item));
+							}
 
 							if (expandOnCheck) {
 								open(item.key);

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -22,6 +22,7 @@ export interface ITreeViewContext<T> extends ITreeState<T> {
 	expanderIcons?: Icons;
 	nestedKey?: string;
 	onLoadMore?: (item: any) => Promise<unknown>;
+	onSelect?: (item: T) => void;
 	onRenameItem?: (item: T) => Promise<any>;
 	rootRef: React.RefObject<HTMLUListElement>;
 	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;


### PR DESCRIPTION
Fixes #4871

This PR I'm adding two new features to the TreeView, one is that it allows to use of the `onKeyDown` callback in the Item and ItemStack components and it is also possible to ignore the default behavior of the component, The second one is adding a new `onSelect` API in the TreeView which is similar to `onSelectionChange` will always be called when there is a selection of an item but passing as a parameter the properties of the item being selected.

It seems to be a default behavior that happens a lot in DXP because cases need item properties to save, this I think could be changed, it's an overload of information being sent between methods unnecessarily as well as being sent to the backend in some At times, the ideal would be to better control the information states and work only with the id of the selected items is less parameter overhead and makes implementations within DXP much simpler, there is a problem is that some components are very isolated, such as selection in Modal, communication between components also becomes more complex with contracts to send all between components but this is something very difficult to solve now and change all cases in DXP.