### PR TITLE
feat(@clayui/css): Custom Checkbox adds readonly styles

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
@@ -149,6 +149,15 @@ $custom-control-input: map-deep-merge(
 		disabled: (
 			custom-control-label: $custom-control-label-disabled,
 		),
+		readonly: (
+			custom-control-label: (
+				color: $gray-900,
+				before: (
+					background-color: $gray-200,
+					border-color: $secondary-l3,
+				),
+			),
+		),
 		checked: (
 			custom-control-label: (
 				before: (
@@ -224,6 +233,17 @@ $custom-checkbox: map-deep-merge(
 						),
 					),
 				),
+				readonly: (
+					custom-control-label: (
+						before: (
+							background-color: $white,
+							border-color: $secondary-l2,
+						),
+						after: (
+							background-image: clay-icon(check-small, $secondary),
+						),
+					),
+				),
 			),
 			indeterminate: (
 				custom-control-label: (
@@ -249,6 +269,17 @@ $custom-checkbox: map-deep-merge(
 								$custom-control-indicator-checked-disabled-bg,
 							border-color:
 								$custom-control-indicator-checked-disabled-border-color,
+						),
+					),
+				),
+				readonly: (
+					custom-control-label: (
+						before: (
+							background-color: $white,
+							border-color: $secondary-l2,
+						),
+						after: (
+							background-image: clay-icon(hr, $secondary),
 						),
 					),
 				),

--- a/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
@@ -14,7 +14,7 @@ $custom-control-indicator-active-box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1),
 	$custom-control-indicator-focus-box-shadow !default;
 
 $custom-control-indicator-disabled-bg: $input-disabled-bg !default;
-$custom-control-indicator-disabled-border-color: transparent !default;
+$custom-control-indicator-disabled-border-color: $secondary-l3 !default;
 
 // Custom Control Indicator Checked
 

--- a/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_custom-forms.scss
@@ -157,6 +157,11 @@ $custom-control-input: map-deep-merge(
 					border-color: $secondary-l3,
 				),
 			),
+			disabled: (
+				custom-control-label: (
+					color: $custom-control-label-disabled-color,
+				),
+			),
 		),
 		checked: (
 			custom-control-label: (
@@ -243,6 +248,16 @@ $custom-checkbox: map-deep-merge(
 							background-image: clay-icon(check-small, $secondary),
 						),
 					),
+					disabled: (
+						custom-control-label: (
+							before: (
+								opacity: 0.4,
+							),
+							after: (
+								opacity: 0.4,
+							),
+						),
+					),
 				),
 			),
 			indeterminate: (
@@ -280,6 +295,16 @@ $custom-checkbox: map-deep-merge(
 						),
 						after: (
 							background-image: clay-icon(hr, $secondary),
+						),
+					),
+					disabled: (
+						custom-control-label: (
+							before: (
+								opacity: 0.4,
+							),
+							after: (
+								opacity: 0.4,
+							),
 						),
 					),
 				),

--- a/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
@@ -271,6 +271,11 @@ $cadmin-custom-control-input: map-deep-merge(
 					border-color: $cadmin-secondary-l3,
 				),
 			),
+			disabled: (
+				custom-control-label: (
+					color: $cadmin-custom-control-label-disabled-color,
+				),
+			),
 		),
 		checked: (
 			custom-control-label: (
@@ -385,6 +390,16 @@ $cadmin-custom-checkbox: map-deep-merge(
 								clay-icon(check-small, $cadmin-secondary),
 						),
 					),
+					disabled: (
+						custom-control-label: (
+							before: (
+								opacity: 0.4,
+							),
+							after: (
+								opacity: 0.4,
+							),
+						),
+					),
 				),
 			),
 			indeterminate: (
@@ -424,6 +439,16 @@ $cadmin-custom-checkbox: map-deep-merge(
 						),
 						after: (
 							background-image: clay-icon(hr, $cadmin-secondary),
+						),
+					),
+					disabled: (
+						custom-control-label: (
+							before: (
+								opacity: 0.4,
+							),
+							after: (
+								opacity: 0.4,
+							),
 						),
 					),
 				),

--- a/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_custom-forms.scss
@@ -24,7 +24,7 @@ $cadmin-custom-control-indicator-active-border-color: $cadmin-custom-control-ind
 $cadmin-custom-control-indicator-active-color: $cadmin-component-active-color !default;
 
 $cadmin-custom-control-indicator-disabled-bg: $cadmin-input-disabled-bg !default;
-$cadmin-custom-control-indicator-disabled-border-color: $cadmin-input-disabled-border-color !default;
+$cadmin-custom-control-indicator-disabled-border-color: $cadmin-secondary-l3 !default;
 $cadmin-custom-control-indicator-disabled-cursor: $cadmin-disabled-cursor !default;
 
 // Custom Control Indicator Checked
@@ -263,6 +263,15 @@ $cadmin-custom-control-input: map-deep-merge(
 			cursor: $cadmin-custom-control-indicator-disabled-cursor,
 			custom-control-label: $cadmin-custom-control-label-disabled,
 		),
+		readonly: (
+			custom-control-label: (
+				color: $cadmin-gray-900,
+				before: (
+					background-color: $cadmin-gray-200,
+					border-color: $cadmin-secondary-l3,
+				),
+			),
+		),
 		checked: (
 			custom-control-label: (
 				before: (
@@ -327,7 +336,7 @@ $cadmin-custom-checkbox-indicator-indeterminate-border-color: $cadmin-custom-che
 
 $cadmin-custom-control-indicator-indeterminate-border-color: $cadmin-custom-control-indicator-checked-active-bg !default;
 
-$cadmin-custom-checkbox-indicator-indeterminate-box-shadow: none !default;
+$cadmin-custom-checkbox-indicator-indeterminate-box-shadow: null !default;
 $cadmin-custom-checkbox-indicator-indeterminate-color: $cadmin-custom-control-indicator-checked-color !default;
 
 $cadmin-custom-checkbox-indicator-icon-indeterminate: clay-icon(
@@ -365,6 +374,18 @@ $cadmin-custom-checkbox: map-deep-merge(
 						),
 					),
 				),
+				readonly: (
+					custom-control-label: (
+						before: (
+							background-color: $cadmin-white,
+							border-color: $cadmin-secondary-l2,
+						),
+						after: (
+							background-image:
+								clay-icon(check-small, $cadmin-secondary),
+						),
+					),
+				),
 			),
 			indeterminate: (
 				custom-control-label: (
@@ -392,6 +413,17 @@ $cadmin-custom-checkbox: map-deep-merge(
 								$cadmin-custom-control-indicator-checked-disabled-bg,
 							border-color:
 								$cadmin-custom-control-indicator-checked-disabled-border-color,
+						),
+					),
+				),
+				readonly: (
+					custom-control-label: (
+						before: (
+							background-color: $cadmin-white,
+							border-color: $cadmin-secondary-l2,
+						),
+						after: (
+							background-image: clay-icon(hr, $cadmin-secondary),
 						),
 					),
 				),

--- a/packages/clay-css/src/scss/mixins/_custom-forms.scss
+++ b/packages/clay-css/src/scss/mixins/_custom-forms.scss
@@ -244,6 +244,69 @@
 				}
 			}
 
+			&[readonly] {
+				@include clay-css(map-deep-get($map, readonly));
+
+				~ .custom-control-label {
+					@include clay-css(
+						map-deep-get($map, readonly, custom-control-label)
+					);
+				}
+
+				~ .custom-control-label::before {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							readonly,
+							custom-control-label,
+							before
+						)
+					);
+				}
+
+				~ .custom-control-label::after {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							readonly,
+							custom-control-label,
+							after
+						)
+					);
+				}
+
+				~ .card {
+					@include clay-card-variant(
+						map-deep-get($map, readonly, card)
+					);
+				}
+			}
+
+			&:checked {
+				~ .custom-control-label::before {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							checked,
+							custom-control-label,
+							before
+						)
+					);
+				}
+
+				~ .custom-control-label::after {
+					@include clay-css(
+						map-deep-get($map, checked, custom-control-label, after)
+					);
+				}
+
+				~ .card {
+					@include clay-card-variant(
+						map-deep-get($map, checked, card)
+					);
+				}
+			}
+
 			&:checked:hover {
 				~ .custom-control-label::before {
 					@include clay-css(
@@ -369,6 +432,38 @@
 				~ .card {
 					@include clay-card-variant(
 						map-deep-get($map, checked, disabled, card)
+					);
+				}
+			}
+
+			&:checked[readonly] {
+				~ .custom-control-label::before {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							checked,
+							readonly,
+							custom-control-label,
+							before
+						)
+					);
+				}
+
+				~ .custom-control-label::after {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							checked,
+							readonly,
+							custom-control-label,
+							after
+						)
+					);
+				}
+
+				~ .card {
+					@include clay-card-variant(
+						map-deep-get($map, checked, readonly, card)
 					);
 				}
 			}
@@ -528,6 +623,38 @@
 				~ .card {
 					@include clay-card-variant(
 						map-deep-get($map, indeterminate, disabled, card)
+					);
+				}
+			}
+
+			&:indeterminate[readonly] {
+				~ .custom-control-label::before {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							indeterminate,
+							readonly,
+							custom-control-label,
+							before
+						)
+					);
+				}
+
+				~ .custom-control-label::after {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							indeterminate,
+							readonly,
+							custom-control-label,
+							after
+						)
+					);
+				}
+
+				~ .card {
+					@include clay-card-variant(
+						map-deep-get($map, indeterminate, readonly, card)
 					);
 				}
 			}

--- a/packages/clay-css/src/scss/mixins/_custom-forms.scss
+++ b/packages/clay-css/src/scss/mixins/_custom-forms.scss
@@ -282,6 +282,51 @@
 				}
 			}
 
+			&[readonly][disabled] {
+				@include clay-css(map-deep-get($map, readonly, disabled));
+
+				~ .custom-control-label {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							readonly,
+							disabled,
+							custom-control-label
+						)
+					);
+				}
+
+				~ .custom-control-label::before {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							readonly,
+							disabled,
+							custom-control-label,
+							before
+						)
+					);
+				}
+
+				~ .custom-control-label::after {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							readonly,
+							disabled,
+							custom-control-label,
+							after
+						)
+					);
+				}
+
+				~ .card {
+					@include clay-card-variant(
+						map-deep-get($map, readonly, disabled, card)
+					);
+				}
+			}
+
 			&:checked {
 				~ .custom-control-label::before {
 					@include clay-css(
@@ -464,6 +509,40 @@
 				~ .card {
 					@include clay-card-variant(
 						map-deep-get($map, checked, readonly, card)
+					);
+				}
+			}
+
+			&:checked[readonly][disabled] {
+				~ .custom-control-label::before {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							checked,
+							readonly,
+							disabled,
+							custom-control-label,
+							before
+						)
+					);
+				}
+
+				~ .custom-control-label::after {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							checked,
+							readonly,
+							disabled,
+							custom-control-label,
+							after
+						)
+					);
+				}
+
+				~ .card {
+					@include clay-card-variant(
+						map-deep-get($map, checked, readonly, disabled, card)
 					);
 				}
 			}
@@ -655,6 +734,46 @@
 				~ .card {
 					@include clay-card-variant(
 						map-deep-get($map, indeterminate, readonly, card)
+					);
+				}
+			}
+
+			&:indeterminate[readonly][disabled] {
+				~ .custom-control-label::before {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							indeterminate,
+							readonly,
+							disabled,
+							custom-control-label,
+							before
+						)
+					);
+				}
+
+				~ .custom-control-label::after {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							indeterminate,
+							readonly,
+							disabled,
+							custom-control-label,
+							after
+						)
+					);
+				}
+
+				~ .card {
+					@include clay-card-variant(
+						map-deep-get(
+							$map,
+							indeterminate,
+							readonly,
+							disabled,
+							card
+						)
 					);
 				}
 			}

--- a/packages/clay-css/src/scss/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/variables/_custom-forms.scss
@@ -363,6 +363,9 @@ $custom-checkbox: map-deep-merge(
 				),
 				readonly: (
 					custom-control-label: (
+						before: (
+							background-color: $white,
+						),
 						after: (
 							background-image:
 								clay-svg-url(

--- a/packages/clay-css/src/scss/variables/_custom-forms.scss
+++ b/packages/clay-css/src/scss/variables/_custom-forms.scss
@@ -287,6 +287,14 @@ $custom-control-input: map-deep-merge(
 					),
 				),
 			),
+			readonly: (
+				custom-control-label: (
+					before: (
+						background-color: $custom-control-indicator-bg,
+						border-color: $custom-control-indicator-border-color,
+					),
+				),
+			),
 		),
 	),
 	$custom-control-input
@@ -353,6 +361,16 @@ $custom-checkbox: map-deep-merge(
 						),
 					),
 				),
+				readonly: (
+					custom-control-label: (
+						after: (
+							background-image:
+								clay-svg-url(
+									"<svg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'><path fill='#{$gray-600}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/></svg>"
+								),
+						),
+					),
+				),
 			),
 			indeterminate: (
 				custom-control-label: (
@@ -382,6 +400,20 @@ $custom-checkbox: map-deep-merge(
 								$custom-control-indicator-checked-disabled-bg,
 							border-color:
 								$custom-control-indicator-checked-disabled-border-color,
+						),
+					),
+				),
+				readonly: (
+					custom-control-label: (
+						before: (
+							background-color: $custom-control-indicator-bg,
+							border-color: $custom-control-indicator-border-color,
+						),
+						after: (
+							background-image:
+								clay-svg-url(
+									"<svg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'><path stroke='#{$gray-800}' d='M0 2h4'/></svg>"
+								),
 						),
 					),
 				),

--- a/packages/clay-form/docs/markup-checkbox-radio.md
+++ b/packages/clay-form/docs/markup-checkbox-radio.md
@@ -13,6 +13,10 @@ mainTabURL: 'docs/components/checkbox.html'
 -   [Disabled](#css-disabled)
 -   [Without Labels](#css-without-labels)
 -   [Custom](#css-custom)
+    -   [Checkboxes](#css-custom-checkboxes)
+        -   [Indeterminate](#css-custom-checkbox-indeterminate)
+        -   [Readonly](#css-custom-checkbox-readonly)
+    -   [Radios](#css-custom-radios)
 
 </div>
 </div>
@@ -380,18 +384,106 @@ Using the `id` binding engine with `<label />`and `<input />`.
 </div>
 ```
 
+#### Custom Checkbox Indeterminate(#css-custom-checkbox-indeterminate)
+
 Custom checkboxes can also utilize the `:indeterminate` pseudo class when manually set via JavaScript (there is no available HTML attribute for specifying it).
+
+<div class="sheet-example">
+	<div class="clay-site-custom-checkbox-indeterminate">
+		<div class="custom-control custom-checkbox">
+			<label>
+				<input class="custom-control-input" type="checkbox">
+				<span class="custom-control-label">
+					<span class="custom-control-label-text">Indeterminate</span>
+				</span>
+			</label>
+		</div>
+	</div>
+</div>
+
+#### Custom Checkbox Readonly(#css-custom-checkbox-readonly)
+
+<div class="clay-site-alert alert alert-warning">
+	This uses the non-standard <code>readonly</code> and <code>onclick="return false;"</code> attributes on the <code>input[type="checkbox"]</code> element. The <code>readonly</code> attribute is <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly" rel="noopener noreferrer" target="_blank">only supported in text controls</a>.
+</div>
+
+The `onclick="return false;"` attribute must be used on the `custom-control-input` to prevent the state of the checkbox from being changed on click.
 
 <div class="sheet-example">
 	<div class="custom-control custom-checkbox">
 		<label>
-			<input class="clay-site-custom-checkbox-indeterminate custom-control-input" type="checkbox">
+			<input class="custom-control-input" onclick="return false;" readonly type="checkbox" />
 			<span class="custom-control-label">
-				<span class="custom-control-label-text">Indeterminate</span>
+				<span class="custom-control-label-text">Unchecked Readonly</span>
 			</span>
 		</label>
 	</div>
+	<div class="custom-control custom-checkbox">
+		<label>
+			<input checked class="custom-control-input" onclick="return false;" readonly type="checkbox" />
+			<span class="custom-control-label">
+				<span class="custom-control-label-text">Checked Readonly</span>
+			</span>
+		</label>
+	</div>
+	<div class="clay-site-custom-checkbox-indeterminate">
+		<div class="custom-control custom-checkbox">
+			<label>
+				<input class="custom-control-input" onclick="return false;" readonly type="checkbox" />
+				<span class="custom-control-label">
+					<span class="custom-control-label-text">Indeterminate Readonly</span>
+				</span>
+			</label>
+		</div>
+	</div>
 </div>
+
+```html
+<div class="custom-control custom-checkbox">
+	<label>
+		<input
+			class="custom-control-input"
+			onclick="return false;"
+			readonly
+			type="checkbox"
+		/>
+		<span class="custom-control-label">
+			<span class="custom-control-label-text">Unchecked Readonly</span>
+		</span>
+	</label>
+</div>
+
+<div class="custom-control custom-checkbox">
+	<label>
+		<input
+			checked
+			class="custom-control-input"
+			onclick="return false;"
+			readonly
+			type="checkbox"
+		/>
+		<span class="custom-control-label">
+			<span class="custom-control-label-text">Checked Readonly</span>
+		</span>
+	</label>
+</div>
+
+<div class="custom-control custom-checkbox">
+	<label>
+		<input
+			class="custom-control-input"
+			onclick="return false;"
+			readonly
+			type="checkbox"
+		/>
+		<span class="custom-control-label">
+			<span class="custom-control-label-text"
+				>Indeterminate Readonly</span
+			>
+		</span>
+	</label>
+</div>
+```
 
 ### Radios(#css-custom-radios)
 
@@ -447,3 +539,13 @@ Custom checkboxes can also utilize the `:indeterminate` pseudo class when manual
 	</label>
 </div>
 ```
+
+<script>
+(function() {
+	var indeterminateCheckbox = document.querySelectorAll('.clay-site-custom-checkbox-indeterminate .custom-control-input');
+
+	indeterminateCheckbox.forEach(function(checkbox) {
+		checkbox.indeterminate = true;
+	});
+})();
+</script>

--- a/packages/clay-form/docs/markup-checkbox-radio.md
+++ b/packages/clay-form/docs/markup-checkbox-radio.md
@@ -16,6 +16,7 @@ mainTabURL: 'docs/components/checkbox.html'
     -   [Checkboxes](#css-custom-checkboxes)
         -   [Indeterminate](#css-custom-checkbox-indeterminate)
         -   [Readonly](#css-custom-checkbox-readonly)
+        -   [Readonly Disabled](#css-custom-checkbox-readonly-disabled)
     -   [Radios](#css-custom-radios)
 
 </div>
@@ -412,7 +413,7 @@ The `onclick="return false;"` attribute must be used on the `custom-control-inpu
 <div class="sheet-example">
 	<div class="custom-control custom-checkbox">
 		<label>
-			<input class="custom-control-input" onclick="return false;" readonly type="checkbox" />
+			<input aria-disabled="true" class="custom-control-input" onclick="return false;" readonly type="checkbox" />
 			<span class="custom-control-label">
 				<span class="custom-control-label-text">Unchecked Readonly</span>
 			</span>
@@ -420,7 +421,7 @@ The `onclick="return false;"` attribute must be used on the `custom-control-inpu
 	</div>
 	<div class="custom-control custom-checkbox">
 		<label>
-			<input checked class="custom-control-input" onclick="return false;" readonly type="checkbox" />
+			<input aria-disabled="true" checked class="custom-control-input" onclick="return false;" readonly type="checkbox" />
 			<span class="custom-control-label">
 				<span class="custom-control-label-text">Checked Readonly</span>
 			</span>
@@ -429,7 +430,7 @@ The `onclick="return false;"` attribute must be used on the `custom-control-inpu
 	<div class="clay-site-custom-checkbox-indeterminate">
 		<div class="custom-control custom-checkbox">
 			<label>
-				<input class="custom-control-input" onclick="return false;" readonly type="checkbox" />
+				<input aria-disabled="true" class="custom-control-input" onclick="return false;" readonly type="checkbox" />
 				<span class="custom-control-label">
 					<span class="custom-control-label-text">Indeterminate Readonly</span>
 				</span>
@@ -442,6 +443,7 @@ The `onclick="return false;"` attribute must be used on the `custom-control-inpu
 <div class="custom-control custom-checkbox">
 	<label>
 		<input
+			aria-disabled="true"
 			class="custom-control-input"
 			onclick="return false;"
 			readonly
@@ -456,6 +458,7 @@ The `onclick="return false;"` attribute must be used on the `custom-control-inpu
 <div class="custom-control custom-checkbox">
 	<label>
 		<input
+			aria-disabled="true"
 			checked
 			class="custom-control-input"
 			onclick="return false;"
@@ -471,6 +474,7 @@ The `onclick="return false;"` attribute must be used on the `custom-control-inpu
 <div class="custom-control custom-checkbox">
 	<label>
 		<input
+			aria-disabled="true"
 			class="custom-control-input"
 			onclick="return false;"
 			readonly
@@ -479,6 +483,94 @@ The `onclick="return false;"` attribute must be used on the `custom-control-inpu
 		<span class="custom-control-label">
 			<span class="custom-control-label-text"
 				>Indeterminate Readonly</span
+			>
+		</span>
+	</label>
+</div>
+```
+
+#### Custom Checkbox Readonly Disabled(#css-custom-checkbox-readonly-disabled)
+
+<div class="sheet-example">
+	<div class="form-group">
+		<div class="custom-control custom-checkbox">
+			<label>
+				<input aria-hidden="true" class="custom-control-input" disabled onclick="return false;" readonly type="checkbox" />
+				<span class="custom-control-label">
+					<span class="custom-control-label-text">Unchecked Disabled Readonly</span>
+				</span>
+			</label>
+		</div>
+		<div class="custom-control custom-checkbox">
+			<label>
+				<input aria-hidden="true" checked class="custom-control-input" disabled onclick="return false;" readonly type="checkbox" />
+				<span class="custom-control-label">
+					<span class="custom-control-label-text">Checked Disabled Readonly</span>
+				</span>
+			</label>
+		</div>
+		<div class="clay-site-custom-checkbox-indeterminate">
+			<div class="custom-control custom-checkbox">
+				<label>
+					<input aria-hidden="true" class="clay-site-custom-checkbox-indeterminate custom-control-input" disabled onclick="return false;" readonly type="checkbox" />
+					<span class="custom-control-label">
+						<span class="custom-control-label-text">Indeterminate Disabled Readonly</span>
+					</span>
+				</label>
+			</div>
+		</div>
+	</div>
+</div>
+
+```html
+<div class="custom-control custom-checkbox">
+	<label>
+		<input
+			aria-hidden="true"
+			class="custom-control-input"
+			disabled
+			onclick="return false;"
+			readonly
+			type="checkbox"
+		/>
+		<span class="custom-control-label">
+			<span class="custom-control-label-text"
+				>Unchecked Disabled Readonly</span
+			>
+		</span>
+	</label>
+</div>
+<div class="custom-control custom-checkbox">
+	<label>
+		<input
+			aria-hidden="true"
+			checked
+			class="custom-control-input"
+			disabled
+			onclick="return false;"
+			readonly
+			type="checkbox"
+		/>
+		<span class="custom-control-label">
+			<span class="custom-control-label-text"
+				>Checked Disabled Readonly</span
+			>
+		</span>
+	</label>
+</div>
+<div class="custom-control custom-checkbox">
+	<label>
+		<input
+			aria-hidden="true"
+			class="clay-site-custom-checkbox-indeterminate custom-control-input"
+			disabled
+			onclick="return false;"
+			readonly
+			type="checkbox"
+		/>
+		<span class="custom-control-label">
+			<span class="custom-control-label-text"
+				>Indeterminate Disabled Readonly</span
 			>
 		</span>
 	</label>

--- a/packages/clay-form/src/Checkbox.tsx
+++ b/packages/clay-form/src/Checkbox.tsx
@@ -33,9 +33,9 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	label?: React.ReactText;
 
 	/**
-	 * Callback for when checkbox value is changed
+	 * Callback for when checkbox value is changed.
 	 */
-	onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const ClayCheckbox = React.forwardRef<HTMLInputElement, IProps>(
@@ -48,6 +48,7 @@ const ClayCheckbox = React.forwardRef<HTMLInputElement, IProps>(
 			indeterminate = false,
 			inline,
 			label,
+			readOnly,
 			...otherProps
 		}: IProps,
 		ref
@@ -74,11 +75,13 @@ const ClayCheckbox = React.forwardRef<HTMLInputElement, IProps>(
 				<label>
 					<input
 						{...otherProps}
+						aria-disabled={readOnly}
 						checked={checked}
 						className={classNames(
 							'custom-control-input',
 							className
 						)}
+						readOnly={readOnly}
 						ref={(r) => {
 							inputRef.current = r;
 							if (typeof ref === 'function') {

--- a/packages/clay-form/src/__tests__/Checkbox.tsx
+++ b/packages/clay-form/src/__tests__/Checkbox.tsx
@@ -3,40 +3,44 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {cleanup, render} from '@testing-library/react';
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
 
 import ClayCheckbox from '../Checkbox';
 
 describe('ClayCheckbox', () => {
+	afterEach(cleanup);
+
 	it('renders', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayCheckbox checked={false} onChange={() => {}} />
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with a label', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayCheckbox
 				checked={false}
 				label="Unchecked"
 				onChange={() => {}}
 			/>
 		);
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders as checked', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayCheckbox checked label="Checked" onChange={() => {}} />
 		);
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with an indeterminate value', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayCheckbox
 				checked
 				indeterminate
@@ -44,11 +48,12 @@ describe('ClayCheckbox', () => {
 				onChange={() => {}}
 			/>
 		);
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders as disabled', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayCheckbox
 				checked={false}
 				disabled
@@ -56,11 +61,12 @@ describe('ClayCheckbox', () => {
 				onChange={() => {}}
 			/>
 		);
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders as checked and disabled', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayCheckbox
 				checked
 				disabled
@@ -68,11 +74,12 @@ describe('ClayCheckbox', () => {
 				onChange={() => {}}
 			/>
 		);
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with an indeterminate value and disabled', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayCheckbox
 				checked
 				disabled
@@ -81,6 +88,15 @@ describe('ClayCheckbox', () => {
 				onChange={() => {}}
 			/>
 		);
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render as read only', () => {
+		const {container} = render(
+			<ClayCheckbox checked label="Indeterminate disabled" readOnly />
+		);
+
+		expect(container).toMatchSnapshot();
 	});
 });

--- a/packages/clay-form/src/__tests__/__snapshots__/Checkbox.tsx.snap
+++ b/packages/clay-form/src/__tests__/__snapshots__/Checkbox.tsx.snap
@@ -1,166 +1,197 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ClayCheckbox render as read only 1`] = `
+<div>
+  <div
+    class="custom-control custom-checkbox"
+  >
+    <label>
+      <input
+        aria-disabled="true"
+        checked=""
+        class="custom-control-input"
+        readonly=""
+        type="checkbox"
+      />
+      <span
+        class="custom-control-label"
+      >
+        <span
+          class="custom-control-label-text"
+        >
+          Indeterminate disabled
+        </span>
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`ClayCheckbox renders 1`] = `
-<div
-  className="custom-control custom-checkbox"
->
-  <label>
-    <input
-      checked={false}
-      className="custom-control-input"
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
-      className="custom-control-label"
-    />
-  </label>
+<div>
+  <div
+    class="custom-control custom-checkbox"
+  >
+    <label>
+      <input
+        class="custom-control-input"
+        type="checkbox"
+      />
+      <span
+        class="custom-control-label"
+      />
+    </label>
+  </div>
 </div>
 `;
 
 exports[`ClayCheckbox renders as checked 1`] = `
-<div
-  className="custom-control custom-checkbox"
->
-  <label>
-    <input
-      checked={true}
-      className="custom-control-input"
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
-      className="custom-control-label"
-    >
+<div>
+  <div
+    class="custom-control custom-checkbox"
+  >
+    <label>
+      <input
+        checked=""
+        class="custom-control-input"
+        type="checkbox"
+      />
       <span
-        className="custom-control-label-text"
+        class="custom-control-label"
       >
-        Checked
+        <span
+          class="custom-control-label-text"
+        >
+          Checked
+        </span>
       </span>
-    </span>
-  </label>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`ClayCheckbox renders as checked and disabled 1`] = `
-<div
-  className="custom-control custom-checkbox"
->
-  <label>
-    <input
-      checked={true}
-      className="custom-control-input"
-      disabled={true}
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
-      className="custom-control-label"
-    >
+<div>
+  <div
+    class="custom-control custom-checkbox"
+  >
+    <label>
+      <input
+        checked=""
+        class="custom-control-input"
+        disabled=""
+        type="checkbox"
+      />
       <span
-        className="custom-control-label-text"
+        class="custom-control-label"
       >
-        Checked disabled
+        <span
+          class="custom-control-label-text"
+        >
+          Checked disabled
+        </span>
       </span>
-    </span>
-  </label>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`ClayCheckbox renders as disabled 1`] = `
-<div
-  className="custom-control custom-checkbox"
->
-  <label>
-    <input
-      checked={false}
-      className="custom-control-input"
-      disabled={true}
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
-      className="custom-control-label"
-    >
+<div>
+  <div
+    class="custom-control custom-checkbox"
+  >
+    <label>
+      <input
+        class="custom-control-input"
+        disabled=""
+        type="checkbox"
+      />
       <span
-        className="custom-control-label-text"
+        class="custom-control-label"
       >
-        Unchecked disabled
+        <span
+          class="custom-control-label-text"
+        >
+          Unchecked disabled
+        </span>
       </span>
-    </span>
-  </label>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`ClayCheckbox renders with a label 1`] = `
-<div
-  className="custom-control custom-checkbox"
->
-  <label>
-    <input
-      checked={false}
-      className="custom-control-input"
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
-      className="custom-control-label"
-    >
+<div>
+  <div
+    class="custom-control custom-checkbox"
+  >
+    <label>
+      <input
+        class="custom-control-input"
+        type="checkbox"
+      />
       <span
-        className="custom-control-label-text"
+        class="custom-control-label"
       >
-        Unchecked
+        <span
+          class="custom-control-label-text"
+        >
+          Unchecked
+        </span>
       </span>
-    </span>
-  </label>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`ClayCheckbox renders with an indeterminate value 1`] = `
-<div
-  className="custom-control custom-checkbox"
->
-  <label>
-    <input
-      checked={true}
-      className="custom-control-input"
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
-      className="custom-control-label"
-    >
+<div>
+  <div
+    class="custom-control custom-checkbox"
+  >
+    <label>
+      <input
+        checked=""
+        class="custom-control-input"
+        type="checkbox"
+      />
       <span
-        className="custom-control-label-text"
+        class="custom-control-label"
       >
-        Indeterminate
+        <span
+          class="custom-control-label-text"
+        >
+          Indeterminate
+        </span>
       </span>
-    </span>
-  </label>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`ClayCheckbox renders with an indeterminate value and disabled 1`] = `
-<div
-  className="custom-control custom-checkbox"
->
-  <label>
-    <input
-      checked={true}
-      className="custom-control-input"
-      disabled={true}
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
-      className="custom-control-label"
-    >
+<div>
+  <div
+    class="custom-control custom-checkbox"
+  >
+    <label>
+      <input
+        checked=""
+        class="custom-control-input"
+        disabled=""
+        type="checkbox"
+      />
       <span
-        className="custom-control-label-text"
+        class="custom-control-label"
       >
-        Indeterminate disabled
+        <span
+          class="custom-control-label-text"
+        >
+          Indeterminate disabled
+        </span>
       </span>
-    </span>
-  </label>
+    </label>
+  </div>
 </div>
 `;


### PR DESCRIPTION
fixes #5085

Nothing needs to be done for the React component, it uses the same markup.