### PR TITLE
fix(@clayui/drop-down): Improves group semantics for DropDown and focus with virtual cursor

### DIFF
--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -197,7 +197,7 @@ function ClayDropDown({
 	}, []);
 
 	return (
-		<FocusScope>
+		<FocusScope arrowKeysLeftRight>
 			<ContainerElement
 				{...otherProps}
 				className={classNames('dropdown', className)}

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -249,19 +249,9 @@ const Item = ({
 };
 
 const Group = ({items, label, spritemap}: IItem & IInternalItem) => (
-	<>
-		<ClayDropDownGroup header={label} />
-		{items && (
-			<li role="none">
-				<DropDownContent
-					aria-label={label}
-					items={items}
-					role="group"
-					spritemap={spritemap}
-				/>
-			</li>
-		)}
-	</>
+	<ClayDropDownGroup header={label}>
+		{items && <Items items={items} spritemap={spritemap} />}
+	</ClayDropDownGroup>
 );
 
 const Contextual = ({
@@ -394,21 +384,13 @@ const RadioGroup = ({
 	);
 
 	return (
-		<>
-			{label && <ClayDropDownGroup header={label} />}
+		<ClayDropDownGroup header={label} role="radiogroup">
 			{items && (
-				<li role="none">
-					<RadioGroupContext.Provider value={params}>
-						<DropDownContent
-							aria-label={label}
-							items={items}
-							role="radiogroup"
-							spritemap={spritemap}
-						/>
-					</RadioGroupContext.Provider>
-				</li>
+				<RadioGroupContext.Provider value={params}>
+					<Items items={items} spritemap={spritemap} />
+				</RadioGroupContext.Provider>
 			)}
-		</>
+		</ClayDropDownGroup>
 	);
 };
 
@@ -424,6 +406,18 @@ const TYPE_MAP = {
 	radiogroup: RadioGroup,
 };
 
+const Items = ({items, spritemap}: IDropDownContentProps) => {
+	return (
+		<>
+			{items.map(({type, ...item}, key) => {
+				const Item = TYPE_MAP[type || 'item'];
+
+				return <Item {...item} key={key} spritemap={spritemap} />;
+			})}
+		</>
+	);
+};
+
 const DropDownContent = ({
 	items,
 	role,
@@ -431,11 +425,7 @@ const DropDownContent = ({
 	...otherProps
 }: IDropDownContentProps) => (
 	<ClayDropDown.ItemList aria-label={otherProps['aria-label']} role={role}>
-		{items.map(({type, ...item}, key) => {
-			const Item = TYPE_MAP[type || 'item'];
-
-			return <Item {...item} key={key} spritemap={spritemap} />;
-		})}
+		<Items items={items} spritemap={spritemap} />
 	</ClayDropDown.ItemList>
 );
 

--- a/packages/clay-drop-down/src/Group.tsx
+++ b/packages/clay-drop-down/src/Group.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React from 'react';
+import React, {useMemo} from 'react';
 
 type Props = {
 	/**
@@ -15,18 +15,43 @@ type Props = {
 	 * Value provided is a display component that is a header for the items in the group.
 	 */
 	header?: string;
+
+	/**
+	 * ARIA to define semantic meaning to content.
+	 */
+	role?: string;
 };
 
-const ClayDropDownGroup = ({children, header}: Props) => {
+let counter = 0;
+
+const ClayDropDownGroup = ({children, header, role = 'group'}: Props) => {
+	const ariaLabel = useMemo(() => {
+		counter++;
+
+		return `clay-dropdown-menu-group-${counter}`;
+	}, []);
+
 	return (
 		<>
 			{header && (
-				<li className="dropdown-subheader" role="presentation">
+				<li
+					className="dropdown-subheader"
+					id={ariaLabel}
+					role="presentation"
+				>
 					{header}
 				</li>
 			)}
 
-			{children}
+			<li role="none">
+				<ul
+					aria-labelledby={ariaLabel}
+					className="list-unstyled"
+					role={role}
+				>
+					{children}
+				</ul>
+			</li>
 		</>
 	);
 };


### PR DESCRIPTION
Closes #5026

Well, this is an accessibility improvement for DropDown that resolves two things, The group semantics mainly for implementation using low-level components and focus control when using the virtual cursor in the screen reader. To better understand this I recommend reading the issue comments https://github.com/liferay/clay/issues/5026#issuecomment-1209895810