### PR TITLE
fix(@clayui/core): fixes error of actions not being navigable via keyboard in TreeView

### DIFF
--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -776,7 +776,6 @@ function Actions({children}: TreeViewItemActionsProps) {
 										child.props.onClick(event);
 									}
 								},
-								tabIndex: -1,
 							})}
 						</Layout.ContentCol>
 					);
@@ -819,7 +818,6 @@ function Actions({children}: TreeViewItemActionsProps) {
 												);
 											}
 										},
-										tabIndex: -1,
 									}
 								),
 							})}

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -263,7 +263,6 @@ exports[`TreeView basic rendering render with actions 1`] = `
             >
               <button
                 class="component-action quick-action-item btn btn-monospaced"
-                tabindex="-1"
                 type="button"
               >
                 <div
@@ -293,7 +292,6 @@ exports[`TreeView basic rendering render with actions 1`] = `
                   aria-haspopup="true"
                   class="dropdown-toggle component-action quick-action-item btn btn-monospaced"
                   style=""
-                  tabindex="-1"
                   type="button"
                 >
                   <div


### PR DESCRIPTION
Fixes #5186

For some reason we added this intentionally but I don't remember, but it seems wrong and also the documentation says it should be keyboard navigable, so removing the `tabIndex` to make the action items navigable.