### PR TITLE
fix(@clayui/css): Buttons `$btn-palette` and `$btn-outline-palette` s…

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_buttons.scss
@@ -119,7 +119,11 @@ input[type='button'] {
 			starts-with($color, '#') or
 			starts-with($color, '%'),
 		$color,
-		str-insert($color, '.btn-', 1)
+		if(
+			starts-with($color, 'btn-'),
+			str-insert($color, '.', 1),
+			str-insert($color, '.btn-', 1)
+		)
 	);
 
 	@if (starts-with($color, '%') or map-get($value, extend)) {
@@ -127,17 +131,9 @@ input[type='button'] {
 			@include clay-button-variant($value);
 		}
 	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%btn-#{$color}'
-		);
+		$placeholder: '%#{str-slice($selector, 2)}';
 
-		$placeholder-focus: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}-focus',
-			'%btn-#{$color}-focus'
-		);
+		$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
 
 		#{$placeholder} {
 			@include clay-button-variant($value);
@@ -161,7 +157,11 @@ input[type='button'] {
 			starts-with($color, '#') or
 			starts-with($color, '%'),
 		$color,
-		str-insert($color, '.btn-outline-', 1)
+		if(
+			starts-with($color, 'btn-'),
+			str-insert($color, '.', 1),
+			str-insert($color, '.btn-outline-', 1)
+		)
 	);
 
 	@if (starts-with($color, '%') or map-get($value, extend)) {
@@ -169,17 +169,9 @@ input[type='button'] {
 			@include clay-button-variant($value);
 		}
 	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%btn-outline-#{$color}'
-		);
+		$placeholder: '%#{str-slice($selector, 2)}';
 
-		$placeholder-focus: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}-focus',
-			'%btn-outline-#{$color}-focus'
-		);
+		$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
 
 		#{$placeholder} {
 			@include clay-button-variant($value);

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -119,7 +119,11 @@ input[type='button'] {
 			starts-with($color, '#') or
 			starts-with($color, '%'),
 		$color,
-		str-insert($color, '.btn-', 1)
+		if(
+			starts-with($color, 'btn-'),
+			str-insert($color, '.', 1),
+			str-insert($color, '.btn-', 1)
+		)
 	);
 
 	@if (starts-with($color, '%') or map-get($value, extend)) {
@@ -127,17 +131,9 @@ input[type='button'] {
 			@include clay-button-variant($value);
 		}
 	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%btn-#{$color}'
-		);
+		$placeholder: '%#{str-slice($selector, 2)}';
 
-		$placeholder-focus: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}-focus',
-			'%btn-#{$color}-focus'
-		);
+		$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
 
 		#{$placeholder} {
 			@include clay-button-variant($value);
@@ -161,7 +157,11 @@ input[type='button'] {
 			starts-with($color, '#') or
 			starts-with($color, '%'),
 		$color,
-		str-insert($color, '.btn-outline-', 1)
+		if(
+			starts-with($color, 'btn-'),
+			str-insert($color, '.', 1),
+			str-insert($color, '.btn-outline-', 1)
+		)
 	);
 
 	@if (starts-with($color, '%') or map-get($value, extend)) {
@@ -169,17 +169,9 @@ input[type='button'] {
 			@include clay-button-variant($value);
 		}
 	} @else {
-		$placeholder: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}',
-			'%btn-outline-#{$color}'
-		);
+		$placeholder: '%#{str-slice($selector, 2)}';
 
-		$placeholder-focus: if(
-			starts-with($color, '.') or starts-with($color, '#'),
-			'%#{str-slice($color, 2)}-focus',
-			'%btn-outline-#{$color}-focus'
-		);
+		$placeholder-focus: '%#{str-slice($selector, 2)}-focus';
 
 		#{$placeholder} {
 			@include clay-button-variant($value);


### PR DESCRIPTION
…hould support keys prefixed with `btn-`

fixes #5028