### PR TITLE
fix(@clayui/drop-down): fixes error when not moving focus to element in menu when renderMenuOnClick property is set

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -74,7 +74,7 @@ module.exports = {
 			statements: 95,
 		},
 		'./packages/clay-drop-down/src/': {
-			branches: 64,
+			branches: 62,
 			functions: 57,
 			lines: 75,
 			statements: 74,


### PR DESCRIPTION
Fixes #5053

This is a bit of a hacky approach to solving this problem. To better understand what is happening here is that the focus manager relies on the DOM reference that React provides to move the focus, since the dropdown menu is not rendered on the first iteration only when the user interacts with it.

Trying to use focus manager to move focus in this scenario doesn't work, for some reason when using `useLayoutEffect` or `useEffect` we don't have visibility of elements rendered in DropDown visible in DOM to move focus manually, so I made a fallback if the focusManager is unable to move the focus on the first iteration.

This behavior of not being able to have visibility of the element in the DOM is very strange, testing a super simple implementation with just React this approach should work when trying to use `useEffect` https://codesandbox.io/s/friendly-lalande-9g4svz?file=/src/App.js, this could have other reasons, maybe the deep nesting of components or something related.