### PR TITLE
chore: add global script to just check TypeScript types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Lint
               run: yarn lint
             - name: Types
-              run: yarn buildTypes
+              run: yarn lint:typescript
             - name: Format
               run: yarn format:check
             - name: Verify Dependencies

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"lint:changed": "git ls-files -mz \"*.js\" \"**/*.js\" \"**/*.ts\" \"**/*.tsx\" | xargs -0 eslint",
 		"lint:fix": "eslint --fix \".*.js\" \"**/*.{js,ts,tsx}\"",
 		"lint:quiet": "eslint --quiet \".*.js\" \"**/*.{js,ts,tsx}\"",
+		"lint:typescript": "tsc --project ./tsconfig.global.json",
 		"lint": "eslint \".*.js\" \"**/*.{js,ts,tsx}\"",
 		"site": "cd clayui.com && yarn build && yarn serve",
 		"sizeLimit": "size-limit",

--- a/tsconfig.global.json
+++ b/tsconfig.global.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.declarations.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"declaration": true,
+		"emitDeclarationOnly": false
+	},
+	"include": ["./packages/clay-*/src/**/*", "*.tsx", "*.ts"]
+}


### PR DESCRIPTION
In PR #5050 I added the possibility to check TypeScript types in CI because we only did that when a new release was made but this directly called `buildTypes` which generates only the types but this is extremely slow it increased the CI time for almost 8m in this step alone, I'm adding a lighter approach that runs the TypeScript CLI globally and just checks the types without generating this is much faster and only takes a few seconds.