### PR TITLE
fix(@clayui/css): Alert Indicator inside alert-autofit-row aren't vertically aligned with text

### DIFF
--- a/packages/clay-alert/src/index.tsx
+++ b/packages/clay-alert/src/index.tsx
@@ -162,11 +162,7 @@ const ClayAlert: React.FunctionComponent<IClayAlertProps> & {
 			role="alert"
 		>
 			<ConditionalContainer>
-				<ClayLayout.ContentRow
-					className={classNames('alert-autofit-row', {
-						'align-items-baseline': variant !== 'feedback',
-					})}
-				>
+				<ClayLayout.ContentRow className="alert-autofit-row">
 					{!VARIANTS.includes(variant as string) && (
 						<ClayLayout.ContentCol>
 							<ClayLayout.ContentSection>

--- a/packages/clay-alert/src/index.tsx
+++ b/packages/clay-alert/src/index.tsx
@@ -162,7 +162,11 @@ const ClayAlert: React.FunctionComponent<IClayAlertProps> & {
 			role="alert"
 		>
 			<ConditionalContainer>
-				<ClayLayout.ContentRow className="alert-autofit-row">
+				<ClayLayout.ContentRow
+					className={classNames('alert-autofit-row', {
+						'align-items-baseline': variant !== 'feedback',
+					})}
+				>
 					{!VARIANTS.includes(variant as string) && (
 						<ClayLayout.ContentCol>
 							<ClayLayout.ContentSection>

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.63.0
+ * Clay 3.64.0
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>

--- a/packages/clay-css/src/scss/cadmin/components/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_alerts.scss
@@ -141,6 +141,7 @@
 
 	.alert-autofit-row,
 	.autofit-row {
+		align-items: unset;
 		display: inline;
 		margin-left: 0;
 		margin-right: 0;

--- a/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_alerts.scss
@@ -199,6 +199,7 @@ $cadmin-alert-indicator: map-deep-merge(
 		lead: (
 			margin-left: $cadmin-alert-lead-spacer-x,
 		),
+		line-height: 1,
 	),
 	$cadmin-alert-indicator
 );
@@ -420,6 +421,7 @@ $cadmin-alert-notification-sm-down: map-merge(
 $cadmin-alert-autofit-row: () !default;
 $cadmin-alert-autofit-row: map-deep-merge(
 	(
+		align-items: baseline,
 		margin-left: -4px,
 		margin-right: -4px,
 		width: auto,

--- a/packages/clay-css/src/scss/components/_alerts.scss
+++ b/packages/clay-css/src/scss/components/_alerts.scss
@@ -136,6 +136,7 @@
 
 	.alert-autofit-row,
 	.autofit-row {
+		align-items: unset;
 		display: inline;
 		margin-left: 0;
 		margin-right: 0;

--- a/packages/clay-css/src/scss/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/variables/_alerts.scss
@@ -177,16 +177,15 @@ $alert-link: map-deep-merge(
 // .alert-indicator
 
 $alert-indicator-font-size: 1.25rem !default;
-$alert-indicator-line-height: 1 !default;
 
 $alert-indicator: () !default;
 $alert-indicator: map-deep-merge(
 	(
 		font-size: $alert-indicator-font-size,
-		line-height: $alert-indicator-line-height,
 		lead: (
 			margin-left: $alert-lead-spacer-x,
 		),
+		line-height: 1,
 	),
 	$alert-indicator
 );
@@ -399,6 +398,7 @@ $alert-notification-sm-down: map-merge(
 $alert-autofit-row: () !default;
 $alert-autofit-row: map-deep-merge(
 	(
+		align-items: baseline,
 		margin-left: -0.5rem,
 		margin-right: -0.5rem,
 		width: auto,

--- a/packages/clay-css/src/scss/variables/_alerts.scss
+++ b/packages/clay-css/src/scss/variables/_alerts.scss
@@ -177,11 +177,13 @@ $alert-link: map-deep-merge(
 // .alert-indicator
 
 $alert-indicator-font-size: 1.25rem !default;
+$alert-indicator-line-height: 1 !default;
 
 $alert-indicator: () !default;
 $alert-indicator: map-deep-merge(
 	(
 		font-size: $alert-indicator-font-size,
+		line-height: $alert-indicator-line-height,
 		lead: (
 			margin-left: $alert-lead-spacer-x,
 		),


### PR DESCRIPTION
Applies the same explanation we did for this PR
https://github.com/liferay-frontend/liferay-portal/pull/2478

=====

[Jira issue](https://issues.liferay.com/browse/LPS-157502)
[Lexicon](https://liferay.design/lexicon/core-components/alerts)

## Motivation

The icon in the alert tag component seems misaligned with the text

## Solution proposed

Use the baseline alignment for the flex children

## How to verify

In any use case of the tag, check the icon + text alignment.

## Screenshots

#### Before

![image](https://user-images.githubusercontent.com/19485114/177292946-1f48d5d8-f921-4e4b-83a2-30bc3086e531.png)


#### After

![image](https://user-images.githubusercontent.com/19485114/177292863-30056c01-af0b-468d-bc97-6d2d6f4e903f.png)
