### PR TITLE
fix(@clayui/drop-down): fix bug of calling `setActive` method when the menu is invisible

### DIFF
--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -56,7 +56,7 @@ const ClayAutocompleteDropDown: React.FunctionComponent<IProps> = ({
 			autoBestAlign={false}
 			className="autocomplete-dropdown-menu"
 			closeOnClickOutside={closeOnClickOutside}
-			onSetActive={onSetActive}
+			onActiveChange={onSetActive}
 			ref={menuElementRef}
 			style={{
 				maxWidth: 'none',

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -321,7 +321,7 @@ const ClayColorPicker: React.FunctionComponent<IProps> = ({
 						className="clay-color-dropdown-menu"
 						containerProps={dropDownContainerProps}
 						focusRefOnEsc={splotchRef}
-						onSetActive={setInternalActive}
+						onActiveChange={setInternalActive}
 						ref={dropdownContainerRef}
 					>
 						{(!onColorsChange ||

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -633,7 +633,7 @@ const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
 							alignElementRef={triggerElementRef}
 							className="date-picker-dropdown-menu"
 							data-testid="dropdown"
-							onSetActive={setExpandedValue}
+							onActiveChange={setExpandedValue}
 							ref={dropdownContainerRef}
 						>
 							<div

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -306,7 +306,7 @@ const Contextual: React.FunctionComponent<
 					alignmentPosition={8}
 					hasLeftSymbols={hasLeftSymbols}
 					hasRightSymbols={hasRightSymbols}
-					onSetActive={setVisible}
+					onActiveChange={setVisible}
 					ref={menuElementRef}
 				>
 					{visible && <MouseSafeArea parentRef={menuElementRef} />}

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -236,6 +236,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 						.map((ref) => ref.current!);
 
 					if (
+						active &&
 						event.target instanceof Node &&
 						!nodes.find((element) =>
 							element.contains(event.target as Node)
@@ -251,7 +252,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 					window.removeEventListener('mousedown', handleClick);
 				};
 			}
-		}, [closeOnClickOutside]);
+		}, [active, closeOnClickOutside]);
 
 		useEffect(() => {
 			const handleEsc = (event: KeyboardEvent) => {

--- a/packages/clay-drop-down/stories/DropDown.stories.tsx
+++ b/packages/clay-drop-down/stories/DropDown.stories.tsx
@@ -473,7 +473,7 @@ export const InModal = () => {
 						<ClayDropDown.Menu
 							active={panelVisibility}
 							alignElementRef={inputRef}
-							onSetActive={() =>
+							onActiveChange={() =>
 								setPanelVisibility(!panelVisibility)
 							}
 							ref={dropdownMenuRef}


### PR DESCRIPTION
Fixes #4928

This fixes the bug of calling the `setActive` method even when the Menu is invisible. Add in the condition checking the status of `active`.