### PR TITLE
fix(@clayui/date-picker): Map id attribute to .form-control and add i…

### DIFF
--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -591,12 +591,13 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		return (
 			<FocusScope>
 				<div className="date-picker">
-					<ClayInput.Group id={id} ref={triggerElementRef}>
+					<ClayInput.Group ref={triggerElementRef}>
 						<ClayInput.GroupItem>
 							<InputDate
 								{...otherProps}
 								ariaLabel={ariaLabels.input}
 								disabled={disabled}
+								id={id}
 								inputName={inputName}
 								onChange={inputChange}
 								placeholder={placeholder}


### PR DESCRIPTION
…nputGroupId attribute

BREAKING CHANGE: The `id` attribute now maps to `.form-control`, use the `inputGroupId` attribute to add an `id` to `.input-group`

fixes #5195