### PR TITLE
fix(@clayui/tooltip): remove the behavior of moving the tooltip when the mouse moves

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -231,7 +231,7 @@ module.exports = {
 		},
 		'./packages/clay-tooltip/src/': {
 			branches: 52,
-			functions: 61,
+			functions: 60,
 			lines: 70,
 			statements: 69,
 		},

--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -403,7 +403,7 @@ const TooltipProvider = ({
 				}
 			);
 		}
-	}, [mousePosition, show, floating]);
+	}, [show, floating]);
 
 	useEffect(() => {
 		if (

--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -218,6 +218,7 @@ const TooltipProvider = ({
 
 	// Using `any` type since TS incorrectly infers setTimeout to be from NodeJS
 	const timeoutIdRef = useRef<any>();
+	const floatingTimeoutIdRef = useRef<any>();
 	const targetRef = useRef<HTMLElement | null>(null);
 	const titleNodeRef = useRef<HTMLElement | null>(null);
 	const tooltipRef = useRef<HTMLElement | null>(null);
@@ -265,7 +266,7 @@ const TooltipProvider = ({
 		}
 	}, []);
 
-	const handleHide = useCallback((event?: any) => {
+	const handleHide = useCallback((event?: any, restore: boolean = true) => {
 		if (
 			event &&
 			(tooltipRef.current?.contains(event.relatedTarget) ||
@@ -277,8 +278,11 @@ const TooltipProvider = ({
 		dispatch({type: 'hide'});
 
 		clearTimeout(timeoutIdRef.current);
+		clearTimeout(floatingTimeoutIdRef.current);
 
-		restoreTitle();
+		if (restore) {
+			restoreTitle();
+		}
 
 		if (targetRef.current) {
 			targetRef.current.removeEventListener('click', handleHide);
@@ -336,6 +340,17 @@ const TooltipProvider = ({
 							setAsHTML,
 							type: 'show',
 						});
+
+						if (isFloating) {
+							clearTimeout(floatingTimeoutIdRef.current);
+
+							floatingTimeoutIdRef.current = setTimeout(
+								() => {
+									handleHide(undefined, false);
+								},
+								customDelay ? Number(customDelay) : delay
+							);
+						}
 					},
 					customDelay ? Number(customDelay) : delay
 				);


### PR DESCRIPTION
https://github.com/liferay/clay/pull/5007#issuecomment-1201277452

Hey @carolrodmar I believe this should be the closest behavior, let me know if something more subtle would be needed. You can test this change in the storybook as soon as the [preview deploy generated by Netlify](https://github.com/liferay/clay/blob/master/docs/netlify_deploy.md#deploy-previews) once the build finishes.