### PR TITLE
docs(RFC): update RFC number and PR number

### DIFF
--- a/docs/proposals/0004-collection-components.md
+++ b/docs/proposals/0004-collection-components.md
@@ -2,7 +2,7 @@
 
 -   Start Date: 31-03-2022
 -   Author: [Matuzalém Teles](https://github.com/matuzalemsteles)
--   RFC PR: (leave this empty)
+-   RFC PR: [#4840](https://github.com/liferay/clay/pull/4840)
 -   Clay Issue: [#4112](https://github.com/liferay/clay/issues/4112)
 -   Status: **Awaiting implementation**
 


### PR DESCRIPTION
This is just a follow-up PR from #4840 to update the RFC number and add the link to the RFC PR in the proposal document.