### PR TITLE
feat(@clayui/core): add paginated data support to TreeView

### DIFF
--- a/packages/clay-core/docs/treeview.mdx
+++ b/packages/clay-core/docs/treeview.mdx
@@ -160,7 +160,12 @@ function Example() {
 
 #### Asynchronous Item
 
-When a tree is very large, loading items (nodes) asynchronously is preferred to decrease the initial payload and memory space.
+When a tree is very large, loading items (nodes) asynchronously is preferred to decrease the initial payload and memory space. TreeView provides two ways to load asynchronous data:
+
+-   Load the children of an item when clicking on the item
+-   Load paginated data from an item
+
+**Load the children of an item**
 
 The TreeView doesn't know when an item is asynchronous, so the developer must specify whether the item is asynchronous or not. The `onLoadMore` property is called every time the item is a leaf node of the tree and depending on the method's return value it will behave differently.
 
@@ -183,6 +188,52 @@ When adding a new asynchronous item to the tree, the `onItemsChange` method is r
 	}}
 >
 	{...}
+</TreeView>
+```
+
+**Load paginated data from an item**
+
+The `onLoadMore` API can also be used to load paginated data for a specific item. The signature just needs to be followed so the TreeView can know what to do.
+
+```jsx
+<TreeView
+	onLoadMore={async (item, cursor) => {
+		const result = await fetch(cursor ?? `example.com/tree/item?parent_id=${item.id}`);
+
+		return {
+			cursor: result.next,
+			items: result.data,
+		};
+	}}
+>
+	{...}
+</TreeView>
+```
+
+The `cursor` helps to store the data that will be used to identify which will be the next request, this can be an `offset`, `cursor`, `id` the URL or any other data that represents the item cursor, when there is no more data just sets the cursor to `null`. The TreeView also exposes a public API that can invoke `loadMore` and find out if there is a cursor for a specific item.
+
+```jsx
+<TreeView {...}>
+	{(item, selection, expand, load) => (
+		<TreeView.Item>
+			<TreeView.ItemStack>{item.name}</TreeView.ItemStack>
+			<TreeView.Group items={item.children}>
+				{(item) => (
+					<TreeView.Item>{item.name}</TreeView.Item>
+				)}
+			</TreeView.Group>
+
+			{expand.has(item.id) && load.has(item.id) !== null && (
+				<Button
+					borderless
+					displayType="secondary"
+					onClick={() => load.loadMore(item.id, item)}
+				>
+					Load more results
+				</Button>
+			)}
+		</TreeView.Item>
+	)}
 </TreeView>
 ```
 

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -10,11 +10,11 @@ import {
 	Collection as CollectionBase,
 	excludeProps,
 } from '../collection';
-import {Expand, Selection, useAPI} from './context';
+import {Expand, LoadMore, Selection, useAPI} from './context';
 import {ItemContextProvider, useItem} from './useItem';
 
 export type ChildrenFunction<T extends Record<string, any>> =
-	ChildrenFunctionBase<T, [Selection, Expand]>;
+	ChildrenFunctionBase<T, [Selection, Expand, LoadMore]>;
 
 export interface ICollectionProps<T> {
 	children: React.ReactNode | ChildrenFunction<T>;

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -13,7 +13,7 @@ import {ChildrenFunction, Collection, ICollectionProps} from './Collection';
 import DragLayer from './DragLayer';
 import {TreeViewGroup} from './TreeViewGroup';
 import {TreeViewItem, TreeViewItemStack} from './TreeViewItem';
-import {Icons, TreeViewContext} from './context';
+import {Icons, OnLoadMore, TreeViewContext} from './context';
 import {ITreeProps, useTree} from './useTree';
 
 interface ITreeViewProps<T>
@@ -70,7 +70,7 @@ interface ITreeViewProps<T>
 	 * decrease the initial payload and memory space. The callback is called every time
 	 * the item is a leaf node of the tree.
 	 */
-	onLoadMore?: (item: T) => Promise<unknown>;
+	onLoadMore?: OnLoadMore<T>;
 
 	/**
 	 * Callback called whenever an item is selected. Similar to the `onSelectionChange`

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -80,7 +80,6 @@ export const TreeViewItem = React.forwardRef<
 		close,
 		expandDoubleClick,
 		expandedKeys,
-		insert,
 		nestedKey,
 		onLoadMore,
 		onRenameItem,
@@ -103,6 +102,8 @@ export const TreeViewItem = React.forwardRef<
 	const clickCapturedRef = useRef(false);
 
 	const api = useAPI();
+
+	const loadMore = api[2];
 
 	const [left, right, ...otherElements] = React.Children.toArray(children);
 
@@ -252,20 +253,11 @@ export const TreeViewItem = React.forwardRef<
 						if (group) {
 							toggle(item.key);
 						} else {
-							if (onLoadMore) {
-								setLoading(true);
-								onLoadMore(item)
-									.then((items) => {
-										setLoading(false);
+							const promise = loadMore(item.key, item, true);
 
-										if (items) {
-											insert([...item.indexes, 0], items);
-											toggle(item.key);
-										}
-									})
-									.catch((error) => {
-										console.error(error);
-									});
+							if (promise) {
+								setLoading(true);
+								promise.then(() => setLoading(false));
 							}
 						}
 					}}
@@ -316,24 +308,11 @@ export const TreeViewItem = React.forwardRef<
 								break;
 							case Keys.Right:
 								if (!group) {
-									if (onLoadMore) {
+									const promise = loadMore(item.key, item);
+
+									if (promise) {
 										setLoading(true);
-										onLoadMore(item)
-											.then((items) => {
-												setLoading(false);
-
-												if (!items) {
-													return;
-												}
-
-												insert(
-													[...item.indexes, 0],
-													items
-												);
-											})
-											.catch((error) => {
-												console.error(error);
-											});
+										promise.then(() => setLoading(false));
 									} else {
 										return;
 									}

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -103,7 +103,7 @@ export const TreeViewItem = React.forwardRef<
 
 	const api = useAPI();
 
-	const loadMore = api[2];
+	const load = api[2];
 
 	const [left, right, ...otherElements] = React.Children.toArray(children);
 
@@ -253,7 +253,7 @@ export const TreeViewItem = React.forwardRef<
 						if (group) {
 							toggle(item.key);
 						} else {
-							const promise = loadMore(item.key, item, true);
+							const promise = load.loadMore(item.key, item, true);
 
 							if (promise) {
 								setLoading(true);
@@ -308,7 +308,10 @@ export const TreeViewItem = React.forwardRef<
 								break;
 							case Keys.Right:
 								if (!group) {
-									const promise = loadMore(item.key, item);
+									const promise = load.loadMore(
+										item.key,
+										item
+									);
 
 									if (promise) {
 										setLoading(true);

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -104,7 +104,7 @@ export const TreeViewItem = React.forwardRef<
 
 	const api = useAPI();
 
-	const [left, right] = React.Children.toArray(children);
+	const [left, right, ...otherElements] = React.Children.toArray(children);
 
 	const group =
 		// @ts-ignore
@@ -468,6 +468,16 @@ export const TreeViewItem = React.forwardRef<
 					</span>
 				</div>
 				{group}
+
+				{Boolean(otherElements.length) && (
+					<div
+						style={{
+							paddingLeft: `${spacing + 24}px`,
+						}}
+					>
+						{otherElements}
+					</div>
+				)}
 			</li>
 		</SpacingContext.Provider>
 	);

--- a/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/tree-view/__tests__/IncrementalInteractions.tsx
@@ -1120,7 +1120,7 @@ describe('TreeView incremental interactions', () => {
 								</TreeView.Group>
 
 								{expand.has(item.id) &&
-									load.has(item.id) !== null && (
+									load.get(item.id) !== null && (
 										<Button
 											borderless
 											displayType="secondary"

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -59,7 +59,7 @@ export type Expand = {
 };
 
 export type LoadMore = {
-	has: (key: Key) => any;
+	get: (key: Key) => any;
 	loadMore: <T>(
 		id: React.Key,
 		item: T,
@@ -126,7 +126,7 @@ export function useAPI(): [Selection, Expand, LoadMore] {
 		[expandedKeys]
 	);
 
-	const hasCursor = useCallback(
+	const getCursor = useCallback(
 		(key: Key) => cursors.current.get(key),
 		[cursors]
 	);
@@ -137,6 +137,6 @@ export function useAPI(): [Selection, Expand, LoadMore] {
 			toggle: selection.toggleSelection,
 		},
 		{has: hasExpandedKey, toggle},
-		{has: hasCursor, loadMore},
+		{get: getCursor, loadMore},
 	];
 }

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -56,11 +56,11 @@ export function ItemContextProvider({children, value}: Props) {
 		dragAndDrop,
 		expandedKeys,
 		items,
+		layout,
 		nestedKey,
 		onItemMove,
 		open,
 		reorder,
-		selection,
 	} = useTreeViewContext();
 	const {
 		indexes: parentIndexes = [],
@@ -88,14 +88,14 @@ export function ItemContextProvider({children, value}: Props) {
 
 	useEffect(
 		() =>
-			selection.createPartialLayoutItem(
+			layout.createPartialLayoutItem(
 				keyRef.current,
 				hasLazyChildren,
 				indexesRef.current,
 				parentKey
 			),
 		[
-			selection.createPartialLayoutItem,
+			layout.createPartialLayoutItem,
 			hasLazyChildren,
 			indexesRef,
 			keyRef,

--- a/packages/clay-core/src/tree-view/useLayout.ts
+++ b/packages/clay-core/src/tree-view/useLayout.ts
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {Key, useCallback, useRef} from 'react';
+
+export type LayoutInfo = {
+	children: Set<Key>;
+
+	/**
+	 * Lazy Child means that the current Node has children but they were not
+	 * created because they are not visible in the DOM.
+	 */
+	lazyChild: boolean;
+	loc: Array<number>;
+	parentKey?: Key;
+};
+
+export type Layout = {
+	createPartialLayoutItem: (
+		key: Key,
+		lazy: boolean,
+		loc: Array<number>,
+		parentKey?: Key
+	) => () => void;
+	layoutKeys: React.MutableRefObject<Map<Key, LayoutInfo>>;
+};
+
+export function useLayout(): Layout {
+	const layoutKeys = useRef(new Map<Key, LayoutInfo>());
+
+	/**
+	 * The method creates the mirror of the tree in a hashmap structure with a
+	 * linked list using `parentKey` and `children`. Adding data to the structure
+	 * is reactive to item component rendering and disassembly. Only the rendered
+	 * items are in the structure, if a component is moved, removed, or added the
+	 * structure is updated automatically.
+	 *
+	 * useEffect(() => createPartialLayoutItem(...), []);
+	 *
+	 * The design of this method is to be coupled to `useEffect` which has the
+	 * mount and unmount behavior, also handles lifecycle and call order,
+	 * `useEffect` in nested components are called bottom-up instead of top-down
+	 * as in rendering.
+	 */
+	const createPartialLayoutItem = useCallback(
+		(key: Key, lazyChild: boolean, loc: Array<number>, parentKey?: Key) => {
+			const keyMap = layoutKeys.current.get(key);
+
+			if (!keyMap) {
+				layoutKeys.current.set(key, {
+					children: new Set(),
+					lazyChild,
+					loc,
+					parentKey,
+				});
+			} else if (keyMap.parentKey !== parentKey) {
+				layoutKeys.current.set(key, {
+					...keyMap,
+					parentKey,
+				});
+			}
+
+			if (parentKey) {
+				const keyMap = layoutKeys.current.get(parentKey);
+
+				if (keyMap) {
+					layoutKeys.current.set(parentKey, {
+						...keyMap,
+						children: new Set([...keyMap.children, key]),
+						lazyChild: false,
+					});
+				} else {
+					// Pre-initializes the parent layout, as this is linked to
+					// React rendering, the mount is used inside `useEffect`
+					// this causes callbacks from the last rendering to be
+					// called first than parents, starting from the bottom up.
+					//
+					// We just add an initial value then update the parentKey
+					// when the corresponding one is called.
+					layoutKeys.current.set(parentKey, {
+						children: new Set([key]),
+						lazyChild: false,
+						loc: loc.slice(0, -1),
+						parentKey: undefined,
+					});
+				}
+			}
+
+			return function unmount() {
+				layoutKeys.current.delete(key);
+
+				if (parentKey && layoutKeys.current.has(parentKey)) {
+					const keyMap = layoutKeys.current.get(
+						parentKey
+					) as LayoutInfo;
+
+					const children = new Set(keyMap.children);
+
+					children.delete(key);
+
+					layoutKeys.current.set(parentKey, {
+						...keyMap,
+						children,
+						lazyChild: children.size === 0,
+					});
+				}
+			};
+		},
+		[layoutKeys]
+	);
+
+	return {createPartialLayoutItem, layoutKeys};
+}

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -6,6 +6,7 @@
 import {useInternalState} from '@clayui/shared';
 import React, {useCallback, useEffect} from 'react';
 
+import {Layout, useLayout} from './useLayout';
 import {
 	IMultipleSelection,
 	IMultipleSelectionState,
@@ -79,6 +80,7 @@ export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {
 	close: (key: Key) => boolean;
 	expandedKeys: Set<Key>;
 	insert: (path: Array<number>, value: unknown) => void;
+	layout: Layout;
 	open: (key: Key) => boolean;
 	remove: (path: Array<number>) => void;
 	reorder: (from: Array<number>, path: Array<number>) => void;
@@ -97,9 +99,12 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 		value: props.items,
 	});
 
+	const layout = useLayout();
+
 	const selection = useMultipleSelection<T>({
 		defaultSelectedKeys: props.defaultSelectedKeys,
 		items,
+		layoutKeys: layout.layoutKeys,
 		nestedKey: props.nestedKey,
 		onSelectionChange: props.onSelectionChange,
 		selectedKeys: props.selectedKeys,
@@ -289,6 +294,7 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 		expandedKeys,
 		insert,
 		items,
+		layout,
 		open,
 		remove,
 		reorder,
@@ -479,7 +485,14 @@ export function createImmutableTree<T extends Array<Record<string, any>>>(
 					const node = nodeByPath(path);
 
 					if (node.parent) {
-						node.parent[nestedKey] = value;
+						if (node.parent[nestedKey]) {
+							node.parent[nestedKey] = [
+								...node.parent[nestedKey],
+								...(value as Array<unknown>),
+							];
+						} else {
+							node.parent[nestedKey] = value;
+						}
 					}
 
 					break;

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -4,7 +4,7 @@
  */
 
 import {useInternalState} from '@clayui/shared';
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 
 import {Layout, useLayout} from './useLayout';
 import {
@@ -78,6 +78,7 @@ export interface ITreeProps<T>
 
 export interface ITreeState<T> extends Pick<ICollectionProps<T>, 'items'> {
 	close: (key: Key) => boolean;
+	cursors: React.MutableRefObject<Map<React.Key, unknown>>;
 	expandedKeys: Set<Key>;
 	insert: (path: Array<number>, value: unknown) => void;
 	layout: Layout;
@@ -98,6 +99,8 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 		onChange: props.onItemsChange,
 		value: props.items,
 	});
+
+	const cursors = useRef<Map<React.Key, unknown>>(new Map());
 
 	const layout = useLayout();
 
@@ -291,6 +294,7 @@ export function useTree<T>(props: ITreeProps<T>): ITreeState<T> {
 
 	return {
 		close,
+		cursors,
 		expandedKeys,
 		insert,
 		items,

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -1078,10 +1078,15 @@ export const AsyncLoadDataPaginated = () => (
 	<TreeView
 		defaultItems={ITEMS_DRIVE}
 		nestedKey="children"
-		onLoadMore={async (item) => {
+		onLoadMore={async (item, cursor: number = 1) => {
 			// Example conditional, I don't want to load data for an item that has
 			// no children.
 			if (!item.children) {
+				return;
+			}
+
+			// No more data to fetch.
+			if (cursor === null) {
 				return;
 			}
 
@@ -1090,9 +1095,11 @@ export const AsyncLoadDataPaginated = () => (
 				setTimeout(() => resolve(''), 1000);
 			});
 
+			const newCursor = cursor + 1;
+
 			return {
 				// Just for simulation
-				cursor: 'http://clay.dev/...',
+				cursor: newCursor <= 3 ? newCursor : null,
 				items: [
 					{
 						id: Math.random(),
@@ -1110,7 +1117,7 @@ export const AsyncLoadDataPaginated = () => (
 			};
 		}}
 	>
-		{(item, selection, expand, loadMore) => (
+		{(item, selection, expand, load) => (
 			<TreeView.Item>
 				<TreeView.ItemStack>
 					<Icon symbol="folder" />
@@ -1125,11 +1132,11 @@ export const AsyncLoadDataPaginated = () => (
 					)}
 				</TreeView.Group>
 
-				{expand.has(item.id) && (
+				{expand.has(item.id) && load.has(item.id) !== null && (
 					<Button
 						borderless
 						displayType="secondary"
-						onClick={() => loadMore(item.id, item)}
+						onClick={() => load.loadMore(item.id, item)}
 					>
 						Load more results
 					</Button>

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -1076,7 +1076,14 @@ export const AsyncLoad = () => (
 
 export const AsyncLoadDataPaginated = () => (
 	<TreeView
-		defaultItems={ITEMS_DRIVE}
+		defaultExpandedKeys={new Set(['root'])}
+		defaultItems={[
+			{
+				children: ITEMS_DRIVE,
+				id: 'root',
+				name: 'Root',
+			},
+		]}
 		nestedKey="children"
 		onLoadMore={async (item, cursor: number = 1) => {
 			// Example conditional, I don't want to load data for an item that has

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -1074,11 +1074,76 @@ export const AsyncLoad = () => (
 	</TreeView>
 );
 
+export const AsyncLoadDataPaginated = () => (
+	<TreeView
+		defaultItems={ITEMS_DRIVE}
+		nestedKey="children"
+		onLoadMore={async (item) => {
+			// Example conditional, I don't want to load data for an item that has
+			// no children.
+			if (!item.children) {
+				return;
+			}
+
+			// Delay to simulate loading of new data
+			await new Promise((resolve) => {
+				setTimeout(() => resolve(''), 1000);
+			});
+
+			return {
+				// Just for simulation
+				cursor: 'http://clay.dev/...',
+				items: [
+					{
+						id: Math.random(),
+						name: `${item.name} ${Math.random()}`,
+					},
+					{
+						id: Math.random(),
+						name: `${item.name} ${Math.random()}`,
+					},
+					{
+						id: Math.random(),
+						name: `${item.name} ${Math.random()}`,
+					},
+				],
+			};
+		}}
+	>
+		{(item, selection, expand, loadMore) => (
+			<TreeView.Item>
+				<TreeView.ItemStack>
+					<Icon symbol="folder" />
+					{item.name}
+				</TreeView.ItemStack>
+				<TreeView.Group items={item.children}>
+					{(item) => (
+						<TreeView.Item>
+							<Icon symbol="folder" />
+							{item.name}
+						</TreeView.Item>
+					)}
+				</TreeView.Group>
+
+				{expand.has(item.id) && (
+					<Button
+						borderless
+						displayType="secondary"
+						onClick={() => loadMore(item.id, item)}
+					>
+						Load more results
+					</Button>
+				)}
+			</TreeView.Item>
+		)}
+	</TreeView>
+);
+
 export const AsyncLoadWithErrorHandling = () => {
 	const [renderToast, setRenderToast] = useState(false);
 
 	const onLoadMore = () => {
-		return new Promise((resolve, reject) => {
+		return new Promise<any>((resolve, reject) => {
 			setTimeout(() => {
 				reject(new Error('Could not load more items'));
 			}, 1000);


### PR DESCRIPTION
Closes #5096

To support paginated data in TreeView, I had to expose a new API to render props to allow it to be called in composition, this is a bit similar to how it works in `useResource`, the return of `loadMore` tells how it will behave, this works like a contract to allow having the behavior of loading the item's children when expanding a node or loading a node's paginated data. It is also possible to say that you do not want to load the data of a specific item, for example in the stories that are in the Storybook.

```jsx
<TreeView
  onLoadMore={async (item) => {
    // Fetch data

    return {
      cursor: result.next,
      items: result.data.list,
    };
  }}
>
  {(item, selection, expand, loadMore) => (
    <TreeView.Item>
      ...

      {expand.has(item.id) && (
        <Button
          borderless
          displayType="secondary"
          onClick={() => loadMore(item.id, item)}
        >
          Load more results
        </Button>
      )}
    </TreeView.Item>
  )}
</TreeView>
```

I tried to make the `loadMore` API public not need to receive an id and the item but unfortunately I couldn't avoid this due to the nesting system, maybe in the future we can avoid it but for now it had to be passed because internally it doesn't we have visibility of this information when the APIs are passed.

## ToDo

- [x] Add documentation for paginated data with `loadMore`
- [x] Add test for use case