### PR TITLE
docs(@clayui/tooltip): updates the floating tooltip demo

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -231,7 +231,7 @@ module.exports = {
 		},
 		'./packages/clay-tooltip/src/': {
 			branches: 52,
-			functions: 60,
+			functions: 61,
 			lines: 70,
 			statements: 69,
 		},

--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -218,7 +218,6 @@ const TooltipProvider = ({
 
 	// Using `any` type since TS incorrectly infers setTimeout to be from NodeJS
 	const timeoutIdRef = useRef<any>();
-	const floatingTimeoutIdRef = useRef<any>();
 	const targetRef = useRef<HTMLElement | null>(null);
 	const titleNodeRef = useRef<HTMLElement | null>(null);
 	const tooltipRef = useRef<HTMLElement | null>(null);
@@ -266,7 +265,7 @@ const TooltipProvider = ({
 		}
 	}, []);
 
-	const handleHide = useCallback((event?: any, restore: boolean = true) => {
+	const handleHide = useCallback((event?: any) => {
 		if (
 			event &&
 			(tooltipRef.current?.contains(event.relatedTarget) ||
@@ -278,11 +277,8 @@ const TooltipProvider = ({
 		dispatch({type: 'hide'});
 
 		clearTimeout(timeoutIdRef.current);
-		clearTimeout(floatingTimeoutIdRef.current);
 
-		if (restore) {
-			restoreTitle();
-		}
+		restoreTitle();
 
 		if (targetRef.current) {
 			targetRef.current.removeEventListener('click', handleHide);
@@ -340,17 +336,6 @@ const TooltipProvider = ({
 							setAsHTML,
 							type: 'show',
 						});
-
-						if (isFloating) {
-							clearTimeout(floatingTimeoutIdRef.current);
-
-							floatingTimeoutIdRef.current = setTimeout(
-								() => {
-									handleHide(undefined, false);
-								},
-								customDelay ? Number(customDelay) : delay
-							);
-						}
 					},
 					customDelay ? Number(customDelay) : delay
 				);

--- a/packages/clay-tooltip/stories/Tooltip.stories.tsx
+++ b/packages/clay-tooltip/stories/Tooltip.stories.tsx
@@ -183,7 +183,6 @@ export const Floating = () => {
 		<ClayTooltipProvider>
 			<div>
 				<div
-					data-tooltip-floating="true"
 					style={{
 						backgroundColor: '#e6e6e6',
 						borderRadius: '10px',
@@ -191,9 +190,35 @@ export const Floating = () => {
 						fontWeight: 500,
 						padding: '60px 100px',
 					}}
-					title="Edit Text"
 				>
-					Placeholder
+					<span data-tooltip-floating="true" title="Edit Text">
+						Placeholder
+					</span>
+				</div>
+
+				<div
+					style={{
+						backgroundColor: '#e6e6e6',
+						borderRadius: '10px',
+						display: 'inline-block',
+						fontWeight: 500,
+						marginTop: '30PX',
+						padding: '60px 100px',
+					}}
+				>
+					<span data-tooltip-floating="true" title="Edit Text">
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+						sed do eiusmod tempor incididunt ut labore et dolore
+						magna aliqua. Fames ac turpis egestas integer eget
+						aliquet nibh praesent tristique. Nibh sed pulvinar proin
+						gravida hendrerit lectus a. Id interdum velit laoreet id
+						donec ultrices tincidunt arcu. Viverra mauris in aliquam
+						sem fringilla ut morbi. Convallis posuere morbi leo urna
+						molestie at elementum eu. Mi bibendum neque egestas
+						congue. Tempus quam pellentesque nec nam aliquam sem et
+						tortor. Faucibus nisl tincidunt eget nullam non nisi
+						est.{' '}
+					</span>
 				</div>
 			</div>
 		</ClayTooltipProvider>


### PR DESCRIPTION
Closes #5029

More context https://github.com/liferay/clay/pull/5023#issuecomment-1209778896, I'm reversing the change I made in the PR that was merged to fix #5029, this behavior is no longer needed because the behavior that was wanted before may be able to arrive by correctly setting the properties.

This is probably the definitive behavior for the floating mode of the tooltip so as not to generate too much confusion I updated the demo in the Storybook to have a more real case of the behavior that originated its creation so as not to create any confusion.

Basically floating it can be used for other use cases as well if it exists, not necessarily in a text as in the demo but also in an item drop zone for example.