### PR TITLE
fix(@clayui/css): Mixins `clay-button-variant` add option to pass sty…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -656,6 +656,22 @@
 					@include clay-css(map-deep-get($map, focus, after));
 				}
 
+				&:hover {
+					@include clay-css(map-deep-get($map, focus, hover));
+
+					&::before {
+						@include clay-css(
+							map-deep-get($map, focus, hover, before)
+						);
+					}
+
+					&::after {
+						@include clay-css(
+							map-deep-get($map, focus, hover, after)
+						);
+					}
+				}
+
 				.inline-item {
 					@include clay-css(map-get($focus, inline-item));
 				}


### PR DESCRIPTION
…les to `:focus:hover`

fixes #5043