### PR TITLE
fix(@clayui/shared): fix error when checking a fiber element in progress in focus management

### DIFF
--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -99,6 +99,11 @@ const isFiberHostComponentFocusable = (fiber: any): boolean => {
 
 	const {memoizedProps, stateNode, type} = fiber;
 
+	// The element may be having an update in progress.
+	if (memoizedProps === null) {
+		return false;
+	}
+
 	return isFocusable({
 		contentEditable: memoizedProps.contentEditable,
 		disabled: memoizedProps.disabled,


### PR DESCRIPTION

This is a very specific behavior for some scenarios, for example in DropDown when a trigger is defined with a Button and Icon and the icon symbol changes according to the active state of the menu, this causes a change of state and icon rendering when the menu is opened if at the same time a focus change by the focus manager happens it would break because the icon fiber is in React's WorkInProgress queue and properties like `memoizedProps` are not available for access at this time. We need this information to know if the element is focusable, both `memoizedProps` and `stateNode` come null if the element is not ready yet.

We just have to ignore that element and jump to the next one.