### PR TITLE
fix(@clayui/tabs): fix error when trying to clone an invalid element

### DIFF
--- a/packages/clay-tabs/src/Content.tsx
+++ b/packages/clay-tabs/src/Content.tsx
@@ -15,7 +15,7 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
 	 * Children elements received from ClayTabs.Content component.
 	 */
-	children: Array<React.ReactElement>;
+	children: React.ReactNode;
 
 	/**
 	 * Flag to indicate if `fade` classname that applies an fading animation should be applied.
@@ -33,15 +33,16 @@ const Content = ({
 	return (
 		<div className={classNames('tab-content', className)} {...otherProps}>
 			{React.Children.map(children, (child, index) => {
-				return (
-					child &&
-					React.cloneElement(child, {
-						...child.props,
-						active: activeIndex === index,
-						fade,
-						key: index,
-					})
-				);
+				if (!React.isValidElement(child)) {
+					return child;
+				}
+
+				return React.cloneElement(child, {
+					...child.props,
+					active: activeIndex === index,
+					fade,
+					key: index,
+				});
 			})}
 		</div>
 	);

--- a/packages/clay-tabs/src/__tests__/index.tsx
+++ b/packages/clay-tabs/src/__tests__/index.tsx
@@ -148,4 +148,28 @@ describe('ClayTabs', () => {
 		fireEvent.click(tabItems[1]);
 		expect(onClick).toBeCalled();
 	});
+
+	it('renders elements not valid tabs should continue to work', () => {
+		const {getAllByRole} = render(
+			<>
+				<ClayTabs>
+					{false && <ClayTabs.Item active>One</ClayTabs.Item>}
+					<ClayTabs.Item>Two</ClayTabs.Item>
+				</ClayTabs>
+				<ClayTabs.Content activeIndex={1}>
+					{false && <ClayTabs.TabPane>Content One</ClayTabs.TabPane>}
+					<ClayTabs.TabPane>Content Two</ClayTabs.TabPane>
+				</ClayTabs.Content>
+			</>
+		);
+
+		const tabItems = getAllByRole('tab');
+		const tabPanels = getAllByRole('tabpanel');
+
+		expect(tabItems[0].innerHTML).toBe('Two');
+		expect(tabItems.length).toBe(1);
+
+		expect(tabPanels[0].innerHTML).toBe('Content Two');
+		expect(tabPanels.length).toBe(1);
+	});
 });

--- a/packages/clay-tabs/src/index.tsx
+++ b/packages/clay-tabs/src/index.tsx
@@ -145,8 +145,12 @@ function ClayTabs({
 			ref={tabsRef}
 			role="tablist"
 		>
-			{React.Children.map(children, (child, index) =>
-				React.cloneElement(child as React.ReactElement, {
+			{React.Children.map(children, (child, index) => {
+				if (!React.isValidElement(child)) {
+					return child;
+				}
+
+				return React.cloneElement(child as React.ReactElement, {
 					active:
 						(child as React.ReactElement).props.active !== undefined
 							? (child as React.ReactElement).props.active
@@ -162,8 +166,8 @@ function ClayTabs({
 							setActive(index);
 						}
 					},
-				})
-			)}
+				});
+			})}
 		</ul>
 	);
 }


### PR DESCRIPTION
Fixes #5169

This prevents the child from being cloned when it is not a valid React element. Adding conditionals in the content rendering breaks the control via index, this is not recommended. It is intentional that this happens here because we could do a filter before doing the clone but that would be a quadratic iteration that I want to avoid and we will support activating tabs in other ways with the help of the collection pattern #5172.