### PR TITLE
fix(@clayui/css): Loading Animation move animation to pseudo elements

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_loaders.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_loaders.scss
@@ -13,7 +13,6 @@ $cadmin-loading-icon-font-size-sm: 16px !default; // 16px
 $cadmin-loading-animation: () !default;
 $cadmin-loading-animation: map-deep-merge(
 	(
-		animation: cadmin-loading-animation-circle 1s linear infinite,
 		display: block,
 		height: 1em,
 		margin-left: auto,
@@ -23,17 +22,20 @@ $cadmin-loading-animation: map-deep-merge(
 		vertical-align: middle,
 		width: 1em,
 		before: (
+			animation: cadmin-loading-animation-circle 1s linear infinite,
 			border-radius: 50%,
 			box-shadow: -0.03125em -0.375em 0 0 currentColor,
 			content: '',
 			height: 0.25em,
 			left: 50%,
+			margin-left: -0.125em,
+			margin-top: -0.125em,
 			position: absolute,
 			top: 50%,
-			transform: translate(-50%, -50%),
 			width: 0.25em,
 		),
 		after: (
+			animation: cadmin-loading-animation-circle 1s linear infinite,
 			background-color: currentColor,
 			border-radius: 50%,
 			content: '',

--- a/packages/clay-css/src/scss/variables/_loaders.scss
+++ b/packages/clay-css/src/scss/variables/_loaders.scss
@@ -13,7 +13,6 @@ $loading-icon-font-size-sm: map-get($font-scale, 4) !default; // 16px
 $loading-animation: () !default;
 $loading-animation: map-deep-merge(
 	(
-		animation: loading-animation-circle 1s linear infinite,
 		display: block,
 		height: 1em,
 		margin-left: auto,
@@ -23,17 +22,20 @@ $loading-animation: map-deep-merge(
 		vertical-align: middle,
 		width: 1em,
 		before: (
+			animation: loading-animation-circle 1s linear infinite,
 			border-radius: 50%,
 			box-shadow: -0.03125em -0.375em 0 0 currentColor,
 			content: '',
 			height: 0.25em,
 			left: 50%,
+			margin-left: -0.125em,
+			margin-top: -0.125em,
 			position: absolute,
 			top: 50%,
-			transform: translate(-50%, -50%),
 			width: 0.25em,
 		),
 		after: (
+			animation: loading-animation-circle 1s linear infinite,
 			background-color: currentColor,
 			border-radius: 50%,
 			content: '',


### PR DESCRIPTION
    - The rotating animation on `.loading-animation` caused elements with overflow: auto to show scrollbars

@matuzalemsteles this should fix the issues in https://github.com/liferay-frontend/liferay-portal/pull/2315. I moved the animation to the pseudo elements.