### PR TITLE
feat(@clayui/css): Convert to use focus-visible pattern

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_application-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_application-bar.scss
@@ -17,6 +17,14 @@ $application-bar-base: map-deep-merge(
 				focus: (
 					box-shadow: $component-focus-box-shadow,
 				),
+				supports-focus-visible: (
+					focus: (
+						box-shadow: none,
+					),
+					focus-visible: (
+						box-shadow: $btn-focus-box-shadow,
+					),
+				),
 				disabled: (
 					box-shadow: none,
 				),

--- a/packages/clay-css/src/scss/atlas/variables/_badges.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_badges.scss
@@ -50,7 +50,16 @@ $badge-primary: map-deep-merge(
 			),
 			focus: (
 				background-color: $badge-primary-hover-bg,
+				box-shadow: $c-unset,
 				color: $badge-primary-hover-color,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 	),
@@ -77,7 +86,16 @@ $badge-secondary: map-deep-merge(
 			),
 			focus: (
 				background-color: $badge-secondary-hover-bg,
+				box-shadow: $c-unset,
 				color: $badge-secondary-hover-color,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 		link: (
@@ -106,7 +124,16 @@ $badge-success: map-deep-merge(
 			),
 			focus: (
 				background-color: $badge-success-hover-bg,
+				box-shadow: $c-unset,
 				color: $badge-success-hover-color,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 	),
@@ -132,7 +159,16 @@ $badge-info: map-deep-merge(
 			),
 			focus: (
 				background-color: $badge-info-hover-bg,
+				box-shadow: $c-unset,
 				color: $badge-info-hover-color,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 	),
@@ -158,7 +194,16 @@ $badge-warning: map-deep-merge(
 			),
 			focus: (
 				background-color: $badge-warning-hover-bg,
+				box-shadow: $c-unset,
 				color: $badge-warning-hover-color,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 	),
@@ -184,7 +229,16 @@ $badge-danger: map-deep-merge(
 			),
 			focus: (
 				background-color: $badge-danger-hover-bg,
+				box-shadow: $c-unset,
 				color: $badge-danger-hover-color,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 	),
@@ -211,7 +265,16 @@ $badge-light: map-deep-merge(
 			),
 			focus: (
 				background-color: $badge-light-hover-bg,
+				box-shadow: $c-unset,
 				color: $badge-light-hover-color,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 		link: (
@@ -240,7 +303,16 @@ $badge-dark: map-deep-merge(
 			),
 			focus: (
 				background-color: $badge-dark-hover-bg,
+				box-shadow: $c-unset,
 				color: $badge-dark-hover-color,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/atlas/variables/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_breadcrumbs.scss
@@ -16,6 +16,14 @@ $breadcrumb-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$breadcrumb-link
 );

--- a/packages/clay-css/src/scss/atlas/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_buttons.scss
@@ -26,6 +26,14 @@ $btn: map-deep-merge(
 		focus: (
 			box-shadow: $btn-focus-box-shadow,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $btn-focus-box-shadow,
+			),
+		),
 		active: (
 			box-shadow: $btn-active-box-shadow,
 		),
@@ -134,11 +142,27 @@ $btn-primary: map-deep-merge(
 			background-image: clay-enable-gradients($primary-d1),
 			box-shadow: c-unset,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: $c-unset,
+			),
+		),
 		active: (
 			background-color: $primary-d2,
 			border-color: transparent,
 			focus: (
 				box-shadow: c-unset,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 		disabled: (
@@ -169,12 +193,28 @@ $btn-secondary: map-deep-merge(
 			box-shadow: c-unset,
 			color: $gray-900,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: $c-unset,
+			),
+		),
 		active: (
 			background-color: $gray-200,
 			border-color: $secondary-l2,
 			color: $gray-900,
 			focus: (
 				box-shadow: c-unset,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 		disabled: (
@@ -202,11 +242,27 @@ $btn-success: map-deep-merge(
 			border-color: transparent,
 			box-shadow: c-unset,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: c-unset,
+			),
+			focus-visible: (
+				box-shadow: c-unset,
+			),
+		),
 		active: (
 			background-color: $success-d2,
 			border-color: transparent,
 			focus: (
 				box-shadow: c-unset,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: c-unset,
+				),
+				focus-visible: (
+					box-shadow: c-unset,
+				),
 			),
 		),
 		disabled: (
@@ -231,11 +287,27 @@ $btn-info: map-deep-merge(
 			border-color: transparent,
 			box-shadow: c-unset,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: c-unset,
+			),
+			focus-visible: (
+				box-shadow: c-unset,
+			),
+		),
 		active: (
 			background-color: $info-d2,
 			border-color: transparent,
 			focus: (
 				box-shadow: c-unset,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: c-unset,
+				),
+				focus-visible: (
+					box-shadow: c-unset,
+				),
 			),
 		),
 		disabled: (
@@ -260,11 +332,27 @@ $btn-warning: map-deep-merge(
 			border-color: transparent,
 			box-shadow: c-unset,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: c-unset,
+			),
+			focus-visible: (
+				box-shadow: c-unset,
+			),
+		),
 		active: (
 			background-color: $warning-d2,
 			border-color: transparent,
 			focus: (
 				box-shadow: c-unset,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: c-unset,
+				),
+				focus-visible: (
+					box-shadow: c-unset,
+				),
 			),
 		),
 		disabled: (
@@ -289,11 +377,27 @@ $btn-danger: map-deep-merge(
 			border-color: transparent,
 			box-shadow: c-unset,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: c-unset,
+			),
+			focus-visible: (
+				box-shadow: c-unset,
+			),
+		),
 		active: (
 			background-color: $danger-d2,
 			border-color: transparent,
 			focus: (
 				box-shadow: c-unset,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: c-unset,
+				),
+				focus-visible: (
+					box-shadow: c-unset,
+				),
 			),
 		),
 		disabled: (
@@ -319,11 +423,27 @@ $btn-light: map-deep-merge(
 			border-color: transparent,
 			box-shadow: c-unset,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: c-unset,
+			),
+			focus-visible: (
+				box-shadow: c-unset,
+			),
+		),
 		active: (
 			background-color: $light-d2,
 			border-color: transparent,
 			focus: (
 				box-shadow: c-unset,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: c-unset,
+				),
+				focus-visible: (
+					box-shadow: c-unset,
+				),
 			),
 		),
 		disabled: (
@@ -348,11 +468,27 @@ $btn-dark: map-deep-merge(
 			border-color: transparent,
 			box-shadow: c-unset,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: c-unset,
+			),
+			focus-visible: (
+				box-shadow: c-unset,
+			),
+		),
 		active: (
 			background-color: $dark-d2,
 			border-color: transparent,
 			focus: (
 				box-shadow: c-unset,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: c-unset,
+				),
+				focus-visible: (
+					box-shadow: c-unset,
+				),
 			),
 		),
 		disabled: (
@@ -376,6 +512,14 @@ $btn-outline-primary: map-deep-merge(
 			box-shadow: map-deep-get($btn-primary, focus, box-shadow),
 			color: $primary,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: map-deep-get($btn-primary, focus, box-shadow),
+			),
+		),
 		active: (
 			background-color:
 				clay-lighten(clay-desaturate($primary, 42.05), 41.76),
@@ -384,6 +528,15 @@ $btn-outline-primary: map-deep-merge(
 			focus: (
 				box-shadow:
 					map-deep-get($btn-primary, active, focus, box-shadow),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow:
+						map-deep-get($btn-primary, active, focus, box-shadow),
+				),
 			),
 		),
 		disabled: (
@@ -411,10 +564,13 @@ $btn-outline-secondary: map-deep-merge(
 			box-shadow: map-deep-get($btn-secondary, focus, box-shadow),
 			color: map-deep-get($btn-secondary, focus, color),
 		),
-		disabled: (
-			background-color: transparent,
-			border-color: $secondary,
-			color: $secondary,
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: map-deep-get($btn-secondary, focus, box-shadow),
+			),
 		),
 		active: (
 			background-color: rgba($gray-900, 0.06),
@@ -425,6 +581,20 @@ $btn-outline-secondary: map-deep-merge(
 				box-shadow:
 					map-deep-get($btn-secondary, active, focus, box-shadow),
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow:
+						map-deep-get($btn-secondary, active, focus, box-shadow),
+				),
+			),
+		),
+		disabled: (
+			background-color: transparent,
+			border-color: $secondary,
+			color: $secondary,
 		),
 	),
 	$btn-outline-secondary
@@ -441,11 +611,28 @@ $btn-outline-info: map-deep-merge(
 			box-shadow: map-deep-get($btn-info, focus, box-shadow),
 			color: $white,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: map-deep-get($btn-info, focus, box-shadow),
+			),
+		),
 		active: (
 			background-color: map-deep-get($btn-info, active, background-color),
 			box-shadow: map-deep-get($btn-info, active, box-shadow),
 			focus: (
 				box-shadow: map-deep-get($btn-info, active, focus, box-shadow),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow:
+						map-deep-get($btn-info, active, focus, box-shadow),
+				),
 			),
 		),
 	),
@@ -465,6 +652,14 @@ $btn-outline-success: map-deep-merge(
 			box-shadow: map-deep-get($btn-success, focus, box-shadow),
 			color: $white,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: map-deep-get($btn-success, focus, box-shadow),
+			),
+		),
 		active: (
 			background-color:
 				map-deep-get($btn-success, active, background-color),
@@ -472,6 +667,15 @@ $btn-outline-success: map-deep-merge(
 			focus: (
 				box-shadow:
 					map-deep-get($btn-success, active, focus, box-shadow),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow:
+						map-deep-get($btn-success, active, focus, box-shadow),
+				),
 			),
 		),
 	),
@@ -491,6 +695,14 @@ $btn-outline-warning: map-deep-merge(
 			box-shadow: map-deep-get($btn-warning, focus, box-shadow),
 			color: $white,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: map-deep-get($btn-warning, focus, box-shadow),
+			),
+		),
 		active: (
 			background-color:
 				map-deep-get($btn-warning, active, background-color),
@@ -498,6 +710,15 @@ $btn-outline-warning: map-deep-merge(
 			focus: (
 				box-shadow:
 					map-deep-get($btn-warning, active, focus, box-shadow),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow:
+						map-deep-get($btn-warning, active, focus, box-shadow),
+				),
 			),
 		),
 	),
@@ -515,12 +736,29 @@ $btn-outline-danger: map-deep-merge(
 			box-shadow: map-deep-get($btn-danger, focus, box-shadow),
 			color: $white,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: map-deep-get($btn-danger, focus, box-shadow),
+			),
+		),
 		active: (
 			background-color:
 				map-deep-get($btn-danger, active, background-color),
 			box-shadow: map-deep-get($btn-danger, active, box-shadow),
 			focus: (
 				box-shadow: map-deep-get($btn-danger, active, focus, box-shadow),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow:
+						map-deep-get($btn-danger, active, focus, box-shadow),
+				),
 			),
 		),
 	),
@@ -538,11 +776,28 @@ $btn-outline-light: map-deep-merge(
 			box-shadow: map-deep-get($btn-light, focus, box-shadow),
 			color: $gray-900,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: map-deep-get($btn-light, focus, box-shadow),
+			),
+		),
 		active: (
 			background-color: map-deep-get($btn-light, active, background-color),
 			box-shadow: map-deep-get($btn-light, active, box-shadow),
 			focus: (
 				box-shadow: map-deep-get($btn-light, active, focus, box-shadow),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow:
+						map-deep-get($btn-light, active, focus, box-shadow),
+				),
 			),
 		),
 	),
@@ -560,11 +815,28 @@ $btn-outline-dark: map-deep-merge(
 			box-shadow: map-deep-get($btn-dark, focus, box-shadow),
 			color: $white,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: $c-unset,
+			),
+			focus-visible: (
+				box-shadow: map-deep-get($btn-dark, focus, box-shadow),
+			),
+		),
 		active: (
 			background-color: map-deep-get($btn-dark, active, background-color),
 			box-shadow: map-deep-get($btn-dark, active, box-shadow),
 			focus: (
 				box-shadow: map-deep-get($btn-dark, active, focus, box-shadow),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: $c-unset,
+				),
+				focus-visible: (
+					box-shadow:
+						map-deep-get($btn-dark, active, focus, box-shadow),
+				),
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_cards.scss
@@ -97,6 +97,15 @@ $card-interactive: map-deep-merge(
 			box-shadow: #{0 0 0 2px #fff,
 			0 0 0 4px #719aff},
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: #{0 0 0 2px #fff,
+				0 0 0 4px #719aff},
+			),
+		),
 		active: (
 			background-color: #f1f2f5,
 		),

--- a/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_dropdowns.scss
@@ -99,6 +99,14 @@ $dropdown-item-base: map-deep-merge(
 			outline: 0,
 			text-decoration: none,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-inset-box-shadow,
+			),
+		),
 		active-class: (
 			c-kbd-inline: (
 				color: $dropdown-link-active-color,

--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -23,6 +23,7 @@ $scaling-breakpoint-down: sm !default;
 $enable-clay-color-functions-process-fallback: false !default;
 
 $enable-caret: false !default;
+$enable-focus-visible: true !default;
 $enable-deprecation-messages: true !default;
 $enable-gradients: false !default;
 $enable-grid-classes: true !default;

--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -15,7 +15,7 @@ $atlas-theme: true !default;
 $enable-bs4-deprecated: true !default;
 $enable-lexicon-flat-colors: true !default;
 $enable-scaling-components: true !default;
-$enable-c-inner: false !default;
+$enable-c-inner: true !default;
 $scaling-breakpoint-down: sm !default;
 
 // This enables Clay color functions to get the fallback color of a CSS Custom Property, convert it to the correct Sass type color, then process it using the corresponding Sass color function. The Clay color function will return a CSS color value. Set this variable to `false` if you want the Clay color function to return the CSS Custom Property without any modifications.

--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -15,7 +15,7 @@ $atlas-theme: true !default;
 $enable-bs4-deprecated: true !default;
 $enable-lexicon-flat-colors: true !default;
 $enable-scaling-components: true !default;
-$enable-c-inner: true !default;
+$enable-c-inner: false !default;
 $scaling-breakpoint-down: sm !default;
 
 // This enables Clay color functions to get the fallback color of a CSS Custom Property, convert it to the correct Sass type color, then process it using the corresponding Sass color function. The Clay color function will return a CSS color value. Set this variable to `false` if you want the Clay color function to return the CSS Custom Property without any modifications.

--- a/packages/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_labels.scss
@@ -43,6 +43,14 @@ $label: map-deep-merge(
 				box-shadow: $component-focus-box-shadow,
 				text-decoration: $label-anchor-hover-text-decoration,
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $btn-focus-box-shadow,
+				),
+			),
 		),
 		link: (
 			text-decoration: $label-link-text-decoration,

--- a/packages/clay-css/src/scss/atlas/variables/_links.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_links.scss
@@ -8,6 +8,14 @@ $component-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$component-link
 );
@@ -21,6 +29,14 @@ $link-primary: map-deep-merge(
 			color: clay-darken($primary, 15%),
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 	),
 	$link-primary
@@ -38,6 +54,14 @@ $link-secondary: map-deep-merge(
 			color: $gray-900,
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 	),
 	$link-secondary
@@ -67,6 +91,14 @@ $component-title-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$component-title-link
 );
@@ -95,6 +127,14 @@ $component-subtitle-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$component-subtitle-link
 );
@@ -114,6 +154,14 @@ $component-action: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			color: $gray-900,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 		active: (
 			background-color: rgba($gray-900, 0.06),
@@ -141,6 +189,14 @@ $link-outline-primary: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			color: $primary,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 		active: (
 			background-color:
 				clay-lighten(clay-desaturate($primary, 42.05), 41.76),
@@ -165,6 +221,14 @@ $link-outline-secondary: map-deep-merge(
 			background-color: rgba($gray-900, 0.03),
 			box-shadow: $component-focus-box-shadow,
 			color: $gray-900,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 		active: (
 			background-color: rgba($gray-900, 0.06),

--- a/packages/clay-css/src/scss/atlas/variables/_list-group.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_list-group.scss
@@ -39,6 +39,14 @@ $list-group-title-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$list-group-title-link
 );
@@ -69,6 +77,14 @@ $list-group-subtitle-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$list-group-subtitle-link
 );
@@ -88,6 +104,14 @@ $list-group-text-link: map-deep-merge(
 		focus: (
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 	),
 	$list-group-text-link
@@ -116,6 +140,14 @@ $list-group-subtext-link: map-deep-merge(
 		focus: (
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 	),
 	$list-group-subtext-link

--- a/packages/clay-css/src/scss/atlas/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_management-bar.scss
@@ -9,6 +9,14 @@ $management-bar-base: map-deep-merge(
 				focus: (
 					box-shadow: $component-focus-box-shadow,
 				),
+				supports-focus-visible: (
+					focus: (
+						box-shadow: none,
+					),
+					focus-visible: (
+						box-shadow: $btn-focus-box-shadow,
+					),
+				),
 				disabled: (
 					box-shadow: none,
 				),

--- a/packages/clay-css/src/scss/atlas/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_menubar.scss
@@ -18,10 +18,17 @@ $menubar-vertical-transparent-md: map-deep-merge(
 			),
 			focus: (
 				background-color: rgba($primary, 0.04),
-				box-shadow:
-					clay-enable-shadows($component-focus-inset-box-shadow),
+				box-shadow: $component-focus-inset-box-shadow,
 				color: $gray-900,
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $component-focus-inset-box-shadow,
+				),
 			),
 			active-class: (
 				background-color: rgba($primary, 0.06),
@@ -61,6 +68,14 @@ $menubar-vertical-transparent-md: map-deep-merge(
 			focus: (
 				box-shadow: clay-enable-shadows($component-focus-box-shadow),
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: clay-enable-shadows($component-focus-box-shadow),
+				),
 			),
 			disabled: (
 				box-shadow: clay-enable-shadows(none),
@@ -90,10 +105,17 @@ $menubar-vertical-transparent-lg: map-deep-merge(
 			),
 			focus: (
 				background-color: rgba($primary, 0.04),
-				box-shadow:
-					clay-enable-shadows($component-focus-inset-box-shadow),
+				box-shadow: $component-focus-inset-box-shadow,
 				color: $gray-900,
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $component-focus-inset-box-shadow,
+				),
 			),
 			active-class: (
 				background-color: rgba($primary, 0.06),
@@ -131,8 +153,16 @@ $menubar-vertical-transparent-lg: map-deep-merge(
 			font-weight: $font-weight-semi-bold,
 			transition: box-shadow 0.15s ease-in-out,
 			focus: (
-				box-shadow: clay-enable-shadows($component-focus-box-shadow),
+				box-shadow: $component-focus-box-shadow,
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $component-focus-box-shadow,
+				),
 			),
 			disabled: (
 				box-shadow: clay-enable-shadows(none),

--- a/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navigation-bar.scss
@@ -22,6 +22,14 @@ $navigation-bar-base: map-deep-merge(
 				focus: (
 					box-shadow: $component-focus-box-shadow,
 				),
+				supports-focus-visible: (
+					focus: (
+						box-shadow: none,
+					),
+					focus-visible: (
+						box-shadow: $component-focus-box-shadow,
+					),
+				),
 				disabled: (
 					box-shadow: none,
 				),

--- a/packages/clay-css/src/scss/atlas/variables/_navs.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_navs.scss
@@ -25,6 +25,14 @@ $nav-link-btn-unstyled: map-deep-merge(
 		focus: (
 			box-shadow: $component-focus-box-shadow,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$nav-link-btn-unstyled
 );
@@ -62,6 +70,14 @@ $nav-tabs-link: map-deep-merge(
 		focus: (
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 		disabled: (
 			box-shadow: none,
@@ -107,6 +123,14 @@ $nav-underline-link: map-deep-merge(
 		focus: (
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 		disabled: (
 			box-shadow: none,

--- a/packages/clay-css/src/scss/atlas/variables/_panels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_panels.scss
@@ -14,6 +14,14 @@ $panel-header-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$panel-header-link
 );
@@ -79,8 +87,15 @@ $panel-unstyled-header-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		focus: (
-			box-shadow: #{0 0 0 0.25rem $body-bg,
-			0 0 0 0.375rem $primary-l1},
+			box-shadow: $component-focus-box-shadow,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 	),
 	$panel-unstyled-header-link

--- a/packages/clay-css/src/scss/atlas/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sheets.scss
@@ -37,9 +37,16 @@ $sheet-subtitle-link: map-deep-merge(
 		border-radius: 1px,
 		transition: box-shadow 0.15s ease-in-out,
 		focus: (
-			box-shadow: #{0 0 0 0.25rem $white,
-			0 0 0 0.375rem $primary-l1},
+			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 	),
 	$sheet-subtitle-link

--- a/packages/clay-css/src/scss/atlas/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_sidebar.scss
@@ -79,8 +79,15 @@ $sidebar-light: map-deep-merge(
 			header: (
 				link: (
 					focus: (
-						box-shadow: #{0 0 0 0.25rem $white,
-						0 0 0 0.375rem $primary-l1},
+						box-shadow: $component-focus-box-shadow,
+					),
+					supports-focus-visible: (
+						focus: (
+							box-shadow: none,
+						),
+						focus-visible: (
+							box-shadow: $component-focus-box-shadow,
+						),
 					),
 				),
 			),

--- a/packages/clay-css/src/scss/atlas/variables/_tables.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tables.scss
@@ -24,6 +24,14 @@ $table-head-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$table-head-link
 );
@@ -75,6 +83,14 @@ $table-title-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$table-title-link
 );
@@ -106,6 +122,14 @@ $table-action-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 		active: (
 			background-color: rgba(0, 0, 0, 0.04),
 		),
@@ -129,6 +153,14 @@ $table-link: map-deep-merge(
 		focus: (
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 	),
 	$table-link
@@ -177,6 +209,14 @@ $table-list-title-link: map-deep-merge(
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 	),
 	$table-list-title-link
 );
@@ -197,6 +237,14 @@ $table-list-link: map-deep-merge(
 		focus: (
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 	),
 	$table-list-link
@@ -219,6 +267,14 @@ $table-list-action-link: map-deep-merge(
 			color: $gray-900,
 			box-shadow: $component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 		active: (
 			background-color: rgba(0, 0, 0, 0.04),

--- a/packages/clay-css/src/scss/atlas/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_utilities.scss
@@ -29,6 +29,14 @@ $close: map-deep-merge(
 		focus: (
 			box-shadow: $component-focus-box-shadow,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
+		),
 		disabled: (
 			color: $gray-600,
 			opacity: 0.65,

--- a/packages/clay-css/src/scss/cadmin/variables/_badges.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_badges.scss
@@ -59,6 +59,14 @@ $cadmin-badge: map-deep-merge(
 				box-shadow: $cadmin-component-focus-box-shadow,
 				outline: 0,
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-component-focus-box-shadow,
+				),
+			),
 		),
 		link: (
 			color: $cadmin-badge-link-color,

--- a/packages/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
@@ -137,10 +137,17 @@ $cadmin-breadcrumb-link: map-deep-merge(
 			text-decoration: $cadmin-breadcrumb-link-hover-text-decoration,
 		),
 		focus: (
-			box-shadow: $cadmin-component-focus-box-shadow,
 			color: $cadmin-breadcrumb-link-hover-color,
 			outline: 0,
 			text-decoration: $cadmin-breadcrumb-link-hover-text-decoration,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 	),
 	$cadmin-breadcrumb-link

--- a/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
@@ -38,7 +38,7 @@ $cadmin-btn: map-deep-merge(
 		border-style: solid,
 		border-width: $cadmin-btn-border-width,
 		border-radius: clay-enable-rounded($cadmin-btn-border-radius),
-		box-shadow: clay-enable-shadows([$cadmin-btn-box-shadow]),
+		box-shadow: clay-enable-shadows($cadmin-btn-box-shadow),
 		color: $cadmin-body-color,
 		cursor: $cadmin-btn-cursor,
 		display: inline-block,
@@ -71,14 +71,30 @@ $cadmin-btn: map-deep-merge(
 			box-shadow: $cadmin-btn-focus-box-shadow,
 			outline: 0,
 		),
-		active: (
-			box-shadow: clay-enable-shadows([$cadmin-btn-active-box-shadow]),
+		supports-focus-visible: (
 			focus: (
-				box-shadow: clay-enable-shadows([$cadmin-btn-focus-box-shadow]),
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-btn-focus-box-shadow,
+			),
+		),
+		active: (
+			box-shadow: clay-enable-shadows($cadmin-btn-active-box-shadow),
+			focus: (
+				box-shadow: $cadmin-btn-focus-box-shadow,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-btn-focus-box-shadow,
+				),
 			),
 		),
 		active-class: (
-			box-shadow: clay-enable-shadows([$cadmin-btn-active-box-shadow]),
+			box-shadow: clay-enable-shadows($cadmin-btn-active-box-shadow),
 		),
 		disabled: (
 			cursor: $cadmin-btn-disabled-cursor,
@@ -662,7 +678,7 @@ $cadmin-btn-link: () !default;
 $cadmin-btn-link: map-deep-merge(
 	(
 		border-radius: 1px,
-		box-shadow: clay-enable-shadows([none]),
+		box-shadow: clay-enable-shadows(none),
 		color: $cadmin-link-color,
 		font-weight: $cadmin-font-weight-normal,
 		text-decoration: $cadmin-link-decoration,
@@ -671,11 +687,10 @@ $cadmin-btn-link: map-deep-merge(
 			text-decoration: $cadmin-link-hover-decoration,
 		),
 		focus: (
-			box-shadow: $cadmin-btn-focus-box-shadow,
 			text-decoration: $cadmin-link-decoration,
 		),
 		active: (
-			box-shadow: clay-enable-shadows([none]),
+			box-shadow: clay-enable-shadows(none),
 		),
 		disabled: (
 			box-shadow: none,
@@ -716,7 +731,6 @@ $cadmin-btn-outline-primary: map-deep-merge(
 		),
 		focus: (
 			background-color: $cadmin-primary-l3,
-			box-shadow: map-get($cadmin-btn-primary, focus-box-shadow),
 			color: $cadmin-primary,
 		),
 		active: (
@@ -747,8 +761,6 @@ $cadmin-btn-outline-secondary: map-deep-merge(
 		focus: (
 			background-color: rgba($cadmin-gray-900, 0.03),
 			border-color: transparent,
-			box-shadow:
-				map-get(map-get($cadmin-btn-secondary, focus), box-shadow),
 			color: map-get(map-get($cadmin-btn-secondary, focus), color),
 		),
 		active: (
@@ -810,14 +822,12 @@ $cadmin-btn-outline-info: map-deep-merge(
 		focus: (
 			background-color:
 				map-get(map-get($cadmin-btn-info, hover), background-color),
-			box-shadow: map-get(map-get($cadmin-btn-info, focus), box-shadow),
 			color: $cadmin-white,
 		),
 		active: (
 			background-color:
 				map-get(map-get($cadmin-btn-info, active), background-color),
 			border-color: $cadmin-info,
-			box-shadow: map-get(map-get($cadmin-btn-info, active), box-shadow),
 			color: color-yiq($cadmin-info),
 		),
 		disabled: (
@@ -843,15 +853,12 @@ $cadmin-btn-outline-warning: map-deep-merge(
 		focus: (
 			background-color:
 				map-get(map-get($cadmin-btn-warning, hover), background-color),
-			box-shadow: map-get(map-get($cadmin-btn-warning, focus), box-shadow),
 			color: $cadmin-white,
 		),
 		active: (
 			background-color:
 				map-get(map-get($cadmin-btn-warning, active), background-color),
 			border-color: $cadmin-warning,
-			box-shadow:
-				map-get(map-get($cadmin-btn-warning, active), box-shadow),
 			color: color-yiq($cadmin-warning),
 		),
 		disabled: (
@@ -877,7 +884,6 @@ $cadmin-btn-outline-danger: map-deep-merge(
 		focus: (
 			background-color:
 				map-get(map-get($cadmin-btn-danger, hover), background-color),
-			box-shadow: map-get(map-get($cadmin-btn-danger, focus), box-shadow),
 			color: $cadmin-white,
 		),
 		active: (
@@ -909,23 +915,13 @@ $cadmin-btn-outline-light: map-deep-merge(
 		focus: (
 			background-color:
 				map-get(map-get($cadmin-btn-light, hover), background-color),
-			box-shadow: map-get(map-get($cadmin-btn-light, focus), box-shadow),
 			color: $cadmin-gray-900,
 		),
 		active: (
 			background-color:
 				map-get(map-get($cadmin-btn-light, active), background-color),
 			border-color: $cadmin-light,
-			box-shadow: map-get(map-get($cadmin-btn-light, active), box-shadow),
 			color: color-yiq($cadmin-light),
-			focus: (
-				box-shadow:
-					clay-enable-shadows(
-						[ $cadmin-btn-active-box-shadow#{','} 0 0 0 $cadmin-btn-focus-width
-							rgba($cadmin-light, 0.5),
-						0 0 0 $cadmin-btn-focus-width rgba($cadmin-light, 0.5) ]
-					),
-			),
 		),
 		disabled: (
 			background-color: transparent,
@@ -950,25 +946,13 @@ $cadmin-btn-outline-dark: map-deep-merge(
 		focus: (
 			background-color:
 				map-get(map-get($cadmin-btn-dark, hover), background-color),
-			box-shadow: map-get(map-get($cadmin-btn-dark, focus), box-shadow),
 			color: $cadmin-white,
 		),
 		active: (
 			background-color:
 				map-get(map-get($cadmin-btn-dark, active), background-color),
 			border-color: $cadmin-dark,
-			box-shadow: map-get(map-get($cadmin-btn-dark, active), box-shadow),
 			color: color-yiq($cadmin-dark),
-			focus: (
-				box-shadow:
-					if(
-						$cadmin-enable-shadows and $cadmin-btn-active-box-shadow
-							!= none,
-						$cadmin-btn-active-box-shadow#{','} 0 0 0 $cadmin-btn-focus-width
-							rgba($cadmin-dark, 0.5),
-						0 0 0 $cadmin-btn-focus-width rgba($cadmin-dark, 0.5)
-					),
-			),
 		),
 		disabled: (
 			background-color: transparent,

--- a/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_dropdowns.scss
@@ -132,6 +132,14 @@ $cadmin-dropdown-item-base: map-deep-merge(
 			outline: 0,
 			text-decoration: none,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-inset-box-shadow,
+			),
+		),
 		active: (
 			background-color: $cadmin-dropdown-link-active-bg,
 			color: $cadmin-dropdown-link-active-color,

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -65,7 +65,7 @@ $cadmin-input: map-deep-merge(
 		border-right-width: $cadmin-input-border-right-width,
 		border-top-width: $cadmin-input-border-top-width,
 		border-radius: clay-enable-rounded($cadmin-input-border-radius),
-		box-shadow: clay-enable-shadows([$cadmin-input-box-shadow]),
+		box-shadow: clay-enable-shadows($cadmin-input-box-shadow),
 		color: $cadmin-input-color,
 		display: block,
 		font-family: $cadmin-input-font-family,

--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -20,6 +20,7 @@ $cadmin-scaling-breakpoint-down: sm !default;
 $cadmin-enable-clay-color-functions-process-fallback: true !default;
 
 $cadmin-enable-caret: false !default;
+$cadmin-enable-focus-visible: true !default;
 $cadmin-enable-rounded: true !default;
 $cadmin-enable-shadows: true !default;
 $cadmin-enable-gradients: false !default;

--- a/packages/clay-css/src/scss/cadmin/variables/_labels.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_labels.scss
@@ -75,6 +75,14 @@ $cadmin-label: map-deep-merge(
 				box-shadow: $cadmin-component-focus-box-shadow,
 				text-decoration: $cadmin-label-anchor-hover-text-decoration,
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-btn-focus-box-shadow,
+				),
+			),
 		),
 		link: (
 			color: $cadmin-label-link-color,

--- a/packages/clay-css/src/scss/cadmin/variables/_links.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_links.scss
@@ -14,6 +14,14 @@ $cadmin-component-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 	),
 	$cadmin-component-link
 );
@@ -32,6 +40,14 @@ $cadmin-link-primary: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 	),
 	$cadmin-link-primary
 );
@@ -49,6 +65,14 @@ $cadmin-link-secondary: map-deep-merge(
 			color: $cadmin-gray-900,
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 	),
 	$cadmin-link-secondary
@@ -139,7 +163,16 @@ $cadmin-link-outline-primary: map-deep-merge(
 		),
 		focus: (
 			background-color: $cadmin-primary-l3,
+			box-shadow: $cadmin-component-focus-box-shadow,
 			color: $cadmin-primary,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 		active: (
 			background-color:
@@ -167,7 +200,16 @@ $cadmin-link-outline-secondary: map-deep-merge(
 		),
 		focus: (
 			background-color: rgba($cadmin-gray-900, 0.03),
+			box-shadow: $cadmin-component-focus-box-shadow,
 			color: $cadmin-gray-900,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 		active: (
 			background-color: rgba($cadmin-gray-900, 0.06),
@@ -241,6 +283,14 @@ $cadmin-component-title-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 	),
 	$cadmin-component-title-link
 );
@@ -278,6 +328,14 @@ $cadmin-component-subtitle-link: map-deep-merge(
 			color: $cadmin-gray-900,
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 	),
 	$cadmin-component-subtitle-link
@@ -319,6 +377,14 @@ $cadmin-component-action: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			color: $cadmin-gray-900,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 		active: (
 			background-color: rgba($cadmin-gray-900, 0.06),

--- a/packages/clay-css/src/scss/cadmin/variables/_list-group.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_list-group.scss
@@ -80,6 +80,14 @@ $cadmin-list-group-title-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 	),
 	$cadmin-list-group-title-link
 );
@@ -117,6 +125,14 @@ $cadmin-list-group-subtitle-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 	),
 	$cadmin-list-group-subtitle-link
 );
@@ -147,6 +163,14 @@ $cadmin-list-group-text-link: map-deep-merge(
 		focus: (
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 	),
 	$cadmin-list-group-text-link
@@ -181,6 +205,14 @@ $cadmin-list-group-subtext-link: map-deep-merge(
 		focus: (
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 	),
 	$cadmin-list-group-subtext-link

--- a/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
@@ -11,6 +11,14 @@ $cadmin-management-bar-base: map-deep-merge(
 				focus: (
 					box-shadow: $cadmin-component-focus-box-shadow,
 				),
+				supports-focus-visible: (
+					focus: (
+						box-shadow: none,
+					),
+					focus-visible: (
+						box-shadow: $cadmin-btn-focus-box-shadow,
+					),
+				),
 				disabled: (
 					box-shadow: none,
 				),

--- a/packages/clay-css/src/scss/cadmin/variables/_menubar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_menubar.scss
@@ -78,12 +78,17 @@ $cadmin-menubar-vertical-transparent-md: map-deep-merge(
 			),
 			focus: (
 				background-color: rgba($cadmin-primary, 0.04),
-				box-shadow:
-					clay-enable-shadows(
-						$cadmin-component-focus-inset-box-shadow
-					),
+				box-shadow: $cadmin-component-focus-inset-box-shadow,
 				color: $cadmin-gray-900,
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-component-focus-inset-box-shadow,
+				),
 			),
 			active: (
 				color: rgba($cadmin-black, 0.9),
@@ -141,9 +146,16 @@ $cadmin-menubar-vertical-transparent-md: map-deep-merge(
 			text-decoration: none,
 			transition: box-shadow 0.15s ease-in-out,
 			focus: (
-				box-shadow:
-					clay-enable-shadows($cadmin-component-focus-box-shadow),
+				box-shadow: $cadmin-component-focus-box-shadow,
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-component-focus-box-shadow,
+				),
 			),
 			disabled: (
 				box-shadow: clay-enable-shadows(none),
@@ -290,12 +302,17 @@ $cadmin-menubar-vertical-transparent-lg: map-deep-merge(
 			),
 			focus: (
 				background-color: rgba($cadmin-primary, 0.04),
-				box-shadow:
-					clay-enable-shadows(
-						$cadmin-component-focus-inset-box-shadow
-					),
+				box-shadow: $cadmin-component-focus-inset-box-shadow,
 				color: $cadmin-gray-900,
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-component-focus-inset-box-shadow,
+				),
 			),
 			active: (
 				color: rgba($cadmin-black, 0.9),
@@ -353,9 +370,16 @@ $cadmin-menubar-vertical-transparent-lg: map-deep-merge(
 			text-decoration: none,
 			transition: box-shadow 0.15s ease-in-out,
 			focus: (
-				box-shadow:
-					clay-enable-shadows($cadmin-component-focus-box-shadow),
+				box-shadow: $cadmin-component-focus-box-shadow,
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-component-focus-box-shadow,
+				),
 			),
 			disabled: (
 				box-shadow: clay-enable-shadows(none),

--- a/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
@@ -35,6 +35,14 @@ $cadmin-navigation-bar-base: map-deep-merge(
 				focus: (
 					box-shadow: $cadmin-component-focus-box-shadow,
 				),
+				supports-focus-visible: (
+					focus: (
+						box-shadow: none,
+					),
+					focus-visible: (
+						box-shadow: $cadmin-btn-focus-box-shadow,
+					),
+				),
 				disabled: (
 					box-shadow: none,
 				),

--- a/packages/clay-css/src/scss/cadmin/variables/_navs.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navs.scss
@@ -39,8 +39,15 @@ $cadmin-nav-link-btn-unstyled: map-deep-merge(
 	(
 		width: 100%,
 		focus: (
-			box-shadow: #{0 0 0 2px $cadmin-white,
-			0 0 0 4px $cadmin-primary-l1},
+			box-shadow: $cadmin-component-focus-box-shadow,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 		disabled: (
 			opacity: 1,
@@ -360,6 +367,14 @@ $cadmin-nav-tabs-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 		active: (
 			background-color: $cadmin-nav-tabs-link-active-bg,
 			border-color: $cadmin-nav-tabs-link-active-border-color,
@@ -469,6 +484,14 @@ $cadmin-nav-underline-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			color: $cadmin-nav-underline-link-hover-color,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 		active-class: (
 			color: $cadmin-nav-underline-link-active-color,

--- a/packages/clay-css/src/scss/cadmin/variables/_pagination.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_pagination.scss
@@ -156,6 +156,14 @@ $cadmin-pagination-link: map-deep-merge(
 		transition: $cadmin-pagination-link-transition,
 		hover: $cadmin-pagination-link-hover,
 		focus: $cadmin-pagination-link-focus,
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-pagination-focus-box-shadow,
+			),
+		),
 		active: $cadmin-pagination-link-active,
 		disabled: $cadmin-pagination-link-disabled,
 		lexicon-icon: (
@@ -349,6 +357,14 @@ $cadmin-pagination-items-per-page-link: map-deep-merge(
 		transition: $cadmin-pagination-items-per-page-transition,
 		hover: $cadmin-pagination-items-per-page-link-hover,
 		focus: $cadmin-pagination-items-per-page-link-focus,
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-pagination-items-per-page-focus-box-shadow,
+			),
+		),
 		active: $cadmin-pagination-items-per-page-link-active,
 		disabled: $cadmin-pagination-items-per-page-link-disabled,
 		lexicon-icon: (

--- a/packages/clay-css/src/scss/cadmin/variables/_panels.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_panels.scss
@@ -58,6 +58,14 @@ $cadmin-panel-header-link: map-deep-merge(
 			outline: 0,
 			z-index: $cadmin-zindex-panel-header-link-focus,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 	),
 	$cadmin-panel-header-link
 );
@@ -179,8 +187,15 @@ $cadmin-panel-unstyled-header-link: map-deep-merge(
 	(
 		border-radius: 1px,
 		focus: (
-			box-shadow: #{0 0 0 4px $cadmin-body-bg,
-			0 0 0 6px $cadmin-primary-l1},
+			box-shadow: $cadmin-component-focus-box-shadow,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 	),
 	$cadmin-panel-unstyled-header-link

--- a/packages/clay-css/src/scss/cadmin/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_sidebar.scss
@@ -128,8 +128,15 @@ $cadmin-sidebar-light: map-deep-merge(
 			header: (
 				link: (
 					focus: (
-						box-shadow: #{0 0 0 4px $cadmin-white,
-						0 0 0 6px $cadmin-primary-l1},
+						box-shadow: $cadmin-component-focus-box-shadow,
+					),
+					supports-focus-visible: (
+						focus: (
+							box-shadow: none,
+						),
+						focus-visible: (
+							box-shadow: $cadmin-component-focus-box-shadow,
+						),
 					),
 				),
 			),
@@ -185,6 +192,14 @@ $cadmin-sidebar-dark: map-deep-merge(
 				focus: (
 					box-shadow: $cadmin-component-focus-box-shadow,
 					outline: 0,
+				),
+				supports-focus-visible: (
+					focus: (
+						box-shadow: none,
+					),
+					focus-visible: (
+						box-shadow: $cadmin-component-focus-box-shadow,
+					),
 				),
 				active: (
 					color: $cadmin-white,
@@ -242,6 +257,14 @@ $cadmin-sidebar-palette: map-deep-merge(
 					focus: (
 						box-shadow: $cadmin-component-focus-box-shadow,
 						outline: 0,
+					),
+					supports-focus-visible: (
+						focus: (
+							box-shadow: none,
+						),
+						focus-visible: (
+							box-shadow: $cadmin-component-focus-box-shadow,
+						),
 					),
 					active: (
 						color: $cadmin-white,

--- a/packages/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -99,6 +99,14 @@ $cadmin-table-head-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 	),
 	$cadmin-table-head-link
 );
@@ -212,6 +220,14 @@ $cadmin-table-title-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 	),
 	$cadmin-table-title-link
 );
@@ -232,6 +248,14 @@ $cadmin-table-link: map-deep-merge(
 		focus: (
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 	),
 	$cadmin-table-link
@@ -262,6 +286,14 @@ $cadmin-table-action-link: map-deep-merge(
 			color: $cadmin-gray-900,
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 		active: (
 			background-color: rgba(0, 0, 0, 0.04),
@@ -651,6 +683,14 @@ $cadmin-table-list-title-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
+		),
 	),
 	$cadmin-table-list-title-link
 );
@@ -671,6 +711,14 @@ $cadmin-table-list-link: map-deep-merge(
 		focus: (
 			box-shadow: $cadmin-component-focus-box-shadow,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 	),
 	$cadmin-table-list-link
@@ -700,6 +748,14 @@ $cadmin-table-list-action-link: map-deep-merge(
 			box-shadow: $cadmin-component-focus-box-shadow,
 			color: $cadmin-gray-900,
 			outline: 0,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-component-focus-box-shadow,
+			),
 		),
 		active: (
 			background-color: rgba(0, 0, 0, 0.04),

--- a/packages/clay-css/src/scss/cadmin/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tbar.scss
@@ -58,12 +58,20 @@ $cadmin-tbar-stacked: map-deep-merge(
 			position: relative,
 			width: 40px,
 			focus: (
-				box-shadow: inset 0 0 0 2px $cadmin-primary-l1#{','} inset 0 0 0
-					4px $cadmin-white,
+				box-shadow: $cadmin-component-focus-inset-box-shadow,
 			),
-			active-focus: (
-				box-shadow: inset 0 0 0 2px $cadmin-primary-l1#{','} inset 0 0 0
-					4px $cadmin-white,
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-component-focus-inset-box-shadow,
+				),
+			),
+			active: (
+				focus: (
+					box-shadow: $cadmin-c-unset,
+				),
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/cadmin/variables/_tooltip.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tooltip.scss
@@ -72,7 +72,7 @@ $cadmin-tooltip-inner: map-merge(
 	(
 		background-color: $cadmin-tooltip-bg,
 		border-radius: clay-enable-rounded($cadmin-tooltip-border-radius),
-		box-shadow: clay-enable-shadows([$cadmin-tooltip-box-shadow]),
+		box-shadow: clay-enable-shadows($cadmin-tooltip-box-shadow),
 		color: $cadmin-tooltip-color,
 		max-width: $cadmin-tooltip-max-width,
 		padding: $cadmin-tooltip-padding-y $cadmin-tooltip-padding-x,

--- a/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_treeview.scss
@@ -23,6 +23,14 @@ $cadmin-treeview: map-merge(
 			focus: (
 				box-shadow: $cadmin-component-focus-inset-box-shadow,
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-component-focus-inset-box-shadow,
+				),
+			),
 		),
 		custom-control: (
 			margin-left: 4px,
@@ -90,6 +98,14 @@ $cadmin-treeview: map-merge(
 			focus: (
 				box-shadow: $cadmin-component-focus-inset-box-shadow,
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $cadmin-component-focus-inset-box-shadow,
+				),
 			),
 			disabled: (
 				cursor: $cadmin-disabled-cursor,

--- a/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
@@ -81,6 +81,14 @@ $cadmin-close: map-deep-merge(
 			opacity: 1,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $cadmin-btn-focus-box-shadow,
+			),
+		),
 		disabled: (
 			box-shadow: none,
 			color: $cadmin-gray-600,

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -256,7 +256,6 @@
 	$ret-val: null;
 
 	$length: length($shadows);
-	$separator: list-separator($shadows);
 
 	$last-item: nth($shadows, $length);
 
@@ -276,18 +275,14 @@
 		)
 	);
 
-	@if ($separator == 'comma') {
-		@if ($length >= 2) {
-			@if ($enable) {
-				$ret-val: nth($shadows, 1);
-			} @else if not ($has-enable-param) {
-				$ret-val: nth($shadows, 2);
-			}
-		}
-	} @else if ($separator == 'space') {
+	@if ($length >= 2) {
 		@if ($enable) {
-			$ret-val: $shadows;
+			$ret-val: nth($shadows, 1);
+		} @else if not ($has-enable-param) {
+			$ret-val: nth($shadows, 2);
 		}
+	} @else if ($enable) {
+		$ret-val: $shadows;
 	}
 
 	@return $ret-val;

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -249,26 +249,40 @@
 	@return null;
 }
 
-/// A function that returns a shadow for use with the `box-shadow` property. This function returns `null` if `$enable-shadows` is set to `false`. This is a workaround for complying with Bootstrap's `$enable-shadows` setting.
-/// @param {List} $shadows - The box shadow. Pass in a single shadow or two shadows using `[$shadow1, $shadow2]` if you need a default shadow even if `$enable-shadows` is `false`. A focus shadow for example.
+/// A function that returns a shadow for use with the `box-shadow` property. This function returns `null` if there is only one shadow and the global variable `$enable-shadows` is set to `false`. You can override the `$enable-shadows` setting by passing a boolean value as the last parameter. This is a workaround for complying with Bootstrap's `$enable-shadows` setting.
+/// @param {ArgList} $shadows... - The box shadow(s) and an optional boolean parameter. Pass in a single shadow or two shadows using `$shadow1, $shadow2` if you need a default shadow even if `$enable-shadows` is `false`. We use this for supplying focus shadows in the base theme.
 
-@function clay-enable-shadows($shadows, $enable: null) {
+@function clay-enable-shadows($shadows...) {
 	$ret-val: null;
 
 	$length: length($shadows);
 	$separator: list-separator($shadows);
 
+	$last-item: nth($shadows, $length);
+
+	$has-enable-param: type-of($last-item) == bool;
+
 	$enable: if(
-		variable-exists(enable-shadows),
-		$enable-shadows,
-		if(variable-exists(cadmin-enable-shadows), $cadmin-enable-shadows, true)
+		$has-enable-param,
+		$last-item,
+		if(
+			variable-exists(enable-shadows),
+			$enable-shadows,
+			if(
+				variable-exists(cadmin-enable-shadows),
+				$cadmin-enable-shadows,
+				true
+			)
+		)
 	);
 
-	@if ($length == 2 and $separator == 'comma') {
-		@if ($enable) {
-			$ret-val: nth($shadows, 1);
-		} @else {
-			$ret-val: nth($shadows, 2);
+	@if ($separator == 'comma') {
+		@if ($length >= 2) {
+			@if ($enable) {
+				$ret-val: nth($shadows, 1);
+			} @else if not ($has-enable-param) {
+				$ret-val: nth($shadows, 2);
+			}
 		}
 	} @else if ($separator == 'space') {
 		@if ($enable) {

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -246,6 +246,16 @@
 
 @mixin clay-button-variant($map) {
 	@if (type-of($map) == 'map') {
+		$focus-visible: if(
+			variable-exists(enable-focus-visible),
+			$enable-focus-visible,
+			if(
+				variable-exists(cadmin-focus-visible),
+				$cadmin-focus-visible,
+				true
+			)
+		);
+
 		$enabled: setter(map-get($map, enabled), true);
 
 		$breakpoint-down: map-get($map, breakpoint-down);
@@ -689,86 +699,88 @@
 				}
 			}
 
-			@supports #{'\selector(:focus-visible)'} {
-				&:focus {
-					@include clay-css(
-						map-deep-get($map, supports-focus-visible, focus)
-					);
-				}
-
-				&:focus-visible {
-					@include clay-css(
-						map-deep-get(
-							$map,
-							supports-focus-visible,
-							focus-visible
-						)
-					);
-
-					&::before {
+			@if ($focus-visible) {
+				@supports #{'\selector(:focus-visible)'} {
+					&:focus {
 						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								before
-							)
+							map-deep-get($map, supports-focus-visible, focus)
 						);
 					}
 
-					&::after {
+					&:focus-visible {
 						@include clay-css(
 							map-deep-get(
 								$map,
 								supports-focus-visible,
-								focus-visible,
-								after
+								focus-visible
 							)
 						);
-					}
 
-					.inline-item {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								inline-item
-							)
-						);
-					}
+						&::before {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									before
+								)
+							);
+						}
 
-					.inline-item-before {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								inline-item-before
-							)
-						);
-					}
+						&::after {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									after
+								)
+							);
+						}
 
-					.inline-item-middle {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								inline-item-middle
-							)
-						);
-					}
+						.inline-item {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									inline-item
+								)
+							);
+						}
 
-					.inline-item-after {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								inline-item-after
-							)
-						);
+						.inline-item-before {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									inline-item-before
+								)
+							);
+						}
+
+						.inline-item-middle {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									inline-item-middle
+								)
+							);
+						}
+
+						.inline-item-after {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									inline-item-after
+								)
+							);
+						}
 					}
 				}
 			}
@@ -800,50 +812,52 @@
 					}
 				}
 
-				@supports #{'\selector(:focus-visible)'} {
-					&:focus {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								active,
-								supports-focus-visible,
-								focus
-							)
-						);
-					}
-
-					&:focus-visible {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								active,
-								supports-focus-visible,
-								focus-visible
-							)
-						);
-
-						&::before {
+				@if ($focus-visible) {
+					@supports #{'\selector(:focus-visible)'} {
+						&:focus {
 							@include clay-css(
 								map-deep-get(
 									$map,
 									active,
 									supports-focus-visible,
-									focus-visible,
-									before
+									focus
 								)
 							);
 						}
 
-						&::after {
+						&:focus-visible {
 							@include clay-css(
 								map-deep-get(
 									$map,
 									active,
 									supports-focus-visible,
-									focus-visible,
-									after
+									focus-visible
 								)
 							);
+
+							&::before {
+								@include clay-css(
+									map-deep-get(
+										$map,
+										active,
+										supports-focus-visible,
+										focus-visible,
+										before
+									)
+								);
+							}
+
+							&::after {
+								@include clay-css(
+									map-deep-get(
+										$map,
+										active,
+										supports-focus-visible,
+										focus-visible,
+										after
+									)
+								);
+							}
 						}
 					}
 				}
@@ -880,28 +894,30 @@
 					@include clay-css(map-deep-get($map, active-class, focus));
 				}
 
-				@supports #{'\selector(:focus-visible)'} {
-					&:focus {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								active-class,
-								supports-focus-visible,
-								focus-visible,
-								focus
-							)
-						);
-					}
+				@if ($focus-visible) {
+					@supports #{'\selector(:focus-visible)'} {
+						&:focus {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									active-class,
+									supports-focus-visible,
+									focus-visible,
+									focus
+								)
+							);
+						}
 
-					&:focus-visible {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								active-class,
-								supports-focus-visible,
-								focus-visible
-							)
-						);
+						&:focus-visible {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									active-class,
+									supports-focus-visible,
+									focus-visible
+								)
+							);
+						}
 					}
 				}
 
@@ -956,50 +972,52 @@
 					}
 				}
 
-				@supports #{'\selector(:focus-visible)'} {
-					&:focus {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								disabled,
-								supports-focus-visible,
-								focus
-							)
-						);
-					}
-
-					&:focus-visible {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								disabled,
-								supports-focus-visible,
-								focus-visible
-							)
-						);
-
-						&::before {
+				@if ($focus-visible) {
+					@supports #{'\selector(:focus-visible)'} {
+						&:focus {
 							@include clay-css(
 								map-deep-get(
 									$map,
 									disabled,
 									supports-focus-visible,
-									focus-visible,
-									before
+									focus
 								)
 							);
 						}
 
-						&::after {
+						&:focus-visible {
 							@include clay-css(
 								map-deep-get(
 									$map,
 									disabled,
 									supports-focus-visible,
-									focus-visible,
-									after
+									focus-visible
 								)
 							);
+
+							&::before {
+								@include clay-css(
+									map-deep-get(
+										$map,
+										disabled,
+										supports-focus-visible,
+										focus-visible,
+										before
+									)
+								);
+							}
+
+							&::after {
+								@include clay-css(
+									map-deep-get(
+										$map,
+										disabled,
+										supports-focus-visible,
+										focus-visible,
+										after
+									)
+								);
+							}
 						}
 					}
 				}

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -689,6 +689,90 @@
 				}
 			}
 
+			@supports #{'\selector(:focus-visible)'} {
+				&:focus {
+					@include clay-css(
+						map-deep-get($map, supports-focus-visible, focus)
+					);
+				}
+
+				&:focus-visible {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							supports-focus-visible,
+							focus-visible
+						)
+					);
+
+					&::before {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								before
+							)
+						);
+					}
+
+					&::after {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								after
+							)
+						);
+					}
+
+					.inline-item {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								inline-item
+							)
+						);
+					}
+
+					.inline-item-before {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								inline-item-before
+							)
+						);
+					}
+
+					.inline-item-middle {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								inline-item-middle
+							)
+						);
+					}
+
+					.inline-item-after {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								inline-item-after
+							)
+						);
+					}
+				}
+			}
+
 			&:active {
 				@include clay-css($active);
 
@@ -713,6 +797,54 @@
 						@include clay-css(
 							map-deep-get($map, active, focus, after)
 						);
+					}
+				}
+
+				@supports #{'\selector(:focus-visible)'} {
+					&:focus {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								active,
+								supports-focus-visible,
+								focus
+							)
+						);
+					}
+
+					&:focus-visible {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								active,
+								supports-focus-visible,
+								focus-visible
+							)
+						);
+
+						&::before {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									active,
+									supports-focus-visible,
+									focus-visible,
+									before
+								)
+							);
+						}
+
+						&::after {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									active,
+									supports-focus-visible,
+									focus-visible,
+									after
+								)
+							);
+						}
 					}
 				}
 
@@ -746,6 +878,31 @@
 
 				&:focus {
 					@include clay-css(map-deep-get($map, active-class, focus));
+				}
+
+				@supports #{'\selector(:focus-visible)'} {
+					&:focus {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								active-class,
+								supports-focus-visible,
+								focus-visible,
+								focus
+							)
+						);
+					}
+
+					&:focus-visible {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								active-class,
+								supports-focus-visible,
+								focus-visible
+							)
+						);
+					}
 				}
 
 				.inline-item {
@@ -796,6 +953,54 @@
 						@include clay-css(
 							map-deep-get($map, disabled, focus, after)
 						);
+					}
+				}
+
+				@supports #{'\selector(:focus-visible)'} {
+					&:focus {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								disabled,
+								supports-focus-visible,
+								focus
+							)
+						);
+					}
+
+					&:focus-visible {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								disabled,
+								supports-focus-visible,
+								focus-visible
+							)
+						);
+
+						&::before {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									disabled,
+									supports-focus-visible,
+									focus-visible,
+									before
+								)
+							);
+						}
+
+						&::after {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									disabled,
+									supports-focus-visible,
+									focus-visible,
+									after
+								)
+							);
+						}
 					}
 				}
 

--- a/packages/clay-css/src/scss/mixins/_cards.scss
+++ b/packages/clay-css/src/scss/mixins/_cards.scss
@@ -295,6 +295,16 @@
 
 @mixin clay-card-variant($map) {
 	@if (type-of($map) == 'map') {
+		$focus-visible: if(
+			variable-exists(enable-focus-visible),
+			$enable-focus-visible,
+			if(
+				variable-exists(cadmin-focus-visible),
+				$cadmin-focus-visible,
+				true
+			)
+		);
+
 		$enabled: setter(map-get($map, enabled), true);
 
 		$base: map-merge(
@@ -730,6 +740,26 @@
 
 				.card-link {
 					@include clay-link($focus-card-link);
+				}
+			}
+
+			@if ($focus-visible) {
+				@supports #{'\selector(:focus-visible)'} {
+					&:focus {
+						@include clay-css(
+							map-deep-get($map, supports-focus-visible, focus)
+						);
+					}
+
+					&:focus-visible {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible
+							)
+						);
+					}
 				}
 			}
 

--- a/packages/clay-css/src/scss/mixins/_close.scss
+++ b/packages/clay-css/src/scss/mixins/_close.scss
@@ -65,6 +65,16 @@
 
 @mixin clay-close($map) {
 	@if (type-of($map) == 'map') {
+		$focus-visible: if(
+			variable-exists(enable-focus-visible),
+			$enable-focus-visible,
+			if(
+				variable-exists(cadmin-focus-visible),
+				$cadmin-focus-visible,
+				true
+			)
+		);
+
 		$enabled: setter(map-get($map, enabled), true);
 
 		$base: map-merge(
@@ -366,21 +376,23 @@
 				@include clay-css($focus);
 			}
 
-			@supports #{'\selector(:focus-visible)'} {
-				&:focus {
-					@include clay-css(
-						map-deep-get($map, supports-focus-visible, focus)
-					);
-				}
+			@if ($focus-visible) {
+				@supports #{'\selector(:focus-visible)'} {
+					&:focus {
+						@include clay-css(
+							map-deep-get($map, supports-focus-visible, focus)
+						);
+					}
 
-				&:focus-visible {
-					@include clay-css(
-						map-deep-get(
-							$map,
-							supports-focus-visible,
-							focus-visible
-						)
-					);
+					&:focus-visible {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible
+							)
+						);
+					}
 				}
 			}
 

--- a/packages/clay-css/src/scss/mixins/_close.scss
+++ b/packages/clay-css/src/scss/mixins/_close.scss
@@ -366,6 +366,24 @@
 				@include clay-css($focus);
 			}
 
+			@supports #{'\selector(:focus-visible)'} {
+				&:focus {
+					@include clay-css(
+						map-deep-get($map, supports-focus-visible, focus)
+					);
+				}
+
+				&:focus-visible {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							supports-focus-visible,
+							focus-visible
+						)
+					);
+				}
+			}
+
 			&:active {
 				@include clay-css($active);
 			}

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -221,6 +221,16 @@
 
 @mixin clay-dropdown-item-variant($map) {
 	@if (type-of($map) == 'map') {
+		$focus-visible: if(
+			variable-exists(enable-focus-visible),
+			$enable-focus-visible,
+			if(
+				variable-exists(cadmin-focus-visible),
+				$cadmin-focus-visible,
+				true
+			)
+		);
+
 		$enabled: setter(map-get($map, enabled), true);
 
 		$base: map-merge(
@@ -506,6 +516,26 @@
 
 				.c-kbd-inline {
 					@include clay-css($focus-c-kbd-inline);
+				}
+			}
+
+			@if ($focus-visible) {
+				@supports #{'\selector(:focus-visible)'} {
+					&:focus {
+						@include clay-css(
+							map-deep-get($map, supports-focus-visible, focus)
+						);
+					}
+
+					&:focus-visible {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible
+							)
+						);
+					}
 				}
 			}
 

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -251,6 +251,16 @@
 
 @mixin clay-link($map) {
 	@if (type-of($map) == 'map') {
+		$focus-visible: if(
+			variable-exists(enable-focus-visible),
+			$enable-focus-visible,
+			if(
+				variable-exists(cadmin-focus-visible),
+				$cadmin-focus-visible,
+				true
+			)
+		);
+
 		$enabled: setter(map-get($map, enabled), true);
 
 		$base: map-merge(
@@ -684,86 +694,88 @@
 				}
 			}
 
-			@supports #{'\selector(:focus-visible)'} {
-				&:focus {
-					@include clay-css(
-						map-deep-get($map, supports-focus-visible, focus)
-					);
-				}
-
-				&:focus-visible {
-					@include clay-css(
-						map-deep-get(
-							$map,
-							supports-focus-visible,
-							focus-visible
-						)
-					);
-
-					&::before {
+			@if ($focus-visible) {
+				@supports #{'\selector(:focus-visible)'} {
+					&:focus {
 						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								before
-							)
+							map-deep-get($map, supports-focus-visible, focus)
 						);
 					}
 
-					&::after {
+					&:focus-visible {
 						@include clay-css(
 							map-deep-get(
 								$map,
 								supports-focus-visible,
-								focus-visible,
-								after
+								focus-visible
 							)
 						);
-					}
 
-					.inline-item {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								inline-item
-							)
-						);
-					}
+						&::before {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									before
+								)
+							);
+						}
 
-					.inline-item-before {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								inline-item-before
-							)
-						);
-					}
+						&::after {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									after
+								)
+							);
+						}
 
-					.inline-item-middle {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								inline-item-middle
-							)
-						);
-					}
+						.inline-item {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									inline-item
+								)
+							);
+						}
 
-					.inline-item-after {
-						@include clay-css(
-							map-deep-get(
-								$map,
-								supports-focus-visible,
-								focus-visible,
-								inline-item-after
-							)
-						);
+						.inline-item-before {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									inline-item-before
+								)
+							);
+						}
+
+						.inline-item-middle {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									inline-item-middle
+								)
+							);
+						}
+
+						.inline-item-after {
+							@include clay-css(
+								map-deep-get(
+									$map,
+									supports-focus-visible,
+									focus-visible,
+									inline-item-after
+								)
+							);
+						}
 					}
 				}
 			}

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -684,6 +684,90 @@
 				}
 			}
 
+			@supports #{'\selector(:focus-visible)'} {
+				&:focus {
+					@include clay-css(
+						map-deep-get($map, supports-focus-visible, focus)
+					);
+				}
+
+				&:focus-visible {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							supports-focus-visible,
+							focus-visible
+						)
+					);
+
+					&::before {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								before
+							)
+						);
+					}
+
+					&::after {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								after
+							)
+						);
+					}
+
+					.inline-item {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								inline-item
+							)
+						);
+					}
+
+					.inline-item-before {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								inline-item-before
+							)
+						);
+					}
+
+					.inline-item-middle {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								inline-item-middle
+							)
+						);
+					}
+
+					.inline-item-after {
+						@include clay-css(
+							map-deep-get(
+								$map,
+								supports-focus-visible,
+								focus-visible,
+								inline-item-after
+							)
+						);
+					}
+				}
+			}
+
 			&:active {
 				@include clay-css($active);
 

--- a/packages/clay-css/src/scss/variables/_badges.scss
+++ b/packages/clay-css/src/scss/variables/_badges.scss
@@ -59,6 +59,14 @@ $badge: map-deep-merge(
 				box-shadow: $component-focus-box-shadow,
 				outline: 0,
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $component-focus-box-shadow,
+				),
+			),
 		),
 		link: (
 			color: $badge-link-color,
@@ -165,6 +173,15 @@ $badge-primary: map-deep-merge(
 					rgba($badge-primary-bg, 0.5),
 				color: $badge-primary-hover-color,
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: 0 0 0 $badge-focus-width
+						rgba($badge-primary-bg, 0.5),
+				),
+			),
 		),
 		link: (
 			color: $badge-primary-link-color,
@@ -208,6 +225,15 @@ $badge-secondary: map-deep-merge(
 				color: $badge-secondary-hover-color,
 				box-shadow: 0 0 0 $badge-focus-width
 					rgba($badge-secondary-bg, 0.5),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: 0 0 0 $badge-focus-width
+						rgba($badge-secondary-bg, 0.5),
+				),
 			),
 		),
 		link: (
@@ -253,6 +279,15 @@ $badge-success: map-deep-merge(
 				box-shadow: 0 0 0 $badge-focus-width
 					rgba($badge-success-bg, 0.5),
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: 0 0 0 $badge-focus-width
+						rgba($badge-success-bg, 0.5),
+				),
+			),
 		),
 		link: (
 			color: $badge-success-link-color,
@@ -295,6 +330,15 @@ $badge-info: map-deep-merge(
 				border-color: $badge-info-hover-border-color,
 				color: $badge-info-hover-color,
 				box-shadow: 0 0 0 $badge-focus-width rgba($badge-info-bg, 0.5),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: 0 0 0 $badge-focus-width
+						rgba($badge-info-bg, 0.5),
+				),
 			),
 		),
 		link: (
@@ -340,6 +384,15 @@ $badge-warning: map-deep-merge(
 				box-shadow: 0 0 0 $badge-focus-width
 					rgba($badge-warning-bg, 0.5),
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: 0 0 0 $badge-focus-width
+						rgba($badge-warning-bg, 0.5),
+				),
+			),
 		),
 		link: (
 			color: $badge-warning-link-color,
@@ -382,6 +435,15 @@ $badge-danger: map-deep-merge(
 				border-color: $badge-danger-hover-border-color,
 				color: $badge-danger-hover-color,
 				box-shadow: 0 0 0 $badge-focus-width rgba($badge-danger-bg, 0.5),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: 0 0 0 $badge-focus-width
+						rgba($badge-danger-bg, 0.5),
+				),
 			),
 		),
 		link: (
@@ -426,6 +488,15 @@ $badge-light: map-deep-merge(
 				color: $badge-light-hover-color,
 				box-shadow: 0 0 0 $badge-focus-width rgba($badge-light-bg, 0.5),
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: 0 0 0 $badge-focus-width
+						rgba($badge-light-bg, 0.5),
+				),
+			),
 		),
 		link: (
 			color: $badge-light-link-color,
@@ -468,6 +539,15 @@ $badge-dark: map-deep-merge(
 				border-color: $badge-dark-hover-border-color,
 				color: $badge-dark-hover-color,
 				box-shadow: 0 0 0 $badge-focus-width rgba($badge-dark-bg, 0.5),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: 0 0 0 $badge-focus-width
+						rgba($badge-dark-bg, 0.5),
+				),
 			),
 		),
 		link: (

--- a/packages/clay-css/src/scss/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/variables/_buttons.scss
@@ -71,10 +71,26 @@ $btn: map-deep-merge(
 			box-shadow: $btn-focus-box-shadow,
 			outline: 0,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $btn-focus-box-shadow,
+			),
+		),
 		active: (
 			box-shadow: clay-enable-shadows($btn-active-box-shadow),
 			focus: (
-				box-shadow: clay-enable-shadows($btn-focus-box-shadow),
+				box-shadow: $btn-focus-box-shadow,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $btn-focus-box-shadow,
+				),
 			),
 		),
 		active-class: (
@@ -85,6 +101,11 @@ $btn: map-deep-merge(
 			opacity: $btn-disabled-opacity,
 			focus: (
 				box-shadow: none,
+			),
+			supports-focus-visible: (
+				focus-visible: (
+					box-shadow: none,
+				),
 			),
 			active: (
 				pointer-events: none,
@@ -403,6 +424,27 @@ $btn-primary: map-deep-merge(
 				),
 			color: color-yiq(clay-darken($primary, 7.5%)),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow:
+					clay-enable-shadows(
+						#{$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($primary), $primary, 15%),
+								0.5
+							)},
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($primary), $primary, 15%),
+								0.5
+							)
+					),
+			),
+		),
 		active: (
 			background-color: clay-darken($primary, 10%),
 			background-image: clay-enable-gradients(none),
@@ -423,6 +465,35 @@ $btn-primary: map-deep-merge(
 								0.5
 							)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($primary),
+										$primary,
+										15%
+									),
+									0.5
+								)},
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($primary),
+										$primary,
+										15%
+									),
+									0.5
+								)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -471,6 +542,35 @@ $btn-secondary: map-deep-merge(
 				),
 			color: color-yiq(clay-darken($secondary, 7.5%)),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow:
+					clay-enable-shadows(
+						#{$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(
+									color-yiq($secondary),
+									$secondary,
+									15%
+								),
+								0.5
+							)},
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(
+									color-yiq($secondary),
+									$secondary,
+									15%
+								),
+								0.5
+							)
+					),
+			),
+		),
 		active: (
 			background-color: clay-darken($secondary, 10%),
 			background-image: clay-enable-gradients(none),
@@ -499,6 +599,35 @@ $btn-secondary: map-deep-merge(
 								0.5
 							)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($secondary),
+										$secondary,
+										15%
+									),
+									0.5
+								)},
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($secondary),
+										$secondary,
+										15%
+									),
+									0.5
+								)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -539,6 +668,27 @@ $btn-success: map-deep-merge(
 				),
 			color: color-yiq(clay-darken($success, 7.5%)),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow:
+					clay-enable-shadows(
+						#{$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($success), $success, 15%),
+								0.5
+							)},
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($success), $success, 15%),
+								0.5
+							)
+					),
+			),
+		),
 		active: (
 			background-color: clay-darken($success, 10%),
 			background-image: clay-enable-gradients(none),
@@ -559,6 +709,35 @@ $btn-success: map-deep-merge(
 								0.5
 							)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($success),
+										$success,
+										15%
+									),
+									0.5
+								)},
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($success),
+										$success,
+										15%
+									),
+									0.5
+								)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -599,6 +778,21 @@ $btn-info: map-deep-merge(
 				),
 			color: color-yiq(clay-darken($info, 7.5%)),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow:
+					clay-enable-shadows(
+						#{$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)},
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)
+					),
+			),
+		),
 		active: (
 			background-color: clay-darken($info, 10%),
 			background-image: clay-enable-gradients(none),
@@ -613,6 +807,27 @@ $btn-info: map-deep-merge(
 						0 0 0 $btn-focus-width
 							rgba(clay-mix(color-yiq($info), $info, 15%), 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($info), $info, 15%),
+									0.5
+								)},
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($info), $info, 15%),
+									0.5
+								)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -653,6 +868,27 @@ $btn-warning: map-deep-merge(
 				),
 			color: color-yiq(clay-darken($warning, 7.5%)),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow:
+					clay-enable-shadows(
+						#{$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($warning), $warning, 15%),
+								0.5
+							)},
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($warning), $warning, 15%),
+								0.5
+							)
+					),
+			),
+		),
 		active: (
 			background-color: clay-darken($warning, 10%),
 			background-image: clay-enable-gradients(clay-darken($warning, 10%)),
@@ -673,6 +909,35 @@ $btn-warning: map-deep-merge(
 								0.5
 							)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($warning),
+										$warning,
+										15%
+									),
+									0.5
+								)},
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(
+										color-yiq($warning),
+										$warning,
+										15%
+									),
+									0.5
+								)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -713,6 +978,27 @@ $btn-danger: map-deep-merge(
 				),
 			color: color-yiq(clay-darken($danger, 7.5%)),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow:
+					clay-enable-shadows(
+						#{$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($danger), $danger, 15%),
+								0.5
+							)},
+						0 0 0 $btn-focus-width
+							rgba(
+								clay-mix(color-yiq($danger), $danger, 15%),
+								0.5
+							)
+					),
+			),
+		),
 		active: (
 			background-color: clay-darken($danger, 10%),
 			background-image: clay-enable-gradients(none),
@@ -733,6 +1019,27 @@ $btn-danger: map-deep-merge(
 								0.5
 							)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($danger), $danger, 15%),
+									0.5
+								)},
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($danger), $danger, 15%),
+									0.5
+								)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -773,6 +1080,21 @@ $btn-light: map-deep-merge(
 				),
 			color: color-yiq(clay-darken($light, 7.5%)),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow:
+					clay-enable-shadows(
+						#{$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)},
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)
+					),
+			),
+		),
 		active: (
 			background-color: clay-darken($light, 10%),
 			background-image: clay-enable-gradients(none),
@@ -787,6 +1109,27 @@ $btn-light: map-deep-merge(
 						0 0 0 $btn-focus-width
 							rgba(clay-mix(color-yiq($light), $light, 15%), 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($light), $light, 15%),
+									0.5
+								)},
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($light), $light, 15%),
+									0.5
+								)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -827,6 +1170,21 @@ $btn-dark: map-deep-merge(
 				),
 			color: color-yiq(clay-darken($dark, 7.5%)),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow:
+					clay-enable-shadows(
+						#{$btn-box-shadow,
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)},
+						0 0 0 $btn-focus-width
+							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)
+					),
+			),
+		),
 		active: (
 			background-color: clay-darken($dark, 10%),
 			background-image: clay-enable-gradients(none),
@@ -841,6 +1199,27 @@ $btn-dark: map-deep-merge(
 						0 0 0 $btn-focus-width
 							rgba(clay-mix(color-yiq($dark), $dark, 15%), 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($dark), $dark, 15%),
+									0.5
+								)},
+							0 0 0 $btn-focus-width
+								rgba(
+									clay-mix(color-yiq($dark), $dark, 15%),
+									0.5
+								)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -870,6 +1249,14 @@ $btn-link: map-deep-merge(
 		focus: (
 			box-shadow: $btn-focus-box-shadow,
 			text-decoration: $link-decoration,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $btn-focus-box-shadow,
+			),
 		),
 		disabled: (
 			box-shadow: none,
@@ -911,6 +1298,14 @@ $btn-outline-primary: map-deep-merge(
 		focus: (
 			box-shadow: 0 0 0 $btn-focus-width rgba($primary, 0.5),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: 0 0 0 $btn-focus-width rgba($primary, 0.5),
+			),
+		),
 		active: (
 			background-color: $primary,
 			border-color: $primary,
@@ -922,6 +1317,19 @@ $btn-outline-primary: map-deep-merge(
 						0 0 0 $btn-focus-width rgba($primary, 0.5)},
 						$c-unset
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($primary, 0.5)},
+							$c-unset
+						),
+				),
 			),
 		),
 		disabled: (
@@ -945,6 +1353,14 @@ $btn-outline-secondary: map-deep-merge(
 		focus: (
 			box-shadow: 0 0 0 $btn-focus-width rgba($secondary, 0.5),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: 0 0 0 $btn-focus-width rgba($secondary, 0.5),
+			),
+		),
 		active: (
 			background-color: $secondary,
 			border-color: $secondary,
@@ -956,6 +1372,19 @@ $btn-outline-secondary: map-deep-merge(
 						0 0 0 $btn-focus-width rgba($secondary, 0.5)},
 						0 0 0 $btn-focus-width rgba($secondary, 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($secondary, 0.5)},
+							0 0 0 $btn-focus-width rgba($secondary, 0.5)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -979,6 +1408,14 @@ $btn-outline-success: map-deep-merge(
 		focus: (
 			box-shadow: 0 0 0 $btn-focus-width rgba($success, 0.5),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: 0 0 0 $btn-focus-width rgba($success, 0.5),
+			),
+		),
 		active: (
 			background-color: $success,
 			border-color: $success,
@@ -990,6 +1427,19 @@ $btn-outline-success: map-deep-merge(
 						0 0 0 $btn-focus-width rgba($success, 0.5)},
 						0 0 0 $btn-focus-width rgba($success, 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($success, 0.5)},
+							0 0 0 $btn-focus-width rgba($success, 0.5)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -1013,6 +1463,14 @@ $btn-outline-info: map-deep-merge(
 		focus: (
 			box-shadow: 0 0 0 $btn-focus-width rgba($info, 0.5),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: 0 0 0 $btn-focus-width rgba($info, 0.5),
+			),
+		),
 		active: (
 			background-color: $info,
 			border-color: $info,
@@ -1024,6 +1482,19 @@ $btn-outline-info: map-deep-merge(
 						0 0 0 $btn-focus-width rgba($info, 0.5)},
 						0 0 0 $btn-focus-width rgba($info, 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($info, 0.5)},
+							0 0 0 $btn-focus-width rgba($info, 0.5)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -1047,6 +1518,14 @@ $btn-outline-warning: map-deep-merge(
 		focus: (
 			box-shadow: 0 0 0 $btn-focus-width rgba($warning, 0.5),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: 0 0 0 $btn-focus-width rgba($warning, 0.5),
+			),
+		),
 		active: (
 			background-color: $warning,
 			border-color: $warning,
@@ -1058,6 +1537,19 @@ $btn-outline-warning: map-deep-merge(
 						0 0 0 $btn-focus-width rgba($warning, 0.5)},
 						0 0 0 $btn-focus-width rgba($warning, 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($warning, 0.5)},
+							0 0 0 $btn-focus-width rgba($warning, 0.5)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -1081,6 +1573,14 @@ $btn-outline-danger: map-deep-merge(
 		focus: (
 			box-shadow: 0 0 0 $btn-focus-width rgba($danger, 0.5),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: 0 0 0 $btn-focus-width rgba($danger, 0.5),
+			),
+		),
 		active: (
 			background-color: $danger,
 			border-color: $danger,
@@ -1092,6 +1592,19 @@ $btn-outline-danger: map-deep-merge(
 						0 0 0 $btn-focus-width rgba($danger, 0.5)},
 						0 0 0 $btn-focus-width rgba($danger, 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($danger, 0.5)},
+							0 0 0 $btn-focus-width rgba($danger, 0.5)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -1115,6 +1628,14 @@ $btn-outline-light: map-deep-merge(
 		focus: (
 			box-shadow: 0 0 0 $btn-focus-width rgba($light, 0.5),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: 0 0 0 $btn-focus-width rgba($light, 0.5),
+			),
+		),
 		active: (
 			background-color: $light,
 			border-color: $light,
@@ -1126,6 +1647,19 @@ $btn-outline-light: map-deep-merge(
 						0 0 0 $btn-focus-width rgba($light, 0.5)},
 						0 0 0 $btn-focus-width rgba($light, 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($light, 0.5)},
+							0 0 0 $btn-focus-width rgba($light, 0.5)
+						),
+				),
 			),
 		),
 		disabled: (
@@ -1149,6 +1683,14 @@ $btn-outline-dark: map-deep-merge(
 		focus: (
 			box-shadow: 0 0 0 $btn-focus-width rgba($dark, 0.5),
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: 0 0 0 $btn-focus-width rgba($dark, 0.5),
+			),
+		),
 		active: (
 			background-color: $dark,
 			border-color: $dark,
@@ -1160,6 +1702,19 @@ $btn-outline-dark: map-deep-merge(
 						0 0 0 $btn-focus-width rgba($dark, 0.5)},
 						0 0 0 $btn-focus-width rgba($dark, 0.5)
 					),
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow:
+						clay-enable-shadows(
+							#{$btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($dark, 0.5)},
+							0 0 0 $btn-focus-width rgba($dark, 0.5)
+						),
+				),
 			),
 		),
 		disabled: (

--- a/packages/clay-css/src/scss/variables/_cards.scss
+++ b/packages/clay-css/src/scss/variables/_cards.scss
@@ -686,7 +686,15 @@ $card-interactive: map-deep-merge(
 		),
 		focus: (
 			border-color: clay-lighten($component-active-bg, 25%),
-			box-shadow: $input-btn-focus-box-shadow,
+			box-shadow: $component-focus-box-shadow,
+		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $component-focus-box-shadow,
+			),
 		),
 		active: (
 			background-color: $gray-200,

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -63,7 +63,7 @@ $input: map-deep-merge(
 		border-right-width: $input-border-right-width,
 		border-top-width: $input-border-top-width,
 		border-radius: clay-enable-rounded($input-border-radius),
-		box-shadow: clay-enable-shadows([$input-box-shadow]),
+		box-shadow: clay-enable-shadows($input-box-shadow),
 		color: $input-color,
 		display: block,
 		font-family: $input-font-family,

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -15,7 +15,7 @@ $clay-unset-placeholder: clay-unset-placeholder !default;
 // Settings
 
 $enable-bs4-deprecated: true !default;
-$enable-c-inner: true !default;
+$enable-c-inner: false !default;
 $enable-lexicon-flat-colors: false !default;
 $enable-scaling-components: false !default;
 $scaling-breakpoint-down: sm !default;

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -26,6 +26,7 @@ $scaling-breakpoint-down: sm !default;
 $enable-clay-color-functions-process-fallback: false !default;
 
 $enable-caret: false !default;
+$enable-focus-visible: true !default;
 $enable-rounded: true !default;
 $enable-shadows: false !default;
 $enable-gradients: false !default;

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -15,7 +15,7 @@ $clay-unset-placeholder: clay-unset-placeholder !default;
 // Settings
 
 $enable-bs4-deprecated: true !default;
-$enable-c-inner: false !default;
+$enable-c-inner: true !default;
 $enable-lexicon-flat-colors: false !default;
 $enable-scaling-components: false !default;
 $scaling-breakpoint-down: sm !default;

--- a/packages/clay-css/src/scss/variables/_pagination.scss
+++ b/packages/clay-css/src/scss/variables/_pagination.scss
@@ -160,6 +160,14 @@ $pagination-link: map-deep-merge(
 		transition: $pagination-link-transition,
 		hover: $pagination-link-hover,
 		focus: $pagination-link-focus,
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $pagination-focus-box-shadow,
+			),
+		),
 		active: $pagination-link-active,
 		disabled: $pagination-link-disabled,
 		lexicon-icon: (
@@ -350,6 +358,14 @@ $pagination-items-per-page-link: map-deep-merge(
 		transition: $pagination-items-per-page-transition,
 		hover: $pagination-items-per-page-link-hover,
 		focus: $pagination-items-per-page-link-focus,
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $pagination-items-per-page-focus-box-shadow,
+			),
+		),
 		active: $pagination-items-per-page-link-active,
 		disabled: $pagination-items-per-page-link-disabled,
 		lexicon-icon: (

--- a/packages/clay-css/src/scss/variables/_sidebar.scss
+++ b/packages/clay-css/src/scss/variables/_sidebar.scss
@@ -171,6 +171,14 @@ $sidebar-dark: map-deep-merge(
 					box-shadow: $component-focus-box-shadow,
 					outline: 0,
 				),
+				supports-focus-visible: (
+					focus: (
+						box-shadow: none,
+					),
+					focus-visible: (
+						box-shadow: $component-focus-box-shadow,
+					),
+				),
 				active: (
 					color: $white,
 				),
@@ -227,6 +235,14 @@ $sidebar-palette: map-deep-merge(
 					focus: (
 						box-shadow: $component-focus-box-shadow,
 						outline: 0,
+					),
+					supports-focus-visible: (
+						focus: (
+							box-shadow: none,
+						),
+						focus-visible: (
+							box-shadow: $component-focus-box-shadow,
+						),
 					),
 					active: (
 						color: $white,

--- a/packages/clay-css/src/scss/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/variables/_tbar.scss
@@ -58,12 +58,20 @@ $tbar-stacked: map-deep-merge(
 			position: relative,
 			width: 2.5rem,
 			focus: (
-				box-shadow: #{inset 0 0 0 0.125rem $primary-l1,
-				inset 0 0 0 0.25rem $white},
+				box-shadow: $component-focus-inset-box-shadow,
 			),
-			active-focus: (
-				box-shadow: #{inset 0 0 0 0.125rem $primary-l1,
-				inset 0 0 0 0.25rem $white},
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $component-focus-inset-box-shadow,
+				),
+			),
+			active: (
+				focus: (
+					box-shadow: $c-unset,
+				),
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/variables/_treeview.scss
+++ b/packages/clay-css/src/scss/variables/_treeview.scss
@@ -23,6 +23,14 @@ $treeview: map-merge(
 			focus: (
 				box-shadow: $component-focus-inset-box-shadow,
 			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $component-focus-inset-box-shadow,
+				),
+			),
 		),
 		custom-control: (
 			margin-left: 4px,
@@ -90,6 +98,14 @@ $treeview: map-merge(
 			focus: (
 				box-shadow: $component-focus-inset-box-shadow,
 				outline: 0,
+			),
+			supports-focus-visible: (
+				focus: (
+					box-shadow: none,
+				),
+				focus-visible: (
+					box-shadow: $component-focus-inset-box-shadow,
+				),
 			),
 			disabled: (
 				cursor: $disabled-cursor,

--- a/packages/clay-css/src/scss/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/variables/_utilities.scss
@@ -84,6 +84,14 @@ $close: map-deep-merge(
 			outline: 0,
 			opacity: 0.75,
 		),
+		supports-focus-visible: (
+			focus: (
+				box-shadow: none,
+			),
+			focus-visible: (
+				box-shadow: $input-btn-focus-box-shadow,
+			),
+		),
 		disabled: (
 			box-shadow: none,
 			cursor: $disabled-cursor,


### PR DESCRIPTION
#4967

@matuzalemsteles `:focus-visible` is working for me in Chrome, FF, MS Edge. The only problem we have is with IE11 and older Safari browsers (I don't think we have any official mandate to support this). I only tested on Safari 14.1.2. The regular focus works the same as `focus-visible`. It doesn't show the focus ring on click; only when you interact with the keyboard.

The way this works is we keep `:focus` the same and use the `@supports selector(:focus-visible) {}` media query to undo the focus ring and re-apply it on `:focus-visible`. I think this is the simplest way. I still need to update this pr, but I didn't want to take too long putting this up for review.

 