### PR TITLE
fix(@clayui/autocomplete): changes the way to identify the new behavior

### DIFF
--- a/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-autocomplete/src/__tests__/__snapshots__/index.tsx.snap
@@ -7,20 +7,7 @@ exports[`ClayAutocomplete renders 1`] = `
   >
     <div
       class="input-group-item"
-    >
-      <input
-        aria-autocomplete="list"
-        aria-controls="clay-id-1"
-        autocomplete="off"
-        autocorrect="off"
-        class="form-control"
-        role="combobox"
-        spellcheck="false"
-        style=""
-        type="text"
-        value=""
-      />
-    </div>
+    />
   </div>
 </div>
 `;
@@ -29,20 +16,7 @@ exports[`ClayAutocomplete renders Autocomplete with other markup component 1`] =
 <div>
   <div
     class="form-control form-control-tag-group"
-  >
-    <input
-      aria-autocomplete="list"
-      aria-controls="clay-id-2"
-      autocomplete="off"
-      autocorrect="off"
-      class="form-control"
-      role="combobox"
-      spellcheck="false"
-      style=""
-      type="text"
-      value=""
-    />
-  </div>
+  />
 </div>
 `;
 

--- a/packages/clay-autocomplete/src/index.tsx
+++ b/packages/clay-autocomplete/src/index.tsx
@@ -31,7 +31,7 @@ AutocompleteMarkup.displayName = 'ClayAutocompleteMarkup';
  * Temporary helper function to determine which version of autocomplete
  * is being used.
  */
-const hasInputOrDropDown = (children?: React.ReactNode) => {
+const hasItems = (children?: React.ReactNode) => {
 	if (!children) {
 		return [];
 	}
@@ -40,9 +40,7 @@ const hasInputOrDropDown = (children?: React.ReactNode) => {
 		if (
 			React.isValidElement(child) &&
 			// @ts-ignore
-			(child.type.displayName === 'ClayAutocompleteDropDown' ||
-				// @ts-ignore
-				child.type.displayName === 'ClayAutocompleteInput')
+			child.type.displayName === 'ClayAutocompleteItem'
 		) {
 			return true;
 		}
@@ -71,12 +69,12 @@ const ClayAutocomplete = React.forwardRef<HTMLDivElement, IProps>(
 		const containerElementRef = React.useRef<null | HTMLDivElement>(null);
 		const [loading, setLoading] = React.useState(false);
 
-		const isOldBehavior = hasInputOrDropDown(children).length >= 1;
+		const isNewBehavior = hasItems(children).length >= 1;
 
 		return (
 			<FocusScope>
 				<Component
-					{...(isOldBehavior ? otherProps : {})}
+					{...(isNewBehavior ? {} : otherProps)}
 					className={className}
 					ref={(r: any) => {
 						if (r) {
@@ -91,7 +89,9 @@ const ClayAutocomplete = React.forwardRef<HTMLDivElement, IProps>(
 						}
 					}}
 				>
-					{isOldBehavior ? (
+					{isNewBehavior ? (
+						<Autocomplete {...otherProps}>{children}</Autocomplete>
+					) : (
 						<Context.Provider
 							value={{
 								containerElementRef,
@@ -102,8 +102,6 @@ const ClayAutocomplete = React.forwardRef<HTMLDivElement, IProps>(
 						>
 							{children}
 						</Context.Provider>
-					) : (
-						<Autocomplete {...otherProps}>{children}</Autocomplete>
 					)}
 				</Component>
 			</FocusScope>


### PR DESCRIPTION
In DXP there are quite complicated compositions and full of wrappers on top of the components, this makes it difficult to identify if the old behavior is being used, so it is easier to identify if the new behavior is used.