### PR TITLE
 fix(clay-css): Grid compare the breakpoint positions instead of the `$container-max-widths` values

### DIFF
--- a/packages/clay-css/src/scss/bootstrap/_grid.scss
+++ b/packages/clay-css/src/scss/bootstrap/_grid.scss
@@ -26,7 +26,13 @@
       }
 
       @each $name, $width in $grid-breakpoints {
-        @if ($container-max-width > $width or $breakpoint == $name) {
+        $container-max-width-pos: index(
+          $grid-breakpoints,
+          $breakpoint map-get($grid-breakpoints, $breakpoint)
+        );
+        $grid-breakpoint-pos: index($grid-breakpoints, $name $width);
+
+        @if ($container-max-width-pos >= $grid-breakpoint-pos) {
           .container#{breakpoint-infix($name, $grid-breakpoints)} {
             @extend %responsive-container-#{$breakpoint};
           }


### PR DESCRIPTION
`$container-max-widths` are verified to be in ascending order we can use the positions instead of values

Percent values should now work. Use to test:

```scss
$container-max-widths:(
  xs: 90%,
  sm: 90%,
  md: 95%,
  lg: 95%,
  xl: 1200px
);
```