### PR TITLE
fix(@clayui/css): Cadmin Buttons btn-monospaced icons should be centered

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_buttons.scss
@@ -94,6 +94,9 @@ $cadmin-btn: map-deep-merge(
 		),
 		inline-item: (
 			font-size: $cadmin-btn-inline-item-font-size,
+			lexicon-icon: (
+				margin-top: 0,
+			),
 		),
 		btn-section: (
 			display: block,
@@ -227,6 +230,9 @@ $cadmin-btn-monospaced: map-deep-merge(
 		mobile: (
 			height: $cadmin-btn-monospaced-size-mobile,
 			width: $cadmin-btn-monospaced-size-mobile,
+		),
+		lexicon-icon: (
+			margin-top: 0,
 		),
 		c-inner: (
 			align-items: center,


### PR DESCRIPTION
fixes #5033