### PR TITLE
fix(@clayui/autocomplete): fix of switching the owner of otherProps on Autocomplete

### DIFF
--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -71,9 +71,12 @@ const ClayAutocomplete = React.forwardRef<HTMLDivElement, IProps>(
 		const containerElementRef = React.useRef<null | HTMLDivElement>(null);
 		const [loading, setLoading] = React.useState(false);
 
+		const isOldBehavior = hasInputOrDropDown(children).length >= 1;
+
 		return (
 			<FocusScope>
 				<Component
+					{...(isOldBehavior ? otherProps : {})}
 					className={className}
 					ref={(r: any) => {
 						if (r) {
@@ -88,7 +91,7 @@ const ClayAutocomplete = React.forwardRef<HTMLDivElement, IProps>(
 						}
 					}}
 				>
-					{hasInputOrDropDown(children).length >= 1 ? (
+					{isOldBehavior ? (
 						<Context.Provider
 							value={{
 								containerElementRef,

--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -9,7 +9,9 @@ import {Keys} from './Keys';
 import {useFocusManagement} from './useFocusManagement';
 
 type Children = React.ReactElement & {
-	ref?: React.MutableRefObject<HTMLElement>;
+	ref?:
+		| React.MutableRefObject<HTMLElement>
+		| ((ref: HTMLElement | null) => void);
 };
 
 type ChildrenFunction =
@@ -116,6 +118,8 @@ export const FocusScope = ({
 						if (ref) {
 							if (typeof ref === 'object') {
 								ref.current = r;
+							} else if (typeof ref === 'function') {
+								ref(r);
 							}
 						}
 					}


### PR DESCRIPTION
These turned out to be bugs introduced by PR #5108.
Add `otherProps` to the Autocomplete container when using the old behavior and for the new one it doesn't add it goes to the new component which is the Input.

The other bug is that `FocusScope` when the child has declared a function in the `ref` of the container, it doesn't call the function so that the forwardRef happens correctly. There was an Autocomplete bug in the old behavior of not aligning the menu with the input.