### PR TITLE
fix(@clayui/drop-down): fix error when not properly rendering markup for simplified collection

### DIFF
--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -164,6 +164,7 @@ function ClayDropDown<T>({
 	offsetFn,
 	onActiveChange,
 	renderMenuOnClick = false,
+	role = 'menu',
 	trigger,
 	...otherProps
 }: IProps<T>) {
@@ -330,12 +331,17 @@ function ClayDropDown<T>({
 									}}
 								>
 									{children instanceof Function ? (
-										<Collection<T>
-											items={items}
-											passthroughKey={false}
+										<ul
+											className="list-unstyled"
+											role={role}
 										>
-											{children}
-										</Collection>
+											<Collection<T>
+												items={items}
+												passthroughKey={false}
+											>
+												{children}
+											</Collection>
+										</ul>
 									) : (
 										children
 									)}


### PR DESCRIPTION
Fixes #5182

This PR just fixes the simplified collection case for DropDown #5182 where the markup wasn't rendering correctly because it doesn't render the `ItemList`, I'm not using it here because it would be a nested Collection rendering which might have problems, as this is a case very simple it is better to just add the markup instead of the component and allow to change the `role`.