### PR TITLE
fix(@clayui/css): Global Variables remove math function parenthesis from $spacers

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -201,36 +201,16 @@ $spacers: () !default;
 $spacers: map-deep-merge(
 	(
 		0: 0,
-		1: (
-			$spacer * 0.25,
-		),
-		2: (
-			$spacer * 0.5,
-		),
-		3: (
-			$spacer * 1,
-		),
-		4: (
-			$spacer * 1.5,
-		),
-		5: (
-			$spacer * 3,
-		),
-		6: (
-			$spacer * 4.5,
-		),
-		7: (
-			$spacer * 6,
-		),
-		8: (
-			$spacer * 7.5,
-		),
-		9: (
-			$spacer * 9,
-		),
-		10: (
-			$spacer * 10,
-		),
+		1: $spacer * 0.25,
+		2: $spacer * 0.5,
+		3: $spacer * 1,
+		4: $spacer * 1.5,
+		5: $spacer * 3,
+		6: $spacer * 4.5,
+		7: $spacer * 6,
+		8: $spacer * 7.5,
+		9: $spacer * 9,
+		10: $spacer * 10,
 	),
 	$spacers
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -246,36 +246,16 @@ $cadmin-spacers: () !default;
 $cadmin-spacers: map-deep-merge(
 	(
 		0: 0,
-		1: (
-			$cadmin-spacer * 0.25,
-		),
-		2: (
-			$cadmin-spacer * 0.5,
-		),
-		3: (
-			$cadmin-spacer * 1,
-		),
-		4: (
-			$cadmin-spacer * 1.5,
-		),
-		5: (
-			$cadmin-spacer * 3,
-		),
-		6: (
-			$cadmin-spacer * 4.5,
-		),
-		7: (
-			$cadmin-spacer * 6,
-		),
-		8: (
-			$cadmin-spacer * 7.5,
-		),
-		9: (
-			$cadmin-spacer * 9,
-		),
-		10: (
-			$cadmin-spacer * 10,
-		),
+		1: $cadmin-spacer * 0.25,
+		2: $cadmin-spacer * 0.5,
+		3: $cadmin-spacer * 1,
+		4: $cadmin-spacer * 1.5,
+		5: $cadmin-spacer * 3,
+		6: $cadmin-spacer * 4.5,
+		7: $cadmin-spacer * 6,
+		8: $cadmin-spacer * 7.5,
+		9: $cadmin-spacer * 9,
+		10: $cadmin-spacer * 10,
 	),
 	$cadmin-spacers
 );

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -95,11 +95,20 @@
 /// @param {Any} $num - The variable
 
 @function math-sign($num) {
+	@if not(type-of($num) == 'number') and not
+		(type-of($num) == 'string') and not
+		($num == null)
+	{
+		@warn 'The value `#{$num}` is of type `#{type-of($num)}`. It must be a `number`, `string`, or `null`. This function has returned a value of `null`.';
+	}
+
 	@if (type-of($num) == 'number') {
 		@return -($num);
 	} @else if (type-of($num) == 'string') {
 		@if (starts-with($num, 'var(--')) {
 			@return calc(#{$num} * -1);
+		} @else {
+			@return $num;
 		}
 	}
 

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -189,28 +189,14 @@ $spacers: () !default;
 $spacers: map-deep-merge(
 	(
 		0: 0,
-		1: (
-			$spacer * 0.25,
-		),
-		2: (
-			$spacer * 0.5,
-		),
+		1: $spacer * 0.25,
+		2: $spacer * 0.5,
 		3: $spacer,
-		4: (
-			$spacer * 1.5,
-		),
-		5: (
-			$spacer * 3,
-		),
-		6: (
-			$spacer * 4.5,
-		),
-		7: (
-			$spacer * 6,
-		),
-		8: (
-			$spacer * 7.5,
-		),
+		4: $spacer * 1.5,
+		5: $spacer * 3,
+		6: $spacer * 4.5,
+		7: $spacer * 6,
+		8: $spacer * 7.5,
 	),
 	$spacers
 );


### PR DESCRIPTION
fixes #4922

- throws warning if type is not number, string, and parameter value is equal to null