### PR TITLE
fix(@clayui/drop-down): fix error when not focusing on first item of DropDown

### DIFF
--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -218,125 +218,113 @@ function ClayDropDown({
 
 	return (
 		<FocusScope>
-			{(focusManager) => (
-				<ContainerElement
-					{...otherProps}
-					className={classNames('dropdown', className)}
-					onKeyUp={handleKeyUp}
-				>
-					{React.cloneElement(trigger, {
-						'aria-controls': ariaControls,
-						'aria-expanded': internalActive,
-						'aria-haspopup': 'true',
-						className: classNames(
-							'dropdown-toggle',
-							trigger.props.className
-						),
-						onClick: (
-							event: React.MouseEvent<HTMLButtonElement>
-						) => {
-							if (trigger.props.onClick) {
-								trigger.props.onClick(event);
-							}
+			<ContainerElement
+				{...otherProps}
+				className={classNames('dropdown', className)}
+				onKeyUp={handleKeyUp}
+			>
+				{React.cloneElement(trigger, {
+					'aria-controls': ariaControls,
+					'aria-expanded': internalActive,
+					'aria-haspopup': 'true',
+					className: classNames(
+						'dropdown-toggle',
+						trigger.props.className
+					),
+					onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+						if (trigger.props.onClick) {
+							trigger.props.onClick(event);
+						}
 
+						openMenu(!internalActive);
+					},
+					onKeyDown: (
+						event: React.KeyboardEvent<HTMLButtonElement>
+					) => {
+						if (trigger.props.onKeyDown) {
+							trigger.props.onKeyDown(event);
+						}
+
+						if (event.key === Keys.Spacebar) {
 							openMenu(!internalActive);
-						},
-						onKeyDown: (
-							event: React.KeyboardEvent<HTMLButtonElement>
-						) => {
-							if (trigger.props.onKeyDown) {
-								trigger.props.onKeyDown(event);
+						}
+
+						if (event.key === Keys.Down) {
+							event.preventDefault();
+							event.stopPropagation();
+
+							openMenu(true);
+						}
+
+						if ([Keys.Spacebar, Keys.Down].includes(event.key)) {
+							event.preventDefault();
+						}
+					},
+					ref: (node: HTMLButtonElement) => {
+						if (node) {
+							triggerElementRef.current = node;
+							// Call the original ref, if any.
+							const {ref} = trigger;
+							if (typeof ref === 'function') {
+								ref(node);
 							}
+						}
+					},
+				})}
 
-							if (event.key === Keys.Spacebar) {
-								openMenu(!internalActive);
-							}
+				{initialized && (
+					<Menu
+						{...menuElementAttrs}
+						active={internalActive}
+						alignElementRef={triggerElementRef}
+						alignmentByViewport={alignmentByViewport}
+						alignmentPosition={alignmentPosition}
+						closeOnClickOutside={closeOnClickOutside}
+						hasLeftSymbols={hasLeftSymbols}
+						hasRightSymbols={hasRightSymbols}
+						height={menuHeight}
+						id={ariaControls}
+						offsetFn={offsetFn}
+						onSetActive={setInternalActive}
+						ref={menuElementRef}
+						width={menuWidth}
+					>
+						<FocusMenu
+							condition={internalActive}
+							onRender={() => {
+								// After a few milliseconds querying the elements in the DOM
+								// inside the menu. This especially when the menu is not
+								// rendered yet only after the menu is opened, React needs
+								// to commit the changes to the DOM so that the elements are
+								// visible and we can move the focus.
+								setTimeout(() => {
+									const first =
+										menuElementRef.current?.querySelector(
+											// @ts-ignore
+											FOCUSABLE_ELEMENTS
+										);
 
-							if (event.key === Keys.Down) {
-								event.preventDefault();
-								event.stopPropagation();
-
-								openMenu(true);
-							}
-
-							if (
-								[Keys.Spacebar, Keys.Down].includes(event.key)
-							) {
-								event.preventDefault();
-							}
-						},
-						ref: (node: HTMLButtonElement) => {
-							if (node) {
-								triggerElementRef.current = node;
-								// Call the original ref, if any.
-								const {ref} = trigger;
-								if (typeof ref === 'function') {
-									ref(node);
-								}
-							}
-						},
-					})}
-
-					{initialized && (
-						<Menu
-							{...menuElementAttrs}
-							active={internalActive}
-							alignElementRef={triggerElementRef}
-							alignmentByViewport={alignmentByViewport}
-							alignmentPosition={alignmentPosition}
-							closeOnClickOutside={closeOnClickOutside}
-							hasLeftSymbols={hasLeftSymbols}
-							hasRightSymbols={hasRightSymbols}
-							height={menuHeight}
-							id={ariaControls}
-							offsetFn={offsetFn}
-							onSetActive={setInternalActive}
-							ref={menuElementRef}
-							width={menuWidth}
-						>
-							<FocusMenu
-								condition={internalActive}
-								onRender={() => {
-									const element = focusManager.focusNext();
-
-									if (element !== document.activeElement) {
-										// If the focus manager is unable to move the focus to
-										// the item inside the menu, as a fallback try after a
-										// few milliseconds querying the elements in the DOM
-										// inside the menu. This especially when the menu is not
-										// rendered yet only after the menu is opened, React
-										// needs to commit the changes to the DOM so that the
-										// elements are visible and we can move the focus.
-										setTimeout(() => {
-											const first =
-												menuElementRef.current?.querySelector(
-													// @ts-ignore
-													FOCUSABLE_ELEMENTS
-												);
-
-											if (first) {
-												first.focus();
-											}
-										}, 10);
+									if (first) {
+										first.focus();
 									}
+								}, 10);
+							}}
+						>
+							<DropDownContext.Provider
+								value={{
+									close: () => {
+										setInternalActive(false);
+										triggerElementRef.current?.focus();
+									},
+									closeOnClick,
 								}}
 							>
-								<DropDownContext.Provider
-									value={{
-										close: () => {
-											setInternalActive(false);
-											triggerElementRef.current?.focus();
-										},
-										closeOnClick,
-									}}
-								>
-									{children}
-								</DropDownContext.Provider>
-							</FocusMenu>
-						</Menu>
-					)}
-				</ContainerElement>
-			)}
+								{children}
+							</DropDownContext.Provider>
+						</FocusMenu>
+					</Menu>
+				)}
+			</ContainerElement>
 		</FocusScope>
 	);
 }


### PR DESCRIPTION
Fixes #5090

As we were using `focusManager` to move the focus it worked but only for the scenario where `renderMenuOnClick` was disabled, when `renderMenuOnClick` is enabled the `focusManager` looks for the next element out of scope as it does not find the Menu rendered yet so fallback was not used.

I went ahead and just used fallback as the first option only and removed the use of `focusManager` for that purpose, I think we could still use `focusManager` as it is a better option and configure it to do nothing when not find a focusable element within the scope by providing some property in the call to `focusManager.focusNext()`, but for now I'll just go with the fallback solution to avoid possible regressions with focusManager to support this use case.