### PR TITLE
feat(@clayui/nav): add accessibility to the Vertical Nav component

### DIFF
--- a/clayui.com/content/docs/components/markup-menubar.md
+++ b/clayui.com/content/docs/components/markup-menubar.md
@@ -1,10 +1,10 @@
 ---
-title: 'Menubar (Vertical Navigation)'
+title: 'Vertical Navigation'
 description: 'An alternative navigation pattern that displays navigation items vertically.'
 order: 5
+lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/vertical-nav/'
+mainTabURL: 'docs/components/vertical-nav.html'
 ---
-
-<div class="clay-site-alert alert alert-info">Check the <a href="https://liferay.design/lexicon" rel="noopener noreferrer" target="_blank">Lexicon</a> <a href="https://liferay.design/lexicon/core-components/navigation/vertical-nav/" rel="noopener noreferrer" target="_blank">Vertical Navigation Pattern</a> for a more in-depth look at the motivations and proper usage of this component.</div>
 
 <div class="nav-toc-absolute">
 <div class="nav-toc">

--- a/jest.config.js
+++ b/jest.config.js
@@ -146,7 +146,7 @@ module.exports = {
 			statements: 98,
 		},
 		'./packages/clay-nav/src/': {
-			branches: 92,
+			branches: 90,
 			functions: 80,
 			lines: 93,
 			statements: 93,
@@ -190,7 +190,7 @@ module.exports = {
 		'./packages/clay-shared/src/': {
 			branches: 37,
 			functions: 23,
-			lines: 51,
+			lines: 50,
 			statements: 53,
 		},
 		'./packages/clay-slider/src/': {

--- a/packages/clay-nav/docs/api-nav.mdx
+++ b/packages/clay-nav/docs/api-nav.mdx
@@ -10,8 +10,6 @@ mainTabURL: 'docs/components/nav.html'
 -   [Nav](#nav)
 -   [Nav.Item](#nav.item)
 -   [Nav.Link](#nav.link)
--   [VerticalNav](#verticalnav)
--   [VerticalNav.Trigger](#verticalnav.trigger)
 
 </div>
 </div>
@@ -29,13 +27,3 @@ mainTabURL: 'docs/components/nav.html'
 ## Nav.Link
 
 <div>[APITable "clay-nav/src/NavLink.tsx"]</div>
-
-## VerticalNav
-
-<div>[APITable "clay-nav/src/Vertical.tsx"]</div>
-
-## VerticalNav.Trigger
-
-<code class="list-api-item-type">
-	Extends from {`React.ComponentProps<typeof ClayButton>`}
-</code>

--- a/packages/clay-nav/docs/api-vertical-nav.mdx
+++ b/packages/clay-nav/docs/api-vertical-nav.mdx
@@ -1,0 +1,24 @@
+---
+title: 'Vertical Navigation'
+description: 'An alternative navigation pattern that displays navigation items vertically.'
+mainTabURL: 'docs/components/vertical-nav.html'
+---
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [VerticalNav](#verticalnav)
+-   [VerticalNav.Trigger](#verticalnav.trigger)
+
+</div>
+</div>
+
+## VerticalNav
+
+<div>[APITable "clay-nav/src/Vertical.tsx"]</div>
+
+## VerticalNav.Trigger
+
+<code class="list-api-item-type">
+	Extends from {`React.ComponentProps<typeof ClayButton>`}
+</code>

--- a/packages/clay-nav/docs/index.js
+++ b/packages/clay-nav/docs/index.js
@@ -49,7 +49,6 @@ const VerticalNavigationCode = `const Component = () => {
 		<ClayVerticalNav
 			items={[
 			{
-				initialExpanded: true,
 				items: [
 				{
 					href: '#nested1',
@@ -67,6 +66,7 @@ const VerticalNavigationCode = `const Component = () => {
 				label: 'Contact',
 			},
 			{
+				initialExpanded: true,
 				items: [
 				{
 					active: true,

--- a/packages/clay-nav/docs/nav.mdx
+++ b/packages/clay-nav/docs/nav.mdx
@@ -4,13 +4,12 @@ description: 'Clay Nav provides a clear and semantic navigation for your site'
 packageNpm: '@clayui/nav'
 ---
 
-import {Navigation, VerticalNavigation} from '$packages/clay-nav/docs/index';
+import {Navigation} from '$packages/clay-nav/docs/index';
 
 <div class="nav-toc-absolute">
 <div class="nav-toc">
 
 -   [Basic Usage](#basic-usage)
--   [Vertical Navigation](#vertical)
 
 </div>
 </div>
@@ -18,43 +17,3 @@ import {Navigation, VerticalNavigation} from '$packages/clay-nav/docs/index';
 ## Basic Usage
 
 <Navigation />
-
-## Vertical Navigation
-
-<VerticalNavigation />
-
-### Custom Trigger
-
-In its mobile version, Vertical Navigation adds a trigger that is responsible for opening the menu, in some cases you may want to customize this trigger, for this use the `<ClayVerticalNav.Trigger />` component.
-
-```js
-<ClayVerticalNav
-	trigger={(props) => (
-		<ClayVerticalNav.Trigger {...props}>
-			<ClayIcon
-				focusable="false"
-				role="presentation"
-				spritemap={spritemap}
-				symbol="ellipsis-v"
-			/>
-		</ClayVerticalNav.Trigger>
-	)}
-/>
-```
-
-Your custom trigger receives the `children` property with the default content, for cases when you just want to change the Trigger Button and not its content.
-
-```js
-<ClayVerticalNav
-	trigger={({onClick}) => (
-		<button className="btn btn-secondary" onClick={onClick}>
-			<ClayIcon
-				focusable="false"
-				role="presentation"
-				spritemap={spritemap}
-				symbol="ellipsis-v"
-			/>
-		</button>
-	)}
-/>
-```

--- a/packages/clay-nav/docs/vertical-nav.mdx
+++ b/packages/clay-nav/docs/vertical-nav.mdx
@@ -1,0 +1,58 @@
+---
+title: 'Vertical Navigation'
+description: 'An alternative patterns that displays navigation items in a vertical menu.'
+lexiconDefinition: 'https://liferay.design/lexicon/core-components/navigation/vertical-nav/'
+packageNpm: '@clayui/nav'
+storybookPath: 'design-system-components-nav--vertical-nav'
+---
+
+import {VerticalNavigation} from '$packages/clay-nav/docs/index';
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Example](#example)
+-   [Custom Trigger](#custom-trigger)
+
+</div>
+</div>
+
+## Example
+
+<VerticalNavigation />
+
+## Custom Trigger
+
+In its mobile version, Vertical Navigation adds a trigger that is responsible for opening the menu, in some cases you may want to customize this trigger, for this use the `<ClayVerticalNav.Trigger />` component.
+
+```js
+<ClayVerticalNav
+	trigger={(props) => (
+		<ClayVerticalNav.Trigger {...props}>
+			<ClayIcon
+				focusable="false"
+				role="presentation"
+				spritemap={spritemap}
+				symbol="ellipsis-v"
+			/>
+		</ClayVerticalNav.Trigger>
+	)}
+/>
+```
+
+Your custom trigger receives the `children` property with the default content, for cases when you just want to change the Trigger Button and not its content.
+
+```js
+<ClayVerticalNav
+	trigger={({onClick}) => (
+		<button className="btn btn-secondary" onClick={onClick}>
+			<ClayIcon
+				focusable="false"
+				role="presentation"
+				spritemap={spritemap}
+				symbol="ellipsis-v"
+			/>
+		</button>
+	)}
+/>
+```

--- a/packages/clay-nav/src/NavLink.tsx
+++ b/packages/clay-nav/src/NavLink.tsx
@@ -35,51 +35,62 @@ export interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	spritemap?: string;
 }
 
-export const NavLink = ({
-	active,
-	children,
-	className,
-	collapsed,
-	disabled,
-	showIcon,
-	spritemap,
-	...otherProps
-}: IProps) => {
-	return (
-		<LinkOrButton
-			{...otherProps}
-			buttonDisplayType="unstyled"
-			buttonType="button"
-			className={classNames('nav-link', className, {
-				active,
-				['collapse-icon']: showIcon,
-				collapsed,
-				disabled,
-			})}
-		>
-			{children}
+export const NavLink = React.forwardRef<
+	HTMLButtonElement | HTMLAnchorElement,
+	IProps
+>(
+	(
+		{
+			active,
+			children,
+			className,
+			collapsed,
+			disabled,
+			showIcon,
+			spritemap,
+			...otherProps
+		},
+		ref
+	) => {
+		return (
+			<LinkOrButton
+				{...otherProps}
+				buttonDisplayType="unstyled"
+				buttonType="button"
+				className={classNames('nav-link', className, {
+					active,
+					['collapse-icon']: showIcon,
+					collapsed,
+					disabled,
+				})}
+				ref={ref}
+			>
+				{children}
 
-			{showIcon && (
-				<>
-					<span className="collapse-icon-closed">
-						<ClayIcon
-							focusable="false"
-							role="presentation"
-							spritemap={spritemap}
-							symbol="caret-right"
-						/>
-					</span>
+				{showIcon && (
+					<>
+						<span className="collapse-icon-closed">
+							<ClayIcon
+								focusable="false"
+								role="presentation"
+								spritemap={spritemap}
+								symbol="caret-right"
+							/>
+						</span>
 
-					<span className="collapse-icon-open">
-						<ClayIcon
-							focusable="false"
-							role="presentation"
-							spritemap={spritemap}
-							symbol="caret-bottom"
-						/>
-					</span>
-				</>
-			)}
-		</LinkOrButton>
-	);
-};
+						<span className="collapse-icon-open">
+							<ClayIcon
+								focusable="false"
+								role="presentation"
+								spritemap={spritemap}
+								symbol="caret-bottom"
+							/>
+						</span>
+					</>
+				)}
+			</LinkOrButton>
+		);
+	}
+);
+
+NavLink.displayName = 'NavLink';

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -140,7 +140,7 @@ function Item({
 	spritemap,
 	...otherProps
 }: INavItemProps) {
-	const [expanded, setExpaned] = React.useState(!initialExpanded);
+	const [expanded, setExpaned] = React.useState(initialExpanded);
 
 	const itemRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
 	const menusRef = useRef<HTMLDivElement>(null);

--- a/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-nav/src/__tests__/__snapshots__/index.tsx.snap
@@ -38,14 +38,20 @@ exports[`ClayVerticalNav renders 1`] = `
       class="collapse menubar-collapse"
     >
       <ul
+        aria-orientation="vertical"
         class="nav nav-nested"
+        role="menubar"
       >
         <li
           class="nav-item"
+          role="none"
         >
           <button
+            aria-expanded="true"
+            aria-haspopup="true"
             class="nav-link collapse-icon btn btn-unstyled"
             role="button"
+            tabindex="-1"
             type="button"
           >
             Home
@@ -79,14 +85,17 @@ exports[`ClayVerticalNav renders 1`] = `
           <div>
             <ul
               class="nav nav-stacked"
+              role="menu"
             >
               <li
                 class="nav-item"
+                role="none"
               >
                 <a
-                  class="nav-link"
+                  class="nav-link collapsed"
                   href="#nested1"
-                  role="button"
+                  role="menuitem"
+                  tabindex="-1"
                 >
                   Nested1
                 </a>

--- a/packages/clay-nav/src/__tests__/index.tsx
+++ b/packages/clay-nav/src/__tests__/index.tsx
@@ -4,7 +4,13 @@
  */
 
 import ClayNav, {ClayVerticalNav} from '..';
-import {cleanup, fireEvent, render} from '@testing-library/react';
+import {
+	cleanup,
+	fireEvent,
+	getAllByRole as docGetAllByRole,
+	render,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 describe('ClayNav', () => {
@@ -21,12 +27,50 @@ describe('ClayNav', () => {
 	});
 });
 
+const ITEMS = [
+	{
+		items: [
+			{
+				href: '#',
+				label: 'Nested1',
+			},
+		],
+		label: 'Home',
+	},
+	{
+		href: '#',
+		label: 'About',
+	},
+	{
+		href: '#',
+		label: 'Contact',
+	},
+	{
+		items: [
+			{
+				active: true,
+				href: '#',
+				label: 'Five',
+			},
+			{
+				href: '#',
+				label: 'Six',
+			},
+		],
+		label: 'Projects',
+	},
+	{
+		href: '#',
+		label: 'Seven',
+	},
+];
+
 describe('ClayVerticalNav', () => {
 	afterEach(() => cleanup());
 
 	const items = [
 		{
-			initialExpanded: false,
+			initialExpanded: true,
 			items: [
 				{
 					href: '#nested1',
@@ -59,5 +103,99 @@ describe('ClayVerticalNav', () => {
 		expect(
 			container.querySelector('.collapsing.show .nav-item')
 		).toBeTruthy();
+	});
+
+	it('expand items by pressing the right arrow key', () => {
+		const {getAllByRole} = render(
+			<ClayVerticalNav items={ITEMS} spritemap="/path/to" />
+		);
+
+		const [, , projects] = getAllByRole('button');
+
+		userEvent.tab();
+		userEvent.tab();
+
+		expect(document.activeElement).toEqual(projects);
+
+		userEvent.keyboard('[ArrowRight]');
+
+		expect(projects.getAttribute('aria-expanded')).toBe('true');
+	});
+
+	it('collapse items by pressing the left arrow key', () => {
+		const {getAllByRole} = render(
+			<ClayVerticalNav items={ITEMS} spritemap="/path/to" />
+		);
+
+		const [, , projects] = getAllByRole('button');
+
+		userEvent.tab();
+		userEvent.tab();
+
+		expect(document.activeElement).toEqual(projects);
+
+		userEvent.keyboard('[ArrowRight]');
+
+		expect(projects.getAttribute('aria-expanded')).toBe('true');
+
+		userEvent.keyboard('[ArrowLeft]');
+
+		expect(projects.getAttribute('aria-expanded')).toBe('false');
+	});
+
+	it('moves focus to first item if item is expanded', () => {
+		const {getAllByRole} = render(
+			<ClayVerticalNav items={ITEMS} spritemap="/path/to" />
+		);
+
+		const [, , projects] = getAllByRole('button');
+
+		userEvent.tab();
+		userEvent.tab();
+
+		expect(document.activeElement).toEqual(projects);
+
+		userEvent.keyboard('[ArrowRight]');
+
+		expect(projects.getAttribute('aria-expanded')).toBe('true');
+
+		userEvent.keyboard('[ArrowRight]');
+
+		const [first] = docGetAllByRole(
+			projects.parentNode as HTMLElement,
+			'menuitem'
+		);
+
+		expect(first).toEqual(document.activeElement);
+	});
+
+	it('move focus to parent if focus is on child when pressing left arrow key', () => {
+		const {getAllByRole} = render(
+			<ClayVerticalNav items={ITEMS} spritemap="/path/to" />
+		);
+
+		const [, , projects] = getAllByRole('button');
+
+		userEvent.tab();
+		userEvent.tab();
+
+		expect(document.activeElement).toEqual(projects);
+
+		userEvent.keyboard('[ArrowRight]');
+
+		expect(projects.getAttribute('aria-expanded')).toBe('true');
+
+		userEvent.keyboard('[ArrowRight]');
+
+		const [first] = docGetAllByRole(
+			projects.parentNode as HTMLElement,
+			'menuitem'
+		);
+
+		expect(first).toEqual(document.activeElement);
+
+		userEvent.keyboard('[ArrowLeft]');
+
+		expect(projects).toEqual(document.activeElement);
 	});
 });

--- a/packages/clay-nav/stories/Nav.stories.tsx
+++ b/packages/clay-nav/stories/Nav.stories.tsx
@@ -14,7 +14,6 @@ export default {
 
 const items = [
 	{
-		initialExpanded: true,
 		items: [
 			{
 				href: '#',
@@ -32,6 +31,7 @@ const items = [
 		label: 'Contact',
 	},
 	{
+		initialExpanded: true,
 		items: [
 			{
 				active: true,

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -6,7 +6,7 @@
 import {useCallback} from 'react';
 
 import {Keys} from './Keys';
-import {FOCUSABLE_ELEMENTS} from './useFocusManagement';
+import {FOCUSABLE_ELEMENTS, isFocusable} from './useFocusManagement';
 
 type Props<T> = {
 	/**
@@ -49,6 +49,13 @@ export function useNavigation<T extends HTMLElement | null>({
 				containeRef.current.querySelectorAll(
 					FOCUSABLE_ELEMENTS.join(',')
 				)
+			).filter((element) =>
+				isFocusable({
+					contentEditable: element.contentEditable,
+					offsetParent: element.offsetParent,
+					tabIndex: 0,
+					tagName: element.tagName,
+				})
 			);
 
 			let tab: HTMLElement | undefined;


### PR DESCRIPTION
Fixes #5170

This PR is a draft to add accessibility to the VerticalNav component, still needs to make adjustments to the interaction with the keyboard is working more or less but I still need to improve the navigation flow of the arrows from top to bottom that is not discarding elements not visible on the screen.

There are also some other interactions using the keyboard, for example for menu with submenus, maybe we can use the same strategy as we do in TreeView:

- pressing the right arrow key on an element with submenu and it has focus, expands the submenu, if pressed again move focus to the first child element
- press the left arrow key on an element with submenu and it has focus, close the menu
- press left arrow key on first submenu item move focus to element parent

### ToDo

- [x] Fix navigation using up and down arrow keys
- [x] Add keyboard interactions to expand/collapse submenu
- [x] Add tests
- [x] Add documentation