### PR TITLE
feat(@clayui/core): add possibility to specify item name key

### DIFF
--- a/packages/clay-core/src/tree-view/DragLayer.tsx
+++ b/packages/clay-core/src/tree-view/DragLayer.tsx
@@ -41,7 +41,7 @@ function getItemStyles(
 	};
 }
 
-const DragLayer = () => {
+const DragLayer = ({itemNameKey}: {itemNameKey: string}) => {
 	const elementRef = useRef<HTMLDivElement | null>(null);
 
 	const {currentOffset, isDragging, item} = useDragLayer(
@@ -58,6 +58,8 @@ const DragLayer = () => {
 		return null;
 	}
 
+	const name = item.item[itemNameKey];
+
 	return (
 		<div style={layerStyles}>
 			<div
@@ -65,7 +67,7 @@ const DragLayer = () => {
 				ref={elementRef}
 				style={getItemStyles(currentOffset, mousePosition, elementRef)}
 			>
-				{item.name}
+				{name}
 			</div>
 		</div>
 	);

--- a/packages/clay-core/src/tree-view/DragLayer.tsx
+++ b/packages/clay-core/src/tree-view/DragLayer.tsx
@@ -54,7 +54,7 @@ const DragLayer = ({itemNameKey}: {itemNameKey: string}) => {
 
 	const mousePosition = useMousePosition();
 
-	if (!isDragging) {
+	if (!isDragging || item.type !== 'treeViewItem') {
 		return null;
 	}
 

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -61,6 +61,12 @@ interface ITreeViewProps<T>
 	expanderIcons?: Icons;
 
 	/**
+	 * Flag to indicate which key name matches the item name to be displayed
+	 * in drag preview.
+	 */
+	itemNameKey?: string;
+
+	/**
 	 * Callback is called when an item is about to be moved elsewhere in the tree.
 	 */
 	onItemMove?: (item: T, parentItem: T) => void;
@@ -141,7 +147,6 @@ export function TreeView<T>({
 		defaultItems,
 		defaultSelectedKeys,
 		expandedKeys,
-		itemNameKey,
 		items,
 		nestedKey,
 		onExpandedChange,
@@ -165,7 +170,6 @@ export function TreeView<T>({
 		expandOnCheck,
 		expanderClassName,
 		expanderIcons,
-		itemNameKey,
 		nestedKey,
 		onItemMove,
 		onLoadMore,

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -118,6 +118,7 @@ export function TreeView<T>({
 	expanderClassName,
 	expanderIcons,
 	expandOnCheck = false,
+	itemNameKey = 'name',
 	items,
 	nestedKey = 'children',
 	onExpandedChange,
@@ -140,6 +141,7 @@ export function TreeView<T>({
 		defaultItems,
 		defaultSelectedKeys,
 		expandedKeys,
+		itemNameKey,
 		items,
 		nestedKey,
 		onExpandedChange,
@@ -163,6 +165,7 @@ export function TreeView<T>({
 		expandOnCheck,
 		expanderClassName,
 		expanderIcons,
+		itemNameKey,
 		nestedKey,
 		onItemMove,
 		onLoadMore,
@@ -197,7 +200,7 @@ export function TreeView<T>({
 						<Collection<T> items={state.items}>
 							{children}
 						</Collection>
-						<DragLayer />
+						<DragLayer itemNameKey={itemNameKey} />
 					</TreeViewContext.Provider>
 				</DndProvider>
 			</ul>

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -65,6 +65,11 @@ export interface ITreeProps<T>
 		IMultipleSelection,
 		Pick<ICollectionProps<T>, 'items' | 'defaultItems'> {
 	/**
+	 * Flag to indicate which key name matches the item name to be displayed in drag preview.
+	 */
+	itemNameKey?: string;
+
+	/**
 	 * Flag to indicate which key name matches the nested rendering of the tree.
 	 */
 	nestedKey?: string;

--- a/packages/clay-core/src/tree-view/useTree.ts
+++ b/packages/clay-core/src/tree-view/useTree.ts
@@ -65,11 +65,6 @@ export interface ITreeProps<T>
 		IMultipleSelection,
 		Pick<ICollectionProps<T>, 'items' | 'defaultItems'> {
 	/**
-	 * Flag to indicate which key name matches the item name to be displayed in drag preview.
-	 */
-	itemNameKey?: string;
-
-	/**
 	 * Flag to indicate which key name matches the nested rendering of the tree.
 	 */
 	nestedKey?: string;


### PR DESCRIPTION
This fixes https://github.com/liferay/clay/issues/5125 and also adds the possibility to specify a different key for item's name from outside. I've also added a check in the drag preview to prevent it to be shown in other drag and drop context, as discussed with @matuzalemsteles in Slack 🙂