### PR TITLE
refactor(@clayui/tooltip): simplifies singleton implementation to add support for showing tooltip in focus using keyboard

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -188,10 +188,10 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-shared/src/': {
-			branches: 42,
-			functions: 29,
-			lines: 59,
-			statements: 60,
+			branches: 41,
+			functions: 24,
+			lines: 52,
+			statements: 54,
 		},
 		'./packages/clay-slider/src/': {
 			branches: 92,

--- a/packages/clay-shared/src/delegate.ts
+++ b/packages/clay-shared/src/delegate.ts
@@ -11,7 +11,8 @@ function delegate(
 	element: HTMLElement,
 	eventName: keyof GlobalEventHandlersEventMap,
 	selector: string,
-	callback: (event: any) => void
+	callback: (event: any) => void,
+	capture?: boolean
 ) {
 	const eventHandler = (event: {
 		delegateTarget?: Element;
@@ -38,11 +39,15 @@ function delegate(
 		}
 	};
 
-	element.addEventListener(eventName, eventHandler as any);
+	element.addEventListener(eventName, eventHandler as any, capture);
 
 	return {
 		dispose() {
-			element.removeEventListener(eventName, eventHandler as any);
+			element.removeEventListener(
+				eventName,
+				eventHandler as any,
+				capture
+			);
 		},
 	};
 }

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -20,5 +20,6 @@ export {setElementFullHeight} from './setElementFullHeight';
 export {useInternalState} from './useInternalState';
 export {useMousePosition} from './useMousePosition';
 export {MouseSafeArea} from './MouseSafeArea';
+export {useInteractionFocus} from './useInteractionFocus';
 export type {IBaseProps as IPortalBaseProps} from './Portal';
 export type {InternalDispatch} from './useInternalState';

--- a/packages/clay-shared/src/useInteractionFocus.ts
+++ b/packages/clay-shared/src/useInteractionFocus.ts
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useEffect} from 'react';
+
+export type Interaction = 'keyboard' | 'pointer' | 'virtual';
+
+let currentInteraction: any = null;
+let hasSetupGlobalListeners = false;
+let hasEventBeforeFocus = false;
+let hasBlurredWindowRecently = false;
+
+function testPlatform(re: RegExp) {
+	return typeof window !== 'undefined' && window.navigator != null
+		? re.test(
+				// @ts-ignore
+				window.navigator['userAgentData']?.platform ||
+					window.navigator.platform
+		  )
+		: false;
+}
+
+function isValidKey(event: KeyboardEvent) {
+	// Control and Shift keys trigger when navigating back to the tab with keyboard.
+	return !(
+		event.metaKey ||
+		(!testPlatform(/^Mac/i) && event.altKey) ||
+		event.ctrlKey ||
+		event.key === 'Control' ||
+		event.key === 'Shift' ||
+		event.key === 'Meta'
+	);
+}
+
+function isVirtualClick(event: MouseEvent | PointerEvent) {
+	if ((event as any).mozInputSource === 0 && event.isTrusted) {
+		return true;
+	}
+
+	return event.detail === 0 && !(event as PointerEvent).pointerType;
+}
+
+function isFocusVisible(): boolean {
+	return currentInteraction !== 'pointer';
+}
+
+function getInteraction(): Interaction {
+	return currentInteraction;
+}
+
+/**
+ * Detects what type of interaction the user is doing with the page, using the
+ * keyboard, pointer or using screen reader. This works like a singleton even
+ * if it is declared more than once.
+ *
+ * This is inspired by the implementation:
+ * https://github.com/adobe/react-spectrum/blob/d10f20a3f4ca7ffa807fcaceb944274da825a7b9/packages/%40react-aria/interactions/src/useFocusVisible.ts
+ */
+export function useInteractionFocus() {
+	useEffect(() => {
+		if (hasSetupGlobalListeners) {
+			return;
+		}
+
+		const onKeyboard = (event: KeyboardEvent) => {
+			hasEventBeforeFocus = true;
+
+			if (isValidKey(event)) {
+				currentInteraction = 'keyboard';
+			}
+		};
+
+		const onClick = (event: MouseEvent) => {
+			if (isVirtualClick(event)) {
+				hasEventBeforeFocus = true;
+				currentInteraction = 'virtual';
+			}
+		};
+
+		const onFocus = (event: FocusEvent) => {
+			if (event.target === window || event.target === document) {
+				return;
+			}
+
+			if (!hasEventBeforeFocus && !hasBlurredWindowRecently) {
+				currentInteraction = 'virtual';
+			}
+
+			hasEventBeforeFocus = false;
+			hasBlurredWindowRecently = false;
+		};
+
+		const onBlur = () => {
+			hasEventBeforeFocus = false;
+			hasBlurredWindowRecently = true;
+		};
+
+		const onPointer = (event: PointerEvent | MouseEvent) => {
+			currentInteraction = 'pointer';
+
+			if (event.type === 'mousedown' || event.type === 'pointerdown') {
+				hasEventBeforeFocus = true;
+			}
+		};
+
+		document.addEventListener('keydown', onKeyboard, true);
+		document.addEventListener('keyup', onKeyboard, true);
+		document.addEventListener('click', onClick, true);
+
+		window.addEventListener('focus', onFocus, true);
+		window.addEventListener('blur', onBlur, false);
+
+		if (typeof PointerEvent !== 'undefined') {
+			document.addEventListener('pointerdown', onPointer, true);
+			document.addEventListener('pointermove', onPointer, true);
+			document.addEventListener('pointerup', onPointer, true);
+		} else {
+			document.addEventListener('mousedown', onPointer, true);
+			document.addEventListener('mousemove', onPointer, true);
+			document.addEventListener('mouseup', onPointer, true);
+		}
+
+		hasSetupGlobalListeners = true;
+
+		return () => {
+			document.removeEventListener('keydown', onKeyboard, true);
+			document.removeEventListener('keyup', onKeyboard, true);
+			document.removeEventListener('click', onClick, true);
+
+			window.removeEventListener('focus', onFocus, true);
+			window.removeEventListener('blur', onBlur, false);
+
+			if (typeof PointerEvent !== 'undefined') {
+				document.removeEventListener('pointerdown', onPointer, true);
+				document.removeEventListener('pointermove', onPointer, true);
+				document.removeEventListener('pointerup', onPointer, true);
+			} else {
+				document.removeEventListener('mousedown', onPointer, true);
+				document.removeEventListener('mousemove', onPointer, true);
+				document.removeEventListener('mouseup', onPointer, true);
+			}
+
+			hasSetupGlobalListeners = false;
+		};
+	}, []);
+
+	return {getInteraction, isFocusVisible};
+}

--- a/packages/clay-tooltip/src/__tests__/index.tsx
+++ b/packages/clay-tooltip/src/__tests__/index.tsx
@@ -33,6 +33,8 @@ describe('ClayTooltip', () => {
 
 		expect(document.querySelector('.tooltip')).toBeFalsy();
 
+		fireEvent.mouseDown(document.body);
+
 		fireEvent.mouseOver(getByTestId('button'));
 
 		act(() => {
@@ -46,6 +48,32 @@ describe('ClayTooltip', () => {
 		act(() => {
 			jest.runAllTimers();
 		});
+
+		expect(document.querySelector('.tooltip')).toBeFalsy();
+	});
+
+	it('show tooltip on element focus and hide on blur', () => {
+		const {getByTestId} = render(
+			<ClayTooltipProvider>
+				<button
+					data-testid="button"
+					data-tooltip-align="bottom"
+					title="Bottom"
+				>
+					tooltip
+				</button>
+			</ClayTooltipProvider>
+		);
+
+		fireEvent.keyDown(document.body, {key: 'Tab'});
+
+		expect(document.querySelector('.tooltip')).toBeFalsy();
+
+		fireEvent.focus(getByTestId('button'));
+
+		expect(document.querySelector('.tooltip')).toBeTruthy();
+
+		fireEvent.blur(getByTestId('button'));
 
 		expect(document.querySelector('.tooltip')).toBeFalsy();
 	});

--- a/packages/clay-tooltip/src/useAlign.ts
+++ b/packages/clay-tooltip/src/useAlign.ts
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {doAlign, useMousePosition} from '@clayui/shared';
+import {alignPoint} from 'dom-align';
+import React, {useEffect} from 'react';
+
+const ALIGNMENTS = [
+	'top',
+	'top-right',
+	'right',
+	'bottom-right',
+	'bottom',
+	'bottom-left',
+	'left',
+	'top-left',
+] as const;
+
+const ALIGNMENTS_MAP = {
+	bottom: ['tc', 'bc'],
+	'bottom-left': ['tl', 'bl'],
+	'bottom-right': ['tr', 'br'],
+	left: ['cr', 'cl'],
+	right: ['cl', 'cr'],
+	top: ['bc', 'tc'],
+	'top-left': ['bl', 'tl'],
+	'top-right': ['br', 'tr'],
+} as const;
+
+const ALIGNMENTS_INVERSE_MAP = {
+	bctc: 'top',
+	bltl: 'top-left',
+	brtr: 'top-right',
+	clcr: 'right',
+	crcl: 'left',
+	tcbc: 'bottom',
+	tlbl: 'bottom-left',
+	trbr: 'bottom-right',
+} as const;
+
+const BOTTOM_OFFSET = [0, 7] as const;
+const LEFT_OFFSET = [-7, 0] as const;
+const RIGHT_OFFSET = [7, 0] as const;
+const TOP_OFFSET = [0, -7] as const;
+
+const OFFSET_MAP = {
+	bctc: TOP_OFFSET,
+	bltl: TOP_OFFSET,
+	brtr: TOP_OFFSET,
+	clcr: RIGHT_OFFSET,
+	crcl: LEFT_OFFSET,
+	tcbc: BOTTOM_OFFSET,
+	tlbl: BOTTOM_OFFSET,
+	trbr: BOTTOM_OFFSET,
+};
+
+const ALIGNMENTS_FORCE_MAP = {
+	...ALIGNMENTS_INVERSE_MAP,
+	bctc: 'top-left',
+	tcbc: 'bottom-left',
+} as const;
+
+export type Align = typeof ALIGNMENTS[number];
+
+type Props = {
+	align: Align;
+	autoAlign: boolean;
+	floating: boolean;
+	isOpen: boolean;
+	onAlign: (align: Align) => void;
+	sourceElement: React.MutableRefObject<HTMLElement | null>;
+	targetElement: React.MutableRefObject<HTMLElement | null>;
+};
+
+export function useAlign({
+	align,
+	autoAlign,
+	floating,
+	isOpen,
+	onAlign,
+	sourceElement,
+	targetElement,
+}: Props) {
+	const mousePosition = useMousePosition(20);
+
+	useEffect(() => {
+		if (sourceElement.current && isOpen && floating) {
+			const points = ALIGNMENTS_MAP[align || 'top'] as [string, string];
+
+			const [clientX, clientY] = mousePosition;
+
+			alignPoint(
+				sourceElement.current,
+				{
+					clientX,
+					clientY,
+				},
+				{
+					offset: OFFSET_MAP[
+						points.join('') as keyof typeof OFFSET_MAP
+					] as [number, number],
+					points,
+				}
+			);
+		}
+	}, [isOpen, floating]);
+
+	useEffect(() => {
+		if (targetElement.current && sourceElement.current && !floating) {
+			const points = ALIGNMENTS_MAP[align || 'top'] as [string, string];
+
+			const alignment = doAlign({
+				overflow: {
+					adjustX: autoAlign,
+					adjustY: autoAlign,
+				},
+				points,
+				sourceElement: sourceElement.current,
+				targetElement: targetElement.current,
+			});
+
+			const alignmentString = alignment.points.join(
+				''
+			) as keyof typeof ALIGNMENTS_INVERSE_MAP;
+
+			const pointsString = points.join('');
+
+			if (alignment.overflow.adjustX) {
+				onAlign(ALIGNMENTS_FORCE_MAP[alignmentString]);
+			} else if (pointsString !== alignmentString) {
+				onAlign(ALIGNMENTS_INVERSE_MAP[alignmentString]);
+			}
+		}
+	}, [align, isOpen]);
+}

--- a/packages/clay-tooltip/src/useClosestTitle.ts
+++ b/packages/clay-tooltip/src/useClosestTitle.ts
@@ -1,0 +1,170 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React, {useCallback, useRef} from 'react';
+
+function matches(
+	element: HTMLElement & {
+		msMatchesSelector?: HTMLElement['matches'];
+	},
+	selectorString: string
+) {
+	if (element.matches) {
+		return element.matches(selectorString);
+	} else if (element.msMatchesSelector) {
+		return element.msMatchesSelector(selectorString);
+	} else if (element.webkitMatchesSelector) {
+		return element.webkitMatchesSelector(selectorString);
+	} else {
+		return false;
+	}
+}
+
+function closestAncestor(node: HTMLElement, s: string) {
+	const element = node;
+	let ancestor: HTMLElement | null = node;
+
+	if (!document.documentElement.contains(element)) {
+		return null;
+	}
+
+	do {
+		if (matches(ancestor, s)) {
+			return ancestor;
+		}
+
+		ancestor = ancestor.parentElement;
+	} while (ancestor !== null);
+
+	return null;
+}
+
+type Props = {
+	onHide: () => void;
+	onClick: () => void;
+	tooltipRef: React.MutableRefObject<HTMLElement | null>;
+};
+
+export function useClosestTitle(props: Props) {
+	const targetRef = useRef<HTMLElement | null>(null);
+	const titleNodeRef = useRef<HTMLElement | null>(null);
+
+	const saveTitle = useCallback((element: HTMLElement) => {
+		titleNodeRef.current = element;
+
+		const title = element.getAttribute('title');
+
+		if (title) {
+			element.setAttribute('data-restore-title', title);
+			element.removeAttribute('title');
+		} else if (element.tagName === 'svg') {
+			const titleTag = element.querySelector('title');
+
+			if (titleTag) {
+				element.setAttribute('data-restore-title', titleTag.innerHTML);
+
+				titleTag.remove();
+			}
+		}
+	}, []);
+
+	const restoreTitle = useCallback(() => {
+		const element = titleNodeRef.current;
+
+		if (element) {
+			const title = element.getAttribute('data-restore-title');
+
+			if (title) {
+				if (element.tagName === 'svg') {
+					const titleTag = document.createElement('title');
+
+					titleTag.innerHTML = title;
+
+					element.appendChild(titleTag);
+				} else {
+					element.setAttribute('title', title);
+				}
+
+				element.removeAttribute('data-restore-title');
+			}
+
+			titleNodeRef.current = null;
+		}
+	}, []);
+
+	const onClick = useCallback((event?: any) => {
+		props.onClick();
+		// eslint-disable-next-line @typescript-eslint/no-use-before-define
+		onHide(event);
+	}, []);
+
+	const onHide = useCallback((event?: any) => {
+		if (
+			event &&
+			(props.tooltipRef.current?.contains(event.relatedTarget) ||
+				targetRef.current?.contains(event.relatedTarget))
+		) {
+			return null;
+		}
+
+		props.onHide();
+
+		restoreTitle();
+
+		if (targetRef.current) {
+			targetRef.current.removeEventListener('click', onClick);
+			targetRef.current = null;
+		}
+	}, []);
+
+	const getProps = useCallback(
+		(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+			if (targetRef.current) {
+				props.onClick();
+
+				if (onHide(event) === null) {
+					return;
+				}
+			}
+
+			const target = event.target as HTMLElement;
+
+			const hasTitle =
+				target &&
+				(target.hasAttribute('[title]') ||
+					target.hasAttribute('[data-title]'));
+
+			const node = hasTitle
+				? target
+				: closestAncestor(target, '[title], [data-title]');
+
+			if (node) {
+				targetRef.current = target;
+
+				target.addEventListener('click', onClick);
+
+				const title =
+					node.getAttribute('title') ||
+					node.getAttribute('data-title') ||
+					'';
+
+				saveTitle(node);
+
+				return {
+					align: node.getAttribute('data-tooltip-align'),
+					delay: node.getAttribute('data-tooltip-delay'),
+					floating: Boolean(
+						node.getAttribute('data-tooltip-floating')
+					),
+					setAsHTML: !!node.getAttribute('data-title-set-as-html'),
+					title,
+				};
+			}
+		},
+		[]
+	);
+
+	return {getProps, onHide, target: targetRef, titleNode: titleNodeRef};
+}

--- a/packages/clay-tooltip/src/useTooltipState.ts
+++ b/packages/clay-tooltip/src/useTooltipState.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useCallback, useRef, useState} from 'react';
+
+type Props = {
+	delay?: number;
+};
+
+export function useTooltipState({delay = 600}: Props) {
+	const [isOpen, setOpen] = useState(false);
+
+	const timeoutIdRef = useRef<any>();
+
+	const open = useCallback((immediate: boolean, customDelay?: number) => {
+		if (!immediate) {
+			clearTimeout(timeoutIdRef.current);
+
+			timeoutIdRef.current = setTimeout(
+				() => {
+					setOpen(true);
+				},
+				customDelay !== undefined ? customDelay : delay
+			);
+		} else {
+			setOpen(true);
+		}
+	}, []);
+
+	const close = useCallback(() => {
+		clearTimeout(timeoutIdRef.current);
+
+		setOpen(false);
+	}, []);
+
+	return {
+		close,
+		isOpen,
+		open,
+	};
+}


### PR DESCRIPTION
Fixes #5153

I had to make a lot of changes to be able to detect when the user is interacting with the elements using only the keyboard, mouse or screen reader, this helps us to identify to show the tooltip only when the user focuses on the element using the keyboard or screen reader, we have to differentiate this because for example clicking on the element also triggers a focus event. I implemented a hook in shared that helps us to identify which type of interaction, this will help us in other components and it works like a singleton because it needs to add several listeners on the page.

I also did a refactoring of the code to try to simplify the implementation to be able to identify when it is hovering or focusing on the element that has a title, that's because when it has focus it doesn't need a delay to show the tooltip.

There is a technical limitation in this tooltip implementation that we have, when focusing on an element using tab the tooltip will be shown and when using the mouse and hovering over the tooltip it will disappear, this is because the structure hierarchy affects the call of events, this starts in the container until you reach the tooltip element. This is exactly because we have a singleton that adds a listener in a global scope and receives the events via bubbling and this further damages the interaction between focus and mouseOver that we use to know when an element is hovering.