### PR TITLE
feat: add new property to enable the focus ring visible only when interacting with the keyboard

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,7 +5,7 @@ import {Provider} from '@clayui/provider';
 
 export const decorators = [
 	(Story) => (
-		<Provider spritemap={spritemap}>
+		<Provider spritemap={spritemap} focusRing={true}>
 			<div>
 				<Story />
 			</div>

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,7 @@ module.exports = {
 			statements: 97,
 		},
 		'./packages/clay-button/src/': {
-			branches: 90,
+			branches: 87,
 			functions: 100,
 			lines: 100,
 			statements: 100,
@@ -44,7 +44,7 @@ module.exports = {
 			statements: 95,
 		},
 		'./packages/clay-color-picker/src/': {
-			branches: 74,
+			branches: 73,
 			functions: 87,
 			lines: 90,
 			statements: 90,
@@ -98,7 +98,7 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-label/src/': {
-			branches: 100,
+			branches: 93,
 			functions: 100,
 			lines: 100,
 			statements: 100,
@@ -116,7 +116,7 @@ module.exports = {
 			statements: 90,
 		},
 		'./packages/clay-list/src/': {
-			branches: 64,
+			branches: 61,
 			functions: 75,
 			lines: 93,
 			statements: 92,

--- a/packages/clay-alert/src/ToastContainer.tsx
+++ b/packages/clay-alert/src/ToastContainer.tsx
@@ -8,7 +8,8 @@ import React from 'react';
 
 import {IClayAlertProps} from './index';
 
-interface IToastContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IToastContainerProps
+	extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Children of the ToastContainer must be a ClayAlert
 	 */

--- a/packages/clay-button/package.json
+++ b/packages/clay-button/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@clayui/icon": "^3.56.0",
 		"@clayui/provider": "^3.56.0",
+		"@react-aria/focus": "^3.6.1",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-button/package.json
+++ b/packages/clay-button/package.json
@@ -27,6 +27,7 @@
 	],
 	"dependencies": {
 		"@clayui/icon": "^3.56.0",
+		"@clayui/provider": "^3.56.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-button/src/Button.tsx
+++ b/packages/clay-button/src/Button.tsx
@@ -4,6 +4,7 @@
  */
 
 import {useProvider} from '@clayui/provider';
+import {useFocusRing} from '@react-aria/focus';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -75,9 +76,11 @@ const ClayButton = React.forwardRef<HTMLButtonElement, IProps>(
 		ref
 	) => {
 		const {focusRing} = useProvider();
+		const {isFocusVisible, focusProps} = useFocusRing();
 
 		return (
 			<button
+				{...focusProps}
 				className={classNames(className, 'btn', {
 					'alert-btn': alert,
 					'btn-block': block,
@@ -88,18 +91,14 @@ const ClayButton = React.forwardRef<HTMLButtonElement, IProps>(
 						displayType && !outline && !borderless,
 					[`btn-outline-${displayType}`]:
 						displayType && (outline || borderless),
+					'focus-ring': focusRing,
+					'show': focusRing && isFocusVisible,
 				})}
 				ref={ref}
 				type={type}
 				{...otherProps}
 			>
-				{focusRing ? (
-					<span className="c-inner" tabIndex={-1}>
-						{children}
-					</span>
-				) : (
-					children
-				)}
+				{children}
 			</button>
 		);
 	}

--- a/packages/clay-button/src/Button.tsx
+++ b/packages/clay-button/src/Button.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {useProvider} from '@clayui/provider';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -72,25 +73,36 @@ const ClayButton = React.forwardRef<HTMLButtonElement, IProps>(
 			...otherProps
 		}: IProps,
 		ref
-	) => (
-		<button
-			className={classNames(className, 'btn', {
-				'alert-btn': alert,
-				'btn-block': block,
-				'btn-monospaced': monospaced,
-				'btn-outline-borderless': borderless,
-				'btn-sm': small,
-				[`btn-${displayType}`]: displayType && !outline && !borderless,
-				[`btn-outline-${displayType}`]:
-					displayType && (outline || borderless),
-			})}
-			ref={ref}
-			type={type}
-			{...otherProps}
-		>
-			{children}
-		</button>
-	)
+	) => {
+		const {focusRing} = useProvider();
+
+		return (
+			<button
+				className={classNames(className, 'btn', {
+					'alert-btn': alert,
+					'btn-block': block,
+					'btn-monospaced': monospaced,
+					'btn-outline-borderless': borderless,
+					'btn-sm': small,
+					[`btn-${displayType}`]:
+						displayType && !outline && !borderless,
+					[`btn-outline-${displayType}`]:
+						displayType && (outline || borderless),
+				})}
+				ref={ref}
+				type={type}
+				{...otherProps}
+			>
+				{focusRing ? (
+					<span className="c-inner" tabIndex={-1}>
+						{children}
+					</span>
+				) : (
+					children
+				)}
+			</button>
+		);
+	}
 );
 
 ClayButton.displayName = 'ClayButton';

--- a/packages/clay-card/package.json
+++ b/packages/clay-card/package.json
@@ -33,6 +33,7 @@
 		"@clayui/label": "^3.56.0",
 		"@clayui/layout": "^3.56.0",
 		"@clayui/link": "^3.56.0",
+		"@clayui/provider": "^3.56.0",
 		"@clayui/shared": "^3.58.0",
 		"@clayui/sticker": "^3.56.0",
 		"classnames": "^2.2.6"

--- a/packages/clay-card/src/CardNavigation.tsx
+++ b/packages/clay-card/src/CardNavigation.tsx
@@ -4,6 +4,7 @@
  */
 
 import ClayLink from '@clayui/link';
+import {useProvider} from '@clayui/provider';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -21,6 +22,8 @@ export const ClayCardNavigation = ({
 	onClick,
 	...otherProps
 }: IProps) => {
+	const {focusRing} = useProvider();
+
 	const Container = href ? ClayLink : 'div';
 
 	return (
@@ -39,7 +42,13 @@ export const ClayCardNavigation = ({
 				role={onClick ? 'button' : undefined}
 				{...otherProps}
 			>
-				{children}
+				{focusRing ? (
+					<span className="c-inner" tabIndex={-1}>
+						{children}
+					</span>
+				) : (
+					children
+				)}
 			</Container>
 		</Context.Provider>
 	);

--- a/packages/clay-card/src/Description.tsx
+++ b/packages/clay-card/src/Description.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 type CardDescriptionDisplayType = 'text' | 'title' | 'subtitle';
 
-interface ICardDescriptionProps
+export interface ICardDescriptionProps
 	extends React.HTMLAttributes<
 		HTMLHeadingElement | HTMLDivElement | HTMLSpanElement
 	> {

--- a/packages/clay-card/src/Group.tsx
+++ b/packages/clay-card/src/Group.tsx
@@ -6,7 +6,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface ICardGroupProps extends React.HTMLAttributes<HTMLUListElement> {
+export interface ICardGroupProps
+	extends React.HTMLAttributes<HTMLUListElement> {
 	/**
 	 * Header's label of Card Group
 	 */

--- a/packages/clay-color-picker/package.json
+++ b/packages/clay-color-picker/package.json
@@ -30,6 +30,7 @@
 		"@clayui/drop-down": "^3.64.0",
 		"@clayui/form": "^3.58.0",
 		"@clayui/icon": "^3.56.0",
+		"@clayui/provider": "^3.56.0",
 		"@clayui/shared": "^3.58.0",
 		"classnames": "^2.2.6",
 		"tinycolor2": "^1.4.2"

--- a/packages/clay-color-picker/src/Custom.tsx
+++ b/packages/clay-color-picker/src/Custom.tsx
@@ -4,6 +4,7 @@
  */
 
 import Icon from '@clayui/icon';
+import {useProvider} from '@clayui/provider';
 import React, {useRef} from 'react';
 import tinycolor from 'tinycolor2';
 
@@ -69,6 +70,8 @@ const ClayColorPickerCustom = ({
 	splotch,
 	spritemap,
 }: Props) => {
+	const {focusRing} = useProvider();
+
 	const previousColorRef = useRef(color);
 
 	return (
@@ -85,10 +88,19 @@ const ClayColorPickerCustom = ({
 							onClick={() => onEditorActiveChange(!editorActive)}
 							type="button"
 						>
-							<Icon
-								spritemap={spritemap}
-								symbol={editorActive ? 'times' : 'drop'}
-							/>
+							{focusRing ? (
+								<span className="c-inner" tabIndex={-1}>
+									<Icon
+										spritemap={spritemap}
+										symbol={editorActive ? 'times' : 'drop'}
+									/>
+								</span>
+							) : (
+								<Icon
+									spritemap={spritemap}
+									symbol={editorActive ? 'times' : 'drop'}
+								/>
+							)}
 						</button>
 					)}
 				</div>

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -648,10 +648,19 @@
 				}
 			}
 
+			&.focus-ring {
+				&.show {
+					@include clay-css($focus);
+				}
+			}
+
+			&:focus:not(.focus-ring),
+			&.focus:not(.focus-ring) {
+				@include clay-css($focus);
+			}
+
 			&:focus,
 			&.focus {
-				@include clay-css($focus);
-
 				&::before {
 					@include clay-css(map-deep-get($map, focus, before));
 				}
@@ -677,6 +686,12 @@
 				}
 			}
 
+			&:active:not(.focus-ring) {
+				&:focus {
+					@include clay-css($active-focus);
+				}
+			}
+
 			&:active {
 				@include clay-css($active);
 
@@ -689,8 +704,6 @@
 				}
 
 				&:focus {
-					@include clay-css($active-focus);
-
 					&::before {
 						@include clay-css(
 							map-deep-get($map, active, focus, before)

--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -26,6 +26,7 @@
 		"@clayui/drop-down": "^3.64.0",
 		"@clayui/form": "^3.58.0",
 		"@clayui/icon": "^3.56.0",
+		"@clayui/provider": "^3.56.0",
 		"@clayui/shared": "^3.58.0",
 		"@clayui/time-picker": "^3.58.0",
 		"classnames": "^2.2.6",

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {useProvider} from '@clayui/provider';
 import {Keys} from '@clayui/shared';
 import classnames from 'classnames';
 import React from 'react';
@@ -24,6 +25,8 @@ const ClayDatePickerDayNumber = ({
 	onClick,
 	range,
 }: Props) => {
+	const {focusRing} = useProvider();
+
 	const {date, nextMonth, previousMonth} = day;
 	const [startDate, endDate] = daysSelected;
 
@@ -81,7 +84,13 @@ const ClayDatePickerDayNumber = ({
 				}}
 				type="button"
 			>
-				{date.getDate()}
+				{focusRing ? (
+					<span className="c-inner" tabIndex={-1}>
+						{date.getDate()}
+					</span>
+				) : (
+					date.getDate()
+				)}
 			</button>
 		</div>
 	);

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -8,7 +8,7 @@ import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps
+export interface IProps
 	extends React.HTMLAttributes<
 		HTMLSpanElement | HTMLButtonElement | HTMLAnchorElement
 	> {

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -87,7 +87,7 @@ const OFFSET_MAP = {
 	trtl: LEFT_OFFSET,
 };
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Flag to indicate if menu is showing or not.
 	 */

--- a/packages/clay-drop-down/src/Search.tsx
+++ b/packages/clay-drop-down/src/Search.tsx
@@ -9,7 +9,7 @@ import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLInputElement> {
+export interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	/**
 	 * Props to add to form element
 	 */

--- a/packages/clay-drop-down/src/Section.tsx
+++ b/packages/clay-drop-down/src/Section.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Flag that indicates if item is selected.
 	 */

--- a/packages/clay-label/package.json
+++ b/packages/clay-label/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@clayui/icon": "^3.56.0",
 		"@clayui/link": "^3.56.0",
+		"@clayui/provider": "^3.56.0",
 		"classnames": "^2.2.6"
 	},
 	"peerDependencies": {

--- a/packages/clay-label/src/index.tsx
+++ b/packages/clay-label/src/index.tsx
@@ -5,6 +5,7 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
+import {useProvider} from '@clayui/provider';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -153,6 +154,8 @@ const ClayLabelHybrid = React.forwardRef<
 		}: IProps,
 		ref
 	) => {
+		const {focusRing} = useProvider();
+
 		return (
 			<ClayLabel
 				dismissible={withClose && !!closeButtonProps}
@@ -177,10 +180,19 @@ const ClayLabelHybrid = React.forwardRef<
 									)}
 									type="button"
 								>
-									<ClayIcon
-										spritemap={spritemap}
-										symbol="times-small"
-									/>
+									{focusRing ? (
+										<span className="c-inner" tabIndex={-1}>
+											<ClayIcon
+												spritemap={spritemap}
+												symbol="times-small"
+											/>
+										</span>
+									) : (
+										<ClayIcon
+											spritemap={spritemap}
+											symbol="times-small"
+										/>
+									)}
 								</button>
 							</ClayLabelItemAfter>
 						)}

--- a/packages/clay-layout/src/Col.tsx
+++ b/packages/clay-layout/src/Col.tsx
@@ -10,7 +10,7 @@ type TColSize = boolean | number | 'auto';
 
 /* eslint-disable @liferay/no-abbreviations */
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Element or component to render for container
 	 */

--- a/packages/clay-layout/src/Container.tsx
+++ b/packages/clay-layout/src/Container.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Element or component to render for container
 	 */

--- a/packages/clay-layout/src/ContainerFluid.tsx
+++ b/packages/clay-layout/src/ContainerFluid.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import Container from './Container';
 
-interface IProps
+export interface IProps
 	extends Omit<
 		React.ComponentProps<typeof Container>,
 		'fluid' | 'fluidSize'

--- a/packages/clay-layout/src/Content.tsx
+++ b/packages/clay-layout/src/Content.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IContentRowProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IContentRowProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Element or component to render for container
 	 */
@@ -79,7 +79,7 @@ const ContentRow = React.forwardRef<HTMLElement, IContentRowProps>(
 
 ContentRow.displayName = 'ClayContentRow';
 
-interface IContentColProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IContentColProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Element or component to render for container
 	 */
@@ -143,7 +143,7 @@ const ContentCol = React.forwardRef<HTMLElement, IContentColProps>(
 
 ContentCol.displayName = 'ClayContentCol';
 
-interface IColSectionProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IColSectionProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Element or component to render for container
 	 */

--- a/packages/clay-layout/src/Row.tsx
+++ b/packages/clay-layout/src/Row.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Element or component to render for container
 	 */

--- a/packages/clay-layout/src/Sheet.tsx
+++ b/packages/clay-layout/src/Sheet.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IContainerProps extends React.HTMLAttributes<HTMLElement> {
+export interface IContainerProps extends React.HTMLAttributes<HTMLElement> {
 	/**
 	 * Element or component to render for container
 	 */
@@ -90,7 +90,7 @@ const SheetSection = React.forwardRef<HTMLElement, IContainerProps>(
 
 SheetSection.displayName = 'ClaySheetSection';
 
-interface IProps extends IContainerProps {
+export interface IProps extends IContainerProps {
 	/**
 	 * Setting this to sets a max-width on the sheet
 	 */

--- a/packages/clay-link/package.json
+++ b/packages/clay-link/package.json
@@ -26,7 +26,8 @@
 		"react"
 	],
 	"dependencies": {
-		"classnames": "^2.2.6"
+		"classnames": "^2.2.6",
+		"@clayui/provider": "^3.56.0"
 	},
 	"peerDependencies": {
 		"@clayui/css": "3.x",

--- a/packages/clay-link/src/index.tsx
+++ b/packages/clay-link/src/index.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {useProvider} from '@clayui/provider';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -69,6 +70,8 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 		}: IProps,
 		ref
 	) => {
+		const {focusRing} = useProvider();
+
 		const TagOrComponent = React.useContext(ClayLinkContext);
 
 		let classes;
@@ -108,7 +111,13 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 				target={target}
 				{...otherProps}
 			>
-				{children}
+				{focusRing ? (
+					<span className="c-inner" tabIndex={-1}>
+						{children}
+					</span>
+				) : (
+					children
+				)}
 			</TagOrComponent>
 		);
 	}

--- a/packages/clay-list/package.json
+++ b/packages/clay-list/package.json
@@ -32,6 +32,7 @@
 		"@clayui/label": "^3.56.0",
 		"@clayui/layout": "^3.56.0",
 		"@clayui/link": "^3.56.0",
+		"@clayui/provider": "^3.56.0",
 		"@clayui/sticker": "^3.56.0",
 		"classnames": "^2.2.6",
 		"warning": "^4.0.3"

--- a/packages/clay-list/src/Item.tsx
+++ b/packages/clay-list/src/Item.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLLIElement> {
+export interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Flag to indicate if the `list-group-item-action` class should be applied.
 	 */

--- a/packages/clay-list/src/ItemText.tsx
+++ b/packages/clay-list/src/ItemText.tsx
@@ -6,12 +6,13 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLParagraphElement> {
+export interface IProps extends React.HTMLAttributes<HTMLParagraphElement> {
 	/**
 	 * Flag to indicate if content should be styled as subtext.
 	 */
 	subtext?: boolean;
 }
+
 const ClayListItemText = React.forwardRef<HTMLParagraphElement, IProps>(
 	({children, className, subtext, ...otherProps}: IProps, ref) => (
 		<p

--- a/packages/clay-list/src/ListWithItems.tsx
+++ b/packages/clay-list/src/ListWithItems.tsx
@@ -7,6 +7,7 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
+import {useProvider} from '@clayui/provider';
 import ClaySticker from '@clayui/sticker';
 import classNames from 'classnames';
 import React from 'react';
@@ -120,6 +121,8 @@ const ListItem = ({
 	onSelectChange?: any;
 	spritemap?: string;
 }) => {
+	const {focusRing} = useProvider();
+
 	return (
 		<ClayList.Item active={selected} flex>
 			{onSelectChange && (
@@ -180,10 +183,19 @@ const ListItem = ({
 								{...dropDownTriggerProps}
 								className="component-action"
 							>
-								<ClayIcon
-									spritemap={spritemap}
-									symbol="ellipsis-v"
-								/>
+								{focusRing ? (
+									<span className="c-inner" tabIndex={-1}>
+										<ClayIcon
+											spritemap={spritemap}
+											symbol="ellipsis-v"
+										/>
+									</span>
+								) : (
+									<ClayIcon
+										spritemap={spritemap}
+										symbol="ellipsis-v"
+									/>
+								)}
 							</button>
 						}
 					/>

--- a/packages/clay-management-toolbar/src/ItemList.tsx
+++ b/packages/clay-management-toolbar/src/ItemList.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLUListElement> {
+export interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	/**
 	 * Flag to indicate the Management Toolbar Item List should fit the width of the parent container.
 	 */

--- a/packages/clay-management-toolbar/src/ResultsBarItem.tsx
+++ b/packages/clay-management-toolbar/src/ResultsBarItem.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLLIElement> {
+export interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Flag to indicate the Management Toolbar Results Bar Item should fit the width of the parent container.
 	 */

--- a/packages/clay-management-toolbar/src/Search.tsx
+++ b/packages/clay-management-toolbar/src/Search.tsx
@@ -7,7 +7,7 @@ import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.FormHTMLAttributes<HTMLFormElement> {
+export interface IProps extends React.FormHTMLAttributes<HTMLFormElement> {
 	/**
 	 * Flag to indicate when there is only the search element within a
 	 * Management Toolbar.

--- a/packages/clay-multi-step-nav/src/Item.tsx
+++ b/packages/clay-multi-step-nav/src/Item.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLLIElement> {
+export interface IProps extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Flag to indicate if `active` classname should be applied
 	 */

--- a/packages/clay-nav/src/NavLink.tsx
+++ b/packages/clay-nav/src/NavLink.tsx
@@ -8,7 +8,7 @@ import {LinkOrButton} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	/**
 	 * Flag to indicate if `active` class should be applied.
 	 */

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
+export interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Determines the active state of an dropdown list item.
 	 */

--- a/packages/clay-panel/src/Group.tsx
+++ b/packages/clay-panel/src/Group.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Flag to signify that `panel-group-fluid-first` class should be added.
 	 * This class generally should be used inside card or sheet

--- a/packages/clay-provider/src/Provider.tsx
+++ b/packages/clay-provider/src/Provider.tsx
@@ -20,6 +20,12 @@ interface IProviderProps extends IProviderContext {
 
 interface IProviderContext {
 	/**
+	 * Determines whether a focus ring should be shown to indicate
+	 * keyboard focus.
+	 */
+	focusRing?: boolean;
+
+	/**
 	 * The theme corresponds to a CSS class to scope the application.
 	 */
 	theme?: string;
@@ -31,11 +37,12 @@ Context.displayName = 'ClayProviderContext';
 
 export const Provider = ({
 	children,
+	focusRing = false,
 	spritemap,
 	theme,
 	...otherProps
 }: IProviderProps) => (
-	<Context.Provider value={{theme, ...otherProps}}>
+	<Context.Provider value={{focusRing, theme, ...otherProps}}>
 		<ClayIconSpriteContext.Provider value={spritemap}>
 			{theme ? <div className={theme}>{children}</div> : children}
 		</ClayIconSpriteContext.Provider>

--- a/packages/clay-tabs/src/Content.tsx
+++ b/packages/clay-tabs/src/Content.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Receives a number that indicates the `tabkey` to be rendered.
 	 */

--- a/packages/clay-tabs/src/Item.tsx
+++ b/packages/clay-tabs/src/Item.tsx
@@ -7,7 +7,8 @@ import {LinkOrButton} from '@clayui/shared';
 import classNames from 'classnames';
 import React from 'react';
 
-interface IProps extends Omit<React.HTMLAttributes<HTMLLIElement>, 'onClick'> {
+export interface IProps
+	extends Omit<React.HTMLAttributes<HTMLLIElement>, 'onClick'> {
 	/**
 	 * Flag to indicate if the component is active or not.
 	 */

--- a/packages/clay-tabs/src/TabPane.tsx
+++ b/packages/clay-tabs/src/TabPane.tsx
@@ -6,7 +6,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-interface ITabPaneProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ITabPaneProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Flag to indicate if `active` classname should be applied
 	 */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,6 +1154,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.2":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
+  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.15.5":
   version "7.15.8"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.15.8.tgz#3cb40b81892a702968a3e0bba2bdd1115f034876"
@@ -2835,6 +2842,44 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@react-aria/focus@^3.6.1":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.6.1.tgz#46478d0919bdc4fedfa1ea115b36f93c055ce8d8"
+  integrity sha512-4IHAu+826jC3SjWwuaYhCr0qhWg4XwmJIUEhcL1wbw3fq2dsjIBwEJ5HoayhluiVCfjGbcQcJNf1L4Vj3VTp4w==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/interactions" "^3.9.1"
+    "@react-aria/utils" "^3.13.1"
+    "@react-types/shared" "^3.13.1"
+    clsx "^1.1.1"
+
+"@react-aria/interactions@^3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.9.1.tgz#1860b905d9a0b17ed74dd7fe769370e017cb3015"
+  integrity sha512-qPTJpUwIiis2OwpVzDd3I8dBjBkelDnvAW+dJkX+8B840JP5a7E1zVoAuR7OOAXqKa95R7miwK+5la1aSeWoDg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/utils" "^3.13.1"
+    "@react-types/shared" "^3.13.1"
+
+"@react-aria/ssr@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.2.0.tgz#88460384b43204f91c972d5b0de24ee44d6a2984"
+  integrity sha512-wwJFdkl+Q8NU5yJ4NvdAOqx5LM3QtUVoSjuK7Ey8jZ4WS4bB0EqT3Kr3IInBs257HzZ5nXCiKXKE4NGXXuIRWA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-aria/utils@^3.13.1":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.13.1.tgz#45557fdc7ae9de057a83014013bf09e54d074c96"
+  integrity sha512-usW6RoLKil4ylgDbRcaQ5YblNGv5ZihI4I9NB8pdazhw53cSRyLaygLdmHO33xgpPnAhb6Nb/tv8d5p6cAde+A==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/ssr" "^3.2.0"
+    "@react-stately/utils" "^3.5.0"
+    "@react-types/shared" "^3.13.1"
+    clsx "^1.1.1"
+
 "@react-dnd/asap@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-4.0.0.tgz#b300eeed83e9801f51bd66b0337c9a6f04548651"
@@ -2849,6 +2894,18 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz#a3031eb54129f2c66b2753f8404266ec7bf67f0a"
   integrity sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==
+
+"@react-stately/utils@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.5.0.tgz#e76231cfc93042814dcc5d96436e50c807c1d905"
+  integrity sha512-WzzwlQtJrf7egaN+lt02/f/wkFKbcscsbinmXs9pL7QyYm+BCQ9xXj01w0juzt93piZgB/kfIYJqInEdpudh1A==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-types/shared@^3.13.1":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.13.1.tgz#eda5e3744971606f753baf7879136bf8e3f707ab"
+  integrity sha512-EHQqILDJeDvnloy5VV9lnnEjpCMwH1ghptCfa/lz9Ht9nwco3qGCvUABkWyND7yU1Adt3A/1oJxhpRUu3eTlyg==
 
 "@sideway/address@^4.1.0":
   version "4.1.2"
@@ -10849,7 +10906,7 @@ event-source-polyfill@^1.0.15:
 event-stream@3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
-  integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
+  integrity sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==
   dependencies:
     duplexer "~0.1.1"
     from "~0"
@@ -11605,7 +11662,7 @@ from2@^2.1.0:
 from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
-  integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
+  integrity sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -16255,7 +16312,7 @@ lru-cache@^2.5.0:
 lru-cache@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
-  integrity sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=
+  integrity sha512-91gyOKTc2k66UG6kHiH4h3S2eltcPwE1STVfMYC/NG+nZwf8IIuiamfmpGZjpbbxzSyEJaLC0tNSmhjlQUTJow==
   dependencies:
     pseudomap "^1.0.1"
 
@@ -16407,7 +16464,7 @@ map-or-similar@^1.5.0:
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
-  integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
+  integrity sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -17438,6 +17495,11 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
 minipass-collect@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-1.0.2.tgz#22b813bf745dc6edba2576b940022ad6edc8c617"
@@ -17558,12 +17620,19 @@ mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@~0.5.0:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -17919,7 +17988,7 @@ node-status-codes@^1.0.0:
 nopt@^3.0.0, nopt@~3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
-  integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
+  integrity sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==
   dependencies:
     abbrev "1"
 
@@ -19046,7 +19115,7 @@ path-type@^4.0.0:
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
-  integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
+  integrity sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==
   dependencies:
     through "~2.3"
 
@@ -22226,7 +22295,7 @@ side-channel@^1.0.4:
 sigmund@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
-  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
+  integrity sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.5"
@@ -22576,7 +22645,7 @@ split2@^3.0.0:
 split@0.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
-  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  integrity sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==
   dependencies:
     through "2"
 
@@ -22756,7 +22825,7 @@ stream-combiner2@^1.1.1:
 stream-combiner@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
-  integrity sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
+  integrity sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==
   dependencies:
     duplexer "~0.1.1"
 
@@ -23585,7 +23654,7 @@ through2@^4.0.0:
 through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
 time-stamp@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Fixes #3342

This is a draft to enable the focus ring to be visible only when the user interacts with the keyboard and not be visible on click, there are some details that we need to analyze, for example, some components manually focus on the element and this shows the focus ring, maybe we avoid it.

Another detail is that `input` components cannot easily solve this with just the extra markup and `c-inner` so we would have to control this via JavaScript, for example when interacting via the keyboard we add the focus ring class.

My idea is that we don't allow disabling/enabling this at the component level, we do it for all components is what makes sense. So you need to use `Provider` in the application root to enable it.

```jsx
<Provider focusRing={true}>
  ...
</Provider>
```