### PR TITLE
fix(@clayui/color-picker): fix error when `onBlur` method is declared but not called

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -47,7 +47,7 @@ module.exports = {
 			branches: 74,
 			functions: 87,
 			lines: 90,
-			statements: 91,
+			statements: 90,
 		},
 		'./packages/clay-core/src/overlay-mask/': {
 			branches: 73,

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -381,6 +381,14 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 								onBlur={(event) => {
 									const value = event.target.value;
 
+									if (otherProps.onBlur) {
+										otherProps.onBlur(event);
+									}
+
+									if (event.defaultPrevented) {
+										return;
+									}
+
 									const newColor = tinycolor(value);
 
 									if (newColor.isValid()) {


### PR DESCRIPTION
Fixes #4920

This is a small fix, which calls the `onBlur` method when it is declared in the component by the developer but I am also adding the possibility to ignore the default behavior of the component when using the `event.preventDefault()` of the `onBlur` method, this is similar to the pattern we use in TreeView, this allows better flexibility to extend behaviors or change when necessary, I believe it is not used much but it helps to create extra input validation mechanism for example that is not covered in some cases of Lexicon.