### PR TITLE
feat(@clayui/css): add support class to remove hover from treeview link

### DIFF
--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -43,6 +43,11 @@ export interface ITreeViewItemProps
 	isDragging?: boolean;
 
 	/**
+	 * Flag to remove the visual of the hover over the item.
+	 */
+	noHover?: boolean;
+
+	/**
 	 * @ignore
 	 */
 	overPosition?: string;
@@ -166,6 +171,8 @@ export const TreeViewItem = React.forwardRef<
 								overTarget && overPosition === 'middle',
 							'treeview-dropping-top':
 								overTarget && overPosition === 'top',
+							'treeview-no-hover':
+								itemStackProps.noHover || nodeProps.noHover,
 						}
 					)}
 					disabled={itemStackProps.disabled || nodeProps.disabled}
@@ -452,6 +459,11 @@ interface ITreeViewItemStackProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * @ignore
 	 */
 	expandable?: boolean;
+
+	/**
+	 * Flag to remove the visual of the hover over the item.
+	 */
+	noHover?: boolean;
 
 	/**
 	 * @ignore

--- a/packages/clay-css/src/scss/cadmin/components/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_treeview.scss
@@ -346,6 +346,16 @@
 				);
 			}
 		}
+
+		&.treeview-no-hover {
+			@include clay-link(
+				map-deep-get(
+					$cadmin-treeview-light,
+					treeview-link,
+					treeview-no-hover
+				)
+			);
+		}
 	}
 
 	.component-action {
@@ -436,6 +446,16 @@
 					)
 				);
 			}
+		}
+
+		&.treeview-no-hover {
+			@include clay-link(
+				map-deep-get(
+					$cadmin-treeview-dark,
+					treeview-link,
+					treeview-no-hover
+				)
+			);
 		}
 	}
 

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -197,6 +197,12 @@ $cadmin-treeview-light: map-deep-merge(
 		),
 		treeview-link: (
 			color: $cadmin-gray-600,
+			treeview-no-hover: (
+				hover: (
+					background-color: transparent,
+					color: $cadmin-gray-600,
+				),
+			),
 			hover: (
 				background-color: $cadmin-gray-100,
 				color: $cadmin-gray-900,
@@ -233,6 +239,12 @@ $cadmin-treeview-dark: map-deep-merge(
 		),
 		treeview-link: (
 			color: $cadmin-secondary-l1,
+			treeview-no-hover: (
+				hover: (
+					background-color: transparent,
+					color: $cadmin-secondary-l1,
+				),
+			),
 			hover: (
 				background-color: rgba($cadmin-white, 0.04),
 			),

--- a/packages/clay-css/src/scss/components/_treeview.scss
+++ b/packages/clay-css/src/scss/components/_treeview.scss
@@ -310,6 +310,12 @@
 				);
 			}
 		}
+
+		&.treeview-no-hover {
+			@include clay-link(
+				map-deep-get($treeview-light, treeview-link, treeview-no-hover)
+			);
+		}
 	}
 
 	.component-action {
@@ -394,6 +400,12 @@
 					)
 				);
 			}
+		}
+
+		&.treeview-no-hover {
+			@include clay-link(
+				map-deep-get($treeview-dark, treeview-link, treeview-no-hover)
+			);
 		}
 	}
 

--- a/packages/clay-css/src/scss/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/variables/_treeview.scss
@@ -198,6 +198,12 @@ $treeview-light: map-deep-merge(
 		),
 		treeview-link: (
 			color: $gray-600,
+			treeview-no-hover: (
+				hover: (
+					background-color: transparent,
+					color: $secondary,
+				),
+			),
 			hover: (
 				background-color: $gray-100,
 				color: $gray-900,
@@ -238,6 +244,12 @@ $treeview-dark: map-deep-merge(
 		),
 		treeview-link: (
 			color: $secondary-l1,
+			treeview-no-hover: (
+				hover: (
+					background-color: transparent,
+					color: $secondary-l1,
+				),
+			),
 			hover: (
 				background-color: rgba($white, 0.04),
 			),


### PR DESCRIPTION
This is a complement to #4949, just adding in a separate PR because I'm not sure if we should go this way, I'm just adding the support class to the atlas but not adding it to `cadmin` yet, I'll add it later if we agree that this is the best solution.

@pat270 let me know what you think, the intention of this PR is to add a class that allows you to disable hover on a specific node.