### PR TITLE
feat(clayui.com): Add Accessibility bar

### DIFF
--- a/clayui.com/src/components/LayoutNav/Search.js
+++ b/clayui.com/src/components/LayoutNav/Search.js
@@ -29,6 +29,8 @@ export default (props) => {
 				/>
 
 				<span className="input-group-addon">
+					<kbd className="mr-2">K</kbd>
+
 					<svg className="lexicon-icon">
 						<use xlinkHref="/images/icons/icons.svg#search" />
 					</svg>

--- a/clayui.com/src/styles/_autocomplete.scss
+++ b/clayui.com/src/styles/_autocomplete.scss
@@ -14,7 +14,6 @@
 			position: absolute;
 			right: 0.875rem;
 			top: 50%;
-			width: 1.5rem;
 			z-index: 9;
 
 			.lexicon-icon {
@@ -26,7 +25,7 @@
 			background-color: white;
 			border-radius: 4px;
 			padding-left: 0.875rem;
-			padding-right: $base-size * 1.5;
+			padding-right: $base-size * 2.5;
 
 			&::-moz-placeholder {
 				opacity: 1;

--- a/clayui.com/src/styles/site/_site.scss
+++ b/clayui.com/src/styles/site/_site.scss
@@ -38,3 +38,22 @@ body {
 		flex-wrap: nowrap;
 	}
 }
+
+.skippy {
+	background-color: $brand-bg-dark;
+	position: fixed;
+	top: 0;
+	width: 100%;
+	z-index: 99;
+
+	&:focus-within a {
+		height: auto !important;
+		overflow: visible !important;
+		width: auto !important;
+		position: static !important;
+	}
+
+	a {
+		color: $brand-lighten;
+	}
+}

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -203,6 +203,21 @@ export default function Documentation(props) {
 
 	return (
 		<div className="docs">
+			<div className="overflow-hidden skippy">
+				<a
+					className="d-inline-flex m-1 p-1 sr-only sr-only-focusable"
+					href="#content"
+				>
+					Skip to main content
+				</a>
+				<a
+					accessKey="k"
+					className="d-inline-flex m-1 p-1 sr-only sr-only-focusable"
+					href="#algolia-doc-search"
+				>
+					Skip to search
+				</a>
+			</div>
 			<Helmet>
 				<title>{title}</title>
 				<meta content={excerpt} name="description" />
@@ -234,7 +249,7 @@ export default function Documentation(props) {
 										<LayoutNav
 											pathname={location.pathname}
 										/>
-										<header>
+										<header id="content">
 											<div className="clay-site-container container-fluid">
 												<div className="row">
 													<div className="col-12">

--- a/clayui.com/src/templates/docs.js
+++ b/clayui.com/src/templates/docs.js
@@ -212,6 +212,7 @@ export default function Documentation(props) {
 				</a>
 				<a
 					accessKey="k"
+					aria-keyshortcuts="k"
 					className="d-inline-flex m-1 p-1 sr-only sr-only-focusable"
 					href="#algolia-doc-search"
 				>


### PR DESCRIPTION
https://github.com/liferay/clay/issues/5073

![image](https://user-images.githubusercontent.com/7963804/188122852-a2130a9d-5d74-43b4-a272-7b7f93d25876.png)

---

I've added a second commit with accesskey K to go to the searchbar

<img width="571" alt="image" src="https://user-images.githubusercontent.com/7963804/188142564-d65f0b77-2d72-4bb0-b3a5-ea4ae8e125c4.png">
