### PR TITLE
fix(@clayui/multi-select): fix error when you have a ref declared it is not possible to delete the label by pressing backspace

### DIFF
--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -243,6 +243,9 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 			}
 		}, [internalValue, isFocused, sourceItems]);
 
+		const inputElementRef =
+			(ref as React.RefObject<HTMLInputElement>) || inputRef;
+
 		const setNewValue = (newVal: Item) => {
 			setItems([...internalItems, newVal]);
 
@@ -280,10 +283,10 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 			} else if (
 				!internalValue &&
 				key === Keys.Backspace &&
-				inputRef.current &&
+				inputElementRef.current &&
 				lastItemRef.current
 			) {
-				inputRef.current.blur();
+				inputElementRef.current.blur();
 				lastItemRef.current.focus();
 			}
 		};
@@ -304,9 +307,6 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 				setItems([...internalItems, ...pastedItems]);
 			}
 		};
-
-		const inputElementRef =
-			(ref as React.RefObject<HTMLInputElement>) || inputRef;
 
 		return (
 			<FocusScope arrowKeysUpDown={false}>
@@ -448,8 +448,8 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 								onItemClick={(item) => {
 									setNewValue(item);
 
-									if (inputRef.current) {
-										inputRef.current.focus();
+									if (inputElementRef.current) {
+										inputElementRef.current.focus();
 									}
 								}}
 								sourceItems={sourceItems}


### PR DESCRIPTION
Fixes #4934

This was a regression from #4918, I didn't change it everywhere to use `inputElementRef` instead of `inputRef`, this is to toggle when the `ref` is declared use it instead, otherwise, we will use a ref internally.