### PR TITLE
feat(@clayui/drop-down): Allow setting a default selected value for the radiogroup

### DIFF
--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -360,8 +360,9 @@ const RadioGroup: React.FunctionComponent<IItem & IInternalItem> = ({
 	name,
 	onChange = () => {},
 	spritemap,
+	value: defaultValue = '',
 }) => {
-	const [value, setValue] = useState('');
+	const [value, setValue] = useState(defaultValue);
 
 	const params = {
 		checked: value,


### PR DESCRIPTION
This pr uses the value inside item to set a default value for the radio group in DropDownWithItems