### PR TITLE
fix(@clayui/shared): add prop to move focus only if in scope

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -188,7 +188,7 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-shared/src/': {
-			branches: 41,
+			branches: 40,
 			functions: 24,
 			lines: 52,
 			statements: 54,

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -313,7 +313,7 @@ function ClayDropDown<T>({
 									// to commit the changes to the DOM so that the elements are
 									// visible and we can move the focus.
 									setTimeout(() => {
-										focusManager.focusNext();
+										focusManager.focusNext(true);
 									}, 10);
 								}}
 							>

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -173,7 +173,11 @@ export function useFocusManagement(scope: React.RefObject<null | HTMLElement>) {
 	const nextFocusInDocRef = React.useRef<HTMLElement | null>(null);
 	const prevFocusInDocRef = React.useRef<HTMLElement | null>(null);
 
-	const moveFocusInScope = (scope: any, backwards: boolean = false) => {
+	const moveFocusInScope = (
+		scope: any,
+		backwards: boolean = false,
+		persistOnScope: boolean = false
+	) => {
 		const fiberFocusElements = getFocusableElementsInScope(scope);
 
 		if (fiberFocusElements.length === 0) {
@@ -201,6 +205,14 @@ export function useFocusManagement(scope: React.RefObject<null | HTMLElement>) {
 
 		const nextFocusInFiber = fiberFocusElements[reactFiberPosition + 1];
 		const prevFocusInFiber = fiberFocusElements[reactFiberPosition - 1];
+
+		// Only moves to the next element if it is in scope.
+		if (
+			persistOnScope &&
+			(!nextFocusInFiber || (backwards && !prevFocusInFiber))
+		) {
+			return null;
+		}
 
 		// If these two nodes are not equal, that means React is likely using
 		// a portal to render the node in a different part of the DOM. When
@@ -257,7 +269,9 @@ export function useFocusManagement(scope: React.RefObject<null | HTMLElement>) {
 	};
 
 	return {
-		focusNext: () => moveFocusInScope(getFiber(scope)),
-		focusPrevious: () => moveFocusInScope(getFiber(scope), true),
+		focusNext: (persistOnScope?: boolean) =>
+			moveFocusInScope(getFiber(scope), false, persistOnScope),
+		focusPrevious: (persistOnScope?: boolean) =>
+			moveFocusInScope(getFiber(scope), true, persistOnScope),
 	};
 }


### PR DESCRIPTION
Well this PR fixes two types of behavior, one when the Menu has no focusable element the focus manager moved the focus out of scope, now we have an option that we can tell the focus manager to move the focus only to some element within the scope.

Another behavior is that `fiber.alternate` sometimes has the old reference of the element and may not find the focusable elements of the menu, as a second attempt when it doesn't find these elements, we try to navigate through `fiber.child` in search of focusable elements.