### PR TITLE
feat(@clayui/drop-down): add collection pattern

### DIFF
--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -27,6 +27,7 @@
 	],
 	"dependencies": {
 		"@clayui/core": "^3.78.2",
+		"@clayui/drop-down": "^3.78.2",
 		"@clayui/form": "^3.78.2",
 		"@clayui/loading-indicator": "^3.60.0",
 		"@clayui/shared": "^3.78.2",

--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {DropDown, __NOT_PUBLIC_COLLECTION} from '@clayui/core';
+import {__NOT_PUBLIC_COLLECTION} from '@clayui/core';
+import DropDown from '@clayui/drop-down';
 import {ClayInput as Input} from '@clayui/form';
 import LoadingIndicator from '@clayui/loading-indicator';
 import {

--- a/packages/clay-autocomplete/src/DropDown.tsx
+++ b/packages/clay-autocomplete/src/DropDown.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {DropDown} from '@clayui/core';
+import DropDown from '@clayui/drop-down';
 import {InternalDispatch} from '@clayui/shared';
 import React from 'react';
 

--- a/packages/clay-autocomplete/src/Item.tsx
+++ b/packages/clay-autocomplete/src/Item.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {DropDown} from '@clayui/core';
+import DropDown from '@clayui/drop-down';
 import fuzzy from 'fuzzy';
 import React from 'react';
 

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -27,7 +27,6 @@
 	],
 	"dependencies": {
 		"@clayui/button": "^3.73.0",
-		"@clayui/drop-down": "^3.78.2",
 		"@clayui/icon": "^3.56.0",
 		"@clayui/layout": "^3.65.1",
 		"@clayui/loading-indicator": "^3.60.0",

--- a/packages/clay-core/src/collection/Collection.tsx
+++ b/packages/clay-core/src/collection/Collection.tsx
@@ -73,6 +73,11 @@ interface IProps<P, K>
 	parentRef: React.RefObject<HTMLElement>;
 
 	/**
+	 * Flag to pass the key value to the element.
+	 */
+	passthroughKey?: boolean;
+
+	/**
 	 * Callback called when the last element of the list is rendered in
 	 * virtualization and infiniteScroll is enabled.
 	 */
@@ -154,6 +159,7 @@ function VirtualDynamicCollection<T extends Record<any, any>, P, K>({
 	onBottom,
 	parentKey,
 	parentRef,
+	passthroughKey,
 	publicApi,
 	...otherProps
 }: VirtualProps<T, P, K>) {
@@ -250,7 +256,7 @@ function VirtualDynamicCollection<T extends Record<any, any>, P, K>({
 
 				return React.cloneElement(child, {
 					key,
-					keyValue: key,
+					...(passthroughKey ? {keyValue: key} : {}),
 					...props,
 				});
 			})}
@@ -276,6 +282,7 @@ export function Collection<
 	onBottom,
 	parentKey,
 	parentRef,
+	passthroughKey = true,
 	publicApi,
 	virtualize = false,
 	...otherProps
@@ -319,6 +326,7 @@ export function Collection<
 				onBottom={onBottom}
 				parentKey={parentKey}
 				parentRef={parentRef}
+				passthroughKey={passthroughKey}
 				publicApi={publicApi}
 			>
 				{children}
@@ -360,7 +368,7 @@ export function Collection<
 
 						return React.cloneElement(child, {
 							key,
-							keyValue: key,
+							...(passthroughKey ? {keyValue: key} : {}),
 						});
 				  })
 				: React.Children.map(children, (child, index) => {
@@ -390,7 +398,7 @@ export function Collection<
 							child as React.ReactElement<{keyValue?: React.Key}>,
 							{
 								key,
-								keyValue: key,
+								...(passthroughKey ? {keyValue: key} : {}),
 							}
 						);
 				  })}

--- a/packages/clay-core/src/collection/Collection.tsx
+++ b/packages/clay-core/src/collection/Collection.tsx
@@ -353,6 +353,10 @@ export function Collection<
 							parentKey
 						);
 
+						if (performFilter(child)) {
+							return;
+						}
+
 						if (ItemContainer) {
 							return (
 								<ItemContainer

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -7,11 +7,6 @@ export {
 	default as Button,
 	ClayButtonWithIcon as ButtonWithIcon,
 } from '@clayui/button';
-export {
-	default as DropDown,
-	ClayDropDownWithItems as DropDownWithItems,
-	ClayDropDownWithDrilldown as DropDownWithDrilldown,
-} from '@clayui/drop-down';
 export {default as Icon} from '@clayui/icon';
 export {
 	default as Modal,

--- a/packages/clay-drop-down/docs/drop-down.mdx
+++ b/packages/clay-drop-down/docs/drop-down.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Drop Down'
+title: 'DropDown'
 description: 'A dropdown menu displays a list of options for the element that triggers it.'
 lexiconDefinition: 'https://liferay.design/lexicon/core-components/dropdowns/'
 packageNpm: '@clayui/drop-down'
@@ -7,6 +7,7 @@ packageNpm: '@clayui/drop-down'
 
 import {
 	DropDown,
+	DropDownExample,
 	DropDownWithItems,
 	DropDownWithDrilldown,
 } from '$packages/clay-drop-down/docs/index';
@@ -14,35 +15,189 @@ import {
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
--   [Composing](#composing)
-    -   [Using dropdown without a trigger](#using-dropdown-without-a-trigger)
--   [DropDownWithItems](#dropdownwithitems)
-    -   [Cascading Menu](#cascading-menu)
--   [DropDownWithDrilldown](#dropdownwithdrilldown)
+-   [Example](#example)
+-   [Introduction](#introduction)
+-   [Content](#content)
+    -   [Static](#static)
+    -   [Dynamic](#dynamic)
+-   [Filter](#filter)
+    -   [Value](#value)
+-   [Without Trigger](#without-trigger)
+-   [Variants](#variants)
+    -   [With Items](#with-items)
+        -   [Cascading Menu](#cascading-menu)
+    -   [Drilldown](#drilldown)
 -   [Caveats](#caveats)
 
 </div>
 </div>
 
-## Composing
+## Example
 
-DropDown's composition gives you the space to create more complex DropDowns, such as adding a form within DropDown, and creating simple DropDowns with the high-level `ClayDropDownWithItems` component that covers most basic Lexicon use cases.
+<DropDownExample />
 
-<DropDown />
+## Introduction
 
-You may want to use only the content of DropDown for other cases, such as mounting an `Autocomplete`, so use `DropDown.Menu` instead of `DropDown` which gives you the flexibility to only control content without a trigger.
+The DropDown component is designed to display menus that when clicked triggers some action, there are different forms of Menu in Clay/Lexicon. This document describes the main ways to build a menu and recommendations.
 
-<div class="clay-site-alert alert alert-warning">
-	<code class="language-text">DropDown</code> consists of a{' '}
-	<code class="language-text">DropDown.Menu</code> that controls the trigger
-	and uses it as the basis for aligning DropDown content.
-</div>
+Clay provides two possible possibilities to build a Menu, using composition that we call low-level that allows you to add new use cases and adapt them to your use case and components like high-level which are property-setting oriented components. We recommend that you always try to use compositing when you need flexibility, whether it's configuring some internal components that aren't possible in a high-level component or adding your own elements to an item, group, or other use cases that don't exist in Clay.
 
-### Using dropdown without a trigger
+## Content
+
+DropDown provides two options for building the menu using static content when data does not change during an application's lifecycle and dynamic for content that changes during the application lifecycle or the data comes from the server.
+
+### Static
+
+The simplest example of a static menu is rendering a simple list of options.
+
+```jsx
+<DropDown trigger={<Button>Click Me</Button>}>
+	<DropDown.ItemList>
+		<DropDown.Item>one</DropDown.Item>
+		<DropDown.Item>two</DropDown.Item>
+		<DropDown.Item>three</DropDown.Item>
+	</DropDown.ItemList>
+</DropDown>
+```
+
+Other cases are also possible, for example rendering a group of options with a search bar to filter the options.
+
+```jsx
+<DropDown trigger={<Button>Click Me</Button>}>
+	<DropDown.Search placeholder="Type to filter" />
+	<DropDown.ItemList>
+		<DropDown.Group header="Numbers">
+			<DropDown.Item>one</DropDown.Item>
+			<DropDown.Item>two</DropDown.Item>
+			<DropDown.Item>three</DropDown.Item>
+		</DropDown.Group>
+		<DropDown.Group header="Letters">
+			<DropDown.Item>a</DropDown.Item>
+			<DropDown.Item>b</DropDown.Item>
+			<DropDown.Item>c</DropDown.Item>
+		</DropDown.Group>
+	</DropDown.ItemList>
+</DropDown>
+```
+
+The example above shows how Clay even with the explicit composition of the menu structure manages to provide the filter to work OOTB with static content.
+
+### Dynamic
+
+```jsx
+<DropDown items={['one', 'two', 'three']} trigger={<Button>Click Me</Button>}>
+	{(item) => <DropDown.Item>{item}</DropDown.Item>}
+</DropDown>
+```
+
+Compositing for dynamic content becomes simpler and also provides the same features as static, such as OOTB filter and groups. The component is also data agnostic designed from the ground up for this purpose to avoid transformations having to be done at render time.
+
+```jsx
+<DropDown filterKey="name" trigger={<Button>Click Me</Button>}>
+	<DropDown.Search placeholder="Type to filter" />
+	<DropDown.ItemList
+		items={[
+			{
+				children: [{name: 'one'}, {name: 'two'}, {name: 'three'}],
+				name: 'Numbers',
+			},
+			{
+				children: [{name: 'a'}, {name: 'b'}, {name: 'c'}],
+				name: 'Letters',
+			},
+		]}
+	>
+		{(item) => (
+			<DropDown.Group
+				header={item.name}
+				items={item.children}
+				key={item.name}
+			>
+				{(item) => (
+					<DropDown.Item key={item.name}>{item.name}</DropDown.Item>
+				)}
+			</DropDown.Group>
+		)}
+	</DropDown.ItemList>
+</DropDown>
+```
+
+## Filter
+
+The filter in a Menu works OOTB, just declaring the `<DropDown.Search />` component in the composition, as in the examples shown for static and dynamic content. The Filter can be done by DropDown itself as well as the developer can control the filter and make his own filter rule.
+
+```jsx
+function Example() {
+	const [value, setValue] = useState('');
+
+	const options = [{name: 'one'}, {name: 'two'}, {name: 'three'}];
+
+	const filteredOptions = useMemo(() => {
+		if (!value) {
+			return options;
+		}
+
+		return options.filter(
+			(option) => option.match(new RegExp(value, 'i')) !== null
+		);
+	}, [options, value]);
+
+	return (
+		<DropDown trigger={<Button>Click Me</Button>}>
+			<DropDown.Search
+				value={value}
+				onChange={setValue}
+				placeholder="Type to filter"
+			/>
+			<DropDown.ItemList items={filteredOptions}>
+				{(item) => (
+					<DropDown.Item key={item.name}>{item.name}</DropDown.Item>
+				)}
+			</DropDown.ItemList>
+		</DropDown>
+	);
+}
+```
+
+If you just need to set an initial value, just use the `defaultValue` property.
+
+```jsx
+<DropDown filterKey="name" trigger={<Button>Click Me</Button>}>
+	<DropDown.Search defaultValue="o" placeholder="Type to filter" />
+	<DropDown.ItemList items={[{name: 'one'}, {name: 'two'}, {name: 'three'}]}>
+		{(item) => <DropDown.Item key={item.name}>{item.name}</DropDown.Item>}
+	</DropDown.ItemList>
+</DropDown>
+```
+
+### Value
+
+DropDown filters items according to the value rendered as `children` of `<DropDown.Item />`, when there are more detailed compositions in the item, the filter will not work because it cannot determine which value to use to filter, in this scenario configure the item's value using the `textValue` property.
+
+```jsx
+<DropDown filterKey="name" trigger={<Button>Click Me</Button>}>
+	<DropDown.Search placeholder="Type to filter" />
+	<DropDown.ItemList items={[{name: 'one'}, {name: 'two'}, {name: 'three'}]}>
+		{(item) => (
+			<DropDown.Item key={item.name} textValue={item.name}>
+				<Checkbox />
+				{item.name}
+			</DropDown.Item>
+		)}
+	</DropDown.ItemList>
+</DropDown>
+```
+
+## Without Trigger
 
 You may want to create a trigger that is not necessarily in the same tree as DropDown, due to HTML markup issues, for these cases you can use `<ClayDropDown.Menu />`.
 
 Using `<ClayDropDown.Menu />` allows you to better control the state of DropDown but you will have to deal with visibility, focus management, and other details.
+
+<div class="clay-site-alert alert alert-warning">
+	As a recommendation only use this component as a last resort, it doesn't
+	provide some OOTB features like focus control or accessibility at all.
+</div>
 
 ```jsx
 import ClayDropDown from '@clayui/drop-down';
@@ -90,13 +245,17 @@ const Menu = ({children, hasLeftSymbols, hasRightSymbols}) => {
 };
 ```
 
-## DropDownWithItems
+## Variants
+
+Clay provides other ways to use the Clay component, which we call high-level components, which are designed to do a specific high-level behavior different from compositing that allow different possibilities, are less flexible.
+
+### With Items
 
 Allows you to create a simple DropDown, through its API you are able to create a Menu with groups of checkboxes and radios, links, buttons, search, caption, etc.
 
 <DropDownWithItems />
 
-### Cascading Menu
+#### Cascading Menu
 
 `DropDownWithItems` allows the possibility to create a contextual menu, the nature of the API allows the creation of more cascade menus but the **Lexicon specification recommends using only one level** and using `DropDownWithDrilldown` component.
 
@@ -122,7 +281,7 @@ const items = [
 ];
 ```
 
-## DropDownWithDrilldown
+### Drilldown
 
 A Drilldown menu allows the user to navigate to and/or select an element from a contextual list. It can be triggered by a dropdown button.
 

--- a/packages/clay-drop-down/docs/index.js
+++ b/packages/clay-drop-down/docs/index.js
@@ -212,4 +212,68 @@ const DropDownWithDrilldown = () => {
 	);
 };
 
-export {DropDown, DropDownWithItems, DropDownWithDrilldown};
+const dropDownExampleImportsCode = `import Button from '@clayui/button';
+import DropDown from '@clayui/drop-down';`;
+
+const dropDownExampleCode = `const Component = () => {
+	const items = [
+		{
+			children: [
+				{id: 2, name: 'Apple'},
+				{id: 3, name: 'Banana'},
+				{id: 4, name: 'Mangos'},
+			],
+			id: 1,
+			name: 'Fruit',
+		},
+		{
+			children: [
+				{id: 6, name: 'Potatoes'},
+				{id: 7, name: 'Tomatoes'},
+				{id: 8, name: 'Onions'},
+			],
+			id: 5,
+			name: 'Vegetable',
+		},
+	];
+
+	return (
+		<DropDown
+			filterKey="name"
+			trigger={<Button>Select</Button>}
+		>
+			<DropDown.Search placeholder="Type to filter" />
+			<DropDown.ItemList items={items}>
+				{(item) => (
+					<DropDown.Group
+						header={item.name}
+						items={item.children}
+						key={item.name}
+					>
+						{(item) => (
+							<DropDown.Item key={item.name}>
+								{item.name}
+							</DropDown.Item>
+						)}
+					</DropDown.Group>
+				)}
+			</DropDown.ItemList>
+		</DropDown>
+	);
+}
+
+render(<Component />)`;
+
+const DropDownExample = () => {
+	const scope = {Button: ClayButton, DropDown: ClayDropDown};
+
+	return (
+		<Editor
+			code={dropDownExampleCode}
+			imports={dropDownExampleImportsCode}
+			scope={scope}
+		/>
+	);
+};
+
+export {DropDown, DropDownExample, DropDownWithItems, DropDownWithDrilldown};

--- a/packages/clay-drop-down/package.json
+++ b/packages/clay-drop-down/package.json
@@ -26,6 +26,7 @@
 		"react"
 	],
 	"dependencies": {
+		"@clayui/core": "^3.77.0",
 		"@clayui/button": "^3.73.0",
 		"@clayui/form": "^3.78.2",
 		"@clayui/icon": "^3.56.0",

--- a/packages/clay-drop-down/package.json
+++ b/packages/clay-drop-down/package.json
@@ -26,7 +26,7 @@
 		"react"
 	],
 	"dependencies": {
-		"@clayui/core": "^3.77.0",
+		"@clayui/core": "^3.78.2",
 		"@clayui/button": "^3.73.0",
 		"@clayui/form": "^3.78.2",
 		"@clayui/icon": "^3.56.0",

--- a/packages/clay-drop-down/src/DropDownContext.ts
+++ b/packages/clay-drop-down/src/DropDownContext.ts
@@ -5,7 +5,15 @@
 
 import React from 'react';
 
-export const DropDownContext = React.createContext({
+type Context = {
+	close: () => void;
+	closeOnClick: boolean;
+	filterKey?: string;
+	onSearch: (value: string) => void;
+	search: string;
+};
+
+export const DropDownContext = React.createContext<Context>({
 	close: () => {},
 	closeOnClick: false,
-});
+} as Context);

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -518,9 +518,7 @@ export const ClayDropDownWithItems = ({
 				{searchable && (
 					<Search
 						{...searchProps}
-						onChange={(event) =>
-							onSearchValueChange(event.target.value)
-						}
+						onChange={onSearchValueChange}
 						spritemap={spritemap}
 						value={searchValue}
 					/>

--- a/packages/clay-drop-down/src/Group.tsx
+++ b/packages/clay-drop-down/src/Group.tsx
@@ -67,7 +67,7 @@ function ClayDropDownGroup<T>({
 				>
 					<Collection<any>
 						filter={filterFn}
-						filterKey="value"
+						filterKey="textValue"
 						items={items}
 						passthroughKey={false}
 					>

--- a/packages/clay-drop-down/src/Group.tsx
+++ b/packages/clay-drop-down/src/Group.tsx
@@ -3,14 +3,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import React, {useMemo} from 'react';
+import {__NOT_PUBLIC_COLLECTION} from '@clayui/core';
+import React, {useCallback, useContext, useMemo} from 'react';
 
-type Props = {
-	/**
-	 * Group content.
-	 */
-	children?: React.ReactNode;
+import {DropDownContext} from './DropDownContext';
 
+import type {ICollectionProps} from '@clayui/core';
+
+const {Collection} = __NOT_PUBLIC_COLLECTION;
+
+export interface IProps<T>
+	extends Omit<ICollectionProps<T, unknown>, 'virtualize'> {
 	/**
 	 * Value provided is a display component that is a header for the items in the group.
 	 */
@@ -20,16 +23,28 @@ type Props = {
 	 * ARIA to define semantic meaning to content.
 	 */
 	role?: string;
-};
+}
 
 let counter = 0;
 
-const ClayDropDownGroup = ({children, header, role = 'group'}: Props) => {
+function ClayDropDownGroup<T>({
+	children,
+	header,
+	items,
+	role = 'group',
+}: IProps<T>) {
 	const ariaLabel = useMemo(() => {
 		counter++;
 
 		return `clay-dropdown-menu-group-${counter}`;
 	}, []);
+
+	const {search} = useContext(DropDownContext);
+
+	const filterFn = useCallback(
+		(value: string) => value.match(new RegExp(search, 'i')) !== null,
+		[search]
+	);
 
 	return (
 		<>
@@ -50,11 +65,18 @@ const ClayDropDownGroup = ({children, header, role = 'group'}: Props) => {
 					className="list-unstyled"
 					role={role}
 				>
-					{children}
+					<Collection<any>
+						filter={filterFn}
+						filterKey="value"
+						items={items}
+						passthroughKey={false}
+					>
+						{children}
+					</Collection>
 				</ul>
 			</li>
 		</>
 	);
-};
+}
 
 export default ClayDropDownGroup;

--- a/packages/clay-drop-down/src/ItemList.tsx
+++ b/packages/clay-drop-down/src/ItemList.tsx
@@ -3,13 +3,31 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {__NOT_PUBLIC_COLLECTION} from '@clayui/core';
 import classnames from 'classnames';
-import React from 'react';
+import React, {useCallback, useContext} from 'react';
+
+import {DropDownContext} from './DropDownContext';
+
+import type {ICollectionProps} from '@clayui/core';
+
+const {Collection} = __NOT_PUBLIC_COLLECTION;
+
+export interface IProps<T>
+	extends Omit<ICollectionProps<T, unknown>, 'virtualize'>,
+		Omit<React.HTMLAttributes<HTMLUListElement>, 'children'> {}
 
 const ClayDropDownItemList = React.forwardRef<
 	HTMLUListElement,
-	React.HTMLAttributes<HTMLUListElement>
->(({children, className, role = 'menu', ...otherProps}, ref) => {
+	IProps<unknown>
+>(({children, className, items, role = 'menu', ...otherProps}, ref) => {
+	const {search} = useContext(DropDownContext);
+
+	const filterFn = useCallback(
+		(value: string) => value.match(new RegExp(search, 'i')) !== null,
+		[search]
+	);
+
 	return (
 		<ul
 			{...otherProps}
@@ -17,7 +35,14 @@ const ClayDropDownItemList = React.forwardRef<
 			ref={ref}
 			role={role}
 		>
-			{children}
+			<Collection<any>
+				filter={filterFn}
+				filterKey="value"
+				items={items}
+				passthroughKey={false}
+			>
+				{children}
+			</Collection>
 		</ul>
 	);
 });

--- a/packages/clay-drop-down/src/ItemList.tsx
+++ b/packages/clay-drop-down/src/ItemList.tsx
@@ -37,7 +37,7 @@ const ClayDropDownItemList = React.forwardRef<
 		>
 			<Collection<any>
 				filter={filterFn}
-				filterKey="value"
+				filterKey="textValue"
 				items={items}
 				passthroughKey={false}
 			>

--- a/packages/clay-drop-down/src/Search.tsx
+++ b/packages/clay-drop-down/src/Search.tsx
@@ -6,19 +6,28 @@
 import ClayButton from '@clayui/button';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import {InternalDispatch, useInternalState} from '@clayui/shared';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useContext, useEffect} from 'react';
 
-export interface IProps extends React.HTMLAttributes<HTMLInputElement> {
+import {DropDownContext} from './DropDownContext';
+
+export interface IProps
+	extends Omit<React.HTMLAttributes<HTMLInputElement>, 'onChange'> {
+	/**
+	 * Initial value of the input (uncontrolled).
+	 */
+	defaultValue?: string;
+
 	/**
 	 * Props to add to form element
 	 */
 	formProps?: React.HTMLAttributes<HTMLFormElement>;
 
 	/**
-	 * Callback for when input value changes.
+	 * Callback for when input value changes (controlled).
 	 */
-	onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+	onChange?: InternalDispatch<string>;
 
 	/**
 	 * Path to the location of the spritemap resource.
@@ -26,20 +35,40 @@ export interface IProps extends React.HTMLAttributes<HTMLInputElement> {
 	spritemap?: string;
 
 	/**
-	 * Value of the searchInput
+	 * Current value of the input (controlled).
 	 */
-	value: React.ReactText;
+	value?: string;
 }
 
 const defaultOnSubmit = (event: React.SyntheticEvent) => event.preventDefault();
 
 const ClayDropDownSearch = ({
 	className,
+	defaultValue = '',
 	formProps = {},
+	onChange,
 	spritemap,
+	value: valueProp,
 	...otherProps
 }: IProps) => {
 	const {className: formClassName, onSubmit, ...otherFormProps} = formProps;
+
+	const [value, setValue, isUncontrolled] = useInternalState({
+		defaultName: 'defaultValue',
+		defaultValue,
+		handleName: 'onChange',
+		name: 'value',
+		onChange,
+		value: valueProp,
+	});
+
+	const {onSearch} = useContext(DropDownContext);
+
+	useEffect(() => {
+		if (isUncontrolled) {
+			onSearch(value);
+		}
+	}, [isUncontrolled, value]);
 
 	return (
 		<form
@@ -50,7 +79,13 @@ const ClayDropDownSearch = ({
 			<div className="dropdown-section">
 				<ClayInput.Group small>
 					<ClayInput.GroupItem>
-						<ClayInput {...otherProps} insetAfter type="text" />
+						<ClayInput
+							{...otherProps}
+							insetAfter
+							onChange={(event) => setValue(event.target.value)}
+							type="text"
+							value={value}
+						/>
 
 						<ClayInput.GroupInsetItem after tag="span">
 							<ClayButton displayType="unstyled" type="button">

--- a/packages/clay-drop-down/src/__tests__/index.tsx
+++ b/packages/clay-drop-down/src/__tests__/index.tsx
@@ -4,7 +4,8 @@
  */
 
 import ClayDropDown, {ClayDropDownWithItems} from '..';
-import {cleanup, fireEvent, render} from '@testing-library/react';
+import {cleanup, fireEvent, getAllByRole, render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
@@ -327,5 +328,187 @@ describe('ClayDropDown', () => {
 		fireEvent.submit(input as HTMLInputElement, {});
 
 		expect(onSubmitFn).toHaveBeenCalled();
+	});
+
+	it('render simple dynamic content', () => {
+		const {getAllByRole} = render(
+			<ClayDropDown
+				items={['one', 'two', 'three']}
+				trigger={<button>Click Me</button>}
+			>
+				{(item) => (
+					<ClayDropDown.Item key={item}>{item}</ClayDropDown.Item>
+				)}
+			</ClayDropDown>
+		);
+
+		const [one, two, three] = getAllByRole('menuitem');
+
+		expect(one).toBeDefined();
+		expect(two).toBeDefined();
+		expect(three).toBeDefined();
+	});
+
+	it('render simple static content', () => {
+		const {getAllByRole} = render(
+			<ClayDropDown trigger={<button>Click Me</button>}>
+				<ClayDropDown.ItemList>
+					<ClayDropDown.Item>one</ClayDropDown.Item>
+					<ClayDropDown.Item>two</ClayDropDown.Item>
+					<ClayDropDown.Item>three</ClayDropDown.Item>
+				</ClayDropDown.ItemList>
+			</ClayDropDown>
+		);
+
+		const [one, two, three] = getAllByRole('menuitem');
+
+		expect(one).toBeDefined();
+		expect(two).toBeDefined();
+		expect(three).toBeDefined();
+	});
+
+	it('render dynamic content with search', () => {
+		const {getAllByRole, getByRole} = render(
+			<ClayDropDown trigger={<button>Click Me</button>}>
+				<ClayDropDown.Search placeholder="Type to filter" />
+				<ClayDropDown.ItemList items={['one', 'two', 'three']}>
+					{(item: string) => (
+						<ClayDropDown.Item key={item}>{item}</ClayDropDown.Item>
+					)}
+				</ClayDropDown.ItemList>
+			</ClayDropDown>
+		);
+
+		const [one, two, three] = getAllByRole('menuitem');
+
+		expect(one).toBeDefined();
+		expect(two).toBeDefined();
+		expect(three).toBeDefined();
+
+		const input = getByRole('textbox');
+
+		userEvent.type(input, 't');
+
+		const items = getAllByRole('menuitem');
+
+		expect(items.length).toBe(2);
+	});
+
+	it('render dynamic content with group', () => {
+		const {getAllByRole: cGetAllByRole} = render(
+			<ClayDropDown
+				items={[
+					{
+						children: [
+							{id: 2, name: 'Apple'},
+							{id: 3, name: 'Banana'},
+							{id: 4, name: 'Mangos'},
+						],
+						id: 1,
+						name: 'Fruit',
+					},
+					{
+						children: [
+							{id: 6, name: 'Potatoes'},
+							{id: 7, name: 'Tomatoes'},
+							{id: 8, name: 'Onions'},
+						],
+						id: 5,
+						name: 'Vegetable',
+					},
+				]}
+				trigger={<button>Click Me</button>}
+			>
+				{(item: any) => (
+					<ClayDropDown.Group
+						header={item.name}
+						items={item.children}
+						key={item.name}
+					>
+						{(item: any) => (
+							<ClayDropDown.Item key={item.name}>
+								{item.name}
+							</ClayDropDown.Item>
+						)}
+					</ClayDropDown.Group>
+				)}
+			</ClayDropDown>
+		);
+
+		const [fruit, vegetable] = cGetAllByRole('group');
+
+		expect(fruit).toBeDefined();
+		expect(vegetable).toBeDefined();
+
+		const [fruit1, fruit2, fruit3] = getAllByRole(fruit, 'menuitem');
+
+		expect(fruit1).toBeDefined();
+		expect(fruit2).toBeDefined();
+		expect(fruit3).toBeDefined();
+
+		const [vegetable1, vegetable2, vegetable3] = getAllByRole(
+			vegetable,
+			'menuitem'
+		);
+
+		expect(vegetable1).toBeDefined();
+		expect(vegetable2).toBeDefined();
+		expect(vegetable3).toBeDefined();
+	});
+
+	it('render dynamic content with group and search', () => {
+		const {getAllByRole: cGetAllByRole, getByRole} = render(
+			<ClayDropDown trigger={<button>Click Me</button>}>
+				<ClayDropDown.Search placeholder="Type to filter" />
+				<ClayDropDown.ItemList
+					items={[
+						{
+							children: [
+								{id: 2, name: 'Apple'},
+								{id: 3, name: 'Banana'},
+								{id: 4, name: 'Mangos'},
+							],
+							id: 1,
+							name: 'Fruit',
+						},
+						{
+							children: [
+								{id: 6, name: 'Potatoes'},
+								{id: 7, name: 'Tomatoes'},
+								{id: 8, name: 'Onions'},
+							],
+							id: 5,
+							name: 'Vegetable',
+						},
+					]}
+				>
+					{(item: any) => (
+						<ClayDropDown.Group
+							header={item.name}
+							items={item.children}
+							key={item.name}
+						>
+							{(item: any) => (
+								<ClayDropDown.Item key={item.name}>
+									{item.name}
+								</ClayDropDown.Item>
+							)}
+						</ClayDropDown.Group>
+					)}
+				</ClayDropDown.ItemList>
+			</ClayDropDown>
+		);
+
+		const input = getByRole('textbox');
+
+		userEvent.type(input, 'ma');
+
+		const [fruit, vegetable] = cGetAllByRole('group');
+
+		const fruits = getAllByRole(fruit, 'menuitem');
+		const vegetables = getAllByRole(vegetable, 'menuitem');
+
+		expect(fruits.length).toBe(1);
+		expect(vegetables.length).toBe(1);
 	});
 });

--- a/packages/clay-drop-down/stories/DropDown.stories.tsx
+++ b/packages/clay-drop-down/stories/DropDown.stories.tsx
@@ -114,6 +114,75 @@ Default.args = {
 	width: '',
 };
 
+export const Dynamic = () => (
+	<ClayDropDown
+		items={['one', 'two', 'three', 'four']}
+		trigger={<ClayButton>Click Me</ClayButton>}
+	>
+		{(item) => <ClayDropDown.Item key={item}>{item}</ClayDropDown.Item>}
+	</ClayDropDown>
+);
+
+export const DynamicWithSearch = () => {
+	return (
+		<ClayDropDown trigger={<ClayButton>Click Me</ClayButton>}>
+			<ClayDropDown.Search placeholder="Type to filter" />
+			<ClayDropDown.ItemList items={['one', 'two', 'three', 'four']}>
+				{(item: string) => (
+					<ClayDropDown.Item key={item}>{item}</ClayDropDown.Item>
+				)}
+			</ClayDropDown.ItemList>
+		</ClayDropDown>
+	);
+};
+
+export const DynamicGroup = () => {
+	const items = [
+		{
+			children: [
+				{id: 2, name: 'Apple'},
+				{id: 3, name: 'Banana'},
+				{id: 4, name: 'Mangos'},
+			],
+			id: 1,
+			name: 'Fruit',
+		},
+		{
+			children: [
+				{id: 6, name: 'Potatoes'},
+				{id: 7, name: 'Tomatoes'},
+				{id: 8, name: 'Onions'},
+			],
+			id: 5,
+			name: 'Vegetable',
+		},
+	];
+
+	return (
+		<ClayDropDown
+			filterKey="name"
+			trigger={<ClayButton>Select</ClayButton>}
+		>
+			<ClayDropDown.Search placeholder="Type to filter" />
+			<ClayDropDown.ItemList items={items}>
+				{(item: any) => (
+					<ClayDropDown.Group
+						header={item.name}
+						items={item.children}
+						key={item.name}
+					>
+						{(item: any) => (
+							<ClayDropDown.Item key={item.name}>
+								{item.name}
+							</ClayDropDown.Item>
+						)}
+					</ClayDropDown.Group>
+				)}
+			</ClayDropDown.ItemList>
+		</ClayDropDown>
+	);
+};
+
 export const Groups = () => (
 	<ClayDropDown
 		alignmentPosition={Align.BottomLeft}


### PR DESCRIPTION
Closes #5101

In order to use the internal component of Collection in DropDown, I had to deal with the circular dependency problem, for that I had to remove the DropDown re-export in the `@clayui/core` package. I believe that no one is still using DropDown through the core, if so I'll update in DXP.

The Collection pattern is now available in the DropDown component, providing features such as static and dynamic content. This lets you simplify some simpler cases, for example how to just render a simple list of options.

```jsx
<DropDown
  items={['one', 'two', 'three', 'four']}
  trigger={<Button>Click Me</Button>}
>
  {(item) => <DropDown.Item key={item}>{item}</DropDown.Item>}
</DropDown>
```

When the component renders for example an input to filter the list, it now works in an OOTB way without having to configure anything extra.

```jsx
<DropDown
  trigger={<Button>Click Me</Button>}
>
  <DropDown.Search placeholder="Type to filter" />
  <DropDown.ItemList items={['one', 'two', 'three', 'four']}>
    {(item) => <DropDown.Item key={item}>{item}</DropDown.Item>}
  </DropDown.ItemList>
</DropDown>
```

This also works for groups, see the example in the storybook. This simplifies the composition to behave according to your data and also agnostic.

There are other features that we could add, for example virtualization for DropDown is disabled because the markup hierarchy level is a tree style, for example in groups. We can change this to render as a list but keep accessibility so we can enable virtualization by default and have no issues with it. We would also be able to add infinite scroll support but I haven't seen at least no case in DXP that would use this, normally DropDown is just used for Menu with a small list less than 20 items.

## ToDo

- [x] Update documentation
- [x] Update tests and add new use cases