### PR TITLE
fix(@clayui/css): fix syntax error in conditional declaration

### DIFF
--- a/packages/clay-css/src/scss/mixins/_badges.scss
+++ b/packages/clay-css/src/scss/mixins/_badges.scss
@@ -152,12 +152,11 @@
 				if(
 					variable-exists(enable-c-inner),
 					$enable-c-inner,
-					if
-						(
-							variable-exists(cadmin-enable-c-inner),
-							$cadmin-enable-c-inner,
-							true
-						)
+					if(
+						variable-exists(cadmin-enable-c-inner),
+						$cadmin-enable-c-inner,
+						true
+					)
 				),
 		),
 		$c-inner

--- a/packages/clay-css/src/scss/mixins/_border-radius.scss
+++ b/packages/clay-css/src/scss/mixins/_border-radius.scss
@@ -3,24 +3,18 @@
 		if(
 			variable-exists(border-radius),
 			$border-radius,
-			if
-				(
-					variable-exists(cadmin-border-radius),
-					$cadmin-border-radius,
-					0.25rem
-				)
+			if(
+				variable-exists(cadmin-border-radius),
+				$cadmin-border-radius,
+				0.25rem
+			)
 		),
 	$fallback-border-radius: false
 ) {
 	$enable: if(
 		variable-exists(enable-rounded),
 		$enable-rounded,
-		if
-			(
-				variable-exists(cadmin-enable-rounded),
-				$cadmin-enable-rounded,
-				true
-			)
+		if(variable-exists(cadmin-enable-rounded), $cadmin-enable-rounded, true)
 	);
 
 	@if ($enable) {
@@ -34,12 +28,7 @@
 	$enable: if(
 		variable-exists(enable-rounded),
 		$enable-rounded,
-		if
-			(
-				variable-exists(cadmin-enable-rounded),
-				$cadmin-enable-rounded,
-				true
-			)
+		if(variable-exists(cadmin-enable-rounded), $cadmin-enable-rounded, true)
 	);
 
 	@if ($enable) {
@@ -52,12 +41,7 @@
 	$enable: if(
 		variable-exists(enable-rounded),
 		$enable-rounded,
-		if
-			(
-				variable-exists(cadmin-enable-rounded),
-				$cadmin-enable-rounded,
-				true
-			)
+		if(variable-exists(cadmin-enable-rounded), $cadmin-enable-rounded, true)
 	);
 
 	@if ($enable) {
@@ -70,12 +54,7 @@
 	$enable: if(
 		variable-exists(enable-rounded),
 		$enable-rounded,
-		if
-			(
-				variable-exists(cadmin-enable-rounded),
-				$cadmin-enable-rounded,
-				true
-			)
+		if(variable-exists(cadmin-enable-rounded), $cadmin-enable-rounded, true)
 	);
 
 	@if ($enable) {
@@ -88,12 +67,7 @@
 	$enable: if(
 		variable-exists(enable-rounded),
 		$enable-rounded,
-		if
-			(
-				variable-exists(cadmin-enable-rounded),
-				$cadmin-enable-rounded,
-				true
-			)
+		if(variable-exists(cadmin-enable-rounded), $cadmin-enable-rounded, true)
 	);
 
 	@if ($enable) {
@@ -106,12 +80,7 @@
 	$enable: if(
 		variable-exists(enable-rounded),
 		$enable-rounded,
-		if
-			(
-				variable-exists(cadmin-enable-rounded),
-				$cadmin-enable-rounded,
-				true
-			)
+		if(variable-exists(cadmin-enable-rounded), $cadmin-enable-rounded, true)
 	);
 
 	@if ($enable) {
@@ -138,12 +107,7 @@
 	$enable: if(
 		variable-exists(enable-rounded),
 		$enable-rounded,
-		if
-			(
-				variable-exists(cadmin-enable-rounded),
-				$cadmin-enable-rounded,
-				true
-			)
+		if(variable-exists(cadmin-enable-rounded), $cadmin-enable-rounded, true)
 	);
 
 	@if ($enable) {
@@ -155,12 +119,7 @@
 	$enable: if(
 		variable-exists(enable-rounded),
 		$enable-rounded,
-		if
-			(
-				variable-exists(cadmin-enable-rounded),
-				$cadmin-enable-rounded,
-				true
-			)
+		if(variable-exists(cadmin-enable-rounded), $cadmin-enable-rounded, true)
 	);
 
 	@if ($enable) {

--- a/packages/clay-css/src/scss/mixins/_box-shadow.scss
+++ b/packages/clay-css/src/scss/mixins/_box-shadow.scss
@@ -9,12 +9,7 @@
 	$enable: if(
 		variable-exists(enable-shadows),
 		$enable-shadows,
-		if
-			(
-				variable-exists(cadmin-enable-shadows),
-				$cadmin-enable-shadows,
-				true
-			)
+		if(variable-exists(cadmin-enable-shadows), $cadmin-enable-shadows, true)
 	);
 
 	@if ($enable) {

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -557,8 +557,7 @@
 						variable-exists(enable-c-inner),
 						$enable-c-inner,
 						$cadmin-enable-c-inner
-							if
-							(
+							if(
 								variable-exists(cadmin-enable-c-inner),
 								$cadmin-enable-c-inner,
 								true
@@ -584,12 +583,11 @@
 					if(
 						variable-exists(enable-c-inner),
 						$enable-c-inner,
-						if
-							(
-								variable-exists(cadmin-enable-c-inner),
-								$cadmin-enable-c-inner,
-								true
-							)
+						if(
+							variable-exists(cadmin-enable-c-inner),
+							$cadmin-enable-c-inner,
+							true
+						)
 					),
 				margin-bottom: math-sign(map-get($map, padding-bottom)),
 				margin-left: math-sign(map-get($map, padding-left)),

--- a/packages/clay-css/src/scss/mixins/_cards.scss
+++ b/packages/clay-css/src/scss/mixins/_cards.scss
@@ -1059,12 +1059,11 @@
 					if(
 						variable-exists(card-border-color),
 						$card-border-color,
-						if
-							(
-								variable-exists(cadmin-card-border-color),
-								$cadmin-card-border-color,
-								null
-							)
+						if(
+							variable-exists(cadmin-card-border-color),
+							$cadmin-card-border-color,
+							null
+						)
 					)
 				),
 			border-style:
@@ -1149,12 +1148,11 @@
 					if(
 						variable-exists(link-cursor),
 						$link-cursor,
-						if
-							(
-								variable-exists(cadmin-link-cursor),
-								$cadmin-link-cursor,
-								null
-							)
+						if(
+							variable-exists(cadmin-link-cursor),
+							$cadmin-link-cursor,
+							null
+						)
 					)
 				),
 		)

--- a/packages/clay-css/src/scss/mixins/_close.scss
+++ b/packages/clay-css/src/scss/mixins/_close.scss
@@ -333,12 +333,11 @@
 					if(
 						variable-exists(enable-c-inner),
 						$enable-c-inner,
-						if
-							(
-								variable-exists(cadmin-enable-c-inner),
-								$cadmin-enable-c-inner,
-								true
-							)
+						if(
+							variable-exists(cadmin-enable-c-inner),
+							$cadmin-enable-c-inner,
+							true
+						)
 					),
 				margin-bottom: math-sign(map-get($map, padding-bottom)),
 				margin-left: math-sign(map-get($map, padding-left)),

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -462,12 +462,11 @@
 					if(
 						variable-exists(enable-c-inner),
 						$enable-c-inner,
-						if
-							(
-								variable-exists(cadmin-enable-c-inner),
-								$cadmin-enable-c-inner,
-								true
-							)
+						if(
+							variable-exists(cadmin-enable-c-inner),
+							$cadmin-enable-c-inner,
+							true
+						)
 					),
 				flex-grow: 1,
 				margin-bottom: math-sign(map-get($map, padding-bottom)),

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -731,12 +731,11 @@
 					if(
 						variable-exists(input-color),
 						$input-color,
-						if
-							(
-								variable-exists(cadmin-input-color),
-								$cadmin-input-color,
-								null
-							)
+						if(
+							variable-exists(cadmin-input-color),
+							$cadmin-input-color,
+							null
+						)
 					)
 				),
 		)

--- a/packages/clay-css/src/scss/mixins/_gradients.scss
+++ b/packages/clay-css/src/scss/mixins/_gradients.scss
@@ -11,12 +11,11 @@
 		if(
 			variable-exists(enable-gradients),
 			$enable-gradients,
-			if
-				(
-					variable-exists(cadmin-enable-gradients),
-					$cadmin-enable-gradients,
-					false
-				)
+			if(
+				variable-exists(cadmin-enable-gradients),
+				$cadmin-enable-gradients,
+				false
+			)
 		)
 	) {
 		background: $color
@@ -26,12 +25,11 @@
 					if(
 						variable-exists(body-bg),
 						$body-bg,
-						if
-							(
-								variable-exists(cadmin-body-bg),
-								$cadmin-body-bg,
-								#fff
-							)
+						if(
+							variable-exists(cadmin-body-bg),
+							$cadmin-body-bg,
+							#fff
+						)
 					),
 					$color,
 					15%

--- a/packages/clay-css/src/scss/mixins/_grid.scss
+++ b/packages/clay-css/src/scss/mixins/_grid.scss
@@ -120,12 +120,11 @@
 				if(
 					variable-exists(enable-grid-classes),
 					$enable-grid-classes,
-					if
-						(
-							variable-exists(cadmin-enable-grid-classes),
-							$cadmin-enable-grid-classes,
-							true
-						)
+					if(
+						variable-exists(cadmin-enable-grid-classes),
+						$cadmin-enable-grid-classes,
+						true
+					)
 				),
 		),
 		$map

--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -40,12 +40,11 @@
 					if(
 						variable-exists(label-border-width),
 						$label-border-width,
-						if
-							(
-								variable-exists(cadmin-label-border-width),
-								$cadmin-label-border-width,
-								null
-							)
+						if(
+							variable-exists(cadmin-label-border-width),
+							$cadmin-label-border-width,
+							null
+						)
 					)
 				),
 			padding-bottom:
@@ -165,12 +164,11 @@
 				if(
 					variable-exists(enable-c-inner),
 					$enable-c-inner,
-					if
-						(
-							variable-exists(cadmin-enable-c-inner),
-							$cadmin-enable-c-inner,
-							true
-						)
+					if(
+						variable-exists(cadmin-enable-c-inner),
+						$cadmin-enable-c-inner,
+						true
+					)
 				),
 			margin-bottom:
 				setter(

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -535,12 +535,11 @@
 					if(
 						variable-exists(enable-c-inner),
 						$enable-c-inner,
-						if
-							(
-								variable-exists(cadmin-enable-c-inner),
-								$cadmin-enable-c-inner,
-								true
-							)
+						if(
+							variable-exists(cadmin-enable-c-inner),
+							$cadmin-enable-c-inner,
+							true
+						)
 					),
 				margin-bottom: math-sign(map-get($map, padding-bottom)),
 				margin-left: math-sign(map-get($map, padding-left)),

--- a/packages/clay-css/src/scss/mixins/_list-group.scss
+++ b/packages/clay-css/src/scss/mixins/_list-group.scss
@@ -68,12 +68,11 @@
 		if(
 			variable-exists(list-group-bg),
 			$list-group-bg,
-			if
-				(
-					variable-exists(cadmin-list-group-bg),
-					$cadmin-list-group-bg,
-					null
-				)
+			if(
+				variable-exists(cadmin-list-group-bg),
+				$cadmin-list-group-bg,
+				null
+			)
 		)
 	);
 	$border-bottom-color: setter(
@@ -81,14 +80,13 @@
 		if(
 			variable-exists(list-group-notification-item-border-bottom-color),
 			$list-group-notification-item-border-bottom-color,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-border-bottom-color
-					),
-					$cadmin-list-group-notification-item-border-bottom-color,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-border-bottom-color
+				),
+				$cadmin-list-group-notification-item-border-bottom-color,
+				null
+			)
 		)
 	);
 	$border-left-color: setter(
@@ -96,14 +94,13 @@
 		if(
 			variable-exists(list-group-notification-item-border-left-color),
 			$list-group-notification-item-border-left-color,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-border-left-color
-					),
-					$cadmin-list-group-notification-item-border-left-color,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-border-left-color
+				),
+				$cadmin-list-group-notification-item-border-left-color,
+				null
+			)
 		)
 	);
 	$border-right-color: setter(
@@ -111,14 +108,13 @@
 		if(
 			variable-exists(list-group-notification-item-border-right-color),
 			$list-group-notification-item-border-right-color,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-border-right-color
-					),
-					$cadmin-list-group-notification-item-border-right-color,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-border-right-color
+				),
+				$cadmin-list-group-notification-item-border-right-color,
+				null
+			)
 		)
 	);
 	$border-top-color: setter(
@@ -126,14 +122,13 @@
 		if(
 			variable-exists(list-group-notification-item-border-top-color),
 			$list-group-notification-item-border-top-color,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-border-top-color
-					),
-					$cadmin-list-group-notification-item-border-top-color,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-border-top-color
+				),
+				$cadmin-list-group-notification-item-border-top-color,
+				null
+			)
 		)
 	);
 
@@ -142,14 +137,13 @@
 		if(
 			variable-exists(list-group-notification-item-border-bottom-width),
 			$list-group-notification-item-border-bottom-width,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-border-bottom-width
-					),
-					$cadmin-list-group-notification-item-border-bottom-width,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-border-bottom-width
+				),
+				$cadmin-list-group-notification-item-border-bottom-width,
+				null
+			)
 		)
 	);
 	$border-left-width: setter(
@@ -157,14 +151,13 @@
 		if(
 			variable-exists(list-group-notification-item-border-left-width),
 			$list-group-notification-item-border-left-width,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-border-left-width
-					),
-					$cadmin-list-group-notification-item-border-left-width,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-border-left-width
+				),
+				$cadmin-list-group-notification-item-border-left-width,
+				null
+			)
 		)
 	);
 	$border-right-width: setter(
@@ -172,14 +165,13 @@
 		if(
 			variable-exists(list-group-notification-item-border-right-width),
 			$list-group-notification-item-border-right-width,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-border-right-width
-					),
-					$cadmin-list-group-notification-item-border-right-width,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-border-right-width
+				),
+				$cadmin-list-group-notification-item-border-right-width,
+				null
+			)
 		)
 	);
 	$border-top-width: setter(
@@ -187,14 +179,13 @@
 		if(
 			variable-exists(list-group-notification-item-border-top-width),
 			$list-group-notification-item-border-top-width,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-border-top-width
-					),
-					$cadmin-list-group-notification-item-border-top-width,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-border-top-width
+				),
+				$cadmin-list-group-notification-item-border-top-width,
+				null
+			)
 		)
 	);
 
@@ -210,12 +201,11 @@
 		if(
 			variable-exists(list-group-active-bg),
 			$list-group-active-bg,
-			if
-				(
-					variable-exists(cadmin-list-group-active-bg),
-					$cadmin-list-group-active-bg,
-					null
-				)
+			if(
+				variable-exists(cadmin-list-group-active-bg),
+				$cadmin-list-group-active-bg,
+				null
+			)
 		)
 	);
 	$active-border-bottom-color: setter(
@@ -225,14 +215,13 @@
 				list-group-notification-item-active-border-bottom-color
 			),
 			$list-group-notification-item-active-border-bottom-color,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-active-border-bottom-color
-					),
-					$cadmin-list-group-notification-item-active-border-bottom-color,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-active-border-bottom-color
+				),
+				$cadmin-list-group-notification-item-active-border-bottom-color,
+				null
+			)
 		)
 	);
 	$active-border-left-color: setter(
@@ -242,14 +231,13 @@
 				list-group-notification-item-active-border-left-color
 			),
 			$list-group-notification-item-active-border-left-color,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-active-border-left-color
-					),
-					$cadmin-list-group-notification-item-active-border-left-color,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-active-border-left-color
+				),
+				$cadmin-list-group-notification-item-active-border-left-color,
+				null
+			)
 		)
 	);
 	$active-border-right-color: setter(
@@ -259,14 +247,13 @@
 				list-group-notification-item-active-border-right-color
 			),
 			$list-group-notification-item-active-border-right-color,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-active-border-right-color
-					),
-					$cadmin-list-group-notification-item-active-border-right-color,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-active-border-right-color
+				),
+				$cadmin-list-group-notification-item-active-border-right-color,
+				null
+			)
 		)
 	);
 	$active-border-top-color: setter(
@@ -276,14 +263,13 @@
 				list-group-notification-item-active-border-top-color
 			),
 			$list-group-notification-item-active-border-top-color,
-			if
-				(
-					variable-exists(
-						cadmin-list-group-notification-item-active-border-top-color
-					),
-					$cadmin-list-group-notification-item-active-border-top-color,
-					null
-				)
+			if(
+				variable-exists(
+					cadmin-list-group-notification-item-active-border-top-color
+				),
+				$cadmin-list-group-notification-item-active-border-top-color,
+				null
+			)
 		)
 	);
 
@@ -305,12 +291,11 @@
 		if(
 			variable-exists(enable-rounded),
 			$enable-rounded,
-			if
-				(
-					variable-exists(cadmin-enable-rounded),
-					$cadmin-enable-rounded,
-					true
-				)
+			if(
+				variable-exists(cadmin-enable-rounded),
+				$cadmin-enable-rounded,
+				true
+			)
 		)
 	) {
 		border-bottom-left-radius: $border-bottom-left-radius;

--- a/packages/clay-css/src/scss/mixins/_menubar.scss
+++ b/packages/clay-css/src/scss/mixins/_menubar.scss
@@ -291,12 +291,11 @@
 				if(
 					variable-exists(enable-c-inner),
 					$enable-c-inner,
-					if
-						(
-							variable-exists(cadmin-enable-c-inner),
-							$cadmin-enable-c-inner,
-							true
-						)
+					if(
+						variable-exists(cadmin-enable-c-inner),
+						$cadmin-enable-c-inner,
+						true
+					)
 				),
 			margin-bottom:
 				setter(
@@ -539,12 +538,11 @@
 					if(
 						variable-exists(navbar-light-color),
 						$navbar-light-color,
-						if
-							(
-								variable-exists(cadmin-navbar-light-color),
-								$cadmin-navbar-light-color,
-								null
-							)
+						if(
+							variable-exists(cadmin-navbar-light-color),
+							$cadmin-navbar-light-color,
+							null
+						)
 					)
 				),
 			hover: (
@@ -560,14 +558,13 @@
 						if(
 							variable-exists(navbar-light-hover-color),
 							$navbar-light-hover-color,
-							if
-								(
-									variable-exists(
-										cadmin-navbar-light-hover-color
-									),
-									$cadmin-navbar-light-hover-color,
-									null
-								)
+							if(
+								variable-exists(
+									cadmin-navbar-light-hover-color
+								),
+								$cadmin-navbar-light-hover-color,
+								null
+							)
 						)
 					),
 			),
@@ -584,14 +581,13 @@
 						if(
 							variable-exists(navbar-light-active-color),
 							$navbar-light-active-color,
-							if
-								(
-									variable-exists(
-										cadmin-navbar-light-active-color
-									),
-									$cadmin-navbar-light-active-color,
-									null
-								)
+							if(
+								variable-exists(
+									cadmin-navbar-light-active-color
+								),
+								$cadmin-navbar-light-active-color,
+								null
+							)
 						)
 					),
 			),
@@ -615,14 +611,13 @@
 						if(
 							variable-exists(navbar-light-disabled-color),
 							$navbar-light-disabled-color,
-							if
-								(
-									variable-exists(
-										cadmin-navbar-light-disabled-color
-									),
-									$cadmin-navbar-light-disabled-color,
-									null
-								)
+							if(
+								variable-exists(
+									cadmin-navbar-light-disabled-color
+								),
+								$cadmin-navbar-light-disabled-color,
+								null
+							)
 						)
 					),
 			),
@@ -649,12 +644,11 @@
 					if(
 						variable-exists(dropdown-link-color),
 						$dropdown-link-color,
-						if
-							(
-								variable-exists(cadmin-dropdown-link-color),
-								$cadmin-dropdown-link-color,
-								null
-							)
+						if(
+							variable-exists(cadmin-dropdown-link-color),
+							$cadmin-dropdown-link-color,
+							null
+						)
 					)
 				),
 			hover: (
@@ -665,14 +659,11 @@
 						if(
 							variable-exists(dropdown-link-hover-bg),
 							$dropdown-link-hover-bg,
-							if
-								(
-									variable-exists(
-										cadmin-dropdown-link-hover-bg
-									),
-									$cadmin-dropdown-link-hover-bg,
-									null
-								)
+							if(
+								variable-exists(cadmin-dropdown-link-hover-bg),
+								$cadmin-dropdown-link-hover-bg,
+								null
+							)
 						)
 					),
 				color:
@@ -682,14 +673,13 @@
 						if(
 							variable-exists(dropdown-link-hover-color),
 							$dropdown-link-hover-color,
-							if
-								(
-									variable-exists(
-										cadmin-dropdown-link-hover-color
-									),
-									$cadmin-dropdown-link-hover-color,
-									null
-								)
+							if(
+								variable-exists(
+									cadmin-dropdown-link-hover-color
+								),
+								$cadmin-dropdown-link-hover-color,
+								null
+							)
 						)
 					),
 			),
@@ -701,14 +691,11 @@
 						if(
 							variable-exists(dropdown-link-active-bg),
 							$dropdown-link-active-bg,
-							if
-								(
-									variable-exists(
-										cadmin-dropdown-link-active-bg
-									),
-									$cadmin-dropdown-link-active-bg,
-									null
-								)
+							if(
+								variable-exists(cadmin-dropdown-link-active-bg),
+								$cadmin-dropdown-link-active-bg,
+								null
+							)
 						)
 					),
 				color:
@@ -718,14 +705,13 @@
 						if(
 							variable-exists(dropdown-link-active-color),
 							$dropdown-link-active-color,
-							if
-								(
-									variable-exists(
-										cadmin-dropdown-link-active-color
-									),
-									$cadmin-dropdown-link-active-color,
-									null
-								)
+							if(
+								variable-exists(
+									cadmin-dropdown-link-active-color
+								),
+								$cadmin-dropdown-link-active-color,
+								null
+							)
 						)
 					),
 			),
@@ -737,14 +723,13 @@
 						if(
 							variable-exists(dropdown-link-active-font-weight),
 							$dropdown-link-active-font-weight,
-							if
-								(
-									variable-exists(
-										cadmin-dropdown-link-active-font-weight
-									),
-									$cadmin-dropdown-link-active-font-weight,
-									null
-								)
+							if(
+								variable-exists(
+									cadmin-dropdown-link-active-font-weight
+								),
+								$cadmin-dropdown-link-active-font-weight,
+								null
+							)
 						)
 					),
 			),
@@ -762,14 +747,13 @@
 						if(
 							variable-exists(dropdown-link-disabled-color),
 							$dropdown-link-disabled-color,
-							if
-								(
-									variable-exists(
-										cadmin-dropdown-link-disabled-color
-									),
-									$cadmin-dropdown-link-disabled-color,
-									null
-								)
+							if(
+								variable-exists(
+									cadmin-dropdown-link-disabled-color
+								),
+								$cadmin-dropdown-link-disabled-color,
+								null
+							)
 						)
 					),
 			),
@@ -791,12 +775,11 @@
 					if(
 						variable-exists(dropdown-bg),
 						$dropdown-bg,
-						if
-							(
-								variable-exists(cadmin-dropdown-bg),
-								$cadmin-dropdown-bg,
-								null
-							)
+						if(
+							variable-exists(cadmin-dropdown-bg),
+							$cadmin-dropdown-bg,
+							null
+						)
 					)
 				),
 			border-color:
@@ -806,12 +789,11 @@
 					if(
 						variable-exists(dropdown-border-color),
 						$dropdown-border-color,
-						if
-							(
-								variable-exists(cadmin-dropdown-border-color),
-								$cadmin-dropdown-border-color,
-								null
-							)
+						if(
+							variable-exists(cadmin-dropdown-border-color),
+							$cadmin-dropdown-border-color,
+							null
+						)
 					)
 				),
 			border-radius:
@@ -821,12 +803,11 @@
 					if(
 						variable-exists(border-radius),
 						$border-radius,
-						if
-							(
-								variable-exists(cadmin-border-radius),
-								$cadmin-border-radius,
-								null
-							)
+						if(
+							variable-exists(cadmin-border-radius),
+							$cadmin-border-radius,
+							null
+						)
 					)
 				),
 			border-style:
@@ -841,12 +822,11 @@
 					if(
 						variable-exists(dropdown-box-shadow),
 						$dropdown-box-shadow,
-						if
-							(
-								variable-exists(cadmin-dropdown-box-shadow),
-								$cadmin-dropdown-box-shadow,
-								null
-							)
+						if(
+							variable-exists(cadmin-dropdown-box-shadow),
+							$cadmin-dropdown-box-shadow,
+							null
+						)
 					)
 				),
 		)

--- a/packages/clay-css/src/scss/mixins/_tbar.scss
+++ b/packages/clay-css/src/scss/mixins/_tbar.scss
@@ -70,12 +70,7 @@
 	$enable-c-inner: if(
 		variable-exists(enable-c-inner),
 		$enable-c-inner,
-		if
-			(
-				variable-exists(cadmin-enable-c-inner),
-				$cadmin-enable-c-inner,
-				true
-			)
+		if(variable-exists(cadmin-enable-c-inner), $cadmin-enable-c-inner, true)
 	);
 
 	$base: map-merge(


### PR DESCRIPTION
Hey @pat270 I'm submitting because this was causing the build to fail in Clay's DXP release, I believe that the way in which the conditional syntax was declared in Sass is causing it to break, which is strange because if I'm not mistaken we use sass build to compile.

For more information https://github.com/liferay-frontend/liferay-portal/pull/2394#issuecomment-1161006017