### PR TITLE
fix(@clayui/shared): fix error when moving focus when reference is null

### DIFF
--- a/packages/clay-shared/src/FocusScope.tsx
+++ b/packages/clay-shared/src/FocusScope.tsx
@@ -112,14 +112,16 @@ export const FocusScope = ({
 					onKeyDown(event);
 				},
 				ref: (r: HTMLElement) => {
-					elRef.current = r;
-					const {ref} = child;
+					if (r) {
+						elRef.current = r;
+						const {ref} = child;
 
-					if (ref) {
-						if (typeof ref === 'object') {
-							ref.current = r;
-						} else if (typeof ref === 'function') {
-							ref(r);
+						if (ref) {
+							if (typeof ref === 'object') {
+								ref.current = r;
+							} else if (typeof ref === 'function') {
+								ref(r);
+							}
 						}
 					}
 				},

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -160,7 +160,7 @@ const getFiber = (scope: React.RefObject<HTMLElement | null>) => {
 
 const getFocusableElementsInScope = (fiberNode: any) => {
 	const focusableElements: Array<any> = [];
-	const {child} = fiberNode?.alternate ?? fiberNode;
+	const {child} = fiberNode.alternate ?? fiberNode;
 
 	if (child !== null) {
 		collectFocusableElements(child, focusableElements);


### PR DESCRIPTION
Related #5158

The previous PR wasn't fixing the root issue, for some reason this is only reproducible in some scenarios in DXP but doesn't fail in our tests.

The scope reference was being set to `null`, this is the default behavior of React when rendering the first time and then updating the reference. We had previously done so not to update the reference with the value `null` during the FocusScope lifecycle.