### PR TITLE
feat(@clayui/color-picker): Convert to use 8 digit hex colors and add alpha slider

### DIFF
--- a/packages/clay-color-picker/package.json
+++ b/packages/clay-color-picker/package.json
@@ -31,6 +31,7 @@
 		"@clayui/form": "^3.79.0",
 		"@clayui/icon": "^3.56.0",
 		"@clayui/shared": "^3.79.0",
+		"@clayui/slider": "^3.78.3",
 		"classnames": "^2.2.6",
 		"tinycolor2": "^1.4.2"
 	},

--- a/packages/clay-color-picker/src/Alpha.tsx
+++ b/packages/clay-color-picker/src/Alpha.tsx
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: © 2019 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ClayInput} from '@clayui/form';
+import ClaySlider from '@clayui/slider';
+import React, {useState} from 'react';
+
+type Props = {
+	/**
+	 * Callback function for when the hue value changes
+	 */
+	onChange: (event: any) => void;
+
+	/**
+	 * The inline styles to add on ClaySlider
+	 */
+	style: {
+		color: string;
+	};
+
+	/**
+	 * The value of the alpha transparency
+	 */
+	value: number;
+};
+
+/**
+ * Renders Alpha component
+ */
+const ClayColorPickerAlpha = ({
+	style,
+	value = 0,
+	onChange = () => {},
+}: Props) => {
+	const [alpha, setAlpha] = useState(value);
+
+	const handleOnChangeEnd = (event: any) => {
+		setAlpha(event.target.value);
+
+		onChange(event);
+
+		event.target.blur();
+
+		event.target.focus();
+	};
+
+	React.useEffect(() => {
+		setAlpha(value);
+	}, [value]);
+
+	return (
+		<div className="clay-color-form-group">
+			<ClaySlider
+				className="clay-color-slider clay-color-slider-alpha"
+				max={1}
+				min={0}
+				onChange={setAlpha}
+				onKeyUp={(event) => {
+					const arrowKeys = [
+						'ArrowDown',
+						'ArrowLeft',
+						'ArrowRight',
+						'ArrowUp',
+					];
+
+					if (arrowKeys.indexOf(event.key) > -1) {
+						handleOnChangeEnd(event);
+					}
+				}}
+				onPointerUp={handleOnChangeEnd}
+				showTooltip={false}
+				step={0.01}
+				style={style}
+				value={alpha}
+			/>
+			<ClayInput.Group>
+				<ClayInput.GroupItem>
+					<ClayInput
+						data-testid="aInput"
+						insetBefore
+						max="1"
+						min="0"
+						onChange={(event) => {
+							const val = event.target.value;
+
+							let newVal = Number(val);
+
+							if (newVal < 0) {
+								newVal = 0;
+							} else if (newVal > 1) {
+								newVal = 1;
+							}
+
+							setAlpha(newVal);
+						}}
+						step="0.01"
+						type="number"
+						value={alpha}
+					/>
+					<ClayInput.GroupInsetItem before tag="label">
+						A
+					</ClayInput.GroupInsetItem>
+				</ClayInput.GroupItem>
+			</ClayInput.Group>
+		</div>
+	);
+};
+
+export default ClayColorPickerAlpha;

--- a/packages/clay-color-picker/src/Alpha.tsx
+++ b/packages/clay-color-picker/src/Alpha.tsx
@@ -9,16 +9,14 @@ import React, {useState} from 'react';
 
 type Props = {
 	/**
-	 * Callback function for when the hue value changes
+	 * Sets the color on ClaySlider form-control-range
 	 */
-	onChange: (event: any) => void;
+	color: string;
 
 	/**
-	 * The inline styles to add on ClaySlider
+	 * Callback function for when the hue value changes
 	 */
-	style: {
-		color: string;
-	};
+	onChange: (event: React.KeyboardEvent<HTMLInputElement>) => void;
 
 	/**
 	 * The value of the alpha transparency
@@ -29,11 +27,7 @@ type Props = {
 /**
  * Renders Alpha component
  */
-const ClayColorPickerAlpha = ({
-	style,
-	value = 0,
-	onChange = () => {},
-}: Props) => {
+const ClayColorPickerAlpha = ({color, onChange, value = 0}: Props) => {
 	const [alpha, setAlpha] = useState(value);
 
 	const handleOnChangeEnd = (event: any) => {
@@ -72,7 +66,9 @@ const ClayColorPickerAlpha = ({
 				onPointerUp={handleOnChangeEnd}
 				showTooltip={false}
 				step={0.01}
-				style={style}
+				style={{
+					color,
+				}}
 				value={alpha}
 			/>
 			<ClayInput.Group>

--- a/packages/clay-color-picker/src/Editor.tsx
+++ b/packages/clay-color-picker/src/Editor.tsx
@@ -123,10 +123,11 @@ type Props = {
 	colors: Array<string>;
 	hex: string;
 	hue: number;
+	internalToHex: (value: Instance) => string;
 	onChange: (color: Instance, active: boolean) => void;
 	onColorChange: (color: Instance) => void;
-	onHueChange: (value: number) => void;
 	onHexChange: (value: string) => void;
+	onHueChange: (value: number) => void;
 };
 
 export function Editor({
@@ -134,6 +135,7 @@ export function Editor({
 	colors,
 	hex,
 	hue,
+	internalToHex,
 	onChange,
 	onColorChange,
 	onHexChange,
@@ -208,12 +210,10 @@ export function Editor({
 			</div>
 
 			<Alpha
-				onChange={(event) => {
+				color={`#${color.toHex()}`}
+				onChange={(event: any) => {
 					setAlpha(event.target.value);
 					onColorChange(color.setAlpha(event.target.value));
-				}}
-				style={{
-					color: `#${color.toHex()}`,
 				}}
 				value={alpha}
 			/>
@@ -231,9 +231,9 @@ export function Editor({
 									);
 
 									if (newColor.isValid()) {
-										onHexChange(newColor.toHex8());
+										onHexChange(internalToHex(newColor));
 									} else {
-										onHexChange(color.toHex8());
+										onHexChange(internalToHex(color));
 									}
 								}}
 								onChange={(event) => {
@@ -255,7 +255,11 @@ export function Editor({
 									}
 								}}
 								type="text"
-								value={hex.toUpperCase().substring(0, 8)}
+								value={
+									hex.toUpperCase().slice(-2) === 'FF'
+										? hex.toUpperCase().substring(0, 6)
+										: hex
+								}
 							/>
 
 							<ClayInput.GroupInsetItem before tag="label">

--- a/packages/clay-color-picker/src/Editor.tsx
+++ b/packages/clay-color-picker/src/Editor.tsx
@@ -7,6 +7,7 @@ import ClayForm, {ClayInput} from '@clayui/form';
 import React, {useEffect, useReducer, useRef, useState} from 'react';
 import tinycolor from 'tinycolor2';
 
+import Alpha from './Alpha';
 import GradientSelector from './GradientSelector';
 import Hue from './Hue';
 import {findColorIndex} from './util';
@@ -37,7 +38,7 @@ export function useEditor(
 		);
 
 		return {
-			hex: color.toHex(),
+			hex: color.toHex8(),
 			hue: color.toHsv().h,
 			splotch: index !== -1 ? index : undefined,
 		};
@@ -147,8 +148,28 @@ export function Editor({
 		[b, 'b'],
 	];
 
+	const [alpha, setAlpha] = useState<number>(1);
+
+	React.useEffect(() => {
+		let currentAlpha = color.getAlpha();
+
+		if (currentAlpha !== 0 && currentAlpha !== 1) {
+			currentAlpha = +currentAlpha.toFixed(2);
+		}
+
+		setAlpha(currentAlpha);
+	}, [alpha, color]);
+
 	return (
 		<>
+			<Hue
+				onChange={(hue) => {
+					onHueChange(hue);
+					onColorChange(tinycolor({h: hue, s, v}).setAlpha(alpha));
+				}}
+				value={hue}
+			/>
+
 			<div className="clay-color-map-group">
 				<GradientSelector
 					color={color}
@@ -159,7 +180,7 @@ export function Editor({
 								h: hue,
 								s: saturation,
 								v: visibility,
-							})
+							}).setAlpha(alpha)
 						);
 					}}
 				/>
@@ -186,12 +207,15 @@ export function Editor({
 				</div>
 			</div>
 
-			<Hue
-				onChange={(hue) => {
-					onHueChange(hue);
-					onColorChange(tinycolor({h: hue, s, v}));
+			<Alpha
+				onChange={(event) => {
+					setAlpha(event.target.value);
+					onColorChange(color.setAlpha(event.target.value));
 				}}
-				value={hue}
+				style={{
+					color: `#${color.toHex()}`,
+				}}
+				value={alpha}
 			/>
 
 			<div className="clay-color-footer">
@@ -207,9 +231,9 @@ export function Editor({
 									);
 
 									if (newColor.isValid()) {
-										onHexChange(newColor.toHex());
+										onHexChange(newColor.toHex8());
 									} else {
-										onHexChange(color.toHex());
+										onHexChange(color.toHex8());
 									}
 								}}
 								onChange={(event) => {
@@ -231,7 +255,7 @@ export function Editor({
 									}
 								}}
 								type="text"
-								value={hex.toUpperCase().substring(0, 6)}
+								value={hex.toUpperCase().substring(0, 8)}
 							/>
 
 							<ClayInput.GroupInsetItem before tag="label">

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -209,6 +209,15 @@ exports[`Interactions color editor interactions ability to change color of click
           </div>
         </div>
         <div
+          class="clay-color-range clay-color-range-hue"
+        >
+          <button
+            class="clay-color-pointer clay-color-range-pointer"
+            style="background: rgb(255, 0, 0); left: -7px;"
+            type="button"
+          />
+        </div>
+        <div
           class="clay-color-map-group"
         >
           <div
@@ -302,13 +311,58 @@ exports[`Interactions color editor interactions ability to change color of click
           </div>
         </div>
         <div
-          class="clay-color-range clay-color-range-hue"
+          class="clay-color-form-group"
         >
-          <button
-            class="clay-color-pointer clay-color-range-pointer"
-            style="background: rgb(255, 0, 0); left: -7px;"
-            type="button"
-          />
+          <div
+            class="clay-range clay-color-slider clay-color-slider-alpha"
+          >
+            <div
+              class="clay-range-input"
+            >
+              <input
+                class="form-control-range"
+                max="1"
+                min="0"
+                step="0.01"
+                style="color: rgb(255, 255, 255);"
+                type="range"
+                value="1"
+              />
+              <div
+                class="clay-range-track"
+              />
+              <div
+                class="clay-range-progress"
+                style="width: 0%;"
+              >
+                <div
+                  class="clay-range-thumb"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="input-group"
+          >
+            <div
+              class="input-group-item"
+            >
+              <input
+                class="form-control input-group-inset input-group-inset-before"
+                data-testid="aInput"
+                max="1"
+                min="0"
+                step="0.01"
+                type="number"
+                value="1"
+              />
+              <label
+                class="input-group-inset-item input-group-inset-item-before"
+              >
+                A
+              </label>
+            </div>
+          </div>
         </div>
         <div
           class="clay-color-footer"

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -180,7 +180,7 @@ describe('Interactions', () => {
 		fireEvent.change(input, {target: {value: 'fff'}});
 		fireEvent.blur(input);
 
-		expect(input.value).toBe('ffffff');
+		expect(input.value).toBe('FFFFFF');
 	});
 
 	it('typing an invalid color in the input sets the input to an empty value', () => {
@@ -535,7 +535,7 @@ describe('Interactions', () => {
 
 			fireEvent.change(bInput, {target: {value: '200'}});
 
-			expect(input.value).toBe('c8c8c8');
+			expect(input.value).toBe('C8C8C8');
 
 			expect(
 				document.body.querySelector(
@@ -564,7 +564,7 @@ describe('Interactions', () => {
 
 			fireEvent.click(blankSplotch as HTMLButtonElement, {});
 
-			expect(input.value).toBe('dfcaff');
+			expect(input.value).toBe('DFCAFF');
 
 			const greenSplotch = (
 				document.body as HTMLButtonElement
@@ -576,7 +576,7 @@ describe('Interactions', () => {
 
 			const purpleSplotchs = (
 				document.body as HTMLButtonElement
-			).querySelectorAll('button[title="#dfcaff"]');
+			).querySelectorAll('button[title="#DFCAFF"]');
 
 			expect(purpleSplotchs.length).toBe(2);
 		});

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -237,6 +237,14 @@ const ClayColorPicker = ({
 
 	const isHex = tinycolor(internalValue).getFormat() === 'hex';
 
+	const internalToHex = (color: any) => {
+		if (color.getAlpha() < 1) {
+			return color.toHex8().toUpperCase();
+		}
+
+		return color.toHex().toUpperCase();
+	};
+
 	const inputColorTypeSupport = useMemo(() => {
 		if (typeof document !== 'undefined') {
 			var input = document.createElement('input');
@@ -376,7 +384,7 @@ const ClayColorPicker = ({
 								label={label}
 								onChange={(color, hex) => {
 									dispatch({
-										hex: color.toHex8(),
+										hex: internalToHex(color),
 										hue: color.toHsv().h,
 									});
 									setValue(hex);
@@ -404,8 +412,9 @@ const ClayColorPicker = ({
 								colors={customColors}
 								hex={state.hex}
 								hue={state.hue}
+								internalToHex={internalToHex}
 								onChange={(color, active) => {
-									const hex = color.toHex8();
+									const hex = internalToHex(color);
 
 									if (active) {
 										const newColors = [...customColors];
@@ -420,7 +429,7 @@ const ClayColorPicker = ({
 									setValue(hex);
 								}}
 								onColorChange={(color) => {
-									const hex = color.toHex8();
+									const hex = internalToHex(color);
 									const newColors = [...customColors];
 
 									newColors[state.splotch!] = hex;
@@ -458,16 +467,11 @@ const ClayColorPicker = ({
 									const newColor = tinycolor(value);
 
 									if (newColor.isValid()) {
-										if (newColor.getFormat() === 'hex') {
-											value = newColor
-												.toHex()
-												.toUpperCase();
-										} else if (
-											newColor.getFormat() === 'hex8'
+										if (
+											newColor.getFormat() ===
+											('hex' || 'hex8')
 										) {
-											value = newColor
-												.toHex8()
-												.toUpperCase();
+											value = internalToHex(newColor);
 										} else if (
 											newColor.toString() !== value
 										) {
@@ -508,7 +512,7 @@ const ClayColorPicker = ({
 											value.includes('var('))
 									) {
 										dispatch({
-											hex: color.toHex8(),
+											hex: internalToHex(color),
 											hue: color.toHsv().h,
 										});
 
@@ -516,7 +520,7 @@ const ClayColorPicker = ({
 											const newColors = [...customColors];
 
 											newColors[state.splotch!] =
-												color.toHex8();
+												internalToHex(color);
 
 											onColorsChange(newColors);
 										} else {

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -376,7 +376,7 @@ const ClayColorPicker = ({
 								label={label}
 								onChange={(color, hex) => {
 									dispatch({
-										hex: color.toHex(),
+										hex: color.toHex8(),
 										hue: color.toHsv().h,
 									});
 									setValue(hex);
@@ -405,7 +405,7 @@ const ClayColorPicker = ({
 								hex={state.hex}
 								hue={state.hue}
 								onChange={(color, active) => {
-									const hex = color.toHex();
+									const hex = color.toHex8();
 
 									if (active) {
 										const newColors = [...customColors];
@@ -420,7 +420,7 @@ const ClayColorPicker = ({
 									setValue(hex);
 								}}
 								onColorChange={(color) => {
-									const hex = color.toHex();
+									const hex = color.toHex8();
 									const newColors = [...customColors];
 
 									newColors[state.splotch!] = hex;
@@ -459,7 +459,15 @@ const ClayColorPicker = ({
 
 									if (newColor.isValid()) {
 										if (newColor.getFormat() === 'hex') {
-											value = newColor.toHex();
+											value = newColor
+												.toHex()
+												.toUpperCase();
+										} else if (
+											newColor.getFormat() === 'hex8'
+										) {
+											value = newColor
+												.toHex8()
+												.toUpperCase();
 										} else if (
 											newColor.toString() !== value
 										) {
@@ -500,7 +508,7 @@ const ClayColorPicker = ({
 											value.includes('var('))
 									) {
 										dispatch({
-											hex: color.toHex(),
+											hex: color.toHex8(),
 											hue: color.toHsv().h,
 										});
 
@@ -508,7 +516,7 @@ const ClayColorPicker = ({
 											const newColors = [...customColors];
 
 											newColors[state.splotch!] =
-												color.toHex();
+												color.toHex8();
 
 											onColorsChange(newColors);
 										} else {

--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.70.0
+ * Clay 3.78.0
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>

--- a/packages/clay-css/src/scss/cadmin/components/_clay-color.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_clay-color.scss
@@ -162,6 +162,48 @@
 	@include clay-button-variant($cadmin-clay-color-range-pointer);
 }
 
+// Clay Color Slider
+
+.clay-color-slider {
+	@include clay-range-variant($cadmin-clay-color-slider);
+}
+
+.clay-color-slider-hue {
+	@include clay-range-variant($cadmin-clay-color-slider-hue);
+}
+
+.clay-color-slider-alpha {
+	@include clay-range-variant($cadmin-clay-color-slider-alpha);
+}
+
+// Clay Color Form Group
+
+.clay-color-form-group {
+	@include clay-css($cadmin-clay-color-form-group);
+
+	.clay-range {
+		@include clay-css(map-get($cadmin-clay-color-form-group, clay-range));
+	}
+
+	.form-control {
+		@include clay-form-control-variant(
+			map-get($cadmin-clay-color-form-group, form-control)
+		);
+	}
+
+	.input-group {
+		$input-group: map-get($cadmin-clay-color-form-group, input-group);
+
+		@include clay-input-group-variant($cadmin-input-group);
+
+		.input-group-inset-item-before {
+			@include clay-css(
+				map-get($input-group, input-group-inset-item-before)
+			);
+		}
+	}
+}
+
 // Clay Color Sm
 
 %clay-color-sm-input-group-inset-item-before {

--- a/packages/clay-css/src/scss/cadmin/variables/_clay-color.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_clay-color.scss
@@ -33,7 +33,7 @@ $cadmin-clay-color-input-group-inset-item-before: map-deep-merge(
 $cadmin-clay-color-dropdown-menu: () !default;
 $cadmin-clay-color-dropdown-menu: map-deep-merge(
 	(
-		max-height: 400px,
+		max-height: 500px,
 		max-width: none,
 		padding-bottom: 0,
 		padding-left: 16px,
@@ -310,6 +310,162 @@ $cadmin-clay-color-range-pointer: map-deep-merge(
 		top: 50%,
 	),
 	$cadmin-clay-color-range-pointer
+);
+
+// Clay Color Form Group
+
+$cadmin-clay-color-form-group: () !default;
+$cadmin-clay-color-form-group: map-deep-merge(
+	(
+		display: flex,
+		align-items: center,
+		margin-top: 4px,
+		margin-bottom: 16px,
+		clay-range: (
+			flex-grow: 1,
+			flex-shrink: 0,
+			margin-right: 16px,
+			width: 144px,
+		),
+		form-control: (
+			padding-left: 0,
+			padding-right: 10%,
+			text-align: right,
+		),
+		input-group: (
+			input-group-inset-item-before: (
+				font-weight: $cadmin-font-weight-semi-bold,
+				padding-left: 10%,
+				padding-right: 0,
+				min-width: 18px,
+			),
+		),
+	),
+	$cadmin-clay-color-form-group
+);
+
+// Clay Color Slider
+
+$cadmin-clay-color-slider: () !default;
+$cadmin-clay-color-slider: map-deep-merge(
+	(
+		clay-range-input: (
+			border-radius: 100px,
+			clay-range-track: (
+				border-radius: inherit,
+				height: 8px,
+				margin-top: -4px,
+			),
+			clay-range-progress: (
+				background-color: transparent,
+				border-radius: inherit,
+				height: 8px,
+				margin-top: -4px,
+				width: 100%,
+			),
+			ms-thumb: (
+				visibility: visible,
+			),
+			moz-range-thumb: (
+				visibility: visible,
+			),
+			webkit-slider-thumb: (
+				visibility: visible,
+			),
+			clay-range-thumb: (
+				background-color: currentColor,
+				border-width: 0,
+				box-shadow: 0 0 0 2px $cadmin-white,
+				height: 10px,
+				margin-top: -5px,
+				transition:
+					clay-enable-transitions(box-shadow 0.15s ease-in-out),
+				visibility: hidden,
+				width: 10px,
+			),
+			form-control-range: (
+				background-color: inherit,
+				border-radius: inherit,
+				color: inherit,
+				height: 8px,
+				webkit-slider-runnable-track: (
+					-webkit-appearance: none,
+					appearance: none,
+				),
+			),
+			focus: (
+				clay-range-thumb: (
+					box-shadow: #{0 0 0 2px $cadmin-white,
+					0 0 0 4px $cadmin-primary-l1},
+				),
+			),
+		),
+	),
+	$cadmin-clay-color-slider
+);
+
+$cadmin-clay-color-slider-hue: () !default;
+$cadmin-clay-color-slider-hue: map-deep-merge(
+	(
+		clay-range-input: (
+			color: #26affd,
+			clay-range-track: (
+				background-image:
+					linear-gradient(
+						270deg,
+						#fc0d1b 0%,
+						#fc22d6 18.23%,
+						#1824fb 34.25%,
+						#2bf6fd 50.28%,
+						#2bfd2e 67.58%,
+						#fcfd37 81.22%,
+						#fc121b 100%
+					),
+			),
+		),
+	),
+	$cadmin-clay-color-slider-hue
+);
+
+$cadmin-clay-color-slider-alpha: () !default;
+$cadmin-clay-color-slider-alpha: map-deep-merge(
+	(
+		clay-range-input: (
+			color: $cadmin-black,
+			clay-range-track: (
+				background-color: $cadmin-white,
+				background-image: #{linear-gradient(
+						45deg,
+						#e7e7ed 25%,
+						transparent 25%
+					),
+				linear-gradient(
+					-45deg,
+					#e7e7ed 25%,
+					transparent 25%,
+				),
+				linear-gradient(
+					45deg,
+					transparent 75%,
+					#e7e7ed 75%,
+				),
+				linear-gradient(-45deg, transparent 75%, #e7e7ed 75%)},
+				background-position: #{0 0,
+				0 4px,
+				4px -4px,
+				-4px 0px},
+				background-size: 8px 8px,
+			),
+			form-control-range: (
+				color: inherit,
+			),
+			clay-range-progress: (
+				background-image:
+					linear-gradient(90deg, transparent 0%, currentcolor 100%),
+			),
+		),
+	),
+	$cadmin-clay-color-slider-alpha
 );
 
 // Clay Color Sm

--- a/packages/clay-css/src/scss/components/_clay-color.scss
+++ b/packages/clay-css/src/scss/components/_clay-color.scss
@@ -156,6 +156,48 @@
 	@include clay-button-variant($clay-color-range-pointer);
 }
 
+// Clay Color Slider
+
+.clay-color-slider {
+	@include clay-range-variant($clay-color-slider);
+}
+
+.clay-color-slider-hue {
+	@include clay-range-variant($clay-color-slider-hue);
+}
+
+.clay-color-slider-alpha {
+	@include clay-range-variant($clay-color-slider-alpha);
+}
+
+// Clay Color Form Group
+
+.clay-color-form-group {
+	@include clay-css($clay-color-form-group);
+
+	.clay-range {
+		@include clay-css(map-get($clay-color-form-group, clay-range));
+	}
+
+	.form-control {
+		@include clay-form-control-variant(
+			map-get($clay-color-form-group, form-control)
+		);
+	}
+
+	.input-group {
+		$input-group: map-get($clay-color-form-group, input-group);
+
+		@include clay-input-group-variant($input-group);
+
+		.input-group-inset-item-before {
+			@include clay-css(
+				map-get($input-group, input-group-inset-item-before)
+			);
+		}
+	}
+}
+
 // Clay Color Sm
 
 %clay-color-sm-input-group-inset-item-before {

--- a/packages/clay-css/src/scss/components/_range.scss
+++ b/packages/clay-css/src/scss/components/_range.scss
@@ -24,8 +24,8 @@
 	}
 }
 
-.clay-range-progress-none .clay-range-progress {
-	visibility: hidden;
+.clay-range-progress-none {
+	@include clay-range-variant($clay-range-progress-none);
 }
 
 .clay-range-title {

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -1517,8 +1517,6 @@
 				position:
 					setter(map-get($clay-range-thumb, position), absolute),
 				top: setter(map-get($clay-range-thumb, top), 50%),
-				visibility:
-					setter(map-get($clay-range-thumb, visibility), hidden),
 				width:
 					setter(
 						map-get($map, thumb-width),
@@ -2292,10 +2290,30 @@
 
 				// Webkit
 
+				&::-webkit-slider-container {
+					@include clay-css(
+						map-deep-get(
+							$map,
+							form-control-range,
+							webkit-slider-container
+						)
+					);
+				}
+
 				&::-webkit-slider-runnable-track {
-					-webkit-appearance: none;
-					appearance: none;
-					height: 100%;
+					$webkit-slider-runnable-track: map-deep-get(
+						$map,
+						form-control-range,
+						webkit-slider-runnable-track
+					);
+
+					@if not($webkit-slider-runnable-track) {
+						-webkit-appearance: none;
+						appearance: none;
+						height: 100%;
+					} @else {
+						@include clay-css($webkit-slider-runnable-track);
+					}
 				}
 
 				&::-webkit-slider-thumb {
@@ -2442,6 +2460,200 @@
 			&::after,
 			&::before {
 				@include clay-css($before-after);
+			}
+		}
+	}
+}
+
+@mixin clay-range-variant($map) {
+	@if (type-of($map) == 'map') {
+		$enabled: setter(map-get($map, enabled), true);
+
+		$clay-range-input: setter(map-get($map, clay-range-input), ());
+
+		$clay-range-thumb: setter(
+			map-get($clay-range-input, clay-range-thumb),
+			()
+		);
+		$clay-range-thumb: map-merge(
+			$clay-range-thumb,
+			(
+				margin-top:
+					setter(map-get($clay-range-thumb, margin-top), c-unset),
+				position: setter(map-get($clay-range-thumb, position), c-unset),
+				right: setter(map-get($clay-range-thumb, right), c-unset),
+				top: setter(map-get($clay-range-thumb, top), c-unset),
+			)
+		);
+
+		$moz-range-thumb: setter(
+			map-get($clay-range-input, moz-range-thumb),
+			()
+		);
+		$moz-range-thumb: map-merge(
+			$moz-range-thumb,
+			(
+				appearance:
+					setter(map-get($moz-range-thumb, appearance), c-unset),
+				position: setter(map-get($moz-range-thumb, position), c-unset),
+			)
+		);
+
+		$ms-thumb: setter(map-get($clay-range-input, ms-thumb), ());
+		$ms-thumb: map-merge(
+			$ms-thumb,
+			(
+				appearance: setter(map-get($ms-thumb, appearance), c-unset),
+			)
+		);
+
+		$webkit-slider-thumb: setter(
+			map-get($clay-range-input, webkit-slider-thumb),
+			()
+		);
+		$webkit-slider-thumb: map-merge(
+			$webkit-slider-thumb,
+			(
+				appearance:
+					setter(map-get($webkit-slider-thumb, appearance), c-unset),
+				position:
+					setter(map-get($webkit-slider-thumb, position), c-unset),
+			)
+		);
+
+		$clay-range-track: setter(
+			map-get($clay-range-input, clay-range-track),
+			()
+		);
+		$clay-range-track: map-merge(
+			$clay-range-track,
+			(
+				margin-top:
+					setter(map-get($clay-range-track, margin-top), c-unset),
+			)
+		);
+
+		$clay-range-progress: setter(
+			map-get($clay-range-input, clay-range-progress),
+			()
+		);
+		$clay-range-progress: map-merge(
+			$clay-range-progress,
+			(
+				margin-top:
+					setter(map-get($clay-range-progress, margin-top), c-unset),
+			)
+		);
+
+		$tooltip: setter(map-get($clay-range-input, tooltip), ());
+		$tooltip: map-merge(
+			$tooltip,
+			(
+				margin-left: setter(map-get($tooltip, margin-left), c-unset),
+			)
+		);
+
+		$clay-tooltip-bottom: setter(
+			map-get($clay-range-input, clay-tooltip-bottom),
+			()
+		);
+		$clay-tooltip-bottom: map-merge(
+			$clay-tooltip-bottom,
+			(
+				padding-top:
+					setter(
+						map-get($map, tooltip-arrow-offset),
+						map-get($clay-tooltip-bottom, padding-top),
+						c-unset
+					),
+				top: setter(map-get($clay-tooltip-bottom, top), c-unset),
+				transform:
+					setter(map-get($clay-tooltip-bottom, transform), c-unset),
+			)
+		);
+
+		$clay-tooltip-bottom-tooltip-arrow: setter(
+			map-get($clay-tooltip-bottom, tooltip-arrow),
+			()
+		);
+		$clay-tooltip-bottom-tooltip-arrow: map-merge(
+			$clay-tooltip-bottom-tooltip-arrow,
+			(
+				margin-left:
+					setter(
+						map-get(
+							$clay-tooltip-bottom-tooltip-arrow,
+							margin-left
+						),
+						c-unset
+					),
+			)
+		);
+
+		$clay-tooltip-bottom: map-deep-merge(
+			$clay-tooltip-bottom,
+			(
+				tooltip-arrow: $clay-tooltip-bottom-tooltip-arrow,
+			)
+		);
+
+		$clay-tooltip-top: setter(
+			map-get($clay-range-input, clay-tooltip-top),
+			()
+		);
+		$clay-tooltip-top: map-merge(
+			$clay-tooltip-top,
+			(
+				bottom: setter(map-get($clay-tooltip-top, bottom), c-unset),
+				padding-bottom:
+					setter(map-get($clay-tooltip-top, padding-bottom), c-unset),
+				transform:
+					setter(map-get($clay-tooltip-top, transform), c-unset),
+			)
+		);
+
+		$clay-tooltip-top-tooltip-arrow: setter(
+			map-get($clay-tooltip-top, tooltip-arrow),
+			()
+		);
+		$clay-tooltip-top-tooltip-arrow: map-merge(
+			$clay-tooltip-top-tooltip-arrow,
+			(
+				margin-left:
+					setter(
+						map-get($clay-tooltip-top-tooltip-arrow, margin-left),
+						c-unset
+					),
+			)
+		);
+
+		$clay-tooltip-top: map-deep-merge(
+			$clay-tooltip-top,
+			(
+				tooltip-arrow: $clay-tooltip-top-tooltip-arrow,
+			)
+		);
+
+		$clay-range-input: map-deep-merge(
+			$clay-range-input,
+			(
+				clay-range-thumb: $clay-range-thumb,
+				moz-range-thumb: $moz-range-thumb,
+				ms-thumb: $ms-thumb,
+				webkit-slider-thumb: $webkit-slider-thumb,
+				clay-range-track: $clay-range-track,
+				clay-range-progress: $clay-range-progress,
+				tooltip: $tooltip,
+				clay-tooltip-bottom: $clay-tooltip-bottom,
+				clay-tooltip-top: $clay-tooltip-top,
+			)
+		);
+
+		@if ($enabled) {
+			@include clay-css($map);
+
+			.clay-range-input {
+				@include clay-range-input-variant($clay-range-input);
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/variables/_clay-color.scss
+++ b/packages/clay-css/src/scss/variables/_clay-color.scss
@@ -33,7 +33,7 @@ $clay-color-input-group-inset-item-before: map-deep-merge(
 $clay-color-dropdown-menu: () !default;
 $clay-color-dropdown-menu: map-deep-merge(
 	(
-		max-height: 400px,
+		max-height: 500px,
 		max-width: none,
 		padding-bottom: 0,
 		padding-left: 1rem,
@@ -307,6 +307,163 @@ $clay-color-range-pointer: map-deep-merge(
 		top: 50%,
 	),
 	$clay-color-range-pointer
+);
+
+// Clay Color Form Group
+
+$clay-color-form-group: () !default;
+$clay-color-form-group: map-deep-merge(
+	(
+		display: flex,
+		align-items: center,
+		margin-top: 0.25rem,
+		margin-bottom: 1rem,
+		clay-range: (
+			flex-grow: 1,
+			flex-shrink: 0,
+			margin-right: 1rem,
+			width: 144px,
+		),
+		form-control: (
+			padding-left: 0,
+			padding-right: 10%,
+			text-align: right,
+		),
+		input-group: (
+			input-group-inset-item-before: (
+				font-weight: $font-weight-semi-bold,
+				padding-left: 10%,
+				padding-right: 0,
+				min-width: 1.125rem,
+			),
+		),
+	),
+	$clay-color-form-group
+);
+
+// Clay Color Slider
+
+$clay-color-slider: () !default;
+$clay-color-slider: map-deep-merge(
+	(
+		clay-range-input: (
+			border-radius: 100px,
+			clay-range-track: (
+				border-radius: inherit,
+				height: 0.5rem,
+				margin-top: -0.25rem,
+			),
+			clay-range-progress: (
+				background-color: transparent,
+				border-radius: inherit,
+				height: 0.5rem,
+				margin-top: -0.25rem,
+				width: 100%,
+			),
+			ms-thumb: (
+				visibility: visible,
+			),
+			moz-range-thumb: (
+				visibility: visible,
+			),
+			webkit-slider-thumb: (
+				visibility: visible,
+			),
+			clay-range-thumb: (
+				background-color: currentColor,
+				border-color: $white,
+				border-style: solid,
+				border-width: 0.125rem,
+				box-shadow: none,
+				height: 0.875rem,
+				margin-top: -0.4375rem,
+				transition:
+					clay-enable-transitions(box-shadow 0.15s ease-in-out),
+				visibility: hidden,
+				width: 0.875rem,
+			),
+			form-control-range: (
+				background-color: inherit,
+				border-radius: inherit,
+				color: inherit,
+				height: 0.5rem,
+				webkit-slider-runnable-track: (
+					-webkit-appearance: none,
+					appearance: none,
+				),
+			),
+			focus: (
+				clay-range-thumb: (
+					box-shadow: 0 0 0 0.125rem $primary-l1,
+				),
+			),
+		),
+	),
+	$clay-color-slider
+);
+
+$clay-color-slider-hue: () !default;
+$clay-color-slider-hue: map-deep-merge(
+	(
+		clay-range-input: (
+			color: #26affd,
+			clay-range-track: (
+				background-image:
+					linear-gradient(
+						270deg,
+						#fc0d1b 0%,
+						#fc22d6 18.23%,
+						#1824fb 34.25%,
+						#2bf6fd 50.28%,
+						#2bfd2e 67.58%,
+						#fcfd37 81.22%,
+						#fc121b 100%
+					),
+			),
+		),
+	),
+	$clay-color-slider-hue
+);
+
+$clay-color-slider-alpha: () !default;
+$clay-color-slider-alpha: map-deep-merge(
+	(
+		clay-range-input: (
+			color: $black,
+			clay-range-track: (
+				background-color: $white,
+				background-image: #{linear-gradient(
+						45deg,
+						#e7e7ed 25%,
+						transparent 25%
+					),
+				linear-gradient(
+					-45deg,
+					#e7e7ed 25%,
+					transparent 25%,
+				),
+				linear-gradient(
+					45deg,
+					transparent 75%,
+					#e7e7ed 75%,
+				),
+				linear-gradient(-45deg, transparent 75%, #e7e7ed 75%)},
+				background-position: #{0 0,
+				0 4px,
+				4px -4px,
+				-4px 0px},
+				background-size: 8px 8px,
+			),
+			form-control-range: (
+				color: inherit,
+			),
+			clay-range-progress: (
+				background-image:
+					linear-gradient(90deg, transparent 0%, currentcolor 100%),
+			),
+		),
+	),
+	$clay-color-slider-alpha
 );
 
 // Clay Color Sm

--- a/packages/clay-css/src/scss/variables/_clay-color.scss
+++ b/packages/clay-css/src/scss/variables/_clay-color.scss
@@ -364,23 +364,23 @@ $clay-color-slider: map-deep-merge(
 				visibility: visible,
 			),
 			moz-range-thumb: (
+				height: 0.625rem,
 				visibility: visible,
+				width: 0.625rem,
 			),
 			webkit-slider-thumb: (
 				visibility: visible,
 			),
 			clay-range-thumb: (
 				background-color: currentColor,
-				border-color: $white,
-				border-style: solid,
-				border-width: 0.125rem,
-				box-shadow: none,
-				height: 0.875rem,
-				margin-top: -0.4375rem,
+				border-width: 0,
+				box-shadow: 0 0 0 0.125rem $white,
+				height: 0.625rem,
+				margin-top: -0.3125rem,
 				transition:
 					clay-enable-transitions(box-shadow 0.15s ease-in-out),
 				visibility: hidden,
-				width: 0.875rem,
+				width: 0.625rem,
 			),
 			form-control-range: (
 				background-color: inherit,
@@ -394,7 +394,8 @@ $clay-color-slider: map-deep-merge(
 			),
 			focus: (
 				clay-range-thumb: (
-					box-shadow: 0 0 0 0.125rem $primary-l1,
+					box-shadow: #{0 0 0 0.125rem $white,
+					0 0 0 0.25rem $primary-l1},
 				),
 			),
 		),
@@ -455,11 +456,9 @@ $clay-color-slider-alpha: map-deep-merge(
 				background-size: 8px 8px,
 			),
 			form-control-range: (
-				color: inherit,
-			),
-			clay-range-progress: (
 				background-image:
 					linear-gradient(90deg, transparent 0%, currentcolor 100%),
+				color: inherit,
 			),
 		),
 	),

--- a/packages/clay-css/src/scss/variables/_range.scss
+++ b/packages/clay-css/src/scss/variables/_range.scss
@@ -65,8 +65,16 @@ $clay-range-input: map-deep-merge(
 			position: absolute,
 			right: -0.75rem,
 			top: 50%,
-			visibility: hidden,
 			width: 1.5rem,
+		),
+		ms-thumb: (
+			visibility: hidden,
+		),
+		moz-range-thumb: (
+			visibility: hidden,
+		),
+		webkit-slider-thumb: (
+			visibility: hidden,
 		),
 		clay-range-track: (
 			appearance: none,
@@ -170,4 +178,28 @@ $clay-range-input: map-deep-merge(
 		),
 	),
 	$clay-range-input
+);
+
+$clay-range-progress-none: () !default;
+$clay-range-progress-none: map-deep-merge(
+	(
+		clay-range-input: (
+			ms-thumb: (
+				visibility: visible,
+			),
+			moz-range-thumb: (
+				visibility: visible,
+			),
+			webkit-slider-thumb: (
+				visibility: visible,
+			),
+			clay-range-thumb: (
+				visibility: hidden,
+			),
+			clay-range-progress: (
+				visibility: hidden,
+			),
+		),
+	),
+	$clay-range-progress-none
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,6 +1215,26 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@clayui/shared@^3.78.3":
+  version "3.78.3"
+  resolved "https://registry.yarnpkg.com/@clayui/shared/-/shared-3.78.3.tgz#e7b94a1bd08b22401e5d1b58520692afdbe33dbb"
+  integrity sha512-xmsFmUNSn0jmrNMt2+CLBcCjRR3stAORAhP7ddTJODTUm/QTvQbPA97ycvIYecHfUH9qcOIGWJ80zbrsodCFJA==
+  dependencies:
+    "@clayui/button" "^3.73.0"
+    "@clayui/link" "^3.56.0"
+    "@clayui/provider" "^3.77.0"
+    classnames "^2.2.6"
+    dom-align "^1.12.2"
+    warning "^4.0.3"
+
+"@clayui/slider@^3.78.3":
+  version "3.78.3"
+  resolved "https://registry.yarnpkg.com/@clayui/slider/-/slider-3.78.3.tgz#492f2d740a03cec7ab4c02b9a593fe2ba38ebb30"
+  integrity sha512-NgzU4GE8hfHzEOOVVhRBhdmkZJNK9V8K5LObTPfKPK1H0+LIoxoUM8FgaBlZSxmu9OOsJkbWsssqZcweEX9/Ig==
+  dependencies:
+    "@clayui/shared" "^3.78.3"
+    classnames "^2.2.6"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -2863,14 +2883,26 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@pmmmwh/react-refresh-webpack-plugin@0.5.1", "@pmmmwh/react-refresh-webpack-plugin@^0.4.3", "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.1.tgz#7e98d6f22c360e1dd00909f5fa9d0f6ecc263292"
-  integrity sha512-ccap6o7+y5L8cnvkZ9h8UXCGyy2DqtwCD+/N3Yru6lxMvcdkPKtdx13qd7sAC9s5qZktOmWf9lfUjsGOvSdYhg==
+"@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
+  integrity sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==
+  dependencies:
+    ansi-html "^0.0.7"
+    error-stack-parser "^2.0.6"
+    html-entities "^1.2.1"
+    native-url "^0.2.6"
+    schema-utils "^2.6.5"
+    source-map "^0.7.3"
+
+"@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.8.tgz#da3383761e2c0c440610819f3204769022a38d12"
+  integrity sha512-wxXRwf+IQ6zvHSJZ+5T2RQNEsq+kx4jKRXfFvdt3nBIUzJUAvXEFsUeoaohDe/Kr84MTjGwcuIUPNcstNJORsA==
   dependencies:
     ansi-html-community "^0.0.8"
     common-path-prefix "^3.0.0"
-    core-js-pure "^3.8.1"
+    core-js-pure "^3.23.3"
     error-stack-parser "^2.0.6"
     find-up "^5.0.0"
     html-entities "^2.1.0"
@@ -5743,7 +5775,7 @@ ansi-html-community@0.0.8, ansi-html-community@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
-ansi-html@0.0.7:
+ansi-html@0.0.7, ansi-html@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
   integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
@@ -7917,7 +7949,7 @@ command-exists@^1.2.4, command-exists@^1.2.6:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
-commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3, commander@^2.8.1, commander@^2.9.0:
+commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -8047,7 +8079,7 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-config-chain@^1.1.12, config-chain@~1.1.5:
+config-chain@^1.1.12:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
   integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
@@ -8291,10 +8323,15 @@ core-js-compat@^3.16.0, core-js-compat@^3.16.2, core-js-compat@^3.8.1:
     browserslist "^4.17.5"
     semver "7.0.0"
 
-core-js-pure@^3.16.0, core-js-pure@^3.8.1:
+core-js-pure@^3.16.0:
   version "3.21.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.21.1.tgz#8c4d1e78839f5f46208de7230cebfb72bc3bdb51"
   integrity sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==
+
+core-js-pure@^3.23.3:
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.0.tgz#7ad8a5dd7d910756f3124374b50026e23265ca9a"
+  integrity sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==
 
 core-js@^2.4.0, core-js@^2.6.10, core-js@^2.6.5:
   version "2.6.12"
@@ -10048,7 +10085,7 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-duplexer@^0.1.1, duplexer@^0.1.2, duplexer@~0.1.1:
+duplexer@^0.1.1, duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
@@ -10078,17 +10115,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
-
-editorconfig@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
-  integrity sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==
-  dependencies:
-    bluebird "^3.0.5"
-    commander "^2.9.0"
-    lru-cache "^3.2.0"
-    semver "^5.1.0"
-    sigmund "^1.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -10847,19 +10873,6 @@ event-source-polyfill@^1.0.15:
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz#d8bb7f99cb6f8119c2baf086d9f6ee0514b6d9c8"
   integrity sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg==
 
-event-stream@3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
-  integrity sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==
-  dependencies:
-    duplexer "~0.1.1"
-    from "~0"
-    map-stream "~0.1.0"
-    pause-stream "0.0.11"
-    split "0.3"
-    stream-combiner "~0.0.4"
-    through "~2.3.1"
-
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -11590,11 +11603,6 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
-
-from@~0:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
-  integrity sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -13340,6 +13348,11 @@ html-encoding-sniffer@^3.0.0:
   integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
   dependencies:
     whatwg-encoding "^2.0.0"
+
+html-entities@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc"
+  integrity sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==
 
 html-entities@^2.1.0:
   version "2.3.2"
@@ -15251,16 +15264,6 @@ jora@^1.0.0-beta.5:
   resolved "https://registry.yarnpkg.com/jora/-/jora-1.0.0-beta.5.tgz#55b2c4d86078af1bc74da401e88b67be42b0bddd"
   integrity sha512-hPJKQyF0eiCqQOwfgIuQa+8wIn+WcEcjjyeOchuiXEUnt6zbV0tHKsUqRRwJY47ZtBiGcJQNr/BGuYW1Sfwbvg==
 
-js-beautify@1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.7.5.tgz#69d9651ef60dbb649f65527b53674950138a7919"
-  integrity sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==
-  dependencies:
-    config-chain "~1.1.5"
-    editorconfig "^0.13.2"
-    mkdirp "~0.5.0"
-    nopt "~3.0.1"
-
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -16303,13 +16306,6 @@ lru-cache@^2.5.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
   integrity sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=
 
-lru-cache@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
-  integrity sha512-91gyOKTc2k66UG6kHiH4h3S2eltcPwE1STVfMYC/NG+nZwf8IIuiamfmpGZjpbbxzSyEJaLC0tNSmhjlQUTJow==
-  dependencies:
-    pseudomap "^1.0.1"
-
 lru-cache@^4.0.0:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -16454,11 +16450,6 @@ map-or-similar@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/map-or-similar/-/map-or-similar-1.5.0.tgz#6de2653174adfb5d9edc33c69d3e92a1b76faf08"
   integrity sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=
-
-map-stream@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
-  integrity sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -17599,7 +17590,7 @@ mkdirp-infer-owner@^2.0.0:
     infer-owner "^1.0.4"
     mkdirp "^1.0.3"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -17751,6 +17742,13 @@ nanospinner@^0.3.0:
   integrity sha512-ToZuxmiRuuNe3McB7CVzP7PCOhzWAy4qx6ndb5QWxJFp6INdg3n0mVm8f7HR6Fz8raRg3/vzglIZYrOSna8vkg==
   dependencies:
     picocolors "^1.0.0"
+
+native-url@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.2.6.tgz#ca1258f5ace169c716ff44eccbddb674e10399ae"
+  integrity sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==
+  dependencies:
+    querystring "^0.2.0"
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -17945,7 +17943,7 @@ node-status-codes@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
   integrity sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=
 
-nopt@^3.0.0, nopt@~3.0.1:
+nopt@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==
@@ -19061,13 +19059,6 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
-pause-stream@0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
-  integrity sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==
-  dependencies:
-    through "~2.3"
 
 pbkdf2@^3.0.3:
   version "3.1.2"
@@ -21975,7 +21966,7 @@ semver-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
   integrity sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -22183,11 +22174,6 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
-
-sigmund@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
-  integrity sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.5"
@@ -22534,13 +22520,6 @@ split2@^3.0.0:
   dependencies:
     readable-stream "^3.0.0"
 
-split@0.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
-  integrity sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==
-  dependencies:
-    through "2"
-
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
@@ -22713,13 +22692,6 @@ stream-combiner2@^1.1.1:
   dependencies:
     duplexer2 "~0.1.0"
     readable-stream "^2.0.2"
-
-stream-combiner@~0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
-  integrity sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==
-  dependencies:
-    duplexer "~0.1.1"
 
 stream-each@^1.1.0:
   version "1.2.3"
@@ -23543,7 +23515,7 @@ through2@^4.0.0:
   dependencies:
     readable-stream "3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3, through@~2.3.1:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==


### PR DESCRIPTION
fixes #5166 issue #5132

I couldn't get the range input to work nicely with color picker. The alpha value updates when the mouse / key is released. I think if we want the alpha to continuously update with `onChange`, we need to restructure the components. I'm hoping there is a better way though. I included the CSS updates in https://github.com/liferay/clay/pull/5156 in this pr.

I was thinking it might be a good idea to add a setting to color picker to disable 8 digit hex support.

![color-picker](https://user-images.githubusercontent.com/788266/199834387-a11bedcd-e466-4432-ae51-fd51c99ec808.gif)
