### PR TITLE
fix(@clayui/css): fix error of loading indicator create scroll when the parent is over cadmin

### DIFF
--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.58.1
+ * Clay 3.60.1
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>

--- a/packages/clay-css/src/scss/cadmin/variables/_loaders.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_loaders.scss
@@ -17,6 +17,7 @@ $cadmin-loading-animation: map-deep-merge(
 		height: 1em,
 		margin-left: auto,
 		margin-right: auto,
+		overflow: hidden,
 		position: relative,
 		text-align: left,
 		vertical-align: middle,

--- a/packages/clay-css/src/scss/variables/_loaders.scss
+++ b/packages/clay-css/src/scss/variables/_loaders.scss
@@ -17,6 +17,7 @@ $loading-animation: map-deep-merge(
 		height: 1em,
 		margin-left: auto,
 		margin-right: auto,
+		overflow: hidden,
 		position: relative,
 		text-align: left,
 		vertical-align: middle,


### PR DESCRIPTION
To understand the context of this, see the comment https://github.com/liferay-frontend/liferay-portal/pull/2315#issuecomment-1150501572