### PR TITLE
feat(@clayui/core): adds OOTB support for Text component in TreeView.Item/ItemStack

### DIFF
--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -543,7 +543,12 @@ export function TreeViewItemStack({
 					return null;
 				}
 
-				if (typeof child === 'string' || typeof child === 'number') {
+				if (
+					typeof child === 'string' ||
+					typeof child === 'number' ||
+					// @ts-ignore
+					child?.type.displayName === 'Text'
+				) {
 					content = <div className="component-text">{child}</div>;
 
 					// @ts-ignore

--- a/packages/clay-core/src/tree-view/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/BasicRendering.tsx
@@ -8,7 +8,7 @@ import {ClayCheckbox as Checkbox} from '@clayui/form';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 
-import {Button, Icon, Provider, TreeView} from '../..';
+import {Button, Icon, Provider, Text, TreeView} from '../..';
 
 const spritemap = 'icons.svg';
 
@@ -262,6 +262,33 @@ describe('TreeView basic rendering', () => {
 							<TreeView.Item>
 								<OptionalCheckbox />
 								Item
+							</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render with text', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView>
+					<TreeView.Item>
+						<TreeView.ItemStack>
+							<OptionalCheckbox />
+							<Text size={3} truncate>
+								Root
+							</Text>
+						</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item>
+								<OptionalCheckbox />
+								<Text size={3} truncate>
+									Text
+								</Text>
 							</TreeView.Item>
 						</TreeView.Group>
 					</TreeView.Item>

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -408,3 +408,99 @@ exports[`TreeView basic rendering render with checkbox 1`] = `
   </ul>
 </div>
 `;
+
+exports[`TreeView basic rendering render with text 1`] = `
+<div>
+  <ul
+    class="treeview treeview-light show-component-expander-on-hover"
+    role="tree"
+  >
+    <li
+      class="treeview-item"
+      role="none"
+    >
+      <div
+        aria-expanded="false"
+        class="treeview-link"
+        role="treeitem"
+        style="padding-left: 0px;"
+        tabindex="0"
+      >
+        <span
+          class="c-inner"
+          style="margin-left: -0px;"
+          tabindex="-2"
+        >
+          <div
+            class="autofit-row"
+          >
+            <div
+              class="autofit-col"
+            >
+              <button
+                aria-controls="$.0"
+                aria-expanded="false"
+                class="component-expander btn btn-monospaced"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="c-inner"
+                  tabindex="-2"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-down"
+                    />
+                  </svg>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="autofit-col"
+            >
+              <div
+                class="custom-control custom-checkbox"
+              >
+                <label>
+                  <input
+                    class="custom-control-input"
+                    type="checkbox"
+                  />
+                  <span
+                    class="custom-control-label"
+                  />
+                </label>
+              </div>
+            </div>
+            <div
+              class="autofit-col autofit-col-expand"
+            >
+              <div
+                class="component-text"
+              >
+                <span
+                  class="text-3 text-truncate"
+                >
+                  Root
+                </span>
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </li>
+  </ul>
+</div>
+`;


### PR DESCRIPTION
Related to the conversation in PR #4883

Allows you to add a Text component to an item in the TreeView to truncate or compose with any other property.

```jsx
<TreeView>
  <TreeView.Item>
    <TreeView.ItemStack>
      <Icon symbol="folder" />
      <Text size={3} truncate>Root</Text>
    </TreeView.ItemStack>
    <TreeView.Group>
      <TreeView.Item>Item</TreeView.Item>
    </TreeView.Group>
  </TreeView.Item>
</TreeView>
```