### PR TITLE
feat(@clayui/css): Mixins clay-alert-variant adds custom-selector key

### DIFF
--- a/packages/clay-css/src/scss/mixins/_alerts.scss
+++ b/packages/clay-css/src/scss/mixins/_alerts.scss
@@ -80,6 +80,18 @@
 /// 	component-subtitle: (
 /// 		// .alert .component-subtitle
 /// 	),
+/// 	custom-selectors: (
+/// 		// add custom selectors here, see examples below
+/// 		btn-primary: (
+/// 			// .alert .btn-primary
+/// 		),
+/// 		btn-secondary: (
+/// 			// .alert .btn-secondary
+/// 		),
+/// 		'#custom-alert-btn': (
+/// 			// .alert #custom-alert-btn
+/// 		),
+/// 	),
 /// )
 
 @mixin clay-alert-variant($map) {
@@ -235,6 +247,20 @@
 
 			.component-subtitle {
 				@include clay-text-typography($component-subtitle);
+			}
+
+			@each $key, $properties in map-get($map, custom-selectors) {
+				@if ($key) {
+					$selector: if(
+						starts-with($key, '.') or starts-with($key, '#'),
+						$key,
+						str-insert($key, '.', 1)
+					);
+
+					#{$selector} {
+						@include clay-button-variant($properties);
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
fixes #4807

- a special key to pass in any selector you want to `.alert`

This doesn't add any CSS, just the option to via Sass maps. We can customize all button variants in alert variants this way.