### PR TITLE
fix(@clayui/css): Multi Select form text should have the same spacing…

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -157,6 +157,28 @@ $input-plaintext-readonly: map-deep-merge(
 	$input-plaintext-readonly
 );
 
+// Form Control Tag Group
+
+$form-control-inset: () !default;
+$form-control-inset: map-deep-merge(
+	(
+		margin-left: 0.5rem,
+	),
+	$form-control-inset
+);
+
+// .form-control-tag-group-sm.form-control
+
+$form-control-tag-group-sm: () !default;
+$form-control-tag-group-sm: map-deep-merge(
+	(
+		form-control-inset: (
+			margin-left: 0.5rem,
+		),
+	),
+	$form-control-tag-group-sm
+);
+
 // Form Feedback
 
 $form-text-color: $gray-600 !default;

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -413,6 +413,7 @@ $form-control-inset: map-deep-merge(
 		color: $input-color,
 		flex-grow: 1,
 		margin-bottom: $form-control-inset-margin-y,
+		margin-left: 0.25rem,
 		margin-top: $form-control-inset-margin-y,
 		min-height: $form-control-inset-min-height,
 		padding: 0,
@@ -440,6 +441,7 @@ $form-control-tag-group: map-deep-merge(
 		flex-wrap: wrap,
 		height: auto,
 		padding-bottom: $form-control-tag-group-padding-y,
+		padding-left: 0.5rem,
 		padding-right: 0.5rem,
 		padding-top: $form-control-tag-group-padding-y,
 	),
@@ -550,6 +552,7 @@ $form-control-tag-group-sm: map-deep-merge(
 		),
 		form-control-inset: (
 			margin-bottom: 0.125rem,
+			margin-left: 0.25rem,
 			margin-top: 0.1875rem,
 		),
 	),


### PR DESCRIPTION
… as it's form-control counter part

fixes #4955 
![small](https://user-images.githubusercontent.com/788266/176960519-3c83fdb1-7def-4715-86bc-5ec0c4f46d26.jpg)

![regular](https://user-images.githubusercontent.com/788266/176960533-1ffa6f1f-1374-403b-8ba8-69eaf5bb130b.jpg)

