### PR TITLE
refactor(@clayui/color-picker): refactors the component state implementation of Custom and create the component editor

### DIFF
--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -3,119 +3,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayForm, {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
-import {InternalDispatch, useInternalState} from '@clayui/shared';
-import React from 'react';
+import React, {useRef} from 'react';
 import tinycolor from 'tinycolor2';
 
-import GradientSelector from './GradientSelector';
-import Hue from './Hue';
 import Splotch from './Splotch';
+import {findColorIndex, getCSSVariableColor} from './util';
 
-const findColorIndex = (colors: Array<string>, color: tinycolor.Instance) =>
-	colors.findIndex((currentColor) =>
-		tinycolor.equals(
-			currentColor.includes('var(')
-				? getCSSVariableColor(currentColor)
-				: tinycolor(currentColor),
-			color
-		)
-	);
-
-function getCSSVariableColor(value: string) {
-	const element = document.createElement('div');
-
-	element.setAttribute('style', `background: ${value};`);
-
-	document.body.appendChild(element);
-
-	const color = tinycolor(getComputedStyle(element).backgroundColor);
-
-	document.body.removeChild(element);
-
-	return color;
-}
-
-interface IRGBInputProps {
-	/**
-	 * Callback function for when the input value is changed
-	 */
-	onChange: (val: {r?: number; g?: number; b?: number}) => void;
-
-	/**
-	 * The name of the input. R, G, or B.
-	 */
-	name: string;
-
-	/**
-	 * The value of the input.
-	 */
-	value: number;
-}
-
-/**
- * Renders input that displays RGB values
- */
-const RGBInput: React.FunctionComponent<IRGBInputProps> = ({
-	name,
-	onChange,
-	value,
-}) => {
-	const inputRef = React.useRef(null);
-	const [inputValue, setInputValue] = React.useState(value);
-
-	const handleOnChange = (event: any) => {
-		const value = event.target.value;
-
-		if (value === '') {
-			return;
-		}
-
-		let newVal = Number(value);
-
-		if (newVal < 0) {
-			newVal = 0;
-		} else if (newVal > 255) {
-			newVal = 255;
-		}
-
-		setInputValue(newVal);
-
-		onChange({[name]: newVal});
-	};
-
-	React.useEffect(() => {
-		if (document.activeElement !== inputRef.current) {
-			setInputValue(value);
-		}
-	}, [value]);
-
-	return (
-		<ClayForm.Group>
-			<ClayInput.Group>
-				<ClayInput.GroupItem>
-					<ClayInput
-						data-testid={`${name}Input`}
-						insetBefore
-						max="255"
-						min="0"
-						onChange={handleOnChange}
-						ref={inputRef}
-						type="number"
-						value={inputValue}
-					/>
-					<ClayInput.GroupInsetItem before tag="label">
-						{name.toUpperCase()}
-					</ClayInput.GroupInsetItem>
-				</ClayInput.GroupItem>
-			</ClayInput.Group>
-		</ClayForm.Group>
-	);
-};
-
-interface IProps {
-	active?: boolean;
+type Props = {
+	color: tinycolor.Instance;
 
 	/**
 	 * List of colors that will display as a color splotch
@@ -123,6 +19,8 @@ interface IProps {
 	 * css variables.
 	 */
 	colors: Array<string>;
+
+	editorActive: boolean;
 
 	/**
 	 * Label describing the set of colors provided
@@ -132,146 +30,49 @@ interface IProps {
 	/**
 	 * Callback for when a color is changed
 	 */
-	onChange: (val: string) => void;
+	onChange: (color: tinycolor.Instance, value: string) => void;
 
 	/**
 	 * Callback for when the list of colors is changed
 	 */
-	onColorsChange: (val: Array<string>) => void;
+	onColorsChange: (hex: string, index: number) => void;
+
+	onEditorActiveChange: (value: boolean) => void;
+
+	onSplotchChange: (value: number) => void;
 
 	/**
 	 * Flag for showing and disabling the palette of colors
 	 */
 	showPalette?: boolean;
 
+	splotch?: number;
+
 	/**
 	 * Path to the location of the spritemap resource.
 	 */
 	spritemap?: string;
-
-	editorActive?: boolean;
-
-	onEditorActiveChange?: InternalDispatch<boolean>;
-
-	value?: string;
-}
+};
 
 const DEFAULT_SPLOTCH_COLOR = 'FFFFFF';
 
-/**
- * Renders the custom color picker
- */
-const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
-	active,
+const ClayColorPickerCustom = ({
+	color,
 	colors,
 	editorActive,
 	label,
 	onChange,
 	onColorsChange,
 	onEditorActiveChange,
+	onSplotchChange,
 	showPalette,
+	splotch,
 	spritemap,
-	value,
-}) => {
-	const inputRef = React.useRef(null);
-
-	const customMenuRef = React.useRef<HTMLDivElement>(null);
-
-	const [activeSplotchIndex, setActiveSplotchIndex] = React.useState(() => {
-		const index = colors.indexOf(value as string);
-
-		return index !== -1 ? index : undefined;
-	});
-
-	const [internalEditorActive, setInternalEditorActive] = useInternalState({
-		defaultName: '',
-		defaultValue: !showPalette,
-		handleName: 'onEditorActiveChange',
-		name: 'editorActive',
-		onChange: onEditorActiveChange,
-		value: editorActive,
-	});
-
-	const color = React.useMemo(
-		() =>
-			value!.includes('var(')
-				? getCSSVariableColor(value!)
-				: tinycolor(value),
-		[value]
-	);
-
-	const previousColorRef = React.useRef(color);
-
-	const [hue, setHue] = React.useState(color.toHsv().h);
-	const [hexInputVal, setHexInputValue] = React.useState(color.toHex());
-
-	const {b, g, r} = color.toRgb();
-	const {s, v} = color.toHsv();
-
-	const rgbArr: Array<[number, string]> = [
-		[r, 'r'],
-		[g, 'g'],
-		[b, 'b'],
-	];
-
-	const setColors = (color: string, index?: number) => {
-		const newColors = [...colors];
-
-		index
-			? (newColors[index] = color)
-			: (newColors[activeSplotchIndex as number] = color);
-
-		onColorsChange(newColors);
-	};
-
-	const setNewColor = (
-		colorValue: tinycolor.Instance,
-		setInput = true,
-		index?: number,
-		hasActive = true
-	) => {
-		const hexString = colorValue.toHex();
-
-		if (hasActive) {
-			setColors(hexString, index);
-		} else {
-			setActiveSplotchIndex(undefined);
-		}
-
-		onChange(hexString);
-
-		if (setInput) {
-			setHexInputValue(hexString);
-		}
-	};
-
-	React.useEffect(() => {
-		if (
-			(color.isValid() || value!.includes('var(')) &&
-			!customMenuRef.current?.contains(document.activeElement)
-		) {
-			setHue(color.toHsv().h);
-			setHexInputValue(color.toHex());
-
-			if (!active) {
-				const colorIndex = findColorIndex(
-					colors,
-					value!.includes('var(')
-						? getCSSVariableColor(value!)
-						: tinycolor(value)
-				);
-
-				if (colorIndex === -1) {
-					setActiveSplotchIndex(undefined);
-				}
-			} else {
-				setColors(color.toHex());
-			}
-		}
-	}, [active, value, color]);
+}: Props) => {
+	const previousColorRef = useRef(color);
 
 	return (
-		<div ref={customMenuRef}>
+		<div>
 			{label && (
 				<div className="clay-color-header">
 					<span className="component-title">{label}</span>
@@ -279,16 +80,14 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 					{showPalette && (
 						<button
 							className={`${
-								internalEditorActive ? 'close' : ''
+								editorActive ? 'close' : ''
 							} component-action`}
-							onClick={() =>
-								setInternalEditorActive(!internalEditorActive)
-							}
+							onClick={() => onEditorActiveChange(!editorActive)}
 							type="button"
 						>
 							<Icon
 								spritemap={spritemap}
-								symbol={internalEditorActive ? 'times' : 'drop'}
+								symbol={editorActive ? 'times' : 'drop'}
 							/>
 						</button>
 					)}
@@ -300,10 +99,10 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 					{colors.map((hex, index) => (
 						<div className="clay-color-swatch-item" key={index}>
 							<Splotch
-								active={index === activeSplotchIndex}
+								active={index === splotch}
 								onClick={() => {
-									if (activeSplotchIndex !== index) {
-										setActiveSplotchIndex(index);
+									if (splotch !== index) {
+										onSplotchChange(index);
 									}
 
 									// The hexadecimal color `#FFFFFF` is treated as an empty
@@ -312,7 +111,7 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 									// slot with the new color if don't have an active slot
 									// being edited.
 									if (hex === DEFAULT_SPLOTCH_COLOR) {
-										setInternalEditorActive(true);
+										onEditorActiveChange(true);
 
 										// Replaces the slot color with the color entered in the
 										// input if it does not have an active slot being edited.
@@ -323,17 +122,21 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 												) &&
 											findColorIndex(colors, color) ===
 												-1 &&
-											typeof activeSplotchIndex ===
-												'undefined'
+											typeof splotch === 'undefined'
 										) {
-											setColors(color.toHex(), index);
-											setHexInputValue(color.toHex());
-											setHue(color.toHsv().h);
+											onColorsChange(
+												color.toHex(),
+												index
+											);
+											onChange(
+												color,
+												color.getOriginalInput() as string
+											);
 										} else {
 											const newColor = tinycolor(hex);
 
-											setNewColor(newColor, true, index);
-											setHue(newColor.toHsv().h);
+											onColorsChange(hex, index);
+											onChange(newColor, hex);
 										}
 									} else {
 										const newColor = hex!.includes('var(')
@@ -342,9 +145,7 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 
 										previousColorRef.current = newColor;
 
-										setHue(newColor.toHsv().h);
-										setHexInputValue(newColor.toHex());
-										onChange(hex);
+										onChange(newColor, hex);
 									}
 								}}
 								value={hex}
@@ -352,119 +153,6 @@ const ClayColorPickerCustom: React.FunctionComponent<IProps> = ({
 						</div>
 					))}
 				</div>
-			)}
-
-			{editorActive && (
-				<>
-					<div className="clay-color-map-group">
-						<GradientSelector
-							color={color}
-							hue={hue}
-							onChange={(saturation, visibility) => {
-								setNewColor(
-									tinycolor({
-										h: hue,
-										s: saturation,
-										v: visibility,
-									})
-								);
-							}}
-						/>
-
-						<div className="clay-color-map-values">
-							{rgbArr.map(([val, key]) => (
-								<RGBInput
-									key={key}
-									name={key}
-									onChange={(newVal) => {
-										const newColor = tinycolor({
-											b,
-											g,
-											r,
-											...newVal,
-										});
-
-										setHue(newColor.toHsv().h);
-										setNewColor(newColor);
-									}}
-									value={val}
-								/>
-							))}
-						</div>
-					</div>
-
-					<Hue
-						onChange={(hue) => {
-							setHue(hue);
-
-							setNewColor(tinycolor({h: hue, s, v}));
-						}}
-						value={hue}
-					/>
-
-					<div className="clay-color-footer">
-						<ClayForm.Group>
-							<ClayInput.Group>
-								<ClayInput.GroupItem>
-									<ClayInput
-										data-testid="customHexInput"
-										insetBefore
-										onBlur={(event) => {
-											const newColor = tinycolor(
-												event.target.value
-											);
-
-											if (newColor.isValid()) {
-												setHexInputValue(
-													newColor.toHex()
-												);
-											} else {
-												setHexInputValue(color.toHex());
-											}
-										}}
-										onChange={(event) => {
-											const newHexValue =
-												event.target.value;
-
-											setHexInputValue(newHexValue);
-
-											const newColor =
-												tinycolor(newHexValue);
-
-											if (newColor.isValid()) {
-												setHue(newColor.toHsv().h);
-
-												const hasColor = findColorIndex(
-													colors,
-													newColor
-												);
-
-												setNewColor(
-													newColor,
-													false,
-													activeSplotchIndex,
-													hasColor === -1
-												);
-											}
-										}}
-										ref={inputRef}
-										type="text"
-										value={hexInputVal
-											.toUpperCase()
-											.substring(0, 6)}
-									/>
-
-									<ClayInput.GroupInsetItem
-										before
-										tag="label"
-									>
-										#
-									</ClayInput.GroupInsetItem>
-								</ClayInput.GroupItem>
-							</ClayInput.Group>
-						</ClayForm.Group>
-					</div>
-				</>
 			)}
 		</div>
 	);

--- a/packages/clay-color-picker/src/Editor.tsx
+++ b/packages/clay-color-picker/src/Editor.tsx
@@ -1,0 +1,246 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import ClayForm, {ClayInput} from '@clayui/form';
+import React, {useEffect, useReducer, useRef, useState} from 'react';
+import tinycolor from 'tinycolor2';
+
+import GradientSelector from './GradientSelector';
+import Hue from './Hue';
+import {findColorIndex} from './util';
+
+import type {Instance} from 'tinycolor2';
+
+type State = {
+	hex: string;
+	hue: number;
+	splotch?: number;
+};
+
+function reducer(state: State, action: Partial<State>) {
+	return {
+		...state,
+		...action,
+	};
+}
+
+export function useEditor(
+	value: string,
+	color: Instance,
+	colors: Array<string>
+) {
+	const [state, dispatch] = useReducer(reducer, {}, () => {
+		const index = colors.findIndex(
+			(color) => color.toUpperCase() === value.toUpperCase()
+		);
+
+		return {
+			hex: color.toHex(),
+			hue: color.toHsv().h,
+			splotch: index !== -1 ? index : undefined,
+		};
+	});
+
+	return [state, dispatch] as const;
+}
+
+type RGBInputProps = {
+	/**
+	 * Callback function for when the input value is changed
+	 */
+	onChange: (val: {r?: number; g?: number; b?: number}) => void;
+
+	/**
+	 * The name of the input. R, G, or B.
+	 */
+	name: string;
+
+	/**
+	 * The value of the input.
+	 */
+	value: number;
+};
+
+/**
+ * Renders input that displays RGB values
+ */
+const RGBInput = ({name, onChange, value}: RGBInputProps) => {
+	const inputRef = useRef(null);
+	const [inputValue, setInputValue] = useState(value);
+
+	useEffect(() => {
+		if (document.activeElement !== inputRef.current) {
+			setInputValue(value);
+		}
+	}, [value]);
+
+	return (
+		<ClayForm.Group>
+			<ClayInput.Group>
+				<ClayInput.GroupItem>
+					<ClayInput
+						data-testid={`${name}Input`}
+						insetBefore
+						max="255"
+						min="0"
+						onChange={(event: any) => {
+							const value = event.target.value;
+
+							if (value === '') {
+								return;
+							}
+
+							let newVal = Number(value);
+
+							if (newVal < 0) {
+								newVal = 0;
+							} else if (newVal > 255) {
+								newVal = 255;
+							}
+
+							setInputValue(newVal);
+
+							onChange({[name]: newVal});
+						}}
+						ref={inputRef}
+						type="number"
+						value={inputValue}
+					/>
+					<ClayInput.GroupInsetItem before tag="label">
+						{name.toUpperCase()}
+					</ClayInput.GroupInsetItem>
+				</ClayInput.GroupItem>
+			</ClayInput.Group>
+		</ClayForm.Group>
+	);
+};
+
+type Props = {
+	color: Instance;
+	colors: Array<string>;
+	hex: string;
+	hue: number;
+	onChange: (color: Instance, active: boolean) => void;
+	onColorChange: (color: Instance) => void;
+	onHueChange: (value: number) => void;
+	onHexChange: (value: string) => void;
+};
+
+export function Editor({
+	color,
+	colors,
+	hex,
+	hue,
+	onChange,
+	onColorChange,
+	onHexChange,
+	onHueChange,
+}: Props) {
+	const {b, g, r} = color.toRgb();
+	const {s, v} = color.toHsv();
+
+	const rgbArr: Array<[number, string]> = [
+		[r, 'r'],
+		[g, 'g'],
+		[b, 'b'],
+	];
+
+	return (
+		<>
+			<div className="clay-color-map-group">
+				<GradientSelector
+					color={color}
+					hue={hue}
+					onChange={(saturation, visibility) => {
+						onColorChange(
+							tinycolor({
+								h: hue,
+								s: saturation,
+								v: visibility,
+							})
+						);
+					}}
+				/>
+
+				<div className="clay-color-map-values">
+					{rgbArr.map(([val, key]) => (
+						<RGBInput
+							key={key}
+							name={key}
+							onChange={(newVal) => {
+								const newColor = tinycolor({
+									b,
+									g,
+									r,
+									...newVal,
+								});
+
+								onHueChange(newColor.toHsv().h);
+								onColorChange(newColor);
+							}}
+							value={val}
+						/>
+					))}
+				</div>
+			</div>
+
+			<Hue
+				onChange={(hue) => {
+					onHueChange(hue);
+					onColorChange(tinycolor({h: hue, s, v}));
+				}}
+				value={hue}
+			/>
+
+			<div className="clay-color-footer">
+				<ClayForm.Group>
+					<ClayInput.Group>
+						<ClayInput.GroupItem>
+							<ClayInput
+								data-testid="customHexInput"
+								insetBefore
+								onBlur={(event) => {
+									const newColor = tinycolor(
+										event.target.value
+									);
+
+									if (newColor.isValid()) {
+										onHexChange(newColor.toHex());
+									} else {
+										onHexChange(color.toHex());
+									}
+								}}
+								onChange={(event) => {
+									const newHexValue = event.target.value;
+
+									onHexChange(newHexValue);
+
+									const newColor = tinycolor(newHexValue);
+
+									if (newColor.isValid()) {
+										onHueChange(newColor.toHsv().h);
+
+										const hasColor = findColorIndex(
+											colors,
+											newColor
+										);
+
+										onChange(newColor, hasColor === -1);
+									}
+								}}
+								type="text"
+								value={hex.toUpperCase().substring(0, 6)}
+							/>
+
+							<ClayInput.GroupInsetItem before tag="label">
+								#
+							</ClayInput.GroupInsetItem>
+						</ClayInput.GroupItem>
+					</ClayInput.Group>
+				</ClayForm.Group>
+			</div>
+		</>
+	);
+}

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -206,110 +206,22 @@ exports[`Interactions color editor interactions ability to change color of click
               />
             </div>
           </div>
+        </div>
+        <div
+          class="clay-color-map-group"
+        >
           <div
-            class="clay-color-map-group"
-          >
-            <div
-              class="clay-color-map clay-color-map-hsb"
-              style="background-color: rgb(255, 0, 0);"
-            >
-              <button
-                class="clay-color-map-pointer clay-color-pointer"
-                style="background: rgb(255, 255, 255); left: -7px; top: -7px;"
-                type="button"
-              />
-            </div>
-            <div
-              class="clay-color-map-values"
-            >
-              <div
-                class="form-group"
-              >
-                <div
-                  class="input-group"
-                >
-                  <div
-                    class="input-group-item"
-                  >
-                    <input
-                      class="form-control input-group-inset input-group-inset-before"
-                      data-testid="rInput"
-                      max="255"
-                      min="0"
-                      type="number"
-                      value="255"
-                    />
-                    <label
-                      class="input-group-inset-item input-group-inset-item-before"
-                    >
-                      R
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="form-group"
-              >
-                <div
-                  class="input-group"
-                >
-                  <div
-                    class="input-group-item"
-                  >
-                    <input
-                      class="form-control input-group-inset input-group-inset-before"
-                      data-testid="gInput"
-                      max="255"
-                      min="0"
-                      type="number"
-                      value="255"
-                    />
-                    <label
-                      class="input-group-inset-item input-group-inset-item-before"
-                    >
-                      G
-                    </label>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="form-group"
-              >
-                <div
-                  class="input-group"
-                >
-                  <div
-                    class="input-group-item"
-                  >
-                    <input
-                      class="form-control input-group-inset input-group-inset-before"
-                      data-testid="bInput"
-                      max="255"
-                      min="0"
-                      type="number"
-                      value="255"
-                    />
-                    <label
-                      class="input-group-inset-item input-group-inset-item-before"
-                    >
-                      B
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="clay-color-range clay-color-range-hue"
+            class="clay-color-map clay-color-map-hsb"
+            style="background-color: rgb(255, 0, 0);"
           >
             <button
-              class="clay-color-pointer clay-color-range-pointer"
-              style="background: rgb(255, 0, 0); left: -7px;"
+              class="clay-color-map-pointer clay-color-pointer"
+              style="background: rgb(255, 255, 255); left: -7px; top: -7px;"
               type="button"
             />
           </div>
           <div
-            class="clay-color-footer"
+            class="clay-color-map-values"
           >
             <div
               class="form-group"
@@ -322,16 +234,104 @@ exports[`Interactions color editor interactions ability to change color of click
                 >
                   <input
                     class="form-control input-group-inset input-group-inset-before"
-                    data-testid="customHexInput"
-                    type="text"
-                    value="DDDDDD"
+                    data-testid="rInput"
+                    max="255"
+                    min="0"
+                    type="number"
+                    value="255"
                   />
                   <label
                     class="input-group-inset-item input-group-inset-item-before"
                   >
-                    #
+                    R
                   </label>
                 </div>
+              </div>
+            </div>
+            <div
+              class="form-group"
+            >
+              <div
+                class="input-group"
+              >
+                <div
+                  class="input-group-item"
+                >
+                  <input
+                    class="form-control input-group-inset input-group-inset-before"
+                    data-testid="gInput"
+                    max="255"
+                    min="0"
+                    type="number"
+                    value="255"
+                  />
+                  <label
+                    class="input-group-inset-item input-group-inset-item-before"
+                  >
+                    G
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div
+              class="form-group"
+            >
+              <div
+                class="input-group"
+              >
+                <div
+                  class="input-group-item"
+                >
+                  <input
+                    class="form-control input-group-inset input-group-inset-before"
+                    data-testid="bInput"
+                    max="255"
+                    min="0"
+                    type="number"
+                    value="255"
+                  />
+                  <label
+                    class="input-group-inset-item input-group-inset-item-before"
+                  >
+                    B
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="clay-color-range clay-color-range-hue"
+        >
+          <button
+            class="clay-color-pointer clay-color-range-pointer"
+            style="background: rgb(255, 0, 0); left: -7px;"
+            type="button"
+          />
+        </div>
+        <div
+          class="clay-color-footer"
+        >
+          <div
+            class="form-group"
+          >
+            <div
+              class="input-group"
+            >
+              <div
+                class="input-group-item"
+              >
+                <input
+                  class="form-control input-group-inset input-group-inset-before"
+                  data-testid="customHexInput"
+                  type="text"
+                  value="DDDDDD"
+                />
+                <label
+                  class="input-group-inset-item input-group-inset-item-before"
+                >
+                  #
+                </label>
               </div>
             </div>
           </div>

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -330,7 +330,7 @@ describe('Interactions', () => {
 
 			fireEvent(gradientMap, mouseMove);
 
-			expect(handleColorsChange).toBeCalledTimes(3);
+			expect(handleColorsChange).toBeCalledTimes(2);
 			expect(handleColorsChange.mock.calls[0][0][0]).toBe('5BB0A5');
 		});
 
@@ -352,7 +352,7 @@ describe('Interactions', () => {
 
 			fireEvent(hueSelector as HTMLElement, mouseMove);
 
-			expect(handleColorsChange).toBeCalledTimes(2);
+			expect(handleColorsChange).toBeCalledTimes(1);
 		});
 
 		it('changes the color by changing the RGB', () => {
@@ -361,13 +361,13 @@ describe('Interactions', () => {
 			const gInput = editorGetByTestId('gInput');
 
 			fireEvent.change(rInput, {target: {value: '200'}});
-			expect(handleColorsChange).toBeCalledTimes(2);
+			expect(handleColorsChange).toBeCalledTimes(1);
 
 			fireEvent.change(gInput, {target: {value: '200'}});
-			expect(handleColorsChange).toBeCalledTimes(3);
+			expect(handleColorsChange).toBeCalledTimes(2);
 
 			fireEvent.change(bInput, {target: {value: '200'}});
-			expect(handleColorsChange).toBeCalledTimes(4);
+			expect(handleColorsChange).toBeCalledTimes(3);
 		});
 
 		it('changes the color by changing the input', () => {
@@ -375,7 +375,7 @@ describe('Interactions', () => {
 
 			fireEvent.change(hexInput, {target: {value: 'DDDDDD'}});
 
-			expect(handleColorsChange).toBeCalledTimes(2);
+			expect(handleColorsChange).toBeCalledTimes(1);
 		});
 
 		it('ability to change color of clicked splotch', () => {
@@ -389,7 +389,7 @@ describe('Interactions', () => {
 
 			fireEvent.change(hexInput, {target: {value: 'DDDDDD'}});
 
-			expect(handleColorsChange).toBeCalledTimes(2);
+			expect(handleColorsChange).toBeCalledTimes(1);
 
 			expect(document.body).toMatchSnapshot();
 		});
@@ -552,6 +552,7 @@ describe('Interactions', () => {
 			) as HTMLInputElement;
 
 			fireEvent.change(input, {target: {value: 'DFCAFF'}});
+			fireEvent.blur(input, {target: {value: 'DFCAFF'}});
 
 			const dropdownToggle = document.querySelector('.dropdown-toggle');
 
@@ -563,7 +564,7 @@ describe('Interactions', () => {
 
 			fireEvent.click(blankSplotch as HTMLButtonElement, {});
 
-			expect(input.value).toBe('DFCAFF');
+			expect(input.value).toBe('dfcaff');
 
 			const greenSplotch = (
 				document.body as HTMLButtonElement

--- a/packages/clay-color-picker/src/util.ts
+++ b/packages/clay-color-picker/src/util.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import tinycolor from 'tinycolor2';
+
 /**
  * Utility function for getting x & y coordinates for gradient
  */
@@ -51,4 +53,31 @@ export function xToSaturation(x: number, node: HTMLElement) {
  */
 export function yToVisibility(y: number, node: HTMLElement) {
 	return Math.round(-((y * 100) / node.getBoundingClientRect().height) + 100);
+}
+
+export const findColorIndex = (
+	colors: Array<string>,
+	color: tinycolor.Instance
+) =>
+	colors.findIndex((currentColor) =>
+		tinycolor.equals(
+			currentColor.includes('var(')
+				? getCSSVariableColor(currentColor)
+				: tinycolor(currentColor),
+			color
+		)
+	);
+
+export function getCSSVariableColor(value: string) {
+	const element = document.createElement('div');
+
+	element.setAttribute('style', `background: ${value};`);
+
+	document.body.appendChild(element);
+
+	const color = tinycolor(getComputedStyle(element).backgroundColor);
+
+	document.body.removeChild(element);
+
+	return color;
 }


### PR DESCRIPTION
Closes #4733

I'm refactoring the implementation of the built-in Custom component and the way it handles state, this was creating a lot of complexity to deal with updating states and having to come up with different ways to update states. This PR creates a new component to separate the Editor from the Custom component because only the editor can be used without the custom and we are also moving the editor state to the root component so it is easier to manipulate the state when the user is still is editing in input for example.