### PR TITLE
feat(@clayui/core): adds new `onItemMove` API

### DIFF
--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -9,7 +9,7 @@ import {Expand, Selection, useAPI} from './context';
 import {ItemContextProvider, useItem} from './useItem';
 
 export type ChildrenFunction<T> = (
-	item: Omit<T, 'indexes' | 'itemRef' | 'key' | 'parentItemRef'>,
+	item: Omit<T, 'index' | 'indexes' | 'itemRef' | 'key' | 'parentItemRef'>,
 	selection: Selection,
 	expand: Expand
 ) => React.ReactElement;
@@ -45,7 +45,7 @@ export function getKey(
 
 export function removeItemInternalProps<T extends Record<any, any>>(props: T) {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const {indexes, itemRef, key, parentItemRef, ...item} = props;
+	const {index, indexes, itemRef, key, parentItemRef, ...item} = props;
 
 	return item;
 }

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -61,6 +61,11 @@ interface ITreeViewProps<T>
 	expanderIcons?: Icons;
 
 	/**
+	 * Callback is called when an item is about to be moved elsewhere in the tree.
+	 */
+	onItemMove?: (item: T, parentItem: T) => void;
+
+	/**
 	 * When a tree is very large, loading items (nodes) asynchronously is preferred to
 	 * decrease the initial payload and memory space. The callback is called every time
 	 * the item is a leaf node of the tree.
@@ -116,6 +121,7 @@ export function TreeView<T>({
 	items,
 	nestedKey = 'children',
 	onExpandedChange,
+	onItemMove,
 	onItemsChange,
 	onLoadMore,
 	onRenameItem,
@@ -158,6 +164,7 @@ export function TreeView<T>({
 		expanderClassName,
 		expanderIcons,
 		nestedKey,
+		onItemMove,
 		onLoadMore,
 		onRenameItem,
 		onSelect,

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -21,6 +21,7 @@ export interface ITreeViewContext<T> extends ITreeState<T> {
 	expanderClassName?: string;
 	expanderIcons?: Icons;
 	nestedKey?: string;
+	onItemMove?: (item: T, parentItem: T) => void;
 	onLoadMore?: (item: any) => Promise<unknown>;
 	onSelect?: (item: T) => void;
 	onRenameItem?: (item: T) => Promise<any>;


### PR DESCRIPTION
Closes #4984

This PR is adding a new `onItemMove` API to the TreeView. Two main things here are that the two parameters correspond to the item being moved and the `parentItem` is the new location of the item, the TreeView also matters of position within the array, this API does not provide this information but if it is something that some devs need we can provide but for that first iteration this is fine.

I had some thoughts that this API could also be an option for the developer to create rules like validating whether moving the item to another place is valid, so we could use the boolean return to ignore the move or move on. I'm not sure if there are use cases for this but we can use this API for that purpose in the next iterations as well.