### PR TITLE
fix(@clayui/tooltip): persist the title attribute when navigate via keyboard

### DIFF
--- a/packages/clay-tooltip/src/TooltipProvider.tsx
+++ b/packages/clay-tooltip/src/TooltipProvider.tsx
@@ -159,7 +159,7 @@ const TooltipProvider = ({
 	const onShow = useCallback(
 		(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
 			if (isHovered.current || isFocused.current) {
-				const props = getProps(event);
+				const props = getProps(event, isHovered.current);
 
 				if (props) {
 					dispatch({

--- a/packages/clay-tooltip/src/useClosestTitle.ts
+++ b/packages/clay-tooltip/src/useClosestTitle.ts
@@ -52,8 +52,6 @@ export function useClosestTitle(props: Props) {
 	const titleNodeRef = useRef<HTMLElement | null>(null);
 
 	const saveTitle = useCallback((element: HTMLElement) => {
-		titleNodeRef.current = element;
-
 		const title = element.getAttribute('title');
 
 		if (title) {
@@ -120,7 +118,10 @@ export function useClosestTitle(props: Props) {
 	}, []);
 
 	const getProps = useCallback(
-		(event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+		(
+			event: React.MouseEvent<HTMLElement, MouseEvent>,
+			hideBrowserTitle: boolean
+		) => {
 			if (targetRef.current) {
 				props.onClick();
 
@@ -150,7 +151,11 @@ export function useClosestTitle(props: Props) {
 					node.getAttribute('data-title') ||
 					'';
 
-				saveTitle(node);
+				titleNodeRef.current = node;
+
+				if (hideBrowserTitle) {
+					saveTitle(node);
+				}
 
 				return {
 					align: node.getAttribute('data-tooltip-align'),


### PR DESCRIPTION
Fixes #5189

This PR follows the approach of persisting the title attribute when browsing via keyboard, since the browser does not show the title in the focus.