### PR TITLE
fix(@clayui/drop-down): improves DropDown accessibility

### DIFF
--- a/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
@@ -32,6 +32,7 @@ exports[`ClayAutocomplete renders DropDown with alignment with container 1`] = `
     <div>
       <div
         class="dropdown-menu autocomplete-dropdown-menu show"
+        role="presentation"
         style="max-width: none;"
       />
     </div>
@@ -50,9 +51,12 @@ exports[`ClayAutocomplete renders Input with classNames when loading for true 1`
 
 exports[`ClayAutocomplete renders Item with matches values 1`] = `
 <div>
-  <li>
+  <li
+    role="none"
+  >
     <span
       class="dropdown-item"
+      role="menuitem"
     >
       Bar
     </span>

--- a/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-breadcrumb/src/__tests__/__snapshots__/index.tsx.snap
@@ -36,6 +36,9 @@ exports[`ClayBreadcrumb calls callback when an item is clicked 1`] = `
       class="dropdown breadcrumb-item"
     >
       <button
+        aria-controls="clay-dropdown-menu-3"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
         style=""
@@ -115,6 +118,9 @@ exports[`ClayBreadcrumb renders 1`] = `
       class="dropdown breadcrumb-item"
     >
       <button
+        aria-controls="clay-dropdown-menu-1"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
         style=""
@@ -195,6 +201,9 @@ exports[`ClayBreadcrumb renders with properties passed by \`ellipsisProps\` 1`] 
       style="font-size: 15px;"
     >
       <button
+        aria-controls="clay-dropdown-menu-2"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle breadcrumb-link btn btn-unstyled"
         data-testid="breadcrumbDropdownTrigger"
         style=""

--- a/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -1501,6 +1501,9 @@ exports[`ClayCardWithHorizontal renders as not selectable 1`] = `
             class="dropdown"
           >
             <button
+              aria-controls="clay-dropdown-menu-2"
+              aria-expanded="false"
+              aria-haspopup="menu"
               class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
               style=""
               type="button"
@@ -2240,6 +2243,9 @@ exports[`ClayCardWithInfo renders as not selectable 1`] = `
             class="dropdown"
           >
             <button
+              aria-controls="clay-dropdown-menu-3"
+              aria-expanded="false"
+              aria-haspopup="menu"
               class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
               style=""
               type="button"
@@ -2871,6 +2877,9 @@ exports[`ClayCardWithUser renders as selectable 1`] = `
               class="dropdown"
             >
               <button
+                aria-controls="clay-dropdown-menu-1"
+                aria-expanded="false"
+                aria-haspopup="menu"
                 class="dropdown-toggle component-action btn btn-monospaced btn-unstyled"
                 style=""
                 type="button"

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -57,6 +57,7 @@ exports[`Interactions color editor interactions ability to change color of click
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu show"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div>
@@ -455,6 +456,7 @@ exports[`Rendering default 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -833,6 +835,7 @@ exports[`Rendering disabled palette 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -1213,6 +1216,7 @@ exports[`Rendering disabled state 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -1598,6 +1602,7 @@ exports[`Rendering renders w/ var() 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -1976,6 +1981,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -2362,6 +2368,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -2740,6 +2747,7 @@ exports[`Rendering small color-picker 1`] = `
     <div>
       <div
         class="dropdown-menu clay-color-dropdown-menu"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -288,6 +288,9 @@ exports[`TreeView basic rendering render with actions 1`] = `
                 class="dropdown"
               >
                 <button
+                  aria-controls="clay-dropdown-menu-1"
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   class="dropdown-toggle component-action quick-action-item btn btn-monospaced"
                   style=""
                   tabindex="-1"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -52,6 +52,7 @@ exports[`BasicRendering renders by default 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -747,6 +748,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -1472,6 +1474,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -2309,6 +2312,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -53,6 +53,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -749,6 +750,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
       <div
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -1445,6 +1447,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -2141,6 +2144,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -2857,6 +2861,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
       <div
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -3553,6 +3558,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -53,6 +53,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -749,6 +750,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -1445,6 +1447,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -2141,6 +2144,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -2837,6 +2841,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -3533,6 +3538,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -4310,6 +4316,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -5006,6 +5013,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div

--- a/packages/clay-drop-down/src/Caption.tsx
+++ b/packages/clay-drop-down/src/Caption.tsx
@@ -15,6 +15,7 @@ const ClayDropDownCaption = ({
 		<div
 			{...otherProps}
 			className={classnames('dropdown-caption', className)}
+			role="presentation"
 		>
 			{children}
 		</div>

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -10,7 +10,7 @@ import {
 	useInternalState,
 } from '@clayui/shared';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import Action from './Action';
 import Caption from './Caption';
@@ -120,6 +120,8 @@ function ClayDropDown(props: IProps): JSX.Element & {
 	Section: typeof Section;
 };
 
+let counter = 0;
+
 function ClayDropDown({
 	active,
 	alignmentByViewport,
@@ -140,10 +142,10 @@ function ClayDropDown({
 	trigger,
 	...otherProps
 }: IProps) {
-	const triggerElementRef = React.useRef<HTMLButtonElement | null>(null);
-	const menuElementRef = React.useRef<HTMLDivElement>(null);
+	const triggerElementRef = useRef<HTMLButtonElement | null>(null);
+	const menuElementRef = useRef<HTMLDivElement>(null);
 
-	const [initialized, setInitialized] = React.useState(!renderMenuOnClick);
+	const [initialized, setInitialized] = useState(!renderMenuOnClick);
 
 	const [internalActive, setInternalActive] = useInternalState({
 		defaultName: 'defaultActive',
@@ -171,13 +173,19 @@ function ClayDropDown({
 		}
 	};
 
-	React.useEffect(() => {
+	useEffect(() => {
 		document.addEventListener('focus', handleFocus, true);
 
 		return () => {
 			document.removeEventListener('focus', handleFocus, true);
 		};
 	}, [handleFocus]);
+
+	const ariaControls = useMemo(() => {
+		counter++;
+
+		return `clay-dropdown-menu-${counter}`;
+	}, []);
 
 	return (
 		<FocusScope>
@@ -187,6 +195,9 @@ function ClayDropDown({
 				onKeyUp={handleKeyUp}
 			>
 				{React.cloneElement(trigger, {
+					'aria-controls': ariaControls,
+					'aria-expanded': internalActive,
+					'aria-haspopup': 'menu',
 					className: classNames(
 						'dropdown-toggle',
 						trigger.props.className
@@ -221,6 +232,7 @@ function ClayDropDown({
 						hasLeftSymbols={hasLeftSymbols}
 						hasRightSymbols={hasRightSymbols}
 						height={menuHeight}
+						id={ariaControls}
 						offsetFn={offsetFn}
 						onSetActive={setInternalActive}
 						ref={menuElementRef}

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -107,6 +107,8 @@ export interface IProps
 	};
 }
 
+let counter = 0;
+
 function ClayDropDown(props: IProps): JSX.Element & {
 	Action: typeof Action;
 	Caption: typeof Caption;
@@ -119,8 +121,6 @@ function ClayDropDown(props: IProps): JSX.Element & {
 	Search: typeof Search;
 	Section: typeof Section;
 };
-
-let counter = 0;
 
 function ClayDropDown({
 	active,

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -46,6 +46,8 @@ interface IItem {
 }
 
 interface IDropDownContentProps {
+	'aria-label'?: string;
+
 	/**
 	 * The path to the SVG spritemap file containing the icons.
 	 */
@@ -55,9 +57,12 @@ interface IDropDownContentProps {
 	 * List of items to display in drop down menu
 	 */
 	items: Array<IItem>;
+
+	role?: string;
 }
 
-export interface IProps extends IDropDownContentProps {
+export interface IProps
+	extends Omit<IDropDownContentProps, 'role' | 'aria-label'> {
 	/**
 	 * Flag to indicate if the DropDown menu is active or not (controlled).
 	 */
@@ -203,7 +208,7 @@ const Checkbox = ({
 	const [value, setValue] = useState<boolean>(checked);
 
 	return (
-		<ClayDropDown.Section>
+		<ClayDropDown.Section role="none">
 			<ClayCheckbox
 				{...otherProps}
 				checked={value}
@@ -244,7 +249,16 @@ const Item = ({
 const Group = ({items, label, spritemap}: IItem & IInternalItem) => (
 	<>
 		<ClayDropDownGroup header={label} />
-		{items && <DropDownContent items={items} spritemap={spritemap} />}
+		{items && (
+			<li role="none">
+				<DropDownContent
+					aria-label={label}
+					items={items}
+					role="group"
+					spritemap={spritemap}
+				/>
+			</li>
+		)}
 	</>
 );
 
@@ -340,7 +354,7 @@ const Radio = ({value = '', ...otherProps}: IItem & IInternalItem) => {
 	const {checked, name, onChange} = useContext(RadioGroupContext);
 
 	return (
-		<ClayDropDown.Section>
+		<ClayDropDown.Section role="none">
 			<ClayRadio
 				{...otherProps}
 				checked={checked === value}
@@ -381,9 +395,14 @@ const RadioGroup = ({
 		<>
 			{label && <ClayDropDownGroup header={label} />}
 			{items && (
-				<li aria-label={label} role="radiogroup">
+				<li role="none">
 					<RadioGroupContext.Provider value={params}>
-						<DropDownContent items={items} spritemap={spritemap} />
+						<DropDownContent
+							aria-label={label}
+							items={items}
+							role="radiogroup"
+							spritemap={spritemap}
+						/>
 					</RadioGroupContext.Provider>
 				</li>
 			)}
@@ -403,8 +422,13 @@ const TYPE_MAP = {
 	radiogroup: RadioGroup,
 };
 
-const DropDownContent = ({items, spritemap}: IDropDownContentProps) => (
-	<ClayDropDown.ItemList>
+const DropDownContent = ({
+	items,
+	role,
+	spritemap,
+	...otherProps
+}: IDropDownContentProps) => (
+	<ClayDropDown.ItemList aria-label={otherProps['aria-label']} role={role}>
 		{items.map(({type, ...item}, key) => {
 			const Item = TYPE_MAP[type || 'item'];
 
@@ -507,7 +531,9 @@ export const ClayDropDownWithItems = ({
 					{caption && <Caption>{caption}</Caption>}
 
 					{footerContent && (
-						<div className="dropdown-section">{footerContent}</div>
+						<div className="dropdown-section" role="presentation">
+							{footerContent}
+						</div>
 					)}
 				</Wrap>
 			</ClayDropDownContext.Provider>

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -55,7 +55,7 @@ const ClayDropDownItem = React.forwardRef<HTMLLIElement, IProps>(
 			href,
 			innerRef,
 			onClick,
-			role,
+			role = 'none',
 			spritemap,
 			symbolLeft,
 			symbolRight,
@@ -79,6 +79,7 @@ const ClayDropDownItem = React.forwardRef<HTMLLIElement, IProps>(
 					href={href}
 					onClick={onClick}
 					ref={innerRef}
+					role="menuitem"
 					tabIndex={disabled ? -1 : tabIndex}
 				>
 					{symbolLeft && (

--- a/packages/clay-drop-down/src/ItemList.tsx
+++ b/packages/clay-drop-down/src/ItemList.tsx
@@ -9,10 +9,15 @@ import React from 'react';
 const ClayDropDownItemList = ({
 	children,
 	className,
+	role = 'menu',
 	...otherProps
 }: React.HTMLAttributes<HTMLUListElement>) => {
 	return (
-		<ul {...otherProps} className={classnames('list-unstyled', className)}>
+		<ul
+			{...otherProps}
+			className={classnames('list-unstyled', className)}
+			role={role}
+		>
 			{children}
 		</ul>
 	);

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -330,6 +330,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 							show: active,
 						})}
 						ref={ref}
+						role="presentation"
 					>
 						{children}
 					</div>

--- a/packages/clay-drop-down/src/Section.tsx
+++ b/packages/clay-drop-down/src/Section.tsx
@@ -22,7 +22,7 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const ClayDropDownSection = React.forwardRef<HTMLLIElement, IProps>(
 	({active, children, className, disabled, innerRef, ...otherProps}, ref) => (
-		<li aria-selected={active} ref={ref}>
+		<li aria-selected={active} ref={ref} role="none">
 			<div
 				{...otherProps}
 				className={classNames('dropdown-section', className, {

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -21,6 +21,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
       <div
         class="dropdown-menu drilldown dropdown-menu-indicator-end show"
         id="clay-dropdown-menu-1"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -193,6 +194,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
       <div
         class="dropdown-menu drilldown dropdown-menu-indicator-end show"
         id="clay-dropdown-menu-2"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -403,6 +405,7 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
       <div
         class="dropdown-menu drilldown dropdown-menu-indicator-end"
         id="clay-dropdown-menu-6"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <div

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -7,6 +7,9 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-1"
+        aria-expanded="true"
+        aria-haspopup="menu"
         class="dropdown-toggle"
         data-testid="trigger"
         style=""
@@ -17,6 +20,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
     <div>
       <div
         class="dropdown-menu drilldown dropdown-menu-indicator-end show"
+        id="clay-dropdown-menu-1"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -175,6 +179,9 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-2"
+        aria-expanded="true"
+        aria-haspopup="menu"
         class="dropdown-toggle"
         data-testid="trigger"
         style=""
@@ -185,6 +192,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
     <div>
       <div
         class="dropdown-menu drilldown dropdown-menu-indicator-end show"
+        id="clay-dropdown-menu-2"
         style="left: -999px; top: -995px;"
       >
         <div
@@ -363,6 +371,9 @@ exports[`ClayDropDownWithDrilldown renders with the menu initially active 1`] = 
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-5"
+        aria-expanded="true"
+        aria-haspopup="menu"
         class="dropdown-toggle"
         data-testid="trigger"
       />
@@ -378,6 +389,9 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-6"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle"
         data-testid="trigger"
         style=""
@@ -388,6 +402,7 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
     <div>
       <div
         class="dropdown-menu drilldown dropdown-menu-indicator-end"
+        id="clay-dropdown-menu-6"
         style="left: -999px; top: -995px;"
       >
         <div

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithItems.tsx.snap
@@ -7,6 +7,9 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-1"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle btn btn-primary"
         type="button"
       >
@@ -24,6 +27,9 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with caption 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-4"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle btn btn-primary"
         type="button"
       >
@@ -41,6 +47,9 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with checkbox 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-3"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle btn btn-primary"
         type="button"
       >
@@ -58,6 +67,9 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with footer content 1
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-5"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle btn btn-primary"
         type="button"
       >
@@ -75,6 +87,9 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with help text 1`] = 
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-6"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle btn btn-primary"
         type="button"
       >
@@ -92,6 +107,9 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with radio group 1`] 
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-2"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle btn btn-primary"
         type="button"
       >
@@ -109,6 +127,9 @@ exports[`ClayDropDownWithItems renders a DropDownWithItems with search 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-7"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle btn btn-primary"
         type="button"
       >

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -7,6 +7,9 @@ exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-2"
+        aria-expanded="true"
+        aria-haspopup="menu"
         class="dropdown-toggle"
         style=""
       >
@@ -18,6 +21,7 @@ exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
     <div>
       <div
         class="dropdown-menu show"
+        id="clay-dropdown-menu-2"
         style="left: -999px; top: -995px;"
       >
         <ul
@@ -61,6 +65,9 @@ exports[`ClayDropDown renders with groups 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-7"
+        aria-expanded="true"
+        aria-haspopup="menu"
         class="dropdown-toggle"
         style=""
       >
@@ -72,6 +79,7 @@ exports[`ClayDropDown renders with groups 1`] = `
     <div>
       <div
         class="dropdown-menu show"
+        id="clay-dropdown-menu-7"
         style="left: -999px; top: -995px;"
       >
         <ul
@@ -151,6 +159,9 @@ exports[`ClayDropDown renders with icons 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-6"
+        aria-expanded="true"
+        aria-haspopup="menu"
         class="dropdown-toggle"
         style=""
       >
@@ -162,6 +173,7 @@ exports[`ClayDropDown renders with icons 1`] = `
     <div>
       <div
         class="dropdown-menu dropdown-menu-indicator-end dropdown-menu-indicator-start show"
+        id="clay-dropdown-menu-6"
         style="left: -999px; top: -995px;"
       >
         <ul
@@ -250,6 +262,9 @@ exports[`ClayDropDown renders with search input 1`] = `
       class="dropdown"
     >
       <button
+        aria-controls="clay-dropdown-menu-5"
+        aria-expanded="true"
+        aria-haspopup="menu"
         class="dropdown-toggle"
         style=""
       >
@@ -261,6 +276,7 @@ exports[`ClayDropDown renders with search input 1`] = `
     <div>
       <div
         class="dropdown-menu show"
+        id="clay-dropdown-menu-5"
         style="left: -999px; top: -995px;"
       >
         <form

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/index.tsx.snap
@@ -22,31 +22,42 @@ exports[`ClayDropDown renders dropdown menu when clicked 1`] = `
       <div
         class="dropdown-menu show"
         id="clay-dropdown-menu-2"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
+          role="menu"
         >
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#one"
+              role="menuitem"
             >
               one
             </a>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#two"
+              role="menuitem"
             >
               two
             </a>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#three"
+              role="menuitem"
             >
               three
             </a>
@@ -80,10 +91,12 @@ exports[`ClayDropDown renders with groups 1`] = `
       <div
         class="dropdown-menu show"
         id="clay-dropdown-menu-7"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
+          role="menu"
         >
           <li
             class="dropdown-subheader"
@@ -91,26 +104,35 @@ exports[`ClayDropDown renders with groups 1`] = `
           >
             Group #1
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#one"
+              role="menuitem"
             >
               one
             </a>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#two"
+              role="menuitem"
             >
               two
             </a>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#three"
+              role="menuitem"
             >
               three
             </a>
@@ -121,26 +143,35 @@ exports[`ClayDropDown renders with groups 1`] = `
           >
             Group #2
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#one"
+              role="menuitem"
             >
               one
             </a>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#two"
+              role="menuitem"
             >
               two
             </a>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#three"
+              role="menuitem"
             >
               three
             </a>
@@ -174,14 +205,19 @@ exports[`ClayDropDown renders with icons 1`] = `
       <div
         class="dropdown-menu dropdown-menu-indicator-end dropdown-menu-indicator-start show"
         id="clay-dropdown-menu-6"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
+          role="menu"
         >
-          <li>
+          <li
+            role="none"
+          >
             <span
               class="dropdown-item"
+              role="menuitem"
             >
               <span
                 class="dropdown-item-indicator-start"
@@ -198,9 +234,12 @@ exports[`ClayDropDown renders with icons 1`] = `
               Left
             </span>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <span
               class="dropdown-item"
+              role="menuitem"
             >
               Right
               <span
@@ -217,9 +256,12 @@ exports[`ClayDropDown renders with icons 1`] = `
               </span>
             </span>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <span
               class="dropdown-item"
+              role="menuitem"
             >
               <span
                 class="dropdown-item-indicator-start"
@@ -277,6 +319,7 @@ exports[`ClayDropDown renders with search input 1`] = `
       <div
         class="dropdown-menu show"
         id="clay-dropdown-menu-5"
+        role="presentation"
         style="left: -999px; top: -995px;"
       >
         <form
@@ -319,27 +362,37 @@ exports[`ClayDropDown renders with search input 1`] = `
         </form>
         <ul
           class="list-unstyled"
+          role="menu"
         >
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#one"
+              role="menuitem"
             >
               one
             </a>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#two"
+              role="menuitem"
             >
               two
             </a>
           </li>
-          <li>
+          <li
+            role="none"
+          >
             <a
               class="dropdown-item"
               href="#three"
+              role="menuitem"
             >
               three
             </a>

--- a/packages/clay-drop-down/stories/DropDown.stories.tsx
+++ b/packages/clay-drop-down/stories/DropDown.stories.tsx
@@ -110,14 +110,13 @@ export const Default = (args: any) => (
 Default.args = {
 	alignmentPosition: 5,
 	height: '',
-	renderMenuOnClick: true,
+	renderMenuOnClick: false,
 	width: '',
 };
 
 export const Groups = () => (
 	<ClayDropDown
 		alignmentPosition={Align.BottomLeft}
-		renderMenuOnClick
 		trigger={<ClayButton>Click Me</ClayButton>}
 	>
 		<ClayDropDown.ItemList>
@@ -151,7 +150,6 @@ export const Groups = () => (
 export const Checkbox = () => (
 	<ClayDropDown
 		alignmentPosition={Align.BottomLeft}
-		renderMenuOnClick
 		trigger={<ClayButton>Click Me</ClayButton>}
 	>
 		<ClayDropDown.ItemList>
@@ -172,7 +170,6 @@ export const Search = () => {
 	return (
 		<ClayDropDown
 			alignmentPosition={Align.BottomLeft}
-			renderMenuOnClick
 			trigger={<ClayButton>Click Me</ClayButton>}
 		>
 			<ClayDropDown.Search
@@ -201,7 +198,6 @@ export const Search = () => {
 export const Radio = () => (
 	<ClayDropDown
 		alignmentPosition={Align.BottomLeft}
-		renderMenuOnClick
 		trigger={<ClayButton>Click Me</ClayButton>}
 	>
 		<ClayDropDown.ItemList>
@@ -220,7 +216,6 @@ export const Radio = () => (
 export const CaptionAndHelp = () => (
 	<ClayDropDown
 		alignmentPosition={Align.BottomLeft}
-		renderMenuOnClick
 		trigger={<ClayButton>Click Me</ClayButton>}
 	>
 		<ClayDropDown.Help>Can I help you?</ClayDropDown.Help>
@@ -246,7 +241,6 @@ export const ItemsWithIcons = () => (
 		alignmentPosition={Align.BottomLeft}
 		hasLeftSymbols
 		hasRightSymbols
-		renderMenuOnClick
 		trigger={<ClayButton>Click Me</ClayButton>}
 	>
 		<ClayDropDown.ItemList>
@@ -271,7 +265,6 @@ export const CustomOffset = () => (
 	<ClayDropDown
 		alignmentPosition={Align.BottomLeft}
 		offsetFn={() => [20, 20]}
-		renderMenuOnClick
 		trigger={<ClayButton>Click Me</ClayButton>}
 	>
 		<ClayDropDown.ItemList>
@@ -336,7 +329,7 @@ export const Drilldown = (args: any) => (
 );
 
 Drilldown.args = {
-	renderMenuOnClick: true,
+	renderMenuOnClick: false,
 };
 
 export const DrillDownWithActive = () => {
@@ -406,7 +399,7 @@ export const DropDownWithItems = (args: any) => {
 };
 
 DropDownWithItems.args = {
-	renderMenuOnClick: true,
+	renderMenuOnClick: false,
 	searchable: true,
 };
 

--- a/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-localized-input/src/__tests__/__snapshots__/index.tsx.snap
@@ -31,6 +31,9 @@ exports[`ClayLocalizedInput renders 1`] = `
           class="dropdown"
         >
           <button
+            aria-controls="clay-dropdown-menu-1"
+            aria-expanded="false"
+            aria-haspopup="menu"
             class="dropdown-toggle btn btn-monospaced btn-secondary"
             style=""
             title="Open Localizations"
@@ -106,6 +109,9 @@ exports[`ClayLocalizedInput renders with prepend content and result formatter 1`
           class="dropdown"
         >
           <button
+            aria-controls="clay-dropdown-menu-2"
+            aria-expanded="false"
+            aria-haspopup="menu"
             class="dropdown-toggle btn btn-monospaced btn-secondary"
             style=""
             title="Open Localizations"

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -141,14 +141,19 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
     <div>
       <div
         class="dropdown-menu autocomplete-dropdown-menu"
+        role="presentation"
         style="max-width: none; left: -999px; top: -995px;"
       >
         <ul
           class="list-unstyled"
+          role="menu"
         >
-          <li>
+          <li
+            role="none"
+          >
             <button
               class="dropdown-item"
+              role="menuitem"
             >
               <strong>
                 one
@@ -511,14 +516,19 @@ exports[`ClayMultiSelect renders with items 1`] = `
 exports[`Interactions Use custom function for filtering autocomplete results 1`] = `
 <div
   class="dropdown-menu autocomplete-dropdown-menu"
+  role="presentation"
   style="max-width: none; left: -999px; top: -995px; width: 0px;"
 >
   <ul
     class="list-unstyled"
+    role="menu"
   >
-    <li>
+    <li
+      role="none"
+    >
       <button
         class="dropdown-item"
+        role="menuitem"
       >
         <strong>
           b
@@ -538,14 +548,19 @@ exports[`Interactions Use custom function for filtering autocomplete results 1`]
 exports[`Interactions Use custom function for filtering autocomplete results 2`] = `
 <div
   class="dropdown-menu autocomplete-dropdown-menu"
+  role="presentation"
   style="max-width: none; left: -999px; top: -995px; width: 0px;"
 >
   <ul
     class="list-unstyled"
+    role="menu"
   >
-    <li>
+    <li
+      role="none"
+    >
       <button
         class="dropdown-item"
+        role="menuitem"
       >
         foo
       </button>

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -9,6 +9,9 @@ exports[`ClayPaginationBar renders 1`] = `
       class="dropdown pagination-items-per-page"
     >
       <button
+        aria-controls="clay-dropdown-menu-1"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle btn btn-unstyled"
         data-testid="selectPaginationBar"
         style=""
@@ -88,6 +91,9 @@ exports[`ClayPaginationBar renders 1`] = `
         class="dropdown page-item"
       >
         <button
+          aria-controls="clay-dropdown-menu-2"
+          aria-expanded="false"
+          aria-haspopup="menu"
           class="dropdown-toggle page-link btn btn-unstyled"
           style=""
           type="button"
@@ -197,6 +203,9 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
         class="dropdown page-item"
       >
         <button
+          aria-controls="clay-dropdown-menu-3"
+          aria-expanded="false"
+          aria-haspopup="menu"
           class="dropdown-toggle page-link btn btn-unstyled"
           style=""
           type="button"

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -38,6 +38,9 @@ exports[`ClayPagination renders 1`] = `
       class="dropdown page-item"
     >
       <button
+        aria-controls="clay-dropdown-menu-1"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle page-link btn btn-unstyled"
         style=""
         type="button"
@@ -100,6 +103,9 @@ exports[`ClayPagination renders 1`] = `
       class="dropdown page-item"
     >
       <button
+        aria-controls="clay-dropdown-menu-2"
+        aria-expanded="false"
+        aria-haspopup="menu"
         class="dropdown-toggle page-link btn btn-unstyled"
         style=""
         type="button"

--- a/packages/clay-upper-toolbar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-upper-toolbar/src/__tests__/__snapshots__/index.tsx.snap
@@ -122,6 +122,9 @@ exports[`ClayUpperToolbar renders 1`] = `
               class="dropdown"
             >
               <button
+                aria-controls="clay-dropdown-menu-1"
+                aria-expanded="false"
+                aria-haspopup="menu"
                 class="dropdown-toggle btn btn-monospaced btn-sm btn-unstyled"
                 style=""
                 type="button"


### PR DESCRIPTION
Fixes #4994

I'm adding some properties to make DropDown more accessible in addition to adding the `aria-expanded` property. I'm marking this PR still as a draft because it looks like pressing enter and the down arrow key is not moving focus to Menu using JAWS screen reader and NVDA on Windows, I'll try to test this to see if this behavior persists because I can't play in Mac voice over.