### PR TITLE
feat(@clayui/date-picker): improves semantic accessibility for the component

### DIFF
--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -28,6 +28,7 @@
 		"@clayui/icon": "^3.56.0",
 		"@clayui/shared": "^3.79.0",
 		"@clayui/time-picker": "^3.79.0",
+		"aria-hidden": "^1.1.3",
 		"classnames": "^2.2.6",
 		"date-fns": "^2.14.0"
 	},

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -27,35 +27,24 @@ const ClayDatePickerDayNumber = ({
 	const {date, nextMonth, previousMonth} = day;
 	const [startDate, endDate] = daysSelected;
 
+	const isStartAndEndDateRange =
+		startDate.toDateString() !== endDate.toDateString() &&
+		isWithinInterval(date, daysSelected);
 	const hasEndDateSelected = date.toDateString() === endDate.toDateString();
 	const hasStartDateSelected =
 		date.toDateString() === startDate.toDateString();
 
-	const classNames = classnames(
-		'date-picker-date date-picker-calendar-item',
-		{
-			active: hasStartDateSelected || (range && hasEndDateSelected),
-			disabled,
-			'next-month-date': nextMonth,
-			'previous-month-date': previousMonth,
-		}
-	);
-
 	return (
 		<div
 			aria-selected={
-				(startDate.toDateString() !== endDate.toDateString() &&
-					isWithinInterval(date, daysSelected)) ||
-				hasStartDateSelected
+				isStartAndEndDateRange || hasStartDateSelected
 					? true
 					: undefined
 			}
 			className={classnames(
 				'date-picker-col',
 				range && {
-					'c-selected':
-						startDate.toDateString() !== endDate.toDateString() &&
-						isWithinInterval(date, daysSelected),
+					'c-selected': isStartAndEndDateRange,
 					'c-selected-end':
 						hasEndDateSelected && !hasStartDateSelected,
 					'c-selected-start':
@@ -71,7 +60,17 @@ const ClayDatePickerDayNumber = ({
 					minutes: 0,
 					seconds: 0,
 				}).toDateString()}
-				className={classNames}
+				className={classnames(
+					'date-picker-date date-picker-calendar-item',
+					{
+						active:
+							hasStartDateSelected ||
+							(range && hasEndDateSelected),
+						disabled,
+						'next-month-date': nextMonth,
+						'previous-month-date': previousMonth,
+					}
+				)}
 				disabled={disabled}
 				onClick={() => onClick(date)}
 				onKeyDown={(event) => {

--- a/packages/clay-date-picker/src/DayNumber.tsx
+++ b/packages/clay-date-picker/src/DayNumber.tsx
@@ -43,6 +43,13 @@ const ClayDatePickerDayNumber = ({
 
 	return (
 		<div
+			aria-selected={
+				(startDate.toDateString() !== endDate.toDateString() &&
+					isWithinInterval(date, daysSelected)) ||
+				hasStartDateSelected
+					? true
+					: undefined
+			}
 			className={classnames(
 				'date-picker-col',
 				range && {
@@ -55,6 +62,7 @@ const ClayDatePickerDayNumber = ({
 						hasStartDateSelected && !hasEndDateSelected,
 				}
 			)}
+			role="gridcell"
 		>
 			<button
 				aria-label={setDate(date, {

--- a/packages/clay-date-picker/src/DaysTable.tsx
+++ b/packages/clay-date-picker/src/DaysTable.tsx
@@ -24,6 +24,7 @@ const ClayDatePickerDaysTable = ({children, weeks}: Props) => {
 				<div
 					className="date-picker-date-row date-picker-row"
 					key={index}
+					role="row"
 				>
 					{days.map((day, index) => {
 						return React.Children.only(children({day, key: index}));

--- a/packages/clay-date-picker/src/WeekdayHeader.tsx
+++ b/packages/clay-date-picker/src/WeekdayHeader.tsx
@@ -23,7 +23,11 @@ const ClayDatePickerWeekdayHeader = ({
 	firstDayOfWeek = 0,
 	weekdaysShort,
 }: Props) => (
-	<div className="date-picker-days-row date-picker-row">
+	<div
+		aria-hidden="true"
+		className="date-picker-days-row date-picker-row"
+		role="presentation"
+	>
 		{weekdaysShort.map((weekday, index) => {
 			return React.Children.only(
 				children({

--- a/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -4,7 +4,12 @@
  */
 
 import ClayDatePicker from '..';
-import {cleanup, fireEvent, render} from '@testing-library/react';
+import {
+	cleanup,
+	fireEvent,
+	queryAllByLabelText,
+	render,
+} from '@testing-library/react';
 import {default as formatDate} from 'date-fns/format';
 import React from 'react';
 
@@ -175,7 +180,7 @@ describe('IncrementalInteractions', () => {
 	});
 
 	it('clicking on the back arrow button the content must be updated with the corresponding month', () => {
-		const {getByLabelText, getByTestId, queryAllByLabelText} = render(
+		const {getByLabelText, getByRole, getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
 				defaultExpanded
@@ -192,7 +197,8 @@ describe('IncrementalInteractions', () => {
 
 		fireEvent.click(backArrowButtonEl);
 
-		const days = queryAllByLabelText('Mar', {exact: false});
+		const grid = getByRole('grid', {hidden: true});
+		const days = queryAllByLabelText(grid, 'Mar', {exact: false});
 
 		expect(yearSelect.value).toBe('2019');
 		expect(monthSelect.value).toBe('2');
@@ -223,7 +229,7 @@ describe('IncrementalInteractions', () => {
 	});
 
 	it('clicking on the next arrow button the content must be updated with the corresponding month', () => {
-		const {getByLabelText, getByTestId, queryAllByLabelText} = render(
+		const {getByLabelText, getByRole, getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
 				defaultExpanded
@@ -238,7 +244,8 @@ describe('IncrementalInteractions', () => {
 
 		fireEvent.click(nextArrowButtonEl);
 
-		const days = queryAllByLabelText('May', {exact: false});
+		const grid = getByRole('grid', {hidden: true});
+		const days = queryAllByLabelText(grid, 'May', {exact: false});
 
 		expect(yearSelect.value).toBe('2019');
 		expect(monthSelect.value).toBe('4');
@@ -246,7 +253,7 @@ describe('IncrementalInteractions', () => {
 	});
 
 	it('clicking the back arrow button should update the date to the end of the previous year when the current month is January', () => {
-		const {getByLabelText, getByTestId, queryAllByLabelText} = render(
+		const {getByLabelText, getByRole, getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
 				defaultExpanded
@@ -268,7 +275,9 @@ describe('IncrementalInteractions', () => {
 
 		const monthSelect: any = getByTestId('month-select');
 		const yearSelect: any = getByTestId('year-select');
-		const days = queryAllByLabelText('Dec', {exact: false});
+
+		const grid = getByRole('grid', {hidden: true});
+		const days = queryAllByLabelText(grid, 'Dec', {exact: false});
 
 		expect(yearSelect.value).toBe('2018');
 		expect(monthSelect.value).toBe('11');
@@ -276,7 +285,7 @@ describe('IncrementalInteractions', () => {
 	});
 
 	it('clicking the next arrow button should update the date to January next year, when the current month is December', () => {
-		const {getByLabelText, getByTestId, queryAllByLabelText} = render(
+		const {getByLabelText, getByRole, getByTestId} = render(
 			<DatePickerWithState
 				ariaLabels={ariaLabels}
 				defaultExpanded
@@ -296,7 +305,9 @@ describe('IncrementalInteractions', () => {
 
 		const monthSelect: any = getByTestId('month-select');
 		const yearSelect: any = getByTestId('year-select');
-		const days = queryAllByLabelText('Jan', {exact: false});
+
+		const grid = getByRole('grid', {hidden: true});
+		const days = queryAllByLabelText(grid, 'Jan', {exact: false});
 
 		expect(yearSelect.value).toBe('2020');
 		expect(monthSelect.value).toBe('0');

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -28,6 +28,9 @@ exports[`BasicRendering renders by default 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-1"
+              aria-expanded="false"
+              aria-haspopup="dialog"
               aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -53,13 +56,13 @@ exports[`BasicRendering renders by default 1`] = `
         aria-hidden="true"
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-1"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -202,9 +205,12 @@ exports[`BasicRendering renders by default 1`] = `
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -286,9 +292,11 @@ exports[`BasicRendering renders by default 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -300,6 +308,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -311,6 +320,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -322,6 +332,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -333,6 +344,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -344,6 +356,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -355,6 +368,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -367,9 +381,11 @@ exports[`BasicRendering renders by default 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -381,6 +397,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -392,6 +409,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -403,6 +421,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -414,6 +433,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -425,6 +445,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -436,6 +457,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -448,9 +470,11 @@ exports[`BasicRendering renders by default 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -462,6 +486,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -473,6 +498,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -484,6 +510,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -494,7 +521,9 @@ exports[`BasicRendering renders by default 1`] = `
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -506,6 +535,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -517,6 +547,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -529,9 +560,11 @@ exports[`BasicRendering renders by default 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -543,6 +576,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -554,6 +588,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -565,6 +600,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -576,6 +612,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -587,6 +624,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -598,6 +636,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -610,9 +649,11 @@ exports[`BasicRendering renders by default 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -624,6 +665,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -635,6 +677,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -646,6 +689,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -657,6 +701,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -668,6 +713,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -679,6 +725,7 @@ exports[`BasicRendering renders by default 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -699,7 +746,10 @@ exports[`BasicRendering renders by default 1`] = `
 
 exports[`BasicRendering renders date picker with dropdown open 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -725,6 +775,9 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-3"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -749,13 +802,13 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-3"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -898,9 +951,12 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -982,9 +1038,11 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -996,6 +1054,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -1007,6 +1066,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -1018,6 +1078,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -1029,6 +1090,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -1040,6 +1102,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -1051,6 +1114,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -1063,9 +1127,11 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -1077,6 +1143,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -1088,6 +1155,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -1099,6 +1167,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -1110,6 +1179,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -1121,6 +1191,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -1132,6 +1203,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -1144,9 +1216,11 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -1158,6 +1232,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -1169,6 +1244,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -1180,6 +1256,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -1190,7 +1267,9 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -1202,6 +1281,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -1213,6 +1293,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -1225,9 +1306,11 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -1239,6 +1322,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -1250,6 +1334,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -1261,6 +1346,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -1272,6 +1358,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -1283,6 +1370,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -1294,6 +1382,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -1306,9 +1395,11 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -1320,6 +1411,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -1331,6 +1423,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -1342,6 +1435,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -1353,6 +1447,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -1364,6 +1459,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -1375,6 +1471,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -1425,7 +1522,10 @@ exports[`BasicRendering renders date picker with native picker 1`] = `
 
 exports[`BasicRendering renders date picker with time 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -1451,6 +1551,9 @@ exports[`BasicRendering renders date picker with time 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-4"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -1475,13 +1578,13 @@ exports[`BasicRendering renders date picker with time 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-4"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -1624,9 +1727,12 @@ exports[`BasicRendering renders date picker with time 1`] = `
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -1708,9 +1814,11 @@ exports[`BasicRendering renders date picker with time 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -1722,6 +1830,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -1733,6 +1842,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -1744,6 +1854,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -1755,6 +1866,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -1766,6 +1878,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -1777,6 +1890,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -1789,9 +1903,11 @@ exports[`BasicRendering renders date picker with time 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -1803,6 +1919,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -1814,6 +1931,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -1825,6 +1943,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -1836,6 +1955,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -1847,6 +1967,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -1858,6 +1979,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -1870,9 +1992,11 @@ exports[`BasicRendering renders date picker with time 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -1884,6 +2008,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -1895,6 +2020,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -1906,6 +2032,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -1916,7 +2043,9 @@ exports[`BasicRendering renders date picker with time 1`] = `
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -1928,6 +2057,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -1939,6 +2069,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -1951,9 +2082,11 @@ exports[`BasicRendering renders date picker with time 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -1965,6 +2098,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -1976,6 +2110,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -1987,6 +2122,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -1998,6 +2134,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -2009,6 +2146,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -2020,6 +2158,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -2032,9 +2171,11 @@ exports[`BasicRendering renders date picker with time 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -2046,6 +2187,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -2057,6 +2199,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -2068,6 +2211,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -2079,6 +2223,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -2090,6 +2235,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -2101,6 +2247,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -2263,7 +2410,10 @@ exports[`BasicRendering renders date picker with time 1`] = `
 
 exports[`BasicRendering renders the date picker with years range 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -2289,6 +2439,9 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-6"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -2313,13 +2466,13 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-6"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -2597,9 +2750,12 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -2681,9 +2837,11 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -2695,6 +2853,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -2706,6 +2865,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -2717,6 +2877,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -2728,6 +2889,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -2739,6 +2901,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -2750,6 +2913,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -2762,9 +2926,11 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -2776,6 +2942,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -2787,6 +2954,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -2798,6 +2966,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -2809,6 +2978,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -2820,6 +2990,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -2831,6 +3002,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -2843,9 +3015,11 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -2857,6 +3031,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -2868,6 +3043,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -2879,6 +3055,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -2889,7 +3066,9 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -2901,6 +3080,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -2912,6 +3092,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -2924,9 +3105,11 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -2938,6 +3121,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -2949,6 +3133,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -2960,6 +3145,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -2971,6 +3157,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -2982,6 +3169,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -2993,6 +3181,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -3005,9 +3194,11 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -3019,6 +3210,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -3030,6 +3222,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -3041,6 +3234,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -3052,6 +3246,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -3063,6 +3258,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -3074,6 +3270,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -54,6 +54,7 @@ exports[`BasicRendering renders by default 1`] = `
     <div>
       <div
         aria-hidden="true"
+        aria-label="Choose date"
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
         id="clay-id-1"
@@ -61,6 +62,7 @@ exports[`BasicRendering renders by default 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -800,6 +802,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
   <div>
     <div>
       <div
+        aria-label="Choose date"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
         id="clay-id-3"
@@ -807,6 +810,7 @@ exports[`BasicRendering renders date picker with dropdown open 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -1576,6 +1580,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
   <div>
     <div>
       <div
+        aria-label="Choose date"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
         id="clay-id-4"
@@ -1583,6 +1588,7 @@ exports[`BasicRendering renders date picker with time 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -2464,6 +2470,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
   <div>
     <div>
       <div
+        aria-label="Choose date"
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
         id="clay-id-6"
@@ -2471,6 +2478,7 @@ exports[`BasicRendering renders the date picker with years range 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -64,6 +64,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="July 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -808,6 +809,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -1555,6 +1557,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -2302,6 +2305,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2018"
           class="date-picker-calendar"
           role="group"
         >
@@ -3066,6 +3070,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -3813,6 +3818,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -2,7 +2,10 @@
 
 exports[`IncrementalInteractions clicking a month on the selector should change the content to the corresponding month 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -29,6 +32,9 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-5"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -53,13 +59,13 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-5"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -202,9 +208,12 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -286,9 +295,11 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Jun 30 2019"
@@ -300,6 +311,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Jul 01 2019"
@@ -311,6 +323,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Jul 02 2019"
@@ -322,6 +335,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Jul 03 2019"
@@ -333,6 +347,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Jul 04 2019"
@@ -344,6 +359,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Jul 05 2019"
@@ -355,6 +371,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Jul 06 2019"
@@ -367,9 +384,11 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Jul 07 2019"
@@ -381,6 +400,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Jul 08 2019"
@@ -392,6 +412,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Jul 09 2019"
@@ -403,6 +424,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Jul 10 2019"
@@ -414,6 +436,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Jul 11 2019"
@@ -425,6 +448,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Jul 12 2019"
@@ -436,6 +460,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Jul 13 2019"
@@ -448,9 +473,11 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Jul 14 2019"
@@ -462,6 +489,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Jul 15 2019"
@@ -473,6 +501,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Jul 16 2019"
@@ -484,6 +513,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Jul 17 2019"
@@ -495,6 +525,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Jul 18 2019"
@@ -506,6 +537,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Jul 19 2019"
@@ -517,6 +549,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Jul 20 2019"
@@ -529,9 +562,11 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Jul 21 2019"
@@ -543,6 +578,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Jul 22 2019"
@@ -554,6 +590,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Jul 23 2019"
@@ -565,6 +602,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Jul 24 2019"
@@ -576,6 +614,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Jul 25 2019"
@@ -587,6 +626,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Jul 26 2019"
@@ -598,6 +638,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Jul 27 2019"
@@ -610,9 +651,11 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Jul 28 2019"
@@ -624,6 +667,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Jul 29 2019"
@@ -635,6 +679,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Jul 30 2019"
@@ -646,6 +691,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Jul 31 2019"
@@ -657,6 +703,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Aug 01 2019"
@@ -668,6 +715,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Aug 02 2019"
@@ -679,6 +727,7 @@ exports[`IncrementalInteractions clicking a month on the selector should change 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Aug 03 2019"
@@ -726,6 +775,9 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-3"
+              aria-expanded="false"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -751,13 +803,13 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
         aria-hidden="true"
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-3"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -900,9 +952,12 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -984,9 +1039,11 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -998,6 +1055,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -1009,6 +1067,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -1020,6 +1079,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -1031,6 +1091,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -1042,6 +1103,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -1053,6 +1115,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -1065,9 +1128,11 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -1079,6 +1144,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -1090,6 +1156,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -1101,6 +1168,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -1112,6 +1180,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -1123,6 +1192,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -1134,6 +1204,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -1146,9 +1217,11 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -1160,6 +1233,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -1171,6 +1245,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -1182,6 +1257,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -1192,7 +1268,9 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -1204,6 +1282,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -1215,6 +1294,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -1227,9 +1307,11 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -1241,6 +1323,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -1252,6 +1335,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -1263,6 +1347,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -1274,6 +1359,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -1285,6 +1371,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -1296,6 +1383,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -1308,9 +1396,11 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -1322,6 +1412,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -1333,6 +1424,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -1344,6 +1436,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -1355,6 +1448,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -1366,6 +1460,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -1377,6 +1472,7 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -1397,7 +1493,10 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
 
 exports[`IncrementalInteractions clicking on the date icon should open the dropdown 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -1424,6 +1523,9 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-2"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -1448,13 +1550,13 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-2"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -1597,9 +1699,12 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -1681,9 +1786,11 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -1695,6 +1802,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -1706,6 +1814,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -1717,6 +1826,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -1728,6 +1838,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -1739,6 +1850,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -1750,6 +1862,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -1762,9 +1875,11 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -1776,6 +1891,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -1787,6 +1903,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -1798,6 +1915,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -1809,6 +1927,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -1820,6 +1939,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -1831,6 +1951,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -1843,9 +1964,11 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -1857,6 +1980,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -1868,6 +1992,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -1879,6 +2004,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -1889,7 +2015,9 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -1901,6 +2029,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -1912,6 +2041,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -1924,9 +2054,11 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -1938,6 +2070,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -1949,6 +2082,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -1960,6 +2094,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -1971,6 +2106,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -1982,6 +2118,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -1993,6 +2130,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -2005,9 +2143,11 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -2019,6 +2159,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -2030,6 +2171,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -2041,6 +2183,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -2052,6 +2195,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -2063,6 +2207,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -2074,6 +2219,7 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -2094,7 +2240,10 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
 
 exports[`IncrementalInteractions clicking on the year selector should switch to the year of the corresponding month selected 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -2121,6 +2270,9 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-6"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -2145,13 +2297,13 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-6"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -2309,9 +2461,12 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -2393,9 +2548,11 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 01 2018"
@@ -2407,6 +2564,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 02 2018"
@@ -2418,6 +2576,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 03 2018"
@@ -2429,6 +2588,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 04 2018"
@@ -2440,6 +2600,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 05 2018"
@@ -2451,6 +2612,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 06 2018"
@@ -2462,6 +2624,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 07 2018"
@@ -2474,9 +2637,11 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 08 2018"
@@ -2488,6 +2653,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 09 2018"
@@ -2499,6 +2665,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 10 2018"
@@ -2510,6 +2677,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 11 2018"
@@ -2521,6 +2689,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 12 2018"
@@ -2532,6 +2701,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 13 2018"
@@ -2543,6 +2713,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 14 2018"
@@ -2555,9 +2726,11 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 15 2018"
@@ -2569,6 +2742,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 16 2018"
@@ -2580,6 +2754,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 17 2018"
@@ -2591,6 +2766,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 18 2018"
@@ -2602,6 +2778,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 19 2018"
@@ -2613,6 +2790,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 20 2018"
@@ -2624,6 +2802,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 21 2018"
@@ -2636,9 +2815,11 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 22 2018"
@@ -2650,6 +2831,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 23 2018"
@@ -2661,6 +2843,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 24 2018"
@@ -2672,6 +2855,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 25 2018"
@@ -2683,6 +2867,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 26 2018"
@@ -2694,6 +2879,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 27 2018"
@@ -2705,6 +2891,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 28 2018"
@@ -2717,9 +2904,11 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 29 2018"
@@ -2731,6 +2920,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 30 2018"
@@ -2742,6 +2932,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue May 01 2018"
@@ -2753,6 +2944,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 02 2018"
@@ -2764,6 +2956,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 03 2018"
@@ -2775,6 +2968,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 04 2018"
@@ -2786,6 +2980,7 @@ exports[`IncrementalInteractions clicking on the year selector should switch to 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 05 2018"
@@ -2833,6 +3028,9 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-4"
+              aria-expanded="false"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -2863,13 +3061,13 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
         aria-hidden="true"
         class="dropdown-menu date-picker-dropdown-menu"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-4"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -3012,9 +3210,12 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -3096,9 +3297,11 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -3110,6 +3313,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -3121,6 +3325,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -3132,6 +3337,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -3143,6 +3349,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -3154,6 +3361,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -3165,6 +3373,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -3177,9 +3386,11 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -3191,6 +3402,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -3202,6 +3414,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -3213,6 +3426,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -3224,6 +3438,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -3235,6 +3450,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -3246,6 +3462,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -3258,9 +3475,11 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -3272,6 +3491,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -3283,6 +3503,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -3294,6 +3515,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -3304,7 +3526,9 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -3316,6 +3540,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -3327,6 +3552,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -3339,9 +3565,11 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -3353,6 +3581,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -3364,6 +3593,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -3375,6 +3605,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -3386,6 +3617,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -3397,6 +3629,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -3408,6 +3641,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -3420,9 +3654,11 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -3434,6 +3670,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -3445,6 +3682,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -3456,6 +3694,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -3467,6 +3706,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -3478,6 +3718,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -3489,6 +3730,7 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -3509,7 +3751,10 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
 
 exports[`IncrementalInteractions date entered in the input element should reflect on the date picker 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -3536,6 +3781,9 @@ exports[`IncrementalInteractions date entered in the input element should reflec
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-1"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -3560,13 +3808,13 @@ exports[`IncrementalInteractions date entered in the input element should reflec
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-1"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -3709,9 +3957,12 @@ exports[`IncrementalInteractions date entered in the input element should reflec
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -3793,9 +4044,11 @@ exports[`IncrementalInteractions date entered in the input element should reflec
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -3807,6 +4060,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -3818,6 +4072,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -3829,6 +4084,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -3840,6 +4096,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -3851,6 +4108,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -3862,6 +4120,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -3874,9 +4133,11 @@ exports[`IncrementalInteractions date entered in the input element should reflec
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -3888,6 +4149,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -3899,6 +4161,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -3909,7 +4172,9 @@ exports[`IncrementalInteractions date entered in the input element should reflec
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -3921,6 +4186,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -3932,6 +4198,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -3943,6 +4210,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -3955,9 +4223,11 @@ exports[`IncrementalInteractions date entered in the input element should reflec
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -3969,6 +4239,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -3980,6 +4251,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -3991,6 +4263,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -4002,6 +4275,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -4013,6 +4287,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -4024,6 +4299,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -4036,9 +4312,11 @@ exports[`IncrementalInteractions date entered in the input element should reflec
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -4050,6 +4328,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -4061,6 +4340,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -4072,6 +4352,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -4083,6 +4364,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -4094,6 +4376,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -4105,6 +4388,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -4117,9 +4401,11 @@ exports[`IncrementalInteractions date entered in the input element should reflec
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -4131,6 +4417,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -4142,6 +4429,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -4153,6 +4441,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -4164,6 +4453,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -4175,6 +4465,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -4186,6 +4477,7 @@ exports[`IncrementalInteractions date entered in the input element should reflec
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -64,6 +64,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -811,6 +812,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -1558,6 +1560,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -2305,6 +2308,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -3052,6 +3056,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -3799,6 +3804,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -4635,6 +4641,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >
@@ -5382,6 +5389,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
         style="left: -999px; top: -995px;"
       >
         <div
+          aria-label="April 2019"
           class="date-picker-calendar"
           role="group"
         >

--- a/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/packages/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -2,7 +2,10 @@
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Friday 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -29,6 +32,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-7"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -53,13 +59,13 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-7"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -202,9 +208,12 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -286,9 +295,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Mar 29 2019"
@@ -300,6 +311,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Mar 30 2019"
@@ -311,6 +323,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -322,6 +335,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -333,6 +347,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -344,6 +359,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -355,6 +371,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -367,9 +384,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -381,6 +400,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -392,6 +412,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -403,6 +424,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -414,6 +436,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -425,6 +448,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -436,6 +460,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -448,9 +473,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -462,6 +489,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -473,6 +501,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -484,6 +513,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -495,6 +525,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -506,6 +537,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -516,7 +548,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -529,9 +563,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -543,6 +579,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -554,6 +591,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -565,6 +603,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -576,6 +615,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -587,6 +627,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -598,6 +639,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -610,9 +652,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -624,6 +668,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -635,6 +680,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -646,6 +692,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -657,6 +704,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -668,6 +716,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -679,6 +728,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -699,7 +749,10 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Monday 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -726,6 +779,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-3"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -750,13 +806,13 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-3"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -899,9 +955,12 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -983,9 +1042,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -997,6 +1058,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -1008,6 +1070,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -1019,6 +1082,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -1030,6 +1094,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -1041,6 +1106,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -1052,6 +1118,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -1064,9 +1131,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -1078,6 +1147,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -1089,6 +1159,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -1100,6 +1171,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -1111,6 +1183,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -1122,6 +1195,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -1133,6 +1207,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -1145,9 +1220,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -1159,6 +1236,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -1170,6 +1248,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -1181,6 +1260,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -1191,7 +1271,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -1203,6 +1285,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -1214,6 +1297,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -1226,9 +1310,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -1240,6 +1326,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -1251,6 +1338,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -1262,6 +1350,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -1273,6 +1362,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -1284,6 +1374,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -1295,6 +1386,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -1307,9 +1399,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -1321,6 +1415,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -1332,6 +1427,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -1343,6 +1439,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -1354,6 +1451,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -1365,6 +1463,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -1376,6 +1475,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -1396,7 +1496,10 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Saturday 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -1423,6 +1526,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-8"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -1447,13 +1553,13 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-8"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -1596,9 +1702,12 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -1680,9 +1789,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Mar 30 2019"
@@ -1694,6 +1805,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -1705,6 +1817,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -1716,6 +1829,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -1727,6 +1841,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -1738,6 +1853,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -1749,6 +1865,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -1761,9 +1878,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -1775,6 +1894,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -1786,6 +1906,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -1797,6 +1918,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -1808,6 +1930,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -1819,6 +1942,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -1830,6 +1954,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -1842,9 +1967,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -1856,6 +1983,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -1867,6 +1995,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -1878,6 +2007,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -1889,6 +2019,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -1899,7 +2030,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -1911,6 +2044,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -1923,9 +2057,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -1937,6 +2073,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -1948,6 +2085,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -1959,6 +2097,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -1970,6 +2109,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -1981,6 +2121,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -1992,6 +2133,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -2004,9 +2146,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -2018,6 +2162,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -2029,6 +2174,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -2040,6 +2186,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -2051,6 +2198,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -2062,6 +2210,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -2073,6 +2222,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -2093,7 +2243,10 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Sunday 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -2120,6 +2273,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-2"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -2144,13 +2300,13 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-2"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -2293,9 +2449,12 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -2377,9 +2536,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -2391,6 +2552,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -2402,6 +2564,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -2413,6 +2576,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -2424,6 +2588,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -2435,6 +2600,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -2446,6 +2612,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -2458,9 +2625,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -2472,6 +2641,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -2483,6 +2653,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -2494,6 +2665,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -2505,6 +2677,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -2516,6 +2689,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -2527,6 +2701,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -2539,9 +2714,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -2553,6 +2730,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -2564,6 +2742,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -2575,6 +2754,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -2585,7 +2765,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -2597,6 +2779,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -2608,6 +2791,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -2620,9 +2804,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -2634,6 +2820,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -2645,6 +2832,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -2656,6 +2844,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -2667,6 +2856,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -2678,6 +2868,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -2689,6 +2880,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -2701,9 +2893,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -2715,6 +2909,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -2726,6 +2921,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -2737,6 +2933,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -2748,6 +2945,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -2759,6 +2957,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -2770,6 +2969,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -2790,7 +2990,10 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Thursday 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -2817,6 +3020,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-6"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -2841,13 +3047,13 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-6"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -2990,9 +3196,12 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -3074,9 +3283,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Mar 28 2019"
@@ -3088,6 +3299,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Mar 29 2019"
@@ -3099,6 +3311,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Mar 30 2019"
@@ -3110,6 +3323,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -3121,6 +3335,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -3132,6 +3347,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -3143,6 +3359,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -3155,9 +3372,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -3169,6 +3388,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -3180,6 +3400,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -3191,6 +3412,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -3202,6 +3424,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -3213,6 +3436,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -3224,6 +3448,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -3236,9 +3461,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -3250,6 +3477,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -3261,6 +3489,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -3272,6 +3501,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -3283,6 +3513,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -3294,6 +3525,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -3305,6 +3537,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -3317,9 +3550,12 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -3331,6 +3567,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -3342,6 +3579,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -3353,6 +3591,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -3364,6 +3603,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -3375,6 +3615,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -3386,6 +3627,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -3398,9 +3640,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -3412,6 +3656,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -3423,6 +3668,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -3434,6 +3680,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -3445,6 +3692,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -3456,6 +3704,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -3467,6 +3716,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -3487,7 +3737,10 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Tuesday 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -3514,6 +3767,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-4"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -3538,13 +3794,13 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-4"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -3687,9 +3943,12 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -3771,9 +4030,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Mar 26 2019"
@@ -3785,6 +4046,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Mar 27 2019"
@@ -3796,6 +4058,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Mar 28 2019"
@@ -3807,6 +4070,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Mar 29 2019"
@@ -3818,6 +4082,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Mar 30 2019"
@@ -3829,6 +4094,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -3840,6 +4106,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -3852,9 +4119,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -3866,6 +4135,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -3877,6 +4147,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -3888,6 +4159,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -3899,6 +4171,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -3910,6 +4183,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -3921,6 +4195,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -3933,9 +4208,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -3947,6 +4224,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -3958,6 +4236,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -3969,6 +4248,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -3980,6 +4260,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -3991,6 +4272,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -4002,6 +4284,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -4014,9 +4297,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -4028,6 +4313,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -4038,7 +4324,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -4050,6 +4338,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -4061,6 +4350,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -4072,6 +4362,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -4083,6 +4374,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -4095,9 +4387,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -4109,6 +4403,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -4120,6 +4415,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -4131,6 +4427,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -4142,6 +4439,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -4153,6 +4451,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -4164,6 +4463,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -4176,9 +4476,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -4190,6 +4492,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -4201,6 +4504,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -4212,6 +4516,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -4223,6 +4528,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -4234,6 +4540,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun May 05 2019"
@@ -4245,6 +4552,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon May 06 2019"
@@ -4265,7 +4573,10 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Wednesday 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -4292,6 +4603,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-5"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -4316,13 +4630,13 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-5"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -4465,9 +4779,12 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -4549,9 +4866,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Mar 27 2019"
@@ -4563,6 +4882,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Mar 28 2019"
@@ -4574,6 +4894,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Mar 29 2019"
@@ -4585,6 +4906,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Mar 30 2019"
@@ -4596,6 +4918,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Mar 31 2019"
@@ -4607,6 +4930,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -4618,6 +4942,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -4630,9 +4955,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -4644,6 +4971,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -4655,6 +4983,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -4666,6 +4995,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -4677,6 +5007,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -4688,6 +5019,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -4699,6 +5031,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -4711,9 +5044,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -4725,6 +5060,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -4736,6 +5072,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -4747,6 +5084,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -4758,6 +5096,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -4769,6 +5108,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -4780,6 +5120,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -4792,9 +5133,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -4805,7 +5148,9 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -4817,6 +5162,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -4828,6 +5174,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -4839,6 +5186,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -4850,6 +5198,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -4861,6 +5210,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -4873,9 +5223,11 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -4887,6 +5239,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -4898,6 +5251,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -4909,6 +5263,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -4920,6 +5275,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -4931,6 +5287,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -4942,6 +5299,7 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -4962,7 +5320,10 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization renders the date picker in russian 1`] = `
 <body>
-  <div>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
     <div
       class="date-picker"
     >
@@ -4989,6 +5350,9 @@ exports[`Internationalization renders the date picker in russian 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
+              aria-controls="clay-id-1"
+              aria-expanded="true"
+              aria-haspopup="dialog"
               aria-label="Choose your desired date"
               class="date-picker-dropdown-toggle btn btn-unstyled"
               data-testid="date-button"
@@ -5013,13 +5377,13 @@ exports[`Internationalization renders the date picker in russian 1`] = `
       <div
         class="dropdown-menu date-picker-dropdown-menu show"
         data-testid="dropdown"
-        role="presentation"
+        id="clay-id-1"
+        role="dialog"
         style="left: -999px; top: -995px;"
       >
         <div
-          aria-modal="true"
           class="date-picker-calendar"
-          role="dialog"
+          role="group"
         >
           <div
             class="date-picker-calendar-header"
@@ -5297,9 +5661,12 @@ exports[`Internationalization renders the date picker in russian 1`] = `
           </div>
           <div
             class="date-picker-calendar-body"
+            role="grid"
           >
             <div
+              aria-hidden="true"
               class="date-picker-days-row date-picker-row"
+              role="presentation"
             >
               <div
                 class="date-picker-col"
@@ -5381,9 +5748,11 @@ exports[`Internationalization renders the date picker in russian 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 01 2019"
@@ -5395,6 +5764,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 02 2019"
@@ -5406,6 +5776,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 03 2019"
@@ -5417,6 +5788,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 04 2019"
@@ -5428,6 +5800,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 05 2019"
@@ -5439,6 +5812,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 06 2019"
@@ -5450,6 +5824,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 07 2019"
@@ -5462,9 +5837,11 @@ exports[`Internationalization renders the date picker in russian 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 08 2019"
@@ -5476,6 +5853,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 09 2019"
@@ -5487,6 +5865,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 10 2019"
@@ -5498,6 +5877,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 11 2019"
@@ -5509,6 +5889,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 12 2019"
@@ -5520,6 +5901,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 13 2019"
@@ -5531,6 +5913,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 14 2019"
@@ -5543,9 +5926,11 @@ exports[`Internationalization renders the date picker in russian 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 15 2019"
@@ -5557,6 +5942,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 16 2019"
@@ -5568,6 +5954,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 17 2019"
@@ -5578,7 +5965,9 @@ exports[`Internationalization renders the date picker in russian 1`] = `
                 </button>
               </div>
               <div
+                aria-selected="true"
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 18 2019"
@@ -5590,6 +5979,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 19 2019"
@@ -5601,6 +5991,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 20 2019"
@@ -5612,6 +6003,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 21 2019"
@@ -5624,9 +6016,11 @@ exports[`Internationalization renders the date picker in russian 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 22 2019"
@@ -5638,6 +6032,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 23 2019"
@@ -5649,6 +6044,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed Apr 24 2019"
@@ -5660,6 +6056,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu Apr 25 2019"
@@ -5671,6 +6068,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri Apr 26 2019"
@@ -5682,6 +6080,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat Apr 27 2019"
@@ -5693,6 +6092,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun Apr 28 2019"
@@ -5705,9 +6105,11 @@ exports[`Internationalization renders the date picker in russian 1`] = `
             </div>
             <div
               class="date-picker-date-row date-picker-row"
+              role="row"
             >
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Mon Apr 29 2019"
@@ -5719,6 +6121,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Tue Apr 30 2019"
@@ -5730,6 +6133,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Wed May 01 2019"
@@ -5741,6 +6145,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Thu May 02 2019"
@@ -5752,6 +6157,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Fri May 03 2019"
@@ -5763,6 +6169,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sat May 04 2019"
@@ -5774,6 +6181,7 @@ exports[`Internationalization renders the date picker in russian 1`] = `
               </div>
               <div
                 class="date-picker-col"
+                role="gridcell"
               >
                 <button
                   aria-label="Sun May 05 2019"

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -218,6 +218,7 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 				buttonDot: 'Select current date',
 				buttonNextMonth: 'Select the next month',
 				buttonPreviousMonth: 'Select the previous month',
+				dialog: 'Choose date',
 			},
 			dateFormat = 'yyyy-MM-dd',
 			defaultExpanded,
@@ -647,6 +648,7 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 						<DropDown.Menu
 							active={expandedValue}
 							alignElementRef={triggerElementRef}
+							aria-label={ariaLabels.dialog}
 							className="date-picker-dropdown-menu"
 							data-testid="dropdown"
 							id={ariaControls}
@@ -654,7 +656,14 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 							ref={dropdownContainerRef}
 							role="dialog"
 						>
-							<div className="date-picker-calendar" role="group">
+							<div
+								aria-label={formatDate(
+									currentMonth,
+									'MMMM yyyy'
+								)}
+								className="date-picker-calendar"
+								role="group"
+							>
 								<DateNavigation
 									ariaLabels={ariaLabels}
 									currentMonth={currentMonth}

--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -7,7 +7,13 @@ import Button from '@clayui/button';
 import DropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
-import {FocusScope, InternalDispatch, useInternalState} from '@clayui/shared';
+import {
+	FocusScope,
+	InternalDispatch,
+	useId,
+	useInternalState,
+} from '@clayui/shared';
+import {hideOthers} from 'aria-hidden';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import DateNavigation from './DateNavigation';
@@ -580,6 +586,15 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			}
 		};
 
+		const ariaControls = useId();
+
+		useEffect(() => {
+			if (dropdownContainerRef.current && expandedValue) {
+				// Hide everything from ARIA except the MenuElement
+				return hideOthers(dropdownContainerRef.current);
+			}
+		}, [expandedValue]);
+
 		useEffect(() => {
 			document.addEventListener('focus', handleFocus, true);
 
@@ -608,6 +623,9 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 							{!useNative && (
 								<ClayInput.GroupInsetItem after>
 									<Button
+										aria-controls={ariaControls}
+										aria-expanded={expandedValue}
+										aria-haspopup="dialog"
 										aria-label={ariaLabels.buttonChooseDate}
 										className="date-picker-dropdown-toggle"
 										data-testid="date-button"
@@ -631,14 +649,12 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 							alignElementRef={triggerElementRef}
 							className="date-picker-dropdown-menu"
 							data-testid="dropdown"
+							id={ariaControls}
 							onActiveChange={setExpandedValue}
 							ref={dropdownContainerRef}
+							role="dialog"
 						>
-							<div
-								aria-modal="true"
-								className="date-picker-calendar"
-								role="dialog"
-							>
+							<div className="date-picker-calendar" role="group">
 								<DateNavigation
 									ariaLabels={ariaLabels}
 									currentMonth={currentMonth}
@@ -649,7 +665,10 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 									spritemap={spritemap}
 									years={years}
 								/>
-								<div className="date-picker-calendar-body">
+								<div
+									className="date-picker-calendar-body"
+									role="grid"
+								>
 									<WeekdayHeader
 										firstDayOfWeek={firstDayOfWeek}
 										weekdaysShort={weekdaysShort}

--- a/packages/clay-date-picker/src/types.ts
+++ b/packages/clay-date-picker/src/types.ts
@@ -19,6 +19,7 @@ export interface IAriaLabels {
 	buttonNextMonth: string;
 	buttonPreviousMonth: string;
 	input?: string;
+	dialog?: string;
 }
 
 export interface IYears {

--- a/packages/clay-date-picker/stories/DatePicker.stories.tsx
+++ b/packages/clay-date-picker/stories/DatePicker.stories.tsx
@@ -27,6 +27,7 @@ const ClayDatePickerWithState = (props: {[key: string]: any}) => {
 					buttonDot: 'Go to today',
 					buttonNextMonth: 'Next month',
 					buttonPreviousMonth: 'Previous month',
+					dialog: 'Choose Date',
 					input: value.toLocaleString(),
 				}}
 				onChange={setValue}

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -214,6 +214,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 			onActiveChange,
 			onSetActive,
 			width,
+			role = 'presentation',
 			...otherProps
 		}: IProps,
 		// TS + refs don't always play nicely together, which is why it is casted
@@ -340,7 +341,7 @@ const ClayDropDownMenu = React.forwardRef<HTMLDivElement, IProps>(
 								ref.current = node;
 							}
 						}}
-						role="presentation"
+						role={role}
 					>
 						{children}
 					</div>


### PR DESCRIPTION
Fixes #5201

This PR improves DatePicker's semantic accessibility but doesn't add the keyboard navigation recommendations yet, I'll add this in another PR once we have a clearer picture of what it should look like.

This PR adds semantic accessibility for the date grid and `aria-hidden` for elements that should not be assertive by SR when the menu is open, the same as we do for the other menus.