### PR TITLE
fix(@clayui/css): Add option to generate placeholders separately in component variant maps

### DIFF
--- a/clayui.com/content/docs/components/markup-aspect-ratio.md
+++ b/clayui.com/content/docs/components/markup-aspect-ratio.md
@@ -6,6 +6,7 @@ title: 'Aspect Ratio'
 <div class="nav-toc">
 
 -   [Aspect Ratio](#css-aspect-ratio)
+    -   [Sass API](#css-aspect-ratio-sass-api)
     -   [Bg Contain](#css-aspect-ratio-bg-contain)
     -   [Bg Cover](#css-aspect-ratio-bg-cover)
     -   [Bg Center](#css-aspect-ratio-bg-center)
@@ -68,6 +69,41 @@ Use `aspect-ratio-3-to-2`, `aspect-ratio-4-to-3`, `aspect-ratio-8-to-3`, `aspect
 <div class="aspect-ratio aspect-ratio-8-to-3"></div>
 <div class="aspect-ratio aspect-ratio-8-to-5"></div>
 <div class="aspect-ratio aspect-ratio-16-to-9"></div>
+```
+
+### Aspect Ratio Sass API(#css-aspect-ratio-sass-api)
+
+The map `$aspect-ratio-sizes` allows generating any number of aspect ratio variants. If a key starts with `.`, `#`, or '%' Clay will output it as is, otherwise we will prepend `.` to the key (e.g., `.aspect-ratio-16-to-9`). It will also generate a Sass placeholder prefixed by `%` (e.g., `%aspect-ratio-16-to-9`).
+
+```scss{expanded}
+$aspect-ratio-sizes: (
+    aspect-ratio-16-to-9: (
+        height: 9,
+        width: 16,
+    ),
+    '.card .aspect-ratio': (
+        extend: '%aspect-ratio-16-to-9',
+    ),
+    '%aspect-ratio-4-to-1': (
+        height: 1,
+        width: 4,
+    ),
+    '.aspect-ratio-4-to-1': (
+        extend: '%aspect-ratio-4-to-1',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.aspect-ratio-16-to-9, .card .aspect-ratio {
+    padding-bottom: calc(9 / 16 * 100%);
+}
+
+.aspect-ratio-4-to-1 {
+    padding-bottom: calc(1 / 4 * 100%);
+}
 ```
 
 ### Aspect Ratio Bg Contain(#css-aspect-ratio-bg-contain)

--- a/clayui.com/content/docs/css/utilities/markup-borders.md
+++ b/clayui.com/content/docs/css/utilities/markup-borders.md
@@ -8,6 +8,7 @@ title: 'Border'
 -   [Additive](#css-additive)
 -   [Subtractive](#css-subtractive)
 -   [Border Color](#css-border-color)
+    -   [Sass API](#css-border-color-sass-api)
 -   [Rounded](#css-rounded)
 -   [Rounded Sizes](#css-rounded-sizes)
 
@@ -162,6 +163,39 @@ title: 'Border'
 <div class="border border-danger"></div>
 <div class="border border-dark"></div>
 <div class="border border-light"></div>
+```
+
+### Border Color Sass API(#css-border-color-sass-api)
+
+The map `$border-theme-colors` allows generating any number of border variants. If a key starts with `.`, `#` or `%`, Clay will output it as is, otherwise we will prepend `.border-` to the key (e.g., `.border-primary`).
+
+```scss{expanded}
+$border-theme-colors: (
+    'primary': (
+        border-color: $primary !important,
+    ),
+    '%b-tertiary': (
+        border-color: green !important,
+    ),
+    '.b-tertiary': (
+        extend: '%border-tertiary',
+    ),
+    '.b-quaternary': (
+        extend: '%border-tertiary',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.border-primary {
+    border-color: #0b5fff !important;
+}
+
+.b-tertiary, .b-quaternary {
+    border-color: green !important;
+}
 ```
 
 ## Rounded(#css-rounded)

--- a/clayui.com/content/docs/css/utilities/markup-color-utilities.md
+++ b/clayui.com/content/docs/css/utilities/markup-color-utilities.md
@@ -7,12 +7,14 @@ title: 'Color Utilities'
 
 -   [Text Color](#css-text-color)
     -   [Link Color](#css-link-color)
+    -   [Sass API](#css-text-color-sass-api)
 -   [Background Color](#css-background-color)
+    -   [Sass API](#css-background-color-sass-api)
 
 </div>
 </div>
 
-## Text Color
+## Text Color(#css-text-color)
 
 <div class="sheet-example">
 	<div class="table-responsive">
@@ -99,7 +101,7 @@ title: 'Color Utilities'
 
 ### Link Color(#css-link-color)
 
-Text color utilities applied to anchor tags.
+Text color utilities applied to anchor tags. These styles will only be output if a text color has `hover` state styles.
 
 <div class="sheet-example">
 	<div class="table-responsive">
@@ -179,6 +181,39 @@ Text color utilities applied to anchor tags.
 <a class="text-white-50" href="#1"></a>
 ```
 
+### Text Color Sass API(#css-text-color-sass-api)
+
+The map `$text-theme-colors` allows generating any number of text color variants. If a key starts with `.`, `#` or `%`, Clay will output it as is, otherwise we will prepend `.text-` to the key (e.g., `.text-primary`).
+
+```scss{expanded}
+$text-theme-colors: (
+    'primary': (
+        color: $primary !important,
+    ),
+    '%text-tertiary': (
+        color: green !important,
+    ),
+    '.text-tertiary': (
+        extend: '%text-tertiary',
+    ),
+    '.text-quaternary': (
+        extend: '%text-tertiary',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.text-primary {
+    color: #0b5fff !important;
+}
+
+.text-tertiary, .text-quaternary {
+    color: green !important;
+}
+```
+
 ## Background Color(#css-background-color)
 
 <div class="sheet-example">
@@ -247,4 +282,37 @@ Text color utilities applied to anchor tags.
 <div class="bg-light"></div>
 <div class="bg-white"></div>
 <div class="bg-transparent"></div>
+```
+
+### Background Color Sass API(#css-background-color-sass-api)
+
+The map `$bg-theme-colors` allows generating any number of background color variants. If a key starts with `.`, `#` or `%`, Clay will output it as is, otherwise we will prepend `.bg-` to the key (e.g., `.bg-primary`).
+
+```scss{expanded}
+$bg-theme-colors: (
+    'primary': (
+        background-color: $primary !important,
+    ),
+    '%bg-tertiary': (
+        background-color: green !important,
+    ),
+    '.bg-tertiary': (
+        extend: '%bg-tertiary',
+    ),
+    '.bg-quaternary': (
+        extend: '%bg-tertiary',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.bg-primary {
+    background-color: #0b5fff !important;
+}
+
+.bg-tertiary, .bg-quaternary {
+    background-color: green !important;
+}
 ```

--- a/clayui.com/content/docs/css/utilities/markup-text.md
+++ b/clayui.com/content/docs/css/utilities/markup-text.md
@@ -7,6 +7,7 @@ lexiconDefinition: 'https://liferay.design/lexicon/foundations/typography/'
 <div class="nav-toc">
 
 -   [Sizes](#css-text-sizes)
+    -   [Sass API](#css-text-sizes-sass-api)
 -   [Weights](#css-text-weights)
 -   [Styles](#css-text-styles)
 -   [Alignment](#css-text-alignment)
@@ -112,6 +113,39 @@ Utility classes for changing the `font-size` of text.
 <span class="text-3">The quick brown fox jumped over the lazy dog.</span>
 <span class="text-2">The quick brown fox jumped over the lazy dog.</span>
 <span class="text-1">The quick brown fox jumped over the lazy dog.</span>
+```
+
+### Text Sizes Sass API(#css-text-sizes-sass-api)
+
+The map `$font-sizes` allows generating any number of text size variants. If a key starts with `.`, `#` or `%`, Clay will output it as is, otherwise we will prepend `.` to the key (e.g., `.text-100`).
+
+```scss{expanded}
+$bg-theme-colors: (
+    text-100: (
+        font-size: 100px,
+    ),
+    '%text-200': (
+        font-size: 200px,
+    ),
+    '.text-200': (
+        extend: '%text-200',
+    ),
+    '.text-250': (
+        extend: '%text-200',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.text-100 {
+    font-size: 100px;
+}
+
+.text-200, .text-250 {
+    font-size: 200px;
+}
 ```
 
 ## Weights(#css-text-weights)

--- a/packages/clay-alert/docs/markup-alert.md
+++ b/packages/clay-alert/docs/markup-alert.md
@@ -10,6 +10,7 @@ mainTabURL: 'docs/components/alert.html'
 
 -   [Colors](#css-colors)
     -   [Non-standard Colors](#css-non-standard-colors)
+    -   [Sass API](#css-alert-variant-sass-api)
 -   [Examples](#css-examples)
     -   [Toast](#css-toast)
     -   [Embedded](#css-embedded)
@@ -88,6 +89,39 @@ The colors below do not follow Lexicon standards but follow the idea of [​​s
 		</div>
 	</div>
 </div>
+
+### Variant Sass API(#css-alert-variant-sass-api)
+
+The map `$alert-palette` allows generating any number of alert variants. If a key starts with `.`, `#` or `%`, Clay will output it as is, otherwise we will prepend `.alert-` to the key (e.g., `.alert-primary`). It will also generate a Sass placeholder prefixed by `%calert-` (e.g., `%alert-primary`).
+
+```scss{expanded}
+$alert-palette: (
+    primary: (
+        background-color: $primary,
+    ),
+    '%alert-tertiary': (
+        background-color: green,
+    ),
+    '.alert-tertiary': (
+        extend: '%alert-tertiary',
+    ),
+    '.alert-quaternary': (
+        extend: '%alert-tertiary',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.alert-primary {
+    background-color: #0b5fff;
+}
+
+.alert-tertiary, .alert-quaternary {
+    background-color: green;
+}
+```
 
 ## Examples(#css-examples)
 

--- a/packages/clay-badge/docs/markup-badge.md
+++ b/packages/clay-badge/docs/markup-badge.md
@@ -9,6 +9,7 @@ mainTabURL: 'docs/components/badge.html'
 <div class="nav-toc">
 
 -   [Variations](#css-variations)
+    -   [Sass API](#css-badge-sass-api)
 -   [Pill Badges](#css-pill-badges)
 -   [Anchor](#css-anchor)
 -   [Links Inside](#css-links-inside)
@@ -84,6 +85,42 @@ Add any of the below mentioned modifier classes to change the appearance of a ba
 <span class="badge badge-dark">
 	<span class="badge-item badge-item-expand">Dark</span>
 </span>
+```
+
+### Badge Sass API(#css-badge-sass-api)
+
+The map `$badge-palette` allows generating any number of badge variants. If a key starts with `.`, `#`, or '%' Clay will output it as is, otherwise we will prepend `.badge-` to the key (e.g., `.badge-primary`). It will also generate a Sass placeholder prefixed by `%badge-` (e.g., `%badge-primary`).
+
+```scss{expanded}
+$badge-palette: (
+    primary: (
+        background-color: $primary,
+    ),
+    '.badge-primary-2': (
+        extend: '%badge-primary',
+    ),
+    '%badge-tertiary': (
+        background-color: green,
+    ),
+    '.badge-tertiary': (
+        extend: '%badge-tertiary',
+    ),
+    '.badge-quaternary': (
+        extend: '%badge-tertiary',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.badge-primary, .badge-primary-2 {
+    background-color: #0b5fff;
+}
+
+.badge-tertiary, .badge-quaternary {
+    background-color: green;
+}
 ```
 
 ## Pill Badges(#css-pill-badges)

--- a/packages/clay-button/docs/markup-button.md
+++ b/packages/clay-button/docs/markup-button.md
@@ -9,10 +9,13 @@ mainTabURL: 'docs/components/button.html'
 <div class="nav-toc">
 
 -   [Examples](#css-examples)
+    -   [Sass API](#css-button-variant-sass-api)
 -   [Sizes](#css-sizes)
+    -   [Sass API](#css-button-size-sass-api)
 -   [Active state](#css-active-state)
 -   [Disabled State](#css-disabled-state)
 -   [Icons](#css-icons)
+    -   [Sass API](#css-button-monospaced-sass-api)
     -   [With text button](#css-with-text-button)
 
 </div>
@@ -44,6 +47,39 @@ mainTabURL: 'docs/components/button.html'
 <button class="btn btn-link" type="button">Link</button>
 ```
 
+### Button Variant Sass API(#css-button-variant-sass-api)
+
+The map `$btn-palette` allows generating any number of button variants. If a key starts with `.`, `#` or `%`, Clay will output it as is, otherwise we will prepend `.btn-` to the key (e.g., `.btn-primary`). It will also generate Sass placeholders prefix/appended by `%btn-` and `%btn-{color}-focus` (e.g., `%btn-primary` and `%btn-primary-focus`), respectively.
+
+```scss{expanded}
+$btn-palette: (
+    primary: (
+        background-color: $primary,
+    ),
+    '%btn-tertiary': (
+        background-color: green,
+    ),
+    '.btn-tertiary': (
+        extend: '%btn-tertiary',
+    ),
+    '.btn-quaternary': (
+        extend: '%btn-tertiary',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.btn-primary {
+    background-color: #0b5fff;
+}
+
+.btn-tertiary, .btn-quaternary {
+    background-color: green;
+}
+```
+
 ## Sizes(#css-sizes)
 
 <div class="sheet-example">
@@ -70,6 +106,39 @@ Create block level buttons—those that span the full width of a parent—by add
 <button class="btn btn-block btn-secondary" type="button">
 	Normal Block Level Button
 </button>
+```
+
+### Button Size Sass API(#css-button-size-sass-api)
+
+The map `$btn-sizes` allows generating any number of button size variants. If a key starts with `btn-` Clay will prepend `.` to the key (e.g., `.btn-sm`). It will also generate a Sass placeholder prefixed by `%clay-` (e.g., `%clay-btn-sm`).
+
+```scss{expanded}
+$btn-sizes: (
+    btn-sm: (
+        font-size: 14px,
+    ),
+    '.btn-xs': (
+        extend: '%clay-btn-sm',
+    ),
+    '%btn-xxs': (
+        font-size: 12px,
+    ),
+    '.btn-xxs': (
+        extend: '%btn-xxs',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.btn-sm, .btn-xs {
+    font-size: 14px;
+}
+
+.btn-xxs {
+    font-size: 12px;
+}
 ```
 
 ## Active State(#css-active-state)
@@ -138,6 +207,39 @@ Try adding the modifier class `.btn-monospaced`.
 		<use href="/images/icons/icons.svg#blogs"></use>
 	</svg>
 </button>
+```
+
+### Button Monospaced Sass API(#css-button-monospaced-sass-api)
+
+The map `$btn-monospaced-sizes` allows generating any number of button monospaced size variants. If a key starts with `btn-monospaced-` Clay will replace it with `.btn-monospaced.btn` (e.g., `.btn-monospaced.btn-sm`). It will also generate a Sass placeholder prefixed by `%clay-` (e.g., `%clay-btn-monospaced-sm`).
+
+```scss{expanded}
+$btn-monospaced-sizes: (
+    btn-monospaced-sm: (
+        font-size: 14px,
+    ),
+    '.btn-monospaced.btn-xs': (
+        extend: '%clay-btn-monospaced-sm',
+    ),
+    '%btn-monospaced-xxs': (
+        font-size: 12px,
+    ),
+    '.btn-monospaced.btn-xxs': (
+        extend: '%btn-monospaced-xxs',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.btn-monospaced.btn-sm, .btn-monospaced.btn-xs {
+    font-size: 14px;
+}
+
+.btn-monospaced.btn-xxs {
+    font-size: 12px;
+}
 ```
 
 ### With Text Button(#css-with-text-button)

--- a/packages/clay-css/src/scss/cadmin/components/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_alerts.scss
@@ -433,12 +433,32 @@
 
 // Alert Variants
 
-@each $cadmin-color, $cadmin-value in $cadmin-alert-palette {
-	%alert-#{$cadmin-color} {
-		@include clay-alert-variant($cadmin-value);
-	}
+@each $color, $value in $cadmin-alert-palette {
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.alert-', 1)
+	);
 
-	.alert-#{$cadmin-color} {
-		@extend %alert-#{$cadmin-color} !optional;
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-alert-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%alert-#{$color}'
+		);
+
+		#{$placeholder} {
+			@include clay-alert-variant($value);
+		}
+
+		#{$selector} {
+			@extend %alert-#{$color} !optional;
+		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_aspect-ratio.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_aspect-ratio.scss
@@ -162,26 +162,41 @@
 
 @each $selector, $value in $cadmin-aspect-ratio-sizes {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
 
-	$placeholder: str-insert(
-		str-slice($selector, 2, str-length($selector)),
-		'%',
-		1
-	);
-
-	#{$placeholder} {
-		@include clay-aspect-ratio(
-			map-get($value, width),
-			map-get($value, height)
+	@if (starts-with($selector, '%')) {
+		#{$selector} {
+			@include clay-aspect-ratio(
+				map-get($value, width),
+				map-get($value, height)
+			);
+		}
+	} @else if (map-get($value, extend)) {
+		#{$selector} {
+			@include clay-css($value);
+		}
+	} @else {
+		$placeholder: str-insert(
+			str-slice($selector, 2, str-length($selector)),
+			'%',
+			1
 		);
-	}
 
-	#{$selector} {
-		@extend #{$placeholder} !optional;
+		#{$placeholder} {
+			@include clay-aspect-ratio(
+				map-get($value, width),
+				map-get($value, height)
+			);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_badges.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_badges.scss
@@ -60,12 +60,32 @@
 
 // Badge Variants
 
-@each $cadmin-color, $cadmin-value in $cadmin-badge-palette {
-	%badge-#{$cadmin-color} {
-		@include clay-badge-variant($cadmin-value);
-	}
+@each $color, $value in $cadmin-badge-palette {
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.badge-', 1)
+	);
 
-	.badge-#{$cadmin-color} {
-		@extend %badge-#{$cadmin-color} !optional;
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-badge-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%badge-#{$color}'
+		);
+
+		#{$placeholder} {
+			@include clay-badge-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_buttons.scss
@@ -18,20 +18,32 @@ fieldset:disabled a.btn {
 
 // Button Sizes
 
-%clay-btn-lg {
-	@include clay-button-variant($cadmin-btn-lg);
-}
+@each $size, $value in $cadmin-btn-sizes {
+	$selector: if(
+		starts-with($size, 'btn-'),
+		clay-str-replace($size, 'btn-', '.btn-'),
+		$size
+	);
 
-.btn-lg {
-	@extend %clay-btn-lg !optional;
-}
+	@if (starts-with($size, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-button-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($size, 'btn-'),
+			'%clay-#{$size}',
+			'%#{str-slice($size, 2)}'
+		);
 
-%clay-btn-sm {
-	@include clay-button-variant($cadmin-btn-sm);
-}
+		#{$placeholder} {
+			@include clay-button-variant($value);
+		}
 
-.btn-sm {
-	@extend %clay-btn-sm !optional;
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
+	}
 }
 
 // Button Block
@@ -67,65 +79,119 @@ input[type='button'] {
 
 // Button Monospaced
 
-.btn-monospaced {
-	@include clay-button-variant($cadmin-btn-monospaced);
+@each $size, $value in $cadmin-btn-monospaced-sizes {
+	$selector: if(
+		starts-with($size, 'btn-monospaced-'),
+		clay-str-replace($size, 'btn-monospaced', '.btn-monospaced.btn'),
+		if(
+			$size == 'btn-monospaced',
+			clay-str-replace($size, 'btn-monospaced', '.btn-monospaced'),
+			$size
+		)
+	);
 
-	&.btn .lexicon-icon {
-		margin-top: 0;
+	@if (starts-with($size, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-button-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($size, 'btn-monospaced'),
+			'%clay-#{$size}',
+			'%#{str-slice($size, 2)}'
+		);
+
+		#{$placeholder} {
+			@include clay-button-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
-}
-
-%clay-btn-monospaced-lg {
-	@include clay-button-variant($cadmin-btn-monospaced-lg);
-}
-
-.btn-monospaced.btn-lg {
-	@extend %clay-btn-monospaced-lg !optional;
-}
-
-%clay-btn-monospaced-sm {
-	@include clay-button-variant($cadmin-btn-monospaced-sm);
-}
-
-.btn-monospaced.btn-sm {
-	@extend %clay-btn-monospaced-sm !optional;
 }
 
 // Button Variants
 
-@each $cadmin-color, $cadmin-value in $cadmin-btn-palette {
-	%btn-#{$cadmin-color} {
-		@include clay-button-variant($cadmin-value);
-	}
+@each $color, $value in $cadmin-btn-palette {
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.btn-', 1)
+	);
 
-	.btn-#{$cadmin-color} {
-		@extend %btn-#{$cadmin-color} !optional;
-	}
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-button-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%btn-#{$color}'
+		);
 
-	%btn-#{$cadmin-color}-focus {
-		background-color: map-get($cadmin-value, focus-bg);
-		border-color: map-get($cadmin-value, focus-border-color);
-		box-shadow: map-get($cadmin-value, focus-box-shadow);
-		color: map-get($cadmin-value, focus-color);
+		$placeholder-focus: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}-focus',
+			'%btn-#{$color}-focus'
+		);
+
+		#{$placeholder} {
+			@include clay-button-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
+
+		#{$placeholder-focus} {
+			@include clay-button-variant(map-get($value, focus));
+		}
 	}
 }
 
 // Button Outline Variants
 
-@each $cadmin-color, $cadmin-value in $cadmin-btn-outline-palette {
-	%btn-outline-#{$cadmin-color} {
-		@include clay-button-variant($cadmin-value);
-	}
+@each $color, $value in $cadmin-btn-outline-palette {
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.btn-outline-', 1)
+	);
 
-	.btn-outline-#{$cadmin-color} {
-		@extend %btn-outline-#{$cadmin-color} !optional;
-	}
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-button-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%btn-outline-#{$color}'
+		);
 
-	%btn-outline-#{$cadmin-color}-focus {
-		background-color: map-get($cadmin-value, focus-bg);
-		border-color: map-get($cadmin-value, focus-border-color);
-		box-shadow: map-get($cadmin-value, focus-box-shadow);
-		color: map-get($cadmin-value, focus-color);
+		$placeholder-focus: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}-focus',
+			'%btn-outline-#{$color}-focus'
+		);
+
+		#{$placeholder} {
+			@include clay-button-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
+
+		#{$placeholder-focus} {
+			@include clay-button-variant(map-get($value, focus));
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_labels.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_labels.scss
@@ -56,24 +56,64 @@
 
 // Label Sizes
 
-@each $cadmin-selector, $cadmin-value in $cadmin-label-sizes {
-	%#{$cadmin-selector} {
-		@include clay-label-variant($cadmin-value);
-	}
+@each $selector, $value in $cadmin-label-sizes {
+	$selector: if(
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
+		$selector,
+		str-insert($selector, '.', 1)
+	);
 
-	.#{$cadmin-selector} {
-		@extend %#{$cadmin-selector} !optional;
+	@if (starts-with($selector, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-label-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($selector, '.') or starts-with($selector, '#'),
+			'%#{str-slice($selector, 2)}',
+			'%#{$selector}'
+		);
+
+		#{$placeholder} {
+			@include clay-label-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 
 // Label Variants
 
-@each $cadmin-color, $cadmin-value in $cadmin-label-palette {
-	%label-#{$cadmin-color} {
-		@include clay-label-variant($cadmin-value);
-	}
+@each $color, $value in $cadmin-label-palette {
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.label-', 1)
+	);
 
-	.label-#{$cadmin-color} {
-		@extend %label-#{$cadmin-color} !optional;
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-label-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%label-#{$color}'
+		);
+
+		#{$placeholder} {
+			@include clay-label-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }

--- a/packages/clay-css/src/scss/cadmin/components/_popovers.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_popovers.scss
@@ -2,7 +2,9 @@
 
 @each $selector, $value in $cadmin-popovers {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
@@ -154,7 +156,9 @@
 
 @each $selector, $value in $cadmin-popover-headers {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
@@ -168,7 +172,9 @@
 
 @each $selector, $value in $cadmin-popover-bodies {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
@@ -182,7 +188,9 @@
 
 @each $selector, $value in $cadmin-popover-widths {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);

--- a/packages/clay-css/src/scss/cadmin/components/_stickers.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_stickers.scss
@@ -68,25 +68,65 @@
 
 // Sticker Sizes
 
-@each $cadmin-selector, $cadmin-value in $cadmin-sticker-sizes {
-	%#{$cadmin-selector} {
-		@include clay-sticker-variant($cadmin-value);
-	}
+@each $selector, $value in $cadmin-sticker-sizes {
+	$selector: if(
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
+		$selector,
+		str-insert($selector, '.', 1)
+	);
 
-	.#{$cadmin-selector} {
-		@extend %#{$cadmin-selector} !optional;
+	@if (starts-with($selector, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-sticker-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($selector, '.') or starts-with($selector, '#'),
+			'%#{str-slice($selector, 2)}',
+			'%#{$selector}'
+		);
+
+		#{$placeholder} {
+			@include clay-sticker-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 
 // Sticker Variants
 
-@each $cadmin-color, $cadmin-value in $cadmin-sticker-palette {
-	%sticker-#{$cadmin-color} {
-		@include clay-sticker-variant($cadmin-value);
-	}
+@each $color, $value in $cadmin-sticker-palette {
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.sticker-', 1)
+	);
 
-	.sticker-#{$cadmin-color} {
-		@extend %sticker-#{$cadmin-color} !optional;
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-sticker-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%sticker-#{$color}'
+		);
+
+		#{$placeholder} {
+			@include clay-sticker-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
@@ -24,40 +24,34 @@
 
 // Background
 
-@each $cadmin-color, $cadmin-value in $cadmin-theme-colors {
-	.bg-#{$cadmin-color} {
-		background-color: $cadmin-value !important;
+@each $color, $value in $cadmin-bg-theme-colors {
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.bg-', 1)
+	);
+
+	#{$selector} {
+		@include clay-css($value);
 	}
 
-	a.bg-#{$cadmin-color},
-	button.bg-#{$cadmin-color} {
+	a#{$selector},
+	button#{$selector} {
 		&:hover,
 		&:focus {
-			background-color: clay-darken($cadmin-value, 10%) !important;
+			@include clay-css(map-get($value, hover));
 		}
 	}
 }
 
 @if $cadmin-enable-gradients {
-	@each $cadmin-color, $cadmin-value in $cadmin-theme-colors {
-		.bg-gradient-#{$cadmin-color} {
-			background: $cadmin-value
-				linear-gradient(
-					180deg,
-					clay-mix($cadmin-body-bg, $cadmin-value, 15%),
-					$cadmin-value
-				)
-				repeat-x !important;
+	@each $color, $value in $cadmin-bg-gradient-theme-colors {
+		.bg-gradient-#{$color} {
+			@include clay-css($value);
 		}
 	}
-}
-
-.bg-white {
-	background-color: $cadmin-white !important;
-}
-
-.bg-transparent {
-	background-color: transparent !important;
 }
 
 // Border
@@ -102,14 +96,18 @@
 	border-left: 0 !important;
 }
 
-@each $cadmin-color, $cadmin-value in $cadmin-theme-colors {
-	.border-#{$cadmin-color} {
-		border-color: $cadmin-value !important;
-	}
-}
+@each $color, $value in $cadmin-border-theme-colors {
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.border-', 1)
+	);
 
-.border-white {
-	border-color: $cadmin-white !important;
+	#{$selector} {
+		@include clay-css($value);
+	}
 }
 
 // Border-radius
@@ -759,7 +757,9 @@
 
 @each $selector, $value in $cadmin-font-sizes {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
@@ -775,38 +775,25 @@
 	color: $cadmin-white !important;
 }
 
-@each $cadmin-color, $cadmin-value in $cadmin-theme-colors {
-	.text-#{$cadmin-color} {
-		color: $cadmin-value !important;
+@each $color, $value in $cadmin-text-theme-colors {
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.text-', 1)
+	);
+
+	#{$selector} {
+		@include clay-css($value);
 	}
 
-	@if $cadmin-emphasized-link-hover-darken-percentage != 0 {
-		a.text-#{$cadmin-color} {
-			&:hover,
-			&:focus {
-				color: clay-darken(
-					$cadmin-value,
-					$cadmin-emphasized-link-hover-darken-percentage
-				) !important;
-			}
+	a#{$selector} {
+		&:hover,
+		&:focus {
+			@include clay-css(map-get($value, hover));
 		}
 	}
-}
-
-.text-body {
-	color: $cadmin-body-color !important;
-}
-
-.text-muted {
-	color: $cadmin-text-muted !important;
-}
-
-.text-black-50 {
-	color: rgba($cadmin-black, 0.5) !important;
-}
-
-.text-white-50 {
-	color: rgba($cadmin-white, 0.5) !important;
 }
 
 // Misc

--- a/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
@@ -187,6 +187,17 @@ $cadmin-btn-sm: map-deep-merge(
 	$cadmin-btn-sm
 );
 
+// Button Sizes
+
+$cadmin-btn-sizes: () !default;
+$cadmin-btn-sizes: map-deep-merge(
+	(
+		btn-lg: $cadmin-btn-lg,
+		btn-sm: $cadmin-btn-sm,
+	),
+	$cadmin-btn-sizes
+);
+
 // Button Monospaced
 
 $cadmin-btn-monospaced-padding-x: 0 !default;
@@ -278,6 +289,18 @@ $cadmin-btn-monospaced-sm: map-deep-merge(
 		),
 	),
 	$cadmin-btn-monospaced-sm
+);
+
+// Button Monospaced Sizes
+
+$cadmin-btn-monospaced-sizes: () !default;
+$cadmin-btn-monospaced-sizes: map-deep-merge(
+	(
+		btn-monospaced: $cadmin-btn-monospaced,
+		btn-monospaced-lg: $cadmin-btn-monospaced-lg,
+		btn-monospaced-sm: $cadmin-btn-monospaced-sm,
+	),
+	$cadmin-btn-monospaced-sizes
 );
 
 // Button Block

--- a/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
@@ -172,6 +172,184 @@ $cadmin-inline-item: map-deep-merge(
 
 $cadmin-page-header-bg: $cadmin-white !default;
 
+// Background
+
+$cadmin-bg-theme-colors: () !default;
+$cadmin-bg-theme-colors: map-deep-merge(
+	(
+		'primary': (
+			background-color: $cadmin-primary !important,
+			hover: (
+				background-color: clay-darken($cadmin-primary, 10%) !important,
+			),
+		),
+		'secondary': (
+			background-color: $cadmin-secondary !important,
+			hover: (
+				background-color: clay-darken($cadmin-secondary, 10%) !important,
+			),
+		),
+		'success': (
+			background-color: $cadmin-success !important,
+			hover: (
+				background-color: clay-darken($cadmin-success, 10%) !important,
+			),
+		),
+		'info': (
+			background-color: $cadmin-info !important,
+			hover: (
+				background-color: clay-darken($cadmin-info, 10%) !important,
+			),
+		),
+		'warning': (
+			background-color: $cadmin-warning !important,
+			hover: (
+				background-color: clay-darken($cadmin-warning, 10%) !important,
+			),
+		),
+		'danger': (
+			background-color: $cadmin-danger !important,
+			hover: (
+				background-color: clay-darken($cadmin-danger, 10%) !important,
+			),
+		),
+		'light': (
+			background-color: $cadmin-light !important,
+			hover: (
+				background-color: clay-darken($cadmin-light, 10%) !important,
+			),
+		),
+		'dark': (
+			background-color: $cadmin-dark !important,
+			hover: (
+				background-color: clay-darken($cadmin-dark, 10%) !important,
+			),
+		),
+		'white': (
+			background-color: $cadmin-white !important,
+		),
+		'transparent': (
+			background-color: transparent !important,
+		),
+	),
+	$cadmin-bg-theme-colors
+);
+
+$cadmin-bg-gradient-theme-colors: () !default;
+$cadmin-bg-gradient-theme-colors: map-deep-merge(
+	(
+		'primary': (
+			background: $cadmin-primary
+				linear-gradient(
+					180deg,
+					clay-mix($cadmin-body-bg, $cadmin-primary, 15%),
+					$cadmin-primary
+				)
+				repeat-x !important,
+		),
+		'secondary': (
+			background: $cadmin-secondary
+				linear-gradient(
+					180deg,
+					clay-mix($cadmin-body-bg, $cadmin-secondary, 15%),
+					$cadmin-secondary
+				)
+				repeat-x !important,
+		),
+		'success': (
+			background: $cadmin-success
+				linear-gradient(
+					180deg,
+					clay-clay-mix($cadmin-body-bg, $cadmin-success, 15%),
+					$cadmin-success
+				)
+				repeat-x !important,
+		),
+		'info': (
+			background: $cadmin-info
+				linear-gradient(
+					180deg,
+					clay-mix($cadmin-body-bg, $cadmin-info, 15%),
+					$cadmin-info
+				)
+				repeat-x !important,
+		),
+		'warning': (
+			background: $cadmin-warning
+				linear-gradient(
+					180deg,
+					clay-mix($cadmin-body-bg, $cadmin-warning, 15%),
+					$cadmin-warning
+				)
+				repeat-x !important,
+		),
+		'danger': (
+			background: $cadmin-danger
+				linear-gradient(
+					180deg,
+					clay-mix($cadmin-body-bg, $cadmin-danger, 15%),
+					$cadmin-danger
+				)
+				repeat-x !important,
+		),
+		'light': (
+			background: $cadmin-light
+				linear-gradient(
+					180deg,
+					clay-mix($cadmin-body-bg, $cadmin-light, 15%),
+					$cadmin-light
+				)
+				repeat-x !important,
+		),
+		'dark': (
+			background: $cadmin-dark
+				linear-gradient(
+					180deg,
+					clay-mix($cadmin-body-bg, $cadmin-dark, 15%),
+					$cadmin-dark
+				)
+				repeat-x !important,
+		),
+	),
+	$cadmin-bg-gradient-theme-colors
+);
+
+// Border
+
+$cadmin-border-theme-colors: () !default;
+$cadmin-border-theme-colors: map-deep-merge(
+	(
+		'primary': (
+			border-color: $cadmin-primary !important,
+		),
+		'secondary': (
+			border-color: $cadmin-secondary !important,
+		),
+		'success': (
+			border-color: $cadmin-success !important,
+		),
+		'info': (
+			border-color: $cadmin-info !important,
+		),
+		'warning': (
+			border-color: $cadmin-warning !important,
+		),
+		'danger': (
+			border-color: $cadmin-danger !important,
+		),
+		'light': (
+			border-color: $cadmin-light !important,
+		),
+		'dark': (
+			border-color: $cadmin-dark !important,
+		),
+		'white': (
+			border-color: $cadmin-white !important,
+		),
+	),
+	$cadmin-border-theme-colors
+);
+
 // Display
 
 $cadmin-displays: none, inline, inline-block, block, table, table-row,
@@ -225,4 +403,113 @@ $cadmin-font-sizes: map-deep-merge(
 		),
 	),
 	$cadmin-font-sizes
+);
+
+// Text
+
+$cadmin-text-theme-colors: () !default;
+$cadmin-text-theme-colors: map-deep-merge(
+	(
+		'primary': (
+			color: $cadmin-primary !important,
+			hover: (
+				color:
+					clay-darken(
+						$cadmin-primary,
+						$cadmin-emphasized-link-hover-darken-percentage
+					)
+					!important,
+			),
+		),
+		'secondary': (
+			color: $cadmin-secondary !important,
+			hover: (
+				color:
+					clay-darken(
+						$cadmin-secondary,
+						$cadmin-emphasized-link-hover-darken-percentage
+					)
+					!important,
+			),
+		),
+		'success': (
+			color: $cadmin-success !important,
+			hover: (
+				color:
+					clay-darken(
+						$cadmin-success,
+						$cadmin-emphasized-link-hover-darken-percentage
+					)
+					!important,
+			),
+		),
+		'info': (
+			color: $cadmin-info !important,
+			hover: (
+				color:
+					clay-darken(
+						$cadmin-info,
+						$cadmin-emphasized-link-hover-darken-percentage
+					)
+					!important,
+			),
+		),
+		'warning': (
+			color: $cadmin-warning !important,
+			hover: (
+				color:
+					clay-darken(
+						$cadmin-warning,
+						$cadmin-emphasized-link-hover-darken-percentage
+					)
+					!important,
+			),
+		),
+		'danger': (
+			color: $cadmin-danger !important,
+			hover: (
+				color:
+					clay-darken(
+						$cadmin-danger,
+						$cadmin-emphasized-link-hover-darken-percentage
+					)
+					!important,
+			),
+		),
+		'light': (
+			color: $cadmin-light !important,
+			hover: (
+				color:
+					clay-darken(
+						$cadmin-light,
+						$cadmin-emphasized-link-hover-darken-percentage
+					)
+					!important,
+			),
+		),
+		'dark': (
+			color: $cadmin-dark !important,
+			hover: (
+				color:
+					clay-darken(
+						$cadmin-dark,
+						$cadmin-emphasized-link-hover-darken-percentage
+					)
+					!important,
+			),
+		),
+		'body': (
+			color: $cadmin-body-color !important,
+		),
+		'muted': (
+			color: $cadmin-text-muted !important,
+		),
+		'black-50': (
+			color: rgba($cadmin-black, 0.5) !important,
+		),
+		'white-50': (
+			color: rgba($cadmin-white, 0.5) !important,
+		),
+	),
+	$cadmin-text-theme-colors
 );

--- a/packages/clay-css/src/scss/components/_alerts.scss
+++ b/packages/clay-css/src/scss/components/_alerts.scss
@@ -420,11 +420,31 @@
 // Alert Variants
 
 @each $color, $value in $alert-palette {
-	%alert-#{$color} {
-		@include clay-alert-variant($value);
-	}
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.alert-', 1)
+	);
 
-	.alert-#{$color} {
-		@extend %alert-#{$color} !optional;
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-alert-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%alert-#{$color}'
+		);
+
+		#{$placeholder} {
+			@include clay-alert-variant($value);
+		}
+
+		#{$selector} {
+			@extend %alert-#{$color} !optional;
+		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_aspect-ratio.scss
+++ b/packages/clay-css/src/scss/components/_aspect-ratio.scss
@@ -162,26 +162,41 @@
 
 @each $selector, $value in $aspect-ratio-sizes {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
 
-	$placeholder: str-insert(
-		str-slice($selector, 2, str-length($selector)),
-		'%',
-		1
-	);
-
-	#{$placeholder} {
-		@include clay-aspect-ratio(
-			map-get($value, width),
-			map-get($value, height)
+	@if (starts-with($selector, '%')) {
+		#{$selector} {
+			@include clay-aspect-ratio(
+				map-get($value, width),
+				map-get($value, height)
+			);
+		}
+	} @else if (map-get($value, extend)) {
+		#{$selector} {
+			@include clay-css($value);
+		}
+	} @else {
+		$placeholder: str-insert(
+			str-slice($selector, 2, str-length($selector)),
+			'%',
+			1
 		);
-	}
 
-	#{$selector} {
-		@extend #{$placeholder} !optional;
+		#{$placeholder} {
+			@include clay-aspect-ratio(
+				map-get($value, width),
+				map-get($value, height)
+			);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_badges.scss
+++ b/packages/clay-css/src/scss/components/_badges.scss
@@ -108,11 +108,31 @@
 // Badge Variants
 
 @each $color, $value in $badge-palette {
-	%badge-#{$color} {
-		@include clay-badge-variant($value);
-	}
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.badge-', 1)
+	);
 
-	.badge-#{$color} {
-		@extend %badge-#{$color} !optional;
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-badge-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%badge-#{$color}'
+		);
+
+		#{$placeholder} {
+			@include clay-badge-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -19,24 +19,30 @@ fieldset:disabled a.btn {
 // Button Sizes
 
 @each $size, $value in $btn-sizes {
-	$placeholder: if(
-		starts-with($size, 'btn-'),
-		'%clay-#{$size}',
-		'%#{str-slice($size, 2)}'
-	);
-
 	$selector: if(
 		starts-with($size, 'btn-'),
 		clay-str-replace($size, 'btn-', '.btn-'),
 		$size
 	);
 
-	#{$placeholder} {
-		@include clay-button-variant($value);
-	}
+	@if (starts-with($size, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-button-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($size, 'btn-'),
+			'%clay-#{$size}',
+			'%#{str-slice($size, 2)}'
+		);
 
-	#{$selector} {
-		@extend #{$placeholder} !optional;
+		#{$placeholder} {
+			@include clay-button-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 
@@ -74,12 +80,6 @@ input[type='button'] {
 // Button Monospaced
 
 @each $size, $value in $btn-monospaced-sizes {
-	$placeholder: if(
-		starts-with($size, 'btn-monospaced'),
-		'%clay-#{$size}',
-		'%#{str-slice($size, 2)}'
-	);
-
 	$selector: if(
 		starts-with($size, 'btn-monospaced-'),
 		clay-str-replace($size, 'btn-monospaced', '.btn-monospaced.btn'),
@@ -90,80 +90,108 @@ input[type='button'] {
 		)
 	);
 
-	#{$placeholder} {
-		@include clay-button-variant($value);
-	}
+	@if (starts-with($size, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-button-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($size, 'btn-monospaced'),
+			'%clay-#{$size}',
+			'%#{str-slice($size, 2)}'
+		);
 
-	#{$selector} {
-		@extend #{$placeholder} !optional;
+		#{$placeholder} {
+			@include clay-button-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 
 // Button Variants
 
 @each $color, $value in $btn-palette {
-	$placeholder: if(
-		starts-with($color, '.') or starts-with($color, '#'),
-		'%#{str-slice($color, 2)}',
-		'%btn-#{$color}'
-	);
-
-	$placeholder-focus: if(
-		starts-with($color, '.') or starts-with($color, '#'),
-		'%#{str-slice($color, 2)}-focus',
-		'%btn-#{$color}-focus'
-	);
-
 	$selector: if(
-		starts-with($color, '.') or starts-with($color, '#'),
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
 		$color,
 		str-insert($color, '.btn-', 1)
 	);
 
-	#{$placeholder} {
-		@include clay-button-variant($value);
-	}
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-button-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%btn-#{$color}'
+		);
 
-	#{$selector} {
-		@extend #{$placeholder} !optional;
-	}
+		$placeholder-focus: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}-focus',
+			'%btn-#{$color}-focus'
+		);
 
-	#{$placeholder-focus} {
-		@include clay-button-variant(map-get($value, focus));
+		#{$placeholder} {
+			@include clay-button-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
+
+		#{$placeholder-focus} {
+			@include clay-button-variant(map-get($value, focus));
+		}
 	}
 }
 
 // Button Outline Variants
 
 @each $color, $value in $btn-outline-palette {
-	$placeholder: if(
-		starts-with($color, '.') or starts-with($color, '#'),
-		'%#{str-slice($color, 2)}',
-		'%btn-outline-#{$color}'
-	);
-
-	$placeholder-focus: if(
-		starts-with($color, '.') or starts-with($color, '#'),
-		'%#{str-slice($color, 2)}-focus',
-		'%btn-outline-#{$color}-focus'
-	);
-
 	$selector: if(
-		starts-with($color, '.') or starts-with($color, '#'),
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
 		$color,
 		str-insert($color, '.btn-outline-', 1)
 	);
 
-	#{$placeholder} {
-		@include clay-button-variant($value);
-	}
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-button-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%btn-outline-#{$color}'
+		);
 
-	#{$selector} {
-		@extend #{$placeholder} !optional;
-	}
+		$placeholder-focus: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}-focus',
+			'%btn-outline-#{$color}-focus'
+		);
 
-	#{$placeholder-focus} {
-		@include clay-button-variant(map-get($value, focus));
+		#{$placeholder} {
+			@include clay-button-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
+
+		#{$placeholder-focus} {
+			@include clay-button-variant(map-get($value, focus));
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_labels.scss
+++ b/packages/clay-css/src/scss/components/_labels.scss
@@ -93,23 +93,63 @@
 // Label Sizes
 
 @each $selector, $value in $label-sizes {
-	%#{$selector} {
-		@include clay-label-variant($value);
-	}
+	$selector: if(
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
+		$selector,
+		str-insert($selector, '.', 1)
+	);
 
-	.#{$selector} {
-		@extend %#{$selector} !optional;
+	@if (starts-with($selector, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-label-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($selector, '.') or starts-with($selector, '#'),
+			'%#{str-slice($selector, 2)}',
+			'%#{$selector}'
+		);
+
+		#{$placeholder} {
+			@include clay-label-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 
 // Label Variants
 
 @each $color, $value in $label-palette {
-	%label-#{$color} {
-		@include clay-label-variant($value);
-	}
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.label-', 1)
+	);
 
-	.label-#{$color} {
-		@extend %label-#{$color} !optional;
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-label-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%label-#{$color}'
+		);
+
+		#{$placeholder} {
+			@include clay-label-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }

--- a/packages/clay-css/src/scss/components/_popovers.scss
+++ b/packages/clay-css/src/scss/components/_popovers.scss
@@ -2,7 +2,9 @@
 
 @each $selector, $value in $popovers {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
@@ -149,7 +151,9 @@
 
 @each $selector, $value in $popover-headers {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
@@ -163,7 +167,9 @@
 
 @each $selector, $value in $popover-bodies {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
@@ -177,7 +183,9 @@
 
 @each $selector, $value in $popover-widths {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);

--- a/packages/clay-css/src/scss/components/_sidebar.scss
+++ b/packages/clay-css/src/scss/components/_sidebar.scss
@@ -112,7 +112,9 @@
 
 @each $color, $value in $sidebar-palette {
 	$selector: if(
-		starts-with($color, '.') or starts-with($color, '#'),
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
 		$color,
 		str-insert($color, '.', 1)
 	);

--- a/packages/clay-css/src/scss/components/_stickers.scss
+++ b/packages/clay-css/src/scss/components/_stickers.scss
@@ -66,24 +66,64 @@
 // Sticker Sizes
 
 @each $selector, $value in $sticker-sizes {
-	%#{$selector} {
-		@include clay-sticker-variant($value);
-	}
+	$selector: if(
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
+		$selector,
+		str-insert($selector, '.', 1)
+	);
 
-	.#{$selector} {
-		@extend %#{$selector} !optional;
+	@if (starts-with($selector, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-sticker-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($selector, '.') or starts-with($selector, '#'),
+			'%#{str-slice($selector, 2)}',
+			'%#{$selector}'
+		);
+
+		#{$placeholder} {
+			@include clay-sticker-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 
 // Sticker Variants
 
 @each $color, $value in $sticker-palette {
-	%sticker-#{$color} {
-		@include clay-sticker-variant($value);
-	}
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.sticker-', 1)
+	);
 
-	.sticker-#{$color} {
-		@extend %sticker-#{$color} !optional;
+	@if (starts-with($color, '%') or map-get($value, extend)) {
+		#{$selector} {
+			@include clay-sticker-variant($value);
+		}
+	} @else {
+		$placeholder: if(
+			starts-with($color, '.') or starts-with($color, '#'),
+			'%#{str-slice($color, 2)}',
+			'%sticker-#{$color}'
+		);
+
+		#{$placeholder} {
+			@include clay-sticker-variant($value);
+		}
+
+		#{$selector} {
+			@extend #{$placeholder} !optional;
+		}
 	}
 }
 

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -25,17 +25,23 @@
 // Background
 
 @each $color, $value in $bg-theme-colors {
-	$hover: setter(map-get($value, hover), ());
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.bg-', 1)
+	);
 
-	.bg-#{$color} {
-		@include clay-css(setter($value, ()));
+	#{$selector} {
+		@include clay-css($value);
 	}
 
-	a.bg-#{$color},
-	button.bg-#{$color} {
+	a#{$selector},
+	button#{$selector} {
 		&:hover,
 		&:focus {
-			@include clay-css($hover);
+			@include clay-css(map-get($value, hover));
 		}
 	}
 }
@@ -43,7 +49,7 @@
 @if $enable-gradients {
 	@each $color, $value in $bg-gradient-theme-colors {
 		.bg-gradient-#{$color} {
-			@include clay-css(setter($value, ()));
+			@include clay-css($value);
 		}
 	}
 }
@@ -91,8 +97,16 @@
 }
 
 @each $color, $value in $border-theme-colors {
-	.border-#{$color} {
-		@include clay-css(setter($value, ()));
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.border-', 1)
+	);
+
+	#{$selector} {
+		@include clay-css($value);
 	}
 }
 
@@ -719,7 +733,9 @@
 
 @each $selector, $value in $font-sizes {
 	$selector: if(
-		starts-with($selector, '.') or starts-with($selector, '#'),
+		starts-with($selector, '.') or
+			starts-with($selector, '#') or
+			starts-with($selector, '%'),
 		$selector,
 		str-insert($selector, '.', 1)
 	);
@@ -736,16 +752,22 @@
 }
 
 @each $color, $value in $text-theme-colors {
-	$hover: setter(map-get($value, hover), ());
+	$selector: if(
+		starts-with($color, '.') or
+			starts-with($color, '#') or
+			starts-with($color, '%'),
+		$color,
+		str-insert($color, '.text-', 1)
+	);
 
-	.text-#{$color} {
-		@include clay-css(setter($value, ()));
+	#{$selector} {
+		@include clay-css($value);
 	}
 
-	a.text-#{$color} {
+	a#{$selector} {
 		&:hover,
 		&:focus {
-			@include clay-css($hover);
+			@include clay-css(map-get($value, hover));
 		}
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -274,6 +274,8 @@
 							transition: none;
 						}
 					}
+				} @else if ($key == 'extend') {
+					@extend #{$value} !optional;
 				} @else if ($key == 'user-select') {
 					-ms-user-select: $value;
 					-moz-user-select: $value;

--- a/packages/clay-label/docs/markup-label.md
+++ b/packages/clay-label/docs/markup-label.md
@@ -9,7 +9,9 @@ mainTabURL: 'docs/components/label.html'
 <div class="nav-toc">
 
 -   [Colors](#css-colors)
+    -   [Sass API](#css-label-variant-sass-api)
 -   [Sizes](#css-sizes)
+    -   [Sass API](#css-label-size-sass-api)
 -   [Variations](#css-variations)
     -   [Simple](#css-simple)
     -   [Dismissible](#css-dismissible)
@@ -98,6 +100,42 @@ mainTabURL: 'docs/components/label.html'
 </span>
 ```
 
+### Label Variant Sass API(#css-label-variant-sass-api)
+
+The map `$label-palette` allows generating any number of label variants. If a key starts with `.`, `#`, or `%` Clay will output it as is, otherwise we will prepend `.label-` to the key (e.g., `.label-primary`). It will also generate a Sass placeholder prefixed by `%label-` (e.g., `%label-primary`).
+
+```scss{expanded}
+$label-palette: (
+    primary: (
+        background-color: $primary,
+    ),
+    '.label-primary-2': (
+        extend: '%label-primary',
+    ),
+    '%label-tertiary': (
+        background-color: green,
+    ),
+    '.label-tertiary': (
+        extend: '%label-tertiary',
+    ),
+    '.label-quaternary': (
+        extend: '%label-tertiary',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.label-primary, .label-primary-2 {
+    background-color: #0b5fff;
+}
+
+.label-tertiary, .label-quaternary {
+    background-color: green;
+}
+```
+
 ## Sizes(#css-sizes)
 
 Use `label-lg` to make the label larger, or use the mixin `label-size($sassMap)` to create a custom sized label:
@@ -114,6 +152,39 @@ Use `label-lg` to make the label larger, or use the mixin `label-size($sassMap)`
 <span class="label label-lg label-success">
 	<span class="label-item label-item-expand"> Large Label </span>
 </span>
+```
+
+### Label Size Sass API(#css-label-size-sass-api)
+
+The map `$label-sizes` allows generating any number of label size variants. If a key starts with `.`, `#`, or `%` Clay will output it as is, otherwise it will prepend `.` to the key (e.g., `.label-lg`). It will also generate a Sass placeholder prefixed by `%` (e.g., `%label-lg`).
+
+```scss{expanded}
+$label-sizes: (
+    label-lg: (
+        font-size: 16px,
+    ),
+    '.label-xl': (
+        extend: '%label-lg',
+    ),
+    '%label-sm': (
+        font-size: 12px,
+    ),
+    '.label-sm': (
+        extend: '%label-sm',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.label-lg, .label-xl {
+    font-size: 16px;
+}
+
+.label-sm {
+    font-size: 12px;
+}
 ```
 
 ## Variations(#css-variations)

--- a/packages/clay-popover/docs/markup-popover.md
+++ b/packages/clay-popover/docs/markup-popover.md
@@ -15,8 +15,10 @@ mainTabURL: 'docs/components/popover.html'
     -   [Left](#css-left)
 -   [Widths](#css-popover-widths)
     -   [Large](#css-popover-width-large)
+    -   [Sass API](#css-popover-width-sass-api)
 -   [Variants](#css-popover-variants)
     -   [Secondary](#css-popover-secondary)
+    -   [Sass API](#css-popover-variants-sass-api)
 
 </div>
 </div>
@@ -365,6 +367,43 @@ A wider popover for more content.
 </div>
 ```
 
+### Popover Width Sass API(#css-popover-width-sass-api)
+
+The map `$popover-widths` allows generating any number of popover widths. If a key starts with `.`, `#`, or `%` Clay will output it as is, otherwise we will prepend `.` to the key (e.g., `.popover-width-lg`). This doesn't generate a Sass placeholder.
+
+```scss{expanded}
+$popover-widths: (
+    popover-width-lg: (
+        max-width: 421px,
+    ),
+    '%popover-width-xl': (
+        max-width: 560px,
+    ),
+    '.popover-width-xl': (
+        extend: '%popover-width-xl',
+    ),
+    '.popover-width-xxl': (
+        max-width: 1000px,
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.popover-width-xl {
+    max-width: 421px;
+}
+
+.popover-width-xl {
+    max-width: 560px;
+}
+
+.popover-width-xxl {
+    max-width: 1000px;
+}
+```
+
 ### Variants(#css-popover-variants)
 
 #### Popover Secondary(#css-popover-secondary)
@@ -427,4 +466,59 @@ A different style of popover with a blue box shadow and no header divider.
 		</div>
 	</div>
 </div>
+```
+
+### Popover Variant Sass API(#css-popover-variants-sass-api)
+
+The map `$popovers` allows generating any number of popover variants. If a key starts with `.`, `#`, or `%` Clay will output it as is, otherwise we will prepend `.` to the key (e.g., `.my-popover-secondary`). This doesn't generate a Sass placeholder.
+
+```scss{expanded}
+$popovers: (
+    my-popover-secondary: (
+        background-color: #eee,
+        popover-header: (
+            background-color: inherit,
+        ),
+    ),
+    '%popover-dark': (
+        background-color: #000,
+        color: #fff,
+        popover-header: (
+            background-color: inherit,
+            color: inherit,
+        ),
+        popover-body: (
+            color: inherit,
+        ),
+    ),
+    '.popover-dark': (
+        extend: '%popover-dark',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.my-popover-secondary {
+    background-color: #eee;
+}
+
+.my-popover-secondary .popover-header {
+    background-color: inherit;
+}
+
+.popover-dark {
+    background-color: #000;
+    color: #fff;
+}
+
+.popover-dark .popover-header {
+    background-color: inherit;
+    color: inherit;
+}
+
+.popover-dark .popover-body {
+    color: inherit;
+}
 ```

--- a/packages/clay-sticker/docs/markup-sticker.md
+++ b/packages/clay-sticker/docs/markup-sticker.md
@@ -9,8 +9,10 @@ mainTabURL: 'docs/components/sticker.html'
 <div class="nav-toc">
 
 -   [Colors](#css-colors)
+    -   [Sass API](#css-sticker-variant-sass-api)
 -   [Position](#css-position)
 -   [Sizes](#css-sizes)
+    -   [Sass API](#css-sticker-size-sass-api)
 -   [Variations](#css-variations)
     -   [Overlay](#css-overlay)
     -   [Outside](#css-outside)
@@ -39,6 +41,46 @@ Lexicon adopts in its design system the following colors below:
 <span class="sticker sticker-info">133</span>
 <span class="sticker sticker-warning">133</span>
 <span class="sticker sticker-danger">133</span>
+```
+
+### Sticker Variant Sass API(#css-sticker-variant-sass-api)
+
+The map `$sticker-palette` allows generating any number of sticker variants. If a key starts with `.`, `#`, or `%` Clay will output it as is, otherwise we will prepend `.sticker-` to the key (e.g., `.sticker-my-primary`). It will also generate a Sass placeholder prefixed by `%sticker-` (e.g., `%sticker-my-primary`).
+
+```scss{expanded}
+$sticker-palette: (
+    my-primary: (
+        background-color: blue,
+        color: #fff,
+    ),
+    '.sticker-primary': (
+        extend: '%sticker-my-primary',
+    ),
+    '%sticker-tertiary': (
+        background-color: green,
+        color: #fff,
+    ),
+    '.sticker-tertiary': (
+        extend: '%sticker-tertiary',
+    ),
+    '.sticker-quaternary': (
+        extend: '%sticker-tertiary',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.sticker-my-primary, .sticker-primary {
+    background-color: blue;
+    color: #fff;
+}
+
+.sticker-tertiary, .sticker-quaternary {
+    background-color: green;
+    color: #fff;
+}
 ```
 
 ## Position(#css-position)
@@ -213,6 +255,36 @@ Stickers come in 4 sizes `sm`, default, `lg`, and `xl`. Create your own custom s
 		</svg>
 	</span>
 </span>
+```
+
+### Sticker Size Sass API(#css-sticker-size-sass-api)
+
+The map `$sticker-sizes` allows generating any number of sticker size variants. If a key starts with `.`, `#`, or `%` Clay will output it as is, otherwise it will prepend `.` to the key (e.g., `.my-sticker-lg`). It will also generate a Sass placeholder prefixed by `%` (e.g., `%my-sticker-lg`).
+
+```scss{expanded}
+$sticker-sizes: (
+    my-sticker-lg: (
+        font-size: 32px,
+        height: 64px,
+        width: 64px,
+    ),
+    sticker-lg: (
+        enabled: false,
+    ),
+    '.sticker-lg': (
+        extend: '%my-sticker-lg',
+    ),
+);
+```
+
+Outputs:
+
+```css{expanded}
+.my-sticker-lg, .sticker-lg {
+    font-size: 32px;
+    height: 64px;
+    width: 64px;
+}
 ```
 
 ## Variations(#css-variations)


### PR DESCRIPTION
fixes #4970

Bootstrap generated variants with theme color keys like `primary`, `secondary`, `success`. We are taking it deeper by allowing custom classes, id's and Sass placeholder.

The old style keys `primary`, `secondary`, `custom-color` will still generate a Sass placeholder and selector with the component prefix (e.g., `%btn-custom-color` and `.btn-custom-color { @extend %btn-custom-color !optional; }`).

The new style keys should be a class, id, or Sass placeholder wrapped in single quotes (e.g., `'.btn-xxl': ( font-size: 100px, )`).

```
$btn-sizes: (
    '%btn-xxl': (
        font-size: 100px,
    ),
    '.btn-xxl': (
        extend: '%btn-xxl',
    ),
);
```

~Still need to update the docs~