### PR TITLE
feat(@clayui/core): adds support for `onItemMove` to decide if item should be droppable

### DIFF
--- a/packages/clay-core/docs/treeview.mdx
+++ b/packages/clay-core/docs/treeview.mdx
@@ -603,6 +603,41 @@ function Example() {
 }
 ```
 
+The component allows you to add rules in Drag and Drop like disabling an item to be draggable and dropable, for this you need to set the `draggable` property of the component to `TreeView.Item` or `TreeView.ItemStack`.
+
+```jsx
+<TreeView dragAndDrop>
+	{(item) => (
+		<TreeView.Item>
+			<TreeView.ItemStack draggable={false}>
+				{item.name}
+			</TreeView.ItemStack>
+			<TreeView.Item.Group items={item.children}>
+				{(item) => (
+					<TreeView.Item draggable={false}>{item.name}</TreeView.Item>
+				)}
+			</TreeView.Item.Group>
+		</TreeView.Item>
+	)}
+</TreeView>
+```
+
+In some cases it is necessary to check if the item can be dropped in another item, for example a TreeView from a file explorer, does not allow moving a file into another file. You need to use `onItemMove` to decide if the item can be droppable on a specific item.
+
+```jsx
+<TreeView
+	dragAndDrop
+	onItemMove={(item, parentItem) => {
+		// your logic here
+
+		// Returning false does not allow the item to be dropped in the parentItem.
+		return false;
+	}}
+>
+	{...}
+</TreeView>
+```
+
 ## Shortcuts
 
 The TreeView implements shortcuts and manages the focus. Some shortcuts and focus trigger some actions like renaming, removing or asynchronous loading if any.

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -69,7 +69,7 @@ interface ITreeViewProps<T>
 	/**
 	 * Callback is called when an item is about to be moved elsewhere in the tree.
 	 */
-	onItemMove?: (item: T, parentItem: T) => void;
+	onItemMove?: (item: T, parentItem: T) => boolean;
 
 	/**
 	 * When a tree is very large, loading items (nodes) asynchronously is preferred to

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -33,6 +33,11 @@ export interface ITreeViewItemProps
 	children: React.ReactNode;
 
 	/**
+	 * Flag to define if the item is draggable and dropable.
+	 */
+	draggable?: boolean;
+
+	/**
 	 * Flag indicating that the component is disabled.
 	 */
 	disabled?: boolean;
@@ -402,7 +407,12 @@ export const TreeViewItem = React.forwardRef<
 					onTouchStart={() => {
 						clickCapturedRef.current = true;
 					}}
-					ref={ref}
+					ref={
+						itemStackProps.draggable === false ||
+						nodeProps.draggable === false
+							? undefined
+							: ref
+					}
 					role="treeitem"
 					style={{
 						...(itemStackProps?.style ?? {}),
@@ -482,6 +492,11 @@ interface ITreeViewItemStackProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * Item content.
 	 */
 	children: React.ReactNode;
+
+	/**
+	 * Flag to define if the item is draggable and dropable.
+	 */
+	draggable?: boolean;
 
 	/**
 	 * Flag indicating that the component is disabled.

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -31,7 +31,7 @@ export interface ITreeViewContext<T> extends ITreeState<T> {
 	expanderClassName?: string;
 	expanderIcons?: Icons;
 	nestedKey?: string;
-	onItemMove?: (item: T, parentItem: T) => void;
+	onItemMove?: (item: T, parentItem: T) => boolean;
 	onLoadMore?: OnLoadMore<T>;
 	onSelect?: (item: T) => void;
 	onRenameItem?: (item: T) => Promise<any>;

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -167,10 +167,14 @@ export function ItemContextProvider({children, value}: Props) {
 			if (onItemMove) {
 				const tree = createImmutableTree(items as any, nestedKey!);
 
-				onItemMove(
+				const isMoved = onItemMove(
 					removeItemInternalProps((dragItem as Value).item),
 					tree.nodeByPath(indexes).parent
 				);
+
+				if (!isMoved) {
+					return;
+				}
 			}
 
 			reorder((dragItem as Value).item.indexes, indexes);


### PR DESCRIPTION
Closes #5011

This PR adds two options to bypass item drag and drop. This provides better options for teams to customize based on their data.

- Disable drag and drop of a specific item using the `draggable` property for `<TreeView.Item />` or `<TreeView.ItemStack />`
- Disable dropping an item on another item by returning `false` in the `onItemMove` function

I also added documentation on these two possibilities.