### PR TITLE
fix(@clayui/css): Clay Multi Select should have small size

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -558,6 +558,16 @@ textarea.form-control-sm,
 	height: $cadmin-input-textarea-height-sm;
 }
 
+// .form-control-tag-group-sm
+
+%clay-form-control-tag-group-sm {
+	@include clay-form-control-variant($cadmin-form-control-tag-group-sm);
+}
+
+.form-control-tag-group-sm.form-control {
+	@extend %clay-form-control-tag-group-sm;
+}
+
 // Form groups
 // Designed to help with the organization and spacing of vertical forms. For
 // horizontal forms, use the predefined grid classes.

--- a/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_input-groups.scss
@@ -124,6 +124,15 @@
 			@extend %clay-color-sm-input-group-inset-item-before !optional;
 		}
 	}
+
+	.form-control {
+		@extend %clay-form-control-sm !optional;
+	}
+
+	.form-control-tag-group,
+	&.form-control-tag-group {
+		@extend %clay-form-control-tag-group-sm !optional;
+	}
 }
 
 .input-group-sm {

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -476,6 +476,37 @@ $cadmin-form-control-tag-group-component-action: map-deep-merge(
 	$cadmin-form-control-tag-group-component-action
 );
 
+// .form-control-tag-group-sm.form-control
+
+$cadmin-form-control-tag-group-sm: () !default;
+$cadmin-form-control-tag-group-sm: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($cadmin-input-border-radius-sm),
+		font-size: $cadmin-input-font-size-sm,
+		height: auto,
+		line-height: $cadmin-input-line-height-sm,
+		min-height: $cadmin-input-height-sm,
+		padding-bottom: 0,
+		padding-left: 0.25rem,
+		padding-right: 0.25rem,
+		padding-top: 0,
+		inline-item: (
+			margin-bottom: 0,
+			margin-top: 0,
+		),
+		label: (
+			margin-bottom: 0.1875rem,
+			margin-right: 0.25rem,
+			margin-top: 0.1875rem,
+		),
+		form-control-inset: (
+			margin-bottom: 0.125rem,
+			margin-top: 0.1875rem,
+		),
+	),
+	$cadmin-form-control-tag-group-sm
+);
+
 // Form Group
 
 $cadmin-form-group-margin-bottom: 24px !default; // 24px
@@ -1697,25 +1728,6 @@ $cadmin-input-group-sm: map-deep-merge(
 		input-group-item: (
 			btn: $cadmin-input-group-sm-item-btn,
 			btn-monospaced: $cadmin-input-group-sm-item-btn-monospaced,
-			form-control: (
-				border-radius:
-					clay-enable-rounded($cadmin-input-border-radius-sm),
-				font-size: $cadmin-input-font-size-sm,
-				height: $cadmin-input-height-sm,
-				line-height: $cadmin-input-line-height-sm,
-				padding-bottom: $cadmin-input-padding-y-sm,
-				padding-left: $cadmin-input-padding-x-sm,
-				padding-right: $cadmin-input-padding-x-sm,
-				padding-top: $cadmin-input-padding-y-sm,
-				label: (
-					margin-bottom: 0.1875rem,
-					margin-top: 0.1875rem,
-				),
-			),
-			form-control-inset: (
-				margin-bottom: 0.125rem,
-				margin-top: 0.1875rem,
-			),
 			form-file: (
 				btn: (
 					border-radius:

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -507,6 +507,16 @@ textarea.form-control-sm,
 	@extend %clay-textarea-form-control-sm !optional;
 }
 
+// .form-control-tag-group-sm
+
+%clay-form-control-tag-group-sm {
+	@include clay-form-control-variant($form-control-tag-group-sm);
+}
+
+.form-control-tag-group-sm.form-control {
+	@extend %clay-form-control-tag-group-sm;
+}
+
 // Fieldset
 
 .form-fieldset {

--- a/packages/clay-css/src/scss/components/_input-groups.scss
+++ b/packages/clay-css/src/scss/components/_input-groups.scss
@@ -176,6 +176,15 @@
 			@extend %clay-color-sm-input-group-inset-item-before !optional;
 		}
 	}
+
+	.form-control {
+		@extend %clay-form-control-sm !optional;
+	}
+
+	.form-control-tag-group,
+	&.form-control-tag-group {
+		@extend %clay-form-control-tag-group-sm !optional;
+	}
 }
 
 .input-group-sm {

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -248,6 +248,15 @@
 /// 			// .form-control.disabled ~ .input-group-inset-item
 /// 		),
 /// 	),
+/// 	inline-item: (
+///			// .form-control .inline-item
+/// 	),
+/// 	label: (
+/// 		// .form-control .label
+/// 	),
+/// 	form-control-inset: (
+///			// .form-control .form-control-inset
+/// 	),
 /// )
 /// -=-=-=-=-=- Deprecated -=-=-=-=-=-
 /// placeholder-color: {Color | String | Null}, // deprecated after 3.7.0
@@ -600,6 +609,20 @@
 						map-deep-get($map, disabled, input-group-inset-item)
 					);
 				}
+			}
+
+			.inline-item {
+				@include clay-css(map-get($map, inline-item));
+			}
+
+			.label {
+				@include clay-css(map-get($map, label));
+			}
+
+			.form-control-inset {
+				@include clay-form-control-variant(
+					map-get($map, form-control-inset)
+				);
 			}
 
 			@include clay-generate-media-breakpoints($map);

--- a/packages/clay-css/src/scss/mixins/_input-groups.scss
+++ b/packages/clay-css/src/scss/mixins/_input-groups.scss
@@ -332,12 +332,6 @@
 				@include clay-form-control-variant(
 					map-deep-get($map, form-control)
 				);
-
-				.label {
-					@include clay-label-variant(
-						map-deep-get($map, form-control, label)
-					);
-				}
 			}
 
 			> .form-file {

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -525,6 +525,37 @@ $form-control-tag-group-component-action: map-deep-merge(
 	$form-control-tag-group-component-action
 );
 
+// .form-control-tag-group-sm.form-control
+
+$form-control-tag-group-sm: () !default;
+$form-control-tag-group-sm: map-deep-merge(
+	(
+		border-radius: clay-enable-rounded($input-border-radius-sm),
+		font-size: $input-font-size-sm,
+		height: auto,
+		line-height: $input-line-height-sm,
+		min-height: $input-height-sm,
+		padding-bottom: 0,
+		padding-left: 0.25rem,
+		padding-right: 0.25rem,
+		padding-top: 0,
+		inline-item: (
+			margin-bottom: 0,
+			margin-top: 0,
+		),
+		label: (
+			margin-bottom: 0.1875rem,
+			margin-right: 0.25rem,
+			margin-top: 0.1875rem,
+		),
+		form-control-inset: (
+			margin-bottom: 0.125rem,
+			margin-top: 0.1875rem,
+		),
+	),
+	$form-control-tag-group-sm
+);
+
 // Form Grid
 
 /// @deprecated as of v3.x with no replacement
@@ -1730,25 +1761,6 @@ $input-group-sm: map-deep-merge(
 		input-group-item: (
 			btn: $input-group-sm-item-btn,
 			btn-monospaced: $input-group-sm-item-btn-monospaced,
-			form-control: (
-				border-radius: clay-enable-rounded($input-border-radius-sm),
-				font-size: $input-font-size-sm,
-				height: auto,
-				line-height: $input-line-height-sm,
-				min-height: $input-height-sm,
-				padding-bottom: 0,
-				padding-left: $input-padding-x-sm,
-				padding-right: $input-padding-x-sm,
-				padding-top: 0,
-				label: (
-					margin-bottom: 0.1875rem,
-					margin-top: 0.1875rem,
-				),
-			),
-			form-control-inset: (
-				margin-bottom: 0.125rem,
-				margin-top: 0.1875rem,
-			),
 			form-file: (
 				btn: (
 					border-radius: clay-enable-rounded($input-border-radius-sm),

--- a/packages/clay-multi-select/docs/index.js
+++ b/packages/clay-multi-select/docs/index.js
@@ -368,10 +368,132 @@ const MultiSelectInputWithCustomAutocomplete = () => {
 	);
 };
 
+const multiSelectSmallImportsCode = `import ClayMultiSelect from '@clayui/multi-select';
+`;
+
+const multiSelectSmallCode = `const Component = () => {
+	const [value, setValue] = useState('');
+	const [items, setItems] = useState([
+		{
+			label: 'one',
+			value: '1',
+		}
+	]);
+
+	return (
+		<ClayMultiSelect
+			inputName="multiSelectSmallInput"
+			items={items}
+			onChange={setValue}
+			onItemsChange={setItems}
+			size="sm"
+			spritemap={spritemap}
+			value={value}
+		/>
+	);
+}
+
+render(<Component />)`;
+
+const MultiSelectSmallInput = () => {
+	const scope = {
+		ClayMultiSelect,
+	};
+
+	return (
+		<Editor
+			code={multiSelectSmallCode}
+			imports={multiSelectSmallImportsCode}
+			scope={scope}
+		/>
+	);
+};
+
+const multiSelectSmallInputWithSelectButtonImportsCode = `import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput} from '@clayui/form';
+import ClayMultiSelect from '@clayui/multi-select';
+`;
+
+const multiSelectSmallWithSelectButtonCode = `const Component = () => {
+	const [value, setValue] = useState('');
+	const [items, setItems] = useState([
+		{
+			label: 'one',
+			value: '1',
+		}
+	]);
+
+	const sourceItems = [
+		{
+			label: 'one',
+			value: '1',
+		},
+		{
+			label: 'two',
+			value: '2',
+		},
+		{
+			label: 'three',
+			value: '3',
+		},
+		{
+			label: 'four',
+			value: '4',
+		},
+	];
+
+	return (
+		<ClayForm.Group>
+			<ClayInput.Group className="input-group-sm">
+				<ClayInput.GroupItem>
+					<ClayMultiSelect
+						inputName="myInput"
+						items={items}
+						onChange={setValue}
+						onItemsChange={setItems}
+						sourceItems={sourceItems}
+						spritemap={spritemap}
+						value={value}
+					/>
+				</ClayInput.GroupItem>
+				<ClayInput.GroupItem shrink>
+					<ClayButton
+						displayType="secondary"
+						onClick={() => alert('Click')}
+					>
+						{'Select'}
+					</ClayButton>
+				</ClayInput.GroupItem>
+			</ClayInput.Group>
+		</ClayForm.Group>
+	);
+}
+
+render(<Component />)`;
+
+const MultiSelectSmallInputWithSelectButton = () => {
+	const scope = {
+		ClayButton,
+		ClayForm,
+		ClayInput,
+		ClayMultiSelect,
+	};
+
+	return (
+		<Editor
+			code={multiSelectSmallWithSelectButtonCode}
+			imports={multiSelectSmallInputWithSelectButtonImportsCode}
+			scope={scope}
+		/>
+	);
+};
+
 export {
 	MultiSelectInput,
 	MultiSelectInputWithAutocomplete,
 	MultiSelectInputWithCustomAutocomplete,
 	MultiSelectInputWithSelectButton,
 	MultiSelectInputWithValidation,
+	MultiSelectSmallInput,
+	MultiSelectSmallInputWithSelectButton,
 };

--- a/packages/clay-multi-select/docs/markup-text-input-multi-select.md
+++ b/packages/clay-multi-select/docs/markup-text-input-multi-select.md
@@ -12,6 +12,8 @@ mainTabURL: 'docs/components/multi-select.html'
 -   [Labels](#css-labels)
 -   [Loading](#css-loading)
 -   [Contenteditable Elements](#css-contenteditable-elements)
+-   [Sizes](#css-clay-multi-select-sizes)
+    -   [Small](#css-clay-multi-select-small)
 
 </div>
 </div>
@@ -701,6 +703,212 @@ mainTabURL: 'docs/components/multi-select.html'
 		</div>
 		<div class="input-group-item input-group-item-shrink">
 			<button class="btn btn-secondary" type="submit">Select</button>
+		</div>
+	</div>
+</div>
+```
+
+## Sizes(#css-clay-multi-select-sizes)
+
+### Small(#css-clay-multi-select-small)
+
+The modifier class `form-control-tag-group-sm` on `form-control-tag-group` will render a smaller version of Clay Multi Select.
+
+<div class="sheet-example">
+	<div class="form-group">
+		<div class="dropdown">
+			<div class="form-control form-control-tag-group form-control-tag-group-sm">
+				<span class="autofit-row">
+					<span class="autofit-col autofit-col-expand">
+						<input class="form-control-inset" type="text" value="some value">
+					</span>
+				</span>
+			</div>
+			<ul class="autocomplete-dropdown-menu dropdown-menu show">
+				<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
+				<li><a class="dropdown-item" href="#1"><strong>some value</strong> meal</a></li>
+			</ul>
+		</div>
+		<div class="form-feedback-group">
+			<div class="form-text">You can use a comma to enter tags.</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<div class="dropdown">
+		<div
+			class="form-control form-control-tag-group form-control-tag-group-sm"
+		>
+			<span class="autofit-row">
+				<span class="autofit-col autofit-col-expand">
+					<input
+						class="form-control-inset"
+						type="text"
+						value="some value"
+					/>
+				</span>
+			</span>
+		</div>
+		<ul class="autocomplete-dropdown-menu dropdown-menu show">
+			<li>
+				<a class="dropdown-item" href="#1"
+					><strong>some value</strong></a
+				>
+			</li>
+			<li>
+				<a class="dropdown-item" href="#1"
+					><strong>some value</strong> meal</a
+				>
+			</li>
+		</ul>
+	</div>
+	<div class="form-feedback-group">
+		<div class="form-text">You can use a comma to enter tags.</div>
+	</div>
+</div>
+```
+
+For variations with buttons, the modifier classes `input-group-sm` or `form-group-sm` can be added to `input-group` or `form-group`, respectively.
+
+<div class="sheet-example">
+	<div class="form-group">
+		<label for="tagsField3">Tags with input-group-sm</label>
+		<div class="input-group input-group-stacked-sm-down input-group-sm">
+			<div class="input-group-item">
+				<div class="dropdown">
+					<div class="form-control form-control-tag-group">
+						<span class="autofit-row">
+							<span class="autofit-col autofit-col-expand">
+								<input class="form-control-inset" id="tagsField3" type="text" value="some value">
+							</span>
+						</span>
+					</div>
+					<ul class="autocomplete-dropdown-menu dropdown-menu">
+						<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
+						<li><a class="dropdown-item" href="#1"><strong>some value</strong> meal</a></li>
+					</ul>
+				</div>
+				<div class="form-feedback-group">
+					<div class="form-text">You can use a comma to enter tags.</div>
+				</div>
+			</div>
+			<div class="input-group-item input-group-item-shrink">
+				<button class="btn btn-secondary" type="button">Select</button>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group">
+	<label for="tagsField3">Tags with input-group-sm</label>
+	<div class="input-group input-group-stacked-sm-down input-group-sm">
+		<div class="input-group-item">
+			<div class="dropdown">
+				<div class="form-control form-control-tag-group">
+					<span class="autofit-row">
+						<span class="autofit-col autofit-col-expand">
+							<input
+								class="form-control-inset"
+								id="tagsField3"
+								type="text"
+								value="some value"
+							/>
+						</span>
+					</span>
+				</div>
+				<ul class="autocomplete-dropdown-menu dropdown-menu">
+					<li>
+						<a class="dropdown-item" href="#1"
+							><strong>some value</strong></a
+						>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1"
+							><strong>some value</strong> meal</a
+						>
+					</li>
+				</ul>
+			</div>
+			<div class="form-feedback-group">
+				<div class="form-text">You can use a comma to enter tags.</div>
+			</div>
+		</div>
+		<div class="input-group-item input-group-item-shrink">
+			<button class="btn btn-secondary" type="button">Select</button>
+		</div>
+	</div>
+</div>
+```
+
+<div class="sheet-example">
+	<div class="form-group-sm">
+		<label for="tagsField4">Tags with form-group-sm</label>
+		<div class="input-group input-group-stacked-sm-down input-group-sm">
+			<div class="input-group-item">
+				<div class="dropdown">
+					<div class="form-control form-control-tag-group">
+						<span class="autofit-row">
+							<span class="autofit-col autofit-col-expand">
+								<input class="form-control-inset" id="tagsField4" type="text" value="some value">
+							</span>
+						</span>
+					</div>
+					<ul class="autocomplete-dropdown-menu dropdown-menu">
+						<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
+						<li><a class="dropdown-item" href="#1"><strong>some value</strong> meal</a></li>
+					</ul>
+				</div>
+				<div class="form-feedback-group">
+					<div class="form-text">You can use a comma to enter tags.</div>
+				</div>
+			</div>
+			<div class="input-group-item input-group-item-shrink">
+				<button class="btn btn-secondary" type="button">Select</button>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="form-group-sm">
+	<label for="tagsField4">Tags with form-group-sm</label>
+	<div class="input-group input-group-stacked-sm-down input-group-sm">
+		<div class="input-group-item">
+			<div class="dropdown">
+				<div class="form-control form-control-tag-group">
+					<span class="autofit-row">
+						<span class="autofit-col autofit-col-expand">
+							<input
+								class="form-control-inset"
+								id="tagsField4"
+								type="text"
+								value="some value"
+							/>
+						</span>
+					</span>
+				</div>
+				<ul class="autocomplete-dropdown-menu dropdown-menu">
+					<li>
+						<a class="dropdown-item" href="#1"
+							><strong>some value</strong></a
+						>
+					</li>
+					<li>
+						<a class="dropdown-item" href="#1"
+							><strong>some value</strong> meal</a
+						>
+					</li>
+				</ul>
+			</div>
+			<div class="form-feedback-group">
+				<div class="form-text">You can use a comma to enter tags.</div>
+			</div>
+		</div>
+		<div class="input-group-item input-group-item-shrink">
+			<button class="btn btn-secondary" type="button">Select</button>
 		</div>
 	</div>
 </div>

--- a/packages/clay-multi-select/docs/multi-select.mdx
+++ b/packages/clay-multi-select/docs/multi-select.mdx
@@ -11,6 +11,8 @@ import {
 	MultiSelectInputWithCustomAutocomplete,
 	MultiSelectInputWithSelectButton,
 	MultiSelectInputWithValidation,
+	MultiSelectSmallInput,
+	MultiSelectSmallInputWithSelectButton,
 } from '$packages/clay-multi-select/docs/index';
 
 <div class="nav-toc-absolute">
@@ -21,6 +23,8 @@ import {
     -   [Select Button](#select-button)
     -   [Validation](#validation)
 -   [Custom Autocomplete](#custom-autocomplete)
+-   [Sizes](#clay-multi-select-sizes)
+    -   [Small](#clay-multi-select-small)
 
 </div>
 </div>
@@ -56,3 +60,17 @@ An input needs validation so you can add some composition props with `<ClayInput
 To customize Autocomplete content to stylize to your needs and also have filter control, you can use the `menuRenderer` API.
 
 <MultiSelectInputWithCustomAutocomplete />
+
+## Sizes(#clay-multi-select-sizes)
+
+The `size` property on `ClayMultiSelect` only modifies the size of the input.
+
+### Small(#clay-multi-select-small)
+
+Render a smaller `ClayMultiSelect` input by setting the `size` property to `sm`.
+
+<MultiSelectSmallInput />
+
+`ClayMultiSelect`'s with the Select Button should use the modifier class `input-group-sm` on `input-group` or `form-group-sm` on `form-group`.
+
+<MultiSelectSmallInputWithSelectButton />

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -42,6 +42,8 @@ type Locator = {
 	value: string;
 };
 
+type Size = null | 'sm';
+
 interface IMenuRendererProps {
 	/**
 	 * Value of input
@@ -146,6 +148,11 @@ export interface IProps
 	onItemsChange: InternalDispatch<Array<Item>>;
 
 	/**
+	 * Determines the size of the Multi Select component.
+	 */
+	size?: Size;
+
+	/**
 	 * List of pre-populated items that will show up in a dropdown menu
 	 */
 	sourceItems?: Array<Item>;
@@ -206,6 +213,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 			onKeyDown = noop,
 			onPaste = noop,
 			placeholder,
+			size,
 			sourceItems = [],
 			spritemap,
 			value,
@@ -315,6 +323,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 						'form-control form-control-tag-group input-group',
 						{
 							focus: isFocused && isValid,
+							[`form-control-tag-group-${size}`]: size,
 						}
 					)}
 					ref={containerRef}

--- a/packages/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/packages/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -13,6 +13,12 @@ import React, {useRef, useState} from 'react';
 import ClayMultiSelect, {itemLabelFilter} from '../src';
 
 export default {
+	argTypes: {
+		size: {
+			control: {type: 'select'},
+			options: [null, 'sm'],
+		},
+	},
 	component: ClayMultiSelect,
 	title: 'Design System/Components/MultiSelect',
 };
@@ -80,6 +86,7 @@ export const Default = (args: any) => {
 				isValid={args.isValid}
 				items={items}
 				onItemsChange={setItems}
+				size={args.size}
 			/>
 		</>
 	);
@@ -89,6 +96,7 @@ Default.args = {
 	disabled: false,
 	disabledClearAll: false,
 	isValid: false,
+	size: null,
 };
 
 export const ComparingItems = () => {


### PR DESCRIPTION
fixes #4911

This provides 3 ways to make Multi Select small. `.form-group-sm` works on all Multi Select. `.input-group-sm` should be used on the first `.input-group` in this [example](https://clayui.com/docs/components/multi-select.html#select-button). `.form-control-tag-group-sm` should go on `.form-control` in this [example](https://clayui.com/docs/components/multi-select.html#autocomplete).

~I still need to update cadmin and I'll update the Multi Select component too.~