### PR TITLE
feat(@clayui/core): adds new APIs to TreeView to control node active state and expand

### DIFF
--- a/packages/clay-core/docs/api-treeview.mdx
+++ b/packages/clay-core/docs/api-treeview.mdx
@@ -11,44 +11,14 @@ mainTabURL: 'docs/components/treeview.html'
 
 ## TreeView.Item
 
-<div class="table-responsive">
-	<table class="table table-autofit table-bordered table-striped">
-		<thead>
-			<tr>
-				<th>Property</th>
-				<th class="table-cell-expand table-cell-minw-150">Type</th>
-				<th>Required</th>
-				<th class="table-cell-expand table-cell-minw-150">Default</th>
-				<th class="table-cell-expand table-cell-minw-250">
-					Description
-				</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr id="api-actions">
-				<td>
-					<div class="table-title">actions</div>
-				</td>
-				<td class="table-cell-expand table-cell-minw-150">{`React.ReactElement`}</td>
-				<td>false</td>
-				<td class="table-cell-expand table-cell-minw-150"></td>
-				<td class="table-cell-expand table-cell-minw-250">
-					Property for rendering actions on a Node.
-				</td>
-			</tr>
-			<tr id="api-children">
-				<td>
-					<div class="table-title">children</div>
-				</td>
-				<td class="table-cell-expand table-cell-minw-150">
-					{`React.ReactNode`}
-				</td>
-				<td>true</td>
-				<td class="table-cell-expand table-cell-minw-150"></td>
-				<td class="table-cell-expand table-cell-minw-250"></td>
-			</tr>
-		</tbody>
-	</table>
+<div>
+	[APITable "clay-core/src/tree-view/TreeViewItem.tsx#ClayTreeViewItem"]
+</div>
+
+## TreeView.ItemStack
+
+<div>
+	[APITable "clay-core/src/tree-view/TreeViewItem.tsx#TreeViewItemStack"]
 </div>
 
 ## TreeView.Group
@@ -76,7 +46,9 @@ mainTabURL: 'docs/components/treeview.html'
 				</td>
 				<td>true</td>
 				<td class="table-cell-expand table-cell-minw-150"></td>
-				<td class="table-cell-expand table-cell-minw-250"></td>
+				<td class="table-cell-expand table-cell-minw-250">
+					Group content.
+				</td>
 			</tr>
 			<tr id="api-items">
 				<td>

--- a/packages/clay-core/docs/treeview.mdx
+++ b/packages/clay-core/docs/treeview.mdx
@@ -28,6 +28,7 @@ import {Example, MultipleSelection} from '$packages/clay-core/docs/treeview';
 -   [Expander](#expander)
     -   [Custom expander](#custom-expander)
     -   [Disabled](#expander-disabled)
+    -   [Manual Expand](#manual-expand)
 -   [Selection](#selection)
     -   [Single Selection](#single-selection)
     -   [Multiple Selection](#multiple-selection)
@@ -347,6 +348,44 @@ The `Expander` is automatically disabled when the item is disabled but you can o
 
 The `expanderDisabled` property is only available in the `<TreeView.ItemStack />` component where the `Expander` is visible and has children.
 
+### Manual Expand
+
+Some more advanced use cases want to change the behavior of expanding the item when the user interacts with the item differently, e.g single click selects, double click expands the item.
+
+The `expand` method is available via render props only when the content is dynamic, the same as selection, expose two methods, `toggle` and `has`.
+
+```jsx
+<TreeView>
+	{(item, selection, expand) => (
+		<TreeView.Item
+			onClick={(event) => {
+				clearTimeout(clickTimerRef.current);
+
+				// Ignores the component's default behavior, clicking the
+				// item expands the item if it has any child items.
+				event.preventDefault();
+
+				switch (event.detail) {
+					case 1:
+						clickTimerRef.current = setTimeout(() => {
+							if (!selection.has(item.id)) {
+								selection.toggle(item.id);
+							}
+						}, 200);
+						break;
+					case 2:
+						expand.toggle(item.id);
+					default:
+						break;
+				}
+			}}
+		>
+			Item
+		</TreeView.Item>
+	)}
+</TreeView>
+```
+
 ## Selection
 
 The selection allows the user to select one or more items in the TreeView, there are three main interactions that can be configured and are defined using the `selectionMode` prop.
@@ -456,10 +495,8 @@ The `selection` method is available via render props when the content is dynamic
 <TreeView>
 	{(item, selection) => (
 		<TreeView.Item
+			active={selection.has(item.id)}
 			onClick={() => selection.toggle(item.id)}
-			style={{
-				backgroundColor: selection.has(item.id) ? 'aliceblue' : '',
-			}}
 		>
 			Drive
 		</TreeView.Item>

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -3,19 +3,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {Key, useCallback} from 'react';
+import React from 'react';
 
-import {useTreeViewContext} from './context';
+import {Expand, Selection, useAPI} from './context';
 import {ItemContextProvider, useItem} from './useItem';
-
-export type Selection = {
-	toggle: (key: Key) => void;
-	has: (key: Key) => boolean;
-};
 
 export type ChildrenFunction<T> = (
 	item: Omit<T, 'indexes' | 'itemRef' | 'key' | 'parentItemRef'>,
-	selection: Selection
+	selection: Selection,
+	expand: Expand
 ) => React.ReactElement;
 
 export interface ICollectionProps<T> {
@@ -58,24 +54,17 @@ export function Collection<T extends Record<any, any>>({
 	children,
 	items,
 }: ICollectionProps<T>) {
-	const {selection} = useTreeViewContext();
+	const api = useAPI();
 	const {key: parentKey} = useItem();
-
-	const hasKey = useCallback(
-		(key: Key) => {
-			return selection.selectedKeys.has(key);
-		},
-		[selection.selectedKeys]
-	);
 
 	return (
 		<>
 			{typeof children === 'function' && items
 				? items.map((item, index) => {
-						const child = children(removeItemInternalProps(item), {
-							has: hasKey,
-							toggle: selection.toggleSelection,
-						});
+						const child = children(
+							removeItemInternalProps(item),
+							...api
+						);
 
 						const key = getKey(
 							index,

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -55,7 +55,7 @@ interface ITreeViewProps<T>
 	 */
 	expanderClassName?: string;
 
-	/*
+	/**
 	 * Flag to modify Node expansion state icons.
 	 */
 	expanderIcons?: Icons;

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -9,10 +9,10 @@ import Layout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {Keys} from '@clayui/shared';
 import classNames from 'classnames';
-import React, {Key, useCallback, useContext, useState} from 'react';
+import React, {useContext, useState} from 'react';
 
 import {removeItemInternalProps} from './Collection';
-import {Icons, useTreeViewContext} from './context';
+import {Icons, useAPI, useTreeViewContext} from './context';
 import {useItem} from './useItem';
 
 export interface ITreeViewItemProps
@@ -60,8 +60,8 @@ export const TreeViewItem = React.forwardRef<
 	ITreeViewItemProps
 >(function TreeViewItemInner(
 	{
-		active,
 		actions,
+		active,
 		children,
 		isDragging,
 		overPosition,
@@ -96,25 +96,17 @@ export const TreeViewItem = React.forwardRef<
 
 	const [loading, setLoading] = useState(false);
 
+	const api = useAPI();
+
 	const [left, right] = React.Children.toArray(children);
 
 	const group =
 		// @ts-ignore
 		right?.type?.displayName === 'ClayTreeViewGroup' ? right : null;
 
-	const hasKey = useCallback(
-		(key: Key) => {
-			return selection.selectedKeys.has(key);
-		},
-		[selection.selectedKeys]
-	);
-
 	if (!group && nestedKey && item[nestedKey] && childrenRoot.current) {
 		return React.cloneElement(
-			childrenRoot.current(removeItemInternalProps(item), {
-				has: hasKey,
-				toggle: selection.toggleSelection,
-			}),
+			childrenRoot.current(removeItemInternalProps(item), ...api),
 			{
 				actions,
 				isDragging,

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -61,7 +61,6 @@ export const TreeViewItem = React.forwardRef<
 >(function TreeViewItemInner(
 	{
 		actions,
-		active,
 		children,
 		isDragging,
 		overPosition,
@@ -155,7 +154,8 @@ export const TreeViewItem = React.forwardRef<
 							active:
 								(selectionMode === 'single' &&
 									selection.selectedKeys.has(item.key)) ||
-								active,
+								itemStackProps.active ||
+								nodeProps.active,
 							collapsed: group && expandedKeys.has(item.key),
 							disabled:
 								itemStackProps.disabled || nodeProps.disabled,
@@ -422,6 +422,11 @@ export const TreeViewItem = React.forwardRef<
 TreeViewItem.displayName = 'ClayTreeViewItem';
 
 interface ITreeViewItemStackProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Flag to set the node to the active state.
+	 */
+	active?: boolean;
+
 	actions?: React.ReactElement;
 	children: React.ReactNode;
 

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -427,7 +427,14 @@ interface ITreeViewItemStackProps extends React.HTMLAttributes<HTMLDivElement> {
 	 */
 	active?: boolean;
 
+	/**
+	 * @ignore
+	 */
 	actions?: React.ReactElement;
+
+	/**
+	 * Item content.
+	 */
 	children: React.ReactNode;
 
 	/**
@@ -441,7 +448,14 @@ interface ITreeViewItemStackProps extends React.HTMLAttributes<HTMLDivElement> {
 	 */
 	expanderDisabled?: boolean;
 
+	/**
+	 * @ignore
+	 */
 	expandable?: boolean;
+
+	/**
+	 * @ignore
+	 */
 	loading?: boolean;
 }
 

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -18,10 +18,18 @@ import {useItem} from './useItem';
 export interface ITreeViewItemProps
 	extends Omit<React.HTMLAttributes<HTMLLIElement>, 'children'> {
 	/**
+	 * Flag to set the node to the active state.
+	 */
+	active?: boolean;
+
+	/**
 	 * Property for rendering actions on a Node.
 	 */
 	actions?: React.ReactElement;
 
+	/**
+	 * Item content.
+	 */
 	children: React.ReactNode;
 
 	/**
@@ -30,17 +38,17 @@ export interface ITreeViewItemProps
 	disabled?: boolean;
 
 	/**
-	 * Internal property.
+	 * @ignore
 	 */
 	isDragging?: boolean;
 
 	/**
-	 * Internal property.
+	 * @ignore
 	 */
 	overPosition?: string;
 
 	/**
-	 * Internal property.
+	 * @ignore
 	 */
 	overTarget?: boolean;
 }
@@ -52,6 +60,7 @@ export const TreeViewItem = React.forwardRef<
 	ITreeViewItemProps
 >(function TreeViewItemInner(
 	{
+		active,
 		actions,
 		children,
 		isDragging,
@@ -152,8 +161,9 @@ export const TreeViewItem = React.forwardRef<
 						nodeProps.className,
 						{
 							active:
-								selectionMode === 'single' &&
-								selection.selectedKeys.has(item.key),
+								(selectionMode === 'single' &&
+									selection.selectedKeys.has(item.key)) ||
+								active,
 							collapsed: group && expandedKeys.has(item.key),
 							disabled:
 								itemStackProps.disabled || nodeProps.disabled,

--- a/packages/clay-core/src/tree-view/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/BasicRendering.tsx
@@ -385,4 +385,27 @@ describe('TreeView basic rendering', () => {
 		).toBeTruthy();
 		expect(container.querySelector('.collapse.show')).toBeTruthy();
 	});
+
+	it('render with item active', () => {
+		const {container} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView>
+					<TreeView.Item>
+						<TreeView.ItemStack active>
+							<OptionalCheckbox />
+							Root
+						</TreeView.ItemStack>
+						<TreeView.Group>
+							<TreeView.Item active>
+								<OptionalCheckbox />
+								Text
+							</TreeView.Item>
+						</TreeView.Group>
+					</TreeView.Item>
+				</TreeView>
+			</Provider>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
 });

--- a/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
@@ -85,6 +85,64 @@ describe('TreeView incremental interactions', () => {
 		expect(container.querySelector('.collapse')).toBeFalsy();
 	});
 
+	it('expand the item using the api', () => {
+		const {container, debug} = render(
+			<Provider spritemap={spritemap}>
+				<TreeView
+					defaultItems={[
+						{
+							children: [
+								{id: 2, name: 'Item 0'},
+								{
+									children: [
+										{id: 4, name: 'Item 2'},
+										{id: 5, name: 'Item 3'},
+									],
+									id: 3,
+									name: 'Item 1',
+								},
+							],
+							id: 1,
+							name: 'Root',
+						},
+					]}
+				>
+					{(item, selection, expand) => (
+						<TreeView.Item>
+							<TreeView.ItemStack
+								onClick={(event) => {
+									event.preventDefault();
+
+									// @ts-ignore
+									if (event.detail === 2) {
+										expand.toggle(item.id);
+									}
+								}}
+							>
+								{item.name}
+							</TreeView.ItemStack>
+							<TreeView.Group items={item.children}>
+								\
+								{(item) => (
+									<TreeView.Item>{item.name}</TreeView.Item>
+								)}
+							</TreeView.Group>
+						</TreeView.Item>
+					)}
+				</TreeView>
+			</Provider>
+		);
+
+		const linkItem = container.querySelector(
+			'.treeview-link'
+		) as HTMLDivElement;
+
+		fireEvent.click(linkItem, {detail: 2});
+
+		expect(linkItem.getAttribute('aria-expanded')).toBe('true');
+		expect(container.querySelector('.collapse.show')).toBeTruthy();
+	});
+
 	describe('selection', () => {
 		describe('checkbox', () => {
 			it("uncheck the checkbox when a sibling item is indeterminate preserve the parent's indeterminate state", () => {

--- a/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
@@ -86,7 +86,7 @@ describe('TreeView incremental interactions', () => {
 	});
 
 	it('expand the item using the api', () => {
-		const {container, debug} = render(
+		const {container} = render(
 			<Provider spritemap={spritemap}>
 				<TreeView
 					defaultItems={[

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -409,6 +409,98 @@ exports[`TreeView basic rendering render with checkbox 1`] = `
 </div>
 `;
 
+exports[`TreeView basic rendering render with item active 1`] = `
+<div>
+  <ul
+    class="treeview show-quick-actions-on-hover treeview-light show-component-expander-on-hover"
+    role="tree"
+  >
+    <li
+      class="treeview-item"
+      role="none"
+    >
+      <div
+        aria-expanded="false"
+        class="treeview-link active"
+        role="treeitem"
+        style="padding-left: 0px;"
+        tabindex="0"
+      >
+        <span
+          class="c-inner"
+          style="margin-left: -0px;"
+          tabindex="-2"
+        >
+          <div
+            class="autofit-row"
+          >
+            <div
+              class="autofit-col"
+            >
+              <button
+                aria-controls="$.0"
+                aria-expanded="false"
+                class="component-expander btn btn-monospaced"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="c-inner"
+                  tabindex="-2"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-down"
+                    />
+                  </svg>
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right component-expanded-d-none"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="icons.svg#angle-right"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="autofit-col"
+            >
+              <div
+                class="custom-control custom-checkbox"
+              >
+                <label>
+                  <input
+                    class="custom-control-input"
+                    type="checkbox"
+                  />
+                  <span
+                    class="custom-control-label"
+                  />
+                </label>
+              </div>
+            </div>
+            <div
+              class="autofit-col autofit-col-expand"
+            >
+              <div
+                class="component-text"
+              >
+                Root
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`TreeView basic rendering render with text 1`] = `
 <div>
   <ul

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {useContext} from 'react';
+import React, {Key, useCallback, useContext} from 'react';
 
 import type {ChildrenFunction} from './Collection';
 import type {ITreeState} from './useTree';
@@ -35,4 +35,38 @@ export const TreeViewContext = React.createContext<ITreeViewContext<any>>(
 
 export function useTreeViewContext(): ITreeViewContext<unknown> {
 	return useContext(TreeViewContext);
+}
+
+export type Selection = {
+	toggle: (key: Key) => void;
+	has: (key: Key) => boolean;
+};
+
+export type Expand = {
+	toggle: (key: Key) => void;
+	has: (key: Key) => boolean;
+};
+
+export function useAPI() {
+	const {expandedKeys, selection, toggle} = useTreeViewContext();
+
+	const hasKey = useCallback(
+		(key: Key) => {
+			return selection.selectedKeys.has(key);
+		},
+		[selection.selectedKeys]
+	);
+
+	const hasExpandedKey = useCallback(
+		(key: Key) => expandedKeys.has(key),
+		[expandedKeys]
+	);
+
+	return [
+		{
+			has: hasKey,
+			toggle: selection.toggleSelection,
+		},
+		{has: hasExpandedKey, toggle},
+	] as const;
 }

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -10,7 +10,7 @@ import {ClayDropDownWithItems as DropDownWithItems} from '@clayui/drop-down';
 import {ClayCheckbox as Checkbox, ClayInput as Input} from '@clayui/form';
 import Icon from '@clayui/icon';
 import Sticker from '@clayui/sticker';
-import React, {useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
 
 import {TreeView} from '../src/tree-view';
 import largeData from './tree-data.mock.json';
@@ -1200,16 +1200,50 @@ export const PerformanceTest = () => {
 };
 
 export const DemoCategoriesSingle = () => {
+	const clickTimerRef = useRef<any>();
+
+	const onCategoryClick = useCallback(
+		(
+			detail: number,
+			item: any,
+			leaf: boolean,
+			selection: any,
+			expand: any
+		) => {
+			switch (detail) {
+				case 1:
+					clickTimerRef.current = setTimeout(() => {
+						if (!selection.has(item.id)) {
+							selection.toggle(item.id);
+						}
+					}, 200);
+					break;
+				case 2:
+					if (!selection.has(item.id)) {
+						selection.toggle(item.id);
+					}
+					if (!leaf) {
+						expand.toggle(item.id);
+					}
+				default:
+					break;
+			}
+		},
+		[]
+	);
+
 	return (
 		<TreeView
 			defaultItems={[
 				{
 					name: 'Animals',
 					vocabulary: true,
+					id: 0,
 				},
 				{
 					name: 'Vegetables',
 					vocabulary: true,
+					id: 1,
 				},
 				{
 					children: [
@@ -1217,36 +1251,77 @@ export const DemoCategoriesSingle = () => {
 							children: [
 								{
 									name: 'Metals',
+									id: 7,
 								},
 								{
 									name: 'Semimetals',
+									id: 8,
 								},
 								{
 									name: 'Nonmetals',
+									id: 9,
 								},
 							],
 							name: 'Native Elements',
+							id: 4,
 						},
 						{
 							name: 'Sulfides',
+							id: 5,
 						},
 						{
 							name: 'Silicates',
+							id: 6,
 						},
 					],
 					name: 'Minerals',
 					vocabulary: true,
+					id: 2,
 				},
 				{
 					name: 'Plants',
 					vocabulary: true,
+					id: 3,
 				},
 			]}
 			showExpanderOnHover={false}
 		>
-			{(item) => (
+			{(item, selection, expand) => (
 				<TreeView.Item>
-					<TreeView.ItemStack>
+					<TreeView.ItemStack
+						onClick={(event) => {
+							clearTimeout(clickTimerRef.current);
+
+							event.preventDefault();
+
+							if (item.vocabulary) {
+								// @ts-ignore
+								switch (event.detail) {
+									case 1:
+										clickTimerRef.current = setTimeout(
+											() => {
+												expand.toggle(item.id);
+											},
+											200
+										);
+										break;
+									case 2:
+										expand.toggle(item.id);
+									default:
+										break;
+								}
+							} else {
+								onCategoryClick(
+									// @ts-ignore
+									event.detail,
+									item,
+									false,
+									selection,
+									expand
+								);
+							}
+						}}
+					>
 						<Icon
 							symbol={
 								item.vocabulary ? 'vocabulary' : 'categories'
@@ -1256,7 +1331,20 @@ export const DemoCategoriesSingle = () => {
 					</TreeView.ItemStack>
 					<TreeView.Group items={item.children}>
 						{(item) => (
-							<TreeView.Item>
+							<TreeView.Item
+								onClick={(event) => {
+									clearTimeout(clickTimerRef.current);
+									event.preventDefault();
+									onCategoryClick(
+										// @ts-ignore
+										event.detail,
+										item,
+										false,
+										selection,
+										expand
+									);
+								}}
+							>
 								<Icon symbol="categories" />
 								{item.name}
 							</TreeView.Item>
@@ -1360,13 +1448,22 @@ export const DemoCategoriesMultiple = () => {
 					vocabulary: true,
 				},
 			]}
-			expandDoubleClick
 			selectionMode="multiple-recursive"
 			showExpanderOnHover={false}
 		>
-			{(item, selection) => (
+			{(item, selection, expand) => (
 				<TreeView.Item>
-					<TreeView.ItemStack>
+					<TreeView.ItemStack
+						onClick={(event) => {
+							event.preventDefault();
+
+							if (item.vocabulary) {
+								expand.toggle(item.id);
+							} else {
+								selection.toggle(item.id);
+							}
+						}}
+					>
 						{!item.vocabulary && <OptionalCheckbox />}
 						<Icon
 							symbol={
@@ -1395,7 +1492,9 @@ export const DemoCategoriesMultiple = () => {
 					</TreeView.ItemStack>
 					<TreeView.Group items={item.children}>
 						{(item) => (
-							<TreeView.Item>
+							<TreeView.Item
+								onClick={() => selection.toggle(item.id)}
+							>
 								<OptionalCheckbox />
 								<Icon symbol="categories" />
 								{item.name}

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -1225,6 +1225,7 @@ export const DemoCategoriesSingle = () => {
 					if (!leaf) {
 						expand.toggle(item.id);
 					}
+					break;
 				default:
 					break;
 			}
@@ -1236,52 +1237,52 @@ export const DemoCategoriesSingle = () => {
 		<TreeView
 			defaultItems={[
 				{
+					id: 0,
 					name: 'Animals',
 					vocabulary: true,
-					id: 0,
 				},
 				{
+					id: 1,
 					name: 'Vegetables',
 					vocabulary: true,
-					id: 1,
 				},
 				{
 					children: [
 						{
 							children: [
 								{
-									name: 'Metals',
 									id: 7,
+									name: 'Metals',
 								},
 								{
-									name: 'Semimetals',
 									id: 8,
+									name: 'Semimetals',
 								},
 								{
-									name: 'Nonmetals',
 									id: 9,
+									name: 'Nonmetals',
 								},
 							],
-							name: 'Native Elements',
 							id: 4,
+							name: 'Native Elements',
 						},
 						{
-							name: 'Sulfides',
 							id: 5,
+							name: 'Sulfides',
 						},
 						{
-							name: 'Silicates',
 							id: 6,
+							name: 'Silicates',
 						},
 					],
+					id: 2,
 					name: 'Minerals',
 					vocabulary: true,
-					id: 2,
 				},
 				{
+					id: 3,
 					name: 'Plants',
 					vocabulary: true,
-					id: 3,
 				},
 			]}
 			showExpanderOnHover={false}
@@ -1307,6 +1308,7 @@ export const DemoCategoriesSingle = () => {
 										break;
 									case 2:
 										expand.toggle(item.id);
+										break;
 									default:
 										break;
 								}


### PR DESCRIPTION
This PR exposes new APIs to allow controlling the TreeView's internal states so that the developer can cover more use cases than the default behavior, read the issue with proposal #4949 to understand the use cases. This PR doesn't have demos to demonstrate how to get to this use case but I'll be adding more in this PR.

Controlling a node's expansion state is similar to controlling a node's selection, APIs are exposed via render props as a low-level API.

```jsx
<TreeView>
  {(item, selection, expand) => (
    <TreeView.Item
      onClick={(event) => {
        clearTimeout(clickTimerRef.current);

        event.preventDefault();

        switch (event.detail) {
          case 1:
            clickTimerRef.current = setTimeout(() => {
              if (!selection.has(item.id)) {
                selection.toggle(item.id);
              }
            }, 200);
            break;
          case 2:
            if (!selection.has(item.id)) {
              selection.toggle(item.id);
            }
            expand.toggle(item.id);
          default:
            break;
        }
      }}
    >
      ...
    </TreeView.Item>
  )}
</TreeView>
```

This is an example of the scenario where the double click has a different behavior than the single click on the same node and the node selection is only considered as selected once.

In the future, we may consider supporting high-level APIs that allow us to deal with this but for now, it is difficult to support this now because they are isolated cases with this behavior and we need to identify patterns to offer a more stable API for this that does not conflict with the default behavior and It's not hard to switch between the behaviors but for now, I can't think of a way to offer that.

## ToDo

- [x] Add documentation
- [x] Add tests
- [x] Add some demos