### PR TITLE
feat(@clayui/tooltip): adds new properties to configure the tooltip to be floating

### DIFF
--- a/custom-types/dom-align/index.d.ts
+++ b/custom-types/dom-align/index.d.ts
@@ -20,6 +20,17 @@ declare module 'dom-align' {
 		useCssRight?: boolean
 	}
 
+	type MousePosition = {
+		clientX: number;
+		clientY: number;
+	};
+
+	export function alignPoint(
+		sourceNode: HTMLElement,
+		target: MousePosition,
+		config?: IConfigOptional
+	): void;
+
 	export default function doAlign(
 		sourceNode: HTMLElement,
 		targetNode: HTMLElement,

--- a/packages/clay-shared/src/useMousePosition.ts
+++ b/packages/clay-shared/src/useMousePosition.ts
@@ -25,21 +25,21 @@ function throttle<T>(callback: Function, limit: number) {
 /**
  * Hook to get the current mouse position
  */
-export const useMousePosition = () => {
+export const useMousePosition = (delay: number = 200) => {
 	const [mousePosition, setMousePosition] = useState<MousePosition>([0, 0]);
 
 	useEffect(() => {
 		const handleMousePosition = throttle(
 			(event: MouseEvent) =>
 				setMousePosition([event.clientX, event.clientY]),
-			200
+			delay
 		);
 
 		window.addEventListener('mousemove', handleMousePosition);
 
 		return () =>
 			window.removeEventListener('mousemove', handleMousePosition);
-	}, []);
+	}, [delay]);
 
 	return mousePosition;
 };

--- a/packages/clay-tooltip/docs/tooltip.mdx
+++ b/packages/clay-tooltip/docs/tooltip.mdx
@@ -35,6 +35,7 @@ Here's a list of html attributes that you can provide to children elements of th
 -   `title` is for the tooltip content.
 -   `data-tooltip-align` is for alignment direction.
 -   `data-tooltip-delay` is for the delay(ms) before showing the tooltip.
+-   `data-tooltip-floating` defines if the tooltip should be floating positioned where the mouse is over the element.
 
 <TooltipProvider />
 

--- a/packages/clay-tooltip/package.json
+++ b/packages/clay-tooltip/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@clayui/shared": "^3.65.0",
 		"classnames": "^2.2.6",
+		"dom-align": "^1.12.2",
 		"warning": "^4.0.3"
 	},
 	"peerDependencies": {

--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -11,8 +11,6 @@ import {
 	doAlign,
 	useMousePosition,
 } from '@clayui/shared';
-
-// @ts-ignore
 import {alignPoint} from 'dom-align';
 import React, {useCallback, useEffect, useReducer, useRef} from 'react';
 import warning from 'warning';

--- a/packages/clay-tooltip/stories/Tooltip.stories.tsx
+++ b/packages/clay-tooltip/stories/Tooltip.stories.tsx
@@ -177,3 +177,25 @@ export const CustomJSX = () => {
 		</div>
 	);
 };
+
+export const Floating = () => {
+	return (
+		<ClayTooltipProvider>
+			<div>
+				<div
+					data-tooltip-floating="true"
+					style={{
+						backgroundColor: '#e6e6e6',
+						borderRadius: '10px',
+						display: 'inline-block',
+						fontWeight: 500,
+						padding: '60px 100px',
+					}}
+					title="Edit Text"
+				>
+					Placeholder
+				</div>
+			</div>
+		</ClayTooltipProvider>
+	);
+};


### PR DESCRIPTION
Closes #4991

This feature is only available with the `<TooltipProvider />`, as we are already using it in DXP the developers just need to add the `data-tooltip-floating="true"` property to the element with the `title` for the tooltip to be floating according to the mouse position on the element. See the [example in the storybook](https://deploy-preview-5007--next-storybook-clayui.netlify.app/?path=/story/design-system-components-tooltip--floating).