### PR TITLE
refactor: Remove typing usage from components with `React.FunctionComponent`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -76,7 +76,7 @@ module.exports = {
 		'./packages/clay-drop-down/src/': {
 			branches: 70,
 			functions: 57,
-			lines: 81,
+			lines: 80,
 			statements: 78,
 		},
 		'./packages/clay-empty-state/src/': {
@@ -88,7 +88,7 @@ module.exports = {
 		'./packages/clay-form/src/': {
 			branches: 62,
 			functions: 70,
-			lines: 86,
+			lines: 85,
 			statements: 85,
 		},
 		'./packages/clay-icon/src/': {
@@ -148,8 +148,8 @@ module.exports = {
 		'./packages/clay-nav/src/': {
 			branches: 92,
 			functions: 80,
-			lines: 94,
-			statements: 94,
+			lines: 93,
+			statements: 93,
 		},
 		'./packages/clay-navigation-bar/src/': {
 			branches: 50,
@@ -215,7 +215,7 @@ module.exports = {
 			branches: 84,
 			functions: 66,
 			lines: 94,
-			statements: 91,
+			statements: 90,
 		},
 		'./packages/clay-time-picker/src/': {
 			branches: 85,

--- a/packages/clay-alert/src/Footer.tsx
+++ b/packages/clay-alert/src/Footer.tsx
@@ -6,9 +6,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayAlertFooter: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayAlertFooter = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	return (
 		<div className={classNames(className, 'alert-footer')} {...otherProps}>
 			{children}

--- a/packages/clay-alert/src/index.tsx
+++ b/packages/clay-alert/src/index.tsx
@@ -111,10 +111,12 @@ const ICON_MAP = {
 
 const VARIANTS = ['inline', 'feedback'];
 
-const ClayAlert: React.FunctionComponent<IClayAlertProps> & {
+function ClayAlert(props: IClayAlertProps): JSX.Element & {
 	Footer: typeof Footer;
 	ToastContainer: typeof ToastContainer;
-} = ({
+};
+
+function ClayAlert({
 	actions,
 	autoClose,
 	children,
@@ -126,13 +128,13 @@ const ClayAlert: React.FunctionComponent<IClayAlertProps> & {
 	title,
 	variant,
 	...otherProps
-}: IClayAlertProps) => {
+}: IClayAlertProps) {
 	const {pauseAutoCloseTimer, startAutoCloseTimer} = useAutoClose(
 		autoClose,
 		onClose
 	);
 
-	const ConditionalContainer: React.FunctionComponent<{}> = ({children}) =>
+	const ConditionalContainer = ({children}: any) =>
 		variant === 'stripe' ? (
 			<div className="container">{children}</div>
 		) : (
@@ -209,7 +211,7 @@ const ClayAlert: React.FunctionComponent<IClayAlertProps> & {
 			</ConditionalContainer>
 		</div>
 	);
-};
+}
 
 ClayAlert.Footer = Footer;
 ClayAlert.ToastContainer = ToastContainer;

--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -37,7 +37,7 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	onSetActive?: (val: boolean) => void;
 }
 
-const ClayAutocompleteDropDown: React.FunctionComponent<IProps> = ({
+const ClayAutocompleteDropDown = ({
 	active = false,
 	alignElementRef,
 	alignmentByViewport,

--- a/packages/clay-autocomplete/src/LoadingIndicator.tsx
+++ b/packages/clay-autocomplete/src/LoadingIndicator.tsx
@@ -9,9 +9,10 @@ import React from 'react';
 
 import Context from './Context';
 
-const LoadingIndicatorMarkup: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, ...otherProps}) => (
+const LoadingIndicatorMarkup = ({
+	children,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<ClayInput.GroupInsetItem {...otherProps} after>
 		<span className="inline-item inline-item-middle">{children}</span>
 	</ClayInput.GroupInsetItem>
@@ -24,7 +25,7 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	component?: React.ComponentType<any>;
 }
 
-const ClayAutocompleteLoadingIndicator: React.FunctionComponent<IProps> = ({
+const ClayAutocompleteLoadingIndicator = ({
 	className,
 	component: Component = LoadingIndicatorMarkup,
 	...otherProps

--- a/packages/clay-autocomplete/src/__tests__/index.tsx
+++ b/packages/clay-autocomplete/src/__tests__/index.tsx
@@ -64,9 +64,9 @@ describe('ClayAutocomplete', () => {
 	});
 
 	it('renders LoadingIndicator with other markup component', () => {
-		const MyMarkup: React.FunctionComponent<
-			React.HTMLAttributes<HTMLSpanElement>
-		> = ({children}) => (
+		const MyMarkup = ({
+			children,
+		}: React.HTMLAttributes<HTMLSpanElement>) => (
 			<span className="autofit-col">
 				<span className="inline-item">{children}</span>
 			</span>

--- a/packages/clay-breadcrumb/src/Ellipsis.tsx
+++ b/packages/clay-breadcrumb/src/Ellipsis.tsx
@@ -22,11 +22,7 @@ interface IEllipsisProps extends React.HTMLAttributes<HTMLLIElement> {
 	spritemap?: string;
 }
 
-const Ellipsis: React.FunctionComponent<IEllipsisProps> = ({
-	items,
-	spritemap,
-	...otherProps
-}) => (
+const Ellipsis = ({items, spritemap, ...otherProps}: IEllipsisProps) => (
 	<ClayDropDown
 		className="breadcrumb-item"
 		containerElement="li"

--- a/packages/clay-breadcrumb/src/index.tsx
+++ b/packages/clay-breadcrumb/src/index.tsx
@@ -43,7 +43,7 @@ const findActiveItems = (items: TItems) => {
 	});
 };
 
-const ClayBreadcrumb: React.FunctionComponent<IProps> = ({
+const ClayBreadcrumb = ({
 	className,
 	ellipsisBuffer = 1,
 	ellipsisProps = {},

--- a/packages/clay-button/src/Group.tsx
+++ b/packages/clay-button/src/Group.tsx
@@ -19,7 +19,7 @@ export interface IButtonGroupProps
 	vertical?: boolean;
 }
 
-const ClayButtonGroup: React.FunctionComponent<IButtonGroupProps> = ({
+const ClayButtonGroup = ({
 	children,
 	className,
 	role = 'group',

--- a/packages/clay-card/src/AspectRatio.tsx
+++ b/packages/clay-card/src/AspectRatio.tsx
@@ -10,19 +10,28 @@ import Context from './Context';
 
 type ContainerAspectRatioType = '1/1' | '3/2' | '4/3' | '8/5' | '16/9';
 
-interface ICardAspectRatioProps
-	extends React.HTMLAttributes<HTMLDivElement | HTMLSpanElement> {
+type Props = {
+	/**
+	 * AspectRatio content.
+	 */
+	children: React.ReactNode;
+
+	/**
+	 * Defines a CSS class for the element.
+	 */
+	className?: string;
+
 	/**
 	 * Contrains an image for a given Aspect Ratio.
 	 */
 	containerAspectRatio?: ContainerAspectRatioType;
-}
+};
 
-const ClayCardAspectRatio: React.FunctionComponent<ICardAspectRatioProps> = ({
+const ClayCardAspectRatio = ({
 	children,
 	className,
 	containerAspectRatio,
-}: ICardAspectRatioProps) => {
+}: Props) => {
 	const {interactive} = React.useContext(Context);
 
 	const TagName = interactive ? 'span' : 'div';

--- a/packages/clay-card/src/Body.tsx
+++ b/packages/clay-card/src/Body.tsx
@@ -8,9 +8,11 @@ import React from 'react';
 
 import Context from './Context';
 
-const ClayCardBody: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayCardBody = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	const {interactive} = React.useContext(Context);
 
 	const TagName = interactive ? 'span' : 'div';

--- a/packages/clay-card/src/Caption.tsx
+++ b/packages/clay-card/src/Caption.tsx
@@ -8,9 +8,11 @@ import React from 'react';
 
 import Context from './Context';
 
-const ClayCardCaption: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement | HTMLSpanElement>
-> = ({children, className, ...otherProps}) => {
+const ClayCardCaption = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement | HTMLSpanElement>) => {
 	const {interactive} = React.useContext(Context);
 
 	const TagName = interactive ? 'span' : 'div';

--- a/packages/clay-card/src/Card.tsx
+++ b/packages/clay-card/src/Card.tsx
@@ -39,14 +39,14 @@ interface IProps
 			HTMLAnchorElement | HTMLSpanElement | HTMLDivElement
 		> {}
 
-const ClayCard: React.FunctionComponent<IProps> = ({
+const ClayCard = ({
 	active,
 	children,
 	className,
 	displayType,
 	selectable = false,
 	...otherProps
-}) => {
+}: IProps) => {
 	const isCardType = {
 		file: displayType === 'file',
 		image: displayType === 'image',
@@ -77,14 +77,21 @@ const ClayCard: React.FunctionComponent<IProps> = ({
 	);
 };
 
-const ClayCardHybrid: React.FunctionComponent<IProps> & {
+function ClayCardHybrid(props: IProps): JSX.Element & {
 	AspectRatio: typeof AspectRatio;
 	Body: typeof Body;
 	Caption: typeof Caption;
 	Description: typeof Description;
 	Group: typeof Group;
 	Row: typeof Row;
-} = ({children, horizontal, interactive, ...otherProps}: IProps) => {
+};
+
+function ClayCardHybrid({
+	children,
+	horizontal,
+	interactive,
+	...otherProps
+}: IProps) {
 	const Container = interactive
 		? ClayCardNavigation
 		: horizontal
@@ -96,7 +103,7 @@ const ClayCardHybrid: React.FunctionComponent<IProps> & {
 			{children}
 		</Container>
 	);
-};
+}
 
 ClayCardHybrid.displayName = 'ClayCard';
 

--- a/packages/clay-card/src/CardHorizontal.tsx
+++ b/packages/clay-card/src/CardHorizontal.tsx
@@ -20,9 +20,11 @@ interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	selectable?: boolean;
 }
 
-const ClayCardHorizontalBody: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => (
+const ClayCardHorizontalBody = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
 		className={classNames('card card-horizontal', className)}
 		{...otherProps}
@@ -31,26 +33,36 @@ const ClayCardHorizontalBody: React.FunctionComponent<
 	</div>
 );
 
-export const ClayCardHorizontal: React.FunctionComponent<IProps> & {
+export function ClayCardHorizontal(props: IProps): JSX.Element & {
 	Body: typeof ClayCardHorizontalBody;
-} = ({active, children, className, selectable, ...otherProps}) => (
-	<Context.Provider value={{horizontal: true, interactive: false}}>
-		<div
-			className={classNames(
-				className,
-				{
-					active,
-					'card card-horizontal': !selectable,
-					'form-check-card form-check form-check-middle-left':
-						selectable,
-				},
-				'card-type-directory'
-			)}
-			{...otherProps}
-		>
-			{children}
-		</div>
-	</Context.Provider>
-);
+};
+
+export function ClayCardHorizontal({
+	active,
+	children,
+	className,
+	selectable,
+	...otherProps
+}: IProps) {
+	return (
+		<Context.Provider value={{horizontal: true, interactive: false}}>
+			<div
+				className={classNames(
+					className,
+					{
+						active,
+						'card card-horizontal': !selectable,
+						'form-check-card form-check form-check-middle-left':
+							selectable,
+					},
+					'card-type-directory'
+				)}
+				{...otherProps}
+			>
+				{children}
+			</div>
+		</Context.Provider>
+	);
+}
 
 ClayCardHorizontal.Body = ClayCardHorizontalBody;

--- a/packages/clay-card/src/CardNavigation.tsx
+++ b/packages/clay-card/src/CardNavigation.tsx
@@ -13,14 +13,14 @@ interface IProps
 	extends Omit<IContext, 'interactive'>,
 		React.BaseHTMLAttributes<HTMLAnchorElement | HTMLDivElement> {}
 
-export const ClayCardNavigation: React.FunctionComponent<IProps> = ({
+export const ClayCardNavigation = ({
 	children,
 	className,
 	horizontal,
 	href,
 	onClick,
 	...otherProps
-}) => {
+}: IProps) => {
 	const Container = href ? ClayLink : 'div';
 
 	return (

--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -63,7 +63,7 @@ interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	title: string;
 }
 
-export const ClayCardWithHorizontal: React.FunctionComponent<IProps> = ({
+export const ClayCardWithHorizontal = ({
 	actions,
 	checkboxProps = {},
 	disabled,

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -110,7 +110,7 @@ interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	title: string;
 }
 
-export const ClayCardWithInfo: React.FunctionComponent<IProps> = ({
+export const ClayCardWithInfo = ({
 	actions,
 	checkboxProps = {},
 	description,

--- a/packages/clay-card/src/CardWithNavigation.tsx
+++ b/packages/clay-card/src/CardWithNavigation.tsx
@@ -59,7 +59,7 @@ interface IProps
 
 const noop = () => {};
 
-export const ClayCardWithNavigation: React.FunctionComponent<IProps> = ({
+export const ClayCardWithNavigation = ({
 	children,
 	description,
 	horizontal = false,

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -85,7 +85,7 @@ interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	userSymbol?: string;
 }
 
-export const ClayCardWithUser: React.FunctionComponent<IProps> = ({
+export const ClayCardWithUser = ({
 	actions,
 	checkboxProps = {},
 	description,

--- a/packages/clay-card/src/Description.tsx
+++ b/packages/clay-card/src/Description.tsx
@@ -39,7 +39,7 @@ interface ICardDescriptionProps
 	truncate?: boolean;
 }
 
-const ClayCardDescription: React.FunctionComponent<ICardDescriptionProps> = ({
+const ClayCardDescription = ({
 	children,
 	className,
 	disabled,

--- a/packages/clay-card/src/Group.tsx
+++ b/packages/clay-card/src/Group.tsx
@@ -13,7 +13,7 @@ interface ICardGroupProps extends React.HTMLAttributes<HTMLUListElement> {
 	label?: string;
 }
 
-const ClayCardGroup: React.FunctionComponent<ICardGroupProps> = ({
+const ClayCardGroup = ({
 	children,
 	className,
 	label,

--- a/packages/clay-card/src/Row.tsx
+++ b/packages/clay-card/src/Row.tsx
@@ -8,9 +8,11 @@ import React from 'react';
 
 import Context from './Context';
 
-const ClayCardRow: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayCardRow = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	const {interactive} = React.useContext(Context);
 
 	const TagName = interactive ? 'span' : 'div';

--- a/packages/clay-charts/src/BillboardWrapper.tsx
+++ b/packages/clay-charts/src/BillboardWrapper.tsx
@@ -14,7 +14,7 @@ interface IProps extends ChartOptions {
 const useIsomorphicLayoutEffect =
 	typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
 
-const BillboardWrapper: React.FunctionComponent<IProps> = ({
+const BillboardWrapper = ({
 	forwardRef,
 	elementProps = {},
 	...otherProps

--- a/packages/clay-charts/src/GeoMap.tsx
+++ b/packages/clay-charts/src/GeoMap.tsx
@@ -233,7 +233,7 @@ export interface IProps {
 /**
  * GeoMap Chart component.
  */
-const Geomap: React.FunctionComponent<IProps> = ({
+const Geomap = ({
 	data,
 	elementProps = {},
 	forwardRef,

--- a/packages/clay-color-picker/src/Basic.tsx
+++ b/packages/clay-color-picker/src/Basic.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import Splotch from './Splotch';
 
-interface IProps {
+type Props = {
 	/**
 	 * List of hex's that will display as a color splotch
 	 */
@@ -22,16 +22,12 @@ interface IProps {
 	 * Callback for when a color is clicked
 	 */
 	onChange: (val: string) => void;
-}
+};
 
 /**
  * Renders basic color picker
  */
-const ClayColorPickerBasic: React.FunctionComponent<IProps> = ({
-	colors,
-	label,
-	onChange,
-}) => (
+const ClayColorPickerBasic = ({colors, label, onChange}: Props) => (
 	<>
 		{label && (
 			<div className="clay-color-header">

--- a/packages/clay-color-picker/src/GradientSelector.tsx
+++ b/packages/clay-color-picker/src/GradientSelector.tsx
@@ -9,7 +9,7 @@ import tinycolor from 'tinycolor2';
 import {usePointerPosition} from './hooks';
 import {colorToXY, xToSaturation, yToVisibility} from './util';
 
-interface IProps {
+type Props = {
 	/**
 	 * Color value that is currently selected.
 	 */
@@ -24,7 +24,7 @@ interface IProps {
 	 * Callback function for when saturation or visibility values change
 	 */
 	onChange?: (saturation: number, visibility: number) => void;
-}
+};
 
 const useIsomorphicLayoutEffect =
 	typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
@@ -32,11 +32,11 @@ const useIsomorphicLayoutEffect =
 /**
  * Renders GradientSelector component
  */
-const ClayColorPickerGradientSelector: React.FunctionComponent<IProps> = ({
+const ClayColorPickerGradientSelector = ({
 	color,
 	onChange = () => {},
 	hue = 0,
-}) => {
+}: Props) => {
 	const containerRef = React.useRef<HTMLDivElement>(null);
 	const selectorActive = React.useRef<boolean>(false);
 

--- a/packages/clay-color-picker/src/Hue.tsx
+++ b/packages/clay-color-picker/src/Hue.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import {usePointerPosition} from './hooks';
 import {hueToX, xToHue} from './util';
 
-interface IProps {
+type Props = {
 	/**
 	 * Callback function for when the hue value changes
 	 */
@@ -18,7 +18,7 @@ interface IProps {
 	 * The value of the Hue of the color
 	 */
 	value: number;
-}
+};
 
 const useIsomorphicLayoutEffect =
 	typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
@@ -26,10 +26,7 @@ const useIsomorphicLayoutEffect =
 /**
  * Renders Hue component
  */
-const ClayColorPickerHue: React.FunctionComponent<IProps> = ({
-	value = 0,
-	onChange = () => {},
-}) => {
+const ClayColorPickerHue = ({value = 0, onChange = () => {}}: Props) => {
 	const containerRef = React.useRef<HTMLDivElement>(null);
 	const selectorActive = React.useRef<boolean>(false);
 

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -177,7 +177,7 @@ interface IProps
 	value?: string;
 }
 
-const ClayColorPicker: React.FunctionComponent<IProps> = ({
+const ClayColorPicker = ({
 	active,
 	ariaLabels = DEFAULT_ARIA_LABELS,
 	colors,

--- a/packages/clay-data-provider/src/index.tsx
+++ b/packages/clay-data-provider/src/index.tsx
@@ -43,7 +43,7 @@ interface IState {
 	networkStatus?: NetworkStatus;
 }
 
-const ClayDataProvider: React.FunctionComponent<IProps> = ({
+const ClayDataProvider = ({
 	children,
 	notifyOnNetworkStatusChange = false,
 	...otherProps

--- a/packages/clay-date-picker/src/DateNavigation.tsx
+++ b/packages/clay-date-picker/src/DateNavigation.tsx
@@ -11,7 +11,7 @@ import {addMonths, range} from './Helpers';
 import Select, {ISelectOption} from './Select';
 import {IAriaLabels, IYears} from './types';
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+type Props = {
 	ariaLabels: IAriaLabels;
 	currentMonth: Date;
 	disabled?: boolean;
@@ -25,9 +25,9 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	spritemap?: string;
 
 	years: IYears;
-}
+};
 
-const ClayDatePickerDateNavigation: React.FunctionComponent<IProps> = ({
+const ClayDatePickerDateNavigation = ({
 	ariaLabels,
 	currentMonth,
 	disabled,
@@ -36,7 +36,7 @@ const ClayDatePickerDateNavigation: React.FunctionComponent<IProps> = ({
 	onMonthChange,
 	spritemap,
 	years,
-}) => {
+}: Props) => {
 	const memoizedYears: Array<ISelectOption> = React.useMemo(
 		() =>
 			range(years).map((elem) => {

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -9,21 +9,21 @@ import React from 'react';
 
 import {IDay, setDate} from './Helpers';
 
-interface IProps {
+type Props = {
 	day: IDay;
 	daysSelected: readonly [Date, Date];
 	disabled?: boolean;
 	range?: boolean;
 	onClick: (date: Date) => void;
-}
+};
 
-const ClayDatePickerDayNumber: React.FunctionComponent<IProps> = ({
+const ClayDatePickerDayNumber = ({
 	day,
 	daysSelected,
 	disabled,
 	onClick,
 	range,
-}) => {
+}: Props) => {
 	const {date, nextMonth, previousMonth} = day;
 	const [startDate, endDate] = daysSelected;
 

--- a/packages/clay-date-picker/src/DaysTable.tsx
+++ b/packages/clay-date-picker/src/DaysTable.tsx
@@ -7,20 +7,17 @@ import React from 'react';
 
 import {IDay, Month} from './Helpers';
 
-interface IChildrenFn {
+type ChildrenFunction = {
 	day: IDay;
 	key: number;
-}
+};
 
-interface IProps {
-	children: (object: IChildrenFn) => React.ReactNode;
+type Props = {
+	children: (object: ChildrenFunction) => React.ReactNode;
 	weeks: Month;
-}
+};
 
-const ClayDatePickerDaysTable: React.FunctionComponent<IProps> = ({
-	children,
-	weeks,
-}) => {
+const ClayDatePickerDaysTable = ({children, weeks}: Props) => {
 	return (
 		<>
 			{weeks.map((days, index) => (

--- a/packages/clay-date-picker/src/TimePicker.tsx
+++ b/packages/clay-date-picker/src/TimePicker.tsx
@@ -6,7 +6,7 @@
 import ClayTimePicker, {Input} from '@clayui/time-picker';
 import React from 'react';
 
-interface IProps {
+type Props = {
 	currentTime: string;
 	disabled?: boolean;
 	onTimeChange: (
@@ -22,18 +22,18 @@ interface IProps {
 
 	timezone?: string;
 	use12Hours?: boolean;
-}
+};
 
 const DEFAULT_VALUE = '--';
 
-const ClayDatePickerTimePicker: React.FunctionComponent<IProps> = ({
+const ClayDatePickerTimePicker = ({
 	currentTime,
 	disabled,
 	onTimeChange,
 	spritemap,
 	timezone,
 	use12Hours,
-}) => {
+}: Props) => {
 	const [values, setValues] = React.useState<Input>({
 		ampm: DEFAULT_VALUE,
 		hours: DEFAULT_VALUE,

--- a/packages/clay-date-picker/src/Weekday.tsx
+++ b/packages/clay-date-picker/src/Weekday.tsx
@@ -5,11 +5,11 @@
 
 import React from 'react';
 
-interface IProps {
+type Props = {
 	weekday: string;
-}
+};
 
-const ClayDatePickerWeekday: React.FunctionComponent<IProps> = ({weekday}) => (
+const ClayDatePickerWeekday = ({weekday}: Props) => (
 	<div className="date-picker-col">
 		<div className="date-picker-calendar-item date-picker-day">
 			<abbr>{weekday}</abbr>

--- a/packages/clay-date-picker/src/WeekdayHeader.tsx
+++ b/packages/clay-date-picker/src/WeekdayHeader.tsx
@@ -7,22 +7,22 @@ import React from 'react';
 
 import {FirstDayOfWeek} from './types';
 
-interface IChildrenProps {
+type ChildrenProps = {
 	key: number;
 	weekday: string;
-}
+};
 
-interface IProps {
-	children: (object: IChildrenProps) => React.ReactNode;
+type Props = {
+	children: (object: ChildrenProps) => React.ReactNode;
 	firstDayOfWeek: FirstDayOfWeek;
 	weekdaysShort: Array<string>;
-}
+};
 
-const ClayDatePickerWeekdayHeader: React.FunctionComponent<IProps> = ({
+const ClayDatePickerWeekdayHeader = ({
 	children,
 	firstDayOfWeek = 0,
 	weekdaysShort,
-}) => (
+}: Props) => (
 	<div className="date-picker-days-row date-picker-row">
 		{weekdaysShort.map((weekday, index) => {
 			return React.Children.only(

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -204,10 +204,7 @@ const normalizeTime = (date: Date) =>
 /**
  * ClayDatePicker component.
  */
-const ClayDatePicker: React.FunctionComponent<IProps> = React.forwardRef<
-	HTMLInputElement,
-	IProps
->(
+const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 	(
 		{
 			ariaLabels = {

--- a/packages/clay-drop-down/src/Action.tsx
+++ b/packages/clay-drop-down/src/Action.tsx
@@ -7,9 +7,11 @@ import ClayButton from '@clayui/button';
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayDropDownAction: React.FunctionComponent<
-	React.HTMLAttributes<HTMLButtonElement>
-> = ({children, className, ...otherProps}) => {
+const ClayDropDownAction = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLButtonElement>) => {
 	return (
 		<div className={classNames('dropdown-section', className)}>
 			<ClayButton block {...otherProps}>

--- a/packages/clay-drop-down/src/Caption.tsx
+++ b/packages/clay-drop-down/src/Caption.tsx
@@ -6,9 +6,11 @@
 import classnames from 'classnames';
 import React from 'react';
 
-const ClayDropDownCaption: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayDropDownCaption = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	return (
 		<div
 			{...otherProps}

--- a/packages/clay-drop-down/src/Divider.tsx
+++ b/packages/clay-drop-down/src/Divider.tsx
@@ -5,9 +5,7 @@
 
 import React from 'react';
 
-const ClayDropDownDivider: React.FunctionComponent<
-	React.HTMLAttributes<HTMLLIElement>
-> = () => (
+const ClayDropDownDivider = () => (
 	<li aria-hidden="true" className="dropdown-divider" role="presentation" />
 );
 

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -106,7 +106,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement | HTMLLIElement> {
 	};
 }
 
-const ClayDropDown: React.FunctionComponent<IProps> & {
+function ClayDropDown(props: IProps): JSX.Element & {
 	Action: typeof Action;
 	Caption: typeof Caption;
 	Divider: typeof Divider;
@@ -117,7 +117,9 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 	Menu: typeof Menu;
 	Search: typeof Search;
 	Section: typeof Section;
-} = ({
+};
+
+function ClayDropDown({
 	active,
 	alignmentByViewport,
 	alignmentPosition,
@@ -136,7 +138,7 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 	renderMenuOnClick = false,
 	trigger,
 	...otherProps
-}: IProps) => {
+}: IProps) {
 	const triggerElementRef = React.useRef<HTMLButtonElement | null>(null);
 	const menuElementRef = React.useRef<HTMLDivElement>(null);
 
@@ -229,7 +231,7 @@ const ClayDropDown: React.FunctionComponent<IProps> & {
 			</ContainerElement>
 		</FocusScope>
 	);
-};
+}
 
 ClayDropDown.Action = Action;
 ClayDropDown.Caption = Caption;

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -105,7 +105,7 @@ type History = {
 	title: string;
 };
 
-export const ClayDropDownWithDrilldown: React.FunctionComponent<IProps> = ({
+export const ClayDropDownWithDrilldown = ({
 	active,
 	alignmentByViewport,
 	alignmentPosition,

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -195,11 +195,11 @@ interface IInternalItem {
 	spritemap?: string;
 }
 
-const Checkbox: React.FunctionComponent<IItem & IInternalItem> = ({
+const Checkbox = ({
 	checked = false,
 	onChange = () => {},
 	...otherProps
-}) => {
+}: IItem & IInternalItem) => {
 	const [value, setValue] = useState<boolean>(checked);
 
 	return (
@@ -218,40 +218,42 @@ const Checkbox: React.FunctionComponent<IItem & IInternalItem> = ({
 
 const ClayDropDownContext = React.createContext({close: () => {}});
 
-const Item: React.FunctionComponent<Omit<IItem, 'onChange'> & IInternalItem> =
-	({label, onClick, ...props}) => {
-		const {close} = useContext(ClayDropDownContext);
-
-		return (
-			<ClayDropDown.Item
-				onClick={(event) => {
-					if (onClick) {
-						onClick(event);
-					}
-
-					close();
-				}}
-				{...props}
-			>
-				{label}
-			</ClayDropDown.Item>
-		);
-	};
-
-const Group: React.FunctionComponent<IItem & IInternalItem> = ({
-	items,
+const Item = ({
 	label,
-	spritemap,
-}) => (
+	onClick,
+	...props
+}: Omit<IItem, 'onChange'> & IInternalItem) => {
+	const {close} = useContext(ClayDropDownContext);
+
+	return (
+		<ClayDropDown.Item
+			onClick={(event) => {
+				if (onClick) {
+					onClick(event);
+				}
+
+				close();
+			}}
+			{...props}
+		>
+			{label}
+		</ClayDropDown.Item>
+	);
+};
+
+const Group = ({items, label, spritemap}: IItem & IInternalItem) => (
 	<>
 		<ClayDropDownGroup header={label} />
 		{items && <DropDownContent items={items} spritemap={spritemap} />}
 	</>
 );
 
-const Contextual: React.FunctionComponent<
-	Omit<IItem, 'onChange'> & IInternalItem
-> = ({items, label, spritemap, ...otherProps}) => {
+const Contextual = ({
+	items,
+	label,
+	spritemap,
+	...otherProps
+}: Omit<IItem, 'onChange'> & IInternalItem) => {
 	const [visible, setVisible] = useState(false);
 	const {close} = useContext(ClayDropDownContext);
 
@@ -334,10 +336,7 @@ interface IRadioContext {
 
 const RadioGroupContext = React.createContext({} as IRadioContext);
 
-const Radio: React.FunctionComponent<IItem & IInternalItem> = ({
-	value = '',
-	...otherProps
-}) => {
+const Radio = ({value = '', ...otherProps}: IItem & IInternalItem) => {
 	const {checked, name, onChange} = useContext(RadioGroupContext);
 
 	return (
@@ -354,14 +353,14 @@ const Radio: React.FunctionComponent<IItem & IInternalItem> = ({
 	);
 };
 
-const RadioGroup: React.FunctionComponent<IItem & IInternalItem> = ({
+const RadioGroup = ({
 	items,
 	label,
 	name,
 	onChange = () => {},
 	spritemap,
 	value: defaultValue = '',
-}) => {
+}: IItem & IInternalItem) => {
 	const [value, setValue] = useState(defaultValue);
 
 	const params = {
@@ -404,10 +403,7 @@ const TYPE_MAP = {
 	radiogroup: RadioGroup,
 };
 
-const DropDownContent: React.FunctionComponent<IDropDownContentProps> = ({
-	items,
-	spritemap,
-}) => (
+const DropDownContent = ({items, spritemap}: IDropDownContentProps) => (
 	<ClayDropDown.ItemList>
 		{items.map(({type, ...item}, key) => {
 			const Item = TYPE_MAP[type || 'item'];
@@ -417,7 +413,7 @@ const DropDownContent: React.FunctionComponent<IDropDownContentProps> = ({
 	</ClayDropDown.ItemList>
 );
 
-export const ClayDropDownWithItems: React.FunctionComponent<IProps> = ({
+export const ClayDropDownWithItems = ({
 	active,
 	alignmentByViewport,
 	alignmentPosition,

--- a/packages/clay-drop-down/src/Group.tsx
+++ b/packages/clay-drop-down/src/Group.tsx
@@ -5,17 +5,19 @@
 
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+type Props = {
+	/**
+	 * Group content.
+	 */
+	children?: React.ReactNode;
+
 	/**
 	 * Value provided is a display component that is a header for the items in the group.
 	 */
 	header?: string;
-}
+};
 
-const ClayDropDownGroup: React.FunctionComponent<IProps> = ({
-	children,
-	header,
-}: IProps) => {
+const ClayDropDownGroup = ({children, header}: Props) => {
 	return (
 		<>
 			{header && (

--- a/packages/clay-drop-down/src/Help.tsx
+++ b/packages/clay-drop-down/src/Help.tsx
@@ -6,9 +6,11 @@
 import classnames from 'classnames';
 import React from 'react';
 
-const ClayDropDownHelp: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayDropDownHelp = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	return (
 		<div
 			{...otherProps}

--- a/packages/clay-drop-down/src/ItemList.tsx
+++ b/packages/clay-drop-down/src/ItemList.tsx
@@ -6,9 +6,11 @@
 import classnames from 'classnames';
 import React from 'react';
 
-const ClayDropDownItemList: React.FunctionComponent<
-	React.HTMLAttributes<HTMLUListElement>
-> = ({children, className, ...otherProps}) => {
+const ClayDropDownItemList = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLUListElement>) => {
 	return (
 		<ul {...otherProps} className={classnames('list-unstyled', className)}>
 			{children}

--- a/packages/clay-drop-down/src/Search.tsx
+++ b/packages/clay-drop-down/src/Search.tsx
@@ -33,7 +33,7 @@ interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 
 const defaultOnSubmit = (event: React.SyntheticEvent) => event.preventDefault();
 
-const ClayDropDownSearch: React.FunctionComponent<IProps> = ({
+const ClayDropDownSearch = ({
 	className,
 	formProps = {},
 	spritemap,

--- a/packages/clay-drop-down/src/__tests__/index.tsx
+++ b/packages/clay-drop-down/src/__tests__/index.tsx
@@ -9,10 +9,7 @@ import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 
-const DropDownWithState: React.FunctionComponent<any> = ({
-	children,
-	...others
-}) => {
+const DropDownWithState = ({children, ...others}: any) => {
 	const [active, setActive] = React.useState(false);
 
 	return (

--- a/packages/clay-drop-down/src/drilldown/Menu.tsx
+++ b/packages/clay-drop-down/src/drilldown/Menu.tsx
@@ -32,7 +32,7 @@ export interface IProps {
 	spritemap?: string;
 }
 
-const DrilldownMenu: React.FunctionComponent<IProps> = ({
+const DrilldownMenu = ({
 	active,
 	direction,
 	header,
@@ -40,7 +40,7 @@ const DrilldownMenu: React.FunctionComponent<IProps> = ({
 	onBack,
 	onForward,
 	spritemap,
-}) => {
+}: IProps) => {
 	const initialClasses = classNames('transitioning', {
 		'drilldown-prev-initial': direction === 'prev',
 	});

--- a/packages/clay-drop-down/src/drilldown/index.tsx
+++ b/packages/clay-drop-down/src/drilldown/index.tsx
@@ -8,11 +8,11 @@ import React from 'react';
 
 import Menu from './Menu';
 
-const Inner: React.FunctionComponent<React.HTMLAttributes<HTMLDivElement>> = ({
+const Inner = ({
 	children,
 	className,
 	...otherProps
-}) => (
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<div className={classNames(className, 'drilldown-inner')} {...otherProps}>
 		{children}
 	</div>

--- a/packages/clay-empty-state/src/index.tsx
+++ b/packages/clay-empty-state/src/index.tsx
@@ -33,7 +33,7 @@ interface IProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
 	title?: string | null;
 }
 
-const ClayEmptyState: React.FunctionComponent<IProps> = ({
+const ClayEmptyState = ({
 	children,
 	className,
 	description = 'Sorry, there are no results found',

--- a/packages/clay-form/src/DualListBox.tsx
+++ b/packages/clay-form/src/DualListBox.tsx
@@ -101,7 +101,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	spritemap?: string;
 }
 
-const ClayDualListBox: React.FunctionComponent<IProps> = ({
+const ClayDualListBox = ({
 	ariaLabels = {
 		transferLTR: 'Transfer Item Left to Right',
 		transferRTL: 'Transfer Item Right to Left',

--- a/packages/clay-form/src/RadioGroup.tsx
+++ b/packages/clay-form/src/RadioGroup.tsx
@@ -58,7 +58,7 @@ interface IGroupProps
 	value?: React.ReactText;
 }
 
-const ClayRadioGroup: React.FunctionComponent<IGroupProps> = ({
+const ClayRadioGroup = ({
 	children,
 	className,
 	defaultValue,

--- a/packages/clay-form/src/Select.tsx
+++ b/packages/clay-form/src/Select.tsx
@@ -6,15 +6,19 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const OptGroup: React.FunctionComponent<
-	React.OptgroupHTMLAttributes<HTMLOptGroupElement>
-> = ({children, ...otherProps}) => (
+const OptGroup = ({
+	children,
+	...otherProps
+}: React.OptgroupHTMLAttributes<HTMLOptGroupElement>) => (
 	<optgroup {...otherProps}>{children}</optgroup>
 );
 
-const Option: React.FunctionComponent<
-	React.OptionHTMLAttributes<HTMLOptionElement>
-> = ({label, ...otherProps}) => <option {...otherProps}>{label}</option>;
+const Option = ({
+	label,
+	...otherProps
+}: React.OptionHTMLAttributes<HTMLOptionElement>) => (
+	<option {...otherProps}>{label}</option>
+);
 
 interface IProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
 	/**
@@ -23,19 +27,23 @@ interface IProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
 	sizing?: 'lg' | 'sm';
 }
 
-const ClaySelect: React.FunctionComponent<IProps> & {
+function ClaySelect(props: IProps): JSX.Element & {
 	OptGroup: typeof OptGroup;
 	Option: typeof Option;
-} = ({children, className, sizing, ...otherProps}: IProps) => (
-	<select
-		{...otherProps}
-		className={classNames('form-control', className, {
-			[`form-control-${sizing}`]: sizing,
-		})}
-	>
-		{children}
-	</select>
-);
+};
+
+function ClaySelect({children, className, sizing, ...otherProps}: IProps) {
+	return (
+		<select
+			{...otherProps}
+			className={classNames('form-control', className, {
+				[`form-control-${sizing}`]: sizing,
+			})}
+		>
+			{children}
+		</select>
+	);
+}
 
 ClaySelect.OptGroup = OptGroup;
 ClaySelect.Option = Option;

--- a/packages/clay-form/src/SelectBox.tsx
+++ b/packages/clay-form/src/SelectBox.tsx
@@ -130,7 +130,7 @@ export const getSelectedIndexes = (
 		return acc;
 	}, []);
 
-const ClaySelectBox: React.FunctionComponent<IProps> = ({
+const ClaySelectBox = ({
 	ariaLabels = {
 		reorderDown: 'Reorder Down',
 		reorderUp: 'Reorder Up',

--- a/packages/clay-form/src/SelectWithOption.tsx
+++ b/packages/clay-form/src/SelectWithOption.tsx
@@ -22,10 +22,7 @@ interface IProps extends React.ComponentProps<typeof Select> {
 	>;
 }
 
-const ClaySelectWithOption: React.FunctionComponent<IProps> = ({
-	options = [],
-	...otherProps
-}: IProps) => (
+const ClaySelectWithOption = ({options = [], ...otherProps}: IProps) => (
 	<Select {...otherProps}>
 		{options.map((option, index) => {
 			if (option.type === 'group') {

--- a/packages/clay-layout/src/index.tsx
+++ b/packages/clay-layout/src/index.tsx
@@ -26,7 +26,7 @@ export {
 	SheetSection,
 };
 
-const ClayLayout: React.FunctionComponent<{}> & {
+function ClayLayout(): null & {
 	Col: typeof Col;
 	Container: typeof Container;
 	ContainerFluid: typeof ContainerFluid;
@@ -38,14 +38,16 @@ const ClayLayout: React.FunctionComponent<{}> & {
 	SheetFooter: typeof SheetFooter;
 	SheetHeader: typeof SheetHeader;
 	SheetSection: typeof SheetSection;
-} = () => {
+};
+
+function ClayLayout() {
 	warning(
 		true,
 		`ClayLayout is a no-op and is not expected to be used by itself. Try using one of the many namespaced components like '<ClayLayout.ContainerFluid>'`
 	);
 
 	return null;
-};
+}
 
 ClayLayout.Col = Col;
 ClayLayout.Container = Container;

--- a/packages/clay-link/src/__tests__/index.tsx
+++ b/packages/clay-link/src/__tests__/index.tsx
@@ -72,10 +72,7 @@ describe('ClayLink', () => {
 	});
 
 	it('uses custom link component via context', () => {
-		const BoldLink: React.FunctionComponent<any> = ({
-			children,
-			...otherProps
-		}) => (
+		const BoldLink = ({children, ...otherProps}: any) => (
 			<a {...otherProps}>
 				<strong>{children}</strong>
 			</a>

--- a/packages/clay-link/stories/Link.stories.tsx
+++ b/packages/clay-link/stories/Link.stories.tsx
@@ -120,10 +120,7 @@ export const Monospaced = () => (
 );
 
 export const CustomLinkComponent = () => {
-	const ConfirmLink: React.FunctionComponent<any> = ({
-		children,
-		...otherProps
-	}) => (
+	const ConfirmLink = ({children, ...otherProps}: any) => (
 		<a
 			{...otherProps}
 			onClick={(event) => {

--- a/packages/clay-list/src/List.tsx
+++ b/packages/clay-list/src/List.tsx
@@ -28,19 +28,21 @@ interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 
 const CLAY_REGEX = /Clay(?!ListItem|ListHeader).+/;
 
-const ClayList: React.FunctionComponent<IProps> & {
+function ClayList(props: IProps): JSX.Element & {
 	Header: typeof Header;
 	Item: typeof Item;
 	ItemField: typeof ClayLayout.ContentCol;
 	ItemText: typeof ItemText;
 	ItemTitle: typeof ItemTitle;
 	QuickActionMenu: typeof QuickActionMenu;
-} = ({
+};
+
+function ClayList({
 	children,
 	className,
 	showQuickActionsOnHover = true,
 	...otherProps
-}: IProps) => {
+}: IProps) {
 	return (
 		<ul
 			{...otherProps}
@@ -69,7 +71,7 @@ const ClayList: React.FunctionComponent<IProps> & {
 				})}
 		</ul>
 	);
-};
+}
 
 ClayList.displayName = 'ClayList';
 

--- a/packages/clay-list/src/ListWithItems.tsx
+++ b/packages/clay-list/src/ListWithItems.tsx
@@ -104,13 +104,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	spritemap?: string;
 }
 
-const ListItem: React.FunctionComponent<
-	IListItem & {
-		selected?: boolean;
-		onSelectChange?: any;
-		spritemap?: string;
-	}
-> = ({
+const ListItem = ({
 	description,
 	dropDownTriggerProps,
 	dropdownActions,
@@ -121,6 +115,10 @@ const ListItem: React.FunctionComponent<
 	selected = false,
 	spritemap,
 	title,
+}: IListItem & {
+	selected?: boolean;
+	onSelectChange?: any;
+	spritemap?: string;
 }) => {
 	return (
 		<ClayList.Item active={selected} flex>
@@ -195,7 +193,7 @@ const ListItem: React.FunctionComponent<
 	);
 };
 
-export const ClayListWithItems: React.FunctionComponent<IProps> = ({
+export const ClayListWithItems = ({
 	className,
 	itemIdentifier = 'id',
 	items = [],

--- a/packages/clay-management-toolbar/src/Item.tsx
+++ b/packages/clay-management-toolbar/src/Item.tsx
@@ -6,11 +6,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const Item: React.FunctionComponent<React.HTMLAttributes<HTMLLIElement>> = ({
+const Item = ({
 	children,
 	className,
 	...otherProps
-}) => (
+}: React.HTMLAttributes<HTMLLIElement>) => (
 	<li {...otherProps} className={classNames('nav-item', className)}>
 		{children}
 	</li>

--- a/packages/clay-management-toolbar/src/ItemList.tsx
+++ b/packages/clay-management-toolbar/src/ItemList.tsx
@@ -13,10 +13,7 @@ interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	expand?: boolean;
 }
 
-const ItemList: React.FunctionComponent<IProps> = ({
-	children,
-	expand,
-}: IProps) => (
+const ItemList = ({children, expand}: IProps) => (
 	<ul
 		className={classNames('navbar-nav', {
 			'navbar-nav-expand': expand,

--- a/packages/clay-management-toolbar/src/ManagementToolbar.tsx
+++ b/packages/clay-management-toolbar/src/ManagementToolbar.tsx
@@ -18,25 +18,34 @@ interface IProps extends React.HTMLAttributes<HTMLElement> {
 	active?: boolean;
 }
 
-const ClayManagementToolbar: React.FunctionComponent<IProps> & {
+function ClayManagementToolbar(props: IProps): JSX.Element & {
 	Item: typeof Item;
 	ItemList: typeof ItemList;
 	Search: typeof Search;
-} = ({active = false, children, className, ...otherProps}: IProps) => (
-	<nav
-		{...otherProps}
-		className={classNames(
-			'management-bar navbar navbar-expand-md',
-			className,
-			{
-				'management-bar-light': !active,
-				'management-bar-primary navbar-nowrap': active,
-			}
-		)}
-	>
-		<ClayLayout.ContainerFluid>{children}</ClayLayout.ContainerFluid>
-	</nav>
-);
+};
+
+function ClayManagementToolbar({
+	active = false,
+	children,
+	className,
+	...otherProps
+}: IProps) {
+	return (
+		<nav
+			{...otherProps}
+			className={classNames(
+				'management-bar navbar navbar-expand-md',
+				className,
+				{
+					'management-bar-light': !active,
+					'management-bar-primary navbar-nowrap': active,
+				}
+			)}
+		>
+			<ClayLayout.ContainerFluid>{children}</ClayLayout.ContainerFluid>
+		</nav>
+	);
+}
 
 ClayManagementToolbar.Item = Item;
 ClayManagementToolbar.ItemList = ItemList;

--- a/packages/clay-management-toolbar/src/ResultsBar.tsx
+++ b/packages/clay-management-toolbar/src/ResultsBar.tsx
@@ -8,20 +8,27 @@ import React from 'react';
 
 import ResultsBarItem from './ResultsBarItem';
 
-const ClayResultsBar: React.FunctionComponent<
-	React.HTMLAttributes<HTMLElement>
-> & {
+function ClayResultsBar(
+	props: React.HTMLAttributes<HTMLElement>
+): JSX.Element & {
 	Item: typeof ResultsBarItem;
-} = ({children, ...otherProps}) => (
-	<nav
-		{...otherProps}
-		className="subnav-tbar subnav-tbar-primary tbar tbar-inline-xs-down"
-	>
-		<ClayLayout.ContainerFluid>
-			<ul className="tbar-nav tbar-nav-wrap">{children}</ul>
-		</ClayLayout.ContainerFluid>
-	</nav>
-);
+};
+
+function ClayResultsBar({
+	children,
+	...otherProps
+}: React.HTMLAttributes<HTMLElement>) {
+	return (
+		<nav
+			{...otherProps}
+			className="subnav-tbar subnav-tbar-primary tbar tbar-inline-xs-down"
+		>
+			<ClayLayout.ContainerFluid>
+				<ul className="tbar-nav tbar-nav-wrap">{children}</ul>
+			</ClayLayout.ContainerFluid>
+		</nav>
+	);
+}
 
 ClayResultsBar.Item = ResultsBarItem;
 

--- a/packages/clay-management-toolbar/src/ResultsBarItem.tsx
+++ b/packages/clay-management-toolbar/src/ResultsBarItem.tsx
@@ -13,7 +13,7 @@ interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	expand?: boolean;
 }
 
-const ResultsBarItem: React.FunctionComponent<IProps> = ({
+const ResultsBarItem = ({
 	children,
 	className,
 	expand = false,

--- a/packages/clay-management-toolbar/src/Search.tsx
+++ b/packages/clay-management-toolbar/src/Search.tsx
@@ -20,12 +20,7 @@ interface IProps extends React.FormHTMLAttributes<HTMLFormElement> {
 	showMobile?: boolean;
 }
 
-const Search: React.FunctionComponent<IProps> = ({
-	children,
-	onlySearch,
-	showMobile,
-	...otherProps
-}: IProps) => {
+const Search = ({children, onlySearch, showMobile, ...otherProps}: IProps) => {
 	const content = (
 		<form {...otherProps} role="search">
 			{children}

--- a/packages/clay-modal/src/Body.tsx
+++ b/packages/clay-modal/src/Body.tsx
@@ -23,7 +23,7 @@ export interface IBodyProps extends React.HTMLAttributes<HTMLDivElement> {
 	url?: string;
 }
 
-const ClayModalBody: React.FunctionComponent<IBodyProps> = ({
+const ClayModalBody = ({
 	children,
 	className,
 	iFrameProps = {},

--- a/packages/clay-modal/src/Footer.tsx
+++ b/packages/clay-modal/src/Footer.tsx
@@ -26,7 +26,7 @@ export interface IFooterProps extends React.HTMLAttributes<HTMLDivElement> {
 	middle?: React.ReactElement;
 }
 
-const ClayModalFooter: React.FunctionComponent<IFooterProps> = ({
+const ClayModalFooter = ({
 	className,
 	first,
 	last,

--- a/packages/clay-modal/src/Header.tsx
+++ b/packages/clay-modal/src/Header.tsx
@@ -10,9 +10,11 @@ import React from 'react';
 
 import Context, {IContext} from './Context';
 
-export const ItemGroup: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => (
+export const ItemGroup = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<div className={classNames('modal-item-group', className)} {...otherProps}>
 		{children}
 	</div>
@@ -25,7 +27,7 @@ export interface IItemProps extends React.HTMLAttributes<HTMLDivElement> {
 	shrink?: boolean;
 }
 
-export const Item: React.FunctionComponent<IItemProps> = ({
+export const Item = ({
 	children,
 	className,
 	shrink,
@@ -41,9 +43,11 @@ export const Item: React.FunctionComponent<IItemProps> = ({
 	</div>
 );
 
-export const TitleSection: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => (
+export const TitleSection = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
 		className={classNames('modal-title-section', className)}
 		{...otherProps}
@@ -52,9 +56,11 @@ export const TitleSection: React.FunctionComponent<
 	</div>
 );
 
-export const Title: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+export const Title = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	const {ariaLabelledby} = React.useContext(Context);
 
 	return (
@@ -68,9 +74,11 @@ export const Title: React.FunctionComponent<
 	);
 };
 
-export const TitleIndicator: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => (
+export const TitleIndicator = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
 		className={classNames('modal-title-indicator', className)}
 		{...otherProps}
@@ -79,9 +87,11 @@ export const TitleIndicator: React.FunctionComponent<
 	</div>
 );
 
-export const SubtitleSection: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => (
+export const SubtitleSection = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<div
 		className={classNames('modal-subtitle-section', className)}
 		{...otherProps}
@@ -90,9 +100,11 @@ export const SubtitleSection: React.FunctionComponent<
 	</div>
 );
 
-export const Subtitle: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => (
+export const Subtitle = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<div className={classNames('modal-subtitle', className)} {...otherProps}>
 		{children}
 	</div>
@@ -105,12 +117,12 @@ const ICON_MAP = {
 	warning: 'warning-full',
 };
 
-const HighLevel: React.FunctionComponent<IContext> = ({
+const HighLevel = ({
 	children,
 	onClose,
 	spritemap,
 	status,
-}) => (
+}: IContext & {children?: React.ReactNode}) => (
 	<>
 		<Title>
 			{status && (
@@ -132,9 +144,11 @@ const HighLevel: React.FunctionComponent<IContext> = ({
 	</>
 );
 
-const ClayModalHeader: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => (
+const ClayModalHeader = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<div className={classNames('modal-header', className)} {...otherProps}>
 		{children}
 	</div>
@@ -148,7 +162,7 @@ export interface IHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
 	withTitle?: boolean;
 }
 
-const ClayModalHeaderHybrid: React.FunctionComponent<IHeaderProps> = ({
+const ClayModalHeaderHybrid = ({
 	children,
 	withTitle = true,
 	...otherProps

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -78,7 +78,7 @@ const warningMessage = `You need to pass the 'observer' prop to ClayModal for ev
 
 let counter = 0;
 
-const ClayModal: React.FunctionComponent<IProps> = ({
+const ClayModal = ({
 	center,
 	children,
 	className,

--- a/packages/clay-modal/src/Provider.tsx
+++ b/packages/clay-modal/src/Provider.tsx
@@ -94,10 +94,7 @@ const reducer = (
 
 const Context = React.createContext<TProvider>([initialState, () => {}]);
 
-const ClayModalProvider: React.FunctionComponent<IProps> = ({
-	children,
-	spritemap,
-}) => {
+const ClayModalProvider = ({children, spritemap}: IProps) => {
 	const [{visible, ...otherState}, dispatch] = React.useReducer(
 		reducer,
 		initialState

--- a/packages/clay-modal/src/Subtitle.tsx
+++ b/packages/clay-modal/src/Subtitle.tsx
@@ -6,9 +6,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayModalItemGroup: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => (
+const ClayModalItemGroup = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
 	<div className={classNames('modal-subtitle', className)} {...otherProps}>
 		{children}
 	</div>

--- a/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-modal/src/__tests__/IncrementalInteractions.tsx
@@ -18,11 +18,11 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	children?: any;
 }
 
-const ModalWithState: React.FunctionComponent<IProps> = ({
+const ModalWithState = ({
 	children,
 	initialVisible = false,
 	...props
-}) => {
+}: IProps) => {
 	const [visible, setVisible] = React.useState(initialVisible);
 	const {observer} = useModal({onClose: () => setVisible(false)});
 

--- a/packages/clay-modal/stories/Modal.stories.tsx
+++ b/packages/clay-modal/stories/Modal.stories.tsx
@@ -289,7 +289,7 @@ export const AutocompleteAndDropDown = () => {
 	);
 };
 
-const MyApp: React.FunctionComponent<any> = () => {
+const MyApp = () => {
 	const [state, dispatch] = useContext(Context);
 
 	return (
@@ -318,7 +318,7 @@ const MyApp: React.FunctionComponent<any> = () => {
 	);
 };
 
-const MyAppWithoutFooterAndHeader: React.FunctionComponent<any> = () => {
+const MyAppWithoutFooterAndHeader = () => {
 	const [, dispatch] = useContext(Context);
 
 	return (

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -61,7 +61,7 @@ interface IMenuRendererProps {
 	value: string;
 }
 
-type MenuRenderer = React.FunctionComponent<IMenuRendererProps>;
+type MenuRenderer = (props: IMenuRendererProps) => JSX.Element;
 
 export interface IProps
 	extends Omit<React.HTMLAttributes<HTMLInputElement>, 'onChange'> {

--- a/packages/clay-multi-step-nav/src/Divider.tsx
+++ b/packages/clay-multi-step-nav/src/Divider.tsx
@@ -5,8 +5,6 @@
 
 import React from 'react';
 
-const ClayMultiStepNavDivider: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = () => <div className="multi-step-divider" />;
+const ClayMultiStepNavDivider = () => <div className="multi-step-divider" />;
 
 export default ClayMultiStepNavDivider;

--- a/packages/clay-multi-step-nav/src/Indicator.tsx
+++ b/packages/clay-multi-step-nav/src/Indicator.tsx
@@ -6,7 +6,7 @@
 import ClayIcon from '@clayui/icon';
 import React from 'react';
 
-interface IProps {
+type Props = {
 	/**
 	 * Flag to indicate if step should show its been completed
 	 */
@@ -33,13 +33,10 @@ interface IProps {
 	 * Value to display below step icon
 	 */
 	subTitle?: React.ReactText;
-}
+};
 
-const ClayMultiStepNavIndicator = React.forwardRef<HTMLDivElement, IProps>(
-	(
-		{complete, innerRef, label, onClick, spritemap, subTitle}: IProps,
-		ref
-	) => (
+const ClayMultiStepNavIndicator = React.forwardRef<HTMLDivElement, Props>(
+	({complete, innerRef, label, onClick, spritemap, subTitle}: Props, ref) => (
 		<div className="multi-step-indicator" ref={ref}>
 			{subTitle && (
 				<div className="multi-step-indicator-label">{subTitle}</div>

--- a/packages/clay-multi-step-nav/src/Item.tsx
+++ b/packages/clay-multi-step-nav/src/Item.tsx
@@ -28,7 +28,7 @@ interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	expand?: boolean;
 }
 
-const ClayMultiStepNavItem: React.FunctionComponent<IProps> = ({
+const ClayMultiStepNavItem = ({
 	active,
 	children,
 	className,

--- a/packages/clay-multi-step-nav/src/MultiStepNav.tsx
+++ b/packages/clay-multi-step-nav/src/MultiStepNav.tsx
@@ -28,19 +28,21 @@ interface IProps extends React.HTMLAttributes<HTMLOListElement> {
 	indicatorLabel?: 'bottom' | 'top';
 }
 
-const ClayMultiStepNav: React.FunctionComponent<IProps> & {
+function ClayMultiStepNav(props: IProps): JSX.Element & {
 	Divider: typeof ClayMultiStepNavDivider;
 	Indicator: typeof ClayMultiStepNavIndicator;
 	Item: typeof ClayMultiStepNavItem;
 	Title: typeof ClayMultiStepNavTitle;
-} = ({
+};
+
+function ClayMultiStepNav({
 	autoCollapse = true,
 	children,
 	className,
 	fixedWidth,
 	indicatorLabel = 'bottom',
 	...otherProps
-}: IProps) => {
+}: IProps) {
 	return (
 		<ol
 			className={classNames('multi-step-nav', className, {
@@ -54,7 +56,7 @@ const ClayMultiStepNav: React.FunctionComponent<IProps> & {
 			{children}
 		</ol>
 	);
-};
+}
 
 ClayMultiStepNav.Divider = ClayMultiStepNavDivider;
 ClayMultiStepNav.Indicator = ClayMultiStepNavIndicator;

--- a/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
+++ b/packages/clay-multi-step-nav/src/MultiStepNavWithBasicItems.tsx
@@ -81,120 +81,114 @@ const IndicatorWithInnerRef = React.forwardRef<HTMLButtonElement, any>(
 
 IndicatorWithInnerRef.displayName = 'ClayIndicatorWithInnerRef';
 
-export const ClayMultiStepNavWithBasicItems: React.FunctionComponent<IProps> =
-	({
-		active,
-		activeIndex,
-		defaultActive,
-		maxStepsShown = MAX_STEPS_SHOWN,
-		onActiveChange,
-		onIndexChange,
-		spritemap,
-		steps,
-		...otherProps
-	}: IProps) => {
-		const [internalActive, setActive] = useInternalState({
-			defaultName: 'defaultActive',
-			defaultValue: defaultActive,
-			handleName: 'onActiveChange',
-			name: 'value',
-			onChange: onActiveChange ?? onIndexChange,
-			value: typeof active === 'undefined' ? activeIndex : active,
-		});
+export const ClayMultiStepNavWithBasicItems = ({
+	active,
+	activeIndex,
+	defaultActive,
+	maxStepsShown = MAX_STEPS_SHOWN,
+	onActiveChange,
+	onIndexChange,
+	spritemap,
+	steps,
+	...otherProps
+}: IProps) => {
+	const [internalActive, setActive] = useInternalState({
+		defaultName: 'defaultActive',
+		defaultValue: defaultActive,
+		handleName: 'onActiveChange',
+		name: 'value',
+		onChange: onActiveChange ?? onIndexChange,
+		value: typeof active === 'undefined' ? activeIndex : active,
+	});
 
-		let dropdownItems;
-		let showSteps = steps;
-		const indexEnd = steps.length - 1;
+	let dropdownItems;
+	let showSteps = steps;
+	const indexEnd = steps.length - 1;
 
-		const lastStep = steps[indexEnd];
+	const lastStep = steps[indexEnd];
 
-		if (steps.length > maxStepsShown) {
-			const indexBeforeDropdown = maxStepsShown - 1;
+	if (steps.length > maxStepsShown) {
+		const indexBeforeDropdown = maxStepsShown - 1;
 
-			dropdownItems = steps
-				.slice(indexBeforeDropdown, indexEnd)
-				.map((step, i) => {
-					const index = indexBeforeDropdown + i;
+		dropdownItems = steps
+			.slice(indexBeforeDropdown, indexEnd)
+			.map((step, i) => {
+				const index = indexBeforeDropdown + i;
 
-					return {
-						active: internalActive === index,
-						label: `${index + 1}. ${step.title}`,
-						onClick: () => setActive(index),
-						symbolRight:
-							internalActive > index ? 'check' : undefined,
-					};
-				});
+				return {
+					active: internalActive === index,
+					label: `${index + 1}. ${step.title}`,
+					onClick: () => setActive(index),
+					symbolRight: internalActive > index ? 'check' : undefined,
+				};
+			});
 
-			showSteps = steps.slice(0, indexBeforeDropdown);
-		}
+		showSteps = steps.slice(0, indexBeforeDropdown);
+	}
 
-		const activeInDropDown =
-			internalActive > showSteps.length - 1 && internalActive < indexEnd;
+	const activeInDropDown =
+		internalActive > showSteps.length - 1 && internalActive < indexEnd;
 
-		return (
-			<ClayMultiStepNav {...otherProps}>
-				{showSteps.map(({subTitle, title}, i: number) => {
-					const complete = internalActive > i;
+	return (
+		<ClayMultiStepNav {...otherProps}>
+			{showSteps.map(({subTitle, title}, i: number) => {
+				const complete = internalActive > i;
 
-					return (
-						<ClayMultiStepNav.Item
-							active={internalActive === i}
+				return (
+					<ClayMultiStepNav.Item
+						active={internalActive === i}
+						complete={complete}
+						expand={i + 1 !== steps.length}
+						key={i}
+					>
+						<ClayMultiStepNav.Title>{title}</ClayMultiStepNav.Title>
+						<ClayMultiStepNav.Divider />
+						<ClayMultiStepNav.Indicator
 							complete={complete}
-							expand={i + 1 !== steps.length}
-							key={i}
-						>
-							<ClayMultiStepNav.Title>
-								{title}
-							</ClayMultiStepNav.Title>
-							<ClayMultiStepNav.Divider />
-							<ClayMultiStepNav.Indicator
-								complete={complete}
-								label={1 + i}
-								onClick={() => setActive(i)}
-								spritemap={spritemap}
-								subTitle={subTitle}
-							/>
-						</ClayMultiStepNav.Item>
-					);
-				})}
+							label={1 + i}
+							onClick={() => setActive(i)}
+							spritemap={spritemap}
+							subTitle={subTitle}
+						/>
+					</ClayMultiStepNav.Item>
+				);
+			})}
 
-				{dropdownItems && (
-					<>
-						<ClayMultiStepNav.Item
-							active={activeInDropDown}
-							complete={internalActive === indexEnd}
-							expand
-						>
-							<ClayMultiStepNav.Title>
-								{activeInDropDown
-									? steps[internalActive].title
-									: steps[showSteps.length].title}
-							</ClayMultiStepNav.Title>
-							<ClayMultiStepNav.Divider />
+			{dropdownItems && (
+				<>
+					<ClayMultiStepNav.Item
+						active={activeInDropDown}
+						complete={internalActive === indexEnd}
+						expand
+					>
+						<ClayMultiStepNav.Title>
+							{activeInDropDown
+								? steps[internalActive].title
+								: steps[showSteps.length].title}
+						</ClayMultiStepNav.Title>
+						<ClayMultiStepNav.Divider />
 
-							<ClayDropDownWithItems
-								items={dropdownItems}
-								spritemap={spritemap}
-								trigger={<IndicatorWithInnerRef />}
-							/>
-						</ClayMultiStepNav.Item>
+						<ClayDropDownWithItems
+							items={dropdownItems}
+							spritemap={spritemap}
+							trigger={<IndicatorWithInnerRef />}
+						/>
+					</ClayMultiStepNav.Item>
 
-						<ClayMultiStepNav.Item
-							active={internalActive === indexEnd}
-						>
-							<ClayMultiStepNav.Title>
-								{lastStep.title}
-							</ClayMultiStepNav.Title>
-							<ClayMultiStepNav.Divider />
-							<ClayMultiStepNav.Indicator
-								label={steps.length}
-								onClick={() => setActive(indexEnd)}
-								spritemap={spritemap}
-								subTitle={lastStep.subTitle}
-							/>
-						</ClayMultiStepNav.Item>
-					</>
-				)}
-			</ClayMultiStepNav>
-		);
-	};
+					<ClayMultiStepNav.Item active={internalActive === indexEnd}>
+						<ClayMultiStepNav.Title>
+							{lastStep.title}
+						</ClayMultiStepNav.Title>
+						<ClayMultiStepNav.Divider />
+						<ClayMultiStepNav.Indicator
+							label={steps.length}
+							onClick={() => setActive(indexEnd)}
+							spritemap={spritemap}
+							subTitle={lastStep.subTitle}
+						/>
+					</ClayMultiStepNav.Item>
+				</>
+			)}
+		</ClayMultiStepNav>
+	);
+};

--- a/packages/clay-multi-step-nav/src/Title.tsx
+++ b/packages/clay-multi-step-nav/src/Title.tsx
@@ -5,8 +5,15 @@
 
 import React from 'react';
 
-const ClayMultiStepNavTitle: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children}) => <div className="multi-step-title">{children}</div>;
+type Props = {
+	/**
+	 * Title content.
+	 */
+	children?: React.ReactNode;
+};
+
+const ClayMultiStepNavTitle = ({children}: Props) => (
+	<div className="multi-step-title">{children}</div>
+);
 
 export default ClayMultiStepNavTitle;

--- a/packages/clay-nav/src/Nav.tsx
+++ b/packages/clay-nav/src/Nav.tsx
@@ -26,17 +26,19 @@ interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	stacked?: boolean;
 }
 
-const Nav: React.FunctionComponent<IProps> & {
+function Nav(props: IProps): JSX.Element & {
 	Item: typeof NavItem;
 	Link: typeof NavLink;
-} = ({
+};
+
+function Nav({
 	children,
 	className,
 	nestMargins,
 	nested,
 	stacked,
 	...otherProps
-}: IProps) => {
+}: IProps) {
 	return (
 		<ul
 			{...otherProps}
@@ -49,7 +51,7 @@ const Nav: React.FunctionComponent<IProps> & {
 			{children}
 		</ul>
 	);
-};
+}
 
 Nav.Item = NavItem;
 Nav.Link = NavLink;

--- a/packages/clay-nav/src/NavItem.tsx
+++ b/packages/clay-nav/src/NavItem.tsx
@@ -6,9 +6,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
-export const NavItem: React.FunctionComponent<
-	React.HTMLAttributes<HTMLLIElement>
-> = ({children, className, ...otherProps}) => {
+export const NavItem = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLLIElement>) => {
 	return (
 		<li {...otherProps} className={classNames('nav-item', className)}>
 			{children}

--- a/packages/clay-nav/src/NavLink.tsx
+++ b/packages/clay-nav/src/NavLink.tsx
@@ -35,7 +35,7 @@ interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	spritemap?: string;
 }
 
-export const NavLink: React.FunctionComponent<IProps> = ({
+export const NavLink = ({
 	active,
 	children,
 	className,

--- a/packages/clay-nav/src/Trigger.tsx
+++ b/packages/clay-nav/src/Trigger.tsx
@@ -9,11 +9,7 @@ import React from 'react';
 
 export interface IProps extends React.ComponentProps<typeof ClayButton> {}
 
-const Trigger: React.FunctionComponent<IProps> = ({
-	children,
-	className,
-	...otherProps
-}: IProps) => (
+const Trigger = ({children, className, ...otherProps}: IProps) => (
 	<ClayButton
 		className={classNames(className, 'menubar-toggler')}
 		displayType="unstyled"

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -172,9 +172,11 @@ function renderItems(items: Array<IItem>, spritemap?: string, level = 0) {
 	});
 }
 
-const ClayVerticalNav: React.FunctionComponent<IProps> & {
+function ClayVerticalNav(props: IProps): JSX.Element & {
 	Trigger: typeof Trigger;
-} = ({
+};
+
+function ClayVerticalNav({
 	activeLabel,
 	decorated,
 	items,
@@ -183,7 +185,7 @@ const ClayVerticalNav: React.FunctionComponent<IProps> & {
 	trigger: CustomTrigger = Trigger,
 	triggerLabel = 'Menu',
 	...otherProps
-}: IProps) => {
+}: IProps) {
 	const [active, setActive] = React.useState(false);
 
 	warning(
@@ -222,7 +224,7 @@ const ClayVerticalNav: React.FunctionComponent<IProps> & {
 			</div>
 		</nav>
 	);
-};
+}
 
 ClayVerticalNav.Trigger = Trigger;
 

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -18,7 +18,7 @@ interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
 	children: React.ReactElement;
 }
 
-const ClayNavigationBarIcon: React.FunctionComponent<IItemProps> = ({
+const ClayNavigationBarIcon = ({
 	active = false,
 	children,
 	className,

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -38,16 +38,18 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	triggerLabel: string;
 }
 
-const ClayNavigationBar: React.FunctionComponent<IProps> & {
+function ClayNavigationBar(props: IProps): JSX.Element & {
 	Item: typeof Item;
-} = ({
+};
+
+function ClayNavigationBar({
 	children,
 	className,
 	inverted = false,
 	spritemap,
 	triggerLabel,
 	...otherProps
-}: IProps) => {
+}: IProps) {
 	const [expanded, setExpanded] = React.useState(false);
 
 	const activeElementsCount = React.Children.map(
@@ -128,7 +130,7 @@ const ClayNavigationBar: React.FunctionComponent<IProps> & {
 			</ClayLayout.ContainerFluid>
 		</nav>
 	);
-};
+}
 
 ClayNavigationBar.Item = Item;
 

--- a/packages/clay-pagination-bar/src/DropDown.tsx
+++ b/packages/clay-pagination-bar/src/DropDown.tsx
@@ -7,9 +7,10 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayPaginationBarDropDown: React.FunctionComponent<
-	React.ComponentProps<typeof ClayDropDownWithItems>
-> = ({className, ...otherProps}) => {
+const ClayPaginationBarDropDown = ({
+	className,
+	...otherProps
+}: React.ComponentProps<typeof ClayDropDownWithItems>) => {
 	return (
 		<ClayDropDownWithItems
 			className={classNames(className, 'pagination-items-per-page')}

--- a/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
+++ b/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
@@ -149,112 +149,111 @@ const DEFAULT_LABELS = {
 	selectPerPageItems: '{0} items',
 };
 
-export const ClayPaginationBarWithBasicItems: React.FunctionComponent<IProps> =
-	({
-		active,
-		activeDelta,
-		activePage,
-		alignmentPosition,
-		defaultActive = 1,
-		deltas = defaultDeltas,
-		disabledPages,
-		disableEllipsis = false,
-		ellipsisBuffer,
-		hrefConstructor,
-		labels = DEFAULT_LABELS,
-		onActiveChange,
-		onDeltaChange,
-		onPageChange,
-		showDeltasDropDown = true,
-		spritemap,
-		totalItems,
-		...otherProps
-	}: IProps) => {
-		const [internalActive, setActive] = useInternalState({
-			defaultName: 'defaultActive',
-			defaultValue: defaultActive,
-			handleName: 'onActiveChange',
-			name: 'value',
-			onChange: onActiveChange ?? onPageChange,
-			value: typeof active === 'undefined' ? activePage : active,
-		});
+export const ClayPaginationBarWithBasicItems = ({
+	active,
+	activeDelta,
+	activePage,
+	alignmentPosition,
+	defaultActive = 1,
+	deltas = defaultDeltas,
+	disabledPages,
+	disableEllipsis = false,
+	ellipsisBuffer,
+	hrefConstructor,
+	labels = DEFAULT_LABELS,
+	onActiveChange,
+	onDeltaChange,
+	onPageChange,
+	showDeltasDropDown = true,
+	spritemap,
+	totalItems,
+	...otherProps
+}: IProps) => {
+	const [internalActive, setActive] = useInternalState({
+		defaultName: 'defaultActive',
+		defaultValue: defaultActive,
+		handleName: 'onActiveChange',
+		name: 'value',
+		onChange: onActiveChange ?? onPageChange,
+		value: typeof active === 'undefined' ? activePage : active,
+	});
 
-		if (!activeDelta) {
-			activeDelta = deltas[0].label;
+	if (!activeDelta) {
+		activeDelta = deltas[0].label;
+	}
+
+	const items: Items = deltas.map(({href, label}) => {
+		const item: {
+			href?: string;
+			label?: string;
+			onClick?: () => void;
+		} = {
+			href,
+			label: sub(labels.selectPerPageItems, [String(label)]),
+		};
+
+		if (!href) {
+			item.onClick = () => {
+				if (onDeltaChange) {
+					onDeltaChange(label as number);
+				}
+			};
 		}
 
-		const items: Items = deltas.map(({href, label}) => {
-			const item: {
-				href?: string;
-				label?: string;
-				onClick?: () => void;
-			} = {
-				href,
-				label: sub(labels.selectPerPageItems, [String(label)]),
-			};
+		return item;
+	});
 
-			if (!href) {
-				item.onClick = () => {
-					if (onDeltaChange) {
-						onDeltaChange(label as number);
-					}
-				};
-			}
+	const totalPages = Math.ceil(totalItems / activeDelta);
 
-			return item;
-		});
+	React.useEffect(() => {
+		if (internalActive > totalPages) {
+			setActive(1);
+		}
+	}, [totalPages]);
 
-		const totalPages = Math.ceil(totalItems / activeDelta);
-
-		React.useEffect(() => {
-			if (internalActive > totalPages) {
-				setActive(1);
-			}
-		}, [totalPages]);
-
-		return (
-			<PaginationBar {...otherProps}>
-				{showDeltasDropDown && (
-					<PaginationBar.DropDown
-						alignmentPosition={alignmentPosition}
-						items={items}
-						trigger={
-							<ClayButton
-								data-testid="selectPaginationBar"
-								displayType="unstyled"
-							>
-								{sub(labels.perPageItems, [activeDelta])}
-
-								<ClayIcon
-									spritemap={spritemap}
-									symbol="caret-double-l"
-								/>
-							</ClayButton>
-						}
-					/>
-				)}
-
-				<PaginationBar.Results>
-					{sub(labels.paginationResults, [
-						(internalActive - 1) * activeDelta + 1,
-						internalActive * activeDelta < totalItems
-							? internalActive * activeDelta
-							: totalItems,
-						totalItems,
-					])}
-				</PaginationBar.Results>
-
-				<ClayPaginationWithBasicItems
-					active={internalActive}
+	return (
+		<PaginationBar {...otherProps}>
+			{showDeltasDropDown && (
+				<PaginationBar.DropDown
 					alignmentPosition={alignmentPosition}
-					disableEllipsis={disableEllipsis}
-					disabledPages={disabledPages}
-					ellipsisBuffer={ellipsisBuffer}
-					hrefConstructor={hrefConstructor}
-					onActiveChange={setActive}
-					spritemap={spritemap}
-					totalPages={totalPages}
+					items={items}
+					trigger={
+						<ClayButton
+							data-testid="selectPaginationBar"
+							displayType="unstyled"
+						>
+							{sub(labels.perPageItems, [activeDelta])}
+
+							<ClayIcon
+								spritemap={spritemap}
+								symbol="caret-double-l"
+							/>
+						</ClayButton>
+					}
 				/>
-			</PaginationBar>
-		);
-	};
+			)}
+
+			<PaginationBar.Results>
+				{sub(labels.paginationResults, [
+					(internalActive - 1) * activeDelta + 1,
+					internalActive * activeDelta < totalItems
+						? internalActive * activeDelta
+						: totalItems,
+					totalItems,
+				])}
+			</PaginationBar.Results>
+
+			<ClayPaginationWithBasicItems
+				active={internalActive}
+				alignmentPosition={alignmentPosition}
+				disableEllipsis={disableEllipsis}
+				disabledPages={disabledPages}
+				ellipsisBuffer={ellipsisBuffer}
+				hrefConstructor={hrefConstructor}
+				onActiveChange={setActive}
+				spritemap={spritemap}
+				totalPages={totalPages}
+			/>
+		</PaginationBar>
+	);
+};

--- a/packages/clay-pagination-bar/src/Results.tsx
+++ b/packages/clay-pagination-bar/src/Results.tsx
@@ -6,9 +6,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayPaginationBarResults: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayPaginationBarResults = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	return (
 		<div
 			{...otherProps}

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -18,41 +18,40 @@ export interface IPaginationEllipsisProps {
 	onPageChange?: (page?: number) => void;
 }
 
-const ClayPaginationEllipsis: React.FunctionComponent<IPaginationEllipsisProps> =
-	({
-		alignmentPosition,
-		disabled = false,
-		disabledPages = [],
-		hrefConstructor,
-		items = [],
-		onPageChange,
-	}: IPaginationEllipsisProps) => {
-		const pages = disabled
-			? []
-			: items.map((page) => ({
-					disabled: disabledPages.includes(page),
-					href: hrefConstructor ? hrefConstructor(page) : undefined,
-					label: String(page),
-					onClick: () => onPageChange && onPageChange(page),
-			  }));
+const ClayPaginationEllipsis = ({
+	alignmentPosition,
+	disabled = false,
+	disabledPages = [],
+	hrefConstructor,
+	items = [],
+	onPageChange,
+}: IPaginationEllipsisProps) => {
+	const pages = disabled
+		? []
+		: items.map((page) => ({
+				disabled: disabledPages.includes(page),
+				href: hrefConstructor ? hrefConstructor(page) : undefined,
+				label: String(page),
+				onClick: () => onPageChange && onPageChange(page),
+		  }));
 
-		return (
-			<ClayDropDownWithItems
-				alignmentPosition={alignmentPosition}
-				className="page-item"
-				containerElement="li"
-				items={pages}
-				trigger={
-					<ClayButton
-						className="page-link"
-						disabled={disabled}
-						displayType="unstyled"
-					>
-						...
-					</ClayButton>
-				}
-			/>
-		);
-	};
+	return (
+		<ClayDropDownWithItems
+			alignmentPosition={alignmentPosition}
+			className="page-item"
+			containerElement="li"
+			items={pages}
+			trigger={
+				<ClayButton
+					className="page-link"
+					disabled={disabled}
+					displayType="unstyled"
+				>
+					...
+				</ClayButton>
+			}
+		/>
+	);
+};
 
 export default ClayPaginationEllipsis;

--- a/packages/clay-pagination/src/Item.tsx
+++ b/packages/clay-pagination/src/Item.tsx
@@ -14,7 +14,7 @@ export interface IPaginationItemProps
 	href?: string;
 }
 
-const ClayPaginationItem: React.FunctionComponent<IPaginationItemProps> = ({
+const ClayPaginationItem = ({
 	active = false,
 	children,
 	disabled = false,

--- a/packages/clay-panel/src/Body.tsx
+++ b/packages/clay-panel/src/Body.tsx
@@ -6,9 +6,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayPanelBody: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayPanelBody = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	return (
 		<div {...otherProps} className={classNames('panel-body', className)}>
 			{children}

--- a/packages/clay-panel/src/Footer.tsx
+++ b/packages/clay-panel/src/Footer.tsx
@@ -6,9 +6,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayPanelFooter: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayPanelFooter = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	return (
 		<div {...otherProps} className={classNames('panel-footer', className)}>
 			{children}

--- a/packages/clay-panel/src/Group.tsx
+++ b/packages/clay-panel/src/Group.tsx
@@ -37,7 +37,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	small?: boolean;
 }
 
-const ClayPanelGroup: React.FunctionComponent<IProps> = ({
+const ClayPanelGroup = ({
 	children,
 	className,
 	fluid,

--- a/packages/clay-panel/src/Header.tsx
+++ b/packages/clay-panel/src/Header.tsx
@@ -6,9 +6,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const ClayPanelHeader: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayPanelHeader = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	return (
 		<div {...otherProps} className={classNames('panel-header', className)}>
 			{children}

--- a/packages/clay-panel/src/Title.tsx
+++ b/packages/clay-panel/src/Title.tsx
@@ -5,9 +5,11 @@
 
 import React from 'react';
 
-const ClayPanelTitle: React.FunctionComponent<
-	React.HTMLAttributes<HTMLDivElement>
-> = ({children, className, ...otherProps}) => {
+const ClayPanelTitle = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => {
 	return (
 		<div {...otherProps} className={className}>
 			{children}

--- a/packages/clay-panel/src/index.tsx
+++ b/packages/clay-panel/src/index.tsx
@@ -67,13 +67,15 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	spritemap?: string;
 }
 
-const ClayPanel: React.FunctionComponent<IProps> & {
+function ClayPanel(props: IProps): JSX.Element & {
 	Body: typeof ClayPanelBody;
 	Footer: typeof ClayPanelFooter;
 	Group: typeof ClayPanelGroup;
 	Header: typeof ClayPanelHeader;
 	Title: typeof ClayPanelTitle;
-} = ({
+};
+
+function ClayPanel({
 	children,
 	className,
 	collapsable,
@@ -86,7 +88,7 @@ const ClayPanel: React.FunctionComponent<IProps> & {
 	showCollapseIcon = true,
 	spritemap,
 	...otherProps
-}: IProps) => {
+}: IProps) {
 	const [internalExpanded, setInternalExpanded] = useInternalState({
 		defaultName: 'defaultExpanded',
 		defaultValue: defaultExpanded,
@@ -198,7 +200,7 @@ const ClayPanel: React.FunctionComponent<IProps> & {
 			)}
 		</div>
 	);
-};
+}
 
 ClayPanel.Body = ClayPanelBody;
 ClayPanel.Group = ClayPanelGroup;

--- a/packages/clay-progress-bar/src/index.tsx
+++ b/packages/clay-progress-bar/src/index.tsx
@@ -30,7 +30,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	warn?: boolean;
 }
 
-const ClayProgressBar: React.FunctionComponent<IProps> = ({
+const ClayProgressBar = ({
 	children,
 	className,
 	feedback = false,

--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -8,7 +8,7 @@ import React, {useContext} from 'react';
 import {Keys} from './Keys';
 import {useFocusManagement} from './useFocusManagement';
 
-interface IProps {
+type Props = {
 	/**
 	 * Flag indicates whether the focus will also be controlled with the right
 	 * and left arrow keys.
@@ -24,7 +24,7 @@ interface IProps {
 	children: React.ReactElement & {
 		ref?: React.MutableRefObject<HTMLElement>;
 	};
-}
+};
 
 /**
  * The context helps to identify if the FocusScope is being declared nested, to
@@ -38,11 +38,11 @@ const FocusConflictContext = React.createContext<boolean>(false);
  * for children's key down events, since the component handles the `onKeyDown`
  * event.
  */
-export const FocusScope: React.FunctionComponent<IProps> = ({
+export const FocusScope = ({
 	arrowKeysLeftRight = false,
 	arrowKeysUpDown = true,
 	children,
-}) => {
+}: Props) => {
 	const elRef = React.useRef<null | HTMLElement>(null);
 	const focusManager = useFocusManagement(elRef);
 

--- a/packages/clay-shared/src/Portal.tsx
+++ b/packages/clay-shared/src/Portal.tsx
@@ -53,13 +53,13 @@ interface IProps extends IBaseProps {
 	subPortalRef?: React.RefObject<Element>;
 }
 
-export const ClayPortal: React.FunctionComponent<IProps> = ({
+export const ClayPortal = ({
 	children,
 	className,
 	containerRef,
 	id,
 	subPortalRef,
-}) => {
+}: IProps) => {
 	const {theme} = useProvider();
 
 	const parentPortalRef = React.useContext(ClayPortalContext);

--- a/packages/clay-slider/src/index.tsx
+++ b/packages/clay-slider/src/index.tsx
@@ -91,7 +91,7 @@ const calcProgressWidth = (
 const useIsomorphicLayoutEffect =
 	typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
 
-const ClaySlider: React.FunctionComponent<IProps> = ({
+const ClaySlider = ({
 	className,
 	defaultValue,
 	disabled,

--- a/packages/clay-sticker/src/index.tsx
+++ b/packages/clay-sticker/src/index.tsx
@@ -57,14 +57,17 @@ export interface IClayStickerProps
 	size?: Size;
 }
 
-const Overlay: React.FunctionComponent<
-	React.HTMLAttributes<HTMLSpanElement> & {
-		/**
-		 * Flag to indicate if `inline-item` class should be applied
-		 */
-		inline?: boolean;
-	}
-> = ({children, className, inline, ...otherProps}) => (
+const Overlay = ({
+	children,
+	className,
+	inline,
+	...otherProps
+}: React.HTMLAttributes<HTMLSpanElement> & {
+	/**
+	 * Flag to indicate if `inline-item` class should be applied
+	 */
+	inline?: boolean;
+}) => (
 	<span
 		className={classNames(className, 'sticker-overlay', {
 			'inline-item': inline,
@@ -75,13 +78,19 @@ const Overlay: React.FunctionComponent<
 	</span>
 );
 
-const Image: React.FunctionComponent<
-	React.ImgHTMLAttributes<HTMLImageElement>
-> = ({className, ...otherProps}) => (
+const Image = ({
+	className,
+	...otherProps
+}: React.ImgHTMLAttributes<HTMLImageElement>) => (
 	<img className={classNames(className, 'sticker-img')} {...otherProps} />
 );
 
-const ClaySticker: React.FunctionComponent<IClayStickerProps> = ({
+function ClaySticker(props: IClayStickerProps): JSX.Element & {
+	Image: typeof Image;
+	Overlay: typeof Overlay;
+};
+
+function ClaySticker({
 	children,
 	className,
 	displayType,
@@ -91,19 +100,24 @@ const ClaySticker: React.FunctionComponent<IClayStickerProps> = ({
 	shape,
 	size,
 	...otherProps
-}: IClayStickerProps) => (
-	<span
-		{...otherProps}
-		className={classNames('sticker', className, {
-			[`sticker-${shape}`]: shape,
-			[`sticker-${displayType}`]: displayType,
-			[`sticker-${position}`]: position,
-			[`sticker-outside`]: position && outside,
-			[`sticker-${size}`]: size,
-		})}
-	>
-		<Overlay inline={inline}>{children}</Overlay>
-	</span>
-);
+}: IClayStickerProps) {
+	return (
+		<span
+			{...otherProps}
+			className={classNames('sticker', className, {
+				[`sticker-${shape}`]: shape,
+				[`sticker-${displayType}`]: displayType,
+				[`sticker-${position}`]: position,
+				[`sticker-outside`]: position && outside,
+				[`sticker-${size}`]: size,
+			})}
+		>
+			<Overlay inline={inline}>{children}</Overlay>
+		</span>
+	);
+}
 
-export default Object.assign(ClaySticker, {Image, Overlay});
+ClaySticker.Image = Image;
+ClaySticker.Overlay = Overlay;
+
+export default ClaySticker;

--- a/packages/clay-tabs/src/Content.tsx
+++ b/packages/clay-tabs/src/Content.tsx
@@ -23,7 +23,7 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	fade?: boolean;
 }
 
-const Content: React.FunctionComponent<IProps> = ({
+const Content = ({
 	activeIndex = 0,
 	children,
 	className,

--- a/packages/clay-tabs/src/TabPane.tsx
+++ b/packages/clay-tabs/src/TabPane.tsx
@@ -23,7 +23,7 @@ const delay = (fn: Function, val: number = 150) =>
 		fn();
 	}, val);
 
-const TabPane: React.FunctionComponent<ITabPaneProps> = ({
+const TabPane = ({
 	active = false,
 	children,
 	className,

--- a/packages/clay-tabs/src/index.tsx
+++ b/packages/clay-tabs/src/index.tsx
@@ -29,19 +29,21 @@ interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	modern?: boolean;
 }
 
-const ClayTabs: React.FunctionComponent<IProps> & {
+function ClayTabs(props: IProps): JSX.Element & {
 	Content: typeof Content;
 	TabPane: typeof TabPane;
 	TabPanel: typeof TabPane;
 	Item: typeof Item;
-} = ({
+};
+
+function ClayTabs({
 	children,
 	className,
 	displayType,
 	justified,
 	modern = true,
 	...otherProps
-}: IProps) => {
+}: IProps) {
 	return (
 		<ul
 			className={classNames(
@@ -65,7 +67,7 @@ const ClayTabs: React.FunctionComponent<IProps> & {
 			{children}
 		</ul>
 	);
-};
+}
 
 ClayTabs.Content = Content;
 ClayTabs.TabPane = TabPane;

--- a/packages/clay-tabs/stories/Tabs.stories.tsx
+++ b/packages/clay-tabs/stories/Tabs.stories.tsx
@@ -9,11 +9,7 @@ import React, {useState} from 'react';
 
 import ClayTabs from '../src';
 
-const DropDownWithState: React.FunctionComponent<any> = ({
-	children,
-	trigger,
-	...others
-}) => {
+const DropDownWithState = ({children, trigger, ...others}: any) => {
 	const [active, setActive] = useState<boolean>(false);
 
 	return (
@@ -21,7 +17,7 @@ const DropDownWithState: React.FunctionComponent<any> = ({
 			active={active}
 			alignmentPosition={Align.BottomLeft}
 			hasRightSymbols
-			onActiveChange={(newVal) => setActive(newVal)}
+			onActiveChange={(newVal: boolean) => setActive(newVal)}
 			trigger={trigger}
 			{...others}
 		>

--- a/packages/clay-time-picker/src/index.tsx
+++ b/packages/clay-time-picker/src/index.tsx
@@ -159,7 +159,7 @@ const DEFAULT_CONFIG = {
 
 const regex = /^\d+$/;
 
-const ClayTimePicker: React.FunctionComponent<IProps> = ({
+const ClayTimePicker = ({
 	ariaLabels = {
 		ampm: 'Select time of day (AM/PM) using up (PM) and down (AM) arrow keys',
 		clear: 'Delete the entered time',

--- a/packages/clay-toolbar/src/Action.tsx
+++ b/packages/clay-toolbar/src/Action.tsx
@@ -24,7 +24,7 @@ export interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	symbol: string;
 }
 
-const Action: React.FunctionComponent<IProps> = ({
+const Action = ({
 	className,
 	disabled,
 	spritemap,

--- a/packages/clay-toolbar/src/Input.tsx
+++ b/packages/clay-toolbar/src/Input.tsx
@@ -9,10 +9,7 @@ import React from 'react';
 
 export interface IProps extends React.ComponentProps<typeof ClayInput> {}
 
-const Input: React.FunctionComponent<IProps> = ({
-	className,
-	...otherProps
-}: IProps) => (
+const Input = ({className, ...otherProps}: IProps) => (
 	<ClayInput.Group>
 		<ClayInput.GroupItem>
 			<ClayInput

--- a/packages/clay-toolbar/src/Item.tsx
+++ b/packages/clay-toolbar/src/Item.tsx
@@ -13,12 +13,7 @@ export interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	expand?: boolean;
 }
 
-const Item: React.FunctionComponent<IProps> = ({
-	children,
-	className,
-	expand,
-	...otherProps
-}: IProps) => {
+const Item = ({children, className, expand, ...otherProps}: IProps) => {
 	return (
 		<li
 			className={classNames(className, 'tbar-item', {

--- a/packages/clay-toolbar/src/Label.tsx
+++ b/packages/clay-toolbar/src/Label.tsx
@@ -9,11 +9,7 @@ import React from 'react';
 
 export interface IProps extends React.ComponentProps<typeof ClayLabel> {}
 
-const Label: React.FunctionComponent<IProps> = ({
-	children,
-	className,
-	...otherProps
-}: IProps) => (
+const Label = ({children, className, ...otherProps}: IProps) => (
 	<ClayLabel
 		className={classNames(className, 'component-label tbar-label')}
 		{...otherProps}

--- a/packages/clay-toolbar/src/Link.tsx
+++ b/packages/clay-toolbar/src/Link.tsx
@@ -14,12 +14,7 @@ export interface IProps extends React.ComponentProps<typeof ClayLink> {
 	disabled?: boolean;
 }
 
-const Link: React.FunctionComponent<IProps> = ({
-	children,
-	className,
-	disabled,
-	...otherProps
-}: IProps) => (
+const Link = ({children, className, disabled, ...otherProps}: IProps) => (
 	<ClayLink
 		className={classNames(className, 'component-link tbar-link', {
 			disabled,

--- a/packages/clay-toolbar/src/Nav.tsx
+++ b/packages/clay-toolbar/src/Nav.tsx
@@ -13,12 +13,7 @@ export interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	wrap?: boolean;
 }
 
-const Nav: React.FunctionComponent<IProps> = ({
-	children,
-	className,
-	wrap,
-	...otherProps
-}: IProps) => (
+const Nav = ({children, className, wrap, ...otherProps}: IProps) => (
 	<ul
 		className={classNames(className, 'tbar-nav', {
 			'tbar-nav-wrap': wrap,

--- a/packages/clay-toolbar/src/Section.tsx
+++ b/packages/clay-toolbar/src/Section.tsx
@@ -6,12 +6,15 @@
 import classNames from 'classnames';
 import React from 'react';
 
-const Section: React.FunctionComponent<React.HTMLAttributes<HTMLDivElement>> =
-	({children, className, ...otherProps}) => (
-		<div className={classNames(className, 'tbar-section')} {...otherProps}>
-			{children}
-		</div>
-	);
+const Section = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLDivElement>) => (
+	<div className={classNames(className, 'tbar-section')} {...otherProps}>
+		{children}
+	</div>
+);
 
 Section.displayName = 'ClayToolbarSection';
 

--- a/packages/clay-toolbar/src/index.tsx
+++ b/packages/clay-toolbar/src/index.tsx
@@ -36,7 +36,7 @@ interface IProps extends React.HTMLAttributes<HTMLElement> {
 		  };
 }
 
-const ClayToolbar: React.FunctionComponent<IProps> & {
+function ClayToolbar(props: IProps): JSX.Element & {
 	Action: typeof Action;
 	Item: typeof Item;
 	Input: typeof Input;
@@ -44,14 +44,16 @@ const ClayToolbar: React.FunctionComponent<IProps> & {
 	Link: typeof Link;
 	Nav: typeof Nav;
 	Section: typeof Section;
-} = ({
+};
+
+function ClayToolbar({
 	children,
 	className,
 	inlineBreakpoint,
 	light,
 	subnav,
 	...otherProps
-}: IProps) => {
+}: IProps) {
 	subnav = subnav === true ? {} : subnav;
 
 	const classes = classNames(
@@ -74,7 +76,7 @@ const ClayToolbar: React.FunctionComponent<IProps> & {
 			{children}
 		</nav>
 	);
-};
+}
 
 ClayToolbar.Action = Action;
 ClayToolbar.Item = Item;

--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -183,16 +183,14 @@ interface IPropsWithScope extends IPropsBase {
 	scope: string;
 }
 
-const TooltipProvider: React.FunctionComponent<
-	IPropsWithChildren | IPropsWithScope
-> = ({
+const TooltipProvider = ({
 	autoAlign = true,
 	children,
 	containerProps = {},
 	contentRenderer = (props) => props.title,
 	delay = 600,
 	scope,
-}) => {
+}: IPropsWithChildren | IPropsWithScope) => {
 	const [{align, message = '', setAsHTML, show}, dispatch] = React.useReducer(
 		reducer,
 		initialState

--- a/packages/clay-upper-toolbar/src/index.tsx
+++ b/packages/clay-upper-toolbar/src/index.tsx
@@ -10,10 +10,7 @@ import React from 'react';
 
 export interface IInputProps extends React.ComponentProps<typeof ClayInput> {}
 
-const Input: React.FunctionComponent<IInputProps> = ({
-	className,
-	...otherProps
-}) => (
+const Input = ({className, ...otherProps}: IInputProps) => (
 	<Item expand>
 		<ClayInput.Group>
 			<ClayInput.GroupItem>
@@ -36,12 +33,7 @@ interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
 	expand?: boolean;
 }
 
-const Item: React.FunctionComponent<IItemProps> = ({
-	children,
-	className,
-	expand,
-	...otherProps
-}: IItemProps) => {
+const Item = ({children, className, expand, ...otherProps}: IItemProps) => {
 	return (
 		<li
 			className={classNames(className, 'tbar-item', {
@@ -56,9 +48,11 @@ const Item: React.FunctionComponent<IItemProps> = ({
 
 Item.displayName = 'ClayUpperToolbarItem';
 
-const ClayUpperToolbar: React.FunctionComponent<
-	React.HTMLAttributes<HTMLElement>
-> = ({children, className, ...otherProps}) => {
+const ClayUpperToolbar = ({
+	children,
+	className,
+	...otherProps
+}: React.HTMLAttributes<HTMLElement>) => {
 	return (
 		<nav
 			className={classNames(

--- a/packages/demos/src/recharts/Tooltip.tsx
+++ b/packages/demos/src/recharts/Tooltip.tsx
@@ -33,13 +33,13 @@ interface IProps extends TooltipProps {
 	itemRenderer?: (val: any) => React.ReactNode;
 }
 
-const ClayRechartsTooltip: React.FunctionComponent<IProps> = ({
+const ClayRechartsTooltip = ({
 	active,
 	label,
 	payload,
 	labelRenderer = (val) => val,
 	itemRenderer = defaultRenderer,
-}) => {
+}: IProps) => {
 	if (active) {
 		return (
 			<div className="popover" style={{position: 'static'}}>

--- a/packages/demos/stories/DragDrop.tsx
+++ b/packages/demos/stories/DragDrop.tsx
@@ -47,12 +47,12 @@ interface IDragItem {
 	type: string;
 }
 
-const DraggableListItem: React.FunctionComponent<IDraggableListItemProps> = ({
+const DraggableListItem = ({
 	id,
 	index,
 	onMove,
 	text,
-}) => {
+}: IDraggableListItemProps) => {
 	const ref = useRef<HTMLLIElement>(null);
 
 	const [, drop] = useDrop({

--- a/packages/demos/stories/TableColumnsDragDrop.tsx
+++ b/packages/demos/stories/TableColumnsDragDrop.tsx
@@ -62,10 +62,7 @@ export interface ICustomDragLayerProps {
 	width: number;
 }
 
-const CustomDragLayer: React.FunctionComponent<ICustomDragLayerProps> = ({
-	columns,
-	width,
-}) => {
+const CustomDragLayer = ({columns, width}: ICustomDragLayerProps) => {
 	const {currentOffset, initialOffset, isDragging, item} = useDragLayer(
 		(monitor) => ({
 			currentOffset: monitor.getSourceClientOffset(),
@@ -115,12 +112,12 @@ export interface IColumnDragPreviewProps {
 	width: number;
 }
 
-const ColumnDragPreview: React.FunctionComponent<IColumnDragPreviewProps> = ({
+const ColumnDragPreview = ({
 	column,
 	currentOffset,
 	initialOffset,
 	width,
-}) => {
+}: IColumnDragPreviewProps) => {
 	const dragLayerStyles: React.CSSProperties = {
 		height: '100%',
 		left: 0,
@@ -205,57 +202,61 @@ interface IDragItem {
 	type: string;
 }
 
-const DraggableTableHeaderCell: React.FunctionComponent<IDraggableTableHeadingProps> =
-	({id, index, onMove, title}) => {
-		const ref = React.useRef<HTMLTableHeaderCellElement>(null);
+const DraggableTableHeaderCell = ({
+	id,
+	index,
+	onMove,
+	title,
+}: IDraggableTableHeadingProps) => {
+	const ref = React.useRef<HTMLTableHeaderCellElement>(null);
 
-		const [{canDrop}, drop] = useDrop({
-			accept: TABLE_COLUMN_DND_TYPE,
-			collect: (monitor: DropTargetMonitor) => ({
-				canDrop: monitor.canDrop(),
-			}),
-			hover(dragItem: IDragItem) {
-				const dragIndex = dragItem.index;
+	const [{canDrop}, drop] = useDrop({
+		accept: TABLE_COLUMN_DND_TYPE,
+		collect: (monitor: DropTargetMonitor) => ({
+			canDrop: monitor.canDrop(),
+		}),
+		hover(dragItem: IDragItem) {
+			const dragIndex = dragItem.index;
 
-				const hoverIndex = index;
+			const hoverIndex = index;
 
-				if (!ref.current || dragIndex === hoverIndex) {
-					return;
-				}
+			if (!ref.current || dragIndex === hoverIndex) {
+				return;
+			}
 
-				onMove(dragIndex, hoverIndex);
+			onMove(dragIndex, hoverIndex);
 
-				dragItem.index = hoverIndex;
-			},
-		});
+			dragItem.index = hoverIndex;
+		},
+	});
 
-		const [{itemBeingDragged}, drag, preview] = useDrag({
-			collect: (monitor: any) => ({
-				itemBeingDragged: monitor.getItem() || {id: 0},
-			}),
-			item: {id, index, type: TABLE_COLUMN_DND_TYPE},
-		});
+	const [{itemBeingDragged}, drag, preview] = useDrag({
+		collect: (monitor: any) => ({
+			itemBeingDragged: monitor.getItem() || {id: 0},
+		}),
+		item: {id, index, type: TABLE_COLUMN_DND_TYPE},
+	});
 
-		React.useEffect(() => {
-			preview(getEmptyImage(), {captureDraggingState: true});
-		}, [preview]);
+	React.useEffect(() => {
+		preview(getEmptyImage(), {captureDraggingState: true});
+	}, [preview]);
 
-		drag(drop(ref));
+	drag(drop(ref));
 
-		return (
-			<ClayTable.Cell
-				className={classNames('c-drag', {
-					'c-dragging': itemBeingDragged.id === id,
-					'c-droppable': canDrop,
-				})}
-				headingCell
-				headingTitle
-				ref={ref}
-			>
-				{title}
-			</ClayTable.Cell>
-		);
-	};
+	return (
+		<ClayTable.Cell
+			className={classNames('c-drag', {
+				'c-dragging': itemBeingDragged.id === id,
+				'c-droppable': canDrop,
+			})}
+			headingCell
+			headingTitle
+			ref={ref}
+		>
+			{title}
+		</ClayTable.Cell>
+	);
+};
 
 const ClayTableWithDraggableColumns: React.FunctionComponent = () => {
 	const [tableColumns, setTableColumns] = React.useState(initialTableColumns);

--- a/packages/demos/stories/TableRowsDragDrop.tsx
+++ b/packages/demos/stories/TableRowsDragDrop.tsx
@@ -79,11 +79,11 @@ interface IDragItem {
 	type: string;
 }
 
-const DraggableTableRow: React.FunctionComponent<IDraggableTableRowProps> = ({
+const DraggableTableRow = ({
 	content,
 	index,
 	onMove,
-}) => {
+}: IDraggableTableRowProps) => {
 	const ref = React.useRef<HTMLTableRowElement>(null);
 
 	const [, drop] = useDrop({

--- a/packages/generator-clay-component/__tests__/test-app.js
+++ b/packages/generator-clay-component/__tests__/test-app.js
@@ -34,10 +34,7 @@ describe('clay-component-generator:app', () => {
 	});
 
 	it('produces MyComponent.tsx with templated content', () => {
-		assert.fileContent(
-			'src/index.tsx',
-			/const MyComponent: React.FunctionComponent<Props> = \(\{/
-		);
+		assert.fileContent('src/index.tsx', /const MyComponent = \(\{/);
 		assert.fileContent('src/index.tsx', /export default MyComponent/);
 	});
 });

--- a/packages/generator-clay-component/app/templates/src/_index.tsx
+++ b/packages/generator-clay-component/app/templates/src/_index.tsx
@@ -7,12 +7,12 @@
 import React from 'react';
 import classNames from 'classnames';
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {}
+interface IProps extends React.HTMLAttributes<HTMLDivElement> {}
 
-const <%= componentName %>: React.FunctionComponent<Props> = ({
+const <%= componentName %> = ({
 	className,
 	...otherProps
-}) => {
+}: IProps) => {
 	return (
 		<div {...otherProps} className={classNames(className)}>{'<%= componentName %>'}</div>
 	);


### PR DESCRIPTION
Fixes #4655

The vast majority of changes are removing the use of `React.FunctionComponent` which is a type that will no longer be present in React types and its use is no longer recommended, mainly because we can't make generic types with it.

Another part of the changes I made was to use `type` to set the types of component props only in use cases where the type doesn't extend from any other interface, just for simpler cases.

Also following the pattern of components that have sub-components, using Function Overloading to define the sub-components.

```jsx
function ClayDropDown(props: IProps): JSX.Element & {
	Action: typeof Action;
	Caption: typeof Caption;
	Divider: typeof Divider;
	Group: typeof Group;
	Help: typeof Help;
	Item: typeof Item;
	ItemList: typeof ItemList;
	Menu: typeof Menu;
	Search: typeof Search;
	Section: typeof Section;
};
```