### PR TITLE
fix(@clayui/tooltip): fixes error when not aligning the tooltip with focus in sequence of elements

### DIFF
--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -21,15 +21,15 @@ import {useTooltipState} from './useTooltipState';
 interface IState {
 	align: Align;
 	floating: boolean;
-	message?: string;
 	setAsHTML?: boolean;
+	title?: string;
 }
 
 const initialState: IState = {
 	align: 'top',
 	floating: false,
-	message: '',
 	setAsHTML: false,
+	title: '',
 };
 
 const TRIGGER_HIDE_EVENTS = [
@@ -117,7 +117,7 @@ const TooltipProvider = ({
 	delay = 600,
 	scope,
 }: IPropsWithChildren | IPropsWithScope) => {
-	const [{align, floating, message = '', setAsHTML}, dispatch] = useReducer(
+	const [{align, floating, setAsHTML, title = ''}, dispatch] = useReducer(
 		reducer,
 		initialState
 	);
@@ -153,6 +153,7 @@ const TooltipProvider = ({
 		onAlign: useCallback((align) => dispatch({align, type: 'update'}), []),
 		sourceElement: tooltipRef,
 		targetElement: titleNode,
+		title,
 	});
 
 	const onShow = useCallback(
@@ -164,8 +165,8 @@ const TooltipProvider = ({
 					dispatch({
 						align: (props.align as any) ?? align,
 						floating: props.floating,
-						message: props.title,
 						setAsHTML: props.setAsHTML,
+						title: props.title,
 						type: 'update',
 					});
 					open(
@@ -281,7 +282,7 @@ const TooltipProvider = ({
 
 	const titleContent = contentRenderer({
 		targetNode: target.current,
-		title: message,
+		title,
 	});
 
 	const tooltip = isOpen && (

--- a/packages/clay-tooltip/src/useAlign.ts
+++ b/packages/clay-tooltip/src/useAlign.ts
@@ -72,6 +72,7 @@ type Props = {
 	onAlign: (align: Align) => void;
 	sourceElement: React.MutableRefObject<HTMLElement | null>;
 	targetElement: React.MutableRefObject<HTMLElement | null>;
+	title: string;
 };
 
 export function useAlign({
@@ -82,6 +83,7 @@ export function useAlign({
 	onAlign,
 	sourceElement,
 	targetElement,
+	title,
 }: Props) {
 	const mousePosition = useMousePosition(20);
 
@@ -108,7 +110,12 @@ export function useAlign({
 	}, [isOpen, floating]);
 
 	useEffect(() => {
-		if (targetElement.current && sourceElement.current && !floating) {
+		if (
+			targetElement.current &&
+			sourceElement.current &&
+			isOpen &&
+			!floating
+		) {
 			const points = ALIGNMENTS_MAP[align || 'top'] as [string, string];
 
 			const alignment = doAlign({
@@ -133,5 +140,5 @@ export function useAlign({
 				onAlign(ALIGNMENTS_INVERSE_MAP[alignmentString]);
 			}
 		}
-	}, [align, isOpen]);
+	}, [align, title, isOpen]);
 }


### PR DESCRIPTION
Fixes #5159

When focusing on elements in sequence that have the tooltip, the alignment wasn't being recalculated because the open state sometimes didn't change from false to true and onwards as long as it has blur and focus is called correctly.

This is because when you have the same state update in sequence, React interrupts the previous update for the latest one... I'm using the tooltip title to trigger the alignment.