### PR TITLE
fix(@clayui/core): revalidate the state of intermediate for recursive multiple selection when the state is controlled

### DIFF
--- a/packages/clay-shared/src/useInternalState.ts
+++ b/packages/clay-shared/src/useInternalState.ts
@@ -40,10 +40,17 @@ export function useInternalState<Value>({
 		`You provided a '${name}' prop for a component without a handler '${handleName}'. This will render the component with an internal state, if the component is to be uncontrolled, use '${defaultName}'. Otherwise, set the '${handleName}' handler.`
 	);
 
-	if (typeof value === 'undefined' || typeof onChange === 'undefined') {
+	const isUncontrolled =
+		typeof value === 'undefined' || typeof onChange === 'undefined';
+
+	if (isUncontrolled) {
 		value = internalValue;
 		onChange = setInternalValue;
 	}
 
-	return [value, onChange] as [Value, InternalDispatch<Value>];
+	return [value, onChange, isUncontrolled] as [
+		Value,
+		InternalDispatch<Value>,
+		boolean
+	];
 }


### PR DESCRIPTION
Fixes #4874

The intermediate state is something internal only and we only add the node to this state when it interacts with public APIs like `selection.toggle` in render props or when the user interacts with the checkbox but we don't cover the case when the developer updates the `selectedKeys ` when being controlled, in this scenario we need to revalidate the intermediate states.

The solution I added was to always revalidate when `selectedKeys` is updated only on recursive multiple selection, a plus point about this is that updating refs doesn't cause a re-render but we need to update at render time so I used `useMemo` instead of `useEffect` here.