### PR TITLE
fix(@clayui/shared): fixes error when identifying non-visible element as focusable

### DIFF
--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -88,7 +88,13 @@ export const FOCUSABLE_ELEMENTS = [
 function collectDocumentFocusableElements() {
 	return Array.from<HTMLElement>(
 		document.querySelectorAll(FOCUSABLE_ELEMENTS.join(','))
-	).filter((element) => isFocusable(element));
+	).filter((element) => {
+		if (isFocusable(element)) {
+			return window.getComputedStyle(element).visibility !== 'hidden';
+		}
+
+		return false;
+	});
 }
 
 // https://github.com/facebook/react/pull/15849#diff-39a673d38713257d5fe7d90aac2acb5aR107


### PR DESCRIPTION
Fixes #5148

Using `window.getComputedStyle` is a bit slow but unfortunately we don't have any other strategy to identify if the element is visible when `visibility` is used on a parent element or a very distant container. I added it just to check as a last resource when the element is marked as focusable, this ensures that we don't need to call `window.getComputedStyle` on every element that exists in the DOM every time.

I only added when getting elements in the document instead of the React tree, I believe that this scenario should not easily exist when the page or there are more elements in the tree in React since FocusScope controls a small part, so this will be more common when the element with FocusScope is rendered alone in the React tree on a page.