### PR TITLE
fix(@clayui/css): Tables table row variants should style the background

### DIFF
--- a/packages/clay-css/src/scss/cadmin/components/_tables.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_tables.scss
@@ -77,14 +77,6 @@ caption {
 
 // Table Row Backgrounds
 
-@each $cadmin-color, $cadmin-value in $cadmin-theme-colors {
-	@include table-row-variant(
-		$cadmin-color,
-		theme-color-level($cadmin-color, $cadmin-table-bg-level),
-		theme-color-level($cadmin-color, $cadmin-table-border-level)
-	);
-}
-
 .table-striped {
 	tbody .table-disabled:nth-of-type(#{$cadmin-table-striped-order}) {
 		td,

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -78,20 +78,28 @@ caption {
 // Table Row Backgrounds
 
 @each $color, $value in $table-row-theme-colors {
-	.table-#{$color} {
-		$table-row: setter($value, ());
+	.table {
+		.table-#{$color} {
+			$table-row: setter($value, ());
 
-		&,
-		> th,
-		> td {
-			@include clay-css($table-row);
-		}
+			&,
+			> th,
+			> td {
+				@include clay-css($table-row);
 
-		th,
-		td,
-		thead th,
-		tbody + tbody {
-			border-color: map-get($table-row, border-color);
+				.table-title {
+					@include clay-text-typography(
+						map-get($table-row, table-title)
+					);
+				}
+			}
+
+			th,
+			td,
+			thead th,
+			tbody + tbody {
+				border-color: map-get($table-row, border-color);
+			}
 		}
 	}
 

--- a/packages/clay-css/src/scss/variables/_tables.scss
+++ b/packages/clay-css/src/scss/variables/_tables.scss
@@ -938,6 +938,12 @@ $table-row-theme-colors: map-deep-merge(
 				background-color:
 					clay-darken(theme-color-level(dark, $table-bg-level), 5%),
 			),
+			table-title: (
+				color: $table-dark-color,
+				href: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$table-row-theme-colors


### PR DESCRIPTION
fixes #4876

This fixes table row modifiers that don't work. I removed them in Cadmin since we don't use them in our admin interface.

![table-row-variants](https://user-images.githubusercontent.com/788266/190494365-b1885554-18b5-40f8-ace8-6a839e12be6e.jpg)
