### PR TITLE
feat(@clayui/core): add index data when moving item in TreeView

### DIFF
--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -67,6 +67,12 @@ interface ITreeViewProps<T>
 	itemNameKey?: string;
 
 	/**
+	 * The callback is called whenever there is an item dragging over
+	 * another item.
+	 */
+	onItemHover?: (item: T, parentItem: T, index: MoveItemIndex) => void;
+
+	/**
 	 * Callback is called when an item is about to be moved elsewhere in the tree.
 	 */
 	onItemMove?: (item: T, parentItem: T, index: MoveItemIndex) => boolean;
@@ -128,6 +134,7 @@ export function TreeView<T>({
 	items,
 	nestedKey = 'children',
 	onExpandedChange,
+	onItemHover,
 	onItemMove,
 	onItemsChange,
 	onLoadMore,
@@ -171,6 +178,7 @@ export function TreeView<T>({
 		expanderClassName,
 		expanderIcons,
 		nestedKey,
+		onItemHover,
 		onItemMove,
 		onLoadMore,
 		onRenameItem,

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -13,7 +13,7 @@ import {ChildrenFunction, Collection, ICollectionProps} from './Collection';
 import DragLayer from './DragLayer';
 import {TreeViewGroup} from './TreeViewGroup';
 import {TreeViewItem, TreeViewItemStack} from './TreeViewItem';
-import {Icons, OnLoadMore, TreeViewContext} from './context';
+import {Icons, MoveItemIndex, OnLoadMore, TreeViewContext} from './context';
 import {ITreeProps, useTree} from './useTree';
 
 interface ITreeViewProps<T>
@@ -69,7 +69,7 @@ interface ITreeViewProps<T>
 	/**
 	 * Callback is called when an item is about to be moved elsewhere in the tree.
 	 */
-	onItemMove?: (item: T, parentItem: T) => boolean;
+	onItemMove?: (item: T, parentItem: T, index: MoveItemIndex) => boolean;
 
 	/**
 	 * When a tree is very large, loading items (nodes) asynchronously is preferred to

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -23,6 +23,11 @@ export type OnLoadMore<T> = (
 	cursor?: any
 ) => Promise<Array<any> | undefined> | Promise<LoadMoreCursor | undefined>;
 
+export type MoveItemIndex = {
+	next: number;
+	previous: number;
+};
+
 export interface ITreeViewContext<T> extends ITreeState<T> {
 	childrenRoot: React.MutableRefObject<ChildrenFunction<Object> | null>;
 	dragAndDrop?: boolean;
@@ -31,7 +36,7 @@ export interface ITreeViewContext<T> extends ITreeState<T> {
 	expanderClassName?: string;
 	expanderIcons?: Icons;
 	nestedKey?: string;
-	onItemMove?: (item: T, parentItem: T) => boolean;
+	onItemMove?: (item: T, parentItem: T, index: MoveItemIndex) => boolean;
 	onLoadMore?: OnLoadMore<T>;
 	onSelect?: (item: T) => void;
 	onRenameItem?: (item: T) => Promise<any>;

--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -37,6 +37,7 @@ export interface ITreeViewContext<T> extends ITreeState<T> {
 	expanderIcons?: Icons;
 	nestedKey?: string;
 	onItemMove?: (item: T, parentItem: T, index: MoveItemIndex) => boolean;
+	onItemHover?: (item: T, parentItem: T, index: MoveItemIndex) => void;
 	onLoadMore?: OnLoadMore<T>;
 	onSelect?: (item: T) => void;
 	onRenameItem?: (item: T) => Promise<any>;

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -169,7 +169,11 @@ export function ItemContextProvider({children, value}: Props) {
 
 				const isMoved = onItemMove(
 					removeItemInternalProps((dragItem as Value).item),
-					tree.nodeByPath(indexes).parent
+					tree.nodeByPath(indexes).parent,
+					{
+						next: indexes[indexes.length - 1],
+						previous: (dragItem as Value).item.index,
+					}
 				);
 
 				if (!isMoved) {

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -51,6 +51,27 @@ function isMovingIntoItself(from: Array<number>, path: Array<number>) {
 	);
 }
 
+function getNewItemPath(item: Value, overPosition: Position) {
+	let indexes = [...item.indexes];
+	const lastIndex = indexes.pop();
+
+	switch (overPosition) {
+		case TARGET_POSITION.BOTTOM:
+			indexes = [...indexes, lastIndex! + 1];
+			break;
+		case TARGET_POSITION.MIDDLE:
+			indexes = [...indexes, lastIndex!, 0];
+			break;
+		case TARGET_POSITION.TOP:
+			indexes = [...indexes, lastIndex!];
+			break;
+		default:
+			break;
+	}
+
+	return indexes;
+}
+
 export function ItemContextProvider({children, value}: Props) {
 	const {
 		dragAndDrop,
@@ -58,6 +79,7 @@ export function ItemContextProvider({children, value}: Props) {
 		items,
 		layout,
 		nestedKey,
+		onItemHover,
 		onItemMove,
 		open,
 		reorder,
@@ -147,22 +169,7 @@ export function ItemContextProvider({children, value}: Props) {
 				return;
 			}
 
-			let indexes = [...item.indexes];
-			const lastIndex = indexes.pop();
-
-			switch (overPosition) {
-				case TARGET_POSITION.BOTTOM:
-					indexes = [...indexes, lastIndex! + 1];
-					break;
-				case TARGET_POSITION.MIDDLE:
-					indexes = [...indexes, lastIndex!, 0];
-					break;
-				case TARGET_POSITION.TOP:
-					indexes = [...indexes, lastIndex!];
-					break;
-				default:
-					break;
-			}
+			const indexes = getNewItemPath(item, overPosition!);
 
 			if (onItemMove) {
 				const tree = createImmutableTree(items as any, nestedKey!);
@@ -210,19 +217,37 @@ export function ItemContextProvider({children, value}: Props) {
 			).getBoundingClientRect();
 			const clientOffsetY = monitor.getClientOffset()!.y;
 
+			let currentPosition: Position = TARGET_POSITION.MIDDLE;
+
 			if (
 				clientOffsetY <
 				dropItemRect.height * DISTANCE + dropItemRect.top
 			) {
-				setOverPosition(TARGET_POSITION.TOP);
+				currentPosition = TARGET_POSITION.TOP;
 			} else if (
 				clientOffsetY >
 				dropItemRect.bottom - dropItemRect.height * DISTANCE
 			) {
-				setOverPosition(TARGET_POSITION.BOTTOM);
-			} else {
-				setOverPosition(TARGET_POSITION.MIDDLE);
+				currentPosition = TARGET_POSITION.BOTTOM;
 			}
+
+			if (onItemHover) {
+				const tree = createImmutableTree(items as any, nestedKey!);
+				const indexes = getNewItemPath(item, currentPosition);
+
+				onItemHover(
+					removeItemInternalProps(
+						(dragItem as unknown as Value).item
+					),
+					tree.nodeByPath(indexes).parent,
+					{
+						next: indexes[indexes.length - 1],
+						previous: (dragItem as unknown as Value).item.index,
+					}
+				);
+			}
+
+			setOverPosition(currentPosition);
 		},
 	});
 


### PR DESCRIPTION
Closes #5141

This is a draft PR, I should add another `onItemHover` API tomorrow and add some usage examples. There is one consideration is that `onItemHover` probably doesn't block any or disable the item from being droppable, so you will have to have the support of a state outside the TreeView to do the conditional using the `draggable` API on the Item. I will study if we can do something internally to improve the DX of use.