### PR TITLE
docs(@clayui/tooltip): adds usage recommendation with disabled elements with title

### DIFF
--- a/packages/clay-tooltip/docs/tooltip.mdx
+++ b/packages/clay-tooltip/docs/tooltip.mdx
@@ -16,6 +16,7 @@ import {
 
 -   [TooltipProvider](#tooltipprovider)
     -   [contentRenderer](#contentrenderer)
+    -   [Disabled elements with title](#disabled-elements-with-title)
 
 </div>
 </div>
@@ -43,3 +44,19 @@ Here's a list of html attributes that you can provide to children elements of th
 `contentRenderer` prop gives you the ability to format the content passed to the Tooltip via the `title` attribute to meet your requirements.
 
 <TooltipProviderRenderer />
+
+### Disabled elements with title
+
+Elements or components that use the browser's native `disabled` property, have the problem of the provider not being able to track element events, natively elements with disabled do not trigger events, such as `click`, `mouseup`, `mousedown`, `keydown`... if the element has a `title` the tooltip will not work correctly, for this scenario we recommend using a different strategy to continue that the element emits events but still has the disabled state. For example, the Button component:
+
+```jsx
+// instead of
+<button className="btn btn-primary" disabled="" title="Open Menu">Click</button>
+<Button disabled title="Top">Top</Button>
+
+// use
+<button className="btn btn-primary disabled" aria-disabled="true" title="Open Menu">Click</button>
+<Button aria-disabled="true" className="disabled" title="Top">Top</Button>
+```
+
+Add the `disabled` CSS class that adds the visual state of disabled and the `aria-disabled` property to keep the element accessible, this same behavior can be repeated for other elements where you want the title even when the component is disabled.


### PR DESCRIPTION
Closes #4992

Adds a recommendation to use the tooltip on disabled elements with title, an idea to try to mitigate this is to make Clay components like `Button` do this by default if the `title` property is set, we would also have to avoid call the component event callbacks to maintain the same behavior as `disabled`, but this can cause other side effects as the events bubbling and in case some applications in DXP have added events that expect elements with the disabled state do not emit events.

I think we can recommend developers to do this first because we would only be able to mitigate this for components in React.js and it could also cause unknown side effects.