### PR TITLE
feat(@clayui/color-picker): Adds splotchProps to pass custom attributes to the input group splotch

### DIFF
--- a/packages/clay-color-picker/src/Splotch.tsx
+++ b/packages/clay-color-picker/src/Splotch.tsx
@@ -29,7 +29,7 @@ interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
  * Renders component that displays a color
  */
 const ClayColorPickerSplotch = React.forwardRef<HTMLButtonElement, IProps>(
-	({active, className, size, value, ...otherProps}, ref) => {
+	({active, className, size, title, value, ...otherProps}, ref) => {
 		const color = tinycolor(value);
 
 		const isHex = (color.getFormat() || '').match('hex');
@@ -47,11 +47,13 @@ const ClayColorPickerSplotch = React.forwardRef<HTMLButtonElement, IProps>(
 				displayType={null}
 				ref={ref}
 				style={{
-					background: `${isHex ? '#' : ''}${value}`,
-					height: size,
-					width: size,
+					background:
+						otherProps?.style?.background ||
+						`${isHex ? '#' : ''}${value}`,
+					height: otherProps?.style?.height || size,
+					width: otherProps?.style?.width || size,
 				}}
-				title={value}
+				title={title || `${isHex ? '#' : ''}${value}`}
 			/>
 		);
 	}

--- a/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-color-picker/src/__tests__/__snapshots__/index.tsx.snap
@@ -30,7 +30,7 @@ exports[`Interactions color editor interactions ability to change color of click
               aria-label="Select a color"
               class="clay-color-btn dropdown-toggle clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFFFFF"
+              title="#FFFFFF"
               type="button"
             />
           </div>
@@ -92,7 +92,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn btn"
                 style="background: rgb(91, 176, 165);"
-                title="5BB0A5"
+                title="#5BB0A5"
                 type="button"
               />
             </div>
@@ -102,7 +102,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn btn"
                 style="background: rgb(0, 255, 255);"
-                title="00FFFF"
+                title="#00FFFF"
                 type="button"
               />
             </div>
@@ -112,7 +112,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn btn"
                 style="background: rgb(0, 0, 255);"
-                title="0000FF"
+                title="#0000FF"
                 type="button"
               />
             </div>
@@ -122,7 +122,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn active clay-color-btn-bordered btn"
                 style="background: rgb(255, 255, 255);"
-                title="FFFFFF"
+                title="#FFFFFF"
                 type="button"
               />
             </div>
@@ -132,7 +132,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn clay-color-btn-bordered btn"
                 style="background: rgb(255, 255, 255);"
-                title="FFFFFF"
+                title="#FFFFFF"
                 type="button"
               />
             </div>
@@ -142,7 +142,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn clay-color-btn-bordered btn"
                 style="background: rgb(255, 255, 255);"
-                title="FFFFFF"
+                title="#FFFFFF"
                 type="button"
               />
             </div>
@@ -152,7 +152,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn clay-color-btn-bordered btn"
                 style="background: rgb(255, 255, 255);"
-                title="FFFFFF"
+                title="#FFFFFF"
                 type="button"
               />
             </div>
@@ -162,7 +162,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn clay-color-btn-bordered btn"
                 style="background: rgb(255, 255, 255);"
-                title="FFFFFF"
+                title="#FFFFFF"
                 type="button"
               />
             </div>
@@ -172,7 +172,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn clay-color-btn-bordered btn"
                 style="background: rgb(255, 255, 255);"
-                title="FFFFFF"
+                title="#FFFFFF"
                 type="button"
               />
             </div>
@@ -182,7 +182,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn clay-color-btn-bordered btn"
                 style="background: rgb(255, 255, 255);"
-                title="FFFFFF"
+                title="#FFFFFF"
                 type="button"
               />
             </div>
@@ -192,7 +192,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn clay-color-btn-bordered btn"
                 style="background: rgb(255, 255, 255);"
-                title="FFFFFF"
+                title="#FFFFFF"
                 type="button"
               />
             </div>
@@ -202,7 +202,7 @@ exports[`Interactions color editor interactions ability to change color of click
               <button
                 class="clay-color-btn clay-color-btn-bordered btn"
                 style="background: rgb(255, 255, 255);"
-                title="FFFFFF"
+                title="#FFFFFF"
                 type="button"
               />
             </div>
@@ -372,7 +372,7 @@ exports[`Interactions opens custom color picker drop down when clicked 1`] = `
             aria-label="Select a color"
             class="clay-color-btn dropdown-toggle btn"
             style="background: rgb(0, 128, 0);"
-            title="008000"
+            title="#008000"
             type="button"
           />
         </div>
@@ -429,7 +429,7 @@ exports[`Rendering default 1`] = `
               aria-label="Select a color"
               class="clay-color-btn dropdown-toggle clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFF"
+              title="#FFF"
               type="button"
             />
           </div>
@@ -477,7 +477,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 0, 0);"
-              title="000000"
+              title="#000000"
               type="button"
             />
           </div>
@@ -487,7 +487,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(95, 95, 95);"
-              title="5F5F5F"
+              title="#5F5F5F"
               type="button"
             />
           </div>
@@ -497,7 +497,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(154, 154, 154);"
-              title="9A9A9A"
+              title="#9A9A9A"
               type="button"
             />
           </div>
@@ -507,7 +507,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(203, 203, 203);"
-              title="CBCBCB"
+              title="#CBCBCB"
               type="button"
             />
           </div>
@@ -517,7 +517,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(225, 225, 225);"
-              title="E1E1E1"
+              title="#E1E1E1"
               type="button"
             />
           </div>
@@ -527,7 +527,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFFFFF"
+              title="#FFFFFF"
               type="button"
             />
           </div>
@@ -537,7 +537,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 13, 13);"
-              title="FF0D0D"
+              title="#FF0D0D"
               type="button"
             />
           </div>
@@ -547,7 +547,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 138, 28);"
-              title="FF8A1C"
+              title="#FF8A1C"
               type="button"
             />
           </div>
@@ -557,7 +557,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(43, 166, 118);"
-              title="2BA676"
+              title="#2BA676"
               type="button"
             />
           </div>
@@ -567,7 +567,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 110, 248);"
-              title="006EF8"
+              title="#006EF8"
               type="button"
             />
           </div>
@@ -577,7 +577,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(127, 38, 255);"
-              title="7F26FF"
+              title="#7F26FF"
               type="button"
             />
           </div>
@@ -587,7 +587,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 33, 160);"
-              title="FF21A0"
+              title="#FF21A0"
               type="button"
             />
           </div>
@@ -597,7 +597,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 95, 95);"
-              title="FF5F5F"
+              title="#FF5F5F"
               type="button"
             />
           </div>
@@ -607,7 +607,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 180, 110);"
-              title="FFB46E"
+              title="#FFB46E"
               type="button"
             />
           </div>
@@ -617,7 +617,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(80, 210, 160);"
-              title="50D2A0"
+              title="#50D2A0"
               type="button"
             />
           </div>
@@ -627,7 +627,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(75, 155, 255);"
-              title="4B9BFF"
+              title="#4B9BFF"
               type="button"
             />
           </div>
@@ -637,7 +637,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(175, 120, 255);"
-              title="AF78FF"
+              title="#AF78FF"
               type="button"
             />
           </div>
@@ -647,7 +647,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 115, 195);"
-              title="FF73C3"
+              title="#FF73C3"
               type="button"
             />
           </div>
@@ -657,7 +657,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 177, 177);"
-              title="FFB1B1"
+              title="#FFB1B1"
               type="button"
             />
           </div>
@@ -667,7 +667,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 222, 192);"
-              title="FFDEC0"
+              title="#FFDEC0"
               type="button"
             />
           </div>
@@ -677,7 +677,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(145, 227, 195);"
-              title="91E3C3"
+              title="#91E3C3"
               type="button"
             />
           </div>
@@ -687,7 +687,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(157, 200, 255);"
-              title="9DC8FF"
+              title="#9DC8FF"
               type="button"
             />
           </div>
@@ -697,7 +697,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(223, 202, 255);"
-              title="DFCAFF"
+              title="#DFCAFF"
               type="button"
             />
           </div>
@@ -707,7 +707,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 197, 230);"
-              title="FFC5E6"
+              title="#FFC5E6"
               type="button"
             />
           </div>
@@ -717,7 +717,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 217, 217);"
-              title="FFD9D9"
+              title="#FFD9D9"
               type="button"
             />
           </div>
@@ -727,7 +727,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 243, 232);"
-              title="FFF3E8"
+              title="#FFF3E8"
               type="button"
             />
           </div>
@@ -737,7 +737,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(177, 235, 213);"
-              title="B1EBD5"
+              title="#B1EBD5"
               type="button"
             />
           </div>
@@ -747,7 +747,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(197, 223, 255);"
-              title="C5DFFF"
+              title="#C5DFFF"
               type="button"
             />
           </div>
@@ -757,7 +757,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(248, 242, 255);"
-              title="F8F2FF"
+              title="#F8F2FF"
               type="button"
             />
           </div>
@@ -767,7 +767,7 @@ exports[`Rendering default 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 237, 247);"
-              title="FFEDF7"
+              title="#FFEDF7"
               type="button"
             />
           </div>
@@ -808,7 +808,7 @@ exports[`Rendering disabled palette 1`] = `
               aria-label="Select a color"
               class="clay-color-btn dropdown-toggle clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFF"
+              title="#FFF"
               type="button"
             />
           </div>
@@ -856,7 +856,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 0, 0);"
-              title="000000"
+              title="#000000"
               type="button"
             />
           </div>
@@ -866,7 +866,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(95, 95, 95);"
-              title="5F5F5F"
+              title="#5F5F5F"
               type="button"
             />
           </div>
@@ -876,7 +876,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(154, 154, 154);"
-              title="9A9A9A"
+              title="#9A9A9A"
               type="button"
             />
           </div>
@@ -886,7 +886,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(203, 203, 203);"
-              title="CBCBCB"
+              title="#CBCBCB"
               type="button"
             />
           </div>
@@ -896,7 +896,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(225, 225, 225);"
-              title="E1E1E1"
+              title="#E1E1E1"
               type="button"
             />
           </div>
@@ -906,7 +906,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFFFFF"
+              title="#FFFFFF"
               type="button"
             />
           </div>
@@ -916,7 +916,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 13, 13);"
-              title="FF0D0D"
+              title="#FF0D0D"
               type="button"
             />
           </div>
@@ -926,7 +926,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 138, 28);"
-              title="FF8A1C"
+              title="#FF8A1C"
               type="button"
             />
           </div>
@@ -936,7 +936,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(43, 166, 118);"
-              title="2BA676"
+              title="#2BA676"
               type="button"
             />
           </div>
@@ -946,7 +946,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 110, 248);"
-              title="006EF8"
+              title="#006EF8"
               type="button"
             />
           </div>
@@ -956,7 +956,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(127, 38, 255);"
-              title="7F26FF"
+              title="#7F26FF"
               type="button"
             />
           </div>
@@ -966,7 +966,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 33, 160);"
-              title="FF21A0"
+              title="#FF21A0"
               type="button"
             />
           </div>
@@ -976,7 +976,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 95, 95);"
-              title="FF5F5F"
+              title="#FF5F5F"
               type="button"
             />
           </div>
@@ -986,7 +986,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 180, 110);"
-              title="FFB46E"
+              title="#FFB46E"
               type="button"
             />
           </div>
@@ -996,7 +996,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(80, 210, 160);"
-              title="50D2A0"
+              title="#50D2A0"
               type="button"
             />
           </div>
@@ -1006,7 +1006,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(75, 155, 255);"
-              title="4B9BFF"
+              title="#4B9BFF"
               type="button"
             />
           </div>
@@ -1016,7 +1016,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(175, 120, 255);"
-              title="AF78FF"
+              title="#AF78FF"
               type="button"
             />
           </div>
@@ -1026,7 +1026,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 115, 195);"
-              title="FF73C3"
+              title="#FF73C3"
               type="button"
             />
           </div>
@@ -1036,7 +1036,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 177, 177);"
-              title="FFB1B1"
+              title="#FFB1B1"
               type="button"
             />
           </div>
@@ -1046,7 +1046,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 222, 192);"
-              title="FFDEC0"
+              title="#FFDEC0"
               type="button"
             />
           </div>
@@ -1056,7 +1056,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(145, 227, 195);"
-              title="91E3C3"
+              title="#91E3C3"
               type="button"
             />
           </div>
@@ -1066,7 +1066,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(157, 200, 255);"
-              title="9DC8FF"
+              title="#9DC8FF"
               type="button"
             />
           </div>
@@ -1076,7 +1076,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(223, 202, 255);"
-              title="DFCAFF"
+              title="#DFCAFF"
               type="button"
             />
           </div>
@@ -1086,7 +1086,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 197, 230);"
-              title="FFC5E6"
+              title="#FFC5E6"
               type="button"
             />
           </div>
@@ -1096,7 +1096,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 217, 217);"
-              title="FFD9D9"
+              title="#FFD9D9"
               type="button"
             />
           </div>
@@ -1106,7 +1106,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 243, 232);"
-              title="FFF3E8"
+              title="#FFF3E8"
               type="button"
             />
           </div>
@@ -1116,7 +1116,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(177, 235, 213);"
-              title="B1EBD5"
+              title="#B1EBD5"
               type="button"
             />
           </div>
@@ -1126,7 +1126,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(197, 223, 255);"
-              title="C5DFFF"
+              title="#C5DFFF"
               type="button"
             />
           </div>
@@ -1136,7 +1136,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(248, 242, 255);"
-              title="F8F2FF"
+              title="#F8F2FF"
               type="button"
             />
           </div>
@@ -1146,7 +1146,7 @@ exports[`Rendering disabled palette 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 237, 247);"
-              title="FFEDF7"
+              title="#FFEDF7"
               type="button"
             />
           </div>
@@ -1188,7 +1188,7 @@ exports[`Rendering disabled state 1`] = `
               class="clay-color-btn dropdown-toggle clay-color-btn-bordered btn"
               disabled=""
               style="background: rgb(255, 255, 255);"
-              title="FFF"
+              title="#FFF"
               type="button"
             />
           </div>
@@ -1237,7 +1237,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 0, 0);"
-              title="000000"
+              title="#000000"
               type="button"
             />
           </div>
@@ -1247,7 +1247,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(95, 95, 95);"
-              title="5F5F5F"
+              title="#5F5F5F"
               type="button"
             />
           </div>
@@ -1257,7 +1257,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(154, 154, 154);"
-              title="9A9A9A"
+              title="#9A9A9A"
               type="button"
             />
           </div>
@@ -1267,7 +1267,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(203, 203, 203);"
-              title="CBCBCB"
+              title="#CBCBCB"
               type="button"
             />
           </div>
@@ -1277,7 +1277,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(225, 225, 225);"
-              title="E1E1E1"
+              title="#E1E1E1"
               type="button"
             />
           </div>
@@ -1287,7 +1287,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFFFFF"
+              title="#FFFFFF"
               type="button"
             />
           </div>
@@ -1297,7 +1297,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 13, 13);"
-              title="FF0D0D"
+              title="#FF0D0D"
               type="button"
             />
           </div>
@@ -1307,7 +1307,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 138, 28);"
-              title="FF8A1C"
+              title="#FF8A1C"
               type="button"
             />
           </div>
@@ -1317,7 +1317,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(43, 166, 118);"
-              title="2BA676"
+              title="#2BA676"
               type="button"
             />
           </div>
@@ -1327,7 +1327,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 110, 248);"
-              title="006EF8"
+              title="#006EF8"
               type="button"
             />
           </div>
@@ -1337,7 +1337,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(127, 38, 255);"
-              title="7F26FF"
+              title="#7F26FF"
               type="button"
             />
           </div>
@@ -1347,7 +1347,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 33, 160);"
-              title="FF21A0"
+              title="#FF21A0"
               type="button"
             />
           </div>
@@ -1357,7 +1357,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 95, 95);"
-              title="FF5F5F"
+              title="#FF5F5F"
               type="button"
             />
           </div>
@@ -1367,7 +1367,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 180, 110);"
-              title="FFB46E"
+              title="#FFB46E"
               type="button"
             />
           </div>
@@ -1377,7 +1377,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(80, 210, 160);"
-              title="50D2A0"
+              title="#50D2A0"
               type="button"
             />
           </div>
@@ -1387,7 +1387,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(75, 155, 255);"
-              title="4B9BFF"
+              title="#4B9BFF"
               type="button"
             />
           </div>
@@ -1397,7 +1397,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(175, 120, 255);"
-              title="AF78FF"
+              title="#AF78FF"
               type="button"
             />
           </div>
@@ -1407,7 +1407,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 115, 195);"
-              title="FF73C3"
+              title="#FF73C3"
               type="button"
             />
           </div>
@@ -1417,7 +1417,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 177, 177);"
-              title="FFB1B1"
+              title="#FFB1B1"
               type="button"
             />
           </div>
@@ -1427,7 +1427,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 222, 192);"
-              title="FFDEC0"
+              title="#FFDEC0"
               type="button"
             />
           </div>
@@ -1437,7 +1437,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(145, 227, 195);"
-              title="91E3C3"
+              title="#91E3C3"
               type="button"
             />
           </div>
@@ -1447,7 +1447,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(157, 200, 255);"
-              title="9DC8FF"
+              title="#9DC8FF"
               type="button"
             />
           </div>
@@ -1457,7 +1457,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(223, 202, 255);"
-              title="DFCAFF"
+              title="#DFCAFF"
               type="button"
             />
           </div>
@@ -1467,7 +1467,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 197, 230);"
-              title="FFC5E6"
+              title="#FFC5E6"
               type="button"
             />
           </div>
@@ -1477,7 +1477,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 217, 217);"
-              title="FFD9D9"
+              title="#FFD9D9"
               type="button"
             />
           </div>
@@ -1487,7 +1487,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 243, 232);"
-              title="FFF3E8"
+              title="#FFF3E8"
               type="button"
             />
           </div>
@@ -1497,7 +1497,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(177, 235, 213);"
-              title="B1EBD5"
+              title="#B1EBD5"
               type="button"
             />
           </div>
@@ -1507,7 +1507,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(197, 223, 255);"
-              title="C5DFFF"
+              title="#C5DFFF"
               type="button"
             />
           </div>
@@ -1517,7 +1517,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(248, 242, 255);"
-              title="F8F2FF"
+              title="#F8F2FF"
               type="button"
             />
           </div>
@@ -1527,7 +1527,7 @@ exports[`Rendering disabled state 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 237, 247);"
-              title="FFEDF7"
+              title="#FFEDF7"
               type="button"
             />
           </div>
@@ -1623,7 +1623,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 0, 0);"
-              title="000000"
+              title="#000000"
               type="button"
             />
           </div>
@@ -1633,7 +1633,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(95, 95, 95);"
-              title="5F5F5F"
+              title="#5F5F5F"
               type="button"
             />
           </div>
@@ -1643,7 +1643,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(154, 154, 154);"
-              title="9A9A9A"
+              title="#9A9A9A"
               type="button"
             />
           </div>
@@ -1653,7 +1653,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(203, 203, 203);"
-              title="CBCBCB"
+              title="#CBCBCB"
               type="button"
             />
           </div>
@@ -1663,7 +1663,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(225, 225, 225);"
-              title="E1E1E1"
+              title="#E1E1E1"
               type="button"
             />
           </div>
@@ -1673,7 +1673,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFFFFF"
+              title="#FFFFFF"
               type="button"
             />
           </div>
@@ -1683,7 +1683,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 13, 13);"
-              title="FF0D0D"
+              title="#FF0D0D"
               type="button"
             />
           </div>
@@ -1693,7 +1693,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 138, 28);"
-              title="FF8A1C"
+              title="#FF8A1C"
               type="button"
             />
           </div>
@@ -1703,7 +1703,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(43, 166, 118);"
-              title="2BA676"
+              title="#2BA676"
               type="button"
             />
           </div>
@@ -1713,7 +1713,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 110, 248);"
-              title="006EF8"
+              title="#006EF8"
               type="button"
             />
           </div>
@@ -1723,7 +1723,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(127, 38, 255);"
-              title="7F26FF"
+              title="#7F26FF"
               type="button"
             />
           </div>
@@ -1733,7 +1733,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 33, 160);"
-              title="FF21A0"
+              title="#FF21A0"
               type="button"
             />
           </div>
@@ -1743,7 +1743,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 95, 95);"
-              title="FF5F5F"
+              title="#FF5F5F"
               type="button"
             />
           </div>
@@ -1753,7 +1753,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 180, 110);"
-              title="FFB46E"
+              title="#FFB46E"
               type="button"
             />
           </div>
@@ -1763,7 +1763,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(80, 210, 160);"
-              title="50D2A0"
+              title="#50D2A0"
               type="button"
             />
           </div>
@@ -1773,7 +1773,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(75, 155, 255);"
-              title="4B9BFF"
+              title="#4B9BFF"
               type="button"
             />
           </div>
@@ -1783,7 +1783,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(175, 120, 255);"
-              title="AF78FF"
+              title="#AF78FF"
               type="button"
             />
           </div>
@@ -1793,7 +1793,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 115, 195);"
-              title="FF73C3"
+              title="#FF73C3"
               type="button"
             />
           </div>
@@ -1803,7 +1803,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 177, 177);"
-              title="FFB1B1"
+              title="#FFB1B1"
               type="button"
             />
           </div>
@@ -1813,7 +1813,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 222, 192);"
-              title="FFDEC0"
+              title="#FFDEC0"
               type="button"
             />
           </div>
@@ -1823,7 +1823,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(145, 227, 195);"
-              title="91E3C3"
+              title="#91E3C3"
               type="button"
             />
           </div>
@@ -1833,7 +1833,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(157, 200, 255);"
-              title="9DC8FF"
+              title="#9DC8FF"
               type="button"
             />
           </div>
@@ -1843,7 +1843,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(223, 202, 255);"
-              title="DFCAFF"
+              title="#DFCAFF"
               type="button"
             />
           </div>
@@ -1853,7 +1853,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 197, 230);"
-              title="FFC5E6"
+              title="#FFC5E6"
               type="button"
             />
           </div>
@@ -1863,7 +1863,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 217, 217);"
-              title="FFD9D9"
+              title="#FFD9D9"
               type="button"
             />
           </div>
@@ -1873,7 +1873,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 243, 232);"
-              title="FFF3E8"
+              title="#FFF3E8"
               type="button"
             />
           </div>
@@ -1883,7 +1883,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(177, 235, 213);"
-              title="B1EBD5"
+              title="#B1EBD5"
               type="button"
             />
           </div>
@@ -1893,7 +1893,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(197, 223, 255);"
-              title="C5DFFF"
+              title="#C5DFFF"
               type="button"
             />
           </div>
@@ -1903,7 +1903,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(248, 242, 255);"
-              title="F8F2FF"
+              title="#F8F2FF"
               type="button"
             />
           </div>
@@ -1913,7 +1913,7 @@ exports[`Rendering renders w/ var() 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 237, 247);"
-              title="FFEDF7"
+              title="#FFEDF7"
               type="button"
             />
           </div>
@@ -1954,7 +1954,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
               aria-label="Select a color"
               class="clay-color-btn dropdown-toggle clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFF"
+              title="#FFF"
               type="button"
             />
           </div>
@@ -2002,7 +2002,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 0, 0);"
-              title="000000"
+              title="#000000"
               type="button"
             />
           </div>
@@ -2012,7 +2012,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(95, 95, 95);"
-              title="5F5F5F"
+              title="#5F5F5F"
               type="button"
             />
           </div>
@@ -2022,7 +2022,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(154, 154, 154);"
-              title="9A9A9A"
+              title="#9A9A9A"
               type="button"
             />
           </div>
@@ -2032,7 +2032,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(203, 203, 203);"
-              title="CBCBCB"
+              title="#CBCBCB"
               type="button"
             />
           </div>
@@ -2042,7 +2042,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(225, 225, 225);"
-              title="E1E1E1"
+              title="#E1E1E1"
               type="button"
             />
           </div>
@@ -2052,7 +2052,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFFFFF"
+              title="#FFFFFF"
               type="button"
             />
           </div>
@@ -2062,7 +2062,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 13, 13);"
-              title="FF0D0D"
+              title="#FF0D0D"
               type="button"
             />
           </div>
@@ -2072,7 +2072,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 138, 28);"
-              title="FF8A1C"
+              title="#FF8A1C"
               type="button"
             />
           </div>
@@ -2082,7 +2082,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(43, 166, 118);"
-              title="2BA676"
+              title="#2BA676"
               type="button"
             />
           </div>
@@ -2092,7 +2092,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 110, 248);"
-              title="006EF8"
+              title="#006EF8"
               type="button"
             />
           </div>
@@ -2102,7 +2102,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(127, 38, 255);"
-              title="7F26FF"
+              title="#7F26FF"
               type="button"
             />
           </div>
@@ -2112,7 +2112,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 33, 160);"
-              title="FF21A0"
+              title="#FF21A0"
               type="button"
             />
           </div>
@@ -2122,7 +2122,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 95, 95);"
-              title="FF5F5F"
+              title="#FF5F5F"
               type="button"
             />
           </div>
@@ -2132,7 +2132,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 180, 110);"
-              title="FFB46E"
+              title="#FFB46E"
               type="button"
             />
           </div>
@@ -2142,7 +2142,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(80, 210, 160);"
-              title="50D2A0"
+              title="#50D2A0"
               type="button"
             />
           </div>
@@ -2152,7 +2152,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(75, 155, 255);"
-              title="4B9BFF"
+              title="#4B9BFF"
               type="button"
             />
           </div>
@@ -2162,7 +2162,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(175, 120, 255);"
-              title="AF78FF"
+              title="#AF78FF"
               type="button"
             />
           </div>
@@ -2172,7 +2172,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 115, 195);"
-              title="FF73C3"
+              title="#FF73C3"
               type="button"
             />
           </div>
@@ -2182,7 +2182,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 177, 177);"
-              title="FFB1B1"
+              title="#FFB1B1"
               type="button"
             />
           </div>
@@ -2192,7 +2192,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 222, 192);"
-              title="FFDEC0"
+              title="#FFDEC0"
               type="button"
             />
           </div>
@@ -2202,7 +2202,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(145, 227, 195);"
-              title="91E3C3"
+              title="#91E3C3"
               type="button"
             />
           </div>
@@ -2212,7 +2212,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(157, 200, 255);"
-              title="9DC8FF"
+              title="#9DC8FF"
               type="button"
             />
           </div>
@@ -2222,7 +2222,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(223, 202, 255);"
-              title="DFCAFF"
+              title="#DFCAFF"
               type="button"
             />
           </div>
@@ -2232,7 +2232,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 197, 230);"
-              title="FFC5E6"
+              title="#FFC5E6"
               type="button"
             />
           </div>
@@ -2242,7 +2242,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 217, 217);"
-              title="FFD9D9"
+              title="#FFD9D9"
               type="button"
             />
           </div>
@@ -2252,7 +2252,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 243, 232);"
-              title="FFF3E8"
+              title="#FFF3E8"
               type="button"
             />
           </div>
@@ -2262,7 +2262,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(177, 235, 213);"
-              title="B1EBD5"
+              title="#B1EBD5"
               type="button"
             />
           </div>
@@ -2272,7 +2272,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(197, 223, 255);"
-              title="C5DFFF"
+              title="#C5DFFF"
               type="button"
             />
           </div>
@@ -2282,7 +2282,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(248, 242, 255);"
-              title="F8F2FF"
+              title="#F8F2FF"
               type="button"
             />
           </div>
@@ -2292,7 +2292,7 @@ exports[`Rendering renders with a hash for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 237, 247);"
-              title="FFEDF7"
+              title="#FFEDF7"
               type="button"
             />
           </div>
@@ -2389,7 +2389,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 0, 0);"
-              title="000000"
+              title="#000000"
               type="button"
             />
           </div>
@@ -2399,7 +2399,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(95, 95, 95);"
-              title="5F5F5F"
+              title="#5F5F5F"
               type="button"
             />
           </div>
@@ -2409,7 +2409,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(154, 154, 154);"
-              title="9A9A9A"
+              title="#9A9A9A"
               type="button"
             />
           </div>
@@ -2419,7 +2419,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(203, 203, 203);"
-              title="CBCBCB"
+              title="#CBCBCB"
               type="button"
             />
           </div>
@@ -2429,7 +2429,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(225, 225, 225);"
-              title="E1E1E1"
+              title="#E1E1E1"
               type="button"
             />
           </div>
@@ -2439,7 +2439,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFFFFF"
+              title="#FFFFFF"
               type="button"
             />
           </div>
@@ -2449,7 +2449,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 13, 13);"
-              title="FF0D0D"
+              title="#FF0D0D"
               type="button"
             />
           </div>
@@ -2459,7 +2459,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 138, 28);"
-              title="FF8A1C"
+              title="#FF8A1C"
               type="button"
             />
           </div>
@@ -2469,7 +2469,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(43, 166, 118);"
-              title="2BA676"
+              title="#2BA676"
               type="button"
             />
           </div>
@@ -2479,7 +2479,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 110, 248);"
-              title="006EF8"
+              title="#006EF8"
               type="button"
             />
           </div>
@@ -2489,7 +2489,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(127, 38, 255);"
-              title="7F26FF"
+              title="#7F26FF"
               type="button"
             />
           </div>
@@ -2499,7 +2499,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 33, 160);"
-              title="FF21A0"
+              title="#FF21A0"
               type="button"
             />
           </div>
@@ -2509,7 +2509,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 95, 95);"
-              title="FF5F5F"
+              title="#FF5F5F"
               type="button"
             />
           </div>
@@ -2519,7 +2519,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 180, 110);"
-              title="FFB46E"
+              title="#FFB46E"
               type="button"
             />
           </div>
@@ -2529,7 +2529,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(80, 210, 160);"
-              title="50D2A0"
+              title="#50D2A0"
               type="button"
             />
           </div>
@@ -2539,7 +2539,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(75, 155, 255);"
-              title="4B9BFF"
+              title="#4B9BFF"
               type="button"
             />
           </div>
@@ -2549,7 +2549,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(175, 120, 255);"
-              title="AF78FF"
+              title="#AF78FF"
               type="button"
             />
           </div>
@@ -2559,7 +2559,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 115, 195);"
-              title="FF73C3"
+              title="#FF73C3"
               type="button"
             />
           </div>
@@ -2569,7 +2569,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 177, 177);"
-              title="FFB1B1"
+              title="#FFB1B1"
               type="button"
             />
           </div>
@@ -2579,7 +2579,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 222, 192);"
-              title="FFDEC0"
+              title="#FFDEC0"
               type="button"
             />
           </div>
@@ -2589,7 +2589,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(145, 227, 195);"
-              title="91E3C3"
+              title="#91E3C3"
               type="button"
             />
           </div>
@@ -2599,7 +2599,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(157, 200, 255);"
-              title="9DC8FF"
+              title="#9DC8FF"
               type="button"
             />
           </div>
@@ -2609,7 +2609,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(223, 202, 255);"
-              title="DFCAFF"
+              title="#DFCAFF"
               type="button"
             />
           </div>
@@ -2619,7 +2619,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 197, 230);"
-              title="FFC5E6"
+              title="#FFC5E6"
               type="button"
             />
           </div>
@@ -2629,7 +2629,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 217, 217);"
-              title="FFD9D9"
+              title="#FFD9D9"
               type="button"
             />
           </div>
@@ -2639,7 +2639,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 243, 232);"
-              title="FFF3E8"
+              title="#FFF3E8"
               type="button"
             />
           </div>
@@ -2649,7 +2649,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(177, 235, 213);"
-              title="B1EBD5"
+              title="#B1EBD5"
               type="button"
             />
           </div>
@@ -2659,7 +2659,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(197, 223, 255);"
-              title="C5DFFF"
+              title="#C5DFFF"
               type="button"
             />
           </div>
@@ -2669,7 +2669,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(248, 242, 255);"
-              title="F8F2FF"
+              title="#F8F2FF"
               type="button"
             />
           </div>
@@ -2679,7 +2679,7 @@ exports[`Rendering renders with a named color for the value 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 237, 247);"
-              title="FFEDF7"
+              title="#FFEDF7"
               type="button"
             />
           </div>
@@ -2720,7 +2720,7 @@ exports[`Rendering small color-picker 1`] = `
               aria-label="Select a color"
               class="clay-color-btn dropdown-toggle clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFF"
+              title="#FFF"
               type="button"
             />
           </div>
@@ -2768,7 +2768,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 0, 0);"
-              title="000000"
+              title="#000000"
               type="button"
             />
           </div>
@@ -2778,7 +2778,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(95, 95, 95);"
-              title="5F5F5F"
+              title="#5F5F5F"
               type="button"
             />
           </div>
@@ -2788,7 +2788,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(154, 154, 154);"
-              title="9A9A9A"
+              title="#9A9A9A"
               type="button"
             />
           </div>
@@ -2798,7 +2798,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(203, 203, 203);"
-              title="CBCBCB"
+              title="#CBCBCB"
               type="button"
             />
           </div>
@@ -2808,7 +2808,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(225, 225, 225);"
-              title="E1E1E1"
+              title="#E1E1E1"
               type="button"
             />
           </div>
@@ -2818,7 +2818,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 255, 255);"
-              title="FFFFFF"
+              title="#FFFFFF"
               type="button"
             />
           </div>
@@ -2828,7 +2828,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 13, 13);"
-              title="FF0D0D"
+              title="#FF0D0D"
               type="button"
             />
           </div>
@@ -2838,7 +2838,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 138, 28);"
-              title="FF8A1C"
+              title="#FF8A1C"
               type="button"
             />
           </div>
@@ -2848,7 +2848,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(43, 166, 118);"
-              title="2BA676"
+              title="#2BA676"
               type="button"
             />
           </div>
@@ -2858,7 +2858,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(0, 110, 248);"
-              title="006EF8"
+              title="#006EF8"
               type="button"
             />
           </div>
@@ -2868,7 +2868,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(127, 38, 255);"
-              title="7F26FF"
+              title="#7F26FF"
               type="button"
             />
           </div>
@@ -2878,7 +2878,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 33, 160);"
-              title="FF21A0"
+              title="#FF21A0"
               type="button"
             />
           </div>
@@ -2888,7 +2888,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 95, 95);"
-              title="FF5F5F"
+              title="#FF5F5F"
               type="button"
             />
           </div>
@@ -2898,7 +2898,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 180, 110);"
-              title="FFB46E"
+              title="#FFB46E"
               type="button"
             />
           </div>
@@ -2908,7 +2908,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(80, 210, 160);"
-              title="50D2A0"
+              title="#50D2A0"
               type="button"
             />
           </div>
@@ -2918,7 +2918,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(75, 155, 255);"
-              title="4B9BFF"
+              title="#4B9BFF"
               type="button"
             />
           </div>
@@ -2928,7 +2928,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(175, 120, 255);"
-              title="AF78FF"
+              title="#AF78FF"
               type="button"
             />
           </div>
@@ -2938,7 +2938,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 115, 195);"
-              title="FF73C3"
+              title="#FF73C3"
               type="button"
             />
           </div>
@@ -2948,7 +2948,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 177, 177);"
-              title="FFB1B1"
+              title="#FFB1B1"
               type="button"
             />
           </div>
@@ -2958,7 +2958,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 222, 192);"
-              title="FFDEC0"
+              title="#FFDEC0"
               type="button"
             />
           </div>
@@ -2968,7 +2968,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(145, 227, 195);"
-              title="91E3C3"
+              title="#91E3C3"
               type="button"
             />
           </div>
@@ -2978,7 +2978,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(157, 200, 255);"
-              title="9DC8FF"
+              title="#9DC8FF"
               type="button"
             />
           </div>
@@ -2988,7 +2988,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(223, 202, 255);"
-              title="DFCAFF"
+              title="#DFCAFF"
               type="button"
             />
           </div>
@@ -2998,7 +2998,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 197, 230);"
-              title="FFC5E6"
+              title="#FFC5E6"
               type="button"
             />
           </div>
@@ -3008,7 +3008,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 217, 217);"
-              title="FFD9D9"
+              title="#FFD9D9"
               type="button"
             />
           </div>
@@ -3018,7 +3018,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(255, 243, 232);"
-              title="FFF3E8"
+              title="#FFF3E8"
               type="button"
             />
           </div>
@@ -3028,7 +3028,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(177, 235, 213);"
-              title="B1EBD5"
+              title="#B1EBD5"
               type="button"
             />
           </div>
@@ -3038,7 +3038,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(197, 223, 255);"
-              title="C5DFFF"
+              title="#C5DFFF"
               type="button"
             />
           </div>
@@ -3048,7 +3048,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn clay-color-btn-bordered btn"
               style="background: rgb(248, 242, 255);"
-              title="F8F2FF"
+              title="#F8F2FF"
               type="button"
             />
           </div>
@@ -3058,7 +3058,7 @@ exports[`Rendering small color-picker 1`] = `
             <button
               class="clay-color-btn btn"
               style="background: rgb(255, 237, 247);"
-              title="FFEDF7"
+              title="#FFEDF7"
               type="button"
             />
           </div>

--- a/packages/clay-color-picker/src/__tests__/index.tsx
+++ b/packages/clay-color-picker/src/__tests__/index.tsx
@@ -432,7 +432,7 @@ describe('Interactions', () => {
 			expect(input.value).toBe('DFCAFF');
 
 			expect(
-				document.body.querySelectorAll('button[title="dfcaff"]').length
+				document.body.querySelectorAll('button[title="#dfcaff"]').length
 			).toBe(0);
 
 			expect(editorGetByTestId('rInput').value).toBe('223');
@@ -455,14 +455,14 @@ describe('Interactions', () => {
 
 			const blankSplotch = (
 				document.body as HTMLButtonElement
-			).querySelector('button[title="FFFFFF"]');
+			).querySelector('button[title="#FFFFFF"]');
 
 			fireEvent.click(blankSplotch as HTMLButtonElement, {});
 
 			expect(input.value).toBe('DFCAFF');
 
 			expect(
-				document.body.querySelectorAll('button[title="dfcaff"]').length
+				document.body.querySelectorAll('button[title="#dfcaff"]').length
 			).toBe(1);
 
 			expect(editorGetByTestId('rInput').value).toBe('223');
@@ -484,7 +484,7 @@ describe('Interactions', () => {
 			fireEvent.click(dropdownToggle as HTMLButtonElement, {});
 
 			const colorSplotch = editorGetByTitle(
-				'008000'
+				'#008000'
 			) as HTMLButtonElement;
 
 			fireEvent.click(colorSplotch as HTMLButtonElement, {});
@@ -498,7 +498,7 @@ describe('Interactions', () => {
 			expect(input.value).toBe('008000');
 
 			expect(
-				document.body.querySelectorAll('button[title="dfcaff"]').length
+				document.body.querySelectorAll('button[title="#dfcaff"]').length
 			).toBe(0);
 
 			expect(editorGetByTestId('rInput').value).toBe('0');
@@ -539,7 +539,7 @@ describe('Interactions', () => {
 
 			expect(
 				document.body.querySelector(
-					'.clay-color-header button[title="c8c8c8"]'
+					'.clay-color-header button[title="#c8c8c8"]'
 				)
 			).toBeNull();
 
@@ -560,7 +560,7 @@ describe('Interactions', () => {
 
 			const blankSplotch = (
 				document.body as HTMLButtonElement
-			).querySelector('button[title="FFFFFF"]');
+			).querySelector('button[title="#FFFFFF"]');
 
 			fireEvent.click(blankSplotch as HTMLButtonElement, {});
 
@@ -568,7 +568,7 @@ describe('Interactions', () => {
 
 			const greenSplotch = (
 				document.body as HTMLButtonElement
-			).querySelector('button[title="008000"]');
+			).querySelector('button[title="#008000"]');
 
 			fireEvent.click(greenSplotch as HTMLButtonElement, {});
 
@@ -576,7 +576,7 @@ describe('Interactions', () => {
 
 			const purpleSplotchs = (
 				document.body as HTMLButtonElement
-			).querySelectorAll('button[title="dfcaff"]');
+			).querySelectorAll('button[title="#dfcaff"]');
 
 			expect(purpleSplotchs.length).toBe(2);
 		});
@@ -594,7 +594,7 @@ describe('Interactions', () => {
 
 			const blankSplotch = (
 				document.body as HTMLButtonElement
-			).querySelector('button[title="FFFFFF"]');
+			).querySelector('button[title="#FFFFFF"]');
 
 			fireEvent.click(blankSplotch as HTMLButtonElement, {});
 

--- a/packages/clay-color-picker/src/index.tsx
+++ b/packages/clay-color-picker/src/index.tsx
@@ -157,6 +157,11 @@ interface IProps
 	small?: boolean;
 
 	/**
+	 * The title of the Main Splotch component
+	 */
+	splotchTitle?: string;
+
+	/**
 	 * Path to the location of the spritemap resource.
 	 */
 	spritemap?: string;
@@ -196,6 +201,7 @@ const ClayColorPicker = ({
 	showPalette = true,
 	showPredefinedColorsWithCustom = false,
 	small,
+	splotchTitle,
 	spritemap,
 	title,
 	useNative = false,
@@ -326,6 +332,7 @@ const ClayColorPicker = ({
 									}
 								}}
 								ref={splotchRef}
+								title={splotchTitle}
 								value={internalValue}
 							/>
 						</ClayInput.GroupText>


### PR DESCRIPTION
fixes #5155 

This adds the `#` symbol to hex values in the title. It also adds `splotchProps` so we can pass attributes to the Input Group splotch. This would allow passing custom titles to the Input Group Splotch.

```
<ClayColorPicker
	splotchProps={{
		title: `Background Color: #${color}`,
	}}
	value={color}
/>
```