### PR TITLE
feat(@clayui/autocomplete): deprecated the `onSetActive` API and replaced it with `onActiveChange`

### DIFF
--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -27,6 +27,7 @@
 	],
 	"dependencies": {
 		"@clayui/drop-down": "^3.74.0",
+		"@clayui/shared": "^3.73.0",
 		"@clayui/form": "^3.74.0",
 		"@clayui/loading-indicator": "^3.60.0",
 		"fuzzy": "^0.1.3"

--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayDropDown from '@clayui/drop-down';
+import DropDown from '@clayui/drop-down';
+import {InternalDispatch} from '@clayui/shared';
 import React from 'react';
 
 import Context from './Context';
@@ -28,11 +29,17 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * Flag to indicate if clicking outside of the menu should automatically close it.
 	 */
 	closeOnClickOutside?: React.ComponentProps<
-		typeof ClayDropDown.Menu
+		typeof DropDown.Menu
 	>['closeOnClickOutside'];
 
 	/**
+	 * Callback for when the active state changes (controlled).
+	 */
+	onActiveChange?: InternalDispatch<boolean>;
+
+	/**
 	 * Callback function for when active state changes.
+	 * @deprecated since v3.74.0 - use `onActiveChange` instead.
 	 */
 	onSetActive?: (val: boolean) => void;
 }
@@ -43,7 +50,8 @@ const ClayAutocompleteDropDown = ({
 	alignmentByViewport,
 	children,
 	closeOnClickOutside,
-	onSetActive = () => {},
+	onActiveChange,
+	onSetActive,
 }: IProps) => {
 	const {containerElementRef} = React.useContext(Context);
 	const menuElementRef = React.useRef<HTMLDivElement>(null);
@@ -56,14 +64,14 @@ const ClayAutocompleteDropDown = ({
 		alignElementRef.current && alignElementRef.current.clientWidth;
 
 	return (
-		<ClayDropDown.Menu
+		<DropDown.Menu
 			active={active}
 			alignElementRef={alignElementRef}
 			alignmentByViewport={alignmentByViewport}
 			autoBestAlign={!!alignmentByViewport}
 			className="autocomplete-dropdown-menu"
 			closeOnClickOutside={closeOnClickOutside}
-			onActiveChange={onSetActive}
+			onActiveChange={onActiveChange ?? onSetActive}
 			ref={menuElementRef}
 			style={{
 				maxWidth: 'none',
@@ -71,7 +79,7 @@ const ClayAutocompleteDropDown = ({
 			}}
 		>
 			{children}
-		</ClayDropDown.Menu>
+		</DropDown.Menu>
 	);
 };
 

--- a/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -112,7 +112,7 @@ export const Keyboard = () => {
 
 								<ClayAutocomplete.DropDown
 									active={active}
-									onSetActive={setActive}
+									onActiveChange={setActive}
 								>
 									<ClayDropDown.ItemList>
 										{filteredItems.map((item) => (


### PR DESCRIPTION
We probably forgot to apply [RFC 0002 Controlled and uncontrolled components](https://github.com/liferay/clay/blob/master/docs/proposals/0002-controlled-and-uncontrolled.md) to this component. I just creating an API to follow the standard and maintaining compatibility.
 