### PR TITLE
fix(@clayui/date-picker): updates Date Picker state when component is controlled

### DIFF
--- a/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
+++ b/packages/clay-date-picker/src/__tests__/BasicRendering.tsx
@@ -114,6 +114,7 @@ describe('BasicRendering', () => {
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				defaultValue="2019-04-10"
+				spritemap={spritemap}
 				years={{end: 2019, start: 2019}}
 			/>
 		);
@@ -141,6 +142,7 @@ describe('BasicRendering', () => {
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				onChange={() => {}}
+				spritemap={spritemap}
 				value="2019-04-10"
 				years={{end: 2019, start: 2019}}
 			/>
@@ -170,6 +172,7 @@ describe('BasicRendering', () => {
 				defaultMonth={new Date(2019, 3, 18)}
 				onChange={() => {}}
 				range
+				spritemap={spritemap}
 				value="2019-04-10 - 2019-04-15"
 				years={{end: 2019, start: 2019}}
 			/>
@@ -230,6 +233,7 @@ describe('BasicRendering', () => {
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				onChange={() => {}}
+				spritemap={spritemap}
 				time
 				value="2019-04-10 05:00"
 				years={{end: 2019, start: 2019}}
@@ -265,6 +269,7 @@ describe('BasicRendering', () => {
 				}}
 				defaultMonth={new Date(2019, 3, 18)}
 				defaultValue="2019-04-10 05:00"
+				spritemap={spritemap}
 				time
 				years={{end: 2019, start: 2019}}
 			/>

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -345,8 +345,10 @@ describe('IncrementalInteractions', () => {
 
 		expect(input.value).toBe('2019-05-01');
 		expect(yearSelect.value).toBe('2019');
-		expect(monthSelect.value).toBe('3');
-		expect(dayNumber.classList).toContain('active');
+		expect(monthSelect.value).toBe('4');
+		expect(
+			getByLabelText(new Date('2019 05 01').toDateString()).classList
+		).toContain('active');
 	});
 
 	describe('TimePicker', () => {
@@ -673,5 +675,56 @@ describe('IncrementalInteractions', () => {
 
 		const dayNumber = getByLabelText(currentDate.toDateString());
 		expect(dayNumber.classList).toContain('active');
+	});
+
+	it('updates date state when resetting input value using the controlled mode', () => {
+		function DatePickerControlled() {
+			const [value, setValue] = React.useState('2019-04-10 - 2019-04-15');
+
+			return (
+				<>
+					<button
+						aria-label="reset"
+						onClick={() => setValue('')}
+						type="button"
+					>
+						RESET
+					</button>
+					<ClayDatePicker
+						ariaLabels={ariaLabels}
+						defaultExpanded
+						defaultMonth={new Date(2019, 3, 18)}
+						onChange={setValue}
+						placeholder="YYYY-MM-DD"
+						range
+						spritemap={spritemap}
+						value={value}
+						years={{end: 2019, start: 2019}}
+					/>
+				</>
+			);
+		}
+
+		const {getByLabelText} = render(<DatePickerControlled />);
+
+		const resetButton = getByLabelText('reset');
+		const dayNumber = getByLabelText(new Date('2019 04 10').toDateString());
+		const endDate = getByLabelText(new Date('2019 04 15').toDateString());
+
+		expect(dayNumber.classList).toContain('active');
+		expect(endDate.classList).toContain('active');
+
+		fireEvent.click(resetButton);
+
+		const input: any = getByLabelText(ariaLabels.input);
+
+		const defaultDate = getByLabelText(
+			new Date('2019 04 18').toDateString()
+		);
+
+		expect(input.value).toBe('');
+		expect(defaultDate.classList).toContain('active');
+		expect(dayNumber.classList).not.toContain('active');
+		expect(endDate.classList).not.toContain('active');
 	});
 });

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -8,7 +8,7 @@ import DropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {FocusScope, InternalDispatch, useInternalState} from '@clayui/shared';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import DateNavigation from './DateNavigation';
 import DayNumber from './DayNumber';
@@ -268,7 +268,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 		// `initialMonth`.
 		initialMonth = defaultMonth ?? initialMonth;
 
-		const [internalValue, setValue] = useInternalState({
+		const [internalValue, setValue, isUncontrolled] = useInternalState({
 			defaultName: 'defaultValue',
 			defaultValue,
 			handleName: 'onChange',
@@ -434,14 +434,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 			setValue(daysSelectedToString);
 		};
 
-		/**
-		 * Control the value of the input propagating with the call
-		 * of `onChange` but does not change what the user types,
-		 * if a date is valid the month of the Date Picker is changed.
-		 */
-		const inputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-			const {value} = event.target;
-
+		const updateDate = useCallback((value: string) => {
 			if (!value) {
 				changeMonth(initialMonth);
 
@@ -478,9 +471,25 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 					}
 				}
 			}
+		}, []);
 
+		/**
+		 * Control the value of the input propagating with the call
+		 * of `onChange` but does not change what the user types,
+		 * if a date is valid the month of the Date Picker is changed.
+		 */
+		const inputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+			const {value} = event.target;
+
+			updateDate(value);
 			setValue(value);
 		};
+
+		useEffect(() => {
+			if (!isUncontrolled) {
+				updateDate(internalValue);
+			}
+		}, [isUncontrolled, internalValue]);
 
 		/**
 		 * Changes selected date to the current date. The same happens when there


### PR DESCRIPTION
Fixes #4888

This PR updates the Date Picker state when the component is controlled if the state is updated by an action other than the Date Picker.
