### PR TITLE
chore(release): Adds input to define specific release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Clay Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        required: false
+        description: 'Defines a specific version (e.g 3.70.0)'
+        type: string
 
 jobs:
   test:
@@ -72,7 +77,8 @@ jobs:
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          lerna version --conventional-commits --no-push --yes
+      - name: Version
+        run: lerna version --conventional-commits ${{ github.event.inputs.version }} --no-push --yes
       - run: git push origin master --follow-tags
       - name: Get SHA
         id: sha


### PR DESCRIPTION
I'm adding the possibility that we can set the release version hardcoded instead of following the conventional commit, we have the case that we want some breaking changes for example to update the visual of the loading indicator without increasing the major version.