### PR TITLE
fix(@clayui/data-provider): add more test scenarios for multiple `useResource` instances and fix error

### DIFF
--- a/packages/clay-data-provider/src/useResource.tsx
+++ b/packages/clay-data-provider/src/useResource.tsx
@@ -536,7 +536,7 @@ const useResource = ({
 		};
 	}, []);
 
-	const fetchingOrError = client.current.isFetching(identifier);
+	let fetchingOrError = client.current.isFetching(identifier);
 
 	// Makes first request if not started at render time
 	if (!fetchingOrError && firstRenderRef.current) {
@@ -544,6 +544,7 @@ const useResource = ({
 
 		if (result) {
 			firstRequestRef.current = true;
+			fetchingOrError = result;
 
 			client.current.update(identifier, result);
 		}


### PR DESCRIPTION
Fixes #5066

I've added a few more test scenarios that cover the scenarios we discovered when we updated the package in DXP, this brings more coverage to the DataProvider tests, I'm still writing tests when it's integrated with Suspense but I'm having some issues with jest. Also I fix a bug that even with `suspense` enabled it wasn't working.