### PR TITLE
fix(@clayui/shared): fix error when fiberNode may come null

### DIFF
--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -160,7 +160,7 @@ const getFiber = (scope: React.RefObject<HTMLElement | null>) => {
 
 const getFocusableElementsInScope = (fiberNode: any) => {
 	const focusableElements: Array<any> = [];
-	const {child} = fiberNode.alternate ?? fiberNode;
+	const {child} = fiberNode?.alternate ?? fiberNode;
 
 	if (child !== null) {
 		collectFocusableElements(child, focusableElements);


### PR DESCRIPTION
This is a very small fix that happened in a test scenario in DXP, it seems that in some cases the `fiberNode` can return `null` which causes a TypeError to be thrown and the application breaks, from what I noticed this only happens in the test but it doesn't happen in the browser, so it may be some different behavior just in the tests.