### PR TITLE
feat(@clayui/core): uses the Collection component for the TreeView

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -58,7 +58,7 @@ module.exports = {
 		'./packages/clay-core/src/tree-view/': {
 			branches: 68,
 			functions: 73,
-			lines: 77,
+			lines: 76,
 			statements: 75,
 		},
 		'./packages/clay-data-provider/src/': {

--- a/packages/clay-core/src/collection/Collection.tsx
+++ b/packages/clay-core/src/collection/Collection.tsx
@@ -6,24 +6,15 @@
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React from 'react';
 
-export type ChildrenFunction<T> = (item: T) => React.ReactElement;
+export type ChildrenFunction<T, P> = P extends Array<unknown>
+	? (item: T, ...args: P) => React.ReactElement
+	: (item: T) => React.ReactElement;
 
-interface IInternalProps {
-	/**
-	 * Component to render.
-	 */
-	as?: 'div' | React.ComponentType | React.ForwardRefExoticComponent<any>;
-
-	estimateSize?: number;
-
-	parentRef: React.RefObject<HTMLElement>;
-}
-
-export interface ICollectionProps<T> {
+export interface ICollectionProps<T, P> {
 	/**
 	 * Children content to render a dynamic or static content.
 	 */
-	children: React.ReactNode | ChildrenFunction<T>;
+	children: React.ReactNode | ChildrenFunction<T, P>;
 
 	/**
 	 * Property to render content with dynamic data.
@@ -36,11 +27,62 @@ export interface ICollectionProps<T> {
 	virtualize?: boolean;
 }
 
+interface IProps<P, K> {
+	/**
+	 * Component to render.
+	 */
+	as?: 'div' | React.ComponentType | React.ForwardRefExoticComponent<any>;
+
+	/**
+	 * Flag to estimate the default height of a list item in pixels.
+	 */
+	estimateSize?: number;
+
+	/**
+	 * Properties that should be omitted from item data when passed to
+	 * children function.
+	 */
+	exclude?: Set<K>;
+
+	/**
+	 * Add the reference of the parent element that will be used to define the
+	 * scroll and get the height of the element for virtualization of the
+	 * collection.
+	 */
+	parentRef: React.RefObject<HTMLElement>;
+
+	/**
+	 * Set for the parent's key to create the unique key of the list items, if
+	 * the collection is rendered nested.
+	 */
+	parentKey?: React.Key;
+
+	/**
+	 * Defines the public APIs that are passed in the children function when
+	 * it is a dynamic collection.
+	 */
+	publicApi?: P;
+
+	/**
+	 * Defines a component that will be used as a wrapper for items in the
+	 * collection if defined.
+	 */
+	itemContainer?: React.ComponentType<Record<string, any>>;
+}
+
 type ChildElement = React.ReactElement<any> & {
 	ref?: (node: HTMLElement | null) => void;
 };
 
-export function getKey(index: number, key?: React.Key | null) {
+/**
+ * Helper function to create a unique key for list or tree when defined by
+ * developer data or obtained by component in React.
+ */
+export function getKey(
+	index: number,
+	key?: React.Key | null,
+	parentKey?: React.Key
+) {
 	if (
 		key != null &&
 		(!String(key).startsWith('.') || String(key).startsWith('.$'))
@@ -48,21 +90,41 @@ export function getKey(index: number, key?: React.Key | null) {
 		return key;
 	}
 
-	return `$.${index}`;
+	return parentKey ? `${parentKey}.${index}` : `$.${index}`;
 }
 
-type VirtualProps<T> = IInternalProps & {
-	children: ChildrenFunction<T>;
+/**
+ * Helper function for omitting properties of an object, similar to
+ * TypeScript's Omit<T, K>.
+ */
+export function excludeProps<T extends Record<string, any>, K extends keyof T>(
+	props: T,
+	items: Set<K>
+) {
+	return (Object.keys(props) as Array<K>).reduce<T>((previous, key) => {
+		if (!items.has(key)) {
+			previous[key] = props[key];
+		}
+
+		return previous;
+	}, {} as T);
+}
+
+type VirtualProps<T, P, K> = IProps<P, K> & {
+	children: ChildrenFunction<T, P>;
 	items: Array<T>;
 };
 
-function VirtualDynamicCollection<T extends Record<any, any>>({
+function VirtualDynamicCollection<T extends Record<any, any>, P, K>({
 	as: Container = 'div',
 	children,
 	estimateSize = 37,
+	exclude,
 	items,
+	parentKey,
 	parentRef,
-}: VirtualProps<T>) {
+	publicApi,
+}: VirtualProps<T, P, K>) {
 	const virtualizer = useVirtualizer({
 		count: items.length,
 		estimateSize: () => estimateSize,
@@ -79,10 +141,17 @@ function VirtualDynamicCollection<T extends Record<any, any>>({
 		>
 			{virtualizer.getVirtualItems().map((virtual) => {
 				const item = items[virtual.index];
+				const publicItem = exclude ? excludeProps(item, exclude) : item;
 
-				const child: ChildElement = children(item);
+				const child: ChildElement = Array.isArray(publicApi)
+					? children(publicItem, ...publicApi)
+					: children(publicItem);
 
-				const key = getKey(virtual.index, item.id ?? child.key);
+				const key = getKey(
+					virtual.index,
+					item.id ?? child.key,
+					parentKey
+				);
 
 				return React.cloneElement(child, {
 					key,
@@ -107,21 +176,31 @@ function VirtualDynamicCollection<T extends Record<any, any>>({
 	);
 }
 
-export function Collection<T extends Record<any, any>>({
+export function Collection<
+	T extends Record<any, any>,
+	P = unknown,
+	K = unknown
+>({
 	as,
 	children,
 	estimateSize,
+	exclude,
+	itemContainer: ItemContainer,
 	items,
+	parentKey,
 	parentRef,
+	publicApi,
 	virtualize = false,
-}: ICollectionProps<T> & Partial<IInternalProps>) {
+}: ICollectionProps<T, P> & Partial<IProps<P, K>>) {
 	if (virtualize && children instanceof Function && items && parentRef) {
 		return (
 			<VirtualDynamicCollection
 				as={as}
 				estimateSize={estimateSize}
 				items={items}
+				parentKey={parentKey}
 				parentRef={parentRef}
+				publicApi={publicApi}
 			>
 				{children}
 			</VirtualDynamicCollection>
@@ -132,11 +211,33 @@ export function Collection<T extends Record<any, any>>({
 
 	return (
 		<Container>
-			{typeof children === 'function' && items
+			{children instanceof Function && items
 				? items.map((item, index) => {
-						const child: ChildElement = children(item);
+						const publicItem = exclude
+							? excludeProps(item, exclude)
+							: item;
+						const child: ChildElement = Array.isArray(publicApi)
+							? children(publicItem, ...publicApi)
+							: children(publicItem);
 
-						const key = getKey(index, item.id ?? child.key);
+						const key = getKey(
+							index,
+							item.id ?? child.key,
+							parentKey
+						);
+
+						if (ItemContainer) {
+							return (
+								<ItemContainer
+									index={index}
+									item={item}
+									key={key}
+									keyValue={key}
+								>
+									{child}
+								</ItemContainer>
+							);
+						}
 
 						return React.cloneElement(child, {
 							key,
@@ -148,11 +249,24 @@ export function Collection<T extends Record<any, any>>({
 							return null;
 						}
 
-						const key = getKey(index, child.key);
+						const key = getKey(index, child.key, parentKey);
+
+						if (ItemContainer) {
+							return (
+								<ItemContainer
+									index={index}
+									key={key}
+									keyValue={key}
+								>
+									{child}
+								</ItemContainer>
+							);
+						}
 
 						return React.cloneElement(
 							child as React.ReactElement<{keyValue?: React.Key}>,
 							{
+								key,
 								keyValue: key,
 							}
 						);

--- a/packages/clay-core/src/collection/index.ts
+++ b/packages/clay-core/src/collection/index.ts
@@ -3,4 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-export {Collection, ICollectionProps} from './Collection';
+export {
+	Collection,
+	ChildrenFunction,
+	excludeProps,
+	ICollectionProps,
+	getKey,
+} from './Collection';

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -16,6 +16,14 @@ interface ITreeViewGroupProps<T>
 	extends ICollectionProps<T>,
 		Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {}
 
+function List({children}: React.HTMLAttributes<HTMLUListElement>) {
+	return (
+		<ul className="treeview-group" role="group">
+			{children}
+		</ul>
+	);
+}
+
 export function TreeViewGroup<T>(props: ITreeViewGroupProps<T>): JSX.Element & {
 	displayName: string;
 };
@@ -60,9 +68,9 @@ export function TreeViewGroup<T extends Record<any, any>>({
 			unmountOnExit
 		>
 			<div>
-				<ul className="treeview-group" role="group">
-					<Collection<T> items={items}>{children}</Collection>
-				</ul>
+				<Collection<T> as={List} items={items}>
+					{children}
+				</Collection>
 			</div>
 		</CSSTransition>
 	);

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -276,101 +276,113 @@ export const TreeViewItem = React.forwardRef<
 
 						const {key} = event;
 
-						if (key === Keys.Left) {
-							if (
-								!close(item.key) &&
-								item.parentItemRef?.current
-							) {
-								item.parentItemRef.current.focus();
+						switch (key) {
+							case Keys.Left:
+								if (
+									!close(item.key) &&
+									item.parentItemRef?.current
+								) {
+									item.parentItemRef.current.focus();
+								}
+								break;
+							case Keys.Right:
+								if (!group) {
+									if (onLoadMore) {
+										setLoading(true);
+										onLoadMore(item)
+											.then((items) => {
+												setLoading(false);
+
+												if (!items) {
+													return;
+												}
+
+												insert(
+													[...item.indexes, 0],
+													items
+												);
+											})
+											.catch((error) => {
+												console.error(error);
+											});
+									} else {
+										return;
+									}
+								}
+
+								if (!open(item.key) && item.itemRef.current) {
+									const group =
+										item.itemRef.current.parentElement?.querySelector<HTMLDivElement>(
+											'.treeview-group'
+										);
+									const firstItemElement =
+										group?.querySelector<HTMLDivElement>(
+											'.treeview-link:not(.disabled)'
+										);
+
+									firstItemElement?.focus();
+								} else {
+									item.itemRef.current?.focus();
+								}
+								break;
+							case Keys.Backspace:
+							case Keys.Del: {
+								remove(item.indexes);
+								item.parentItemRef.current?.focus();
+								break;
 							}
-						}
+							case Keys.Home: {
+								const firstListElement = rootRef.current
+									?.firstElementChild as HTMLLinkElement;
+								const linkElement =
+									firstListElement.firstElementChild as HTMLDivElement;
 
-						if (key === Keys.Right) {
-							if (!group) {
-								if (onLoadMore) {
-									setLoading(true);
-									onLoadMore(item)
-										.then((items) => {
-											setLoading(false);
+								linkElement.focus();
+								break;
+							}
+							case Keys.End: {
+								const lastListElement = rootRef.current
+									?.lastElementChild as HTMLLinkElement;
+								const linkElement =
+									lastListElement.firstElementChild as HTMLDivElement;
 
-											if (!items) {
-												return;
-											}
+								linkElement.focus();
+								break;
+							}
+							case Keys.Spacebar: {
+								selection.toggleSelection(item.key);
 
-											insert([...item.indexes, 0], items);
+								if (onSelect) {
+									onSelect(removeItemInternalProps(item));
+								}
+								break;
+							}
+							case Keys.R.toLowerCase():
+							case Keys.R:
+							case Keys.F2: {
+								if (onRenameItem) {
+									onRenameItem({...item})
+										.then((newItem) => {
+											replace(item.indexes, {
+												...newItem,
+												index: item.index,
+												indexes: item.indexes,
+												itemRef: item.itemRef,
+												key: item.key,
+												parentItemRef:
+													item.parentItemRef,
+											});
+
+											item.itemRef.current?.focus();
 										})
 										.catch((error) => {
 											console.error(error);
 										});
-								} else {
-									return;
 								}
+								break;
 							}
-							if (!open(item.key) && item.itemRef.current) {
-								const group =
-									item.itemRef.current.parentElement?.querySelector<HTMLDivElement>(
-										'.treeview-group'
-									);
-								const firstItemElement =
-									group?.querySelector<HTMLDivElement>(
-										'.treeview-link:not(.disabled)'
-									);
-								firstItemElement?.focus();
-							} else {
-								item.itemRef.current?.focus();
-							}
-						}
-
-						if (key === Keys.Backspace || key === Keys.Del) {
-							remove(item.indexes);
-
-							item.parentItemRef.current?.focus();
-						}
-
-						if (key === Keys.End) {
-							const lastListElement = rootRef.current
-								?.lastElementChild as HTMLLinkElement;
-							const linkElement =
-								lastListElement.firstElementChild as HTMLDivElement;
-							linkElement.focus();
-						}
-
-						if (key === Keys.Home) {
-							const firstListElement = rootRef.current
-								?.firstElementChild as HTMLLinkElement;
-							const linkElement =
-								firstListElement.firstElementChild as HTMLDivElement;
-							linkElement.focus();
-						}
-
-						if (
-							(key.toUpperCase() === Keys.R || key === Keys.F2) &&
-							onRenameItem
-						) {
-							onRenameItem({...item})
-								.then((newItem) => {
-									replace(item.indexes, {
-										...newItem,
-										index: item.index,
-										indexes: item.indexes,
-										itemRef: item.itemRef,
-										key: item.key,
-										parentItemRef: item.parentItemRef,
-									});
-
-									item.itemRef.current?.focus();
-								})
-								.catch((error) => {
-									console.error(error);
-								});
-						}
-
-						if (key === Keys.Spacebar) {
-							selection.toggleSelection(item.key);
-
-							if (onSelect) {
-								onSelect(removeItemInternalProps(item));
-							}
+							default:
+								break;
 						}
 					}}
 					ref={ref}

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -48,7 +48,7 @@ export type Expand = {
 	has: (key: Key) => boolean;
 };
 
-export function useAPI() {
+export function useAPI(): [Selection, Expand] {
 	const {expandedKeys, selection, toggle} = useTreeViewContext();
 
 	const hasKey = useCallback(
@@ -69,5 +69,5 @@ export function useAPI() {
 			toggle: selection.toggleSelection,
 		},
 		{has: hasExpandedKey, toggle},
-	] as const;
+	];
 }

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -6,7 +6,7 @@
 import {useInternalState} from '@clayui/shared';
 import {Key, useCallback, useMemo, useRef} from 'react';
 
-import {getKey} from './Collection';
+import {getKey} from '../collection';
 import {ITreeProps, createImmutableTree} from './useTree';
 
 import type {ICollectionProps} from './Collection';

--- a/packages/clay-core/src/vertical-bar/Bar.tsx
+++ b/packages/clay-core/src/vertical-bar/Bar.tsx
@@ -10,7 +10,7 @@ import {Collection} from '../collection';
 
 import type {ICollectionProps} from '../collection';
 
-interface IProps<T> extends ICollectionProps<T> {
+interface IProps<T> extends ICollectionProps<T, unknown> {
 	/**
 	 * Flag to determine which style the Bar will display.
 	 */

--- a/packages/clay-core/src/vertical-bar/Content.tsx
+++ b/packages/clay-core/src/vertical-bar/Content.tsx
@@ -15,7 +15,7 @@ type Context = {
 
 export const ContentContext = React.createContext<Context>({} as Context);
 
-interface IProps<T> extends Omit<ICollectionProps<T>, 'virtualize'> {
+interface IProps<T> extends Omit<ICollectionProps<T, unknown>, 'virtualize'> {
 	/**
 	 * Flag to determine which style the VerticalBar will display.
 	 */


### PR DESCRIPTION

Closes #5098, From #5045

In PR #5045 the idea is to create a Collection virtualization with support for the Tree data structure, the first thing that needed to be done is to make the TreeView component use the base component of Collection. This PR brings the commits of the other PR that adds new functionality to the Collection component to support the TreeView use cases, a gain of this is that we can have the Collection centralized now and we leave #5045 with low priority for now and on hold, see the comments in PR.

I'm submitting this in a new PR to keep progress history of the virtualization implementation for Tree. 