### PR TITLE
fix(@clayui/css): Removes unused sm, lg, xl breakpoint styles from Navigation, Management and Application Bars

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_management-bar.scss
@@ -32,6 +32,7 @@ $cadmin-management-bar-size: map-deep-merge(
 		min-height: 64px,
 		padding-x: 0,
 		padding-y: 0,
+		font-size-mobile: $cadmin-navbar-font-size,
 		height-mobile: 48px,
 		min-height-mobile: 48px,
 		btn-monospaced-font-size: 16px,
@@ -44,8 +45,536 @@ $cadmin-management-bar-size: map-deep-merge(
 		toggler-margin-x: 14px,
 		active-border-bottom-width: 4px,
 		nav-item-dropdown-margin-top: 0,
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$cadmin-management-bar-size
+);
+
+$cadmin-management-bar-base: () !default;
+$cadmin-management-bar-base: map-deep-merge(
+	(
+		border-color: transparent,
+		border-style: solid,
+		navbar-nav: (
+			nav-link: (
+				border-radius: $cadmin-border-radius,
+				outline: 0,
+				transition: box-shadow 0.15s ease-in-out,
+				focus: (
+					box-shadow: $cadmin-btn-focus-box-shadow,
+				),
+				disabled: (
+					box-shadow: none,
+				),
+			),
+		),
+		navbar-overlay: (
+			padding: 0,
+		),
+		media-breakpoint-down: (
+			sm: (
+				navbar-expand-md: (
+					min-height:
+						map-get($cadmin-management-bar-size, min-height-mobile),
+					navbar-collapse-absolute: (
+						navbar-collapse: (
+							border-color: transparent,
+							border-style: solid,
+							border-width: 0
+								map-get(
+									$cadmin-management-bar-size,
+									border-right-width
+								)
+								map-get(
+									$cadmin-management-bar-size,
+									border-bottom-width
+								)
+								map-get(
+									$cadmin-management-bar-size,
+									border-left-width
+								),
+							box-shadow:
+								clay-enable-shadows(
+									map-get(
+										$cadmin-management-bar-size,
+										box-shadow
+									)
+								),
+							left:
+								math-sign(
+									map-get(
+										$cadmin-management-bar-size,
+										border-left-width
+									)
+								),
+							margin-top:
+								map-get(
+									$cadmin-management-bar-size,
+									border-bottom-width
+								),
+							padding-bottom:
+								map-get($cadmin-management-bar-size, padding-y),
+							padding-left:
+								map-get($cadmin-management-bar-size, padding-x),
+							padding-right:
+								map-get($cadmin-management-bar-size, padding-x),
+							padding-top:
+								map-get($cadmin-management-bar-size, padding-y),
+							right:
+								math-sign(
+									map-get(
+										$cadmin-management-bar-size,
+										border-right-width
+									)
+								),
+						),
+					),
+					navbar-form: (
+						height:
+							calc(
+								#{map-get(
+										$cadmin-management-bar-size,
+										height-mobile
+									)} - #{map-get(
+										$cadmin-management-bar-size,
+										border-bottom-width
+									)}
+							),
+						padding-bottom:
+							setter(
+								map-get(
+									$cadmin-management-bar-size,
+									link-padding-y-mobile
+								),
+								calc(
+									(
+											#{map-get(
+													$cadmin-management-bar-size,
+													link-height-mobile
+												)} - (#{map-get(
+															$cadmin-management-bar-size,
+															font-size-mobile
+														)} * #{$cadmin-line-height-base})
+										) * 0.5
+								)
+							),
+						padding-left:
+							map-get(
+								$cadmin-management-bar-size,
+								link-padding-x-mobile
+							),
+						padding-right:
+							map-get(
+								$cadmin-management-bar-size,
+								link-padding-x-mobile
+							),
+						padding-top:
+							setter(
+								map-get(
+									$cadmin-management-bar-size,
+									link-padding-y-mobile
+								),
+								calc(
+									(
+											#{map-get(
+													$cadmin-management-bar-size,
+													link-height-mobile
+												)} - (#{map-get(
+															$cadmin-management-bar-size,
+															font-size-mobile
+														)} * #{$cadmin-line-height-base})
+										) * 0.5
+								)
+							),
+						form-control: (
+							height:
+								map-get(
+									$cadmin-management-bar-size,
+									form-control-height-mobile
+								),
+							padding-bottom: 0,
+							padding-top: 0,
+						),
+					),
+				),
+			),
+		),
+		media-breakpoint-up: (
+			md: (
+				navbar-expand-md: (
+					navbar-form: (
+						height:
+							calc(
+								#{map-get($cadmin-management-bar-size, height)} -
+									#{map-get(
+										$cadmin-management-bar-size,
+										border-bottom-width
+									)}
+							),
+						padding-left:
+							map-get($cadmin-management-bar-size, link-padding-x),
+						padding-right:
+							map-get($cadmin-management-bar-size, link-padding-x),
+						container: (
+							padding-left: 0,
+							padding-right: 0,
+						),
+						container-fluid: (
+							padding-left: 0,
+							padding-right: 0,
+						),
+						form-control: (
+							height:
+								map-get(
+									$cadmin-management-bar-size,
+									form-control-height
+								),
+						),
+					),
+					navbar-nav: (
+						nav-item: (
+							custom-control: (
+								margin-left:
+									setter(
+										map-get(
+											$cadmin-management-bar-size,
+											btn-margin-x
+										),
+										map-get(
+											$cadmin-management-bar-size,
+											link-padding-x
+										)
+									),
+								margin-right:
+									setter(
+										map-get(
+											$cadmin-management-bar-size,
+											btn-margin-x
+										),
+										map-get(
+											$cadmin-management-bar-size,
+											link-padding-x
+										)
+									),
+							),
+						),
+						nav-link: (
+							margin-bottom:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										link-margin-y
+									),
+									calc(
+										(
+												(
+														#{map-get(
+																$cadmin-management-bar-size,
+																height
+															)} - #{map-get(
+																$cadmin-management-bar-size,
+																border-bottom-width
+															)}
+													) - #{map-get(
+														$cadmin-management-bar-size,
+														link-height
+													)}
+											) * 0.5
+									)
+								),
+							margin-left:
+								map-get(
+									$cadmin-management-bar-size,
+									link-margin-x
+								),
+							margin-right:
+								map-get(
+									$cadmin-management-bar-size,
+									link-margin-x
+								),
+							margin-top:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										link-margin-y
+									),
+									calc(
+										(
+												(
+														#{map-get(
+																$cadmin-management-bar-size,
+																height
+															)} - #{map-get(
+																$cadmin-management-bar-size,
+																border-bottom-width
+															)}
+													) - #{map-get(
+														$cadmin-management-bar-size,
+														link-height
+													)}
+											) * 0.5
+									)
+								),
+							padding-bottom:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										link-padding-y
+									),
+									calc(
+										(
+												#{map-get(
+														$cadmin-management-bar-size,
+														link-height
+													)} - (#{map-get(
+																$cadmin-management-bar-size,
+																font-size
+															)} * #{$cadmin-line-height-base})
+											) * 0.5
+									)
+								),
+							padding-left:
+								map-get(
+									$cadmin-management-bar-size,
+									link-padding-x
+								),
+							padding-right:
+								map-get(
+									$cadmin-management-bar-size,
+									link-padding-x
+								),
+							padding-top:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										link-padding-y
+									),
+									calc(
+										(
+												#{map-get(
+														$cadmin-management-bar-size,
+														link-height
+													)} - (#{map-get(
+																$cadmin-management-bar-size,
+																font-size
+															)} * #{$cadmin-line-height-base})
+											) * 0.5
+									)
+								),
+						),
+						nav-link-monospaced: (
+							font-size:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-monospaced-font-size
+								),
+							margin-bottom:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										btn-margin-y
+									),
+									calc(
+										(
+												#{map-get(
+														$cadmin-management-bar-size,
+														height
+													)} - #{map-get(
+														$cadmin-management-bar-size,
+														border-bottom-width
+													)} - #{map-get(
+														$cadmin-management-bar-size,
+														padding-y
+													)} * 2 - #{setter(
+														map-get(
+															$cadmin-management-bar-size,
+															btn-monospaced-size
+														),
+														2rem
+													)}
+											) * 0.5
+									)
+								),
+							margin-left:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-margin-x
+								),
+							margin-right:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-margin-x
+								),
+							margin-top:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										btn-margin-y
+									),
+									calc(
+										(
+												#{map-get(
+														$cadmin-management-bar-size,
+														height
+													)} - #{map-get(
+														$cadmin-management-bar-size,
+														border-bottom-width
+													)} - #{map-get(
+														$cadmin-management-bar-size,
+														padding-y
+													)} * 2 - #{setter(
+														map-get(
+															$cadmin-management-bar-size,
+															btn-monospaced-size
+														),
+														2rem
+													)}
+											) * 0.5
+									)
+								),
+							padding: 0,
+						),
+						nav-btn: (
+							font-size: inherit,
+							height:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-monospaced-size
+								),
+							margin-bottom:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										btn-margin-y
+									),
+									calc(
+										(
+												#{map-get(
+														$cadmin-management-bar-size,
+														height
+													)} - #{map-get(
+														$cadmin-management-bar-size,
+														border-bottom-width
+													)} - #{map-get(
+														$cadmin-management-bar-size,
+														padding-y
+													)} * 2 - #{setter(
+														map-get(
+															$cadmin-management-bar-size,
+															btn-monospaced-size
+														),
+														2rem
+													)}
+											) * 0.5
+									)
+								),
+							margin-left:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-margin-x
+								),
+							margin-right:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-margin-x
+								),
+							margin-top:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										btn-margin-y
+									),
+									calc(
+										(
+												#{map-get(
+														$cadmin-management-bar-size,
+														height
+													)} - #{map-get(
+														$cadmin-management-bar-size,
+														border-bottom-width
+													)} - #{map-get(
+														$cadmin-management-bar-size,
+														padding-y
+													)} * 2 - #{setter(
+														map-get(
+															$cadmin-management-bar-size,
+															btn-monospaced-size
+														),
+														2rem
+													)}
+											) * 0.5
+									)
+								),
+							min-width:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-monospaced-size
+								),
+							padding-bottom:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										btn-padding-y
+									),
+									calc(
+										(
+												#{map-get(
+														$cadmin-management-bar-size,
+														link-height
+													)} - (#{map-get(
+																$cadmin-management-bar-size,
+																font-size
+															)} * #{$cadmin-line-height-base})
+											) * 0.5
+									)
+								),
+							padding-left:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-padding-x
+								),
+							padding-right:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-padding-x
+								),
+							padding-top:
+								setter(
+									map-get(
+										$cadmin-management-bar-size,
+										btn-padding-y
+									),
+									calc(
+										(
+												#{map-get(
+														$cadmin-management-bar-size,
+														link-height
+													)} - (#{map-get(
+																$cadmin-management-bar-size,
+																font-size
+															)} * #{$cadmin-line-height-base})
+											) * 0.5
+									)
+								),
+						),
+						nav-btn-monospaced: (
+							font-size:
+								map-get(
+									$cadmin-management-bar-size,
+									btn-monospaced-font-size
+								),
+							padding-bottom: 0,
+							padding-left: 0,
+							padding-right: 0,
+							padding-top: 0,
+						),
+					),
+				),
+			),
+		),
+	),
+	$cadmin-management-bar-base
 );
 
 $cadmin-management-bar-light: () !default;

--- a/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
@@ -17,6 +17,8 @@ $cadmin-navigation-bar-size: map-deep-merge(
 		toggler-link-height: 32px,
 		toggler-link-margin-y: 7.5px,
 		toggler-link-padding-y: 0,
+		media-breakpoint-down: (),
+		media-breakpoint-up: (),
 	),
 	$cadmin-navigation-bar-size
 );
@@ -38,8 +40,250 @@ $cadmin-navigation-bar-base: map-deep-merge(
 				),
 			),
 		),
-		media-breakpoint-down: (),
-		media-breakpoint-up: (),
+		media-breakpoint-down: (
+			sm: (
+				navbar-expand-md: (
+					navbar-collapse-absolute: (
+						navbar-collapse: (
+							border-color:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										border-color
+									),
+									transparent
+								),
+							border-style:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										border-style
+									),
+									solid
+								),
+							border-bottom-width:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										border-bottom-width
+									),
+									1px
+								),
+							border-left-width:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										border-left-width
+									),
+									0
+								),
+							border-right-width:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										border-right-width
+									),
+									0
+								),
+							border-top-width:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										border-top-width
+									),
+									0
+								),
+							box-shadow:
+								clay-enable-shadows(
+									setter(
+										map-get(
+											$cadmin-navigation-bar-size,
+											box-shadow
+										),
+										null
+									)
+								),
+							left:
+								math-sign(
+									setter(
+										map-get(
+											$cadmin-navigation-bar-size,
+											border-left-width
+										),
+										0
+									)
+								),
+							margin-top:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										border-bottom-width
+									),
+									1px
+								),
+							padding-bottom:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										padding-y
+									),
+									0
+								),
+							padding-left:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										padding-x
+									),
+									0
+								),
+							padding-right:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										padding-x
+									),
+									0
+								),
+							padding-top:
+								setter(
+									map-get(
+										$cadmin-navigation-bar-size,
+										padding-y
+									),
+									0
+								),
+							right:
+								math-sign(
+									setter(
+										map-get(
+											$cadmin-navigation-bar-size,
+											border-right-width
+										),
+										0
+									)
+								),
+						),
+					),
+					navbar-collapse: (
+						navbar-nav: (
+							dropdown-divider: (
+								margin-left:
+									math-sign(
+										setter(
+											map-get(
+												$cadmin-navigation-bar-size,
+												padding-x
+											),
+											null
+										)
+									),
+								margin-right:
+									math-sign(
+										setter(
+											map-get(
+												$cadmin-navigation-bar-size,
+												padding-x
+											),
+											null
+										)
+									),
+							),
+							dropdown-item: (
+								padding-bottom:
+									setter(
+										map-get(
+											$cadmin-navigation-bar-size,
+											collapse-dropdown-item-padding-y-mobile
+										),
+										11.5px
+									),
+								padding-left:
+									setter(
+										map-get(
+											$cadmin-navigation-bar-size,
+											collapse-dropdown-item-padding-x-mobile
+										),
+										16px
+									),
+								padding-right:
+									setter(
+										map-get(
+											$cadmin-navigation-bar-size,
+											collapse-dropdown-item-padding-x-mobile
+										),
+										16px
+									),
+								padding-top:
+									setter(
+										map-get(
+											$cadmin-navigation-bar-size,
+											collapse-dropdown-item-padding-y-mobile
+										),
+										11.5px
+									),
+							),
+						),
+					),
+				),
+			),
+		),
+		media-breakpoint-up: (
+			md: (
+				navbar-expand-md: (
+					navbar-underline: (
+						navbar-nav: (
+							nav-link: (
+								active-class: (
+									after: (
+										bottom:
+											setter(
+												map-get(
+													$cadmin-navigation-bar-size,
+													active-border-offset-bottom
+												),
+												-1px
+											),
+										height:
+											setter(
+												map-get(
+													$cadmin-navigation-bar-size,
+													active-border-bottom-width
+												),
+												4px
+											),
+										left:
+											setter(
+												map-get(
+													$cadmin-navigation-bar-size,
+													active-border-offset-x
+												),
+												null
+											),
+										right:
+											setter(
+												map-get(
+													$cadmin-navigation-bar-size,
+													active-border-offset-x
+												),
+												null
+											),
+										top:
+											setter(
+												map-get(
+													$cadmin-navigation-bar-size,
+													active-border-offset-top
+												),
+												null
+											),
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		),
 	),
 	$cadmin-navigation-bar-base
 );

--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -983,8 +983,7 @@
 						map-deep-get($map, navbar-underline, navbar-nav)
 					);
 
-					.nav-link,
-					.btn-unstyled {
+					.nav-link {
 						@include clay-link(
 							map-deep-get(
 								$map,
@@ -1092,8 +1091,7 @@
 			}
 
 			.navbar-nav {
-				.nav-link,
-				.btn-unstyled {
+				.nav-link {
 					@include clay-link(
 						map-deep-get($map, navbar-nav, nav-link)
 					);
@@ -1486,8 +1484,7 @@
 			}
 
 			.navbar-nav {
-				.nav-link,
-				.btn-unstyled {
+				.nav-link {
 					@include clay-link($nav-link);
 				}
 

--- a/packages/clay-css/src/scss/mixins/_navbar.scss
+++ b/packages/clay-css/src/scss/mixins/_navbar.scss
@@ -654,223 +654,227 @@
 					&#{$infix} {
 						// .navbar-expand, sm, md, lg, xl
 						@if not($infix == '') {
-							// .navbar-expand-sm, md, lg, xl
-							@include media-breakpoint-down($breakpoint) {
-								min-height: $min-height-mobile;
+							@if not(map-get($map, media-breakpoint-down)) {
+								// .navbar-expand-sm, md, lg, xl
+								@include media-breakpoint-down($breakpoint) {
+									min-height: $min-height-mobile;
 
-								&.navbar-collapse-absolute {
+									&.navbar-collapse-absolute {
+										.navbar-collapse {
+											border-color: transparent;
+											border-style: solid;
+											border-width: 0 $border-right-width
+												$border-bottom-width
+												$border-left-width;
+
+											@include box-shadow($box-shadow);
+
+											left: -$border-left-width;
+											margin-top: $border-bottom-width;
+											padding-bottom: $padding-y;
+											padding-left: $padding-x;
+											padding-right: $padding-x;
+											padding-top: $padding-y;
+											right: -$border-right-width;
+										}
+									}
+
 									.navbar-collapse {
-										border-color: transparent;
-										border-style: solid;
-										border-width: 0 $border-right-width
-											$border-bottom-width
-											$border-left-width;
+										.navbar-nav {
+											.dropdown-divider {
+												margin-left: -$padding-x;
+												margin-right: -$padding-x;
+											}
 
-										@include box-shadow($box-shadow);
-
-										left: -$border-left-width;
-										margin-top: $border-bottom-width;
-										padding-bottom: $padding-y;
-										padding-left: $padding-x;
-										padding-right: $padding-x;
-										padding-top: $padding-y;
-										right: -$border-right-width;
-									}
-								}
-
-								.navbar-collapse {
-									.navbar-nav {
-										.dropdown-divider {
-											margin-left: -$padding-x;
-											margin-right: -$padding-x;
-										}
-
-										.dropdown-item {
-											padding-bottom: $collapse-dropdown-item-padding-y-mobile;
-											padding-left: $collapse-dropdown-item-padding-x-mobile;
-											padding-right: $collapse-dropdown-item-padding-x-mobile;
-											padding-top: $collapse-dropdown-item-padding-y-mobile;
+											.dropdown-item {
+												padding-bottom: $collapse-dropdown-item-padding-y-mobile;
+												padding-left: $collapse-dropdown-item-padding-x-mobile;
+												padding-right: $collapse-dropdown-item-padding-x-mobile;
+												padding-top: $collapse-dropdown-item-padding-y-mobile;
+											}
 										}
 									}
-								}
 
-								.navbar-form {
-									height: calc(
-										#{$height-mobile} - #{$border-bottom-width} -
-											#{$border-top-width}
-									);
-									padding-bottom: $link-padding-y-mobile;
-									padding-left: $link-padding-x-mobile;
-									padding-right: $link-padding-x-mobile;
-									padding-top: $link-padding-y-mobile;
+									.navbar-form {
+										height: calc(
+											#{$height-mobile} - #{$border-bottom-width} -
+												#{$border-top-width}
+										);
+										padding-bottom: $link-padding-y-mobile;
+										padding-left: $link-padding-x-mobile;
+										padding-right: $link-padding-x-mobile;
+										padding-top: $link-padding-y-mobile;
 
-									.form-control {
-										height: $form-control-height-mobile;
-										padding-bottom: 0;
-										padding-top: 0;
-									}
-								}
-							}
-						}
-
-						@include media-breakpoint-up($next) {
-							.container,
-							.container-fluid {
-								@if ($scaling-navbar) {
-									padding-left: $container-padding-x;
-									padding-right: $container-padding-x;
-								}
-							}
-
-							.navbar-brand {
-								@if ($scaling-navbar) {
-									font-size: $brand-font-size;
-									margin-right: $brand-margin-right;
-									padding-bottom: $brand-padding-y;
-									padding-left: $brand-padding-x;
-									padding-right: $brand-padding-x;
-									padding-top: $brand-padding-y;
-
-									@if ($enable-c-inner) {
-										.c-inner {
-											margin-bottom: math-sign(
-												$brand-padding-y
-											);
-											margin-left: math-sign(
-												$brand-padding-x
-											);
-											margin-right: math-sign(
-												$brand-padding-x
-											);
-											margin-top: math-sign(
-												$brand-padding-y
-											);
+										.form-control {
+											height: $form-control-height-mobile;
+											padding-bottom: 0;
+											padding-top: 0;
 										}
 									}
 								}
 							}
 
-							.navbar-form {
-								@if ($scaling-navbar) {
-									height: calc(
-										#{$height} -
-											#{$border-bottom-width} -
-											#{$border-top-width}
-									);
-									padding-left: $link-padding-x;
-									padding-right: $link-padding-x;
-
-									> .container,
-									> .container-fluid {
-										padding-left: 0;
-										padding-right: 0;
-									}
-
-									.form-control {
-										height: $form-control-height;
-									}
-								}
-							}
-
-							.nav-btn {
-								@if ($scaling-navbar) {
-									font-size: $btn-font-size;
-									height: $btn-monospaced-size;
-									margin-bottom: $btn-margin-y;
-									margin-left: $btn-margin-x;
-									margin-right: $btn-margin-x;
-									margin-top: $btn-margin-y;
-									padding-bottom: $btn-padding-y;
-									padding-left: $btn-padding-x;
-									padding-right: $btn-padding-x;
-									padding-top: $btn-padding-y;
-									min-width: $btn-monospaced-size;
-
-									@if ($enable-c-inner) {
-										.c-inner {
-											margin-bottom: math-sign(
-												$btn-padding-y
-											);
-											margin-left: math-sign(
-												$btn-padding-x
-											);
-											margin-right: math-sign(
-												$btn-padding-x
-											);
-											margin-top: math-sign(
-												$btn-padding-y
-											);
+							@if not(map-get($map, media-breakpoint-up)) {
+								@include media-breakpoint-up($next) {
+									.container,
+									.container-fluid {
+										@if ($scaling-navbar) {
+											padding-left: $container-padding-x;
+											padding-right: $container-padding-x;
 										}
 									}
-								}
-							}
 
-							.nav-btn-monospaced {
-								@if ($scaling-navbar) {
-									font-size: $btn-monospaced-font-size;
-									padding: 0;
+									.navbar-brand {
+										@if ($scaling-navbar) {
+											font-size: $brand-font-size;
+											margin-right: $brand-margin-right;
+											padding-bottom: $brand-padding-y;
+											padding-left: $brand-padding-x;
+											padding-right: $brand-padding-x;
+											padding-top: $brand-padding-y;
 
-									@if ($enable-c-inner) {
-										.c-inner {
-											margin: 0;
+											@if ($enable-c-inner) {
+												.c-inner {
+													margin-bottom: math-sign(
+														$brand-padding-y
+													);
+													margin-left: math-sign(
+														$brand-padding-x
+													);
+													margin-right: math-sign(
+														$brand-padding-x
+													);
+													margin-top: math-sign(
+														$brand-padding-y
+													);
+												}
+											}
 										}
 									}
-								}
-							}
 
-							.nav-item {
-								> .custom-control,
-								> .form-check {
-									@if ($scaling-navbar) {
-										margin-left: $btn-margin-x;
-										margin-right: $btn-margin-x;
-									}
-								}
-							}
+									.navbar-form {
+										@if ($scaling-navbar) {
+											height: calc(
+												#{$height} -
+													#{$border-bottom-width} -
+													#{$border-top-width}
+											);
+											padding-left: $link-padding-x;
+											padding-right: $link-padding-x;
 
-							.nav-link,
-							.navbar-text {
-								@if ($scaling-navbar) {
-									margin-bottom: $link-margin-y;
-									margin-left: $link-margin-x;
-									margin-right: $link-margin-x;
-									margin-top: $link-margin-y;
-									padding-bottom: $link-padding-y;
-									padding-left: $link-padding-x;
-									padding-right: $link-padding-x;
-									padding-top: $link-padding-y;
+											> .container,
+											> .container-fluid {
+												padding-left: 0;
+												padding-right: 0;
+											}
 
-									@if ($enable-c-inner) {
-										.c-inner {
-											margin-bottom: math-sign(
-												$link-padding-y
-											);
-											margin-left: math-sign(
-												$link-padding-x
-											);
-											margin-right: math-sign(
-												$link-padding-x
-											);
-											margin-top: math-sign(
-												$link-padding-y
-											);
+											.form-control {
+												height: $form-control-height;
+											}
 										}
 									}
-								}
-							}
 
-							.nav-link-monospaced {
-								@if ($scaling-navbar) {
-									font-size: $btn-monospaced-font-size;
-									margin-bottom: $btn-margin-y;
-									margin-left: $btn-margin-x;
-									margin-right: $btn-margin-x;
-									margin-top: $btn-margin-y;
-									padding: 0;
+									.nav-btn {
+										@if ($scaling-navbar) {
+											font-size: $btn-font-size;
+											height: $btn-monospaced-size;
+											margin-bottom: $btn-margin-y;
+											margin-left: $btn-margin-x;
+											margin-right: $btn-margin-x;
+											margin-top: $btn-margin-y;
+											padding-bottom: $btn-padding-y;
+											padding-left: $btn-padding-x;
+											padding-right: $btn-padding-x;
+											padding-top: $btn-padding-y;
+											min-width: $btn-monospaced-size;
 
-									@if ($enable-c-inner) {
-										.c-inner {
-											margin: 0;
+											@if ($enable-c-inner) {
+												.c-inner {
+													margin-bottom: math-sign(
+														$btn-padding-y
+													);
+													margin-left: math-sign(
+														$btn-padding-x
+													);
+													margin-right: math-sign(
+														$btn-padding-x
+													);
+													margin-top: math-sign(
+														$btn-padding-y
+													);
+												}
+											}
+										}
+									}
+
+									.nav-btn-monospaced {
+										@if ($scaling-navbar) {
+											font-size: $btn-monospaced-font-size;
+											padding: 0;
+
+											@if ($enable-c-inner) {
+												.c-inner {
+													margin: 0;
+												}
+											}
+										}
+									}
+
+									.nav-item {
+										> .custom-control,
+										> .form-check {
+											@if ($scaling-navbar) {
+												margin-left: $btn-margin-x;
+												margin-right: $btn-margin-x;
+											}
+										}
+									}
+
+									.nav-link,
+									.navbar-text {
+										@if ($scaling-navbar) {
+											margin-bottom: $link-margin-y;
+											margin-left: $link-margin-x;
+											margin-right: $link-margin-x;
+											margin-top: $link-margin-y;
+											padding-bottom: $link-padding-y;
+											padding-left: $link-padding-x;
+											padding-right: $link-padding-x;
+											padding-top: $link-padding-y;
+
+											@if ($enable-c-inner) {
+												.c-inner {
+													margin-bottom: math-sign(
+														$link-padding-y
+													);
+													margin-left: math-sign(
+														$link-padding-x
+													);
+													margin-right: math-sign(
+														$link-padding-x
+													);
+													margin-top: math-sign(
+														$link-padding-y
+													);
+												}
+											}
+										}
+									}
+
+									.nav-link-monospaced {
+										@if ($scaling-navbar) {
+											font-size: $btn-monospaced-font-size;
+											margin-bottom: $btn-margin-y;
+											margin-left: $btn-margin-x;
+											margin-right: $btn-margin-x;
+											margin-top: $btn-margin-y;
+											padding: 0;
+
+											@if ($enable-c-inner) {
+												.c-inner {
+													margin: 0;
+												}
+											}
 										}
 									}
 								}
@@ -880,72 +884,80 @@
 				}
 			}
 
-			// Navbar Overlay Styles for `.navbar-overlay-xs-down`,
-			// `.navbar-overlay-sm-down`, `.navbar-overlay-md-down`,
-			// `.navbar-overlay-lg-down`, `.navbar-overlay-up`
+			// if media-breakpoint-up doesn't exist output styles .navbar-expand-{sm|md|lg|xl|??}
 
-			@each $breakpoint in map-keys($breakpoints) {
-				$index: index(map-keys($breakpoints), $breakpoint);
-				$length: length(map-keys($breakpoints));
-				$infix: '.navbar-overlay-#{$breakpoint}-down';
+			@if not(map-get($map, media-breakpoint-down)) {
+				// Navbar Overlay Styles for `.navbar-overlay-xs-down`,
+				// `.navbar-overlay-sm-down`, `.navbar-overlay-md-down`,
+				// `.navbar-overlay-lg-down`, `.navbar-overlay-up`
 
-				@if ($index == $length) {
-					$infix: '.navbar-overlay-up';
-				}
-
-				#{$infix} {
-					@include media-breakpoint-down($breakpoint) {
-						@include border-radius(
-							if(
-								variable-exists(navbar-border-radius),
-								$navbar-border-radius,
-								if(
-									variable-exists(
-										cadmin-navbar-border-radius
-									),
-									$cadmin-navbar-border-radius,
-									null
-								)
-							)
-						);
-
-						padding-bottom: $padding-y;
-						padding-left: $padding-x;
-						padding-right: $padding-x;
-						padding-top: $padding-y;
-					}
-				}
-			}
-
-			// Navbar Underline
-
-			&.navbar-underline {
-				.navbar-toggler-link {
-					&:after {
-						bottom: $active-border-offset-bottom-mobile;
-						height: $active-border-bottom-width;
-						left: $active-border-offset-x;
-						right: $active-border-offset-x;
-						top: $active-border-offset-top;
-					}
-				}
-			}
-
-			&.navbar-underline.navbar-expand {
 				@each $breakpoint in map-keys($breakpoints) {
-					$next: breakpoint-next($breakpoint, $breakpoints);
-					$infix: breakpoint-infix($next, $breakpoints);
+					$index: index(map-keys($breakpoints), $breakpoint);
+					$length: length(map-keys($breakpoints));
+					$infix: '.navbar-overlay-#{$breakpoint}-down';
 
-					&#{$infix} {
-						// .navbar-expand, sm, md, lg, xl
-						@include media-breakpoint-up($next) {
-							.navbar-nav .nav-link {
-								&.active:after {
-									bottom: $active-border-offset-bottom;
-									height: $active-border-bottom-width;
-									left: $active-border-offset-x;
-									right: $active-border-offset-x;
-									top: $active-border-offset-top;
+					@if ($index == $length) {
+						$infix: '.navbar-overlay-up';
+					}
+
+					#{$infix} {
+						@include media-breakpoint-down($breakpoint) {
+							@include border-radius(
+								if(
+									variable-exists(navbar-border-radius),
+									$navbar-border-radius,
+									if(
+										variable-exists(
+											cadmin-navbar-border-radius
+										),
+										$cadmin-navbar-border-radius,
+										null
+									)
+								)
+							);
+
+							padding-bottom: $padding-y;
+							padding-left: $padding-x;
+							padding-right: $padding-x;
+							padding-top: $padding-y;
+						}
+					}
+				}
+
+				// Navbar Underline
+
+				&.navbar-underline {
+					.navbar-toggler-link {
+						&:after {
+							bottom: $active-border-offset-bottom-mobile;
+							height: $active-border-bottom-width;
+							left: $active-border-offset-x;
+							right: $active-border-offset-x;
+							top: $active-border-offset-top;
+						}
+					}
+				}
+
+				// if media-breakpoint-up doesn't exist output styles .navbar-expand-{sm|md|lg|xl|??}
+
+				@if not(map-get($map, media-breakpoint-up)) {
+					&.navbar-underline.navbar-expand {
+						@each $breakpoint in map-keys($breakpoints) {
+							$next: breakpoint-next($breakpoint, $breakpoints);
+							$infix: breakpoint-infix($next, $breakpoints);
+
+							&#{$infix} {
+								// .navbar-expand, sm, md, lg, xl
+								@include media-breakpoint-up($next) {
+									.navbar-nav .nav-link {
+										&.active:after {
+											bottom: $active-border-offset-bottom;
+											height: $active-border-bottom-width;
+											left: $active-border-offset-x;
+											right: $active-border-offset-x;
+											top: $active-border-offset-top;
+										}
+									}
 								}
 							}
 						}
@@ -1704,7 +1716,7 @@
 			}
 
 			// if media-breakpoint-down doesn't exist output styles .navbar-expand-{sm|md|lg|xl|??}
-			// deprecated use `media-breakpoint-down` key instead
+			// deprecated use the key `media-breakpoint-down` instead
 
 			@if not(map-get($map, media-breakpoint-down)) {
 				&.navbar-expand {
@@ -1781,7 +1793,7 @@
 			}
 
 			// if media-breakpoint-up doesn't exist output styles .navbar-expand through .navbar-expand-{sm|md|lg|xl|??}
-			// deprecated use `media-breakpoint-up` key instead
+			// deprecated use the key `media-breakpoint-up` instead
 
 			@if not(map-get($map, media-breakpoint-up)) {
 				&.navbar-expand {


### PR DESCRIPTION
fixes #3236

I was hoping to completely remove the dependency to the mixin `clay-navbar-size`, but it's too breaking. I moved as much as I could to use `clay-navbar-variant`. This reduces the size of Clay CSS and Cadmin by 42kb  and 29kb respectively.