### PR TITLE
Navigation bar does not inform screen readers of "current page".

### DIFF
--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -24,6 +24,8 @@ const ClayNavigationBarIcon = ({
 	className,
 	...otherProps
 }: IItemProps) => {
+	const ariaCurrent = active ? 'page' : false;
+
 	return (
 		<li {...otherProps} className={classNames('nav-item', className)}>
 			{React.Children.map(
@@ -37,7 +39,7 @@ const ClayNavigationBarIcon = ({
 					) {
 						return React.cloneElement(child, {
 							...child.props,
-							'aria-current': active,
+							'aria-current': ariaCurrent,
 							children: (
 								<span className="navbar-text-truncate">
 									{child.props.children}

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -24,8 +24,6 @@ const ClayNavigationBarIcon = ({
 	className,
 	...otherProps
 }: IItemProps) => {
-	const ariaCurrent = active ? 'page' : false;
-
 	return (
 		<li {...otherProps} className={classNames('nav-item', className)}>
 			{React.Children.map(
@@ -39,7 +37,7 @@ const ClayNavigationBarIcon = ({
 					) {
 						return React.cloneElement(child, {
 							...child.props,
-							'aria-current': ariaCurrent,
+							'aria-current': active ? 'page' : undefined,
 							children: (
 								<span className="navbar-text-truncate">
 									{child.props.children}

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -37,6 +37,7 @@ const ClayNavigationBarIcon = ({
 					) {
 						return React.cloneElement(child, {
 							...child.props,
+							'aria-current': active,
 							children: (
 								<span className="navbar-text-truncate">
 									{child.props.children}

--- a/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -15,6 +15,7 @@ exports[`ClayNavigationBar collapses the previously expanded dropdown when trigg
         class="nav-item"
       >
         <a
+          aria-current="page"
           class="nav-link active link-unstyled"
           href="#1"
         >
@@ -85,6 +86,7 @@ exports[`ClayNavigationBar renders 1`] = `
               class="nav-item"
             >
               <a
+                aria-current="page"
                 class="nav-link active link-unstyled"
                 href="#1"
               >
@@ -201,6 +203,7 @@ exports[`ClayNavigationBar renders a dropdown when clicking the trigger element 
         class="nav-item"
       >
         <a
+          aria-current="page"
           class="nav-link active link-unstyled"
           href="#1"
         >
@@ -285,6 +288,7 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
               class="nav-item"
             >
               <button
+                aria-current="page"
                 class="nav-link active btn btn-unstyled"
                 type="button"
               >
@@ -358,6 +362,7 @@ exports[`ClayNavigationBar renders with a single item 1`] = `
               class="nav-item"
             >
               <a
+                aria-current="page"
                 class="nav-link active link-unstyled"
                 href="#1"
               >
@@ -417,6 +422,7 @@ exports[`ClayNavigationBar throws a warning when passing more than one active pr
               class="nav-item"
             >
               <a
+                aria-current="page"
                 class="nav-link active link-unstyled"
                 href="#1"
               >
@@ -431,6 +437,7 @@ exports[`ClayNavigationBar throws a warning when passing more than one active pr
               class="nav-item"
             >
               <button
+                aria-current="page"
                 class="nav-link active btn btn-unstyled"
                 type="button"
               >


### PR DESCRIPTION
Hi!

This is a fix for the accessibility issue mentioned here: https://github.com/liferay/clay/issues/5002

It's meant to address the client reported issue seen on [LPP-45909](https://issues.liferay.com/browse/LPP-45909) as HRG-06 where screen readers are not informed of what the 'current page' on a navigation bar, even when highlighting it.

I've attempted to format the commits correctly, but please let me know if anything needs adjusting. Thanks!