### PR TITLE
feat(@clayui/tabs): add new API to configure browsing behavior between tabs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -212,10 +212,10 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-tabs/src/': {
-			branches: 84,
+			branches: 58,
 			functions: 66,
-			lines: 94,
-			statements: 90,
+			lines: 78,
+			statements: 76,
 		},
 		'./packages/clay-time-picker/src/': {
 			branches: 85,

--- a/packages/clay-tabs/docs/index.js
+++ b/packages/clay-tabs/docs/index.js
@@ -13,48 +13,42 @@ const tabsImportsCode = `import ClayTabs from '@clayui/tabs';
 `;
 
 const tabsCode = `const Component = () => {
-    const [activeTabKeyValue, setActiveTabKeyValue] = useState(0);
+    const [active, setActive] = useState(0);
 
     return (
         <>
-            <ClayTabs modern>
+            <ClayTabs active={active} modern onActiveChange={setActive}>
                 <ClayTabs.Item
-                    active={activeTabKeyValue === 0}
                     innerProps={{
                         'aria-controls': 'tabpanel-1',
                     }}
-                    onClick={() => setActiveTabKeyValue(0)}
                 >
-                    {'Tab 1'}
+                    Tab 1
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue === 1}
                     innerProps={{
                         'aria-controls': 'tabpanel-2',
                     }}
-                    onClick={() => setActiveTabKeyValue(1)}
                 >
-                    {'Tab 2'}
+                    Tab 2
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue === 2}
                     innerProps={{
                         'aria-controls': 'tabpanel-3',
                     }}
-                    onClick={() => setActiveTabKeyValue(2)}
                 >
-                    {'Tab 3'}
+                    Tab 3
                 </ClayTabs.Item>
             </ClayTabs>
-            <ClayTabs.Content activeIndex={activeTabKeyValue} fade>
+            <ClayTabs.Content activeIndex={active} fade>
                 <ClayTabs.TabPane aria-labelledby="tab-1">
-                    {\`1. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    1. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
                 <ClayTabs.TabPane aria-labelledby="tab-2">
-                    {\`2. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    2. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
                 <ClayTabs.TabPane aria-labelledby="tab-3">
-                    {\`3. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    3. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
             </ClayTabs.Content>
         </>
@@ -96,7 +90,7 @@ const tabsDropdownCode = `const Component = () => {
         );
     };
 
-    const [activeTabKeyValue, setActiveTabKeyValue] = useState(0);
+    const [active, setActive] = useState(0);
 
     const dropdownTabsItems = [
         {
@@ -116,54 +110,45 @@ const tabsDropdownCode = `const Component = () => {
 
     return (
         <ClayIconSpriteContext.Provider value={spritemap}>
-            <ClayTabs modern>
+            <ClayTabs active={active} modern onActiveChange={setActive}>
                 <ClayTabs.Item
-                    active={activeTabKeyValue === 0}
                     innerProps={{
                         'aria-controls': 'tabpanel-1',
                     }}
-                    onClick={() => setActiveTabKeyValue(0)}
                 >
-                    {'Tab 1'}
+                    Tab 1
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue === 1}
                     innerProps={{
                         'aria-controls': 'tabpanel-2',
                     }}
-                    onClick={() => setActiveTabKeyValue(1)}
                 >
-                    {'Tab 2'}
+                    Tab 2
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue === 2}
                     innerProps={{
                         'aria-controls': 'tabpanel-3',
                     }}
-                    onClick={() => setActiveTabKeyValue(2)}
                 >
-                    {'Tab 3'}
+                    Tab 3
                 </ClayTabs.Item>
                 <ClayTabs.Item
-                    active={activeTabKeyValue === 3}
                     innerProps={{
                         'aria-controls': 'tabpanel-4',
                     }}
-                    onClick={() => setActiveTabKeyValue(3)}
                 >
-                    {'Tab 4'}
+                    Tab 4
                 </ClayTabs.Item>
 
                 <DropDownWithState
                     trigger={
                         <ClayTabs.Item
-                            active={[5, 6, 7].includes(activeTabKeyValue)}
+                            active={[5, 6, 7].includes(active)}
                             innerProps={{
                                 'aria-controls': 'tabpanel-5',
                             }}
-                            onClick={() => setActiveTabKeyValue(4)}
                         >
-                            {'More'}
+                            More
                             <ClayIcon symbol="caret-bottom" />
                         </ClayTabs.Item>
                     }
@@ -174,10 +159,10 @@ const tabsDropdownCode = `const Component = () => {
                                 return (
                                     <ClayDropDown.Item
                                         active={
-                                            activeTabKeyValue === tabkey
+                                            active === tabkey
                                         }
                                         aria-selected={
-                                            activeTabKeyValue === tabkey
+                                            active === tabkey
                                         }
                                         disabled={disabled}
                                         key={i}
@@ -187,7 +172,7 @@ const tabsDropdownCode = `const Component = () => {
                                         role="tab"
                                         spritemap={spritemap}
                                         symbolRight={
-                                            activeTabKeyValue === tabkey
+                                            active === tabkey
                                                 ? 'check'
                                                 : undefined
                                         }
@@ -201,32 +186,32 @@ const tabsDropdownCode = `const Component = () => {
                 </DropDownWithState>
             </ClayTabs>
             <ClayTabs.Content
-                activeIndex={activeTabKeyValue}
+                activeIndex={active}
                 fade
             >
                 <ClayTabs.TabPane aria-labelledby="tab-1">
-                    {\`1. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    1. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
                 <ClayTabs.TabPane aria-labelledby="tab-2">
-                    {\`2. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    2. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
                 <ClayTabs.TabPane aria-labelledby="tab-3">
-                    {\`3. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    3. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
                 <ClayTabs.TabPane aria-labelledby="tab-4">
-                    {\`4. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    4. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
                 <ClayTabs.TabPane aria-labelledby="tab-5">
-                    {\`5. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    5. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
                 <ClayTabs.TabPane aria-labelledby="tab-6">
-                    {\`6. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    6. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
                 <ClayTabs.TabPane aria-labelledby="tab-7">
-                    {\`7. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    7. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
                 <ClayTabs.TabPane aria-labelledby="tab-8">
-                    {\`8. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.\`}
+                    8. Proin efficitur imperdiet dolor, a iaculis orci lacinia eu.
                 </ClayTabs.TabPane>
             </ClayTabs.Content>
         </ClayIconSpriteContext.Provider>

--- a/packages/clay-tabs/src/Item.tsx
+++ b/packages/clay-tabs/src/Item.tsx
@@ -69,7 +69,7 @@ const Item = React.forwardRef<any, IProps>(
 				onClick={onClick}
 				ref={ref}
 				role="tab"
-				tabIndex={!active ? -1 : undefined}
+				tabIndex={!active ? -1 : 0}
 			>
 				{children}
 			</LinkOrButton>

--- a/packages/clay-tabs/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-tabs/src/__tests__/__snapshots__/index.tsx.snap
@@ -24,6 +24,7 @@ exports[`ClayTabs renders with items 1`] = `
         class="nav-link active btn btn-unstyled"
         data-testid="tabItem"
         role="tab"
+        tabindex="0"
         type="button"
       >
         Dummy1

--- a/packages/clay-tabs/src/__tests__/index.tsx
+++ b/packages/clay-tabs/src/__tests__/index.tsx
@@ -9,32 +9,16 @@ import {cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
 const ClayTabsWithItems = () => {
-	const [activeTabKeyValue, setActiveTabKeyValue] = React.useState<number>(0);
+	const [active, setActive] = React.useState<number>(0);
 
 	return (
 		<>
-			<ClayTabs>
-				<ClayTabs.Item
-					active={activeTabKeyValue == 0}
-					onClick={() => setActiveTabKeyValue(0)}
-				>
-					Dummy1
-				</ClayTabs.Item>
-				<ClayTabs.Item
-					active={activeTabKeyValue == 1}
-					data-testid="tabItem2"
-					onClick={() => setActiveTabKeyValue(1)}
-				>
-					Dummy2
-				</ClayTabs.Item>
-				<ClayTabs.Item
-					active={activeTabKeyValue == 2}
-					onClick={() => setActiveTabKeyValue(2)}
-				>
-					Dummy3
-				</ClayTabs.Item>
+			<ClayTabs active={active} onActiveChange={setActive}>
+				<ClayTabs.Item>Dummy1</ClayTabs.Item>
+				<ClayTabs.Item data-testid="tabItem2">Dummy2</ClayTabs.Item>
+				<ClayTabs.Item>Dummy3</ClayTabs.Item>
 			</ClayTabs>
-			<ClayTabs.Content activeIndex={activeTabKeyValue}>
+			<ClayTabs.Content activeIndex={active}>
 				<ClayTabs.TabPane data-testid="tabPane1">
 					Tab Content 1
 				</ClayTabs.TabPane>
@@ -96,8 +80,9 @@ describe('ClayTabs', () => {
 		const {getAllByTestId} = render(
 			<>
 				<ClayTabs>
-					<ClayTabs.Item active href="https://clay.dev/foo" />
-					One
+					<ClayTabs.Item active href="https://clay.dev/foo">
+						One
+					</ClayTabs.Item>
 					<ClayTabs.Item href="https://clay.dev/bar">
 						Two
 					</ClayTabs.Item>

--- a/packages/clay-tabs/src/index.tsx
+++ b/packages/clay-tabs/src/index.tsx
@@ -3,8 +3,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import {
+	FOCUSABLE_ELEMENTS,
+	InternalDispatch,
+	Keys,
+	useInternalState,
+} from '@clayui/shared';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useRef} from 'react';
 
 import Content from './Content';
 import Item from './Item';
@@ -13,6 +19,25 @@ import TabPane from './TabPane';
 export type DisplayType = null | 'basic' | 'underline';
 
 export interface IProps extends React.HTMLAttributes<HTMLUListElement> {
+	/**
+	 * Flag to indicate the navigation behavior in the tab.
+	 *
+	 * - manual - it will just move the focus and tab activation is done just
+	 * by pressing space or enter.
+	 * - automatic - moves the focus to the tab and activates the tab.
+	 */
+	activation?: 'manual' | 'automatic';
+
+	/**
+	 * The current tab active (controlled).
+	 */
+	active?: number;
+
+	/**
+	 * Initial active tab when rendering component (uncontrolled).
+	 */
+	defaultActive?: number;
+
 	/**
 	 * Determines how tab is displayed.
 	 */
@@ -27,6 +52,11 @@ export interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	 * Applies a modern style to the tab.
 	 */
 	modern?: boolean;
+
+	/**
+	 * Callback is called when the active tab changes (controlled).
+	 */
+	onActiveChange?: InternalDispatch<number>;
 }
 
 function ClayTabs(props: IProps): JSX.Element & {
@@ -37,13 +67,28 @@ function ClayTabs(props: IProps): JSX.Element & {
 };
 
 function ClayTabs({
+	activation = 'manual',
+	active: externalActive,
 	children,
 	className,
+	defaultActive = 0,
 	displayType,
 	justified,
 	modern = true,
+	onActiveChange,
 	...otherProps
 }: IProps) {
+	const tabsRef = useRef<HTMLUListElement>(null);
+
+	const [active, setActive] = useInternalState({
+		defaultName: 'defaultActive',
+		defaultValue: defaultActive,
+		handleName: 'onActiveChange',
+		name: 'active',
+		onChange: onActiveChange,
+		value: externalActive,
+	});
+
 	return (
 		<ul
 			{...otherProps}
@@ -62,9 +107,63 @@ function ClayTabs({
 
 				className
 			)}
+			onKeyDown={(event) => {
+				if (!tabsRef.current) {
+					return;
+				}
+
+				if (event.key === Keys.Left || event.key === Keys.Right) {
+					const tabs = Array.from<HTMLElement>(
+						tabsRef.current.querySelectorAll(
+							FOCUSABLE_ELEMENTS.join(',')
+						)
+					);
+					const activeElement = document.activeElement as HTMLElement;
+
+					const position = tabs.indexOf(activeElement);
+
+					const tab =
+						tabs[
+							event.key === Keys.Left
+								? position - 1
+								: position + 1
+						];
+
+					if (tab) {
+						tab.focus();
+
+						if (activation === 'automatic') {
+							const newActive = Array.from(
+								tabsRef.current.querySelectorAll('a, button')
+							).indexOf(tab);
+
+							setActive(newActive);
+						}
+					}
+				}
+			}}
+			ref={tabsRef}
 			role="tablist"
 		>
-			{children}
+			{React.Children.map(children, (child, index) =>
+				React.cloneElement(child as React.ReactElement, {
+					active:
+						(child as React.ReactElement).props.active !== undefined
+							? (child as React.ReactElement).props.active
+							: active === index,
+					onClick: (
+						event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+					) => {
+						const {onClick} = (child as React.ReactElement).props;
+
+						if (onClick) {
+							onClick(event);
+						} else {
+							setActive(index);
+						}
+					},
+				})
+			)}
 		</ul>
 	);
 }

--- a/packages/clay-tabs/stories/Tabs.stories.tsx
+++ b/packages/clay-tabs/stories/Tabs.stories.tsx
@@ -3,31 +3,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayDropDown, {Align} from '@clayui/drop-down';
-import ClayIcon from '@clayui/icon';
 import React, {useState} from 'react';
 
 import ClayTabs from '../src';
 
-const DropDownWithState = ({children, trigger, ...others}: any) => {
-	const [active, setActive] = useState<boolean>(false);
-
-	return (
-		<ClayDropDown
-			active={active}
-			alignmentPosition={Align.BottomLeft}
-			hasRightSymbols
-			onActiveChange={(newVal: boolean) => setActive(newVal)}
-			trigger={trigger}
-			{...others}
-		>
-			{children}
-		</ClayDropDown>
-	);
-};
-
 export default {
 	argTypes: {
+		activation: {
+			control: {type: 'select'},
+			options: ['manual', 'automatic', null],
+		},
 		displayType: {
 			control: {type: 'select'},
 			options: ['basic', 'underline', null],
@@ -38,119 +23,53 @@ export default {
 };
 
 export const Default = (args: any) => {
-	const [activeIndex, setActiveIndex] = useState<number>(0);
-
-	const dropdownTabsItems = [
-		{
-			disabled: true,
-			label: 'Tab 6',
-			tabkey: 5,
-		},
-		{
-			label: 'Tab 7',
-			tabkey: 6,
-		},
-		{
-			label: 'Tab 8',
-			tabkey: 7,
-		},
-	];
+	const [active, setActive] = useState<number>(0);
 
 	return (
 		<>
 			<ClayTabs
+				activation={args.activation}
+				active={active}
 				displayType={args.displayType}
 				justified={args.justified}
 				modern={args.modern}
+				onActiveChange={setActive}
 			>
 				<ClayTabs.Item
-					active={activeIndex == 0}
 					disabled={args.disabledFirstTab}
-					href="#"
 					innerProps={{
 						'aria-controls': 'tabpanel1',
 					}}
-					onClick={() => setActiveIndex(0)}
 				>
 					Tab 1
 				</ClayTabs.Item>
 				<ClayTabs.Item
-					active={activeIndex == 1}
 					disabled={args.disabledSecondTab}
-					href="#"
 					innerProps={{
 						'aria-controls': 'tabpanel2',
 					}}
-					onClick={() => setActiveIndex(1)}
 				>
 					Tab 2
 				</ClayTabs.Item>
 				<ClayTabs.Item
-					active={activeIndex == 2}
 					disabled={args.disabledThirdTab}
-					href="#"
 					innerProps={{
 						'aria-controls': 'tabpanel3',
 					}}
-					onClick={() => setActiveIndex(2)}
 				>
 					Tab 3
 				</ClayTabs.Item>
 				<ClayTabs.Item
-					active={activeIndex == 3}
 					disabled={args.disabledFourthTab}
-					href="#"
 					innerProps={{
 						'aria-controls': 'tabpanel4',
 					}}
-					onClick={() => setActiveIndex(3)}
 				>
 					Tab 4
 				</ClayTabs.Item>
-
-				<DropDownWithState
-					trigger={
-						<ClayTabs.Item
-							active={[5, 6, 7].includes(activeIndex)}
-							disabled={args.disabledFourthTab}
-							innerProps={{
-								'aria-controls': 'tabpanel5',
-							}}
-							onClick={() => setActiveIndex(4)}
-						>
-							Tab 5
-							<ClayIcon symbol="caret-bottom" />
-						</ClayTabs.Item>
-					}
-				>
-					<ClayDropDown.ItemList>
-						{dropdownTabsItems.map(
-							({disabled = false, label, tabkey}, i) => {
-								return (
-									<ClayDropDown.Item
-										active={activeIndex === tabkey}
-										aria-controls={`tabpanel${tabkey}`}
-										aria-selected={activeIndex === tabkey}
-										disabled={disabled}
-										key={i}
-										onClick={() => setActiveIndex(tabkey)}
-										role="tab"
-										symbolRight={
-											activeIndex === tabkey
-												? 'check'
-												: undefined
-										}
-									>
-										{label}
-									</ClayDropDown.Item>
-								);
-							}
-						)}
-					</ClayDropDown.ItemList>
-				</DropDownWithState>
 			</ClayTabs>
-			<ClayTabs.Content activeIndex={activeIndex} fade={args.fade}>
-				<ClayTabs.TabPane id="tabpanel1" role="tabpanel">
+			<ClayTabs.Content activeIndex={active} fade={args.fade}>
+				<ClayTabs.TabPane id="tabpanel1">
 					{`1. Single origin, extra id beans, eu to go, skinny
 				americano ut aftertas te sugar. At americano, viennese
 				variety iced grounds, grinder froth and pumpkin spice
@@ -160,7 +79,7 @@ export const Default = (args: any) => {
 				plunger pot. Single shot variety pumpkin spice seasonal
 				skinny barista carajillo robust cream.`}
 				</ClayTabs.TabPane>
-				<ClayTabs.TabPane id="tabpanel2" role="tabpanel">
+				<ClayTabs.TabPane id="tabpanel2">
 					{`2. Single origin, extra id beans, eu to go, skinny
 				americano ut aftertaste sugar. At americano, viennese
 				variety iced grounds, grinder froth and pumpkin spice
@@ -170,7 +89,7 @@ export const Default = (args: any) => {
 				plunger pot. Single shot variety pumpkin spice seasonal
 				skinny barista carajillo robust cream.`}
 				</ClayTabs.TabPane>
-				<ClayTabs.TabPane id="tabpanel3" role="tabpanel">
+				<ClayTabs.TabPane id="tabpanel3">
 					{`3. Single origin, extra id beans, eu to go, skinny
 				americano ut aftertaste sugar. At americano, viennese
 				variety iced grounds, grinder froth and pumpkin spice
@@ -180,7 +99,7 @@ export const Default = (args: any) => {
 				plunger pot. Single shot variety pumpkin spice seasonal
 				skinny barista carajillo robust cream.`}
 				</ClayTabs.TabPane>
-				<ClayTabs.TabPane id="tabpanel4" role="tabpanel">
+				<ClayTabs.TabPane id="tabpanel4">
 					{`4. Single origin, extra id beans, eu to go, skinny
 				americano ut aftertaste sugar. At americano, viennese
 				variety iced grounds, grinder froth and pumpkin spice
@@ -190,38 +109,8 @@ export const Default = (args: any) => {
 				plunger pot. Single shot variety pumpkin spice seasonal
 				skinny barista carajillo robust cream.`}
 				</ClayTabs.TabPane>
-				<ClayTabs.TabPane id="tabpanel5" role="tabpanel">
+				<ClayTabs.TabPane id="tabpanel5">
 					{`4. Single origin, extra id beans, eu to go, skinny
-				americano ut aftertaste sugar. At americano, viennese
-				variety iced grounds, grinder froth and pumpkin spice
-				aromatic. Cultivar aged lungo, grounds café au lait,
-				skinny, blue mountain, in variety sugar shop roast.
-				Wings, blue mountain affogato organic cappuccino java
-				plunger pot. Single shot variety pumpkin spice seasonal
-				skinny barista carajillo robust cream.`}
-				</ClayTabs.TabPane>
-				<ClayTabs.TabPane id="tabpanel6" role="tabpanel">
-					{`6. Single origin, extra id beans, eu to go, skinny
-				americano ut aftertaste sugar. At americano, viennese
-				variety iced grounds, grinder froth and pumpkin spice
-				aromatic. Cultivar aged lungo, grounds café au lait,
-				skinny, blue mountain, in variety sugar shop roast.
-				Wings, blue mountain affogato organic cappuccino java
-				plunger pot. Single shot variety pumpkin spice seasonal
-				skinny barista carajillo robust cream.`}
-				</ClayTabs.TabPane>
-				<ClayTabs.TabPane id="tabpanel7" role="tabpanel">
-					{`7. Single origin, extra id beans, eu to go, skinny
-				americano ut aftertaste sugar. At americano, viennese
-				variety iced grounds, grinder froth and pumpkin spice
-				aromatic. Cultivar aged lungo, grounds café au lait,
-				skinny, blue mountain, in variety sugar shop roast.
-				Wings, blue mountain affogato organic cappuccino java
-				plunger pot. Single shot variety pumpkin spice seasonal
-				skinny barista carajillo robust cream.`}
-				</ClayTabs.TabPane>
-				<ClayTabs.TabPane id="tabpanel8" role="tabpanel">
-					{`8. Single origin, extra id beans, eu to go, skinny
 				americano ut aftertaste sugar. At americano, viennese
 				variety iced grounds, grinder froth and pumpkin spice
 				aromatic. Cultivar aged lungo, grounds café au lait,
@@ -236,6 +125,7 @@ export const Default = (args: any) => {
 };
 
 Default.args = {
+	activation: 'manual',
 	disabledFirstTab: false,
 	disabledFourthTab: false,
 	disabledSecondTab: true,
@@ -246,23 +136,17 @@ Default.args = {
 };
 
 export const WithState = () => {
-	const [activeIndex, setActiveIndex] = useState(0);
+	const [active, setActive] = useState(0);
 
 	return (
 		<div style={{padding: 50}}>
-			<ClayTabs modern={false}>
-				{['Tab 1', 'Tab 2', 'Tab 3'].map((item, index) => (
-					<ClayTabs.Item
-						active={activeIndex === index}
-						key={item}
-						onClick={() => setActiveIndex(index)}
-					>
-						{item}
-					</ClayTabs.Item>
+			<ClayTabs active={active} modern={false} onActiveChange={setActive}>
+				{['Tab 1', 'Tab 2', 'Tab 3'].map((item) => (
+					<ClayTabs.Item key={item}>{item}</ClayTabs.Item>
 				))}
 			</ClayTabs>
 
-			<ClayTabs.Content activeIndex={activeIndex} fade>
+			<ClayTabs.Content activeIndex={active} fade>
 				<ClayTabs.TabPane>
 					Single origin, extra id beans, eu to go, skinny americano ut
 					aftertaste sugar. At americano, viennese variety iced


### PR DESCRIPTION
Fixes #5151

In order to be able to control the automatic activation state of the tab when navigating, we have to have control of the active state, in the current implementation, the developer controls the state. In this PR I am applying the pattern from [RFC 0002 Controlled and uncontrolled components](https://github.com/liferay/clay/blob/master/docs/proposals/0002-controlled-and-uncontrolled.md) to allow the component to have state visibility, this makes it possible during tab navigation when selecting a tab changes the current tab.

```jsx
const [active, setActive] = useState(0);

<>
  <ClayTabs
    active={active}
    onActiveChange={setActive}
  >
    <ClayTabs.Item
      innerProps={{
        'aria-controls': 'tabpanel1',
      }}
    >
      Tab 1
    </ClayTabs.Item>
    <ClayTabs.Item
      innerProps={{
        'aria-controls': 'tabpanel2',
      }}
    >
      Tab 2
    </ClayTabs.Item>
  </ClayTabs>
  <ClayTabs.Content activeIndex={active} fade={args.fade}>
    <ClayTabs.TabPane id="tabpanel1">
      Tab 1
    </ClayTabs.TabPane>
    <ClayTabs.TabPane id="tabpanel2">
      Tab 2
    </ClayTabs.TabPane>
  </ClayTabs.Content>
</>
```

This makes it simpler to handle the active state of tabs. This component can be made simpler and provide some OOTB features, such as not needing to configure `aria-controls` to associate the tab with the panel, but this will only be possible when we start to apply the collection pattern in this component #5032.

Also before that we need to review this component to improve the composition so that the `ClayTabs.Content` component doesn't become like sibling of `ClayTabs` to improve the data flow, in this PR if the `active` is uncontrolled not work because it doesn't have how to pass the state of `active` to `ClayTabs.Content` for it to work correctly needs to be controlled, so this is one of the reasons to refresh the composition of Tabs.