### PR TITLE
feat(@clayui/drop-down): Focus improvements in DropDown and new `closeOnClick` API

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -74,7 +74,7 @@ module.exports = {
 			statements: 95,
 		},
 		'./packages/clay-drop-down/src/': {
-			branches: 66,
+			branches: 65,
 			functions: 57,
 			lines: 78,
 			statements: 77,

--- a/packages/clay-drop-down/docs/index.js
+++ b/packages/clay-drop-down/docs/index.js
@@ -24,16 +24,17 @@ const dropDownCode = `const Component = () => {
 					id: 'dropdownMenuReactPortalDiv',
 				},
 			}}
+			closeOnClick
 		>
 			<ClayDropDown.Help>{'Can I help you?'}</ClayDropDown.Help>
 			<ClayDropDown.ItemList>
 				<ClayDropDown.Group header="Group #1">
 					{[
-						{href: '#one', label: 'one'},
-						{href: '#two', label: 'two'},
-						{href: '#three', label: 'three'},
+						{label: 'one'},
+						{label: 'two'},
+						{label: 'three'},
 					].map((item, i) => (
-						<ClayDropDown.Item href={item.href} key={i}>
+						<ClayDropDown.Item onClick={() => {}} key={i}>
 							{item.label}
 						</ClayDropDown.Item>
 					))}
@@ -89,9 +90,7 @@ const dropDownWithItemsCode = `const Component = () => {
 	const items = [
 		{
 			label: 'clickable',
-			onClick: () => {
-				alert('you clicked!');
-			},
+			onClick: (event) => event.preventDefault(),
 		},
 		{
 			type: 'divider',

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -15,6 +15,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import Action from './Action';
 import Caption from './Caption';
 import Divider from './Divider';
+import {DropDownContext} from './DropDownContext';
 import Group from './Group';
 import Help from './Help';
 import Item from './Item';
@@ -50,6 +51,11 @@ export interface IProps
 	 * HTML element tag that the container should render.
 	 */
 	containerElement?: React.JSXElementConstructor<any> | 'div' | 'li';
+
+	/**
+	 * Flag that indicates whether to close DropDown when clicking on the item.
+	 */
+	closeOnClick?: boolean;
 
 	closeOnClickOutside?: React.ComponentProps<
 		typeof Menu
@@ -128,6 +134,7 @@ function ClayDropDown({
 	alignmentPosition,
 	children,
 	className,
+	closeOnClick = false,
 	closeOnClickOutside,
 	containerElement: ContainerElement = 'div',
 	defaultActive = false,
@@ -238,7 +245,17 @@ function ClayDropDown({
 						ref={menuElementRef}
 						width={menuWidth}
 					>
-						{children}
+						<DropDownContext.Provider
+							value={{
+								close: () => {
+									setInternalActive(false);
+									triggerElementRef.current?.focus();
+								},
+								closeOnClick,
+							}}
+						>
+							{children}
+						</DropDownContext.Provider>
 					</Menu>
 				)}
 			</ContainerElement>

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -169,24 +169,26 @@ function ClayDropDown({
 		}
 	};
 
-	const handleFocus = (event: FocusEvent) => {
-		if (
-			!menuElementRef.current?.parentElement?.contains(
-				event.target as Node
-			) &&
-			!triggerElementRef.current?.contains(event.target as Node)
-		) {
-			setInternalActive(false);
-		}
-	};
-
 	useEffect(() => {
-		document.addEventListener('focus', handleFocus, true);
+		if (internalActive) {
+			const onFocus = (event: FocusEvent) => {
+				if (
+					!menuElementRef.current?.parentElement?.contains(
+						event.target as Node
+					) &&
+					!triggerElementRef.current?.contains(event.target as Node)
+				) {
+					setInternalActive(false);
+				}
+			};
 
-		return () => {
-			document.removeEventListener('focus', handleFocus, true);
-		};
-	}, [handleFocus]);
+			document.addEventListener('focus', onFocus, true);
+
+			return () => {
+				document.removeEventListener('focus', onFocus, true);
+			};
+		}
+	}, [internalActive]);
 
 	const ariaControls = useMemo(() => {
 		counter++;

--- a/packages/clay-drop-down/src/DropDownContext.ts
+++ b/packages/clay-drop-down/src/DropDownContext.ts
@@ -1,0 +1,11 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+export const DropDownContext = React.createContext({
+	close: () => {},
+	closeOnClick: false,
+});

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -114,7 +114,9 @@ export interface IProps
 	/**
 	 * Element that is used as the trigger which will activate the dropdown on click.
 	 */
-	trigger: React.ReactElement;
+	trigger: React.ReactElement & {
+		ref?: (node: HTMLButtonElement | null) => void;
+	};
 
 	/**
 	 * Add informational text at the top of DropDown.
@@ -462,6 +464,8 @@ export const ClayDropDownWithItems = ({
 	spritemap,
 	trigger,
 }: IProps) => {
+	const triggerElementRef = useRef<HTMLButtonElement | null>(null);
+
 	const [internalActive, setInternalActive] = useInternalState({
 		defaultName: 'defaultActive',
 		defaultValue: defaultActive,
@@ -498,10 +502,26 @@ export const ClayDropDownWithItems = ({
 			offsetFn={offsetFn}
 			onActiveChange={setInternalActive}
 			renderMenuOnClick={renderMenuOnClick}
-			trigger={trigger}
+			trigger={React.cloneElement(trigger, {
+				ref: (node: HTMLButtonElement) => {
+					if (node) {
+						triggerElementRef.current = node;
+						// Call the original ref, if any.
+						const {ref} = trigger;
+						if (typeof ref === 'function') {
+							ref(node);
+						}
+					}
+				},
+			})}
 		>
 			<ClayDropDownContext.Provider
-				value={{close: () => setInternalActive(false)}}
+				value={{
+					close: () => {
+						setInternalActive(false);
+						triggerElementRef.current?.focus();
+					},
+				}}
 			>
 				{helpText && <Help>{helpText}</Help>}
 

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -88,7 +88,12 @@ const ClayDropDownItem = React.forwardRef<HTMLLIElement, IProps>(
 					})}
 					disabled={disabled}
 					href={href}
-					onClick={(event) => {
+					onClick={(
+						event: React.MouseEvent<
+							HTMLButtonElement | HTMLAnchorElement,
+							MouseEvent
+						>
+					) => {
 						if (onClick) {
 							onClick(event);
 						}

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -6,7 +6,9 @@
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useContext} from 'react';
+
+import {DropDownContext} from './DropDownContext';
 
 export interface IProps
 	extends React.HTMLAttributes<
@@ -74,6 +76,8 @@ const ClayDropDownItem = React.forwardRef<HTMLLIElement, IProps>(
 		const clickableElement = onClick ? 'button' : 'span';
 		const ItemElement = href ? ClayLink : clickableElement;
 
+		const {close, closeOnClick} = useContext(DropDownContext);
+
 		return (
 			<li aria-selected={active} ref={ref} role={role}>
 				<ItemElement
@@ -84,7 +88,19 @@ const ClayDropDownItem = React.forwardRef<HTMLLIElement, IProps>(
 					})}
 					disabled={disabled}
 					href={href}
-					onClick={onClick}
+					onClick={(event) => {
+						if (onClick) {
+							onClick(event);
+						}
+
+						if (event.defaultPrevented) {
+							return;
+						}
+
+						if (closeOnClick) {
+							close();
+						}
+					}}
 					ref={innerRef}
 					role={roleItem}
 					tabIndex={disabled ? -1 : tabIndex}


### PR DESCRIPTION
Fixes #5022

This PR fixes the focus loss when clicking on an item in DropDown, the issue is that this was not the main problem in the documentation example, because something was breaking and resetting the component because clicking on the item and closing the dropdown was not supported in low-level component but now I've added this new functionality by enabling the `closeOnClick` property on `<ClayDropDown />`.