### PR TITLE
fix(@clayui/css): Global Functions speed up `map-deep-get`

### DIFF
--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -795,14 +795,8 @@
 	$newMap: $map;
 
 	@each $key in $keys {
-		@if (type-of($newMap) == 'list' and length($newMap) == 0) or
-			(type-of($newMap) == 'null')
-		{
-			$newMap: map-new();
-		}
-
-		@if (type-of($newMap) != map) {
-			@error ('argument `$map: #{$map}` of `map-deep-get($map, $keys)` must be a map');
+		@if (type-of($newMap) != 'map') {
+			@return null;
 		}
 
 		$newMap: map-get($newMap, $key);


### PR DESCRIPTION
- removes converting null and list to empty map to prevent running map-get on non existing maps
- removes error message and just returns null

Couldn't get it faster with a for loop and chaining `map-get`'s due to needing to use the `nth` function. This came out 500ms faster for 100,000 iterations of `map-deep-get` over the old one.