### PR TITLE
feat(clayui.com): Add key shortcut keys by platform type and hiding it in mobile

### DIFF
--- a/clayui.com/src/components/LayoutNav/Search.js
+++ b/clayui.com/src/components/LayoutNav/Search.js
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {useEffect} from 'react';
+import React, {useEffect, useRef} from 'react';
 
 export default (props) => {
+	const autocompleteRef = useRef();
 	useEffect(() => {
 		if (window.docsearch) {
 			window.docsearch({
@@ -14,27 +15,41 @@ export default (props) => {
 				inputSelector: '#algolia-doc-search',
 			});
 		}
+
+		const platform = (
+			navigator?.userAgentData?.platform || navigator?.platform
+		).toLowerCase();
+
+		if (platform.includes('mac')) {
+			autocompleteRef.current.setAttribute('data-platform', 'mac');
+		} else if (platform.includes('linux')) {
+			autocompleteRef.current.setAttribute('data-platform', 'linux');
+		}
 	}, []);
 
 	return (
-		<div className="page-autocomplete">
-			<div className="input-group">
-				<input
-					className="form-control"
-					id="algolia-doc-search"
-					name="q"
-					placeholder={props.placeholder}
-					required
-					type="text"
-				/>
+		<div className="platform" ref={autocompleteRef}>
+			<div className="page-autocomplete">
+				<div className="input-group">
+					<input
+						className="form-control"
+						id="algolia-doc-search"
+						name="q"
+						placeholder={props.placeholder}
+						required
+						type="text"
+					/>
 
-				<span className="input-group-addon">
-					<kbd className="mr-2">K</kbd>
+					<span aria-hidden="true" className="input-group-addon">
+						<span className="c-kbd c-kbd-sm d-md-block d-none mr-2">
+							<kbd className="c-kbd">K</kbd>
+						</span>
 
-					<svg className="lexicon-icon">
-						<use xlinkHref="/images/icons/icons.svg#search" />
-					</svg>
-				</span>
+						<svg className="lexicon-icon">
+							<use xlinkHref="/images/icons/icons.svg#search" />
+						</svg>
+					</span>
+				</div>
 			</div>
 		</div>
 	);

--- a/clayui.com/src/styles/_autocomplete.scss
+++ b/clayui.com/src/styles/_autocomplete.scss
@@ -16,6 +16,20 @@
 			top: 50%;
 			z-index: 9;
 
+			> .c-kbd {
+				&:before {
+					content: 'ctrl + ';
+				}
+
+				@at-root [data-platform='mac'] &:before {
+					content: 'ctrl + ⌥ + ';
+				}
+
+				@at-root [data-platform='linux'] &:before {
+					content: 'alt + ';
+				}
+			}
+
 			.lexicon-icon {
 				margin-top: 0;
 			}
@@ -25,7 +39,11 @@
 			background-color: white;
 			border-radius: 4px;
 			padding-left: 0.875rem;
-			padding-right: $base-size * 2.5;
+			padding-right: $base-size * 4;
+
+			@at-root [data-platform='mac'] & {
+				padding-right: $base-size * 5;
+			}
 
 			&::-moz-placeholder {
 				opacity: 1;


### PR DESCRIPTION
Native combination keys should be known by user but a good practice is print the all combination so:
- In mac is "control + option + K"
- In linux is "alt + K"
- In windows is "control + K"

So I've added the combinations:

Linux:
<img width="266" alt="image" src="https://user-images.githubusercontent.com/7963804/188623451-e9581f3d-38bf-4605-a5d9-61f043b73bfb.png">

Mac:
<img width="266" alt="image" src="https://user-images.githubusercontent.com/7963804/188623602-13fc2b40-4961-4cd8-9463-fe795d9bf108.png">

Windows:
<img width="265" alt="image" src="https://user-images.githubusercontent.com/7963804/188623752-9ab0f76b-5872-47e6-b6d9-0feb33a512ce.png">

It is a good exercise if we consider to add native shortcuts without conflicting to screen readers and exposing the key by "aria-keyshortcuts".
If we would use this example in general, probably we could move the `@at-root` clases to a general new `.c-kbd-platform-frefix` class or something similar so then you add the class and the key is preceded by the platform native combination.

Of course, key combinations can be changed in SO configuration but those cases cannot be covered even by native aria, so I think is not a stopper.

In small devices we hide the shortcut since most probably they have not physical keyboard.

Feel free to modify the react part.