### PR TITLE
fix(@clayui/css): Links `.component-action` and `.link-outline` should have focus shadow

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_links.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_links.scss
@@ -111,7 +111,7 @@ $component-action: map-deep-merge(
 		),
 		focus: (
 			background-color: rgba($gray-900, 0.03),
-			box-shadow: map-get($btn-secondary, focus-box-shadow),
+			box-shadow: $component-focus-box-shadow,
 			color: $gray-900,
 			outline: 0,
 		),
@@ -123,7 +123,6 @@ $component-action: map-deep-merge(
 			background-color: transparent,
 			box-shadow: none,
 		),
-		btn-focus-box-shadow: map-get($btn-secondary, focus-box-shadow),
 	),
 	$component-action
 );
@@ -139,20 +138,13 @@ $link-outline-primary: map-deep-merge(
 		),
 		focus: (
 			background-color: $primary-l3,
-			box-shadow: map-get($btn-outline-primary, focus-box-shadow),
 			color: $primary,
-			outline: 0,
 		),
 		active: (
 			background-color:
 				clay-lighten(clay-desaturate($primary, 42.05), 41.76),
 			color: $primary,
 		),
-		disabled: (
-			box-shadow: none,
-		),
-		btn-focus-box-shadow: map-get($btn-outline-primary, focus-box-shadow),
-		btn-focus-outline: 0,
 	),
 	$link-outline-primary
 );
@@ -167,18 +159,11 @@ $link-outline-secondary: map-deep-merge(
 		),
 		focus: (
 			background-color: rgba($gray-900, 0.03),
-			box-shadow: map-get($btn-outline-secondary, focus-box-shadow),
 			color: $gray-900,
-			outline: 0,
 		),
-		btn-focus-box-shadow: map-get($btn-outline-secondary, focus-box-shadow),
-		btn-focus-outline: 0,
 		active: (
 			background-color: rgba($gray-900, 0.06),
 			color: $gray-900,
-		),
-		disabled: (
-			box-shadow: none,
 		),
 	),
 	$link-outline-secondary

--- a/packages/clay-css/src/scss/cadmin/variables/_links.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_links.scss
@@ -111,7 +111,12 @@ $cadmin-link-outline: map-deep-merge(
 		hover: (
 			text-decoration: none,
 		),
+		focus: (
+			box-shadow: $cadmin-component-focus-box-shadow,
+			outline: 0,
+		),
 		disabled: (
+			box-shadow: none,
 			active: (
 				pointer-events: none,
 			),
@@ -134,9 +139,7 @@ $cadmin-link-outline-primary: map-deep-merge(
 		),
 		focus: (
 			background-color: $cadmin-primary-l3,
-			box-shadow: map-get($cadmin-btn-outline-primary, focus-box-shadow),
 			color: $cadmin-primary,
-			outline: 0,
 		),
 		active: (
 			background-color:
@@ -145,14 +148,10 @@ $cadmin-link-outline-primary: map-deep-merge(
 		),
 		disabled: (
 			background-color: transparent,
-			box-shadow: none,
 			color: $cadmin-primary,
 			cursor: $cadmin-btn-disabled-cursor,
 			opacity: $cadmin-btn-disabled-opacity,
 		),
-		btn-focus-box-shadow:
-			map-get($cadmin-btn-outline-primary, focus-box-shadow),
-		btn-focus-outline: 0,
 	),
 	$cadmin-link-outline-primary
 );
@@ -168,9 +167,7 @@ $cadmin-link-outline-secondary: map-deep-merge(
 		),
 		focus: (
 			background-color: rgba($cadmin-gray-900, 0.03),
-			box-shadow: map-get($cadmin-btn-outline-secondary, focus-box-shadow),
 			color: $cadmin-gray-900,
-			outline: 0,
 		),
 		active: (
 			background-color: rgba($cadmin-gray-900, 0.06),
@@ -178,14 +175,10 @@ $cadmin-link-outline-secondary: map-deep-merge(
 		),
 		disabled: (
 			background-color: transparent,
-			box-shadow: none,
 			color: $cadmin-secondary,
 			cursor: $cadmin-btn-disabled-cursor,
 			opacity: $cadmin-btn-disabled-opacity,
 		),
-		btn-focus-box-shadow:
-			map-get($cadmin-btn-outline-secondary, focus-box-shadow),
-		btn-focus-outline: 0,
 	),
 	$cadmin-link-outline-secondary
 );
@@ -323,7 +316,7 @@ $cadmin-component-action: map-deep-merge(
 		),
 		focus: (
 			background-color: rgba($cadmin-gray-900, 0.03),
-			box-shadow: map-get($cadmin-btn-secondary, focus-box-shadow),
+			box-shadow: $cadmin-component-focus-box-shadow,
 			color: $cadmin-gray-900,
 			outline: 0,
 		),
@@ -341,8 +334,6 @@ $cadmin-component-action: map-deep-merge(
 				pointer-events: none,
 			),
 		),
-		btn-focus-box-shadow: map-get($cadmin-btn-secondary, focus-box-shadow),
-		btn-focus-outline: 0,
 		lexicon-icon: (
 			margin-top: 0,
 		),

--- a/packages/clay-css/src/scss/variables/_links.scss
+++ b/packages/clay-css/src/scss/variables/_links.scss
@@ -94,7 +94,12 @@ $link-outline: map-deep-merge(
 		hover: (
 			text-decoration: none,
 		),
+		focus: (
+			box-shadow: $component-focus-box-shadow,
+			outline: 0,
+		),
 		disabled: (
+			box-shadow: none,
 			active: (
 				pointer-events: none,
 			),
@@ -115,8 +120,6 @@ $link-outline-primary: map-deep-merge(
 			background-color: $primary,
 			color: $white,
 		),
-		btn-focus-box-shadow: 0 0 0 $btn-focus-width rgba($primary, 0.5),
-		btn-focus-outline: 0,
 		active: (
 			background-color: $primary,
 			color: $white,
@@ -140,8 +143,6 @@ $link-outline-secondary: map-deep-merge(
 			background-color: $secondary,
 			color: $white,
 		),
-		btn-focus-box-shadow: 0 0 0 $btn-focus-width rgba($secondary, 0.5),
-		btn-focus-outline: 0,
 		active: (
 			background-color: $secondary,
 			color: $white,
@@ -278,14 +279,17 @@ $component-action: map-deep-merge(
 			background-color: $secondary,
 			color: $white,
 		),
-		btn-focus-box-shadow: 0 0 0 $btn-focus-width rgba($secondary, 0.5),
-		btn-focus-outline: 0,
+		focus: (
+			box-shadow: $component-focus-box-shadow,
+			outline: 0,
+		),
 		active: (
 			background-color: $secondary,
 			color: $white,
 		),
 		disabled: (
 			background-color: transparent,
+			box-shadow: none,
 			color: $secondary,
 			cursor: $disabled-cursor,
 			opacity: $btn-disabled-opacity,


### PR DESCRIPTION
fixes #5130