### PR TITLE
fix(@clayui/core): fixes error of duplicating element rendering in TreeView

### DIFF
--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -451,7 +451,7 @@ export const TreeViewItem = React.forwardRef<
 				</div>
 				{group}
 
-				{Boolean(otherElements.length) && (
+				{left && group && Boolean(otherElements.length) && (
 					<div
 						style={{
 							paddingLeft: `${spacing + 24}px`,


### PR DESCRIPTION
We added this recently which allows rendering other elements when it has declared as sibling of `TreeView.ItemStack` and `TreeView.Group` this allows rendering other child elements, but when there is the composition of `TreeView.Item` having only node elements, the elements were rendered twice.

This bug was caught by running the visual test with Chromatic https://www.chromatic.com/test?appId=627ec7506f193c004ac64938&id=6334b9128e3868d044515a22. 