### PR TITLE
chore(@clayui/core): fix error in TreeView example in Storybook

### DIFF
--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -1139,7 +1139,7 @@ export const AsyncLoadDataPaginated = () => (
 					)}
 				</TreeView.Group>
 
-				{expand.has(item.id) && load.has(item.id) !== null && (
+				{expand.has(item.id) && load.get(item.id) !== null && (
 					<Button
 						borderless
 						displayType="secondary"


### PR DESCRIPTION
It just fixes the error of a TreeView example that was failing, this ends up not being caught by CI because the Storybook loaded the examples on demand and not at compile time.