### PR TITLE
fix(@clayui/multi-select): fix error when showing placeholder when it has items

### DIFF
--- a/packages/clay-multi-select/src/__tests__/index.tsx
+++ b/packages/clay-multi-select/src/__tests__/index.tsx
@@ -130,6 +130,20 @@ describe('ClayMultiSelect', () => {
 
 		expect(document.body).toMatchSnapshot();
 	});
+
+	it("don't show a placeholder when you have items", () => {
+		const onItemsChangeFn = jest.fn();
+
+		const {container} = render(
+			<ClayMultiSelectWithState
+				items={items}
+				onItemsChange={onItemsChangeFn}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		expect(container.querySelector('input')!.placeholder).toBe('');
+	});
 });
 
 describe('Interactions', () => {

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -199,15 +199,16 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 			},
 			menuRenderer: MenuRenderer = MultiSelectMenuRenderer,
 			onBlur = noop,
-			onClearAllButtonClick,
 			onChange,
+			onClearAllButtonClick,
 			onFocus = noop,
 			onItemsChange,
 			onKeyDown = noop,
 			onPaste = noop,
-			value,
+			placeholder,
 			sourceItems = [],
 			spritemap,
+			value,
 			...otherProps
 		}: IProps,
 		ref
@@ -392,6 +393,9 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 							}}
 							onKeyDown={handleKeyDown}
 							onPaste={handlePaste}
+							placeholder={
+								internalItems.length ? undefined : placeholder
+							}
 							ref={inputRef}
 							type="text"
 							value={internalValue}


### PR DESCRIPTION
Fixes #4912

I added a test case as well to cover this use case, as this component is not a conventional input but tries to mimic one with selected labels, we need to ignore the placeholder when labels exist.