### PR TITLE
fix(@clayui/drop-down): fixes Drilldown accessibility issues

### DIFF
--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {InternalDispatch} from '@clayui/shared';
+import {InternalDispatch, useInteractionFocus, useInternalState} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useEffect, useRef, useState} from 'react';
 
@@ -130,16 +130,16 @@ export const ClayDropDownWithDrilldown = ({
 	const [direction, setDirection] = useState<'prev' | 'next'>();
 	const [history, setHistory] = useState<Array<History>>([]);
 
+	const {isFocusVisible} = useInteractionFocus();
+
 	const focusHistory = useRef<Array<HTMLElement>>([]);
 
 	const innerRef = useRef<HTMLDivElement>(null);
 
-	const isKeyboard = useRef<boolean>(false);
-
 	const menuIds = Object.keys(menus);
 
 	useEffect(() => {
-		if (!isKeyboard.current) {
+		if (!isFocusVisible()) {
 			return;
 		}
 
@@ -220,13 +220,6 @@ export const ClayDropDownWithDrilldown = ({
 								setDirection('next');
 
 								setActiveMenu(childId);
-							}}
-							onKeyDown={(event) => {
-								if (event.key !== 'Enter') {
-									isKeyboard.current = false;
-								} else {
-									isKeyboard.current = true;
-								}
 							}}
 							spritemap={spritemap}
 						/>

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -122,7 +122,7 @@ export const ClayDropDownWithDrilldown = ({
 	alignmentPosition,
 	className,
 	containerElement,
-	defaultActive,
+	defaultActive = false,
 	defaultActiveMenu,
 	initialActiveMenu,
 	menuElementAttrs,
@@ -146,6 +146,15 @@ export const ClayDropDownWithDrilldown = ({
 	const [history, setHistory] = useState<Array<History>>([]);
 
 	const {isFocusVisible} = useInteractionFocus();
+
+	const [active, setActive] = useInternalState({
+		defaultName: 'defaultActive',
+		defaultValue: defaultActive,
+		handleName: 'onActiveChange',
+		name: 'active',
+		onChange: onActiveChange,
+		value: externalActive,
+	});
 
 	const focusHistory = useRef<Array<HTMLElement>>([]);
 
@@ -189,7 +198,6 @@ export const ClayDropDownWithDrilldown = ({
 			alignmentPosition={alignmentPosition}
 			className={className}
 			containerElement={containerElement}
-			defaultActive={defaultActive}
 			hasRightSymbols
 			menuElementAttrs={{
 				...menuElementAttrs,
@@ -198,7 +206,16 @@ export const ClayDropDownWithDrilldown = ({
 			menuHeight={menuHeight}
 			menuWidth={menuWidth}
 			offsetFn={offsetFn}
-			onActiveChange={onActiveChange}
+			onActiveChange={(value: boolean) => {
+				if (!active) {
+					setActiveMenu(defaultActiveMenu);
+					focusHistory.current = [];
+					setHistory([]);
+					setDirection('prev');
+				}
+
+				setActive(value);
+			}}
 			renderMenuOnClick={renderMenuOnClick}
 			trigger={trigger}
 		>

--- a/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -3,13 +3,19 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {InternalDispatch, useInteractionFocus, useInternalState} from '@clayui/shared';
+import {
+	InternalDispatch,
+	useInteractionFocus,
+	useInternalState,
+} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useEffect, useRef, useState} from 'react';
 
 import ClayDropDown from './DropDown';
 import ClayDropDownMenu from './Menu';
 import Drilldown from './drilldown';
+
+import type {Messages} from './drilldown';
 
 export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
@@ -61,16 +67,21 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 		typeof ClayDropDown
 	>['menuElementAttrs'];
 
+	menuHeight?: React.ComponentProps<typeof ClayDropDown>['menuHeight'];
+
+	menuWidth?: React.ComponentProps<typeof ClayDropDown>['menuWidth'];
+
+	/**
+	 * Messages for drilldown.
+	 */
+	messages?: Messages;
+
 	/**
 	 * Map of menus and items to be used in the drilldown. Each key should be a unique identifier for the menu.
 	 */
 	menus: {
 		[id: string]: React.ComponentProps<typeof Drilldown.Menu>['items'];
 	};
-
-	menuHeight?: React.ComponentProps<typeof ClayDropDown>['menuHeight'];
-
-	menuWidth?: React.ComponentProps<typeof ClayDropDown>['menuWidth'];
 
 	/**
 	 * Function for setting the offset of the menu from the trigger.
@@ -106,7 +117,7 @@ type History = {
 };
 
 export const ClayDropDownWithDrilldown = ({
-	active,
+	active: externalActive,
 	alignmentByViewport,
 	alignmentPosition,
 	className,
@@ -118,6 +129,10 @@ export const ClayDropDownWithDrilldown = ({
 	menuHeight,
 	menuWidth,
 	menus,
+	messages = {
+		back: '',
+		goTo: '',
+	},
 	offsetFn,
 	onActiveChange,
 	renderMenuOnClick,
@@ -200,6 +215,7 @@ export const ClayDropDownWithDrilldown = ({
 							}
 							items={menus[menuKey]}
 							key={menuKey}
+							messages={messages}
 							onBack={() => {
 								const [parent] = history.slice(-1);
 

--- a/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
+++ b/packages/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
@@ -166,7 +166,7 @@ describe('ClayDropDownWithDrilldown', () => {
 		const {getByTestId} = render(
 			<ClayDropDownWithDrilldown
 				active={false}
-				initialActiveMenu="x0a3"
+				defaultActiveMenu="x0a3"
 				menus={{
 					x0a3: [
 						{onClick: onActiveChange, title: 'Toggle'},

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -46,6 +46,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   data-testid="menu-item-Hash Link"
                   href="#"
                   role="menuitem"
+                  tabindex="-1"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"
@@ -61,6 +62,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Alert!"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -77,6 +79,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -118,6 +121,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   data-testid="menu-item-2nd hash link"
                   href="#"
                   role="menuitem"
+                  tabindex="-1"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"
@@ -133,6 +137,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -173,6 +178,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-The"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -189,6 +195,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-End"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -253,6 +260,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                   data-testid="menu-item-Hash Link"
                   href="#"
                   role="menuitem"
+                  tabindex="-1"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"
@@ -272,6 +280,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Alert!"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -292,6 +301,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -333,6 +343,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                   data-testid="menu-item-2nd hash link"
                   href="#"
                   role="menuitem"
+                  tabindex="-1"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"
@@ -352,6 +363,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -392,6 +404,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-The"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -412,6 +425,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-End"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -491,6 +505,7 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Toggle"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -507,6 +522,7 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
                   class="dropdown-item btn btn-unstyled"
                   data-testid="menu-item-Subnav"
                   role="menuitem"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -548,6 +564,7 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
                   data-testid="menu-item-2nd hash link"
                   href="#"
                   role="menuitem"
+                  tabindex="-1"
                 >
                   <span
                     class="dropdown-item-indicator-text-end"

--- a/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
+++ b/packages/clay-drop-down/src/__tests__/__snapshots__/DropDownWithDrilldown.tsx.snap
@@ -31,7 +31,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
           class="drilldown-inner"
         >
           <div
-            aria-hidden="true"
+            aria-hidden="false"
             class="drilldown-item drilldown-current"
           >
             <ul
@@ -85,7 +85,9 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                     Subnav
                   </span>
                   <span
+                    aria-label=" Subnav"
                     class="dropdown-item-indicator-end"
+                    title=" Subnav"
                   >
                     <svg
                       class="lexicon-icon lexicon-icon-angle-right"
@@ -101,7 +103,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
             </ul>
           </div>
           <div
-            aria-hidden="false"
+            aria-hidden="true"
             class="drilldown-item"
           >
             <ul
@@ -139,7 +141,9 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
                     Subnav
                   </span>
                   <span
+                    aria-label=" Subnav"
                     class="dropdown-item-indicator-end"
+                    title=" Subnav"
                   >
                     <svg
                       class="lexicon-icon lexicon-icon-angle-right"
@@ -155,7 +159,7 @@ exports[`ClayDropDownWithDrilldown renders 1`] = `
             </ul>
           </div>
           <div
-            aria-hidden="false"
+            aria-hidden="true"
             class="drilldown-item"
           >
             <ul
@@ -235,7 +239,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
         >
           <div
             aria-hidden="true"
-            class="drilldown-item drilldown-current"
+            class="drilldown-item"
           >
             <ul
               class="inline-scroller"
@@ -296,7 +300,9 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                     Subnav
                   </span>
                   <span
+                    aria-label=" Subnav"
                     class="dropdown-item-indicator-end"
+                    title=" Subnav"
                   >
                     <svg
                       class="lexicon-icon lexicon-icon-angle-right"
@@ -312,7 +318,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
             </ul>
           </div>
           <div
-            aria-hidden="false"
+            aria-hidden="true"
             class="drilldown-item"
           >
             <ul
@@ -354,7 +360,9 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
                     Subnav
                   </span>
                   <span
+                    aria-label=" Subnav"
                     class="dropdown-item-indicator-end"
+                    title=" Subnav"
                   >
                     <svg
                       class="lexicon-icon lexicon-icon-angle-right"
@@ -370,7 +378,7 @@ exports[`ClayDropDownWithDrilldown renders dividers 1`] = `
             </ul>
           </div>
           <div
-            aria-hidden="false"
+            aria-hidden="true"
             class="drilldown-item"
           >
             <ul
@@ -469,7 +477,7 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
           class="drilldown-inner"
         >
           <div
-            aria-hidden="true"
+            aria-hidden="false"
             class="drilldown-item drilldown-current"
           >
             <ul
@@ -507,7 +515,9 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
                     Subnav
                   </span>
                   <span
+                    aria-label=" Subnav"
                     class="dropdown-item-indicator-end"
+                    title=" Subnav"
                   >
                     <svg
                       class="lexicon-icon lexicon-icon-angle-right"
@@ -523,7 +533,7 @@ exports[`ClayDropDownWithDrilldown the menu can be toggled by clicking in an ite
             </ul>
           </div>
           <div
-            aria-hidden="false"
+            aria-hidden="true"
             class="drilldown-item"
           >
             <ul

--- a/packages/clay-drop-down/src/drilldown/Menu.tsx
+++ b/packages/clay-drop-down/src/drilldown/Menu.tsx
@@ -14,6 +14,11 @@ import Divider from '../Divider';
 
 type TType = 'divider';
 
+export type Messages = {
+	goTo: string;
+	back: string;
+};
+
 export interface IItem extends React.ComponentProps<typeof LinkOrButton> {
 	child?: string;
 	title?: string;
@@ -27,6 +32,7 @@ export interface IProps {
 	direction?: 'prev' | 'next';
 	header?: string;
 	items: Array<IItem>;
+	messages: Messages;
 	onBack: () => void;
 	onForward: (title: string, child: string) => void;
 	spritemap?: string;
@@ -37,6 +43,7 @@ const DrilldownMenu = ({
 	direction,
 	header,
 	items,
+	messages,
 	onBack,
 	onForward,
 	spritemap,
@@ -69,10 +76,12 @@ const DrilldownMenu = ({
 							onClick={onBack}
 						>
 							<ClayButtonWithIcon
+								aria-label={messages.back}
 								className="component-action dropdown-item-indicator-start"
 								onClick={onBack}
 								spritemap={spritemap}
 								symbol="angle-left"
+								title={messages.back}
 							/>
 
 							<span className="dropdown-item-indicator-text-start">
@@ -138,7 +147,11 @@ const DrilldownMenu = ({
 											</span>
 
 											{child && (
-												<span className="dropdown-item-indicator-end">
+												<span
+													aria-label={`${messages.goTo} ${title}`}
+													className="dropdown-item-indicator-end"
+													title={`${messages.goTo} ${title}`}
+												>
 													<ClayIcon
 														spritemap={spritemap}
 														symbol="angle-right"

--- a/packages/clay-drop-down/src/drilldown/Menu.tsx
+++ b/packages/clay-drop-down/src/drilldown/Menu.tsx
@@ -81,6 +81,7 @@ const DrilldownMenu = ({
 								onClick={onBack}
 								spritemap={spritemap}
 								symbol="angle-left"
+								tabIndex={-1}
 								title={messages.back}
 							/>
 
@@ -132,6 +133,7 @@ const DrilldownMenu = ({
 												}
 											}}
 											role="menuitem"
+											tabIndex={-1}
 										>
 											{symbol && (
 												<span className="dropdown-item-indicator-start">

--- a/packages/clay-drop-down/src/drilldown/Menu.tsx
+++ b/packages/clay-drop-down/src/drilldown/Menu.tsx
@@ -29,7 +29,6 @@ export interface IProps {
 	items: Array<IItem>;
 	onBack: () => void;
 	onForward: (title: string, child: string) => void;
-	onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
 	spritemap?: string;
 }
 
@@ -40,7 +39,6 @@ const DrilldownMenu = ({
 	items,
 	onBack,
 	onForward,
-	onKeyDown,
 	spritemap,
 }: IProps) => {
 	const initialClasses = classNames('transitioning', {
@@ -73,7 +71,6 @@ const DrilldownMenu = ({
 							<ClayButtonWithIcon
 								className="component-action dropdown-item-indicator-start"
 								onClick={onBack}
-								onKeyDown={onKeyDown}
 								spritemap={spritemap}
 								symbol="angle-left"
 							/>
@@ -125,7 +122,6 @@ const DrilldownMenu = ({
 													onForward(title, child);
 												}
 											}}
-											onKeyDown={onKeyDown}
 											role="menuitem"
 										>
 											{symbol && (

--- a/packages/clay-drop-down/src/drilldown/Menu.tsx
+++ b/packages/clay-drop-down/src/drilldown/Menu.tsx
@@ -49,7 +49,7 @@ const DrilldownMenu = ({
 
 	return (
 		<CSSTransition
-			aria-hidden={active}
+			aria-hidden={!active}
 			className={classNames('drilldown-item', {
 				'drilldown-current': active,
 			})}

--- a/packages/clay-drop-down/src/drilldown/index.tsx
+++ b/packages/clay-drop-down/src/drilldown/index.tsx
@@ -8,6 +8,8 @@ import React from 'react';
 
 import Menu from './Menu';
 
+import type {Messages} from './Menu';
+
 const Inner = React.forwardRef<
 	HTMLDivElement,
 	React.HTMLAttributes<HTMLDivElement>
@@ -26,4 +28,5 @@ const Inner = React.forwardRef<
 	);
 });
 
+export type {Messages};
 export default {Inner, Menu};

--- a/packages/clay-drop-down/stories/DropDown.stories.tsx
+++ b/packages/clay-drop-down/stories/DropDown.stories.tsx
@@ -391,7 +391,7 @@ export const AlignmentPositions = () => (
 
 export const Drilldown = (args: any) => (
 	<ClayDropDownWithDrilldown
-		initialActiveMenu="x0a3"
+		defaultActiveMenu="x0a3"
 		menus={{
 			x0a3: [
 				{href: '#', title: 'Hash Link'},
@@ -406,6 +406,10 @@ export const Drilldown = (args: any) => (
 				{child: 'x0a5', title: 'Subnav'},
 			],
 			x0a5: [{title: 'The'}, {type: 'divider'}, {title: 'End'}],
+		}}
+		messages={{
+			back: 'Back',
+			goTo: 'Go to',
 		}}
 		renderMenuOnClick={args.renderMenuOnClick}
 		trigger={<ClayButton>Click Me</ClayButton>}
@@ -426,7 +430,7 @@ export const DrillDownWithActive = () => {
 	return (
 		<ClayDropDownWithDrilldown
 			active={active}
-			initialActiveMenu="x0a3"
+			defaultActiveMenu="x0a3"
 			menus={{
 				x0a3: [
 					{href: '#', title: 'Hash Link'},
@@ -444,6 +448,10 @@ export const DrillDownWithActive = () => {
 					{child: 'x0a5', title: 'Subnav'},
 				],
 				x0a5: [{title: 'The'}, {title: 'End'}],
+			}}
+			messages={{
+				back: 'Back',
+				goTo: 'Go to',
 			}}
 			onActiveChange={onActiveChange}
 			trigger={<ClayButton>Click Me</ClayButton>}


### PR DESCRIPTION
Related #5041

This PR fixes some accessibility issues that exist in Drilldown, some like `aria-hidden="true"` for the active menu and not exposing an API to add aria-label to buttons with unlabeled actions for example.

I also noticed that there are some cases that this component is not covering according to the documentation https://docs.google.com/document/d/1PVQwknqVIOQhf2JL0kEv0k6WHOExKOskiX-CxxWYRqs/edit#, so maybe a review is needed on this component, I should create a separate issue to deal with it.