### PR TITLE
fix(@clayui/tabs): add configurable tabIndex property to TabPane component

### DIFF
--- a/packages/clay-tabs/src/TabPane.tsx
+++ b/packages/clay-tabs/src/TabPane.tsx
@@ -28,6 +28,7 @@ const TabPane = ({
 	children,
 	className,
 	fade,
+	tabIndex = 0,
 	...otherProps
 }: ITabPaneProps) => {
 	const [internalActive, setInternalActive] = React.useState(active);
@@ -68,7 +69,7 @@ const TabPane = ({
 				className
 			)}
 			role="tabpanel"
-			tabIndex={0}
+			tabIndex={tabIndex}
 		>
 			{children}
 		</div>


### PR DESCRIPTION
Fixes #5163

This allows you to configure the Panel `tabIndex` when you don't want the Panel to receive the focus but the first focusable item.