### PR TITLE
fix(@clayui/drop-down): fixes error when losing focus using arrow keys in Drilldown and improves accessibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -74,10 +74,10 @@ module.exports = {
 			statements: 95,
 		},
 		'./packages/clay-drop-down/src/': {
-			branches: 70,
+			branches: 66,
 			functions: 57,
-			lines: 80,
-			statements: 78,
+			lines: 78,
+			statements: 77,
 		},
 		'./packages/clay-empty-state/src/': {
 			branches: 100,

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -105,11 +105,6 @@ type History = {
 	title: string;
 };
 
-type FocusHistory = {
-	id: string;
-	element: HTMLElement;
-};
-
 export const ClayDropDownWithDrilldown = ({
 	active,
 	alignmentByViewport,
@@ -135,7 +130,7 @@ export const ClayDropDownWithDrilldown = ({
 	const [direction, setDirection] = useState<'prev' | 'next'>();
 	const [history, setHistory] = useState<Array<History>>([]);
 
-	const focusHistory = useRef<Array<FocusHistory>>([]);
+	const focusHistory = useRef<Array<HTMLElement>>([]);
 
 	const innerRef = useRef<HTMLDivElement>(null);
 
@@ -157,7 +152,7 @@ export const ClayDropDownWithDrilldown = ({
 					focusHistory.current.length - 1
 				);
 
-				previous?.element.focus();
+				previous?.focus();
 			} else {
 				const itemEl = innerRef.current.querySelector<HTMLElement>(
 					'.drilldown-current a.dropdown-item, .drilldown-current button.dropdown-item'
@@ -165,10 +160,7 @@ export const ClayDropDownWithDrilldown = ({
 
 				focusHistory.current = [
 					...focusHistory.current,
-					{
-						element: document.activeElement as HTMLElement,
-						id: activeMenu!,
-					},
+					document.activeElement as HTMLElement,
 				];
 				itemEl?.focus();
 			}

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -5,7 +5,7 @@
 
 import {InternalDispatch} from '@clayui/shared';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import ClayDropDown from './DropDown';
 import ClayDropDownMenu from './Menu';
@@ -105,6 +105,11 @@ type History = {
 	title: string;
 };
 
+type FocusHistory = {
+	id: string;
+	element: HTMLElement;
+};
+
 export const ClayDropDownWithDrilldown = ({
 	active,
 	alignmentByViewport,
@@ -124,13 +129,51 @@ export const ClayDropDownWithDrilldown = ({
 	spritemap,
 	trigger,
 }: IProps) => {
-	const [activeMenu, setActiveMenu] = React.useState(
+	const [activeMenu, setActiveMenu] = useState(
 		defaultActiveMenu ?? initialActiveMenu
 	);
-	const [direction, setDirection] = React.useState<'prev' | 'next'>();
-	const [history, setHistory] = React.useState<Array<History>>([]);
+	const [direction, setDirection] = useState<'prev' | 'next'>();
+	const [history, setHistory] = useState<Array<History>>([]);
+
+	const focusHistory = useRef<Array<FocusHistory>>([]);
+
+	const innerRef = useRef<HTMLDivElement>(null);
+
+	const isKeyboard = useRef<boolean>(false);
 
 	const menuIds = Object.keys(menus);
+
+	useEffect(() => {
+		if (!isKeyboard.current) {
+			return;
+		}
+
+		if (innerRef.current) {
+			if (direction === 'prev') {
+				const [previous] = focusHistory.current.slice(-1);
+
+				focusHistory.current = focusHistory.current.slice(
+					0,
+					focusHistory.current.length - 1
+				);
+
+				previous?.element.focus();
+			} else {
+				const itemEl = innerRef.current.querySelector<HTMLElement>(
+					'.drilldown-current a.dropdown-item, .drilldown-current button.dropdown-item'
+				);
+
+				focusHistory.current = [
+					...focusHistory.current,
+					{
+						element: document.activeElement as HTMLElement,
+						id: activeMenu!,
+					},
+				];
+				itemEl?.focus();
+			}
+		}
+	}, [activeMenu, direction, innerRef, focusHistory, menus]);
 
 	return (
 		<ClayDropDown
@@ -152,7 +195,7 @@ export const ClayDropDownWithDrilldown = ({
 			renderMenuOnClick={renderMenuOnClick}
 			trigger={trigger}
 		>
-			<Drilldown.Inner>
+			<Drilldown.Inner ref={innerRef}>
 				{menuIds.map((menuKey) => {
 					return (
 						<Drilldown.Menu
@@ -185,6 +228,13 @@ export const ClayDropDownWithDrilldown = ({
 								setDirection('next');
 
 								setActiveMenu(childId);
+							}}
+							onKeyDown={(event) => {
+								if (event.key !== 'Enter') {
+									isKeyboard.current = false;
+								} else {
+									isKeyboard.current = true;
+								}
 							}}
 							spritemap={spritemap}
 						/>

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -23,16 +23,21 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
           class="drilldown-inner"
         >
           <div
+            aria-hidden="true"
             class="drilldown-item drilldown-current"
           >
             <ul
               class="inline-scroller"
+              role="menu"
             >
-              <li>
+              <li
+                role="none"
+              >
                 <a
                   class="dropdown-item"
                   data-testid="menu-item-Hash Link"
                   href="#"
+                  role="menuitem"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"
@@ -41,10 +46,13 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   </span>
                 </a>
               </li>
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Alert!"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -54,10 +62,13 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   </span>
                 </button>
               </li>
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -82,16 +93,21 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
             </ul>
           </div>
           <div
+            aria-hidden="false"
             class="drilldown-item"
           >
             <ul
               class="inline-scroller"
+              role="menu"
             >
-              <li>
+              <li
+                role="none"
+              >
                 <a
                   class="dropdown-item"
                   data-testid="menu-item-2nd hash link"
                   href="#"
+                  role="menuitem"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"
@@ -100,10 +116,13 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   </span>
                 </a>
               </li>
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -128,15 +147,20 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
             </ul>
           </div>
           <div
+            aria-hidden="false"
             class="drilldown-item"
           >
             <ul
               class="inline-scroller"
+              role="menu"
             >
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-The"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -146,10 +170,13 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   </span>
                 </button>
               </li>
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-End"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -191,16 +218,21 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
           class="drilldown-inner"
         >
           <div
+            aria-hidden="true"
             class="drilldown-item drilldown-current"
           >
             <ul
               class="inline-scroller"
+              role="menu"
             >
-              <li>
+              <li
+                role="none"
+              >
                 <a
                   class="dropdown-item"
                   data-testid="menu-item-Hash Link"
                   href="#"
+                  role="menuitem"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"
@@ -214,10 +246,13 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                 class="dropdown-divider"
                 role="presentation"
               />
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Alert!"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -232,10 +267,13 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                 class="dropdown-divider"
                 role="presentation"
               />
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -260,16 +298,21 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
             </ul>
           </div>
           <div
+            aria-hidden="false"
             class="drilldown-item"
           >
             <ul
               class="inline-scroller"
+              role="menu"
             >
-              <li>
+              <li
+                role="none"
+              >
                 <a
                   class="dropdown-item"
                   data-testid="menu-item-2nd hash link"
                   href="#"
+                  role="menuitem"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"
@@ -283,10 +326,13 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                 class="dropdown-divider"
                 role="presentation"
               />
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -311,15 +357,20 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
             </ul>
           </div>
           <div
+            aria-hidden="false"
             class="drilldown-item"
           >
             <ul
               class="inline-scroller"
+              role="menu"
             >
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-The"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -334,10 +385,13 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                 class="dropdown-divider"
                 role="presentation"
               />
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-End"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -394,15 +448,20 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
           class="drilldown-inner"
         >
           <div
+            aria-hidden="true"
             class="drilldown-item drilldown-current"
           >
             <ul
               class="inline-scroller"
+              role="menu"
             >
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Toggle"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -412,10 +471,13 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
                   </span>
                 </button>
               </li>
-              <li>
+              <li
+                role="none"
+              >
                 <button
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
+                  role="menuitem"
                   type="button"
                 >
                   <span
@@ -440,16 +502,21 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
             </ul>
           </div>
           <div
+            aria-hidden="false"
             class="drilldown-item"
           >
             <ul
               class="inline-scroller"
+              role="menu"
             >
-              <li>
+              <li
+                role="none"
+              >
                 <a
                   class="dropdown-item"
                   data-testid="menu-item-2nd hash link"
                   href="#"
+                  role="menuitem"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"

--- a/packages/clay-drop-down/src/drilldown/Menu.tsx
+++ b/packages/clay-drop-down/src/drilldown/Menu.tsx
@@ -29,6 +29,7 @@ export interface IProps {
 	items: Array<IItem>;
 	onBack: () => void;
 	onForward: (title: string, child: string) => void;
+	onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
 	spritemap?: string;
 }
 
@@ -39,6 +40,7 @@ const DrilldownMenu = ({
 	items,
 	onBack,
 	onForward,
+	onKeyDown,
 	spritemap,
 }: IProps) => {
 	const initialClasses = classNames('transitioning', {
@@ -47,6 +49,7 @@ const DrilldownMenu = ({
 
 	return (
 		<CSSTransition
+			aria-hidden={active}
 			className={classNames('drilldown-item', {
 				'drilldown-current': active,
 			})}
@@ -70,6 +73,7 @@ const DrilldownMenu = ({
 							<ClayButtonWithIcon
 								className="component-action dropdown-item-indicator-start"
 								onClick={onBack}
+								onKeyDown={onKeyDown}
 								spritemap={spritemap}
 								symbol="angle-left"
 							/>
@@ -84,7 +88,7 @@ const DrilldownMenu = ({
 				)}
 
 				{items && (
-					<ul className="inline-scroller">
+					<ul className="inline-scroller" role="menu">
 						{items.map(
 							(
 								{
@@ -101,7 +105,7 @@ const DrilldownMenu = ({
 								type === 'divider' ? (
 									<Divider key={`${j}-divider`} />
 								) : (
-									<li key={`${j}-${title}`}>
+									<li key={`${j}-${title}`} role="none">
 										<LinkOrButton
 											{...other}
 											buttonDisplayType="unstyled"
@@ -121,6 +125,8 @@ const DrilldownMenu = ({
 													onForward(title, child);
 												}
 											}}
+											onKeyDown={onKeyDown}
+											role="menuitem"
 										>
 											{symbol && (
 												<span className="dropdown-item-indicator-start">

--- a/packages/clay-drop-down/src/drilldown/index.tsx
+++ b/packages/clay-drop-down/src/drilldown/index.tsx
@@ -8,14 +8,22 @@ import React from 'react';
 
 import Menu from './Menu';
 
-const Inner = ({
-	children,
-	className,
-	...otherProps
-}: React.HTMLAttributes<HTMLDivElement>) => (
-	<div className={classNames(className, 'drilldown-inner')} {...otherProps}>
-		{children}
-	</div>
-);
+const Inner = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
+>(function InnerForward(
+	{children, className, ...otherProps}: React.HTMLAttributes<HTMLDivElement>,
+	ref
+) {
+	return (
+		<div
+			{...otherProps}
+			className={classNames(className, 'drilldown-inner')}
+			ref={ref}
+		>
+			{children}
+		</div>
+	);
+});
 
 export default {Inner, Menu};


### PR DESCRIPTION
Fixes #4996

I had to do a little history logic to be able to navigate between the menus and go back to the element with the previous focus, so we get more accessible navigation using the arrow keys, also the focus is only activated when the keyboard is used for navigation.