### PR TITLE
fix(@clayui/css): c-slideout should use display: flex on tbar-stacked for show/transition

### DIFF
--- a/packages/clay-css/src/scss/mixins/_slideout.scss
+++ b/packages/clay-css/src/scss/mixins/_slideout.scss
@@ -18,51 +18,43 @@
 
 @mixin clay-slideout-variant($map) {
 	@if (setter(map-get($map, enabled), true)) {
-		@include clay-css(setter($map, ()));
+		@include clay-css($map);
 
 		&.c-slideout-shown {
-			@include clay-css(setter(map-get($map, c-slideout-shown), ()));
+			@include clay-css(map-get($map, c-slideout-shown));
 		}
 
 		&.c-slideout-tbar-shown {
-			@include clay-css(setter(map-get($map, c-slideout-tbar-shown), ()));
+			@include clay-css(map-get($map, c-slideout-tbar-shown));
 		}
 
 		&.c-slideout-tbar-shown .sidebar {
-			@include clay-css(
-				setter(map-get($map, c-slideout-tbar-shown-sidebar), ())
-			);
+			@include clay-css(map-get($map, c-slideout-tbar-shown-sidebar));
 		}
 
 		.sidebar {
-			@include clay-css(setter(map-get($map, sidebar), ()));
+			@include clay-css(map-get($map, sidebar));
 		}
 
 		.sidebar.c-slideout-show {
-			@include clay-css(
-				setter(map-get($map, sidebar-c-slideout-show), ())
-			);
+			@include clay-css(map-get($map, sidebar-c-slideout-show));
 		}
 
 		.sidebar.c-slideout-transition {
-			@include clay-css(
-				setter(map-get($map, sidebar-c-slideout-transition), ())
-			);
+			@include clay-css(map-get($map, sidebar-c-slideout-transition));
 		}
 
 		.tbar-stacked {
-			@include clay-css(setter(map-get($map, tbar-stacked), ()));
+			@include clay-css(map-get($map, tbar-stacked));
 		}
 
 		.tbar-stacked.c-slideout-show {
-			@include clay-css(
-				setter(map-get($map, tbar-stacked-c-slideout-show), ())
-			);
+			@include clay-css(map-get($map, tbar-stacked-c-slideout-show));
 		}
 
 		.tbar-stacked.c-slideout-transition {
 			@include clay-css(
-				setter(map-get($map, tbar-stacked-c-slideout-transition), ())
+				map-get($map, tbar-stacked-c-slideout-transition)
 			);
 		}
 	}

--- a/packages/clay-css/src/scss/variables/_slideout.scss
+++ b/packages/clay-css/src/scss/variables/_slideout.scss
@@ -74,10 +74,10 @@ $c-slideout: map-deep-merge(
 			z-index: 1,
 		),
 		tbar-stacked-c-slideout-show: (
-			display: block,
+			display: flex,
 		),
 		tbar-stacked-c-slideout-transition: (
-			display: block,
+			display: flex,
 		),
 	),
 	$c-slideout


### PR DESCRIPTION
fixes #4896

@matuzalemsteles `tbar-item-expand` should work now for the Vertical Navigation. 