### PR TITLE
fix(@clayui/css): Reduce the uses of the `setter()` function to speed up build

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -223,7 +223,8 @@ $input-danger-readonly: () !default;
 $input-danger-readonly: map-deep-merge(
 	(
 		background-color:
-			setter(
+			if(
+				map-get($input-readonly, bg),
 				map-get($input-readonly, bg),
 				map-get($input-readonly, background-color)
 			),
@@ -283,7 +284,8 @@ $input-warning-readonly: () !default;
 $input-warning-readonly: map-deep-merge(
 	(
 		background-color:
-			setter(
+			if(
+				map-get($input-readonly, bg),
 				map-get($input-readonly, bg),
 				map-get($input-readonly, background-color)
 			),
@@ -343,7 +345,8 @@ $input-success-readonly: () !default;
 $input-success-readonly: map-deep-merge(
 	(
 		background-color:
-			setter(
+			if(
+				map-get($input-readonly, bg),
 				map-get($input-readonly, bg),
 				map-get($input-readonly, background-color)
 			),

--- a/packages/clay-css/src/scss/cadmin/components/_alerts.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_alerts.scss
@@ -20,7 +20,8 @@
 .alert-indicator {
 	@include clay-css($cadmin-alert-indicator);
 	+ .lead {
-		$lead: setter(map-get($cadmin-alert-indicator, lead), ());
+		$lead: map-get($cadmin-alert-indicator, lead);
+		$lead: if($lead, $lead, ());
 
 		@include clay-css($lead);
 	}
@@ -74,10 +75,8 @@
 	@include clay-css($cadmin-alert-notifications-absolute);
 
 	@include clay-scale-component(null, $breakpoint-down) {
-		$mobile: setter(
-			map-get($cadmin-alert-notifications-absolute, mobile),
-			()
-		);
+		$mobile: map-get($cadmin-alert-notifications-absolute, mobile);
+		$mobile: if($mobile, $mobile, ());
 
 		@include clay-css($mobile);
 	}
@@ -92,7 +91,8 @@
 	@include clay-css($cadmin-alert-notifications-fixed);
 
 	@include clay-scale-component(null, $breakpoint-down) {
-		$mobile: setter(map-get($cadmin-alert-notifications-fixed, mobile), ());
+		$mobile: map-get($cadmin-alert-notifications-fixed, mobile);
+		$mobile: if($mobile, $mobile, ());
 
 		@include clay-css($mobile);
 	}
@@ -175,16 +175,19 @@
 	@include clay-css($cadmin-alert-inline);
 
 	&.alert-dismissible {
-		$alert-dismissible: setter(
-			map-get($cadmin-alert-inline, alert-dismissible),
-			()
-		);
+		$alert-dismissible: map-get($cadmin-alert-inline, alert-dismissible);
+		$alert-dismissible: if($alert-dismissible, $alert-dismissible, ());
 
 		@include clay-css($alert-dismissible);
 
 		&.alert-fluid {
-			$alert-dismissible-alert-fluid: setter(
-				map-get($cadmin-alert-inline, alert-dismissible-alert-fluid),
+			$alert-dismissible-alert-fluid: map-get(
+				$cadmin-alert-inline,
+				alert-dismissible-alert-fluid
+			);
+			$alert-dismissible-alert-fluid: if(
+				$alert-dismissible-alert-fluid,
+				$alert-dismissible-alert-fluid,
 				()
 			);
 
@@ -192,10 +195,11 @@
 
 			> .container,
 			> .container-fluid {
-				$container-fluid: setter(
-					map-get($alert-dismissible-alert-fluid, container-fluid),
-					()
+				$container-fluid: map-get(
+					$alert-dismissible-alert-fluid,
+					container-fluid
 				);
+				$container-fluid: if($container-fluid, $container-fluid, ());
 
 				@include clay-css($container-fluid);
 
@@ -209,10 +213,8 @@
 					@include clay-css($alert-autofit-row);
 
 					.btn-group {
-						$btn-group: setter(
-							map-get($alert-autofit-row, btn-group),
-							()
-						);
+						$btn-group: map-get($alert-autofit-row, btn-group);
+						$btn-group: if($btn-group, $btn-group, ());
 
 						@include clay-css($btn-group);
 					}
@@ -222,22 +224,22 @@
 	}
 
 	> .alert-autofit-row {
-		$alert-autofit-row: setter(
-			map-get($cadmin-alert-inline, alert-autofit-row),
-			()
-		);
+		$alert-autofit-row: map-get($cadmin-alert-inline, alert-autofit-row);
+		$alert-autofit-row: if($alert-autofit-row, $alert-autofit-row, ());
 
 		@include clay-css($alert-autofit-row);
 
 		.btn-group {
-			$btn-group: setter(map-get($alert-autofit-row, btn-group), ());
+			$btn-group: map-get($alert-autofit-row, btn-group);
+			$btn-group: if($btn-group, $btn-group, ());
 
 			@include clay-css($btn-group);
 		}
 	}
 
 	.close {
-		$close: setter(map-get($cadmin-alert-inline, close), ());
+		$close: map-get($cadmin-alert-inline, close);
+		$close: if($close, $close, ());
 
 		@include clay-close($close);
 	}
@@ -249,28 +251,32 @@
 	@include clay-css($cadmin-alert-autofit-stacked);
 
 	> .alert-autofit-row {
-		$alert-autofit-row: setter(
-			map-get($cadmin-alert-autofit-stacked, alert-autofit-row),
-			()
+		$alert-autofit-row: map-get(
+			$cadmin-alert-autofit-stacked,
+			alert-autofit-row
 		);
+		$alert-autofit-row: if($alert-autofit-row, $alert-autofit-row, ());
 
 		@include clay-css($alert-autofit-row);
 
 		> .autofit-col {
-			$autofit-col: setter(map-get($alert-autofit-row, autofit-col), ());
+			$autofit-col: map-get($alert-autofit-row, autofit-col);
+			$autofit-col: if($autofit-col, $autofit-col, ());
 
 			@include clay-css($autofit-col);
 		}
 
 		.btn-group {
-			$btn-group: setter(map-get($alert-autofit-row, btn-group), ());
+			$btn-group: map-get($alert-autofit-row, btn-group);
+			$btn-group: if($btn-group, $btn-group, ());
 
 			@include clay-css($btn-group);
 		}
 	}
 
 	.close {
-		$close: setter(map-get($cadmin-alert-autofit-stacked, close), ());
+		$close: map-get($cadmin-alert-autofit-stacked, close);
+		$close: if($close, $close, ());
 
 		@include clay-close($close);
 	}
@@ -282,17 +288,19 @@
 	@include clay-css($cadmin-alert-autofit-stacked-sm-down);
 
 	> .alert-autofit-row {
-		$alert-autofit-row: setter(
-			map-get($cadmin-alert-autofit-stacked-sm-down, alert-autofit-row),
-			()
+		$alert-autofit-row: map-get(
+			$cadmin-alert-autofit-stacked-sm-down,
+			alert-autofit-row
 		);
+		$alert-autofit-row: if($alert-autofit-row, $alert-autofit-row, ());
 
 		@include media-breakpoint-down(sm, $cadmin-grid-breakpoints) {
 			@include clay-css($alert-autofit-row);
 		}
 
 		> .autofit-col {
-			$autofit-col: setter(map-get($alert-autofit-row, autofit-col), ());
+			$autofit-col: map-get($alert-autofit-row, autofit-col);
+			$autofit-col: if($autofit-col, $autofit-col, ());
 
 			@include media-breakpoint-down(sm, $cadmin-grid-breakpoints) {
 				@include clay-css($autofit-col);
@@ -300,7 +308,8 @@
 		}
 
 		.btn-group {
-			$btn-group: setter(map-get($alert-autofit-row, btn-group), ());
+			$btn-group: map-get($alert-autofit-row, btn-group);
+			$btn-group: if($btn-group, $btn-group, ());
 
 			@include media-breakpoint-down(sm, $cadmin-grid-breakpoints) {
 				@include clay-css($btn-group);
@@ -309,10 +318,8 @@
 	}
 
 	.close {
-		$close: setter(
-			map-get($cadmin-alert-autofit-stacked-sm-down, close),
-			()
-		);
+		$close: map-get($cadmin-alert-autofit-stacked-sm-down, close);
+		$close: if($close, $close, ());
 
 		@include media-breakpoint-down(sm, $cadmin-grid-breakpoints) {
 			@include clay-css($close);
@@ -326,17 +333,19 @@
 	@include clay-css($cadmin-alert-autofit-stacked-xs-down);
 
 	> .alert-autofit-row {
-		$alert-autofit-row: setter(
-			map-get($cadmin-alert-autofit-stacked-xs-down, alert-autofit-row),
-			()
+		$alert-autofit-row: map-get(
+			$cadmin-alert-autofit-stacked-xs-down,
+			alert-autofit-row
 		);
+		$alert-autofit-row: if($alert-autofit-row, $alert-autofit-row, ());
 
 		@include media-breakpoint-down(xs, $cadmin-grid-breakpoints) {
 			@include clay-css($alert-autofit-row);
 		}
 
 		> .autofit-col {
-			$autofit-col: setter(map-get($alert-autofit-row, autofit-col), ());
+			$autofit-col: map-get($alert-autofit-row, autofit-col);
+			$autofit-col: if($autofit-col, $autofit-col, ());
 
 			@include media-breakpoint-down(xs, $cadmin-grid-breakpoints) {
 				@include clay-css($autofit-col);
@@ -344,7 +353,8 @@
 		}
 
 		.btn-group {
-			$btn-group: setter(map-get($alert-autofit-row, btn-group), ());
+			$btn-group: map-get($alert-autofit-row, btn-group);
+			$btn-group: if($btn-group, $btn-group, ());
 
 			@include media-breakpoint-down(xs, $cadmin-grid-breakpoints) {
 				@include clay-css($btn-group);
@@ -353,10 +363,8 @@
 	}
 
 	.close {
-		$close: setter(
-			map-get($cadmin-alert-autofit-stacked-xs-down, close),
-			()
-		);
+		$close: map-get($cadmin-alert-autofit-stacked-xs-down, close);
+		$close: if($close, $close, ());
 
 		@include media-breakpoint-down(xs, $cadmin-grid-breakpoints) {
 			@include clay-css($close);
@@ -370,59 +378,61 @@
 	@include clay-css($cadmin-alert-indicator-start);
 
 	&.alert-fluid {
-		$alert-fluid: setter(
-			map-get($cadmin-alert-indicator-start, alert-fluid),
-			()
-		);
+		$alert-fluid: map-get($cadmin-alert-indicator-start, alert-fluid);
+		$alert-fluid: if($alert-fluid, $alert-fluid, ());
 
 		@include clay-css($alert-fluid);
 
 		> .container,
 		> .container-fluid {
-			$container-fluid: setter(
-				map-get($alert-fluid, container-fluid),
-				()
-			);
+			$container-fluid: map-get($alert-fluid, container-fluid);
+			$container-fluid: if($container-fluid, $container-fluid, ());
 
 			@include clay-css($container-fluid);
 		}
 	}
 
 	&.alert-feedback {
-		$alert-feedback: setter(
-			map-get($cadmin-alert-indicator-start, alert-feedback),
-			()
-		);
+		$alert-feedback: map-get($cadmin-alert-indicator-start, alert-feedback);
+		$alert-feedback: if($alert-feedback, $alert-feedback, ());
 
 		@include clay-css($alert-feedback);
 	}
 
 	.alert-indicator {
-		$alert-indicator: setter(
-			map-get($cadmin-alert-indicator-start, alert-indicator),
-			()
+		$alert-indicator: map-get(
+			$cadmin-alert-indicator-start,
+			alert-indicator
 		);
+		$alert-indicator: if($alert-indicator, $alert-indicator, ());
 
 		@include clay-css($alert-indicator);
 
 		+ .lead {
-			$lead: setter(map-get($alert-indicator, lead), ());
+			$lead: map-get($alert-indicator, lead);
+			$lead: if($lead, $lead, ());
 
 			@include clay-css($lead);
 		}
 	}
 
 	.alert-autofit-row {
-		$alert-autofit-row: setter(
-			map-get($cadmin-alert-indicator-start, alert-autofit-row),
-			()
+		$alert-autofit-row: map-get(
+			$cadmin-alert-indicator-start,
+			alert-autofit-row
 		);
+		$alert-autofit-row: if($alert-autofit-row, $alert-autofit-row, ());
 
 		@include clay-css($alert-autofit-row);
 
 		.alert-indicator:only-child {
-			$alert-indicator-only-child: setter(
-				map-get($alert-autofit-row, alert-indicator-only-child),
+			$alert-indicator-only-child: map-get(
+				$alert-autofit-row,
+				alert-indicator-only-child
+			);
+			$alert-indicator-only-child: if(
+				$alert-indicator-only-child,
+				$alert-indicator-only-child,
 				()
 			);
 

--- a/packages/clay-css/src/scss/cadmin/components/_buttons.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_buttons.scss
@@ -3,16 +3,26 @@
 }
 
 fieldset:disabled a.btn {
-	$btn-disabled: setter(map-get($cadmin-btn, disabled), ());
+	$btn-disabled: map-get($cadmin-btn, disabled);
+	$btn-disabled: if($btn-disabled, $btn-disabled, ());
 
 	@include clay-css($btn-disabled);
 
 	&:focus {
-		@include clay-css(setter(map-get($btn-disabled, focus), ()));
+		$btn-disabled-focus: map-get($btn-disabled, focus);
+		$btn-disabled-focus: if($btn-disabled-focus, $btn-disabled-focus, ());
+
+		@include clay-css($btn-disabled-focus);
 	}
 
 	&:active {
-		@include clay-css(setter(map-get($btn-disabled, active), ()));
+		$btn-disabled-active: map-get($btn-disabled, active);
+		$btn-disabled-active: if(
+			$btn-disabled-active,
+			$btn-disabled-active,
+			()
+		);
+		@include clay-css($btn-disabled-active);
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_custom-forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_custom-forms.scss
@@ -66,13 +66,15 @@
 	@include clay-css($cadmin-custom-control);
 
 	&:only-child {
-		$only-child: setter(map-get($cadmin-custom-control, only-child), ());
+		$only-child: map-get($cadmin-custom-control, only-child);
+		$only-child: if($only-child, $only-child, ());
 
 		@include clay-css($only-child);
 	}
 
 	label {
-		$label: setter(map-get($cadmin-custom-control, label), ());
+		$label: map-get($cadmin-custom-control, label);
+		$label: if($label, $label, ());
 
 		@include clay-css($label);
 	}
@@ -106,7 +108,8 @@ label.custom-control-label {
 // Custom Control Indicator
 
 .custom-control-label::before {
-	$before: setter(map-get($cadmin-custom-control-label, before), ());
+	$before: map-get($cadmin-custom-control-label, before);
+	$before: if($before, $before, ());
 
 	@extend %cadmin-pseudo-reset !optional;
 
@@ -114,7 +117,8 @@ label.custom-control-label {
 }
 
 .custom-control-label::after {
-	$after: setter(map-get($cadmin-custom-control-label, after), ());
+	$after: map-get($cadmin-custom-control-label, after);
+	$after: if($after, $after, ());
 
 	@extend %cadmin-pseudo-reset !optional;
 

--- a/packages/clay-css/src/scss/cadmin/components/_date-picker.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_date-picker.scss
@@ -78,16 +78,19 @@
 	@include clay-css($cadmin-date-picker-col);
 
 	&.c-selected {
-		$cadmin-_c-selected: setter(
-			map-get($cadmin-date-picker-col, c-selected),
-			()
-		);
+		$cadmin-_c-selected: map-get($cadmin-date-picker-col, c-selected);
+		$cadmin-_c-selected: if($cadmin-_c-selected, $cadmin-_c-selected, ());
 
 		@include clay-css($cadmin-_c-selected);
 
 		&:first-child {
-			$cadmin-_c-selected-first-child: setter(
-				map-get($cadmin-date-picker-col, c-selected-first-child),
+			$cadmin-_c-selected-first-child: map-get(
+				$cadmin-date-picker-col,
+				c-selected-first-child
+			);
+			$cadmin-_c-selected-first-child: if(
+				$cadmin-_c-selected-first-child,
+				$cadmin-_c-selected-first-child,
 				()
 			);
 
@@ -95,8 +98,13 @@
 		}
 
 		&:last-child {
-			$cadmin-_c-selected-last-child: setter(
-				map-get($cadmin-date-picker-col, c-selected-last-child),
+			$cadmin-_c-selected-last-child: map-get(
+				$cadmin-date-picker-col,
+				c-selected-last-child
+			);
+			$cadmin-_c-selected-last-child: if(
+				$cadmin-_c-selected-last-child,
+				$cadmin-_c-selected-last-child,
 				()
 			);
 
@@ -105,8 +113,13 @@
 	}
 
 	&.c-selected-start {
-		$cadmin-_c-selected-start: setter(
-			map-get($cadmin-date-picker-col, c-selected-start),
+		$cadmin-_c-selected-start: map-get(
+			$cadmin-date-picker-col,
+			c-selected-start
+		);
+		$cadmin-_c-selected-start: if(
+			$cadmin-_c-selected-start,
+			$cadmin-_c-selected-start,
 			()
 		);
 
@@ -114,8 +127,13 @@
 	}
 
 	&.c-selected-end {
-		$cadmin-_c-selected-end: setter(
-			map-get($cadmin-date-picker-col, c-selected-end),
+		$cadmin-_c-selected-end: map-get(
+			$cadmin-date-picker-col,
+			c-selected-end
+		);
+		$cadmin-_c-selected-end: if(
+			$cadmin-_c-selected-end,
+			$cadmin-_c-selected-end,
 			()
 		);
 

--- a/packages/clay-css/src/scss/cadmin/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_dropdowns.scss
@@ -12,13 +12,17 @@
 	@include media-breakpoint-down(
 		map-get($cadmin-dropdown-header, breakpoint-down)
 	) {
-		@include clay-css(setter(map-get($cadmin-dropdown-header, mobile), ()));
+		$dropdown-header: map-get($cadmin-dropdown-header, mobile);
+		$dropdown-header: if($dropdown-header, $dropdown-header, ());
+
+		@include clay-css($dropdown-header);
 	}
 
 	&:first-child {
-		@include clay-css(
-			setter(map-get($cadmin-dropdown-header, first-child), ())
-		);
+		$first-child: map-get($cadmin-dropdown-header, first-child);
+		$first-child: if($first-child, $first-child, ());
+
+		@include clay-css($first-child);
 	}
 }
 
@@ -26,9 +30,9 @@
 	@include clay-css($cadmin-dropdown-subheader);
 
 	&:first-child {
-		@include clay-css(
-			setter(map-get($cadmin-dropdown-subheader, first-child), ())
-		);
+		$first-child: map-get($cadmin-dropdown-subheader, first-child);
+		$first-child: if($first-child, $first-child, ());
+		@include clay-css($first-child);
 	}
 }
 
@@ -60,51 +64,74 @@
 	@include clay-css($cadmin-dropdown-section);
 
 	.form-group + .form-group {
-		@include clay-css(
-			setter(
-				map-deep-get($cadmin-dropdown-section, form-group, form-group),
-				()
-			)
+		$form-group: map-deep-get(
+			$cadmin-dropdown-section,
+			form-group,
+			form-group
 		);
+		$form-group: if($form-group, $form-group, ());
+
+		@include clay-css($form-group);
 	}
 
 	.custom-control {
-		@include clay-css(
-			setter(map-get($cadmin-dropdown-section, custom-control), ())
-		);
+		$custom-control: map-get($cadmin-dropdown-section, custom-control);
+		$custom-control: if($custom-control, $custom-control, ());
+
+		@include clay-css($custom-control);
 	}
 
 	.custom-control-label {
-		@include clay-css(
-			setter(map-get($cadmin-dropdown-section, custom-control-label), ())
+		$custom-control-label: map-get(
+			$cadmin-dropdown-section,
+			custom-control-label
 		);
+		$custom-control-label: if(
+			$custom-control-label,
+			$custom-control-label,
+			()
+		);
+
+		@include clay-css($custom-control-label);
 	}
 
 	.custom-control-label-text {
-		@include clay-css(
-			setter(
-				map-get($cadmin-dropdown-section, custom-control-label-text),
-				()
-			)
+		$custom-control-label-text: map-get(
+			$cadmin-dropdown-section,
+			custom-control-label-text
 		);
+		$custom-control-label-text: if(
+			$custom-control-label-text,
+			$custom-control-label-text,
+			()
+		);
+
+		@include clay-css($custom-control-label-text);
 	}
 
 	&.active {
-		@include clay-css(
-			setter(map-get($cadmin-dropdown-section, active), ())
+		$dropdown-section-active: map-get($cadmin-dropdown-section, active);
+		$dropdown-section-active: if(
+			$dropdown-section-active,
+			$dropdown-section-active,
+			()
 		);
 
+		@include clay-css($dropdown-section-active);
+
 		.custom-control-label {
-			@include clay-css(
-				setter(
-					map-deep-get(
-						$cadmin-dropdown-section,
-						active,
-						custom-control-label
-					),
-					()
-				)
+			$custom-control-label: map-deep-get(
+				$cadmin-dropdown-section,
+				active,
+				custom-control-label
 			);
+			$custom-control-label: if(
+				$custom-control-label,
+				$custom-control-label,
+				()
+			);
+
+			@include clay-css($custom-control-label);
 		}
 	}
 }
@@ -220,9 +247,10 @@
 	@include clay-css($cadmin-dropdown-action);
 
 	> .dropdown-toggle {
-		@include clay-button-variant(
-			setter(map-get($cadmin-dropdown-action, dropdown-toggle), ())
-		);
+		$dropdown-toggle: map-get($cadmin-dropdown-action, dropdown-toggle);
+		$dropdown-toggle: if($dropdown-toggle, $dropdown-toggle, ());
+
+		@include clay-button-variant($dropdown-toggle);
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -26,34 +26,36 @@ label {
 	@include clay-css($cadmin-input-label);
 
 	@include clay-scale-component {
-		$mobile: setter(map-get($cadmin-input-label, mobile), ());
+		$mobile: map-get($cadmin-input-label, mobile);
+		$mobile: if($mobile, $mobile, ());
 
 		@include clay-css($mobile);
 	}
 
 	&.focus {
-		$focus: setter(map-get($cadmin-input-label, focus), ());
+		$focus: map-get($cadmin-input-label, focus);
+		$focus: if($focus, $focus, ());
 
 		@include clay-css($focus);
 	}
 
 	&[for] {
-		$for: setter(map-get($cadmin-input-label, for), ());
+		$for: map-get($cadmin-input-label, for);
+		$for: if($for, $for, ());
 
 		@include clay-css($for);
 	}
 
 	+ .form-text {
-		$form-text: setter(map-get($cadmin-input-label, form-text), ());
+		$form-text: map-get($cadmin-input-label, form-text);
+		$form-text: if($form-text, $form-text, ());
 
 		@include clay-css($form-text);
 	}
 
 	.reference-mark {
-		$reference-mark: setter(
-			map-get($cadmin-input-label, reference-mark),
-			()
-		);
+		$reference-mark: map-get($cadmin-input-label, reference-mark);
+		$reference-mark: if($reference-mark, $reference-mark, ());
 
 		@include clay-css($reference-mark);
 	}
@@ -73,7 +75,8 @@ label {
 
 fieldset[disabled] label,
 label.disabled {
-	$disabled: setter(map-get($cadmin-input-label, disabled), ());
+	$disabled: map-get($cadmin-input-label, disabled);
+	$disabled: if($disabled, $disabled, ());
 
 	@include clay-css($disabled);
 }
@@ -91,7 +94,8 @@ fieldset[disabled] label {
 	@include clay-form-control-variant($cadmin-input);
 
 	@include clay-scale-component {
-		$mobile: setter(map-get($cadmin-input, mobile), ());
+		$mobile: map-get($cadmin-input, mobile);
+		$mobile: if($mobile, $mobile, ());
 
 		@include clay-css($mobile);
 	}
@@ -132,7 +136,8 @@ fieldset[disabled] label {
 // This adds disabled styles to div.form-control inside a disabled fielset.
 
 fieldset[disabled] .form-control {
-	$disabled: setter(map-get($cadmin-input, disabled), ());
+	$disabled: map-get($cadmin-input, disabled);
+	$disabled: if($disabled, $disabled, ());
 
 	@include clay-css($disabled);
 }
@@ -291,13 +296,15 @@ select.form-control {
 	@include clay-css($cadmin-form-control-select);
 
 	&:hover {
-		$hover: setter(map-get($cadmin-form-control-select, hover), ());
+		$hover: map-get($cadmin-form-control-select, hover);
+		$hover: if($hover, $hover, ());
 
 		@include clay-css($hover);
 	}
 
 	&:focus {
-		$focus: setter(map-get($cadmin-form-control-select, focus), ());
+		$focus: map-get($cadmin-form-control-select, focus);
+		$focus: if($focus, $focus, ());
 
 		@include clay-css($focus);
 	}
@@ -536,10 +543,13 @@ textarea.form-control-lg,
 }
 
 %clay-select-form-control-sm {
-	@include clay-css(setter($cadmin-form-control-select-sm, ()));
+	@include clay-css(
+		if($cadmin-form-control-select-sm, $cadmin-form-control-select-sm, ())
+	);
 
 	@include clay-scale-component {
-		$mobile: setter(map-get($cadmin-form-control-select-sm, mobile), ());
+		$mobile: map-get($cadmin-form-control-select-sm, mobile);
+		$mobile: if($mobile, $mobile, ());
 
 		@include clay-css($mobile);
 	}

--- a/packages/clay-css/src/scss/cadmin/components/_icons.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_icons.scss
@@ -1,5 +1,5 @@
 .lexicon-icon {
-	@include clay-css(setter($cadmin-lexicon-icon, ()));
+	@include clay-css(if($cadmin-lexicon-icon, $cadmin-lexicon-icon, ()));
 }
 
 .order-arrow-down-active {

--- a/packages/clay-css/src/scss/cadmin/components/_labels.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_labels.scss
@@ -10,29 +10,45 @@
 	@include clay-css($cadmin-label-item);
 
 	a {
-		@include clay-link(setter(map-get($cadmin-label-item, link), ()));
+		$link: map-get($cadmin-label-item, link);
+		$link: if($link, $link, ());
+
+		@include clay-link($link);
 	}
 
 	.btn-unstyled {
-		@include clay-button-variant(
-			setter(map-get($cadmin-label-item, btn-unstyled), ())
-		);
+		$btn-unstyled: map-get($cadmin-label-item, btn-unstyled);
+		$btn-unstyled: if($btn-unstyled, $btn-unstyled, ());
+
+		@include clay-button-variant($btn-unstyled);
 	}
 
 	.close {
-		@include clay-close(setter(map-get($cadmin-label-item, close), ()));
+		$close: map-get($cadmin-label-item, close);
+		$close: if($close, $close, ());
+
+		@include clay-close($close);
 	}
 
 	.lexicon-icon {
-		@include clay-css(
-			setter(map-get($cadmin-label-item, lexicon-icon), ())
-		);
+		$lexicon-icon: map-get($cadmin-label-item, lexicon-icon);
+		$lexicon-icon: if($lexicon-icon, $lexicon-icon, ());
+
+		@include clay-css($lexicon-icon);
 	}
 
 	.text-truncate-inline {
-		@include clay-css(
-			setter(map-get($cadmin-label-item, text-truncate-inline), ())
+		$text-truncate-inline: map-get(
+			$cadmin-label-item,
+			text-truncate-inline
 		);
+		$text-truncate-inline: if(
+			$text-truncate-inline,
+			$text-truncate-inline,
+			()
+		);
+
+		@include clay-css($text-truncate-inline);
 	}
 }
 
@@ -40,9 +56,10 @@
 	@include clay-css($cadmin-label-item-expand);
 
 	a {
-		@include clay-link(
-			setter(map-get($cadmin-label-item-expand, link), ())
-		);
+		$link: map-get($cadmin-label-item-expand, link);
+		$link: if($link, $link, ());
+
+		@include clay-link($link);
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/components/_modals.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_modals.scss
@@ -165,7 +165,8 @@
 	@include clay-css($cadmin-modal-header);
 
 	@include clay-scale-component(null, $breakpoint-down) {
-		$mobile: setter(map-get($cadmin-modal-header, mobile), ());
+		$mobile: map-get($cadmin-modal-header, mobile);
+		$mobile: if($mobile, $mobile, ());
 
 		@include clay-css($mobile);
 	}
@@ -176,10 +177,8 @@
 	@include clay-css($cadmin-modal-body);
 
 	&.inline-scroller {
-		$inline-scroller: setter(
-			map-get($cadmin-modal-body, inline-scroller),
-			()
-		);
+		$inline-scroller: map-get($cadmin-modal-body, inline-scroller);
+		$inline-scroller: if($inline-scroller, $inline-scroller, ());
 
 		@include clay-css($inline-scroller);
 	}

--- a/packages/clay-css/src/scss/cadmin/components/_progress-bars.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_progress-bars.scss
@@ -88,19 +88,15 @@
 	@include clay-css($cadmin-progress-group-addon);
 
 	&:first-child {
-		$first-child: setter(
-			map-get($cadmin-progress-group-addon, first-child),
-			()
-		);
+		$first-child: map-get($cadmin-progress-group-addon, first-child);
+		$first-child: if($first-child, $first-child, ());
 
 		@include clay-css($first-child);
 	}
 
 	&:last-child {
-		$last-child: setter(
-			map-get($cadmin-progress-group-addon, last-child),
-			()
-		);
+		$last-child: map-get($cadmin-progress-group-addon, last-child);
+		$last-child: if($last-child, $last-child, ());
 
 		@include clay-css($last-child);
 	}

--- a/packages/clay-css/src/scss/cadmin/components/_stickers.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_stickers.scss
@@ -33,28 +33,22 @@
 	@include clay-css($cadmin-sticker-outside);
 
 	&.sticker-bottom-left {
-		$bottom-left: setter(
-			map-get($cadmin-sticker-outside, sticker-bottom-left),
-			()
-		);
+		$bottom-left: map-get($cadmin-sticker-outside, sticker-bottom-left);
+		$bottom-left: if($bottom-left, $bottom-left, ());
 
 		@include clay-css($bottom-left);
 	}
 
 	&.sticker-bottom-right {
-		$bottom-right: setter(
-			map-get($cadmin-sticker-outside, sticker-bottom-right),
-			()
-		);
+		$bottom-right: map-get($cadmin-sticker-outside, sticker-bottom-right);
+		$bottom-right: if($bottom-right, $bottom-right, ());
 
 		@include clay-css($bottom-right);
 	}
 
 	&.sticker-top-right {
-		$top-right: setter(
-			map-get($cadmin-sticker-outside, sticker-top-right),
-			()
-		);
+		$top-right: map-get($cadmin-sticker-outside, sticker-top-right);
+		$top-right: if($top-right, $top-right, ());
 
 		@include clay-css($top-right);
 	}

--- a/packages/clay-css/src/scss/cadmin/components/_type.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_type.scss
@@ -189,7 +189,10 @@ strong {
 	@include clay-css($cadmin-c-kbd-group);
 
 	> .c-kbd {
-		@include clay-css(setter(map-get($cadmin-c-kbd-group, c-kbd), ()));
+		$kbd: map-get($cadmin-c-kbd-group, c-kbd);
+		$kbd: if($kbd, $kbd, ());
+
+		@include clay-css($kbd);
 	}
 }
 
@@ -254,7 +257,10 @@ strong {
 	@include clay-css($cadmin-c-kbd-group-sm);
 
 	> .c-kbd {
-		@include clay-css(setter(map-get($cadmin-c-kbd-group-sm, c-kbd), ()));
+		$kbd: map-get($cadmin-c-kbd-group-sm, c-kbd);
+		$kbd: if($kbd, $kbd, ());
+
+		@include clay-css($kbd);
 	}
 }
 
@@ -273,7 +279,10 @@ strong {
 	@include clay-css($cadmin-c-kbd-group-lg);
 
 	> .c-kbd {
-		@include clay-css(setter(map-get($cadmin-c-kbd-group-lg, c-kbd), ()));
+		$kbd: map-get($cadmin-c-kbd-group-lg, c-kbd);
+		$kbd: if($kbd, $kbd, ());
+
+		@include clay-css($kbd);
 	}
 }
 

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -737,29 +737,34 @@ $cadmin-has-error: map-deep-merge(
 		input-group-item: (
 			focus: (
 				box-shadow:
-					setter(
+					if(
+						$cadmin-input-danger-focus-box-shadow,
 						$cadmin-input-danger-focus-box-shadow,
 						$cadmin-input-danger-box-shadow
 					),
 				input-group-inset: (
 					background-color:
-						setter(
+						if(
+							$cadmin-input-danger-focus-bg,
 							$cadmin-input-danger-focus-bg,
 							$cadmin-input-danger-bg
 						),
 					border-color:
-						setter(
+						if(
+							$cadmin-input-danger-focus-border-color,
 							$cadmin-input-danger-focus-border-color,
 							$cadmin-input-danger-border-color
 						),
 					input-group-inset-item: (
 						background-color:
-							setter(
+							if(
+								$cadmin-input-danger-focus-bg,
 								$cadmin-input-danger-focus-bg,
 								$cadmin-input-danger-bg
 							),
 						border-color:
-							setter(
+							if(
+								$cadmin-input-danger-focus-border-color,
 								$cadmin-input-danger-focus-border-color,
 								$cadmin-input-danger-border-color
 							),
@@ -776,12 +781,14 @@ $cadmin-has-error: map-deep-merge(
 					box-shadow: none,
 					input-group-inset-item: (
 						background-color:
-							setter(
+							if(
+								$cadmin-input-danger-focus-bg,
 								$cadmin-input-danger-focus-bg,
 								$cadmin-input-danger-bg
 							),
 						border-color:
-							setter(
+							if(
+								$cadmin-input-danger-focus-border-color,
 								$cadmin-input-danger-focus-border-color,
 								$cadmin-input-danger-border-color
 							),
@@ -907,29 +914,34 @@ $cadmin-has-warning: map-deep-merge(
 		input-group-item: (
 			focus: (
 				box-shadow:
-					setter(
+					if(
+						$cadmin-input-warning-focus-box-shadow,
 						$cadmin-input-warning-focus-box-shadow,
 						$cadmin-input-warning-box-shadow
 					),
 				input-group-inset: (
 					background-color:
-						setter(
+						if(
+							$cadmin-input-warning-focus-bg,
 							$cadmin-input-warning-focus-bg,
 							$cadmin-input-warning-bg
 						),
 					border-color:
-						setter(
+						if(
+							$cadmin-input-warning-focus-border-color,
 							$cadmin-input-warning-focus-border-color,
 							$cadmin-input-warning-border-color
 						),
 					input-group-inset-item: (
 						background-color:
-							setter(
+							if(
+								$cadmin-input-warning-focus-bg,
 								$cadmin-input-warning-focus-bg,
 								$cadmin-input-warning-bg
 							),
 						border-color:
-							setter(
+							if(
+								$cadmin-input-warning-focus-border-color,
 								$cadmin-input-warning-focus-border-color,
 								$cadmin-input-warning-border-color
 							),
@@ -946,12 +958,14 @@ $cadmin-has-warning: map-deep-merge(
 					box-shadow: none,
 					input-group-inset-item: (
 						background-color:
-							setter(
+							if(
+								$cadmin-input-warning-focus-bg,
 								$cadmin-input-warning-focus-bg,
 								$cadmin-input-warning-bg
 							),
 						border-color:
-							setter(
+							if(
+								$cadmin-input-warning-focus-border-color,
 								$cadmin-input-warning-focus-border-color,
 								$cadmin-input-warning-border-color
 							),
@@ -1077,29 +1091,34 @@ $cadmin-has-success: map-deep-merge(
 		input-group-item: (
 			focus: (
 				box-shadow:
-					setter(
+					if(
+						$cadmin-input-success-focus-box-shadow,
 						$cadmin-input-success-focus-box-shadow,
 						$cadmin-input-success-box-shadow
 					),
 				input-group-inset: (
 					background-color:
-						setter(
+						if(
+							$cadmin-input-success-focus-bg,
 							$cadmin-input-success-focus-bg,
 							$cadmin-input-success-bg
 						),
 					border-color:
-						setter(
+						if(
+							$cadmin-input-success-focus-border-color,
 							$cadmin-input-success-focus-border-color,
 							$cadmin-input-success-border-color
 						),
 					input-group-inset-item: (
 						background-color:
-							setter(
+							if(
+								$cadmin-input-success-focus-bg,
 								$cadmin-input-success-focus-bg,
 								$cadmin-input-success-bg
 							),
 						border-color:
-							setter(
+							if(
+								$cadmin-input-success-focus-border-color,
 								$cadmin-input-success-focus-border-color,
 								$cadmin-input-success-border-color
 							),
@@ -1116,12 +1135,14 @@ $cadmin-has-success: map-deep-merge(
 					box-shadow: none,
 					input-group-inset-item: (
 						background-color:
-							setter(
+							if(
+								$cadmin-input-success-focus-bg,
 								$cadmin-input-success-focus-bg,
 								$cadmin-input-success-bg
 							),
 						border-color:
-							setter(
+							if(
+								$cadmin-input-success-focus-border-color,
 								$cadmin-input-success-focus-border-color,
 								$cadmin-input-success-border-color
 							),

--- a/packages/clay-css/src/scss/components/_alerts.scss
+++ b/packages/clay-css/src/scss/components/_alerts.scss
@@ -167,8 +167,13 @@
 		@include clay-css(map-get($alert-inline, alert-dismissible));
 
 		&.alert-fluid {
-			$alert-dismissible-alert-fluid: setter(
-				map-get($alert-inline, alert-dismissible-alert-fluid),
+			$alert-dismissible-alert-fluid: map-get(
+				$alert-inline,
+				alert-dismissible-alert-fluid
+			);
+			$alert-dismissible-alert-fluid: if(
+				$alert-dismissible-alert-fluid,
+				$alert-dismissible-alert-fluid,
 				()
 			);
 
@@ -176,17 +181,24 @@
 
 			> .container,
 			> .container-fluid {
-				$container-fluid: setter(
-					map-get($alert-dismissible-alert-fluid, container-fluid),
-					()
+				$container-fluid: map-get(
+					$alert-dismissible-alert-fluid,
+					container-fluid
 				);
+				$container-fluid: if($container-fluid, $container-fluid, ());
 
 				@include clay-css($container-fluid);
 
 				> .alert-autofit-row {
+					$container-fluid-alert-autofit-row: map-get(
+						$container-fluid,
+						alert-autofit-row
+					);
+
 					@include clay-css(
-						setter(
-							map-get($container-fluid, alert-autofit-row),
+						if(
+							$container-fluid-alert-autofit-row,
+							$container-fluid-alert-autofit-row,
 							map-get($alert-inline, alert-autofit-row)
 						)
 					);
@@ -202,10 +214,8 @@
 	}
 
 	> .alert-autofit-row {
-		$alert-autofit-row: setter(
-			map-get($alert-inline, alert-autofit-row),
-			()
-		);
+		$alert-autofit-row: map-get($alert-inline, alert-autofit-row);
+		$alert-autofit-row: if($alert-autofit-row, $alert-autofit-row, ());
 
 		@include clay-css($alert-autofit-row);
 
@@ -225,10 +235,8 @@
 	@include clay-css($alert-autofit-stacked);
 
 	> .alert-autofit-row {
-		$alert-autofit-row: setter(
-			map-get($alert-autofit-stacked, alert-autofit-row),
-			()
-		);
+		$alert-autofit-row: map-get($alert-autofit-stacked, alert-autofit-row);
+		$alert-autofit-row: if($alert-autofit-row, $alert-autofit-row, ());
 
 		@include clay-css($alert-autofit-row);
 
@@ -252,7 +260,8 @@
 	@include clay-css($alert-autofit-stacked-sm-down);
 
 	> .alert-autofit-row {
-		$alert-autofit-row: setter(
+		$alert-autofit-row: if(
+			map-get($alert-autofit-stacked-sm-down, alert-autofit-row),
 			map-get($alert-autofit-stacked-sm-down, alert-autofit-row),
 			()
 		);
@@ -287,10 +296,11 @@
 	@include clay-css($alert-autofit-stacked-xs-down);
 
 	> .alert-autofit-row {
-		$alert-autofit-row: setter(
-			map-get($alert-autofit-stacked-xs-down, alert-autofit-row),
-			()
+		$alert-autofit-row: map-get(
+			$alert-autofit-stacked-xs-down,
+			alert-autofit-row
 		);
+		$alert-autofit-row: if($alert-autofit-row, $alert-autofit-row, ());
 
 		@include media-breakpoint-down(xs) {
 			@include clay-css($alert-autofit-row);
@@ -322,7 +332,8 @@
 	@include clay-css($alert-indicator-start);
 
 	&.alert-fluid {
-		$alert-fluid: setter(map-get($alert-indicator-start, alert-fluid), ());
+		$alert-fluid: map-get($alert-indicator-start, alert-fluid);
+		$alert-fluid: if($alert-fluid, $alert-fluid, ());
 
 		@include clay-css($alert-fluid);
 
@@ -337,10 +348,8 @@
 	}
 
 	.alert-indicator {
-		$alert-indicator: setter(
-			map-get($alert-indicator-start, alert-indicator),
-			()
-		);
+		$alert-indicator: map-get($alert-indicator-start, alert-indicator);
+		$alert-indicator: if($alert-indicator, $alert-indicator, ());
 
 		@include clay-css($alert-indicator);
 
@@ -350,10 +359,8 @@
 	}
 
 	.alert-autofit-row {
-		$alert-autofit-row: setter(
-			map-get($alert-indicator-start, alert-autofit-row),
-			()
-		);
+		$alert-autofit-row: map-get($alert-indicator-start, alert-autofit-row);
+		$alert-autofit-row: if($alert-autofit-row, $alert-autofit-row, ());
 
 		@include clay-css($alert-autofit-row);
 

--- a/packages/clay-css/src/scss/components/_buttons.scss
+++ b/packages/clay-css/src/scss/components/_buttons.scss
@@ -3,7 +3,8 @@
 }
 
 fieldset:disabled a.btn {
-	$btn-disabled: setter(map-get($btn, disabled), ());
+	$btn-disabled: map-get($btn, disabled);
+	$btn-disabled: if($btn-disabled, $btn-disabled, ());
 
 	@include clay-css($btn-disabled);
 

--- a/packages/clay-css/src/scss/components/_tables.scss
+++ b/packages/clay-css/src/scss/components/_tables.scss
@@ -80,7 +80,7 @@ caption {
 @each $color, $value in $table-row-theme-colors {
 	.table {
 		.table-#{$color} {
-			$table-row: setter($value, ());
+			$table-row: if($value, $value, ());
 
 			&,
 			> th,
@@ -107,7 +107,8 @@ caption {
 	// Note: this is not available for cells or rows within `thead` or `tfoot`.
 
 	.table-hover {
-		$hover: setter(map-get($value, hover), ());
+		$hover: map-get($value, hover);
+		$hover: if($hover, $hover, ());
 
 		.table-#{$color} {
 			&:hover {

--- a/packages/clay-css/src/scss/components/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/components/_toggle-switch.scss
@@ -25,10 +25,8 @@
 }
 
 .toggle-switch-text-left {
-	$breakpoint-down: setter(
-		map-get($toggle-switch-text-left, breakpoint-down),
-		sm
-	);
+	$breakpoint-down: map-get($toggle-switch-text-left, breakpoint-down);
+	$breakpoint-down: if($breakpoint-down, $breakpoint-down, sm);
 
 	@include clay-css($toggle-switch-text-left);
 
@@ -38,10 +36,8 @@
 }
 
 .toggle-switch-text-right {
-	$breakpoint-down: setter(
-		map-get($toggle-switch-text-right, breakpoint-down),
-		sm
-	);
+	$breakpoint-down: map-get($toggle-switch-text-right, breakpoint-down);
+	$breakpoint-down: if($breakpoint-down, $breakpoint-down, sm);
 
 	@include clay-css($toggle-switch-text-right);
 

--- a/packages/clay-css/src/scss/functions/_global-functions.scss
+++ b/packages/clay-css/src/scss/functions/_global-functions.scss
@@ -383,7 +383,8 @@
 /// @param {List} $breakpoint-names[map-keys($breakpoints)] - A list of all the keys in $breakpoints
 
 @function breakpoint-next($name, $breakpoints: null, $breakpoint-names: null) {
-	$breakpoints: setter(
+	$breakpoints: if(
+		$breakpoints,
 		$breakpoints,
 		if(
 			variable-exists(grid-breakpoints),
@@ -402,7 +403,11 @@
 		)
 	);
 
-	$breakpoint-names: setter($breakpoint-names, map-keys($breakpoints));
+	$breakpoint-names: if(
+		$breakpoint-names,
+		$breakpoint-names,
+		map-keys($breakpoints)
+	);
 
 	$n: index($breakpoint-names, $name);
 
@@ -423,7 +428,8 @@
 	$breakpoints: null,
 	$breakpoint-names: null
 ) {
-	$breakpoints: setter(
+	$breakpoints: if(
+		$breakpoints,
 		$breakpoints,
 		if(
 			variable-exists(grid-breakpoints),
@@ -442,7 +448,11 @@
 		)
 	);
 
-	$breakpoint-names: setter($breakpoint-names, map-keys($breakpoints));
+	$breakpoint-names: if(
+		$breakpoint-names,
+		$breakpoint-names,
+		map-keys($breakpoints)
+	);
 
 	@each $value in $breakpoint-names {
 		@if (breakpoint-next($value) == $name) {
@@ -459,7 +469,8 @@
 /// @param {Map} $breakpoints[$grid-breakpoints] - A map that defines the breakpoints
 
 @function breakpoint-min($name, $breakpoints: null) {
-	$breakpoints: setter(
+	$breakpoints: if(
+		$breakpoints,
 		$breakpoints,
 		if(
 			variable-exists(grid-breakpoints),
@@ -492,7 +503,8 @@
 /// @param {Map} $breakpoints[$grid-breakpoints] - A map that defines the breakpoints
 
 @function breakpoint-max($name, $breakpoints: null) {
-	$breakpoints: setter(
+	$breakpoints: if(
+		$breakpoints,
 		$breakpoints,
 		if(
 			variable-exists(grid-breakpoints),
@@ -523,7 +535,8 @@
 /// @param {Map} $breakpoints[$grid-breakpoints] - A map that defines the breakpoints
 
 @function breakpoint-infix($name, $breakpoints: null) {
-	$breakpoints: setter(
+	$breakpoints: if(
+		$breakpoints,
 		$breakpoints,
 		if(
 			variable-exists(grid-breakpoints),
@@ -568,7 +581,8 @@
 
 	$yiq: (($r * 299) + ($g * 587) + ($b * 114)) * 0.001;
 
-	$dark: setter(
+	$dark: if(
+		$dark,
 		$dark,
 		if(
 			variable-exists(yiq-text-dark),
@@ -581,7 +595,8 @@
 		)
 	);
 
-	$light: setter(
+	$light: if(
+		$light,
 		$light,
 		if(
 			variable-exists(yiq-text-light),
@@ -594,7 +609,8 @@
 		)
 	);
 
-	$threshold: setter(
+	$threshold: if(
+		$threshold,
 		$threshold,
 		if(
 			variable-exists(yiq-contrasted-threshold),
@@ -672,7 +688,8 @@
 	$color-base: if($level > 0, $black, $white);
 	$level: abs($level);
 
-	$color-interval: setter(
+	$color-interval: if(
+		$color-interval,
 		$color-interval,
 		if(
 			variable-exists(theme-color-interval),

--- a/packages/clay-css/src/scss/mixins/_alerts.scss
+++ b/packages/clay-css/src/scss/mixins/_alerts.scss
@@ -96,7 +96,8 @@
 
 @mixin clay-alert-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -106,9 +107,11 @@
 			)
 		);
 
-		$alert-indicator: setter(map-get($map, alert-indicator), ());
+		$alert-indicator: map-get($map, alert-indicator);
+		$alert-indicator: if($alert-indicator, $alert-indicator, ());
 
-		$close: setter(map-get($map, close), ());
+		$close: map-get($map, close);
+		$close: if($close, $close, ());
 		$close: map-deep-merge(
 			$close,
 			(
@@ -124,7 +127,8 @@
 			)
 		);
 
-		$lead: setter(map-get($map, lead), ());
+		$lead: map-get($map, lead);
+		$lead: if($lead, $lead, ());
 		$lead: map-deep-merge(
 			$lead,
 			(
@@ -132,7 +136,8 @@
 			)
 		);
 
-		$alert-link: setter(map-get($map, alert-link), ());
+		$alert-link: map-get($map, alert-link);
+		$alert-link: if($alert-link, $alert-link, ());
 		$alert-link: map-deep-merge(
 			$alert-link,
 			(
@@ -167,19 +172,22 @@
 			}
 
 			&.alert-dismissible {
-				@include clay-css(setter(map-get($map, alert-dismissible), ()));
+				$alert-dismissible: map-get($map, alert-dismissible);
+
+				@include clay-css(
+					if($alert-dismissible, $alert-dismissible, ())
+				);
 
 				.container,
 				.container-fluid {
+					$container-fluid: map-deep-get(
+						$map,
+						alert-dismissible,
+						container-fluid
+					);
+
 					@include clay-css(
-						setter(
-							map-deep-get(
-								$map,
-								alert-dismissible,
-								container-fluid
-							),
-							()
-						)
+						if($container-fluid, $container-fluid, ())
 					);
 				}
 			}
@@ -214,7 +222,8 @@
 
 			.container,
 			.container-fluid {
-				@include clay-css(setter(map-get($map, container-fluid), ()));
+				$container-fluid: map-get($map, container-fluid);
+				@include clay-css(if($container-fluid, $container-fluid, ()));
 			}
 
 			.lead {

--- a/packages/clay-css/src/scss/mixins/_aspect-ratio.scss
+++ b/packages/clay-css/src/scss/mixins/_aspect-ratio.scss
@@ -36,7 +36,8 @@
 
 @mixin clay-aspect-ratio-item-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);
@@ -59,12 +60,13 @@
 
 @mixin clay-aspect-ratio-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$horizontal: map-get($map, horizontal);
 		$vertical: map-get($map, vertical);
 
-		$base: setter($map, ());
+		$base: if($map, $map, ());
 		$base: map-merge(
 			$map,
 			(
@@ -78,7 +80,8 @@
 			)
 		);
 
-		$lexicon-icon: setter(map-get($map, lexicon-icon), ());
+		$lexicon-icon: map-get($map, lexicon-icon);
+		$lexicon-icon: if($lexicon-icon, $lexicon-icon, ());
 		$lexicon-icon: map-merge(
 			$lexicon-icon,
 			(

--- a/packages/clay-css/src/scss/mixins/_background.scss
+++ b/packages/clay-css/src/scss/mixins/_background.scss
@@ -65,22 +65,41 @@
 
 @mixin clay-indicator-bg($map) {
 	$indicator: map-get($map, indicator);
-	$indicator-bg-position: setter(
-		map-get($map, indicator-bg-position),
+
+	$indicator-bg-position: map-get($map, indicator-bg-position);
+	$indicator-bg-position: if(
+		$indicator-bg-position,
+		$indicator-bg-position,
 		top 0.125rem left
 	);
-	$indicator-bg-size: setter(map-get($map, indicator-bg-size), 100%);
-	$indicator-display: setter(map-get($map, indicator-display), inline-block);
-	$indicator-height: setter(
-		map-get($map, indicator-height),
+
+	$indicator-bg-size: map-get($map, indicator-bg-size);
+	$indicator-bg-size: if($indicator-bg-size, $indicator-bg-size, 100%);
+
+	$indicator-display: map-get($map, indicator-display);
+	$indicator-display: if(
+		$indicator-display,
+		$indicator-display,
+		inline-block
+	);
+
+	$indicator-height: map-get($map, indicator-height);
+	$indicator-height: if(
+		$indicator-height,
+		$indicator-height,
 		#{$line-height-base}em
 	);
+
 	$indicator-text-indent: map-get($map, indicator-text-indent);
-	$indicator-vertical-align: setter(
-		map-get($map, indicator-vertical-align),
-		middle
+
+	$indicator-vertical-align: map-get($map, indicator-vertical-align);
+	$indicator-vertical-align: if(
+		$indicator-vertical-align,
+		$indicator-vertical-align middle
 	);
-	$indicator-width: setter(map-get($map, indicator-width), 1em);
+
+	$indicator-width: map-get($map, indicator-width);
+	$indicator-width: if($indicator-width, $indicator-width, 1em);
 
 	background-image: $indicator;
 	background-position: $indicator-bg-position;

--- a/packages/clay-css/src/scss/mixins/_badges.scss
+++ b/packages/clay-css/src/scss/mixins/_badges.scss
@@ -17,14 +17,20 @@
 /// - Update or Deprecate this mixin in favor of a `clay-badge-variant` mixin
 
 @mixin clay-badge-size($map) {
-	$border-width: setter(map-get($map, border-width), $badge-border-width);
+	$border-width: map-get($map, border-width);
+	$border-width: if($border-width, $border-width, $badge-border-width);
+
 	$font-size: map-get($map, font-size);
 	$height: map-get($map, height);
 	$padding-x: map-get($map, padding-x);
-	$padding-y: setter(map-get($map, padding-y), 0);
 
-	$lexicon-icon-height: setter(
-		map-get($map, lexicon-icon-height),
+	$padding-y: map-get($map, padding-y);
+	$padding-y: if($padding-y, $padding-y, 0);
+
+	$lexicon-icon-height: map-get($map, lexicon-icon-height);
+	$lexicon-icon-height: if(
+		$lexicon-icon-height,
+		$lexicon-icon-height,
 		map-get($map, lexicon-icon-width)
 	);
 	$lexicon-icon-margin-top: map-get($map, lexicon-icon-margin-top);
@@ -63,7 +69,8 @@
 
 @mixin clay-badge-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -93,7 +100,8 @@
 			)
 		);
 
-		$href: setter(map-get($map, href), ());
+		$href: map-get($map, href);
+		$href: if($href, $href, ());
 		$href: map-deep-merge(
 			$href,
 			(
@@ -134,7 +142,8 @@
 			)
 		);
 
-		$link: setter(map-get($map, link), ());
+		$link: map-get($map, link);
+		$link: if($link, $link, ());
 		$link: map-deep-merge(
 			$link,
 			(
@@ -156,7 +165,8 @@
 			)
 		);
 
-		$c-inner: setter(map-get($map, c-inner), ());
+		$c-inner: map-get($map, c-inner);
+		$c-inner: if($c-inner, $c-inner, ());
 		$c-inner: map-merge(
 			(
 				enabled:
@@ -173,9 +183,11 @@
 			$c-inner
 		);
 
-		$badge-item: setter(map-get($map, badge-item), ());
+		$badge-item: map-get($map, badge-item);
+		$badge-item: if($badge-item, $badge-item, ());
 
-		$badge-item-expand: setter(map-get($map, badge-item-expand), ());
+		$badge-item-expand: map-get($map, badge-item-expand);
+		$badge-item-expand: if($badge-item-expand, $badge-item-expand, ());
 
 		@if ($enabled) {
 			@include clay-css($base);

--- a/packages/clay-css/src/scss/mixins/_buttons.scss
+++ b/packages/clay-css/src/scss/mixins/_buttons.scss
@@ -246,7 +246,8 @@
 
 @mixin clay-button-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$breakpoint-down: map-get($map, breakpoint-down);
 
@@ -258,7 +259,8 @@
 			)
 		);
 
-		$hover: setter(map-get($map, hover), ());
+		$hover: map-get($map, hover);
+		$hover: if($hover, $hover, ());
 		$hover: map-merge(
 			$hover,
 			(
@@ -292,7 +294,8 @@
 			)
 		);
 
-		$focus: setter(map-get($map, focus), ());
+		$focus: map-get($map, focus);
+		$focus: if($focus, $focus, ());
 		$focus: map-merge(
 			$focus,
 			(
@@ -331,7 +334,8 @@
 			)
 		);
 
-		$active: setter(map-get($map, active), ());
+		$active: map-get($map, active);
+		$active: if($active, $active, ());
 		$active: map-merge(
 			$active,
 			(
@@ -368,8 +372,14 @@
 			)
 		);
 
-		$nested-active-focus: setter(map-get($active, focus), ());
-		$active-focus: setter(map-get($map, active-focus), ());
+		$nested-active-focus: map-get($active, focus);
+		$nested-active-focus: if(
+			$nested-active-focus,
+			$nested-active-focus,
+			()
+		);
+		$active-focus: map-get($map, active-focus);
+		$active-focus: if($active-focus, $active-focus, ());
 		$active-focus: map-merge($nested-active-focus, $active-focus);
 		$active-focus: map-merge(
 			$active-focus,
@@ -384,12 +394,14 @@
 			)
 		);
 
-		$active-class: setter(map-get($map, active-class), ());
+		$active-class: map-get($map, active-class);
+		$active-class: if($active-class, $active-class, ());
 		$active-class: map-merge($active, $active-class);
 
 		$show: map-deep-merge($active-class, map-get($map, show));
 
-		$disabled: setter(map-get($map, disabled), ());
+		$disabled: map-get($map, disabled);
+		$disabled: if($disabled, $disabled, ());
 		$disabled: map-merge(
 			$disabled,
 			(
@@ -431,11 +443,18 @@
 			)
 		);
 
-		$nested-disabled-active: setter(map-get($disabled, active), ());
-		$disabled-active: setter(map-get($map, disabled-active), ());
+		$nested-disabled-active: map-get($disabled, active);
+		$nested-disabled-active: if(
+			$nested-disabled-active,
+			$nested-disabled-active,
+			()
+		);
+		$disabled-active: map-get($map, disabled-active);
+		$disabled-active: if($disabled-active, $disabled-active, ());
 		$disabled-active: map-merge($nested-disabled-active, $disabled-active);
 
-		$lexicon-icon: setter(map-get($map, lexicon-icon), ());
+		$lexicon-icon: map-get($map, lexicon-icon);
+		$lexicon-icon: if($lexicon-icon, $lexicon-icon, ());
 		$lexicon-icon: map-merge(
 			$lexicon-icon,
 			(
@@ -467,7 +486,8 @@
 			)
 		);
 
-		$inline-item: setter(map-get($map, inline-item), ());
+		$inline-item: map-get($map, inline-item);
+		$inline-item: if($inline-item, $inline-item, ());
 		$inline-item: map-merge(
 			$inline-item,
 			(
@@ -479,8 +499,10 @@
 			)
 		);
 
-		$btn-section: setter(map-get($map, btn-section), ());
-		$section: setter(map-get($map, section), ());
+		$btn-section: map-get($map, btn-section);
+		$btn-section: if($btn-section, $btn-section, ());
+		$section: map-get($map, section);
+		$section: if($section, $section, ());
 		$section: map-merge($btn-section, $section);
 		$section: map-merge(
 			$section,
@@ -503,7 +525,8 @@
 			)
 		);
 
-		$mobile: setter(map-get($map, mobile), ());
+		$mobile: map-get($map, mobile);
+		$mobile: if($mobile, $mobile, ());
 		$mobile: map-merge(
 			$mobile,
 			(
@@ -545,7 +568,8 @@
 			)
 		);
 
-		$mobile-c-inner: setter(map-get($mobile, c-inner), ());
+		$mobile-c-inner: map-get($mobile, c-inner);
+		$mobile-c-inner: if($mobile-c-inner, $mobile-c-inner, ());
 		$mobile-c-inner: map-merge(
 			(
 				enabled:
@@ -567,12 +591,15 @@
 			$mobile-c-inner
 		);
 
-		$loading-animation: setter(
-			map-get($map, loading-animation),
+		$loading-animation: map-get($map, loading-animation);
+		$loading-animation: if(
+			$loading-animation,
+			$loading-animation,
 			clay-unset-placeholder
 		);
 
-		$c-inner: setter(map-get($map, c-inner), ());
+		$c-inner: map-get($map, c-inner);
+		$c-inner: if($c-inner, $c-inner, ());
 		$c-inner: map-merge(
 			(
 				enabled:

--- a/packages/clay-css/src/scss/mixins/_cards.scss
+++ b/packages/clay-css/src/scss/mixins/_cards.scss
@@ -32,7 +32,8 @@
 
 @mixin clay-card-section-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -42,7 +43,8 @@
 			)
 		);
 
-		$autofit-col: setter(map-get($map, autofit-col), ());
+		$autofit-col: map-get($map, autofit-col);
+		$autofit-col: if($autofit-col, $autofit-col, ());
 		$autofit-col: map-merge(
 			$autofit-col,
 			(
@@ -295,7 +297,8 @@
 
 @mixin clay-card-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -305,7 +308,8 @@
 			)
 		);
 
-		$hover: setter(map-get($map, hover), ());
+		$hover: map-get($map, hover);
+		$hover: if($hover, $hover, ());
 		$hover: map-merge(
 			$hover,
 			(
@@ -334,29 +338,55 @@
 			)
 		);
 
-		$old-hover-card-title: setter(map-get($map, hover-card-title), ());
-		$hover-card-title: setter(map-get($hover, card-title), ());
-		$hover-card-title: map-merge($hover-card-title, $old-hover-card-title);
-
-		$old-hover-card-subtitle: setter(
-			map-get($map, hover-card-subtitle),
+		$old-hover-card-title: map-get($map, hover-card-title);
+		$old-hover-card-title: if(
+			$old-hover-card-title,
+			$old-hover-card-title,
 			()
 		);
-		$hover-card-subtitle: setter(map-get($hover, card-subtitle), ());
+		$hover-card-title: map-get($hover, card-title);
+		$hover-card-title: if($hover-card-title, $hover-card-title, ());
+		$hover-card-title: map-merge($hover-card-title, $old-hover-card-title);
+
+		$old-hover-card-subtitle: map-get($map, hover-card-subtitle);
+		$old-hover-card-subtitle: if(
+			$old-hover-card-subtitle,
+			$old-hover-card-subtitle,
+			()
+		);
+		$hover-card-subtitle: map-get($hover, card-subtitle);
+		$hover-card-subtitle: if(
+			$hover-card-subtitle,
+			$hover-card-subtitle,
+			()
+		);
 		$hover-card-subtitle: map-merge(
 			$hover-card-subtitle,
 			$old-hover-card-subtitle
 		);
 
-		$old-hover-card-text: setter(map-get($map, hover-card-text), ());
-		$hover-card-text: setter(map-get($hover, card-text), ());
+		$old-hover-card-text: map-get($map, hover-card-text);
+		$old-hover-card-text: if(
+			$old-hover-card-text,
+			$old-hover-card-text,
+			()
+		);
+		$hover-card-text: map-get($hover, card-text);
+		$hover-card-text: if($hover-card-text, $hover-card-text, ());
 		$hover-card-text: map-merge($hover-card-text, $old-hover-card-text);
 
-		$old-hover-card-link: setter(map-get($map, hover-card-link), ());
-		$hover-card-link: setter(map-get($hover, card-link), ());
+		$old-hover-card-link: map-get($map, hover-card-link);
+		$old-hover-card-link: if(
+			$old-hover-card-link,
+			$old-hover-card-link,
+			()
+		);
+		$hover-card-link: map-get($hover, card-link);
+		$hover-card-link: if($hover-card-link, $hover-card-link, ());
 		$hover-card-link: map-merge($hover-card-link, $old-hover-card-link);
 
-		$focus: setter(map-get($map, focus), ());
+		$focus: map-get($map, focus);
+		$focus: if($focus, $focus, ());
 		$focus: map-merge(
 			$focus,
 			(
@@ -385,29 +415,55 @@
 			)
 		);
 
-		$old-focus-card-title: setter(map-get($map, focus-card-title), ());
-		$focus-card-title: setter(map-get($focus, card-title), ());
-		$focus-card-title: map-merge($focus-card-title, $old-focus-card-title);
-
-		$old-focus-card-subtitle: setter(
-			map-get($map, focus-card-subtitle),
+		$old-focus-card-title: map-get($map, focus-card-title);
+		$old-focus-card-title: if(
+			$old-focus-card-title,
+			$old-focus-card-title,
 			()
 		);
-		$focus-card-subtitle: setter(map-get($focus, card-subtitle), ());
+		$focus-card-title: map-get($focus, card-title);
+		$focus-card-title: if($focus-card-title, $focus-card-title, ());
+		$focus-card-title: map-merge($focus-card-title, $old-focus-card-title);
+
+		$old-focus-card-subtitle: map-get($map, focus-card-subtitle);
+		$old-focus-card-subtitle: if(
+			$old-focus-card-subtitle,
+			$old-focus-card-subtitle,
+			()
+		);
+		$focus-card-subtitle: map-get($focus, card-subtitle);
+		$focus-card-subtitle: if(
+			$focus-card-subtitle,
+			$focus-card-subtitle,
+			()
+		);
 		$focus-card-subtitle: map-merge(
 			$focus-card-subtitle,
 			$old-focus-card-subtitle
 		);
 
-		$old-focus-card-text: setter(map-get($map, focus-card-text), ());
-		$focus-card-text: setter(map-get($focus, card-text), ());
+		$old-focus-card-text: map-get($map, focus-card-text);
+		$old-focus-card-text: if(
+			$old-focus-card-text,
+			$old-focus-card-text,
+			()
+		);
+		$focus-card-text: map-get($focus, card-text);
+		$focus-card-text: if($focus-card-text, $focus-card-text, ());
 		$focus-card-text: map-merge($focus-card-text, $old-focus-card-text);
 
-		$old-focus-card-link: setter(map-get($map, focus-card-link), ());
-		$focus-card-link: setter(map-get($focus, card-link), ());
+		$old-focus-card-link: map-get($map, focus-card-link);
+		$old-focus-card-link: if(
+			$old-focus-card-link,
+			$old-focus-card-link,
+			()
+		);
+		$focus-card-link: map-get($focus, card-link);
+		$focus-card-link: if($focus-card-link, $focus-card-link, ());
 		$focus-card-link: map-merge($focus-card-link, $old-focus-card-link);
 
-		$active: setter(map-get($map, active), ());
+		$active: map-get($map, active);
+		$active: if($active, $active, ());
 		$active: map-merge(
 			$active,
 			(
@@ -429,39 +485,72 @@
 			)
 		);
 
-		$old-active-card-title: setter(map-get($map, active-card-title), ());
-		$active-card-title: setter(map-get($active, card-title), ());
+		$old-active-card-title: map-get($map, active-card-title);
+		$old-active-card-title: if(
+			$old-active-card-title,
+			$old-active-card-title,
+			()
+		);
+		$active-card-title: map-get($active, card-title);
+		$active-card-title: if($active-card-title, $active-card-title, ());
 		$active-card-title: map-merge(
 			$active-card-title,
 			$old-active-card-title
 		);
 
-		$old-active-card-subtitle: setter(
-			map-get($map, active-card-subtitle),
+		$old-active-card-subtitle: map-get($map, active-card-subtitle);
+		$old-active-card-subtitle: if(
+			$old-active-card-subtitle,
+			$old-active-card-subtitle,
 			()
 		);
-		$active-card-subtitle: setter(map-get($active, card-subtitle), ());
+		$active-card-subtitle: map-get($active, card-subtitle);
+		$active-card-subtitle: if(
+			$active-card-subtitle,
+			$active-card-subtitle,
+			()
+		);
 		$active-card-subtitle: map-merge(
 			$active-card-subtitle,
 			$old-active-card-subtitle
 		);
 
-		$old-active-card-text: setter(map-get($map, active-card-text), ());
-		$active-card-text: setter(map-get($active, card-text), ());
+		$old-active-card-text: map-get($map, active-card-text);
+		$old-active-card-text: if(
+			$old-active-card-text,
+			$old-active-card-text,
+			()
+		);
+		$active-card-text: map-get($active, card-text);
+		$active-card-text: if($active-card-text, $active-card-text, ());
 		$active-card-text: map-merge($active-card-text, $old-active-card-text);
 
-		$old-active-card-link: setter(map-get($map, active-card-link), ());
-		$active-card-link: setter(map-get($active, card-link), ());
+		$old-active-card-link: map-get($map, active-card-link);
+		$old-active-card-link: if(
+			$old-active-card-link,
+			$old-active-card-link,
+			()
+		);
+		$active-card-link: map-get($active, card-link);
+		$active-card-link: if($active-card-link, $active-card-link, ());
 		$active-card-link: map-merge($active-card-link, $old-active-card-link);
 
-		$aspect-ratio: setter(map-get($map, aspect-ratio), ());
+		$aspect-ratio: map-get($map, aspect-ratio);
+		$aspect-ratio: if($aspect-ratio, $aspect-ratio, ());
 
-		$aspect-ratio-custom-control-label: setter(
-			map-deep-get($aspect-ratio, custom-control, label),
+		$aspect-ratio-custom-control-label: map-deep-get(
+			$aspect-ratio,
+			custom-control,
+			label
+		);
+		$aspect-ratio-custom-control-label: if(
+			$aspect-ratio-custom-control-label,
+			$aspect-ratio-custom-control-label,
 			()
 		);
 
-		$checkbox: setter(map-get($map, checkbox), ());
+		$checkbox: map-get($map, checkbox);
+		$checkbox: if($checkbox, $checkbox, ());
 		$checkbox: map-merge(
 			$checkbox,
 			(
@@ -530,7 +619,8 @@
 			checkered-foreground-color
 		);
 
-		$card-body: setter(map-get($map, card-body), ());
+		$card-body: map-get($map, card-body);
+		$card-body: if($card-body, $card-body, ());
 		$card-body: map-merge(
 			$card-body,
 			(
@@ -557,7 +647,8 @@
 			)
 		);
 
-		$card-row: setter(map-get($map, card-row), ());
+		$card-row: map-get($map, card-row);
+		$card-row: if($card-row, $card-row, ());
 		$card-row: map-merge(
 			$card-row,
 			(
@@ -569,17 +660,30 @@
 			)
 		);
 
-		$card-type-asset-icon: setter(map-get($map, card-type-asset-icon), ());
-
-		$asset-icon: setter(map-get($map, asset-icon), ());
-
-		$asset-icon-lexicon-icon: setter(
-			map-get($asset-icon, lexicon-icon),
+		$card-type-asset-icon: map-get($map, card-type-asset-icon);
+		$card-type-asset-icon: if(
+			$card-type-asset-icon,
+			$card-type-asset-icon,
 			()
 		);
 
-		$card-type-asset-icon-lexicon-icon: setter(
-			map-get($card-type-asset-icon, lexicon-icon),
+		$asset-icon: map-get($map, asset-icon);
+		$asset-icon: if($asset-icon, $asset-icon, ());
+
+		$asset-icon-lexicon-icon: map-get($asset-icon, lexicon-icon);
+		$asset-icon-lexicon-icon: if(
+			$asset-icon-lexicon-icon,
+			$asset-icon-lexicon-icon,
+			()
+		);
+
+		$card-type-asset-icon-lexicon-icon: map-get(
+			$card-type-asset-icon,
+			lexicon-icon
+		);
+		$card-type-asset-icon-lexicon-icon: if(
+			$card-type-asset-icon-lexicon-icon,
+			$card-type-asset-icon-lexicon-icon,
 			()
 		);
 		$card-type-asset-icon-lexicon-icon: map-merge(
@@ -633,8 +737,10 @@
 			)
 		);
 
-		$card-type-asset-icon-sticker: setter(
-			map-get($card-type-asset-icon, sticker),
+		$card-type-asset-icon-sticker: map-get($card-type-asset-icon, sticker);
+		$card-type-asset-icon-sticker: if(
+			$card-type-asset-icon-sticker,
+			$card-type-asset-icon-sticker,
 			()
 		);
 		$card-type-asset-icon-sticker: map-merge(
@@ -653,7 +759,8 @@
 			)
 		);
 
-		$dropdown-action: setter(map-get($map, dropdown-action), ());
+		$dropdown-action: map-get($map, dropdown-action);
+		$dropdown-action: if($dropdown-action, $dropdown-action, ());
 		$dropdown-action: map-merge(
 			$dropdown-action,
 			(
@@ -787,8 +894,10 @@
 				}
 			}
 
+			$after-highlight-variant: map-get($map, after-highlight);
+
 			@include clay-after-highlight-variant(
-				setter(map-get($map, after-highlight), ())
+				if($after-highlight-variant, $after-highlight-variant, ())
 			);
 
 			&::before {
@@ -1042,9 +1151,11 @@
 /// - Add @link to documentation
 
 @mixin clay-card-type-asset($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled, $enabled, true);
 
-	$aspect-ratio: setter(map-get($map, aspect-ratio), ());
+	$aspect-ratio: map-get($map, aspect-ratio);
+	$aspect-ratio: if($aspect-ratio, $aspect-ratio, ());
 	$aspect-ratio: map-merge(
 		$aspect-ratio,
 		(
@@ -1093,7 +1204,8 @@
 	$aspect-ratio-horizontal: map-get($aspect-ratio, horizontal);
 	$aspect-ratio-vertical: map-get($aspect-ratio, vertical);
 
-	$card-body: setter(map-get($map, card-body), ());
+	$card-body: map-get($map, card-body);
+	$card-body: if($card-body, $card-body, ());
 	$card-body: map-merge(
 		$card-body,
 		(
@@ -1120,7 +1232,8 @@
 		)
 	);
 
-	$card-row: setter(map-get($map, card-row), ());
+	$card-row: map-get($map, card-row);
+	$card-row: if($card-row, $card-row, ());
 	$card-row: map-merge(
 		$card-row,
 		(
@@ -1133,7 +1246,8 @@
 		)
 	);
 
-	$checkbox: setter(map-get($map, checkbox), ());
+	$checkbox: map-get($map, checkbox);
+	$checkbox: if($checkbox, $checkbox, ());
 	$checkbox: map-merge(
 		$checkbox,
 		(
@@ -1154,7 +1268,8 @@
 		)
 	);
 
-	$card-type-asset-icon: setter(map-get($map, card-type-asset-icon), ());
+	$card-type-asset-icon: map-get($map, card-type-asset-icon);
+	$card-type-asset-icon: if($card-type-asset-icon, $card-type-asset-icon, ());
 	$card-type-asset-icon: map-merge(
 		$card-type-asset-icon,
 		(
@@ -1172,9 +1287,10 @@
 		)
 	);
 
-	$card-type-asset-icon-sticker: setter(
-		map-get($card-type-asset-icon, sticker),
-		()
+	$card-type-asset-icon-sticker: map-get($card-type-asset-icon, sticker);
+	$card-type-asset-icon-sticker: if(
+		$card-type-asset-icon-sticker,
+		$card-type-asset-icon-sticker ()
 	);
 	$card-type-asset-icon-sticker: map-merge(
 		$card-type-asset-icon-sticker,
@@ -1305,9 +1421,11 @@
 /// - Add @link to documentation
 
 @mixin clay-card-type-asset-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled, $enabled, true);
 
-	$aspect-ratio: setter(map-get($map, aspect-ratio), ());
+	$aspect-ratio: map-get($map, aspect-ratio);
+	$aspect-ratio: if($aspect-ratio, $aspect-ratio, ());
 	$aspect-ratio: map-merge(
 		$aspect-ratio,
 		(
@@ -1330,7 +1448,8 @@
 		checkered-foreground-color
 	);
 
-	$asset-icon: setter(map-get($map, asset-icon), ());
+	$asset-icon: map-get($map, asset-icon);
+	$asset-icon: if($asset-icon, $asset-icon, ());
 	$asset-icon: map-merge(
 		$asset-icon,
 		(
@@ -1357,7 +1476,12 @@
 		)
 	);
 
-	$asset-icon-lexicon-icon: setter(map-get($asset-icon, lexicon-icon), ());
+	$asset-icon-lexicon-icon: map-get($asset-icon, lexicon-icon);
+	$asset-icon-lexicon-icon: if(
+		$asset-icon-lexicon-icon,
+		$asset-icon-lexicon-icon,
+		()
+	);
 	$asset-icon-lexicon-icon: map-merge(
 		$asset-icon-lexicon-icon,
 		(
@@ -1416,11 +1540,13 @@
 /// - Add @link to documentation
 
 @mixin clay-card-type-directory($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled, $enabled, true);
 
-	$base: setter($map, ());
+	$base: if($map, $map, ());
 
-	$card-body: setter(map-get($map, card-body), ());
+	$card-body: map-get($map, card-body);
+	$card-body: if($card-body, $card-body, ());
 	$card-body: map-merge(
 		$card-body,
 		(
@@ -1447,7 +1573,8 @@
 		)
 	);
 
-	$sticker: setter(map-get($map, sticker), ());
+	$sticker: map-get($map, sticker);
+	$sticker: if($sticker, $sticker, ());
 	$sticker: map-merge(
 		$sticker,
 		(
@@ -1470,7 +1597,8 @@
 
 	$sticker-size: map-get($map, sticker-size);
 
-	$dropdown-action: setter(map-get($map, dropdown-action), ());
+	$dropdown-action: map-get($map, dropdown-action);
+	$dropdown-action: if($dropdown-action, $dropdown-action, ());
 	$dropdown-action: map-merge(
 		$dropdown-action,
 		(
@@ -1574,7 +1702,8 @@
 
 @mixin clay-form-check-card-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);

--- a/packages/clay-css/src/scss/mixins/_custom-forms.scss
+++ b/packages/clay-css/src/scss/mixins/_custom-forms.scss
@@ -101,7 +101,8 @@
 
 @mixin clay-custom-control-input-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);
@@ -899,7 +900,8 @@
 
 @mixin clay-custom-control-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		@include clay-css($map);
 

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -39,7 +39,8 @@
 
 @mixin clay-dropdown-menu-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$breakpoint-down: map-get($map, breakpoint-down);
 
@@ -56,7 +57,8 @@
 			)
 		);
 
-		$mobile: setter(map-get($map, mobile), ());
+		$mobile: map-get($map, mobile);
+		$mobile: if($mobile, $mobile, ());
 		$mobile: map-merge(
 			$mobile,
 			(
@@ -221,7 +223,8 @@
 
 @mixin clay-dropdown-item-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -231,7 +234,8 @@
 			)
 		);
 
-		$hover: setter(map-get($map, hover), ());
+		$hover: map-get($map, hover);
+		$hover: if($hover, $hover, ());
 		$hover: map-deep-merge(
 			$hover,
 			(
@@ -260,7 +264,8 @@
 			setter(map-get($map, hover-c-kbd-inline), ())
 		);
 
-		$focus: setter(map-get($map, focus), ());
+		$focus: map-get($map, focus);
+		$focus: if($focus, $focus, ());
 		$focus: map-deep-merge(
 			$focus,
 			(
@@ -341,7 +346,8 @@
 			setter(map-get($map, active-c-kbd-inline), ())
 		);
 
-		$active-class: setter(map-get($map, active-class), ());
+		$active-class: map-get($map, active-class);
+		$active-class: if($active-class, $active-class, ());
 		$active-class: map-deep-merge($active, $active-class);
 		$active-class: map-deep-merge(
 			$active-class,
@@ -379,7 +385,8 @@
 			setter(map-get($map, active-class-c-kbd-inline), ())
 		);
 
-		$disabled: setter(map-get($map, disabled), ());
+		$disabled: map-get($map, disabled);
+		$disabled: if($disabled, $disabled, ());
 		$disabled: map-deep-merge(
 			$disabled,
 			(
@@ -451,7 +458,8 @@
 			)
 		);
 
-		$c-inner: setter(map-get($map, c-inner), ());
+		$c-inner: map-get($map, c-inner);
+		$c-inner: if($c-inner, $c-inner, ());
 		$c-inner: map-merge(
 			(
 				enabled:

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -295,9 +295,10 @@
 
 @mixin clay-form-control-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
-		$base: setter($map, ());
+		$base: if($map, $map, ());
 		$base: map-merge(
 			$map,
 			(
@@ -331,7 +332,8 @@
 			)
 		);
 
-		$placeholder: setter(map-get($map, placeholder), ());
+		$placeholder: map-get($map, placeholder);
+		$placeholder: if($placeholder, $placeholder, ());
 		$placeholder: map-deep-merge(
 			$placeholder,
 			(
@@ -348,7 +350,8 @@
 			)
 		);
 
-		$selection: setter(map-get($map, selection), ());
+		$selection: map-get($map, selection);
+		$selection: if($selection, $selection, ());
 		$selection: map-deep-merge(
 			$selection,
 			(
@@ -365,7 +368,8 @@
 			)
 		);
 
-		$hover: setter(map-get($map, hover), ());
+		$hover: map-get($map, hover);
+		$hover: if($hover, $hover, ());
 		$hover: map-deep-merge(
 			$hover,
 			(
@@ -389,8 +393,14 @@
 			)
 		);
 
-		$old-hover-placeholder: setter(map-get($map, hover-placeholder), ());
-		$hover-placeholder: setter(map-get($hover, placeholder), ());
+		$old-hover-placeholder: map-get($map, hover-placeholder);
+		$old-hover-placeholder: if(
+			$old-hover-placeholder,
+			$old-hover-placeholder,
+			()
+		);
+		$hover-placeholder: map-get($hover, placeholder);
+		$hover-placeholder: if($hover-placeholder, $hover-placeholder, ());
 		$hover-placeholder: map-deep-merge(
 			$hover-placeholder,
 			$old-hover-placeholder
@@ -406,7 +416,8 @@
 			)
 		);
 
-		$focus: setter(map-get($map, focus), ());
+		$focus: map-get($map, focus);
+		$focus: if($focus, $focus, ());
 		$focus: map-deep-merge(
 			$focus,
 			(
@@ -435,8 +446,14 @@
 			)
 		);
 
-		$old-focus-placeholder: setter(map-get($map, focus-placeholder), ());
-		$focus-placeholder: setter(map-get($focus, placeholder), ());
+		$old-focus-placeholder: map-get($map, focus-placeholder);
+		$old-focus-placeholder: if(
+			$old-focus-placeholder,
+			$old-focus-placeholder,
+			()
+		);
+		$focus-placeholder: map-get($focus, placeholder);
+		$focus-placeholder: if($focus-placeholder, $focus-placeholder, ());
 		$focus-placeholder: map-deep-merge(
 			$focus-placeholder,
 			$old-focus-placeholder
@@ -463,7 +480,8 @@
 		$readonly-opacity: map-get($map, readonly-opacity);
 		$readonly-placeholder-color: map-get($map, readonly-placeholder-color);
 
-		$disabled: setter(map-get($map, disabled), ());
+		$disabled: map-get($map, disabled);
+		$disabled: if($disabled, $disabled, ());
 		$disabled: map-deep-merge(
 			$disabled,
 			(
@@ -505,11 +523,18 @@
 			)
 		);
 
-		$old-disabled-placeholder: setter(
-			map-get($map, disabled-placeholder),
+		$old-disabled-placeholder: map-get($map, disabled-placeholder);
+		$old-disabled-placeholder: if(
+			$old-disabled-placeholder,
+			$old-disabled-placeholder,
 			()
 		);
-		$disabled-placeholder: setter(map-get($disabled, placeholder), ());
+		$disabled-placeholder: map-get($disabled, placeholder);
+		$disabled-placeholder: if(
+			$disabled-placeholder,
+			$disabled-placeholder,
+			()
+		);
 		$disabled-placeholder: map-deep-merge(
 			$disabled-placeholder,
 			$old-disabled-placeholder
@@ -701,9 +726,10 @@
 /// - Add @link to documentation
 
 @mixin clay-select-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled, $enabled, true);
 
-	$base: setter($map, ());
+	$base: if($map, $map, ());
 	$base: map-merge(
 		$base,
 		(
@@ -741,7 +767,8 @@
 		)
 	);
 
-	$hover: setter(map-get($map, hover), ());
+	$hover: map-get($map, hover);
+	$hover: if($hover, $hover, ());
 	$hover: map-deep-merge(
 		$hover,
 		(
@@ -764,7 +791,8 @@
 		)
 	);
 
-	$focus: setter(map-get($map, focus), ());
+	$focus: map-get($map, focus);
+	$focus: if($focus, $focus, ());
 	$focus: map-deep-merge(
 		$focus,
 		(
@@ -792,7 +820,8 @@
 		)
 	);
 
-	$disabled: setter(map-get($map, disabled), ());
+	$disabled: map-get($map, disabled);
+	$disabled: if($disabled, $disabled, ());
 	$disabled: map-deep-merge(
 		$disabled,
 		(
@@ -831,7 +860,8 @@
 		)
 	);
 
-	$disabled-option: setter(map-get($disabled, option), ());
+	$disabled-option: map-get($disabled, option);
+	$disabled-option: if($disabled-option, $disabled-option, ());
 	$disabled-option: map-deep-merge(
 		$disabled-option,
 		(
@@ -843,7 +873,8 @@
 		)
 	);
 
-	$option: setter(map-get($map, option), ());
+	$option: map-get($map, option);
+	$option: if($option, $option, ());
 
 	@if ($enabled) {
 		@include clay-css($base);
@@ -1065,7 +1096,8 @@
 /// )
 
 @mixin clay-form-validation-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled, $enabled, true);
 
 	@if ($enabled) {
 		@include clay-css($map);
@@ -1429,9 +1461,11 @@
 
 @mixin clay-range-input-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
-		$clay-range-thumb: setter(map-get($map, clay-range-thumb), ());
+		$clay-range-thumb: map-get($map, clay-range-thumb);
+		$clay-range-thumb: if($clay-range-thumb, $clay-range-thumb, ());
 		$clay-range-thumb: map-merge(
 			$clay-range-thumb,
 			(
@@ -1504,7 +1538,8 @@
 			)
 		);
 
-		$moz-range-thumb: setter(map-get($map, moz-range-thumb), ());
+		$moz-range-thumb: map-get($map, moz-range-thumb);
+		$moz-range-thumb: if($moz-range-thumb, $moz-range-thumb, ());
 		$moz-range-thumb: map-merge(
 			$moz-range-thumb,
 			(
@@ -1524,7 +1559,8 @@
 			)
 		);
 
-		$ms-thumb: setter(map-get($map, ms-thumb), ());
+		$ms-thumb: map-get($map, ms-thumb);
+		$ms-thumb: if($ms-thumb, $ms-thumb, ());
 		$ms-thumb: map-merge(
 			$ms-thumb,
 			(
@@ -1541,7 +1577,12 @@
 			)
 		);
 
-		$webkit-slider-thumb: setter(map-get($map, webkit-slider-thumb), ());
+		$webkit-slider-thumb: map-get($map, webkit-slider-thumb);
+		$webkit-slider-thumb: if(
+			$webkit-slider-thumb,
+			$webkit-slider-thumb,
+			()
+		);
 		$webkit-slider-thumb: map-merge(
 			$webkit-slider-thumb,
 			(
@@ -1563,7 +1604,8 @@
 			)
 		);
 
-		$clay-range-track: setter(map-get($map, clay-range-track), ());
+		$clay-range-track: map-get($map, clay-range-track);
+		$clay-range-track: if($clay-range-track, $clay-range-track, ());
 		$clay-range-track: map-merge(
 			$clay-range-track,
 			(
@@ -1636,7 +1678,12 @@
 			)
 		);
 
-		$clay-range-progress: setter(map-get($map, clay-range-progress), ());
+		$clay-range-progress: map-get($map, clay-range-progress);
+		$clay-range-progress: if(
+			$clay-range-progress,
+			$clay-range-progress,
+			()
+		);
 		$clay-range-progress: map-merge(
 			$clay-range-progress,
 			(
@@ -1711,7 +1758,8 @@
 			)
 		);
 
-		$tooltip: setter(map-get($map, tooltip), ());
+		$tooltip: map-get($map, tooltip);
+		$tooltip: if($tooltip, $tooltip, ());
 		$tooltip: map-merge(
 			$tooltip,
 			(
@@ -1744,7 +1792,8 @@
 			)
 		);
 
-		$tooltip-inner: setter(map-get($map, tooltip-inner), ());
+		$tooltip-inner: map-get($map, tooltip-inner);
+		$tooltip-inner: if($tooltip-inner, $tooltip-inner, ());
 		$tooltip-inner: map-merge(
 			$tooltip-inner,
 			(
@@ -1786,7 +1835,8 @@
 			)
 		);
 
-		$tooltip-arrow: setter(map-get($map, tooltip-arrow), ());
+		$tooltip-arrow: map-get($map, tooltip-arrow);
+		$tooltip-arrow: if($tooltip-arrow, $tooltip-arrow, ());
 		$tooltip-arrow: map-merge(
 			$tooltip-arrow,
 			(
@@ -1818,7 +1868,12 @@
 			)
 		);
 
-		$clay-tooltip-bottom: setter(map-get($map, clay-tooltip-bottom), ());
+		$clay-tooltip-bottom: map-get($map, clay-tooltip-bottom);
+		$clay-tooltip-bottom: if(
+			$clay-tooltip-bottom,
+			$clay-tooltip-bottom,
+			()
+		);
 		$clay-tooltip-bottom: map-merge(
 			$clay-tooltip-bottom,
 			(
@@ -1842,8 +1897,14 @@
 			)
 		);
 
-		$clay-tooltip-bottom-tooltip-arrow: setter(
-			map-deep-get($map, clay-tooltip-bottom, tooltip-arrow),
+		$clay-tooltip-bottom-tooltip-arrow: map-deep-get(
+			$map,
+			clay-tooltip-bottom,
+			tooltip-arrow
+		);
+		$clay-tooltip-bottom-tooltip-arrow: if(
+			$clay-tooltip-bottom-tooltip-arrow,
+			$clay-tooltip-bottom-tooltip-arrow,
 			()
 		);
 		$clay-tooltip-bottom-tooltip-arrow: map-merge(
@@ -1860,7 +1921,8 @@
 			)
 		);
 
-		$clay-tooltip-top: setter(map-get($map, clay-tooltip-top), ());
+		$clay-tooltip-top: map-get($map, clay-tooltip-top);
+		$clay-tooltip-top: if($clay-tooltip-top, $clay-tooltip-top, ());
 		$clay-tooltip-top: map-merge(
 			$clay-tooltip-top,
 			(
@@ -1884,8 +1946,14 @@
 			)
 		);
 
-		$clay-tooltip-top-tooltip-arrow: setter(
-			map-deep-get($map, clay-tooltip-top, tooltip-arrow),
+		$clay-tooltip-top-tooltip-arrow: map-deep-get(
+			$map,
+			clay-tooltip-top,
+			tooltip-arrow
+		);
+		$clay-tooltip-top-tooltip-arrow: if(
+			$clay-tooltip-top-tooltip-arrow,
+			$clay-tooltip-top-tooltip-arrow,
 			()
 		);
 		$clay-tooltip-top-tooltip-arrow: map-merge(
@@ -1899,7 +1967,8 @@
 			)
 		);
 
-		$form-control-range: setter(map-get($map, form-control-range), ());
+		$form-control-range: map-get($map, form-control-range);
+		$form-control-range: if($form-control-range, $form-control-range, ());
 		$form-control-range: map-merge(
 			$form-control-range,
 			(
@@ -1936,7 +2005,8 @@
 			)
 		);
 
-		$data-label-min-max: setter(map-get($map, data-label-min-max), ());
+		$data-label-min-max: map-get($map, data-label-min-max);
+		$data-label-min-max: if($data-label-min-max, $data-label-min-max, ());
 		$data-label-min-max: map-merge(
 			$data-label-min-max,
 			(
@@ -1948,7 +2018,8 @@
 			)
 		);
 
-		$before-after: setter(map-get($map, before-after), ());
+		$before-after: map-get($map, before-after);
+		$before-after: if($before-after, $before-after, ());
 		$before-after: map-merge(
 			$before-after,
 			(
@@ -1995,8 +2066,10 @@
 			)
 		);
 
-		$data-label-min-before: setter(
-			map-deep-get($map, data-label-min, before),
+		$data-label-min-before: map-deep-get($map, data-label-min, before);
+		$data-label-min-before: if(
+			$data-label-min-before,
+			$data-label-min-before,
 			()
 		);
 		$data-label-min-before: map-merge(
@@ -2015,8 +2088,10 @@
 			)
 		);
 
-		$data-label-max-after: setter(
-			map-deep-get($map, data-label-max, after),
+		$data-label-max-after: map-deep-get($map, data-label-max, after);
+		$data-label-max-after: if(
+			$data-label-max-after,
+			$data-label-max-after,
 			()
 		);
 		$data-label-max-after: map-merge(
@@ -2035,7 +2110,8 @@
 			)
 		);
 
-		$hover: setter(map-deep-get($map, form-control-range, hover), ());
+		$hover: map-deep-get($map, form-control-range, hover);
+		$hover: if($hover, $hover, ());
 		$hover: map-merge(
 			$hover,
 			(
@@ -2047,8 +2123,10 @@
 			)
 		);
 
-		$hover-clay-range-thumb: setter(
-			map-deep-get($map, hover, clay-range-thumb),
+		$hover-clay-range-thumb: map-deep-get($map, hover, clay-range-thumb);
+		$hover-clay-range-thumb: if(
+			$hover-clay-range-thumb,
+			$hover-clay-range-thumb,
 			()
 		);
 		$hover-clay-range-thumb: map-merge(
@@ -2061,7 +2139,9 @@
 					),
 			)
 		);
-		$focus: setter(map-deep-get($map, form-control-range, focus), ());
+
+		$focus: map-deep-get($map, form-control-range, focus);
+		$focus: if($focus, $focus, ());
 		$focus: map-merge(
 			$focus,
 			(
@@ -2073,8 +2153,10 @@
 			)
 		);
 
-		$focus-clay-range-thumb: setter(
-			map-deep-get($map, focus, clay-range-thumb),
+		$focus-clay-range-thumb: map-deep-get($map, focus, clay-range-thumb);
+		$focus-clay-range-thumb: if(
+			$focus-clay-range-thumb,
+			$focus-clay-range-thumb,
 			()
 		);
 		$focus-clay-range-thumb: map-merge(
@@ -2088,7 +2170,8 @@
 			)
 		);
 
-		$disabled: setter(map-deep-get($map, form-control-range, disabled), ());
+		$disabled: map-deep-get($map, form-control-range, disabled);
+		$disabled: if($disabled, $disabled, ());
 		$disabled: map-merge(
 			$disabled,
 			(
@@ -2105,8 +2188,14 @@
 			)
 		);
 
-		$disabled-clay-range-thumb: setter(
-			map-deep-get($map, disabled, clay-range-thumb),
+		$disabled-clay-range-thumb: map-deep-get(
+			$map,
+			disabled,
+			clay-range-thumb
+		);
+		$disabled-clay-range-thumb: if(
+			$disabled-clay-range-thumb,
+			$disabled-clay-range-thumb,
 			()
 		);
 		$disabled-clay-range-thumb: map-merge(
@@ -2125,8 +2214,15 @@
 			)
 		);
 
-		$disabled-clay-range-track: setter(
-			map-deep-get($map, form-control-range, disabled, clay-range-track),
+		$disabled-clay-range-track: map-deep-get(
+			$map,
+			form-control-range,
+			disabled,
+			clay-range-track
+		);
+		$disabled-clay-range-track: if(
+			$disabled-clay-range-track,
+			$disabled-clay-range-track,
 			()
 		);
 		$disabled-clay-range-track: map-merge(
@@ -2140,13 +2236,15 @@
 			)
 		);
 
-		$disabled-clay-range-progress: setter(
-			map-deep-get(
-				$map,
-				form-control-range,
-				disabled,
-				clay-range-progress
-			),
+		$disabled-clay-range-progress: map-deep-get(
+			$map,
+			form-control-range,
+			disabled,
+			clay-range-progress
+		);
+		$disabled-clay-range-progress: if(
+			$disabled-clay-range-progress,
+			$disabled-clay-range-progress,
 			()
 		);
 		$disabled-clay-range-progress: map-merge(

--- a/packages/clay-css/src/scss/mixins/_globals.scss
+++ b/packages/clay-css/src/scss/mixins/_globals.scss
@@ -237,7 +237,8 @@
 			'z-index'
 		);
 
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		@if ($enabled) {
 			@each $key, $value in $map {

--- a/packages/clay-css/src/scss/mixins/_grid.scss
+++ b/packages/clay-css/src/scss/mixins/_grid.scss
@@ -43,9 +43,13 @@
 
 @mixin clay-container($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
+
 		$breakpoint-up: map-get($map, breakpoint-up);
-		$breakpoint-down: setter(clay-breakpoint-prev($breakpoint-up), null);
+
+		$breakpoint-down: clay-breakpoint-prev($breakpoint-up);
+		$breakpoint-down: if($breakpoint-down, $breakpoint-down, null);
 
 		$base: map-merge(
 			$map,
@@ -70,7 +74,8 @@
 			)
 		);
 
-		$mobile: setter(map-get($map, mobile), ());
+		$mobile: map-get($map, mobile);
+		$mobile: if($mobile, $mobile, ());
 		$mobile: map-merge(
 			$mobile,
 			(

--- a/packages/clay-css/src/scss/mixins/_highlight.scss
+++ b/packages/clay-css/src/scss/mixins/_highlight.scss
@@ -23,7 +23,8 @@
 /// - Add @link to documentation
 
 @mixin clay-after-highlight-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled, $enabled, true);
 
 	$base: map-merge(
 		$map,
@@ -33,7 +34,8 @@
 		)
 	);
 
-	$hover: setter(map-get($map, hover), ());
+	$hover: map-get($map, hover);
+	$hover: if($hover, $hover, ());
 	$hover: map-merge(
 		$hover,
 		(
@@ -48,7 +50,8 @@
 		)
 	);
 
-	$focus: setter(map-get($map, focus), ());
+	$focus: map-get($map, focus);
+	$focus: if($focus, $focus, ());
 	$focus: map-merge(
 		$focus,
 		(
@@ -63,7 +66,8 @@
 		)
 	);
 
-	$active: setter(map-get($map, active), ());
+	$active: map-get($map, active);
+	$active: if($active, $active, ());
 	$active: map-merge(
 		$active,
 		(

--- a/packages/clay-css/src/scss/mixins/_input-groups.scss
+++ b/packages/clay-css/src/scss/mixins/_input-groups.scss
@@ -22,12 +22,15 @@
 /// shrink-margin-top: {Number | String | Null}, // deprecated after 3.9.0
 
 @mixin clay-input-group-stacked($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled, $enabled, true);
 
-	$breakpoint: setter(map-get($map, breakpoint), md);
+	$breakpoint: map-get($map, breakpoint);
+	$breakpoint: if($breakpoint, $breakpoint, md);
 	$breakpoint-down: clay-breakpoint-prev($breakpoint);
 
-	$item: setter(map-get($map, item), ());
+	$item: map-get($map, item);
+	$item: if($item, $item, ());
 	$item: map-merge(
 		$item,
 		(
@@ -55,7 +58,8 @@
 		)
 	);
 
-	$item-shrink: setter(map-get($map, item-shrink), ());
+	$item-shrink: map-get($map, item-shrink);
+	$item-shrink: if($item-shrink, $item-shrink, ());
 	$item-shrink: map-merge(
 		$item-shrink,
 		(
@@ -149,7 +153,8 @@
 
 @mixin clay-input-group-text-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -291,7 +296,8 @@
 
 @mixin clay-input-group-item-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);
@@ -454,7 +460,8 @@
 
 @mixin clay-input-group-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);

--- a/packages/clay-css/src/scss/mixins/_labels.scss
+++ b/packages/clay-css/src/scss/mixins/_labels.scss
@@ -29,9 +29,10 @@
 
 @mixin clay-label-size($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
-		$base: setter($map, ());
+		$base: if($map, $map, ());
 		$base: map-merge(
 			$base,
 			(
@@ -71,7 +72,8 @@
 			)
 		);
 
-		$label-item: setter(map-get($map, label-item), ());
+		$label-item: map-get($map, label-item);
+		$label-item: if($label-item, $label-item, ());
 		$label-item: map-merge(
 			$label-item,
 			(
@@ -88,7 +90,8 @@
 			)
 		);
 
-		$label-item-before: setter(map-get($map, label-item-before), ());
+		$label-item-before: map-get($map, label-item-before);
+		$label-item-before: if($label-item-before, $label-item-before, ());
 		$label-item-before: map-merge(
 			$label-item-before,
 			(
@@ -100,7 +103,8 @@
 			)
 		);
 
-		$label-item-after: setter(map-get($map, label-item-after), ());
+		$label-item-after: map-get($map, label-item-after);
+		$label-item-after: if($label-item-after, $label-item-after, ());
 		$label-item-after: map-merge(
 			$label-item-after,
 			(
@@ -112,7 +116,8 @@
 			)
 		);
 
-		$lexicon-icon: setter(map-get($map, lexicon-icon), ());
+		$lexicon-icon: map-get($map, lexicon-icon);
+		$lexicon-icon: if($lexicon-icon, $lexicon-icon, ());
 		$lexicon-icon: map-merge(
 			$lexicon-icon,
 			(
@@ -135,7 +140,8 @@
 			)
 		);
 
-		$sticker: setter(map-get($map, sticker), ());
+		$sticker: map-get($map, sticker);
+		$sticker: if($sticker, $sticker, ());
 		$sticker: map-merge(
 			$sticker,
 			(
@@ -162,7 +168,8 @@
 			)
 		);
 
-		$sticker-overlay: setter(map-get($map, sticker-overlay), ());
+		$sticker-overlay: map-get($map, sticker-overlay);
+		$sticker-overlay: if($sticker-overlay, $sticker-overlay, ());
 		$sticker-overlay: map-merge(
 			$sticker-overlay,
 			(
@@ -174,7 +181,8 @@
 			)
 		);
 
-		$c-inner: setter(map-get($map, c-inner), ());
+		$c-inner: map-get($map, c-inner);
+		$c-inner: if($c-inner, $c-inner, ());
 		$c-inner: map-deep-merge(
 			$c-inner,
 			(
@@ -348,7 +356,8 @@
 
 @mixin clay-label-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -378,7 +387,8 @@
 			)
 		);
 
-		$disabled: setter(map-get($map, disabled), ());
+		$disabled: map-get($map, disabled);
+		$disabled: if($disabled, $disabled, ());
 		$disabled: map-merge(
 			$disabled,
 			(
@@ -405,7 +415,8 @@
 			)
 		);
 
-		$href: setter(map-get($map, href), ());
+		$href: map-get($map, href);
+		$href: if($href, $href, ());
 		$href: map-deep-merge(
 			$href,
 			(
@@ -476,7 +487,8 @@
 			)
 		);
 
-		$lexicon-icon: setter(map-get($map, lexicon-icon), ());
+		$lexicon-icon: map-get($map, lexicon-icon);
+		$lexicon-icon: if($lexicon-icon, $lexicon-icon, ());
 		$lexicon-icon: map-merge(
 			$lexicon-icon,
 			(
@@ -499,7 +511,8 @@
 			)
 		);
 
-		$label-item: setter(map-get($map, label-item), ());
+		$label-item: map-get($map, label-item);
+		$label-item: if($label-item, $label-item, ());
 		$label-item: map-merge(
 			$label-item,
 			(
@@ -538,7 +551,8 @@
 			)
 		);
 
-		$label-item-before: setter(map-get($map, label-item-before), ());
+		$label-item-before: map-get($map, label-item-before);
+		$label-item-before: if($label-item-before, $label-item-before, ());
 		$label-item-before: map-merge(
 			$label-item-before,
 			(
@@ -550,7 +564,8 @@
 			)
 		);
 
-		$label-item-after: setter(map-get($map, label-item-after), ());
+		$label-item-after: map-get($map, label-item-after);
+		$label-item-after: if($label-item-after, $label-item-after, ());
 		$label-item-after: map-merge(
 			$label-item-after,
 			(
@@ -562,7 +577,8 @@
 			)
 		);
 
-		$link: setter(map-get($map, link), ());
+		$link: map-get($map, link);
+		$link: if($link, $link, ());
 		$link: map-deep-merge(
 			$link,
 			(
@@ -587,7 +603,8 @@
 			)
 		);
 
-		$sticker: setter(map-get($map, sticker), ());
+		$sticker: map-get($map, sticker);
+		$sticker: if($sticker, $sticker, ());
 		$sticker: map-merge(
 			$sticker,
 			(
@@ -614,7 +631,8 @@
 			)
 		);
 
-		$sticker-overlay: setter(map-get($map, sticker-overlay), ());
+		$sticker-overlay: map-get($map, sticker-overlay);
+		$sticker-overlay: if($sticker-overlay, $sticker-overlay, ());
 		$sticker-overlay: map-merge(
 			$sticker-overlay,
 			(
@@ -626,7 +644,8 @@
 			)
 		);
 
-		$c-inner: setter(map-get($map, c-inner), ());
+		$c-inner: map-get($map, c-inner);
+		$c-inner: if($c-inner, $c-inner, ());
 		$c-inner: map-deep-merge(
 			$c-inner,
 			(

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -251,7 +251,8 @@
 
 @mixin clay-link($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -261,7 +262,8 @@
 			)
 		);
 
-		$hover: setter(map-get($map, hover), ());
+		$hover: map-get($map, hover);
+		$hover: if($hover, $hover, ());
 		$hover: map-merge(
 			$hover,
 			(
@@ -295,7 +297,8 @@
 			)
 		);
 
-		$focus: setter(map-get($map, focus), ());
+		$focus: map-get($map, focus);
+		$focus: if($focus, $focus, ());
 		$focus: map-merge(
 			$focus,
 			(
@@ -344,7 +347,8 @@
 			)
 		);
 
-		$active: setter(map-get($map, active), ());
+		$active: map-get($map, active);
+		$active: if($active, $active, ());
 		$active: map-merge(
 			$active,
 			(
@@ -376,7 +380,8 @@
 			)
 		);
 
-		$active-class: setter(map-get($map, active-class), ());
+		$active-class: map-get($map, active-class);
+		$active-class: if($active-class, $active-class, ());
 		$active-class: map-merge(
 			$active-class,
 			(
@@ -413,7 +418,8 @@
 			)
 		);
 
-		$disabled: setter(map-get($map, disabled), ());
+		$disabled: map-get($map, disabled);
+		$disabled: if($disabled, $disabled, ());
 		$disabled: map-merge(
 			$disabled,
 			(
@@ -460,7 +466,8 @@
 			)
 		);
 
-		$disabled-active: setter(map-get($disabled, active), ());
+		$disabled-active: map-get($disabled, active);
+		$disabled-active: if($disabled-active, $disabled-active, ());
 		$disabled-active: map-deep-merge(
 			$disabled-active,
 			map-get($map, disabled-active)
@@ -476,10 +483,12 @@
 			)
 		);
 
-		$show: setter(map-get($map, show), ());
+		$show: map-get($map, show);
+		$show: if($show, $show, ());
 		$show: map-merge($active-class, $show);
 
-		$btn-focus: setter(map-get($map, btn-focus), ());
+		$btn-focus: map-get($map, btn-focus);
+		$btn-focus: if($btn-focus, $btn-focus, ());
 		$btn-focus: map-merge(
 			$btn-focus,
 			(
@@ -496,7 +505,8 @@
 			)
 		);
 
-		$lexicon-icon: setter(map-get($map, lexicon-icon), ());
+		$lexicon-icon: map-get($map, lexicon-icon);
+		$lexicon-icon: if($lexicon-icon, $lexicon-icon, ());
 		$lexicon-icon: map-merge(
 			$lexicon-icon,
 			(
@@ -528,7 +538,8 @@
 			)
 		);
 
-		$c-inner: setter(map-get($map, c-inner), ());
+		$c-inner: map-get($map, c-inner);
+		$c-inner: if($c-inner, $c-inner, ());
 		$c-inner: map-merge(
 			(
 				enabled:
@@ -863,15 +874,19 @@
 
 @mixin clay-text-typography($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled, $enabled, true);
 
 		@if ($enabled) {
-			$clay-link: setter(map-get($map, clay-link), ());
+			$clay-link: map-get($map, clay-link);
+			$clay-link: if($clay-link, $clay-link, ());
 
-			$link: setter(map-get($map, link), ());
+			$link: map-get($map, link);
+			$link: if($link, $link, ());
 			$link: map-merge($link, $clay-link);
 
-			$href: setter(map-get($map, href), ());
+			$href: map-get($map, href);
+			$href: if($href, $href, ());
 			$href: map-deep-merge($href, $link);
 
 			@include clay-css($map);

--- a/packages/clay-css/src/scss/mixins/_list-group.scss
+++ b/packages/clay-css/src/scss/mixins/_list-group.scss
@@ -63,8 +63,10 @@
 /// - Add @link to documentation
 
 @mixin clay-list-group-notification-item-variant($map) {
-	$bg: setter(
-		map-get($map, bg),
+	$bg: map-get($map, bg);
+	$bg: if(
+		$bg,
+		$bg,
 		if(
 			variable-exists(list-group-bg),
 			$list-group-bg,
@@ -75,8 +77,11 @@
 			)
 		)
 	);
-	$border-bottom-color: setter(
-		map-get($map, border-bottom-color),
+
+	$border-bottom-color: map-get($map, border-bottom-color);
+	$border-bottom-color: if(
+		$border-bottom-color,
+		$border-bottom-color,
 		if(
 			variable-exists(list-group-notification-item-border-bottom-color),
 			$list-group-notification-item-border-bottom-color,
@@ -89,8 +94,11 @@
 			)
 		)
 	);
-	$border-left-color: setter(
-		map-get($map, border-left-color),
+
+	$border-left-color: map-get($map, border-left-color);
+	$border-left-color: if(
+		$border-left-color,
+		$border-left-color,
 		if(
 			variable-exists(list-group-notification-item-border-left-color),
 			$list-group-notification-item-border-left-color,
@@ -103,8 +111,11 @@
 			)
 		)
 	);
-	$border-right-color: setter(
-		map-get($map, border-right-color),
+
+	$border-right-color: map-get($map, border-right-color);
+	$border-right-color: if(
+		$border-right-color,
+		$border-right-color,
 		if(
 			variable-exists(list-group-notification-item-border-right-color),
 			$list-group-notification-item-border-right-color,
@@ -117,8 +128,11 @@
 			)
 		)
 	);
-	$border-top-color: setter(
-		map-get($map, border-top-color),
+
+	$border-top-color: map-get($map, border-top-color);
+	$border-top-color: if(
+		$border-top-color,
+		$border-top-color,
 		if(
 			variable-exists(list-group-notification-item-border-top-color),
 			$list-group-notification-item-border-top-color,
@@ -132,8 +146,10 @@
 		)
 	);
 
-	$border-bottom-width: setter(
-		map-get($map, border-bottom-width),
+	$border-bottom-width: map-get($map, border-bottom-width);
+	$border-bottom-width: if(
+		$border-bottom-width,
+		$border-bottom-width,
 		if(
 			variable-exists(list-group-notification-item-border-bottom-width),
 			$list-group-notification-item-border-bottom-width,
@@ -146,8 +162,11 @@
 			)
 		)
 	);
-	$border-left-width: setter(
-		map-get($map, border-left-width),
+
+	$border-left-width: map-get($map, border-left-width);
+	$border-left-width: if(
+		$border-left-width,
+		$border-left-width,
 		if(
 			variable-exists(list-group-notification-item-border-left-width),
 			$list-group-notification-item-border-left-width,
@@ -160,8 +179,11 @@
 			)
 		)
 	);
-	$border-right-width: setter(
-		map-get($map, border-right-width),
+
+	$border-right-width: map-get($map, border-right-width);
+	$border-right-width: if(
+		$border-right-width,
+		$border-right-width,
 		if(
 			variable-exists(list-group-notification-item-border-right-width),
 			$list-group-notification-item-border-right-width,
@@ -174,8 +196,11 @@
 			)
 		)
 	);
-	$border-top-width: setter(
-		map-get($map, border-top-width),
+
+	$border-top-width: map-get($map, border-top-width);
+	$border-top-width: if(
+		$border-top-width,
+		$border-top-width,
 		if(
 			variable-exists(list-group-notification-item-border-top-width),
 			$list-group-notification-item-border-top-width,
@@ -196,8 +221,10 @@
 
 	$color: map-get($map, color);
 
-	$active-bg: setter(
-		map-get($map, active-bg),
+	$active-bg: map-get($map, active-bg);
+	$active-bg: if(
+		$active-bg,
+		$active-bg,
 		if(
 			variable-exists(list-group-active-bg),
 			$list-group-active-bg,
@@ -208,8 +235,11 @@
 			)
 		)
 	);
-	$active-border-bottom-color: setter(
-		map-get($map, active-border-bottom-color),
+
+	$active-border-bottom-color: map-get($map, active-border-bottom-color);
+	$active-border-bottom-color: if(
+		$active-border-bottom-color,
+		$active-border-bottom-color,
 		if(
 			variable-exists(
 				list-group-notification-item-active-border-bottom-color
@@ -224,8 +254,11 @@
 			)
 		)
 	);
-	$active-border-left-color: setter(
-		map-get($map, active-border-left-color),
+
+	$active-border-left-color: map-get($map, active-border-left-color);
+	$active-border-left-color: if(
+		$active-border-left-color,
+		$active-border-left-color,
 		if(
 			variable-exists(
 				list-group-notification-item-active-border-left-color
@@ -240,8 +273,11 @@
 			)
 		)
 	);
-	$active-border-right-color: setter(
-		map-get($map, active-border-right-color),
+
+	$active-border-right-color: map-get($map, active-border-right-color);
+	$active-border-right-color: if(
+		$active-border-right-color,
+		$active-border-right-color,
 		if(
 			variable-exists(
 				list-group-notification-item-active-border-right-color
@@ -256,8 +292,11 @@
 			)
 		)
 	);
-	$active-border-top-color: setter(
-		map-get($map, active-border-top-color),
+
+	$active-border-top-color: map-get($map, active-border-top-color);
+	$active-border-top-color: if(
+		$active-border-top-color,
+		$active-border-top-color,
 		if(
 			variable-exists(
 				list-group-notification-item-active-border-top-color

--- a/packages/clay-css/src/scss/mixins/_loaders.scss
+++ b/packages/clay-css/src/scss/mixins/_loaders.scss
@@ -35,10 +35,12 @@
 /// - Add @link to documentation
 
 @mixin clay-loading-animation-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled, $enabled, true);
 	$mixin-name: 'clay-loading-animation-variant';
 
-	$after: setter(map-get($map, after), ());
+	$after: map-get($map, after);
+	$after: if($after, $after, ());
 	$after-color: setter(map-get($map, color), map-get($after, color));
 
 	$ball-0-scale: setter(map-get($map, ball-0-scale), 0em);

--- a/packages/clay-css/src/scss/mixins/_menubar.scss
+++ b/packages/clay-css/src/scss/mixins/_menubar.scss
@@ -44,16 +44,23 @@
 /// - Add @link to documentation
 
 @mixin clay-menubar-vertical-expand($map) {
-	$enabled: setter(map-get($map, enabled), true);
-	$breakpoint-up: setter(map-get($map, breakpoint-up), md);
-	$breakpoint-down: setter(
-		map-get($map, breakpoint-down),
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled, $enabled, true);
+
+	$breakpoint-up: map-get($map, breakpoint-up);
+	$breakpoint-up: if($breakpoint-up, $breakpoint-up, md);
+
+	$breakpoint-down: map-get($map, breakpoint-down);
+	$breakpoint-down: if(
+		$breakpoint-down,
+		$breakpoint-down,
 		clay-breakpoint-prev($breakpoint-up)
 	);
 
 	// .menubar-vertical-expand-{md}
 
-	$mobile: setter(map-get($map, mobile), ());
+	$mobile: map-get($map, mobile);
+	$mobile: if($mobile, $mobile, ());
 	$mobile: map-merge(
 		$mobile,
 		(
@@ -127,7 +134,8 @@
 
 	// .menubar-collapse
 
-	$collapse-mobile: setter(map-get($map, collapse-mobile), ());
+	$collapse-mobile: map-get($map, collapse-mobile);
+	$collapse-mobile: if($collapse-mobile, $collapse-mobile, ());
 	$collapse-mobile: map-merge(
 		$collapse-mobile,
 		(
@@ -174,7 +182,8 @@
 		)
 	);
 
-	$nav-nested-mobile: setter(map-get($map, nav-nested-mobile), ());
+	$nav-nested-mobile: map-get($map, nav-nested-mobile);
+	$nav-nested-mobile: if($nav-nested-mobile, $nav-nested-mobile, ());
 	$nav-nested-mobile: map-merge(
 		$nav-nested-mobile,
 		(
@@ -191,8 +200,10 @@
 		)
 	);
 
-	$nav-nested-margins-mobile: setter(
-		map-get($map, nav-nested-margins-mobile),
+	$nav-nested-margins-mobile: map-get($map, nav-nested-margins-mobile);
+	$nav-nested-margins-mobile: if(
+		$nav-nested-margins-mobile,
+		$nav-nested-margins-mobile,
 		()
 	);
 	$nav-nested-margins-mobile: map-merge(
@@ -213,7 +224,8 @@
 
 	// .menubar-toggler
 
-	$toggler-mobile: setter(map-get($map, toggler-mobile), ());
+	$toggler-mobile: map-get($map, toggler-mobile);
+	$toggler-mobile: if($toggler-mobile, $toggler-mobile, ());
 	$toggler-mobile: map-deep-merge(
 		$toggler-mobile,
 		(
@@ -260,7 +272,12 @@
 		)
 	);
 
-	$_toggler-mobile-c-inner: setter(map-get($toggler-mobile, c-inner), ());
+	$_toggler-mobile-c-inner: map-get($toggler-mobile, c-inner);
+	$_toggler-mobile-c-inner: if(
+		$_toggler-mobile-c-inner,
+		$_toggler-mobile-c-inner,
+		()
+	);
 	$_toggler-mobile-c-inner: map-merge(
 		$_toggler-mobile-c-inner,
 		(
@@ -297,7 +314,8 @@
 		)
 	);
 
-	$_old-toggler-c-inner: setter(map-get($map, toggler-c-inner), ());
+	$_old-toggler-c-inner: map-get($map, toggler-c-inner);
+	$_old-toggler-c-inner: if($_old-toggler-c-inner, $_old-toggler-c-inner, ());
 	$_toggler-mobile-c-inner: map-merge(
 		$_toggler-mobile-c-inner,
 		$_old-toggler-c-inner
@@ -457,8 +475,12 @@
 /// - Add @link to documentation
 
 @mixin clay-menubar-vertical-variant($map) {
-	$enable: setter(map-get($map, enable), true);
-	$breakpoint-up: setter(map-get($map, breakpoint-up), md);
+	$enable: map-get($map, enable);
+	$enable: if($enable, $enable, true);
+
+	$breakpoint-up: map-get($map, breakpoint-up);
+	$breakpoint-up: if($breakpoint-up, $breakpoint-up, md);
+
 	$breakpoint-down: clay-breakpoint-prev($breakpoint-up);
 
 	// .menubar-vertical-expand-{md}.menubar-{variant}
@@ -471,7 +493,8 @@
 		)
 	);
 
-	$mobile: setter(map-get($map, mobile), ());
+	$mobile: map-get($map, mobile);
+	$mobile: if($mobile, $mobile, ());
 	$mobile: map-merge(
 		$mobile,
 		(
@@ -495,11 +518,21 @@
 
 	// .nav-link
 
-	$link: setter(map-get($map, link), ());
-	$link-hover: setter(map-get($link, hover), ());
-	$link-active: setter(map-get($link, active), ());
-	$link-active-class: setter(map-get($link, active-class), ());
-	$link-disabled: setter(map-get($link, disabled), ());
+	$link: map-get($map, link);
+	$link: if($link, $link, ());
+
+	$link-hover: map-get($link, hover);
+	$link-hover: if($link-hover, $link-hover, ());
+
+	$link-active: map-get($link, active);
+	$link-active: if($link-active, $link-active, ());
+
+	$link-active-class: map-get($link, active-class);
+	$link-active-class: if($link-active-class, $link-active-class, ());
+
+	$link-disabled: map-get($link, disabled);
+	$link-disabled: if($link-disabled, $link-disabled, ());
+
 	$link: map-deep-merge(
 		$link,
 		(
@@ -603,11 +636,25 @@
 		)
 	);
 
-	$link-mobile: setter(map-get($map, link-mobile), ());
-	$link-mobile-hover: setter(map-get($link-mobile, hover), ());
-	$link-mobile-active: setter(map-get($link-mobile, active), ());
-	$link-mobile-active-class: setter(map-get($link-mobile, active-class), ());
-	$link-mobile-disabled: setter(map-get($link-mobile, disabled), ());
+	$link-mobile: map-get($map, link-mobile);
+	$link-mobile: if($link-mobile, $link-mobile, ());
+
+	$link-mobile-hover: map-get($link-mobile, hover);
+	$link-mobile-hover: if($link-mobile-hover, $link-mobile-hover, ());
+
+	$link-mobile-active: map-get($link-mobile, active);
+	$link-mobile-active: if($link-mobile-active, $link-mobile-active, ());
+
+	$link-mobile-active-class: map-get($link-mobile, active-class);
+	$link-mobile-active-class: if(
+		$link-mobile-active-class,
+		$link-mobile-active-class,
+		()
+	);
+
+	$link-mobile-disabled: map-get($link-mobile, disabled);
+	$link-mobile-disabled: if($link-mobile-disabled, $link-mobile-disabled, ());
+
 	$link-mobile: map-deep-merge(
 		$link-mobile,
 		(
@@ -741,7 +788,8 @@
 
 	// .menubar-collapse
 
-	$collapse-mobile: setter(map-get($map, collapse-mobile), ());
+	$collapse-mobile: map-get($map, collapse-mobile);
+	$collapse-mobile: if($collapse-mobile, $collapse-mobile, ());
 	$collapse-mobile: map-deep-merge(
 		$collapse-mobile,
 		(
@@ -811,7 +859,8 @@
 
 	// .menubar-toggler
 
-	$toggler-mobile: setter(map-get($map, toggler-mobile), ());
+	$toggler-mobile: map-get($map, toggler-mobile);
+	$toggler-mobile: if($toggler-mobile, $toggler-mobile, ());
 	$toggler-mobile: map-deep-merge(
 		$toggler-mobile,
 		(

--- a/packages/clay-css/src/scss/mixins/_modals.scss
+++ b/packages/clay-css/src/scss/mixins/_modals.scss
@@ -21,9 +21,11 @@
 /// footer-border-color: {Color | String | List | Null}, // deprecated after 3.9.0
 
 @mixin clay-modal-variant($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled != null, $enabled, true);
 
-	$header: setter(map-get($map, header), ());
+	$header: map-get($map, header);
+	$header: if($header, $header, ());
 	$header: map-merge(
 		$header,
 		(
@@ -41,7 +43,8 @@
 		)
 	);
 
-	$header-close: setter(map-get($map, header-close), ());
+	$header-close: map-get($map, header-close);
+	$header-close: if($header-close, $header-close, ());
 	$header-close: map-merge(
 		$header-close,
 		(
@@ -53,7 +56,12 @@
 		)
 	);
 
-	$header-close-btn-focus: setter(map-get($header-close, btn-focus), ());
+	$header-close-btn-focus: map-get($header-close, btn-focus);
+	$header-close-btn-focus: if(
+		$header-close-btn-focus,
+		$header-close-btn-focus,
+		()
+	);
 	$header-close-btn-focus: map-merge(
 		$header-close-btn-focus,
 		(
@@ -70,7 +78,8 @@
 		)
 	);
 
-	$body: setter(map-get($map, body), ());
+	$body: map-get($map, body);
+	$body: if($body, $body, ());
 	$body: map-merge(
 		$body,
 		(
@@ -80,7 +89,8 @@
 		)
 	);
 
-	$footer: setter(map-get($map, footer), ());
+	$footer: map-get($map, footer);
+	$footer: if($footer, $footer, ());
 	$footer: map-merge(
 		$footer,
 		(

--- a/packages/clay-css/src/scss/mixins/_nav.scss
+++ b/packages/clay-css/src/scss/mixins/_nav.scss
@@ -92,7 +92,8 @@
 
 @mixin clay-nav-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -102,9 +103,11 @@
 			)
 		);
 
-		$nav-link: setter(map-get($map, nav-link), ());
+		$nav-link: map-get($map, nav-link);
+		$nav-link: if($nav-link, $nav-link, ());
 
-		$nav-link-hover: setter(map-get($nav-link, hover), ());
+		$nav-link-hover: map-get($nav-link, hover);
+		$nav-link-hover: if($nav-link-hover, $nav-link-hover, ());
 		$nav-link-hover: map-merge(
 			$nav-link-hover,
 			(
@@ -121,7 +124,8 @@
 			)
 		);
 
-		$nav-link-focus: setter(map-get($nav-link, focus), ());
+		$nav-link-focus: map-get($nav-link, focus);
+		$nav-link-focus: if($nav-link-focus, $nav-link-focus, ());
 		$nav-link-focus: map-merge(
 			$nav-link-focus,
 			(
@@ -138,7 +142,12 @@
 			)
 		);
 
-		$nav-link-active-class: setter(map-get($nav-link, active-class), ());
+		$nav-link-active-class: map-get($nav-link, active-class);
+		$nav-link-active-class: if(
+			$nav-link-active-class,
+			$nav-link-active-class,
+			()
+		);
 		$nav-link-active-class: map-merge(
 			$nav-link-active-class,
 			(
@@ -160,7 +169,8 @@
 			)
 		);
 
-		$nav-link-disabled: setter(map-get($nav-link, disabled), ());
+		$nav-link-disabled: map-get($nav-link, disabled);
+		$nav-link-disabled: if($nav-link-disabled, $nav-link-disabled, ());
 		$nav-link-disabled: map-merge(
 			$nav-link-disabled,
 			(

--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -3,7 +3,8 @@
 // @param $map - Sass map that contain Navbar properties to modify
 
 @mixin clay-navbar-size($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled != null, $enabled, true);
 
 	$enable-c-inner: if(
 		variable-exists(enable-c-inner),
@@ -37,21 +38,38 @@
 		)
 	);
 
-	$scaling-navbar: setter(map-get($map, scaling-navbar), false);
+	$scaling-navbar: map-get($map, scaling-navbar);
+	$scaling-navbar: if($scaling-navbar, $scaling-navbar, false);
 	$container-padding-x: map-get($map, container-padding-x);
-	$container-padding-x-mobile: setter(
-		map-get($map, container-padding-x-mobile),
+
+	$container-padding-x-mobile: map-get($map, container-padding-x-mobile);
+	$container-padding-x-mobile: if(
+		$container-padding-x-mobile,
+		$container-padding-x-mobile,
 		$container-padding-x
 	);
 
-	$height: setter(map-get($map, height), 3.5rem);
-	$border-bottom-width: setter(map-get($map, border-bottom-width), 0px);
-	$border-left-width: setter(map-get($map, border-left-width), 0px);
-	$border-right-width: setter(map-get($map, border-right-width), 0px);
-	$border-top-width: setter(map-get($map, border-top-width), 0px);
+	$height: map-get($map, height);
+	$height: if($height, $height, 3.5rem);
+
+	$border-bottom-width: map-get($map, border-bottom-width);
+	$border-bottom-width: if($border-bottom-width, $border-bottom-width, 0px);
+
+	$border-left-width: map-get($map, border-left-width);
+	$border-left-width: if($border-left-width, $border-left-width, 0px);
+
+	$border-right-width: map-get($map, border-right-width);
+	$border-right-width: if($border-right-width, $border-right-width, 0px);
+
+	$border-top-width: map-get($map, border-top-width);
+	$border-top-width: if($border-top-width, $border-top-width, 0px);
+
 	$box-shadow: map-get($map, box-shadow);
-	$font-size: setter(
-		map-get($map, font-size),
+
+	$font-size: map-get($map, font-size);
+	$font-size: if(
+		$font-size,
+		$font-size,
 		if(
 			variable-exists(font-size-base),
 			$font-size-base,
@@ -62,9 +80,13 @@
 			)
 		)
 	);
+
 	$min-height: map-get($map, min-height);
-	$padding-x: setter(
-		map-get($map, padding-x),
+
+	$padding-x: map-get($map, padding-x);
+	$padding-x: if(
+		$padding-x,
+		$padding-x,
 		if(
 			variable-exists(navbar-padding-x),
 			$navbar-padding-x,
@@ -75,8 +97,11 @@
 			)
 		)
 	);
-	$padding-y: setter(
-		map-get($map, padding-y),
+
+	$padding-y: map-get($map, padding-y);
+	$padding-y: if(
+		$padding-y,
+		$padding-y,
 		if(
 			variable-exists(navbar-padding-y),
 			$navbar-padding-y,
@@ -88,14 +113,20 @@
 		)
 	);
 	$padding-y: if($padding-y == 0 or $padding-y == null, 0px, $padding-y);
-	$link-height: setter(
-		map-get($map, link-height),
+
+	$link-height: map-get($map, link-height);
+	$link-height: if(
+		$link-height,
+		$link-height,
 		'#{$height} - #{$border-bottom-width} - #{$border-top-width} - #{$padding-y} * 2'
 	);
 
 	$link-margin-x: map-get($map, link-margin-x);
-	$link-margin-y: setter(
-		map-get($map, link-margin-y),
+
+	$link-margin-y: map-get($map, link-margin-y);
+	$link-margin-y: if(
+		$link-margin-y,
+		$link-margin-y,
 		calc(
 			(
 					(
@@ -104,8 +135,11 @@
 				) * 0.5
 		)
 	);
-	$link-padding-x: setter(
-		map-get($map, link-padding-x),
+
+	$link-padding-x: map-get($map, link-padding-x);
+	$link-padding-x: if(
+		$link-padding-x,
+		$link-padding-x,
 		if(
 			variable-exists(navbar-nav-link-padding-x),
 			$navbar-nav-link-padding-x,
@@ -116,8 +150,11 @@
 			)
 		)
 	);
-	$link-padding-y: setter(
-		map-get($map, link-padding-y),
+
+	$link-padding-y: map-get($map, link-padding-y);
+	$link-padding-y: if(
+		$link-padding-y,
+		$link-padding-y,
 		(
 			calc(
 				(#{$link-height} - (#{$font-size} * #{$_line-height-base})) *
@@ -125,12 +162,20 @@
 			)
 		)
 	);
-	$btn-font-size: setter(map-get($map, btn-font-size), $font-size);
+
+	$btn-font-size: map-get($map, btn-font-size);
+	$btn-font-size: if($btn-font-size, $btn-font-size, $font-size);
+
 	$btn-monospaced-font-size: map-get($map, btn-monospaced-font-size);
 	$btn-monospaced-size: map-get($map, btn-monospaced-size);
-	$btn-margin-x: setter(map-get($map, btn-margin-x), $link-padding-x);
-	$btn-margin-y: setter(
-		map-get($map, btn-margin-y),
+
+	$btn-margin-x: map-get($map, btn-margin-x);
+	$btn-margin-x: if($btn-margin-x, $btn-margin-x, $link-padding-x);
+
+	$btn-margin-y: map-get($map, btn-margin-y);
+	$btn-margin-y: if(
+		$btn-margin-y,
+		$btn-margin-y,
 		calc(
 			(
 					#{$height} - #{$border-bottom-width} - #{$border-top-width} -
@@ -152,11 +197,19 @@
 				) * 0.5
 		)
 	);
-	$btn-padding-x: setter(map-get($map, btn-padding-x), $link-padding-x);
-	$btn-padding-y: setter(map-get($map, btn-padding-y), $link-padding-y);
+
+	$btn-padding-x: map-get($map, btn-padding-x);
+	$btn-padding-x: if($btn-padding-x, $btn-padding-x, $link-padding-x);
+
+	$btn-padding-y: map-get($map, btn-padding-y);
+	$btn-padding-y: if($btn-padding-y, $btn-padding-y, $link-padding-y);
+
 	$form-control-height: map-get($map, form-control-height);
-	$brand-font-size: setter(
-		map-get($map, brand-font-size),
+
+	$brand-font-size: map-get($map, brand-font-size);
+	$brand-font-size: if(
+		$brand-font-size,
+		$brand-font-size,
 		if(
 			variable-exists(navbar-brand-font-size),
 			$navbar-brand-font-size,
@@ -167,14 +220,23 @@
 			)
 		)
 	);
+
 	$brand-max-width: map-get($map, brand-max-width);
-	$brand-margin-right: setter(
-		map-get($map, brand-margin-right),
+
+	$brand-margin-right: map-get($map, brand-margin-right);
+	$brand-margin-right: if(
+		$brand-margin-right,
+		$brand-margin-right,
 		$link-padding-x
 	);
-	$brand-padding-x: setter(map-get($map, brand-padding-x), $link-padding-x);
-	$brand-padding-y: setter(
-		map-get($map, brand-padding-y),
+
+	$brand-padding-x: map-get($map, brand-padding-x);
+	$brand-padding-x: if($brand-padding-x, $brand-padding-x, $link-padding-x);
+
+	$brand-padding-y: map-get($map, brand-padding-y);
+	$brand-padding-y: if(
+		$brand-padding-y,
+		$brand-padding-y,
 		(
 			calc(
 				(
@@ -185,25 +247,39 @@
 			)
 		)
 	);
+
 	$title-font-size: map-get($map, title-font-size);
 	$title-font-weight: map-get($map, title-font-weight);
 	$title-margin-bottom: map-get($map, title-margin-bottom);
 	$title-text-transform: map-get($map, title-text-transform);
 	$nav-item-dropdown-margin-top: map-get($map, nav-item-dropdown-margin-top);
 
-	$height-mobile: setter(map-get($map, height-mobile), $height);
-	$font-size-mobile: setter(map-get($map, font-size-mobile), $font-size);
+	$height-mobile: map-get($map, height-mobile);
+	$height-mobile: if($height-mobile, $height-mobile, $height);
+
+	$font-size-mobile: map-get($map, font-size-mobile);
+	$font-size-mobile: if($font-size-mobile, $font-size-mobile, $font-size);
+
 	$min-height-mobile: map-get($map, min-height-mobile);
-	$link-height-mobile: setter(
-		map-get($map, link-height-mobile),
+
+	$link-height-mobile: map-get($map, link-height-mobile);
+	$link-height-mobile: if(
+		$link-height-mobile,
+		$link-height-mobile,
 		'#{$height-mobile} - #{$border-bottom-width} - #{$border-top-width} - #{$padding-y} * 2'
 	);
-	$link-margin-x-mobile: setter(
-		map-get($map, link-margin-x-mobile),
+
+	$link-margin-x-mobile: map-get($map, link-margin-x-mobile);
+	$link-margin-x-mobile: if(
+		$link-margin-x-mobile,
+		$link-margin-x-mobile,
 		$link-margin-x
 	);
-	$link-margin-y-mobile: setter(
-		map-get($map, link-margin-y-mobile),
+
+	$link-margin-y-mobile: map-get($map, link-margin-y-mobile);
+	$link-margin-y-mobile: if(
+		$link-margin-y-mobile,
+		$link-margin-y-mobile,
 		calc(
 			(
 					(
@@ -212,36 +288,60 @@
 				) * 0.5
 		)
 	);
-	$link-padding-x-mobile: setter(
-		map-get($map, link-padding-x-mobile),
+
+	$link-padding-x-mobile: map-get($map, link-padding-x-mobile);
+	$link-padding-x-mobile: if(
+		$link-padding-x-mobile,
+		$link-padding-x-mobile,
 		$link-padding-x
 	);
-	$link-padding-y-mobile: setter(
-		map-get($map, link-padding-y-mobile),
+
+	$link-padding-y-mobile: map-get($map, link-padding-y-mobile);
+	$link-padding-y-mobile: if(
+		$link-padding-y-mobile,
+		$link-padding-y-mobile,
 		calc(
 			(
 					#{$link-height-mobile} - (#{$font-size-mobile} * #{$_line-height-base})
 				) * 0.5
 		)
 	);
-	$btn-font-size-mobile: setter(
-		map-get($map, btn-font-size-mobile),
+
+	$btn-font-size-mobile: map-get($map, btn-font-size-mobile);
+	$btn-font-size-mobile: if(
+		$btn-font-size-mobile,
+		$btn-font-size-mobile,
 		$font-size-mobile
 	);
-	$btn-monospaced-font-size-mobile: setter(
-		map-get($map, btn-monospaced-font-size-mobile),
+
+	$btn-monospaced-font-size-mobile: map-get(
+		$map,
+		btn-monospaced-font-size-mobile
+	);
+	$btn-monospaced-font-size-mobile: if(
+		$btn-monospaced-font-size-mobile,
+		$btn-monospaced-font-size-mobile,
 		$btn-monospaced-font-size
 	);
-	$btn-monospaced-size-mobile: setter(
-		map-get($map, btn-monospaced-size-mobile),
+
+	$btn-monospaced-size-mobile: map-get($map, btn-monospaced-size-mobile);
+	$btn-monospaced-size-mobile: if(
+		$btn-monospaced-size-mobile,
+		$btn-monospaced-size-mobile,
 		$btn-monospaced-size
 	);
-	$btn-margin-x-mobile: setter(
-		map-get($map, btn-margin-x-mobile),
+
+	$btn-margin-x-mobile: map-get($map, btn-margin-x-mobile);
+	$btn-margin-x-mobile: if(
+		$btn-margin-x-mobile,
+		$btn-margin-x-mobile,
 		$link-padding-x-mobile
 	);
-	$btn-margin-y-mobile: setter(
-		map-get($map, btn-margin-y-mobile),
+
+	$btn-margin-y-mobile: map-get($map, btn-margin-y-mobile);
+	$btn-margin-y-mobile: if(
+		$btn-margin-y-mobile,
+		$btn-margin-y-mobile,
 		calc(
 			(
 					#{$height-mobile} - #{$border-bottom-width} - #{$border-top-width} -
@@ -263,17 +363,27 @@
 				) * 0.5
 		)
 	);
-	$btn-padding-x-mobile: setter(
-		map-get($map, btn-padding-x-mobile),
+
+	$btn-padding-x-mobile: map-get($map, brand-padding-x-mobile);
+	$btn-padding-x-mobile: if(
+		$btn-padding-x-mobile,
+		$btn-padding-x-mobile,
 		$link-padding-x-mobile
 	);
-	$btn-padding-y-mobile: setter(
-		map-get($map, btn-padding-y-mobile),
+
+	$btn-padding-y-mobile: map-get($map, btn-padding-y-mobile);
+	$btn-padding-y-mobile: if(
+		$btn-padding-y-mobile,
+		$btn-padding-y-mobile,
 		$link-padding-x-mobile
 	);
+
 	$form-control-height-mobile: map-get($map, form-control-height-mobile);
-	$brand-font-size-mobile: setter(
-		map-get($map, brand-font-size-mobile),
+
+	$brand-font-size-mobile: map-get($map, brand-font-size-mobile);
+	$brand-font-size-mobile: if(
+		$brand-font-size-mobile,
+		$brand-font-size-mobile,
 		if(
 			variable-exists(font-size-lg-mobile),
 			$font-size-lg-mobile,
@@ -284,16 +394,25 @@
 			)
 		)
 	);
-	$brand-margin-right-mobile: setter(
-		map-get($map, brand-margin-right-mobile),
+
+	$brand-margin-right-mobile: map-get($map, brand-margin-right-mobile);
+	$brand-margin-right-mobile: if(
+		$brand-margin-right-mobile,
+		$brand-margin-right-mobile,
 		0
 	);
-	$brand-padding-x-mobile: setter(
-		map-get($map, brand-padding-x-mobile),
+
+	$brand-padding-x-mobile: map-get($map, brand-padding-x-mobile);
+	$brand-padding-x-mobile: if(
+		$brand-padding-x-mobile,
+		$brand-padding-x-mobile,
 		$link-padding-x-mobile
 	);
-	$brand-padding-y-mobile: setter(
-		map-get($map, brand-padding-y-mobile),
+
+	$brand-padding-y-mobile: map-get($map, brand-padding-y-mobile);
+	$brand-padding-y-mobile: if(
+		$brand-padding-y-mobile,
+		$brand-padding-y-mobile,
 		(
 			calc(
 				(
@@ -303,17 +422,21 @@
 			)
 		)
 	);
+
 	$collapse-dropdown-item-padding-x-mobile: map-get(
 		$map,
 		collapse-dropdown-item-padding-x-mobile
 	);
+
 	$collapse-dropdown-item-padding-y-mobile: map-get(
 		$map,
 		collapse-dropdown-item-padding-y-mobile
 	);
 
-	$toggler-font-size: setter(
-		map-get($map, toggler-font-size),
+	$toggler-font-size: map-get($map, toggler-font-size);
+	$toggler-font-size: if(
+		$toggler-font-size,
+		$toggler-font-size,
 		if(
 			variable-exists(navbar-toggler-font-size),
 			$navbar-toggler-font-size,
@@ -324,17 +447,27 @@
 			)
 		)
 	);
-	$toggler-height: setter(
-		map-get($map, toggler-height),
+
+	$toggler-height: map-get($map, toggler-height);
+	$toggler-height: if(
+		$toggler-height,
+		$toggler-height,
 		calc(#{$height-mobile} * 0.66667)
 	);
-	$toggler-margin-x: setter(
-		map-get($map, toggler-margin-x),
+
+	$toggler-margin-x: map-get($map, toggler-margin-x);
+	$toggler-margin-x: if(
+		$toggler-margin-x,
+		$toggler-margin-x,
 		$link-padding-x-mobile
 	);
+
 	$toggler-margin-y: map-get($map, toggler-margin-y);
-	$toggler-padding-x: setter(
-		map-get($map, toggler-padding-x),
+
+	$toggler-padding-x: map-get($map, toggler-padding-x);
+	$toggler-padding-x: if(
+		$toggler-padding-x,
+		$toggler-padding-x,
 		if(
 			variable-exists(navbar-toggler-padding-x),
 			$navbar-toggler-padding-x,
@@ -345,8 +478,11 @@
 			)
 		)
 	);
-	$toggler-padding-y: setter(
-		map-get($map, toggler-padding-y),
+
+	$toggler-padding-y: map-get($map, toggler-padding-y);
+	$toggler-padding-y: if(
+		$toggler-padding-y,
+		$toggler-padding-y,
 		if(
 			variable-exists(navbar-toggler-padding-y),
 			$navbar-toggler-padding-y,
@@ -358,23 +494,43 @@
 		)
 	);
 
-	$toggler-link-font-size: setter(
-		map-get($map, toggler-link-font-size),
+	$toggler-link-font-size: map-get($map, toggler-link-font-size);
+	$toggler-link-font-size: if(
+		$toggler-link-font-size,
+		$toggler-link-font-size,
 		$font-size-mobile
 	);
-	$toggler-link-height: setter(map-get($map, toggler-link-height), auto);
-	$toggler-link-line-height: setter(
-		map-get($map, toggler-link-line-height),
+
+	$toggler-link-height: map-get($map, toggler-link-height);
+	$toggler-link-height: if($toggler-link-height, $toggler-link-height, auto);
+
+	$toggler-link-line-height: map-get($map, toggler-link-line-height);
+	$toggler-link-line-height: if(
+		$toggler-link-line-height,
+		$toggler-link-line-height,
 		$_line-height-base
 	);
-	$toggler-link-margin-x: setter(map-get($map, toggler-link-margin-x), 0);
+
+	$toggler-link-margin-x: map-get($map, toggler-link-margin-x);
+	$toggler-link-margin-x: if(
+		$toggler-link-margin-x,
+		$toggler-link-margin-x,
+		0
+	);
+
 	$toggler-link-margin-y: map-get($map, toggler-link-margin-y);
-	$toggler-link-padding-x: setter(
-		map-get($map, toggler-link-padding-x),
+
+	$toggler-link-padding-x: map-get($map, toggler-link-padding-x);
+	$toggler-link-padding-x: if(
+		$toggler-link-padding-x,
+		$toggler-link-padding-x,
 		$link-padding-x-mobile
 	);
-	$toggler-link-padding-y: setter(
-		map-get($map, toggler-link-padding-y),
+
+	$toggler-link-padding-y: map-get($map, toggler-link-padding-y);
+	$toggler-link-padding-y: if(
+		$toggler-link-padding-y,
+		$toggler-link-padding-y,
 		calc(
 			(
 					#{$height-mobile} - #{$border-bottom-width} - #{$border-top-width} -
@@ -383,19 +539,31 @@
 		)
 	);
 
-	$active-border-bottom-width: setter(
-		map-get($map, active-border-bottom-width),
+	$active-border-bottom-width: map-get($map, active-border-bottom-width);
+	$active-border-bottom-width: if(
+		$active-border-bottom-width,
+		$active-border-bottom-width,
 		0.125rem
 	);
+
 	$active-border-offset-x: map-get($map, active-border-offset-x);
-	$active-border-offset-bottom: setter(
-		map-get($map, active-border-offset-bottom),
+
+	$active-border-offset-bottom: map-get($map, active-border-offset-bottom);
+	$active-border-offset-bottom: if(
+		$active-border-offset-bottom,
+		$active-border-offset-bottom,
 		calc((#{$border-bottom-width} + #{$padding-y} + #{$link-margin-y}) * -1)
 	);
+
 	$active-border-offset-top: map-get($map, active-border-offset-top);
 
-	$active-border-offset-bottom-mobile: setter(
-		map-get($map, active-border-offset-bottom-mobile),
+	$active-border-offset-bottom-mobile: map-get(
+		$map,
+		active-border-offset-bottom-mobile
+	);
+	$active-border-offset-bottom-mobile: if(
+		$active-border-offset-bottom-mobile,
+		$active-border-offset-bottom-mobile,
 		calc(
 			(#{$border-bottom-width} + #{$padding-y} + #{$link-margin-y-mobile}) *
 				-1
@@ -885,7 +1053,8 @@
 
 @mixin clay-navbar-expand-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);
@@ -1107,7 +1276,9 @@
 
 @mixin clay-navbar-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
+
 		$breakpoints: if(
 			variable-exists(grid-breakpoints),
 			$grid-breakpoints,

--- a/packages/clay-css/src/scss/mixins/_pagination.scss
+++ b/packages/clay-css/src/scss/mixins/_pagination.scss
@@ -104,7 +104,8 @@
 
 @mixin clay-pagination-items-per-page-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);
@@ -285,7 +286,8 @@
 
 @mixin clay-pagination-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);

--- a/packages/clay-css/src/scss/mixins/_panels.scss
+++ b/packages/clay-css/src/scss/mixins/_panels.scss
@@ -57,7 +57,8 @@
 
 @mixin clay-panel-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -67,7 +68,8 @@
 			)
 		);
 
-		$header: setter(map-get($map, header), ());
+		$header: map-get($map, header);
+		$header: if($header, $header, ());
 		$header: map-merge(
 			$header,
 			(
@@ -144,8 +146,14 @@
 			)
 		);
 
-		$old-header-collapsed: setter(map-get($map, header-collapsed), ());
-		$header-collapsed: setter(map-get($header, collapsed), ());
+		$old-header-collapsed: map-get($map, header-collapsed);
+		$old-header-collapsed: if(
+			$old-header-collapsed,
+			$old-header-collapsed,
+			()
+		);
+		$header-collapsed: map-get($header, collapsed);
+		$header-collapsed: if($header-collapsed, $header-collapsed, ());
 		$header-collapsed: map-merge($header-collapsed, $old-header-collapsed);
 		$header-collapsed: map-merge(
 			$header-collapsed,
@@ -158,8 +166,10 @@
 			)
 		);
 
-		$old-header-c-inner: setter(map-get($map, header-c-inner), ());
-		$header-c-inner: setter(map-get($header, c-inner), ());
+		$old-header-c-inner: map-get($map, header-c-inner);
+		$old-header-c-inner: if($old-header-c-inner, $old-header-c-inner, ());
+		$header-c-inner: map-get($header, c-inner);
+		$header-c-inner: if($header-c-inner, $header-c-inner, ());
 		$header-c-inner: map-merge(
 			(
 				enabled:
@@ -180,11 +190,14 @@
 			$header-c-inner
 		);
 
-		$old-header-link: setter(map-get($map, header-link), ());
-		$header-link: setter(map-get($header, link), ());
+		$old-header-link: map-get($map, header-link);
+		$old-header-link: if($old-header-link, $old-header-link, ());
+		$header-link: map-get($header, link);
+		$header-link: if($header-link, $header-link, ());
 		$header-link: map-deep-merge($header-link, $old-header-link);
 
-		$title: setter(map-get($map, title), ());
+		$title: map-get($map, title);
+		$title: if($title, $title, ());
 		$title: map-merge(
 			$title,
 			(
@@ -206,7 +219,8 @@
 			)
 		);
 
-		$collapse-icon: setter(map-get($map, collapse-icon), ());
+		$collapse-icon: map-get($map, collapse-icon);
+		$collapse-icon: if($collapse-icon, $collapse-icon, ());
 		$collapse-icon: map-merge(
 			$collapse-icon,
 			(
@@ -238,7 +252,8 @@
 			)
 		);
 
-		$body: setter(map-get($map, body), ());
+		$body: map-get($map, body);
+		$body: if($body, $body, ());
 		$body: map-merge(
 			$body,
 			(
@@ -285,7 +300,8 @@
 			)
 		);
 
-		$footer: setter(map-get($map, footer), ());
+		$footer: map-get($map, footer);
+		$footer: if($footer, $footer, ());
 		$footer: map-merge(
 			$footer,
 			(

--- a/packages/clay-css/src/scss/mixins/_popovers.scss
+++ b/packages/clay-css/src/scss/mixins/_popovers.scss
@@ -24,7 +24,8 @@
 
 @mixin clay-popover-header-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);
@@ -88,7 +89,8 @@
 
 @mixin clay-popover-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);

--- a/packages/clay-css/src/scss/mixins/_scale-component.scss
+++ b/packages/clay-css/src/scss/mixins/_scale-component.scss
@@ -6,7 +6,8 @@
 /// @param {Bool} $scale[$enable-scaling-components] - Enables or disables this mixin
 
 @mixin clay-scale-component($scale: null, $breakpoint-down: null) {
-	$breakpoint-down: setter(
+	$breakpoint-down: if(
+		$breakpoint-down,
 		$breakpoint-down,
 		if(
 			variable-exists(scaling-breakpoint-down),
@@ -19,7 +20,8 @@
 		)
 	);
 
-	$scale: setter(
+	$scale: if(
+		$scale,
 		$scale,
 		if(
 			variable-exists(enable-scaling-components),

--- a/packages/clay-css/src/scss/mixins/_sheet.scss
+++ b/packages/clay-css/src/scss/mixins/_sheet.scss
@@ -13,13 +13,16 @@
 /// - Add @link to documentation
 
 @mixin sheet-footer-btn-block($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled != null, $enabled, true);
 
 	$breakpoint-down: map-get($map, breakpoint-down);
 
-	$mobile: setter(map-get($map, mobile), ());
+	$mobile: map-get($map, mobile);
+	$mobile: if($mobile, $mobile, ());
 
-	$btn-mobile: setter(map-get($mobile, btn), ());
+	$btn-mobile: map-get($mobile, btn);
+	$btn-mobile: if($btn-mobile, $btn-mobile, ());
 	$btn-mobile: map-merge(
 		$btn-mobile,
 		(

--- a/packages/clay-css/src/scss/mixins/_sidebar.scss
+++ b/packages/clay-css/src/scss/mixins/_sidebar.scss
@@ -102,7 +102,8 @@
 
 @mixin clay-sidebar-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled !=null, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -169,10 +170,13 @@
 			setter(map-get($map, nav-nested-link), ())
 		);
 
-		$sidebar-list-group: setter(map-get($map, sidebar-list-group), ());
+		$sidebar-list-group: map-get($map, sidebar-list-group);
+		$sidebar-list-group: if($sidebar-list-group, $sidebar-list-group, ());
 
-		$sidebar-list-group-item: setter(
-			map-get($sidebar-list-group, list-group-item),
+		$sidebar-list-group-item: map-get($sidebar-list-group, list-group-item);
+		$sidebar-list-group-item: if(
+			$sidebar-list-group-item,
+			$sidebar-list-group-item,
 			()
 		);
 		$sidebar-list-group-item: map-merge(

--- a/packages/clay-css/src/scss/mixins/_slideout.scss
+++ b/packages/clay-css/src/scss/mixins/_slideout.scss
@@ -17,7 +17,10 @@
 /// tbar-stacked-c-slideout-transition: {Map | Null}, // Pass parameters to `clay-css` mixin
 
 @mixin clay-slideout-variant($map) {
-	@if (setter(map-get($map, enabled), true)) {
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled != null, $enabled, true);
+
+	@if ($enabled) {
 		@include clay-css($map);
 
 		&.c-slideout-shown {

--- a/packages/clay-css/src/scss/mixins/_stickers.scss
+++ b/packages/clay-css/src/scss/mixins/_stickers.scss
@@ -16,11 +16,16 @@
 
 @mixin clay-sticker-size($map) {
 	$font-size: map-get($map, font-size);
+
 	$inline-item-font-size: map-get($map, inline-item-font-size);
-	$outside-offset: setter(
-		map-get($map, outside-offset),
+
+	$outside-offset: map-get($map, outside-offset);
+	$outside-offset: if(
+		$outside-offset,
+		$outside-offset,
 		math-sign(map-get($map, size) * 0.5)
 	);
+
 	$size: map-get($map, size);
 
 	font-size: $font-size;
@@ -114,7 +119,8 @@
 
 @mixin clay-sticker-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		$base: map-merge(
 			$map,
@@ -128,7 +134,8 @@
 			)
 		);
 
-		$inline-item: setter(map-get($map, inline-item), ());
+		$inline-item: map-get($map, inline-item);
+		$inline-item: if($inline-item, $inline-item, ());
 		$inline-item: map-merge(
 			$inline-item,
 			(
@@ -140,8 +147,10 @@
 			)
 		);
 
-		$outside-offset: setter(
-			map-get($map, outside-offset),
+		$outside-offset: map-get($map, outside-offset);
+		$outside-offset: if(
+			$outside-offset,
+			$outside-offset,
 			if(
 				map-get($map, size),
 				calc(#{math-sign(map-get($map, size))} / 2),
@@ -149,33 +158,76 @@
 			)
 		);
 
-		$sticker-outside: setter(map-get($map, sticker-outside), ());
+		$sticker-outside: map-get($map, sticker-outside);
+		$sticker-outside: if($sticker-outside, $sticker-outside, ());
 
-		$sticker-outside-bottom-left: setter(
-			map-get($sticker-outside, sticker-bottom-left),
+		$_old-sticker-outside-bottom-left: map-get(
+			$map,
+			sticker-outside-bottom-left
+		);
+		$_old-sticker-outside-bottom-left: if(
+			$_old-sticker-outside-bottom-left,
+			$_old-sticker-outside-bottom-left,
+			()
+		);
+		$sticker-outside-bottom-left: map-get(
+			$sticker-outside,
+			sticker-bottom-left
+		);
+		$sticker-outside-bottom-left: if(
+			$sticker-outside-bottom-left,
+			$sticker-outside-bottom-left,
 			()
 		);
 		$sticker-outside-bottom-left: map-merge(
 			$sticker-outside-bottom-left,
-			setter(map-get($map, sticker-outside-bottom-left), ())
+			$_old-sticker-outside-bottom-left
 		);
 
-		$sticker-outside-bottom-right: setter(
-			map-get($sticker-outside, sticker-bottom-right),
+		$_old-sticker-outside-bottom-right: map-get(
+			$map,
+			sticker-outside-bottom-right
+		);
+		$_old-sticker-outside-bottom-right: if(
+			$_old-sticker-outside-bottom-right,
+			$_old-sticker-outside-bottom-right,
+			()
+		);
+		$sticker-outside-bottom-right: map-get(
+			$sticker-outside,
+			sticker-bottom-right
+		);
+		$sticker-outside-bottom-right: if(
+			$sticker-outside-bottom-right,
+			$sticker-outside-bottom-right,
 			()
 		);
 		$sticker-outside-bottom-right: map-merge(
 			$sticker-outside-bottom-right,
-			setter(map-get($map, sticker-outside-bottom-right), ())
+			$_old-sticker-outside-bottom-right
 		);
 
-		$sticker-outside-top-right: setter(
-			map-get($sticker-outside, sticker-top-right),
+		$_old-sticker-outside-top-right: map-get(
+			$map,
+			sticker-outside-top-right
+		);
+		$_old-sticker-outside-top-right: if(
+			$_old-sticker-outside-top-right,
+			$_old-sticker-outside-top-right,
+			()
+		);
+		$sticker-outside-top-right: map-get(
+			$sticker-outside,
+			sticker-top-right
+		);
+		$sticker-outside-top-right: if(
+			$sticker-outside-top-right,
+			$sticker-outside-top-right,
 			()
 		);
 		$sticker-outside-top-right: map-merge(
 			$sticker-outside-top-right,
-			setter(map-get($map, sticker-outside-top-right), ())
+			$_old-sticker-outside-top-right
 		);
 
 		@if ($outside-offset) {

--- a/packages/clay-css/src/scss/mixins/_tables.scss
+++ b/packages/clay-css/src/scss/mixins/_tables.scss
@@ -52,7 +52,8 @@
 
 @mixin clay-table-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);
@@ -390,17 +391,23 @@
 /// c-droppable-after: {Map | Null}, // See Mixin `clay-css` for available keys. This is an extra pseudo element if you need.
 
 @mixin clay-table-drag-variant($map) {
-	$cell: setter(map-get($map, cell), ());
+	$cell: map-get($map, cell);
+	$cell: if($cell, $cell, ());
 
-	$c-drag: setter(map-get($map, c-drag), ());
+	$c-drag: map-get($map, c-drag);
+	$c-drag: if($c-drag, $c-drag, ());
 
-	$c-dragging-before: setter(map-get($map, c-dragging-before), ());
+	$c-dragging-before: map-get($map, c-dragging-before);
+	$c-dragging-before: if($c-dragging-before, $c-dragging-before, ());
 
-	$c-dragging-after: setter(map-get($map, c-dragging-after), ());
+	$c-dragging-after: map-get($map, c-dragging-after);
+	$c-dragging-after: if($c-dragging-after, $c-dragging-after, ());
 
-	$c-droppable-before: setter(map-get($map, c-droppable-before), ());
+	$c-droppable-before: map-get($map, c-droppable-before);
+	$c-droppable-before: if($c-droppable-before, $c-droppable-before, ());
 
-	$c-droppable-after: setter(map-get($map, c-droppable-after), ());
+	$c-droppable-after: map-get($map, c-droppable-after);
+	$c-droppable-after: if($c-droppable-after, $c-droppable-after, ());
 
 	@include clay-css($map);
 
@@ -443,11 +450,14 @@
 /// cell: {Map | Null}, // See Mixin `clay-css` for available keys. This styles the table cell (th and td) in the `table-clone` variant.
 
 @mixin clay-table-clone-variant($map) {
-	$before: setter(map-get($map, before), ());
+	$before: map-get($map, before);
+	$before: if($before, $before, ());
 
-	$after: setter(map-get($map, after), ());
+	$after: map-get($map, after);
+	$after: if($after, $after, ());
 
-	$cell: setter(map-get($map, cell), ());
+	$cell: map-get($map, cell);
+	$cell: if($cell, $cell, ());
 
 	@include clay-css($map);
 

--- a/packages/clay-css/src/scss/mixins/_tbar.scss
+++ b/packages/clay-css/src/scss/mixins/_tbar.scss
@@ -93,7 +93,8 @@
 		)
 	);
 
-	$strong: setter(map-get($map, strong), ());
+	$strong: map-get($map, strong);
+	$strong: if($strong, $strong, ());
 	$strong: map-merge(
 		$strong,
 		(
@@ -105,7 +106,8 @@
 		)
 	);
 
-	$item: setter(map-get($map, item), ());
+	$item: map-get($map, item);
+	$item: if($item, $item, ());
 	$item: map-merge(
 		$item,
 		(
@@ -137,7 +139,8 @@
 		)
 	);
 
-	$btn: setter(map-get($map, btn), ());
+	$btn: map-get($map, btn);
+	$btn: if($btn, $btn, ());
 	$btn: map-merge(
 		$btn,
 		(
@@ -185,7 +188,8 @@
 		)
 	);
 
-	$btn-c-inner: setter(map-get($map, btn-c-inner), ());
+	$btn-c-inner: map-get($map, btn-c-inner);
+	$btn-c-inner: if($btn-c-inner, $btn-c-inner, ());
 	$btn-c-inner: map-merge(
 		(
 			enabled: $enable-c-inner,
@@ -197,7 +201,8 @@
 		$btn-c-inner
 	);
 
-	$btn-monospaced: setter(map-get($map, btn-monospaced), ());
+	$btn-monospaced: map-get($map, btn-monospaced);
+	$btn-monospaced: if($btn-monospaced, $btn-monospaced, ());
 	$btn-monospaced: map-merge(
 		$btn-monospaced,
 		(
@@ -256,7 +261,12 @@
 		)
 	);
 
-	$btn-monospaced-c-inner: setter(map-get($map, btn-monospaced-c-inner), ());
+	$btn-monospaced-c-inner: map-get($map, btn-monospaced-c-inner);
+	$btn-monospaced-c-inner: if(
+		$btn-monospaced-c-inner,
+		$btn-monospaced-c-inner,
+		()
+	);
 	$btn-monospaced-c-inner: map-merge(
 		(
 			enabled: $enable-c-inner,
@@ -265,7 +275,8 @@
 		$btn-monospaced-c-inner
 	);
 
-	$link: setter(map-get($map, link), ());
+	$link: map-get($map, link);
+	$link: if($link, $link, ());
 	$link: map-merge(
 		$link,
 		(
@@ -309,7 +320,8 @@
 		)
 	);
 
-	$link-c-inner: setter(map-get($map, link-c-inner), ());
+	$link-c-inner: map-get($map, link-c-inner);
+	$link-c-inner: if($link-c-inner, $link-c-inner, ());
 	$link-c-inner: map-merge(
 		(
 			enabled: $enable-c-inner,
@@ -321,7 +333,8 @@
 		$link-c-inner
 	);
 
-	$link-monospaced: setter(map-get($map, link-monospaced), ());
+	$link-monospaced: map-get($map, link-monospaced);
+	$link-monospaced: if($link-monospaced, $link-monospaced, ());
 	$link-monospaced: map-merge(
 		(
 			border-radius:
@@ -378,8 +391,10 @@
 		$link-monospaced
 	);
 
-	$link-monospaced-c-inner: setter(
-		map-get($map, link-monospaced-c-inner),
+	$link-monospaced-c-inner: map-get($map, link-monospaced-c-inner);
+	$link-monospaced-c-inner: if(
+		$link-monospaced-c-inner,
+		$link-monospaced-c-inner,
 		()
 	);
 	$link-monospaced-c-inner: map-merge(
@@ -390,7 +405,8 @@
 		$link-monospaced-c-inner
 	);
 
-	$section: setter(map-get($map, section), ());
+	$section: map-get($map, section);
+	$section: if($section, $section, ());
 	$section: map-merge(
 		$section,
 		(

--- a/packages/clay-css/src/scss/mixins/_toggle-switch.scss
+++ b/packages/clay-css/src/scss/mixins/_toggle-switch.scss
@@ -63,7 +63,8 @@
 
 @mixin clay-toggle-switch-bar-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);
@@ -643,8 +644,11 @@
 
 @mixin clay-toggle-switch-check-variant($map) {
 	@if (type-of($map) == 'map') {
-		$breakpoint-down: setter(map-get($map, breakpoint-down), sm);
-		$enabled: setter(map-get($map, enabled), true);
+		$breakpoint-down: map-get($map, breakpoint-down);
+		$breakpoint-down: if($breakpoint-down, $breakpoint-down, sm);
+
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@include clay-css($map);
 
@@ -968,8 +972,11 @@
 
 @mixin clay-toggle-switch-variant($map) {
 	@if (type-of($map) == 'map') {
-		$breakpoint-down: setter(map-get($map, breakpoint-down), sm);
-		$enabled: setter(map-get($map, enabled), true);
+		$breakpoint-down: map-get($map, breakpoint-down);
+		$breakpoint-down: if($breakpoint-down, $breakpoint-down, sm);
+
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@include clay-css($map);
 

--- a/packages/clay-css/src/scss/mixins/_tooltip.scss
+++ b/packages/clay-css/src/scss/mixins/_tooltip.scss
@@ -27,7 +27,8 @@
 
 @mixin clay-tooltip-variant($map) {
 	@if (type-of($map) == 'map') {
-		$enabled: setter(map-get($map, enabled), true);
+		$enabled: map-get($map, enabled);
+		$enabled: if($enabled != null, $enabled, true);
 
 		@if ($enabled) {
 			@include clay-css($map);

--- a/packages/clay-css/src/scss/mixins/_transition.scss
+++ b/packages/clay-css/src/scss/mixins/_transition.scss
@@ -2,13 +2,28 @@
 /// @param {Arglist} $transition...
 
 @mixin transition($transition...) {
-	$enable: setter(
-		if(
-			variable-exists(enable-shadows),
-			$enable-transitions,
-			$cadmin-enable-transitions
-		),
-		true
+	$enable: if(
+		variable-exists(enable-transitions),
+		$enable-transitions,
+		if
+			(
+				variable-exists(cadmin-enable-transitions),
+				$cadmin-enable-transitions,
+				true
+			)
+	);
+
+	$reduced-motion-media-query: if(
+		variable-exists(enable-prefers-reduced-motion-media-query),
+		$enable-prefers-reduced-motion-media-query,
+		if
+			(
+				variable-exists(
+					cadmin-enable-prefers-reduced-motion-media-query
+				),
+				$cadmin-enable-prefers-reduced-motion-media-query,
+				false
+			)
 	);
 
 	@if ($enable) {
@@ -19,16 +34,7 @@
 		}
 	}
 
-	@if (
-		setter(
-			if(
-				variable-exists(enable-shadows),
-				$enable-prefers-reduced-motion-media-query,
-				$cadmin-enable-prefers-reduced-motion-media-query
-			),
-			true
-		)
-	) {
+	@if ($reduced-motion-media-query) {
 		@media (prefers-reduced-motion: reduce) {
 			transition: none;
 		}

--- a/packages/clay-css/src/scss/mixins/_utilities.scss
+++ b/packages/clay-css/src/scss/mixins/_utilities.scss
@@ -123,9 +123,11 @@
 /// autofit-col-padding-top: {Number | String | Null}, // deprecated after 3.9.0
 
 @mixin clay-autofit-row($map) {
-	$enabled: setter(map-get($map, enabled), true);
+	$enabled: map-get($map, enabled);
+	$enabled: if($enabled != null, $enabled, true);
 
-	$autofit-col: setter(map-get($map, autofit-col), ());
+	$autofit-col: map-get($map, autofit-col);
+	$autofit-col: if($autofit-col, $autofit-col, ());
 	$autofit-col: map-merge(
 		$autofit-col,
 		(

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -826,23 +826,34 @@ $has-error: map-deep-merge(
 		input-group-item: (
 			focus: (
 				box-shadow:
-					setter(
+					if(
+						$input-danger-focus-box-shadow,
 						$input-danger-focus-box-shadow,
 						$input-danger-box-shadow
 					),
 				input-group-inset: (
 					background-color:
-						setter($input-danger-focus-bg, $input-danger-bg),
+						if(
+							$input-danger-focus-bg,
+							$input-danger-focus-bg,
+							$input-danger-bg
+						),
 					border-color:
-						setter(
+						if(
+							$input-danger-focus-border-color,
 							$input-danger-focus-border-color,
 							$input-danger-border-color
 						),
 					input-group-inset-item: (
 						background-color:
-							setter($input-danger-focus-bg, $input-danger-bg),
+							if(
+								$input-danger-focus-bg,
+								$input-danger-focus-bg,
+								$input-danger-bg
+							),
 						border-color:
-							setter(
+							if(
+								$input-danger-focus-border-color,
 								$input-danger-focus-border-color,
 								$input-danger-border-color
 							),
@@ -859,9 +870,14 @@ $has-error: map-deep-merge(
 					box-shadow: none,
 					input-group-inset-item: (
 						background-color:
-							setter($input-danger-focus-bg, $input-danger-bg),
+							if(
+								$input-danger-focus-bg,
+								$input-danger-focus-bg,
+								$input-danger-bg
+							),
 						border-color:
-							setter(
+							if(
+								$input-danger-focus-border-color,
 								$input-danger-focus-border-color,
 								$input-danger-border-color
 							),
@@ -979,23 +995,34 @@ $has-warning: map-deep-merge(
 		input-group-item: (
 			focus: (
 				box-shadow:
-					setter(
+					if(
+						$input-warning-focus-box-shadow,
 						$input-warning-focus-box-shadow,
 						$input-warning-box-shadow
 					),
 				input-group-inset: (
 					background-color:
-						setter($input-warning-focus-bg, $input-warning-bg),
+						if(
+							$input-warning-focus-bg,
+							$input-warning-focus-bg,
+							$input-warning-bg
+						),
 					border-color:
-						setter(
+						if(
+							$input-warning-focus-border-color,
 							$input-warning-focus-border-color,
 							$input-warning-border-color
 						),
 					input-group-inset-item: (
 						background-color:
-							setter($input-warning-focus-bg, $input-warning-bg),
+							if(
+								$input-warning-focus-bg,
+								$input-warning-focus-bg,
+								$input-warning-bg
+							),
 						border-color:
-							setter(
+							if(
+								$input-warning-focus-border-color,
 								$input-warning-focus-border-color,
 								$input-warning-border-color
 							),
@@ -1012,9 +1039,14 @@ $has-warning: map-deep-merge(
 					box-shadow: none,
 					input-group-inset-item: (
 						background-color:
-							setter($input-warning-focus-bg, $input-warning-bg),
+							if(
+								$input-warning-focus-bg,
+								$input-warning-focus-bg,
+								$input-warning-bg
+							),
 						border-color:
-							setter(
+							if(
+								$input-warning-focus-border-color,
 								$input-warning-focus-border-color,
 								$input-warning-border-color
 							),
@@ -1132,23 +1164,34 @@ $has-success: map-deep-merge(
 		input-group-item: (
 			focus: (
 				box-shadow:
-					setter(
+					if(
+						$input-success-focus-box-shadow,
 						$input-success-focus-box-shadow,
 						$input-success-box-shadow
 					),
 				input-group-inset: (
 					background-color:
-						setter($input-success-focus-bg, $input-success-bg),
+						if(
+							$input-success-focus-bg,
+							$input-success-focus-bg,
+							$input-success-bg
+						),
 					border-color:
-						setter(
+						if(
+							$input-success-focus-border-color,
 							$input-success-focus-border-color,
 							$input-success-border-color
 						),
 					input-group-inset-item: (
 						background-color:
-							setter($input-success-focus-bg, $input-success-bg),
+							if(
+								$input-success-focus-bg,
+								$input-success-focus-bg,
+								$input-success-bg
+							),
 						border-color:
-							setter(
+							if(
+								$input-success-focus-border-color,
 								$input-success-focus-border-color,
 								$input-success-border-color
 							),
@@ -1165,9 +1208,14 @@ $has-success: map-deep-merge(
 					box-shadow: none,
 					input-group-inset-item: (
 						background-color:
-							setter($input-success-focus-bg, $input-success-bg),
+							if(
+								$input-success-focus-bg,
+								$input-success-focus-bg,
+								$input-success-bg
+							),
 						border-color:
-							setter(
+							if(
+								$input-success-focus-border-color,
 								$input-success-focus-border-color,
 								$input-success-border-color
 							),


### PR DESCRIPTION
fixes #5114

This is a really big change. I think it reduced the build time, but can't say for sure due to processes running on my computer. Here is a really small sample of `yarn compile` I did in the master branch.

```
✨  Done in 35.85s.
✨  Done in 35.51s.
✨  Done in 35.07s.
✨  Done in 34.73s.
```

This is a sample of build times on this branch.

```
✨  Done in 35.98s.
✨  Done in 35.37s.
✨  Done in 35.34s.
✨  Done in 34.21s.
```

My localized performance test said 100,000 iterations of `setter` vs `if` statement is ~900ms slower. I'm not sure if this is worth merging. I'm going to mark this as draft so we can discuss.