### PR TITLE
fix(@clayui/drop-down): adds keyboard navigation with looped arrow keys

### DIFF
--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -9,6 +9,7 @@ import {
 	InternalDispatch,
 	Keys,
 	useInternalState,
+	useNavigation,
 } from '@clayui/shared';
 import {hideOthers} from 'aria-hidden';
 import classNames from 'classnames';
@@ -229,8 +230,15 @@ function ClayDropDown<T>({
 		[initialized]
 	);
 
+	const navigationProps = useNavigation({
+		activation: 'manual',
+		containeRef: menuElementRef,
+		loop: true,
+		orientation: 'vertical',
+	});
+
 	return (
-		<FocusScope>
+		<FocusScope arrowKeysUpDown={false}>
 			{(focusManager) => (
 				<ContainerElement
 					{...otherProps}
@@ -302,6 +310,7 @@ function ClayDropDown<T>({
 							id={ariaControls}
 							offsetFn={offsetFn}
 							onActiveChange={setInternalActive}
+							onKeyDown={navigationProps.onKeyDown}
 							ref={menuElementRef}
 							width={menuWidth}
 						>
@@ -328,6 +337,7 @@ function ClayDropDown<T>({
 										filterKey,
 										onSearch: setSearch,
 										search,
+										tabFocus: false,
 									}}
 								>
 									{children instanceof Function ? (

--- a/packages/clay-drop-down/src/DropDownContext.ts
+++ b/packages/clay-drop-down/src/DropDownContext.ts
@@ -11,9 +11,11 @@ type Context = {
 	filterKey?: string;
 	onSearch: (value: string) => void;
 	search: string;
+	tabFocus: boolean;
 };
 
 export const DropDownContext = React.createContext<Context>({
 	close: () => {},
 	closeOnClick: false,
+	tabFocus: true,
 } as Context);

--- a/packages/clay-drop-down/src/Item.tsx
+++ b/packages/clay-drop-down/src/Item.tsx
@@ -77,7 +77,7 @@ const ClayDropDownItem = React.forwardRef<HTMLLIElement, IProps>(
 		const clickableElement = onClick ? 'button' : 'span';
 		const ItemElement = href ? ClayLink : clickableElement;
 
-		const {close, closeOnClick} = useContext(DropDownContext);
+		const {close, closeOnClick, tabFocus} = useContext(DropDownContext);
 
 		return (
 			<li aria-selected={active} ref={ref} role={role} style={style}>
@@ -109,7 +109,7 @@ const ClayDropDownItem = React.forwardRef<HTMLLIElement, IProps>(
 					}}
 					ref={innerRef}
 					role={roleItem}
-					tabIndex={disabled ? -1 : tabIndex}
+					tabIndex={disabled || !tabFocus ? -1 : tabIndex}
 				>
 					{symbolLeft && (
 						<span className="dropdown-item-indicator-start">

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -24,17 +24,23 @@ type Props<T> = {
 	containeRef: React.MutableRefObject<T>;
 
 	/**
+	 * Flag to indicate if navigation should loop.
+	 */
+	loop?: boolean;
+
+	/**
 	 * Indicates whether the element's orientation is horizontal or vertical.
 	 */
-	orientation: 'horizontal' | 'vertical';
+	orientation?: 'horizontal' | 'vertical';
 };
 
 const verticalKeys = [Keys.Up, Keys.Down, Keys.Home, Keys.End];
 const horizontalKeys = [Keys.Left, Keys.Right, Keys.Home, Keys.End];
 
 export function useNavigation<T extends HTMLElement | null>({
-	activation,
+	activation = 'manual',
 	containeRef,
+	loop = false,
 	orientation = 'horizontal',
 }: Props<T>) {
 	const onKeyDown = useCallback((event: React.KeyboardEvent<HTMLElement>) => {
@@ -52,6 +58,7 @@ export function useNavigation<T extends HTMLElement | null>({
 			).filter((element) =>
 				isFocusable({
 					contentEditable: element.contentEditable,
+					disabled: element.getAttribute('disabled') !== null,
 					offsetParent: element.offsetParent,
 					tabIndex: 0,
 					tagName: element.tagName,
@@ -72,6 +79,10 @@ export function useNavigation<T extends HTMLElement | null>({
 						orientation === 'vertical' ? Keys.Up : Keys.Left;
 
 					tab = tabs[event.key === key ? position - 1 : position + 1];
+
+					if (loop && !tab) {
+						tab = tabs[event.key === key ? tabs.length - 1 : 0];
+					}
 
 					break;
 				}


### PR DESCRIPTION
Fixes #5041

This PR adds using loop navigation using keyboard arrow keys and disables tabbing in menu, still need to adjust move focus to first menu item which is having some conflicts with FocusScope and useNavigation because we have to disable tab of the Menu items.

### ToDo

- [ ] Fixes tests
- [ ] Move focus to first menu item