### PR TITLE
chore(@clayui/core): clicking on a node intermediate should uncheck the node and its children

### DIFF
--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -415,16 +415,15 @@ export function useMultipleSelection<T>(
 
 					const keyMap = layoutKeys.current.get(key) as LayoutInfo;
 
-					// Resets the intermediate state because the element will be selected
-					// or otherwise the state must be false because it will be unchecking
-					// all its children.
-					intermediateKeys.current.delete(key);
-
 					if (selecteds.has(key)) {
 						selecteds.delete(key);
-					} else {
+					} else if (!intermediateKeys.current.has(key)) {
 						selecteds.add(key);
 					}
+
+					// Resets the intermediate state because its selected state
+					// will change.
+					intermediateKeys.current.delete(key);
 
 					toggleChildrenSelection(
 						keyMap,


### PR DESCRIPTION
Closes #4897

We are changing the behavior in favor of maintaining consistency and improving the UX of selecting a node with an intermediate state. To understand more about the reasons for this change see issue #4897.

The new rule here is that "select" a node that is in the intermediate state must go into the unchecked state as well as its children if it is in recursive multiple selection mode. This works not only when clicking the checkbox but also when using the `selection.toggle` API which is available via render props.