### PR TITLE
feat(@clayui/tabs): adds new compositing pattern

### DIFF
--- a/packages/clay-tabs/src/Content.tsx
+++ b/packages/clay-tabs/src/Content.tsx
@@ -56,8 +56,11 @@ const Content = ({
 						typeof active === 'number'
 							? active === index
 							: activeIndex === index,
+					'aria-labelledby': tabsId
+						? `${tabsId}-tab-${index}`
+						: child.props['aria-labelledby'],
 					fade,
-					id: tabsId ? `${tabsId}-${index}` : child.props.id,
+					id: tabsId ? `${tabsId}-tabpanel-${index}` : child.props.id,
 					key: index,
 				});
 			})}

--- a/packages/clay-tabs/src/Content.tsx
+++ b/packages/clay-tabs/src/Content.tsx
@@ -8,9 +8,15 @@ import React from 'react';
 
 export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
-	 * Receives a number that indicates the `tabkey` to be rendered.
+	 * @ignore
 	 */
-	activeIndex: number;
+	active?: React.Key;
+
+	/**
+	 * Receives a number that indicates the `tabkey` to be rendered.
+	 * @deprecated since v3.78.2 - No longer needed in new composition.
+	 */
+	activeIndex?: number;
 
 	/**
 	 * Children elements received from ClayTabs.Content component.
@@ -21,13 +27,20 @@ export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	 * Flag to indicate if `fade` classname that applies an fading animation should be applied.
 	 */
 	fade?: boolean;
+
+	/**
+	 * @ignore
+	 */
+	tabsId?: string;
 }
 
 const Content = ({
+	active,
 	activeIndex = 0,
 	children,
 	className,
 	fade = false,
+	tabsId,
 	...otherProps
 }: IProps) => {
 	return (
@@ -39,8 +52,12 @@ const Content = ({
 
 				return React.cloneElement(child, {
 					...child.props,
-					active: activeIndex === index,
+					active:
+						typeof active === 'number'
+							? active === index
+							: activeIndex === index,
 					fade,
+					id: tabsId ? `${tabsId}-${index}` : child.props.id,
 					key: index,
 				});
 			})}

--- a/packages/clay-tabs/src/List.tsx
+++ b/packages/clay-tabs/src/List.tsx
@@ -135,7 +135,9 @@ export function List({
 							? (child as React.ReactElement).props.active
 							: active === index,
 					innerProps: {
-						'aria-controls': tabsId && `${tabsId}-${index}`,
+						'aria-controls':
+							tabsId && `${tabsId}-tabpanel-${index}`,
+						id: tabsId && `${tabsId}-tab-${index}`,
 						...(child.props.innerProps ?? {}),
 					},
 					onClick: (

--- a/packages/clay-tabs/src/List.tsx
+++ b/packages/clay-tabs/src/List.tsx
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {FOCUSABLE_ELEMENTS, InternalDispatch, Keys} from '@clayui/shared';
+import classNames from 'classnames';
+import React, {useRef} from 'react';
+
+export interface IProps extends React.HTMLAttributes<HTMLUListElement> {
+	/**
+	 * @ignore
+	 */
+	activation?: 'manual' | 'automatic';
+
+	/**
+	 * @ignore
+	 */
+	active?: React.Key;
+
+	/**
+	 * The tabs content.
+	 */
+	children: React.ReactNode;
+
+	/**
+	 * The custom class.
+	 */
+	className?: string;
+
+	/**
+	 * @ignore
+	 */
+	displayType?: null | 'basic' | 'underline';
+
+	/**
+	 * @ignore
+	 */
+	justified?: boolean;
+
+	/**
+	 * @ignore
+	 */
+	modern?: boolean;
+
+	/**
+	 * @ignore
+	 */
+	onActiveChange?: InternalDispatch<number>;
+
+	/**
+	 * @ignore
+	 */
+	tabsId?: string;
+}
+
+export function List({
+	activation,
+	active,
+	children,
+	className,
+	displayType,
+	justified,
+	modern,
+	onActiveChange,
+	tabsId,
+	...otherProps
+}: IProps) {
+	const tabsRef = useRef<HTMLUListElement>(null);
+
+	return (
+		<ul
+			{...otherProps}
+			className={classNames(
+				'nav',
+				{'nav-justified': justified},
+				!displayType
+					? {
+							'nav-tabs': !modern,
+							'nav-underline': modern,
+					  }
+					: {
+							'nav-tabs': displayType === 'basic',
+							'nav-underline': displayType === 'underline',
+					  },
+
+				className
+			)}
+			onKeyDown={(event) => {
+				if (!tabsRef.current) {
+					return;
+				}
+
+				if (event.key === Keys.Left || event.key === Keys.Right) {
+					const tabs = Array.from<HTMLElement>(
+						tabsRef.current.querySelectorAll(
+							FOCUSABLE_ELEMENTS.join(',')
+						)
+					);
+					const activeElement = document.activeElement as HTMLElement;
+
+					const position = tabs.indexOf(activeElement);
+
+					const tab =
+						tabs[
+							event.key === Keys.Left
+								? position - 1
+								: position + 1
+						];
+
+					if (tab) {
+						tab.focus();
+
+						if (activation === 'automatic') {
+							const newActive = Array.from(
+								tabsRef.current.querySelectorAll('a, button')
+							).indexOf(tab);
+
+							onActiveChange!(newActive);
+						}
+					}
+				}
+			}}
+			ref={tabsRef}
+			role="tablist"
+		>
+			{React.Children.map(children, (child, index) => {
+				if (!React.isValidElement(child)) {
+					return child;
+				}
+
+				return React.cloneElement(child as React.ReactElement, {
+					active:
+						(child as React.ReactElement).props.active !== undefined
+							? (child as React.ReactElement).props.active
+							: active === index,
+					innerProps: {
+						'aria-controls': tabsId && `${tabsId}-${index}`,
+						...(child.props.innerProps ?? {}),
+					},
+					onClick: (
+						event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+					) => {
+						const {onClick} = (child as React.ReactElement).props;
+
+						if (onClick) {
+							onClick(event);
+						} else {
+							onActiveChange!(index);
+						}
+					},
+				});
+			})}
+		</ul>
+	);
+}
+
+List.displayName = 'ClayTabsList';

--- a/packages/clay-tabs/src/List.tsx
+++ b/packages/clay-tabs/src/List.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {FOCUSABLE_ELEMENTS, InternalDispatch, Keys} from '@clayui/shared';
+import {InternalDispatch, useNavigation} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useRef} from 'react';
 
@@ -68,6 +68,12 @@ export function List({
 }: IProps) {
 	const tabsRef = useRef<HTMLUListElement>(null);
 
+	const {onKeyDown} = useNavigation({
+		activation,
+		containeRef: tabsRef,
+		orientation: 'horizontal',
+	});
+
 	return (
 		<ul
 			{...otherProps}
@@ -86,41 +92,7 @@ export function List({
 
 				className
 			)}
-			onKeyDown={(event) => {
-				if (!tabsRef.current) {
-					return;
-				}
-
-				if (event.key === Keys.Left || event.key === Keys.Right) {
-					const tabs = Array.from<HTMLElement>(
-						tabsRef.current.querySelectorAll(
-							FOCUSABLE_ELEMENTS.join(',')
-						)
-					);
-					const activeElement = document.activeElement as HTMLElement;
-
-					const position = tabs.indexOf(activeElement);
-
-					const tab =
-						tabs[
-							event.key === Keys.Left
-								? position - 1
-								: position + 1
-						];
-
-					if (tab) {
-						tab.focus();
-
-						if (activation === 'automatic') {
-							const newActive = Array.from(
-								tabsRef.current.querySelectorAll('a, button')
-							).indexOf(tab);
-
-							onActiveChange!(newActive);
-						}
-					}
-				}
-			}}
+			onKeyDown={onKeyDown}
 			ref={tabsRef}
 			role="tablist"
 		>

--- a/packages/clay-tabs/src/__tests__/index.tsx
+++ b/packages/clay-tabs/src/__tests__/index.tsx
@@ -172,4 +172,24 @@ describe('ClayTabs', () => {
 		expect(tabPanels[0].innerHTML).toBe('Content Two');
 		expect(tabPanels.length).toBe(1);
 	});
+
+	it('renders the new default composition', () => {
+		const {getAllByRole} = render(
+			<ClayTabs>
+				<ClayTabs.List>
+					<ClayTabs.Item>Tab 1</ClayTabs.Item>
+					<ClayTabs.Item>Tab 2</ClayTabs.Item>
+					<ClayTabs.Item>Tab 3</ClayTabs.Item>
+				</ClayTabs.List>
+				<ClayTabs.Panels>
+					<ClayTabs.TabPanel>Tab Content 1</ClayTabs.TabPanel>
+					<ClayTabs.TabPanel>Tab Content 2</ClayTabs.TabPanel>
+					<ClayTabs.TabPanel>Tab Content 3</ClayTabs.TabPanel>
+				</ClayTabs.Panels>
+			</ClayTabs>
+		);
+
+		expect(getAllByRole('tab').length).toBe(3);
+		expect(getAllByRole('tabpanel').length).toBe(3);
+	});
 });

--- a/packages/clay-tabs/stories/Tabs.stories.tsx
+++ b/packages/clay-tabs/stories/Tabs.stories.tsx
@@ -11,7 +11,7 @@ export default {
 	argTypes: {
 		activation: {
 			control: {type: 'select'},
-			options: ['manual', 'automatic', null],
+			options: ['manual', 'automatic'],
 		},
 		displayType: {
 			control: {type: 'select'},
@@ -133,6 +133,25 @@ Default.args = {
 	displayType: 'underline',
 	justified: false,
 	modern: true,
+};
+
+export const NewDefault = (args: any) => (
+	<ClayTabs activation={args.activation} displayType={args.displayType}>
+		<ClayTabs.List>
+			<ClayTabs.Item>Tab 1</ClayTabs.Item>
+			<ClayTabs.Item>Tab 2</ClayTabs.Item>
+			<ClayTabs.Item>Tab 3</ClayTabs.Item>
+		</ClayTabs.List>
+		<ClayTabs.Panels>
+			<ClayTabs.TabPanel>Tab Content 1</ClayTabs.TabPanel>
+			<ClayTabs.TabPanel>Tab Content 2</ClayTabs.TabPanel>
+			<ClayTabs.TabPanel>Tab Content 3</ClayTabs.TabPanel>
+		</ClayTabs.Panels>
+	</ClayTabs>
+);
+
+NewDefault.args = {
+	activation: 'manual',
 };
 
 export const WithState = () => {


### PR DESCRIPTION
Closes #5171

This PR implements a more simplified composition and better DX than before, which makes it easier to control internal states and improve the flow of data through components. It will also be possible to more easily implement the Collection pattern and other features such as responsive tabs.

```jsx
<Tabs>
  <Tabs.List>
    <Tabs.Item>Tab 1</Tabs.Item>
    <Tabs.Item>Tab 2</Tabs.Item>
    <Tabs.Item>Tab 3</Tabs.Item>
  </Tabs.List>
  <Tabs.Panels>
    <Tabs.TabPanel>Tab Content 1</Tabs.TabPanel>
    <Tabs.TabPanel>Tab Content 2</Tabs.TabPanel>
    <Tabs.TabPanel>Tab Content 3</Tabs.TabPanel>
  </Tabs.Panels>
</Tabs>
```

The component still maintains backward compatibility which should stop supporting the next major version. Also now the automatic activation mode works with the component in uncontrolled mode.

The `Tabs.Content` component is also deprecated in favor of encouraging new composition, there is also a strategy I'm thinking that instead of having `TabPanel` and `Item` components, we can just have the `Item` component that it adapts according to its parent, this makes writing and composing the component more intuitive.

An important premise of components is that we don't want developers to worry about what we're doing behind the scenes or what semantics are being rendered, we don't want them to worry about that, it makes development faster and leaves the responsibility to handle semantics and accessibility from our side.

I would also leave to rewrite the documentation when I start working on issue #5172.