### PR TITLE
fix(@clay/modal): fix error of content outside the modal is still navigable with JAWS

### DIFF
--- a/packages/clay-modal/package.json
+++ b/packages/clay-modal/package.json
@@ -29,6 +29,7 @@
 		"@clayui/button": "^3.73.0",
 		"@clayui/icon": "^3.56.0",
 		"@clayui/shared": "^3.78.2",
+		"aria-hidden": "^1.1.3",
 		"classnames": "^2.2.6",
 		"warning": "^4.0.3"
 	},

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -4,6 +4,7 @@
  */
 
 import {ClayPortal, IPortalBaseProps} from '@clayui/shared';
+import {hideOthers} from 'aria-hidden';
 import classNames from 'classnames';
 import React, {useEffect, useMemo, useRef} from 'react';
 import warning from 'warning';
@@ -119,6 +120,13 @@ const ClayModal = ({
 
 	const [show, content] =
 		observer && observer.mutation ? observer.mutation : [false, false];
+
+	useEffect(() => {
+		if (modalElementRef.current && show) {
+			// Hide everything from ARIA except the Modal Body
+			return hideOthers(modalElementRef.current);
+		}
+	}, [show]);
 
 	return (
 		<ClayPortal

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -24,6 +24,7 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
     <div
       aria-hidden="true"
       class="modal-backdrop fade show"
+      data-aria-hidden="true"
     />
     <div
       class="fade modal d-block show"
@@ -92,13 +93,18 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
       </div>
     </div>
     <button
+      aria-hidden="true"
       class="btn btn-primary"
+      data-aria-hidden="true"
       data-testid="button"
       type="button"
     >
       Open modal
     </button>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
 </body>
 `;

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -8,6 +8,7 @@ exports[`ClayModal renders 1`] = `
     <div
       aria-hidden="true"
       class="modal-backdrop fade show"
+      data-aria-hidden="true"
     />
     <div
       class="fade modal d-block show"
@@ -76,7 +77,10 @@ exports[`ClayModal renders 1`] = `
       </div>
     </div>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
 </body>
 `;
 
@@ -88,6 +92,7 @@ exports[`ClayModal renders Header w/ low-level API 1`] = `
     <div
       aria-hidden="true"
       class="modal-backdrop fade show"
+      data-aria-hidden="true"
     />
     <div
       class="fade modal d-block show"
@@ -140,7 +145,10 @@ exports[`ClayModal renders Header w/ low-level API 1`] = `
       </div>
     </div>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
 </body>
 `;
 
@@ -152,6 +160,7 @@ exports[`ClayModal renders a body component with url 1`] = `
     <div
       aria-hidden="true"
       class="modal-backdrop fade show"
+      data-aria-hidden="true"
     />
     <div
       class="fade modal d-block show"
@@ -177,7 +186,10 @@ exports[`ClayModal renders a body component with url 1`] = `
       </div>
     </div>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
 </body>
 `;
 
@@ -189,6 +201,7 @@ exports[`ClayModal renders a footer component with buttons 1`] = `
     <div
       aria-hidden="true"
       class="modal-backdrop fade show"
+      data-aria-hidden="true"
     />
     <div
       class="fade modal d-block show"
@@ -240,7 +253,10 @@ exports[`ClayModal renders a footer component with buttons 1`] = `
       </div>
     </div>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
 </body>
 `;
 
@@ -252,6 +268,7 @@ exports[`ClayModal renders with Header 1`] = `
     <div
       aria-hidden="true"
       class="modal-backdrop fade show"
+      data-aria-hidden="true"
     />
     <div
       class="fade modal d-block show"
@@ -293,7 +310,10 @@ exports[`ClayModal renders with Header 1`] = `
       </div>
     </div>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
 </body>
 `;
 
@@ -305,6 +325,7 @@ exports[`ClayModal renders with center 1`] = `
     <div
       aria-hidden="true"
       class="modal-backdrop fade show"
+      data-aria-hidden="true"
     />
     <div
       class="fade modal d-block show"
@@ -321,7 +342,10 @@ exports[`ClayModal renders with center 1`] = `
       </div>
     </div>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
 </body>
 `;
 
@@ -333,6 +357,7 @@ exports[`ClayModal renders with size 1`] = `
     <div
       aria-hidden="true"
       class="modal-backdrop fade show"
+      data-aria-hidden="true"
     />
     <div
       class="fade modal d-block show"
@@ -349,7 +374,10 @@ exports[`ClayModal renders with size 1`] = `
       </div>
     </div>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
 </body>
 `;
 
@@ -361,6 +389,7 @@ exports[`ClayModal renders with status 1`] = `
     <div
       aria-hidden="true"
       class="modal-backdrop fade show"
+      data-aria-hidden="true"
     />
     <div
       class="fade modal d-block show"
@@ -377,6 +406,9 @@ exports[`ClayModal renders with status 1`] = `
       </div>
     </div>
   </div>
-  <div />
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  />
 </body>
 `;


### PR DESCRIPTION
Fixes #5184

Using the same strategy that was used for Autocomplete and Dropdown with menus in the body, using the `aria-hidden` package to add the attribute on all elements of the document with `aria-hidden="true"` minus the content, this prevents elements outside the menu or modal from being navigable when using a screen reader.