### PR TITLE
feat(@clayui/multi-select): adds accessibility improvements to MultiSelect

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -134,10 +134,10 @@ module.exports = {
 			statements: 85,
 		},
 		'./packages/clay-multi-select/src/': {
-			branches: 85,
+			branches: 64,
 			functions: 80,
-			lines: 87,
-			statements: 86,
+			lines: 78,
+			statements: 78,
 		},
 		'./packages/clay-multi-step-nav/src/': {
 			branches: 94,

--- a/jest.config.js
+++ b/jest.config.js
@@ -134,7 +134,7 @@ module.exports = {
 			statements: 85,
 		},
 		'./packages/clay-multi-select/src/': {
-			branches: 64,
+			branches: 62,
 			functions: 80,
 			lines: 78,
 			statements: 78,

--- a/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
@@ -367,8 +367,8 @@ $cadmin-border-theme-colors: map-deep-merge(
 
 // Display
 
-$cadmin-displays: none, inline, inline-block, grid, block, table, table-row,
-	table-cell, flex, inline-flex !default;
+$cadmin-displays: none, inline, inline-block, grid, block, contents, table,
+	table-row, table-cell, flex, inline-flex !default;
 
 // Overflow
 

--- a/packages/clay-css/src/scss/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/variables/_utilities.scss
@@ -357,8 +357,8 @@ $border-theme-colors: map-deep-merge(
 
 // Display
 
-$displays: none, inline, inline-block, block, grid, table, table-row, table-cell,
-	flex, inline-flex !default;
+$displays: none, inline, inline-block, block, grid, contents, table, table-row,
+	table-cell, flex, inline-flex !default;
 
 // Overflow
 

--- a/packages/clay-drop-down/src/Menu.tsx
+++ b/packages/clay-drop-down/src/Menu.tsx
@@ -170,8 +170,14 @@ const Menu = React.forwardRef<HTMLDivElement, IProps>(
 	) => {
 		const setActive = onActiveChange ?? onSetActive;
 
-		const menuRef = useRef<HTMLDivElement | null>(null);
+		const menuInternalRef = useRef<HTMLDivElement | null>(null);
 		const subPortalRef = useRef<HTMLDivElement | null>(null);
+
+		let menuRef = menuInternalRef;
+
+		if (ref) {
+			menuRef = ref as React.MutableRefObject<HTMLDivElement | null>;
+		}
 
 		useOverlayPosition(
 			{
@@ -210,16 +216,7 @@ const Menu = React.forwardRef<HTMLDivElement, IProps>(
 							[`dropdown-menu-width-${width}`]: width,
 							show: active,
 						})}
-						ref={(node) => {
-							menuRef.current = node;
-
-							if (ref instanceof Function) {
-								ref(node);
-							} else if (ref instanceof Object) {
-								// @ts-ignore
-								ref.current = node;
-							}
-						}}
+						ref={menuRef}
 						role={role}
 					>
 						{children}

--- a/packages/clay-multi-select/package.json
+++ b/packages/clay-multi-select/package.json
@@ -30,6 +30,7 @@
 		"@clayui/button": "^3.82.0",
 		"@clayui/drop-down": "^3.82.0",
 		"@clayui/form": "^3.82.0",
+		"@clayui/icon": "^3.56.0",
 		"@clayui/label": "^3.56.0",
 		"@clayui/loading-indicator": "^3.60.0",
 		"@clayui/shared": "^3.82.0",

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -19,6 +19,14 @@ exports[`ClayMultiSelect renders 1`] = `
           value=""
         />
       </div>
+      <div
+        class="sr-only"
+      >
+        <span
+          aria-live="polite"
+          aria-relevant="text"
+        />
+      </div>
     </div>
   </div>
 </body>
@@ -150,6 +158,14 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
           class="form-control-inset"
           type="text"
           value="one"
+        />
+      </div>
+      <div
+        class="sr-only"
+      >
+        <span
+          aria-live="polite"
+          aria-relevant="text"
         />
       </div>
       <div
@@ -339,6 +355,14 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
           value=""
         />
       </div>
+      <div
+        class="sr-only"
+      >
+        <span
+          aria-live="polite"
+          aria-relevant="text"
+        />
+      </div>
     </div>
   </div>
 </body>
@@ -470,6 +494,14 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
           class="form-control-inset"
           type="text"
           value=""
+        />
+      </div>
+      <div
+        class="sr-only"
+      >
+        <span
+          aria-live="polite"
+          aria-relevant="text"
         />
       </div>
       <div
@@ -622,6 +654,14 @@ exports[`ClayMultiSelect renders with items 1`] = `
           class="form-control-inset"
           type="text"
           value=""
+        />
+      </div>
+      <div
+        class="sr-only"
+      >
+        <span
+          aria-live="polite"
+          aria-relevant="text"
         />
       </div>
       <div

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -7,18 +7,26 @@ exports[`ClayMultiSelect renders 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
-        aria-describedby="clay-id-2"
-        class="input-group-item input-group-item-shrink input-group-prepend"
-        role="grid"
-      />
-      <div
-        class="input-group-item input-group-prepend"
+        class="input-group-item"
       >
-        <input
-          class="form-control-inset"
-          type="text"
-          value=""
-        />
+        <div
+          class="input-group"
+        >
+          <div
+            aria-describedby="clay-id-2"
+            class="input-group-item d-contents input-group-item-shrink input-group-prepend"
+            role="grid"
+          />
+          <div
+            class="input-group-item input-group-prepend"
+          >
+            <input
+              class="form-control-inset"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
       </div>
       <div
         class="sr-only"
@@ -45,132 +53,141 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
-        aria-describedby="clay-id-10"
-        class="input-group-item input-group-item-shrink input-group-prepend"
-        role="grid"
+        class="input-group-item"
       >
-        <span
-          aria-labelledby="clay-id-9-label-1-text"
-          class="label label-secondary"
-          id="clay-id-9-label-1-span"
-          role="row"
-          tabindex="0"
+        <div
+          class="input-group"
         >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-9-label-1-text"
-            role="gridcell"
+          <div
+            aria-describedby="clay-id-10"
+            class="input-group-item d-contents input-group-item-shrink input-group-prepend"
+            role="grid"
           >
-            foo
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove foo"
-              class="close"
-              id="clay-id-9-label-1-close"
-              tabindex="-1"
-              type="button"
+            <span
+              aria-labelledby="clay-id-9-label-1-text"
+              class="label label-secondary"
+              id="clay-id-9-label-1-span"
+              role="row"
+              tabindex="0"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-9-label-1-text"
+                role="gridcell"
               >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-9-label-2-text"
-          class="label label-secondary"
-          id="clay-id-9-label-2-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-9-label-2-text"
-            role="gridcell"
-          >
-            bar
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove bar"
-              class="close"
-              id="clay-id-9-label-2-close"
+                foo
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove foo"
+                  class="close"
+                  id="clay-id-9-label-1-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+            <span
+              aria-labelledby="clay-id-9-label-2-text"
+              class="label label-secondary"
+              id="clay-id-9-label-2-span"
+              role="row"
               tabindex="-1"
-              type="button"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-9-label-2-text"
+                role="gridcell"
               >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-9-label-3-text"
-          class="label label-secondary"
-          id="clay-id-9-label-3-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-9-label-3-text"
-            role="gridcell"
-          >
-            baz
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove baz"
-              class="close"
-              id="clay-id-9-label-3-close"
+                bar
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove bar"
+                  class="close"
+                  id="clay-id-9-label-2-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+            <span
+              aria-labelledby="clay-id-9-label-3-text"
+              class="label label-secondary"
+              id="clay-id-9-label-3-span"
+              role="row"
               tabindex="-1"
-              type="button"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-9-label-3-text"
+                role="gridcell"
               >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-      </div>
-      <div
-        class="input-group-item input-group-prepend"
-      >
-        <input
-          class="form-control-inset"
-          type="text"
-          value="one"
-        />
+                baz
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove baz"
+                  class="close"
+                  id="clay-id-9-label-3-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+          </div>
+          <div
+            class="input-group-item input-group-prepend"
+          >
+            <input
+              class="form-control-inset"
+              type="text"
+              value="one"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="input-group-item input-group-item-shrink"
       >
         <button
+          aria-label="Clear All"
           class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
           title="Clear All"
           type="button"
@@ -197,341 +214,6 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
           aria-live="polite"
           aria-relevant="text"
         />
-      </div>
-    </div>
-  </div>
-  <div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="dropdown-menu autocomplete-dropdown-menu"
-        role="presentation"
-        style="max-width: none; left: -999px; top: -995px;"
-      >
-        <ul
-          class="list-unstyled"
-          role="menu"
-        >
-          <li
-            role="presentation"
-          >
-            <button
-              class="dropdown-item"
-              role="menuitem"
-            >
-              <strong>
-                one
-              </strong>
-              <p>
-                Name
-              </p>
-            </button>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ClayMultiSelect renders as disabled 1`] = `
-<body>
-  <div>
-    <div
-      class="form-control form-control-tag-group input-group"
-    >
-      <div
-        aria-describedby="clay-id-8"
-        class="input-group-item input-group-item-shrink input-group-prepend"
-        role="grid"
-      >
-        <span
-          aria-labelledby="clay-id-7-label-1-text"
-          class="label label-secondary"
-          id="clay-id-7-label-1-span"
-          role="row"
-          tabindex="0"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-7-label-1-text"
-            role="gridcell"
-          >
-            foo
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove foo"
-              class="close"
-              disabled=""
-              id="clay-id-7-label-1-close"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-7-label-2-text"
-          class="label label-secondary"
-          id="clay-id-7-label-2-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-7-label-2-text"
-            role="gridcell"
-          >
-            bar
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove bar"
-              class="close"
-              disabled=""
-              id="clay-id-7-label-2-close"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-7-label-3-text"
-          class="label label-secondary"
-          id="clay-id-7-label-3-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-7-label-3-text"
-            role="gridcell"
-          >
-            baz
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove baz"
-              class="close"
-              disabled=""
-              id="clay-id-7-label-3-close"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-      </div>
-      <div
-        class="input-group-item input-group-prepend"
-      >
-        <input
-          class="form-control-inset"
-          disabled=""
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        class="sr-only"
-      >
-        <span
-          id="clay-id-8"
-        >
-          Use the arrow keys to navigate the labels and pressing backspace will delete.
-        </span>
-        <span
-          aria-live="polite"
-          aria-relevant="text"
-        />
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ClayMultiSelect renders as not valid 1`] = `
-<body>
-  <div>
-    <div
-      class="form-control form-control-tag-group input-group"
-    >
-      <div
-        aria-describedby="clay-id-6"
-        class="input-group-item input-group-item-shrink input-group-prepend"
-        role="grid"
-      >
-        <span
-          aria-labelledby="clay-id-5-label-1-text"
-          class="label label-secondary"
-          id="clay-id-5-label-1-span"
-          role="row"
-          tabindex="0"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-5-label-1-text"
-            role="gridcell"
-          >
-            foo
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove foo"
-              class="close"
-              id="clay-id-5-label-1-close"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-5-label-2-text"
-          class="label label-secondary"
-          id="clay-id-5-label-2-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-5-label-2-text"
-            role="gridcell"
-          >
-            bar
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove bar"
-              class="close"
-              id="clay-id-5-label-2-close"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-5-label-3-text"
-          class="label label-secondary"
-          id="clay-id-5-label-3-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-5-label-3-text"
-            role="gridcell"
-          >
-            baz
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove baz"
-              class="close"
-              id="clay-id-5-label-3-close"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-      </div>
-      <div
-        class="input-group-item input-group-prepend"
-      >
-        <input
-          class="form-control-inset"
-          type="text"
-          value=""
-        />
-      </div>
-      <div
-        class="input-group-item input-group-item-shrink"
-      >
-        <button
-          aria-label="Clear All"
-          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
-          title="Clear All"
-          type="button"
-        >
-          <svg
-            class="lexicon-icon lexicon-icon-times-circle"
-            role="presentation"
-          >
-            <use
-              xlink:href="/foo/bar#times-circle"
-            />
-          </svg>
-        </button>
       </div>
     </div>
   </div>
@@ -576,130 +258,313 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
-        class="input-group-item input-group-item-shrink input-group-prepend"
-        role="grid"
+        class="input-group-item"
       >
-        <span
-          aria-labelledby="clay-id-4-label-1-text"
-          class="label label-secondary"
-          id="clay-id-4-label-1-span"
-          role="row"
-          tabindex="0"
+        <div
+          class="input-group"
         >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-4-label-1-text"
-            role="gridcell"
+          <div
+            aria-describedby="clay-id-8"
+            class="input-group-item d-contents input-group-item-shrink input-group-prepend"
+            role="grid"
           >
-            foo
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove foo"
-              class="close"
-              disabled=""
-              id="clay-id-4-label-1-close"
-              tabindex="-1"
-              type="button"
+            <span
+              aria-labelledby="clay-id-7-label-1-text"
+              class="label label-secondary"
+              id="clay-id-7-label-1-span"
+              role="row"
+              tabindex="0"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-7-label-1-text"
+                role="gridcell"
               >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-4-label-2-text"
-          class="label label-secondary"
-          id="clay-id-4-label-2-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-4-label-2-text"
-            role="gridcell"
-          >
-            bar
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove bar"
-              class="close"
-              disabled=""
-              id="clay-id-4-label-2-close"
+                foo
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove foo"
+                  class="close"
+                  disabled=""
+                  id="clay-id-7-label-1-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+            <span
+              aria-labelledby="clay-id-7-label-2-text"
+              class="label label-secondary"
+              id="clay-id-7-label-2-span"
+              role="row"
               tabindex="-1"
-              type="button"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-7-label-2-text"
+                role="gridcell"
               >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-4-label-3-text"
-          class="label label-secondary"
-          id="clay-id-4-label-3-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-4-label-3-text"
-            role="gridcell"
-          >
-            baz
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove baz"
-              class="close"
-              disabled=""
-              id="clay-id-4-label-3-close"
+                bar
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove bar"
+                  class="close"
+                  disabled=""
+                  id="clay-id-7-label-2-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+            <span
+              aria-labelledby="clay-id-7-label-3-text"
+              class="label label-secondary"
+              id="clay-id-7-label-3-span"
+              role="row"
               tabindex="-1"
-              type="button"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-7-label-3-text"
+                role="gridcell"
               >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
+                baz
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove baz"
+                  class="close"
+                  disabled=""
+                  id="clay-id-7-label-3-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+          </div>
+          <div
+            class="input-group-item input-group-prepend"
+          >
+            <input
+              class="form-control-inset"
+              disabled=""
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
       </div>
       <div
-        class="input-group-item input-group-prepend"
+        class="sr-only"
       >
-        <input
-          class="form-control-inset"
-          disabled=""
-          type="text"
-          value=""
+        <span
+          id="clay-id-8"
+        >
+          Use the arrow keys to navigate the labels and pressing backspace will delete.
+        </span>
+        <span
+          aria-live="polite"
+          aria-relevant="text"
         />
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ClayMultiSelect renders as not valid 1`] = `
+<body>
+  <div>
+    <div
+      class="form-control form-control-tag-group input-group"
+    >
+      <div
+        class="input-group-item"
+      >
+        <div
+          class="input-group"
+        >
+          <div
+            aria-describedby="clay-id-6"
+            class="input-group-item d-contents input-group-item-shrink input-group-prepend"
+            role="grid"
+          >
+            <span
+              aria-labelledby="clay-id-5-label-1-text"
+              class="label label-secondary"
+              id="clay-id-5-label-1-span"
+              role="row"
+              tabindex="0"
+            >
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-5-label-1-text"
+                role="gridcell"
+              >
+                foo
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove foo"
+                  class="close"
+                  id="clay-id-5-label-1-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+            <span
+              aria-labelledby="clay-id-5-label-2-text"
+              class="label label-secondary"
+              id="clay-id-5-label-2-span"
+              role="row"
+              tabindex="-1"
+            >
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-5-label-2-text"
+                role="gridcell"
+              >
+                bar
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove bar"
+                  class="close"
+                  id="clay-id-5-label-2-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+            <span
+              aria-labelledby="clay-id-5-label-3-text"
+              class="label label-secondary"
+              id="clay-id-5-label-3-span"
+              role="row"
+              tabindex="-1"
+            >
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-5-label-3-text"
+                role="gridcell"
+              >
+                baz
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove baz"
+                  class="close"
+                  id="clay-id-5-label-3-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+          </div>
+          <div
+            class="input-group-item input-group-prepend"
+          >
+            <input
+              class="form-control-inset"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="input-group-item input-group-item-shrink"
+      >
+        <button
+          aria-label="Clear All"
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
+          title="Clear All"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-times-circle"
+            role="presentation"
+          >
+            <use
+              xlink:href="/foo/bar#times-circle"
+            />
+          </svg>
+        </button>
       </div>
       <div
         class="sr-only"
@@ -726,127 +591,135 @@ exports[`ClayMultiSelect renders with items 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
-        aria-describedby="clay-id-4"
-        class="input-group-item input-group-item-shrink input-group-prepend"
-        role="grid"
+        class="input-group-item"
       >
-        <span
-          aria-labelledby="clay-id-3-label-1-text"
-          class="label label-secondary"
-          id="clay-id-3-label-1-span"
-          role="row"
-          tabindex="0"
+        <div
+          class="input-group"
         >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-3-label-1-text"
-            role="gridcell"
+          <div
+            aria-describedby="clay-id-4"
+            class="input-group-item d-contents input-group-item-shrink input-group-prepend"
+            role="grid"
           >
-            foo
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove foo"
-              class="close"
-              id="clay-id-3-label-1-close"
-              tabindex="-1"
-              type="button"
+            <span
+              aria-labelledby="clay-id-3-label-1-text"
+              class="label label-secondary"
+              id="clay-id-3-label-1-span"
+              role="row"
+              tabindex="0"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-3-label-1-text"
+                role="gridcell"
               >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-3-label-2-text"
-          class="label label-secondary"
-          id="clay-id-3-label-2-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-3-label-2-text"
-            role="gridcell"
-          >
-            bar
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove bar"
-              class="close"
-              id="clay-id-3-label-2-close"
+                foo
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove foo"
+                  class="close"
+                  id="clay-id-3-label-1-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+            <span
+              aria-labelledby="clay-id-3-label-2-text"
+              class="label label-secondary"
+              id="clay-id-3-label-2-span"
+              role="row"
               tabindex="-1"
-              type="button"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-3-label-2-text"
+                role="gridcell"
               >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-3-label-3-text"
-          class="label label-secondary"
-          id="clay-id-3-label-3-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-3-label-3-text"
-            role="gridcell"
-          >
-            baz
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove baz"
-              class="close"
-              id="clay-id-3-label-3-close"
+                bar
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove bar"
+                  class="close"
+                  id="clay-id-3-label-2-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+            <span
+              aria-labelledby="clay-id-3-label-3-text"
+              class="label label-secondary"
+              id="clay-id-3-label-3-span"
+              role="row"
               tabindex="-1"
-              type="button"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
+              <span
+                class="label-item label-item-expand"
+                id="clay-id-3-label-3-text"
+                role="gridcell"
               >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-      </div>
-      <div
-        class="input-group-item input-group-prepend"
-      >
-        <input
-          class="form-control-inset"
-          type="text"
-          value=""
-        />
+                baz
+              </span>
+              <span
+                class="label-item label-item-after"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Remove baz"
+                  class="close"
+                  id="clay-id-3-label-3-close"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-times-small"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="/foo/bar#times-small"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+          </div>
+          <div
+            class="input-group-item input-group-prepend"
+          >
+            <input
+              class="form-control-inset"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
       </div>
       <div
         class="input-group-item input-group-item-shrink"
@@ -879,25 +752,6 @@ exports[`ClayMultiSelect renders with items 1`] = `
           aria-live="polite"
           aria-relevant="text"
         />
-      </div>
-      <div
-        class="input-group-item input-group-item-shrink"
-      >
-        <button
-          aria-label="Clear All"
-          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
-          title="Clear All"
-          type="button"
-        >
-          <svg
-            class="lexicon-icon lexicon-icon-times-circle"
-            role="presentation"
-          >
-            <use
-              xlink:href="/foo/bar#times-circle"
-            />
-          </svg>
-        </button>
       </div>
     </div>
   </div>

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -35,6 +35,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
         role="grid"
       >
         <span
+          aria-labelledby="clay-id-5-label-1-text"
           class="label label-secondary"
           id="clay-id-5-label-1-span"
           role="row"
@@ -42,6 +43,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-5-label-1-text"
             role="gridcell"
           >
             foo
@@ -69,6 +71,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
           </span>
         </span>
         <span
+          aria-labelledby="clay-id-5-label-2-text"
           class="label label-secondary"
           id="clay-id-5-label-2-span"
           role="row"
@@ -76,6 +79,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-5-label-2-text"
             role="gridcell"
           >
             bar
@@ -103,6 +107,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
           </span>
         </span>
         <span
+          aria-labelledby="clay-id-5-label-3-text"
           class="label label-secondary"
           id="clay-id-5-label-3-span"
           role="row"
@@ -110,6 +115,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-5-label-3-text"
             role="gridcell"
           >
             baz
@@ -212,6 +218,7 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
         role="grid"
       >
         <span
+          aria-labelledby="clay-id-4-label-1-text"
           class="label label-secondary"
           id="clay-id-4-label-1-span"
           role="row"
@@ -219,6 +226,7 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-4-label-1-text"
             role="gridcell"
           >
             foo
@@ -247,6 +255,7 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
           </span>
         </span>
         <span
+          aria-labelledby="clay-id-4-label-2-text"
           class="label label-secondary"
           id="clay-id-4-label-2-span"
           role="row"
@@ -254,6 +263,7 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-4-label-2-text"
             role="gridcell"
           >
             bar
@@ -282,6 +292,7 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
           </span>
         </span>
         <span
+          aria-labelledby="clay-id-4-label-3-text"
           class="label label-secondary"
           id="clay-id-4-label-3-span"
           role="row"
@@ -289,6 +300,7 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-4-label-3-text"
             role="gridcell"
           >
             baz
@@ -343,6 +355,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
         role="grid"
       >
         <span
+          aria-labelledby="clay-id-3-label-1-text"
           class="label label-secondary"
           id="clay-id-3-label-1-span"
           role="row"
@@ -350,6 +363,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-3-label-1-text"
             role="gridcell"
           >
             foo
@@ -377,6 +391,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
           </span>
         </span>
         <span
+          aria-labelledby="clay-id-3-label-2-text"
           class="label label-secondary"
           id="clay-id-3-label-2-span"
           role="row"
@@ -384,6 +399,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-3-label-2-text"
             role="gridcell"
           >
             bar
@@ -411,6 +427,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
           </span>
         </span>
         <span
+          aria-labelledby="clay-id-3-label-3-text"
           class="label label-secondary"
           id="clay-id-3-label-3-span"
           role="row"
@@ -418,6 +435,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-3-label-3-text"
             role="gridcell"
           >
             baz
@@ -489,6 +507,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
         role="grid"
       >
         <span
+          aria-labelledby="clay-id-2-label-1-text"
           class="label label-secondary"
           id="clay-id-2-label-1-span"
           role="row"
@@ -496,6 +515,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-2-label-1-text"
             role="gridcell"
           >
             foo
@@ -523,6 +543,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
           </span>
         </span>
         <span
+          aria-labelledby="clay-id-2-label-2-text"
           class="label label-secondary"
           id="clay-id-2-label-2-span"
           role="row"
@@ -530,6 +551,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-2-label-2-text"
             role="gridcell"
           >
             bar
@@ -557,6 +579,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
           </span>
         </span>
         <span
+          aria-labelledby="clay-id-2-label-3-text"
           class="label label-secondary"
           id="clay-id-2-label-3-span"
           role="row"
@@ -564,6 +587,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
         >
           <span
             class="label-item label-item-expand"
+            id="clay-id-2-label-3-text"
             role="gridcell"
           >
             baz

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -7,7 +7,11 @@ exports[`ClayMultiSelect renders 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
-        class="input-group-item"
+        class="input-group-item input-group-item-shrink input-group-prepend"
+        role="grid"
+      />
+      <div
+        class="input-group-item input-group-prepend"
       >
         <input
           class="form-control-inset"
@@ -27,22 +31,30 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
-        class="input-group-item"
+        class="input-group-item input-group-item-shrink input-group-prepend"
+        role="grid"
       >
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-5-label-1-span"
+          role="row"
+          tabindex="0"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             foo
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove foo"
               class="close"
+              id="clay-id-5-label-1-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -57,19 +69,26 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
           </span>
         </span>
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-5-label-2-span"
+          role="row"
+          tabindex="-1"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             bar
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove bar"
               class="close"
+              id="clay-id-5-label-2-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -84,19 +103,26 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
           </span>
         </span>
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-5-label-3-span"
+          role="row"
+          tabindex="-1"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             baz
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove baz"
               class="close"
+              id="clay-id-5-label-3-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -110,6 +136,10 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="input-group-item input-group-prepend"
+      >
         <input
           class="form-control-inset"
           type="text"
@@ -178,23 +208,31 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
-        class="input-group-item"
+        class="input-group-item input-group-item-shrink input-group-prepend"
+        role="grid"
       >
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-4-label-1-span"
+          role="row"
+          tabindex="0"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             foo
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove foo"
               class="close"
               disabled=""
+              id="clay-id-4-label-1-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -209,20 +247,27 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
           </span>
         </span>
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-4-label-2-span"
+          role="row"
+          tabindex="-1"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             bar
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove bar"
               class="close"
               disabled=""
+              id="clay-id-4-label-2-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -237,20 +282,27 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
           </span>
         </span>
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-4-label-3-span"
+          role="row"
+          tabindex="-1"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             baz
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove baz"
               class="close"
               disabled=""
+              id="clay-id-4-label-3-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -264,6 +316,10 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="input-group-item input-group-prepend"
+      >
         <input
           class="form-control-inset"
           disabled=""
@@ -283,22 +339,30 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
-        class="input-group-item"
+        class="input-group-item input-group-item-shrink input-group-prepend"
+        role="grid"
       >
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-3-label-1-span"
+          role="row"
+          tabindex="0"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             foo
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove foo"
               class="close"
+              id="clay-id-3-label-1-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -313,19 +377,26 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
           </span>
         </span>
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-3-label-2-span"
+          role="row"
+          tabindex="-1"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             bar
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove bar"
               class="close"
+              id="clay-id-3-label-2-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -340,19 +411,26 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
           </span>
         </span>
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-3-label-3-span"
+          role="row"
+          tabindex="-1"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             baz
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove baz"
               class="close"
+              id="clay-id-3-label-3-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -366,6 +444,10 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="input-group-item input-group-prepend"
+      >
         <input
           class="form-control-inset"
           type="text"
@@ -403,22 +485,30 @@ exports[`ClayMultiSelect renders with items 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
-        class="input-group-item"
+        class="input-group-item input-group-item-shrink input-group-prepend"
+        role="grid"
       >
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-2-label-1-span"
+          role="row"
+          tabindex="0"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             foo
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove foo"
               class="close"
+              id="clay-id-2-label-1-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -433,19 +523,26 @@ exports[`ClayMultiSelect renders with items 1`] = `
           </span>
         </span>
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-2-label-2-span"
+          role="row"
+          tabindex="-1"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             bar
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove bar"
               class="close"
+              id="clay-id-2-label-2-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -460,19 +557,26 @@ exports[`ClayMultiSelect renders with items 1`] = `
           </span>
         </span>
         <span
-          class="label label-dismissible label-secondary"
+          class="label label-secondary"
+          id="clay-id-2-label-3-span"
+          role="row"
+          tabindex="-1"
         >
           <span
             class="label-item label-item-expand"
+            role="gridcell"
           >
             baz
           </span>
           <span
             class="label-item label-item-after"
+            role="gridcell"
           >
             <button
               aria-label="Remove baz"
               class="close"
+              id="clay-id-2-label-3-close"
+              tabindex="-1"
               type="button"
             >
               <svg
@@ -486,6 +590,10 @@ exports[`ClayMultiSelect renders with items 1`] = `
             </button>
           </span>
         </span>
+      </div>
+      <div
+        class="input-group-item input-group-prepend"
+      >
         <input
           class="form-control-inset"
           type="text"

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -13,7 +13,6 @@ exports[`ClayMultiSelect renders 1`] = `
           class="input-group"
         >
           <div
-            aria-describedby="clay-id-2"
             class="input-group-item d-contents input-group-item-shrink input-group-prepend"
             role="grid"
           />
@@ -34,7 +33,7 @@ exports[`ClayMultiSelect renders 1`] = `
         <span
           id="clay-id-2"
         >
-          Use the arrow keys to navigate the labels and pressing backspace will delete.
+          Press backspace to delete the current row.
         </span>
         <span
           aria-live="polite"
@@ -59,21 +58,19 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
           class="input-group"
         >
           <div
-            aria-describedby="clay-id-10"
             class="input-group-item d-contents input-group-item-shrink input-group-prepend"
             role="grid"
           >
             <span
-              aria-labelledby="clay-id-9-label-1-text"
               class="label label-secondary"
-              id="clay-id-9-label-1-span"
               role="row"
-              tabindex="0"
             >
               <span
+                aria-describedby="clay-id-10"
                 class="label-item label-item-expand"
-                id="clay-id-9-label-1-text"
+                id="clay-id-9-label-1-span"
                 role="gridcell"
+                tabindex="0"
               >
                 foo
               </span>
@@ -100,16 +97,15 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
               </span>
             </span>
             <span
-              aria-labelledby="clay-id-9-label-2-text"
               class="label label-secondary"
-              id="clay-id-9-label-2-span"
               role="row"
-              tabindex="-1"
             >
               <span
+                aria-describedby="clay-id-10"
                 class="label-item label-item-expand"
-                id="clay-id-9-label-2-text"
+                id="clay-id-9-label-2-span"
                 role="gridcell"
+                tabindex="-1"
               >
                 bar
               </span>
@@ -136,16 +132,15 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
               </span>
             </span>
             <span
-              aria-labelledby="clay-id-9-label-3-text"
               class="label label-secondary"
-              id="clay-id-9-label-3-span"
               role="row"
-              tabindex="-1"
             >
               <span
+                aria-describedby="clay-id-10"
                 class="label-item label-item-expand"
-                id="clay-id-9-label-3-text"
+                id="clay-id-9-label-3-span"
                 role="gridcell"
+                tabindex="-1"
               >
                 baz
               </span>
@@ -208,7 +203,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
         <span
           id="clay-id-10"
         >
-          Use the arrow keys to navigate the labels and pressing backspace will delete.
+          Press backspace to delete the current row.
         </span>
         <span
           aria-live="polite"
@@ -264,21 +259,19 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
           class="input-group"
         >
           <div
-            aria-describedby="clay-id-8"
             class="input-group-item d-contents input-group-item-shrink input-group-prepend"
             role="grid"
           >
             <span
-              aria-labelledby="clay-id-7-label-1-text"
               class="label label-secondary"
-              id="clay-id-7-label-1-span"
               role="row"
-              tabindex="0"
             >
               <span
+                aria-describedby="clay-id-8"
                 class="label-item label-item-expand"
-                id="clay-id-7-label-1-text"
+                id="clay-id-7-label-1-span"
                 role="gridcell"
+                tabindex="0"
               >
                 foo
               </span>
@@ -306,16 +299,15 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
               </span>
             </span>
             <span
-              aria-labelledby="clay-id-7-label-2-text"
               class="label label-secondary"
-              id="clay-id-7-label-2-span"
               role="row"
-              tabindex="-1"
             >
               <span
+                aria-describedby="clay-id-8"
                 class="label-item label-item-expand"
-                id="clay-id-7-label-2-text"
+                id="clay-id-7-label-2-span"
                 role="gridcell"
+                tabindex="-1"
               >
                 bar
               </span>
@@ -343,16 +335,15 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
               </span>
             </span>
             <span
-              aria-labelledby="clay-id-7-label-3-text"
               class="label label-secondary"
-              id="clay-id-7-label-3-span"
               role="row"
-              tabindex="-1"
             >
               <span
+                aria-describedby="clay-id-8"
                 class="label-item label-item-expand"
-                id="clay-id-7-label-3-text"
+                id="clay-id-7-label-3-span"
                 role="gridcell"
+                tabindex="-1"
               >
                 baz
               </span>
@@ -398,7 +389,7 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
         <span
           id="clay-id-8"
         >
-          Use the arrow keys to navigate the labels and pressing backspace will delete.
+          Press backspace to delete the current row.
         </span>
         <span
           aria-live="polite"
@@ -423,21 +414,19 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
           class="input-group"
         >
           <div
-            aria-describedby="clay-id-6"
             class="input-group-item d-contents input-group-item-shrink input-group-prepend"
             role="grid"
           >
             <span
-              aria-labelledby="clay-id-5-label-1-text"
               class="label label-secondary"
-              id="clay-id-5-label-1-span"
               role="row"
-              tabindex="0"
             >
               <span
+                aria-describedby="clay-id-6"
                 class="label-item label-item-expand"
-                id="clay-id-5-label-1-text"
+                id="clay-id-5-label-1-span"
                 role="gridcell"
+                tabindex="0"
               >
                 foo
               </span>
@@ -464,16 +453,15 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
               </span>
             </span>
             <span
-              aria-labelledby="clay-id-5-label-2-text"
               class="label label-secondary"
-              id="clay-id-5-label-2-span"
               role="row"
-              tabindex="-1"
             >
               <span
+                aria-describedby="clay-id-6"
                 class="label-item label-item-expand"
-                id="clay-id-5-label-2-text"
+                id="clay-id-5-label-2-span"
                 role="gridcell"
+                tabindex="-1"
               >
                 bar
               </span>
@@ -500,16 +488,15 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
               </span>
             </span>
             <span
-              aria-labelledby="clay-id-5-label-3-text"
               class="label label-secondary"
-              id="clay-id-5-label-3-span"
               role="row"
-              tabindex="-1"
             >
               <span
+                aria-describedby="clay-id-6"
                 class="label-item label-item-expand"
-                id="clay-id-5-label-3-text"
+                id="clay-id-5-label-3-span"
                 role="gridcell"
+                tabindex="-1"
               >
                 baz
               </span>
@@ -572,7 +559,7 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
         <span
           id="clay-id-6"
         >
-          Use the arrow keys to navigate the labels and pressing backspace will delete.
+          Press backspace to delete the current row.
         </span>
         <span
           aria-live="polite"
@@ -597,21 +584,19 @@ exports[`ClayMultiSelect renders with items 1`] = `
           class="input-group"
         >
           <div
-            aria-describedby="clay-id-4"
             class="input-group-item d-contents input-group-item-shrink input-group-prepend"
             role="grid"
           >
             <span
-              aria-labelledby="clay-id-3-label-1-text"
               class="label label-secondary"
-              id="clay-id-3-label-1-span"
               role="row"
-              tabindex="0"
             >
               <span
+                aria-describedby="clay-id-4"
                 class="label-item label-item-expand"
-                id="clay-id-3-label-1-text"
+                id="clay-id-3-label-1-span"
                 role="gridcell"
+                tabindex="0"
               >
                 foo
               </span>
@@ -638,16 +623,15 @@ exports[`ClayMultiSelect renders with items 1`] = `
               </span>
             </span>
             <span
-              aria-labelledby="clay-id-3-label-2-text"
               class="label label-secondary"
-              id="clay-id-3-label-2-span"
               role="row"
-              tabindex="-1"
             >
               <span
+                aria-describedby="clay-id-4"
                 class="label-item label-item-expand"
-                id="clay-id-3-label-2-text"
+                id="clay-id-3-label-2-span"
                 role="gridcell"
+                tabindex="-1"
               >
                 bar
               </span>
@@ -674,16 +658,15 @@ exports[`ClayMultiSelect renders with items 1`] = `
               </span>
             </span>
             <span
-              aria-labelledby="clay-id-3-label-3-text"
               class="label label-secondary"
-              id="clay-id-3-label-3-span"
               role="row"
-              tabindex="-1"
             >
               <span
+                aria-describedby="clay-id-4"
                 class="label-item label-item-expand"
-                id="clay-id-3-label-3-text"
+                id="clay-id-3-label-3-span"
                 role="gridcell"
+                tabindex="-1"
               >
                 baz
               </span>
@@ -746,7 +729,7 @@ exports[`ClayMultiSelect renders with items 1`] = `
         <span
           id="clay-id-4"
         >
-          Use the arrow keys to navigate the labels and pressing backspace will delete.
+          Press backspace to delete the current row.
         </span>
         <span
           aria-live="polite"

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -7,6 +7,7 @@ exports[`ClayMultiSelect renders 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
+        aria-describedby="clay-id-2"
         class="input-group-item input-group-item-shrink input-group-prepend"
         role="grid"
       />
@@ -22,6 +23,11 @@ exports[`ClayMultiSelect renders 1`] = `
       <div
         class="sr-only"
       >
+        <span
+          id="clay-id-2"
+        >
+          Use the arrow keys to navigate the labels and pressing backspace will delete.
+        </span>
         <span
           aria-live="polite"
           aria-relevant="text"
@@ -39,6 +45,354 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
       class="form-control form-control-tag-group input-group"
     >
       <div
+        aria-describedby="clay-id-10"
+        class="input-group-item input-group-item-shrink input-group-prepend"
+        role="grid"
+      >
+        <span
+          aria-labelledby="clay-id-9-label-1-text"
+          class="label label-secondary"
+          id="clay-id-9-label-1-span"
+          role="row"
+          tabindex="0"
+        >
+          <span
+            class="label-item label-item-expand"
+            id="clay-id-9-label-1-text"
+            role="gridcell"
+          >
+            foo
+          </span>
+          <span
+            class="label-item label-item-after"
+            role="gridcell"
+          >
+            <button
+              aria-label="Remove foo"
+              class="close"
+              id="clay-id-9-label-1-close"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times-small"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/foo/bar#times-small"
+                />
+              </svg>
+            </button>
+          </span>
+        </span>
+        <span
+          aria-labelledby="clay-id-9-label-2-text"
+          class="label label-secondary"
+          id="clay-id-9-label-2-span"
+          role="row"
+          tabindex="-1"
+        >
+          <span
+            class="label-item label-item-expand"
+            id="clay-id-9-label-2-text"
+            role="gridcell"
+          >
+            bar
+          </span>
+          <span
+            class="label-item label-item-after"
+            role="gridcell"
+          >
+            <button
+              aria-label="Remove bar"
+              class="close"
+              id="clay-id-9-label-2-close"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times-small"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/foo/bar#times-small"
+                />
+              </svg>
+            </button>
+          </span>
+        </span>
+        <span
+          aria-labelledby="clay-id-9-label-3-text"
+          class="label label-secondary"
+          id="clay-id-9-label-3-span"
+          role="row"
+          tabindex="-1"
+        >
+          <span
+            class="label-item label-item-expand"
+            id="clay-id-9-label-3-text"
+            role="gridcell"
+          >
+            baz
+          </span>
+          <span
+            class="label-item label-item-after"
+            role="gridcell"
+          >
+            <button
+              aria-label="Remove baz"
+              class="close"
+              id="clay-id-9-label-3-close"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times-small"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/foo/bar#times-small"
+                />
+              </svg>
+            </button>
+          </span>
+        </span>
+      </div>
+      <div
+        class="input-group-item input-group-prepend"
+      >
+        <input
+          class="form-control-inset"
+          type="text"
+          value="one"
+        />
+      </div>
+      <div
+        class="input-group-item input-group-item-shrink"
+      >
+        <button
+          class="component-action btn btn-monospaced btn-outline-borderless btn-outline-secondary"
+          title="Clear All"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-times-circle"
+            role="presentation"
+          >
+            <use
+              xlink:href="/foo/bar#times-circle"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="sr-only"
+      >
+        <span
+          id="clay-id-10"
+        >
+          Use the arrow keys to navigate the labels and pressing backspace will delete.
+        </span>
+        <span
+          aria-live="polite"
+          aria-relevant="text"
+        />
+      </div>
+    </div>
+  </div>
+  <div>
+    <div>
+      <div
+        aria-hidden="true"
+        class="dropdown-menu autocomplete-dropdown-menu"
+        role="presentation"
+        style="max-width: none; left: -999px; top: -995px;"
+      >
+        <ul
+          class="list-unstyled"
+          role="menu"
+        >
+          <li
+            role="presentation"
+          >
+            <button
+              class="dropdown-item"
+              role="menuitem"
+            >
+              <strong>
+                one
+              </strong>
+              <p>
+                Name
+              </p>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ClayMultiSelect renders as disabled 1`] = `
+<body>
+  <div>
+    <div
+      class="form-control form-control-tag-group input-group"
+    >
+      <div
+        aria-describedby="clay-id-8"
+        class="input-group-item input-group-item-shrink input-group-prepend"
+        role="grid"
+      >
+        <span
+          aria-labelledby="clay-id-7-label-1-text"
+          class="label label-secondary"
+          id="clay-id-7-label-1-span"
+          role="row"
+          tabindex="0"
+        >
+          <span
+            class="label-item label-item-expand"
+            id="clay-id-7-label-1-text"
+            role="gridcell"
+          >
+            foo
+          </span>
+          <span
+            class="label-item label-item-after"
+            role="gridcell"
+          >
+            <button
+              aria-label="Remove foo"
+              class="close"
+              disabled=""
+              id="clay-id-7-label-1-close"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times-small"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/foo/bar#times-small"
+                />
+              </svg>
+            </button>
+          </span>
+        </span>
+        <span
+          aria-labelledby="clay-id-7-label-2-text"
+          class="label label-secondary"
+          id="clay-id-7-label-2-span"
+          role="row"
+          tabindex="-1"
+        >
+          <span
+            class="label-item label-item-expand"
+            id="clay-id-7-label-2-text"
+            role="gridcell"
+          >
+            bar
+          </span>
+          <span
+            class="label-item label-item-after"
+            role="gridcell"
+          >
+            <button
+              aria-label="Remove bar"
+              class="close"
+              disabled=""
+              id="clay-id-7-label-2-close"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times-small"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/foo/bar#times-small"
+                />
+              </svg>
+            </button>
+          </span>
+        </span>
+        <span
+          aria-labelledby="clay-id-7-label-3-text"
+          class="label label-secondary"
+          id="clay-id-7-label-3-span"
+          role="row"
+          tabindex="-1"
+        >
+          <span
+            class="label-item label-item-expand"
+            id="clay-id-7-label-3-text"
+            role="gridcell"
+          >
+            baz
+          </span>
+          <span
+            class="label-item label-item-after"
+            role="gridcell"
+          >
+            <button
+              aria-label="Remove baz"
+              class="close"
+              disabled=""
+              id="clay-id-7-label-3-close"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-times-small"
+                role="presentation"
+              >
+                <use
+                  xlink:href="/foo/bar#times-small"
+                />
+              </svg>
+            </button>
+          </span>
+        </span>
+      </div>
+      <div
+        class="input-group-item input-group-prepend"
+      >
+        <input
+          class="form-control-inset"
+          disabled=""
+          type="text"
+          value=""
+        />
+      </div>
+      <div
+        class="sr-only"
+      >
+        <span
+          id="clay-id-8"
+        >
+          Use the arrow keys to navigate the labels and pressing backspace will delete.
+        </span>
+        <span
+          aria-live="polite"
+          aria-relevant="text"
+        />
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ClayMultiSelect renders as not valid 1`] = `
+<body>
+  <div>
+    <div
+      class="form-control form-control-tag-group input-group"
+    >
+      <div
+        aria-describedby="clay-id-6"
         class="input-group-item input-group-item-shrink input-group-prepend"
         role="grid"
       >
@@ -157,15 +511,7 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
         <input
           class="form-control-inset"
           type="text"
-          value="one"
-        />
-      </div>
-      <div
-        class="sr-only"
-      >
-        <span
-          aria-live="polite"
-          aria-relevant="text"
+          value=""
         />
       </div>
       <div
@@ -359,6 +705,11 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
         class="sr-only"
       >
         <span
+          id="clay-id-6"
+        >
+          Use the arrow keys to navigate the labels and pressing backspace will delete.
+        </span>
+        <span
           aria-live="polite"
           aria-relevant="text"
         />
@@ -368,13 +719,14 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
 </body>
 `;
 
-exports[`ClayMultiSelect renders as not valid 1`] = `
+exports[`ClayMultiSelect renders with items 1`] = `
 <body>
   <div>
     <div
       class="form-control form-control-tag-group input-group"
     >
       <div
+        aria-describedby="clay-id-4"
         class="input-group-item input-group-item-shrink input-group-prepend"
         role="grid"
       >
@@ -497,14 +849,6 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
         />
       </div>
       <div
-        class="sr-only"
-      >
-        <span
-          aria-live="polite"
-          aria-relevant="text"
-        />
-      </div>
-      <div
         class="input-group-item input-group-item-shrink"
       >
         <button
@@ -523,142 +867,14 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
           </svg>
         </button>
       </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ClayMultiSelect renders with items 1`] = `
-<body>
-  <div>
-    <div
-      class="form-control form-control-tag-group input-group"
-    >
-      <div
-        class="input-group-item input-group-item-shrink input-group-prepend"
-        role="grid"
-      >
-        <span
-          aria-labelledby="clay-id-2-label-1-text"
-          class="label label-secondary"
-          id="clay-id-2-label-1-span"
-          role="row"
-          tabindex="0"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-2-label-1-text"
-            role="gridcell"
-          >
-            foo
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove foo"
-              class="close"
-              id="clay-id-2-label-1-close"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-2-label-2-text"
-          class="label label-secondary"
-          id="clay-id-2-label-2-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-2-label-2-text"
-            role="gridcell"
-          >
-            bar
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove bar"
-              class="close"
-              id="clay-id-2-label-2-close"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-        <span
-          aria-labelledby="clay-id-2-label-3-text"
-          class="label label-secondary"
-          id="clay-id-2-label-3-span"
-          role="row"
-          tabindex="-1"
-        >
-          <span
-            class="label-item label-item-expand"
-            id="clay-id-2-label-3-text"
-            role="gridcell"
-          >
-            baz
-          </span>
-          <span
-            class="label-item label-item-after"
-            role="gridcell"
-          >
-            <button
-              aria-label="Remove baz"
-              class="close"
-              id="clay-id-2-label-3-close"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                class="lexicon-icon lexicon-icon-times-small"
-                role="presentation"
-              >
-                <use
-                  xlink:href="/foo/bar#times-small"
-                />
-              </svg>
-            </button>
-          </span>
-        </span>
-      </div>
-      <div
-        class="input-group-item input-group-prepend"
-      >
-        <input
-          class="form-control-inset"
-          type="text"
-          value=""
-        />
-      </div>
       <div
         class="sr-only"
       >
+        <span
+          id="clay-id-4"
+        >
+          Use the arrow keys to navigate the labels and pressing backspace will delete.
+        </span>
         <span
           aria-live="polite"
           aria-relevant="text"

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -220,7 +220,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 			defaultValue = '',
 			disabled,
 			disabledClearAll,
-			hotkeysDescription = 'Use the arrow keys to navigate the labels and pressing backspace will delete.',
+			hotkeysDescription = 'Press backspace to delete the current row.',
 			inputName,
 			inputValue,
 			isLoading = false,
@@ -396,10 +396,9 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 					label,
 				};
 
-				setItems([
-					...internalItems.slice(0, index),
-					...internalItems.slice(index + 1),
-				]);
+				setItems(
+					internalItems.filter((_, itemIndex) => itemIndex !== index)
+				);
 			},
 			[internalItems]
 		);
@@ -422,7 +421,6 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 					<ClayInput.GroupItem>
 						<ClayInput.Group>
 							<ClayInput.GroupItem
-								aria-describedby={ariaDescriptionId}
 								aria-labelledby={otherProps['aria-labelledby']}
 								className="d-contents"
 								onFocus={(event) =>
@@ -444,11 +442,11 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 													KeysSides.includes(
 														event.key
 													)
-														? '[role=row], button'
+														? '[role=gridcell][tabindex], button'
 														: lastFocusedItem?.includes(
 																'span'
 														  )
-														? '[role=row]'
+														? '[role=gridcell][tabindex]'
 														: 'button'
 												)
 											);
@@ -523,9 +521,6 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 									const id = `${labelId}-label-${
 										item[locator.value]
 									}-span`;
-									const textId = `${labelId}-label-${
-										item[locator.value]
-									}-text`;
 									const closeId = `${labelId}-label-${
 										item[locator.value]
 									}-close`;
@@ -533,8 +528,6 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 									return (
 										<React.Fragment key={id}>
 											<ClayLabel
-												aria-labelledby={textId}
-												id={id}
 												onKeyDown={({key}) => {
 													if (
 														key === Keys.Backspace
@@ -547,18 +540,22 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 												}}
 												role="row"
 												spritemap={spritemap}
-												tabIndex={
-													(lastFocusedItem === null &&
-														i === 0) ||
-													lastFocusedItem === id
-														? 0
-														: -1
-												}
 												withClose={false}
 											>
 												<ClayLabel.ItemExpand
-													id={textId}
+													aria-describedby={
+														ariaDescriptionId
+													}
+													id={id}
 													role="gridcell"
+													tabIndex={
+														(lastFocusedItem ===
+															null &&
+															i === 0) ||
+														lastFocusedItem === id
+															? 0
+															: -1
+													}
 												>
 													{item[locator.label]}
 												</ClayLabel.ItemExpand>

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -431,6 +431,9 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 							const id = `${labelId}-label-${
 								item[locator.value]
 							}-span`;
+							const textId = `${labelId}-label-${
+								item[locator.value]
+							}-text`;
 							const closeId = `${labelId}-label-${
 								item[locator.value]
 							}-close`;
@@ -473,6 +476,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 							return (
 								<React.Fragment key={id}>
 									<ClayLabel
+										aria-labelledby={textId}
 										id={id}
 										onKeyDown={({key}) => {
 											if (key === Keys.Backspace) {
@@ -491,7 +495,10 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 										}
 										withClose={false}
 									>
-										<ClayLabel.ItemExpand role="gridcell">
+										<ClayLabel.ItemExpand
+											id={textId}
+											role="gridcell"
+										>
 											{item[locator.label]}
 										</ClayLabel.ItemExpand>
 

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -230,6 +230,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 		const inputRef = useRef<HTMLInputElement | null>(null);
 		const lastItemRef = useRef<HTMLSpanElement | null>(null);
 
+		const labelsRef = useRef<HTMLDivElement | null>(null);
 		const lastFocusedItemRef = useRef<string | null>(null);
 
 		const [active, setActive] = useState(false);
@@ -420,6 +421,9 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 							}
 						}}
 						prepend
+						ref={(ref) => {
+							labelsRef.current = ref;
+						}}
 						role="grid"
 						shrink
 					>
@@ -431,14 +435,43 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 								item[locator.value]
 							}-close`;
 
-							const removeItem = () =>
+							const removeItem = () => {
+								if (labelsRef.current) {
+									const focusableElements =
+										Array.from<HTMLElement>(
+											labelsRef.current.querySelectorAll(
+												'button'
+											)
+										);
+
+									const position = focusableElements.indexOf(
+										document.activeElement as HTMLElement
+									);
+									const closeElement =
+										focusableElements[
+											focusableElements.length - 1 >
+											position
+												? position + 1
+												: position - 1
+										];
+
+									if (closeElement) {
+										closeElement.focus();
+										lastFocusedItemRef.current =
+											closeElement.getAttribute('id');
+									} else {
+										lastFocusedItemRef.current = null;
+									}
+								}
+
 								setItems([
 									...internalItems.slice(0, i),
 									...internalItems.slice(i + 1),
 								]);
+							};
 
 							return (
-								<React.Fragment key={i}>
+								<React.Fragment key={id}>
 									<ClayLabel
 										id={id}
 										onKeyDown={({key}) => {

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -257,7 +257,10 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 		const lastChangesRef = useRef<LastChangeLiveRegion | null>(null);
 
 		const labelsRef = useRef<HTMLDivElement | null>(null);
-		const lastFocusedItemRef = useRef<string | null>(null);
+
+		const [lastFocusedItem, setLastFocusedItem] = useState<string | null>(
+			null
+		);
 
 		const [active, setActive] = useState(false);
 		const [isFocused, setIsFocused] = useState(false);
@@ -381,11 +384,10 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 
 					if (closeElement) {
 						closeElement.focus();
-						lastFocusedItemRef.current =
-							closeElement.getAttribute('id');
+						setLastFocusedItem(closeElement.getAttribute('id'));
 					} else {
 						inputElementRef.current?.focus();
-						lastFocusedItemRef.current = null;
+						setLastFocusedItem(null);
 					}
 				}
 
@@ -417,216 +419,244 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 					)}
 					ref={containerRef}
 				>
-					<ClayInput.GroupItem
-						aria-describedby={ariaDescriptionId}
-						aria-labelledby={otherProps['aria-labelledby']}
-						onFocus={(event) => {
-							lastFocusedItemRef.current =
-								event.target.getAttribute('id')!;
-						}}
-						onKeyDown={(event) => {
-							if (KeysNavigation.includes(event.key)) {
-								// Query labels and buttons to exclude the label that are
-								// focusable the navigation order depends on which orientation
-								// the navigation is happen.
-								// - Left and Right. Query all elements.
-								// - Up and Down. Query for elements of the same type as the
-								//   last focused element.
-								const focusableElements =
-									Array.from<HTMLElement>(
-										event.currentTarget.querySelectorAll(
-											KeysSides.includes(event.key)
-												? '[role=row], button'
-												: lastFocusedItemRef.current?.includes(
-														'span'
-												  )
-												? '[role=row]'
-												: 'button'
-										)
-									);
-
-								const position = focusableElements.indexOf(
-									document.activeElement as HTMLElement
-								);
-
-								const key = KeysSides.includes(event.key)
-									? Keys.Left
-									: Keys.Up;
-
-								const label =
-									focusableElements[
-										event.key === key
-											? position - 1
-											: position + 1
-									];
-
-								if (label) {
-									lastFocusedItemRef.current =
-										label.getAttribute('id')!;
-									label.focus();
+					<ClayInput.GroupItem>
+						<ClayInput.Group>
+							<ClayInput.GroupItem
+								aria-describedby={ariaDescriptionId}
+								aria-labelledby={otherProps['aria-labelledby']}
+								className="d-contents"
+								onFocus={(event) =>
+									setLastFocusedItem(
+										event.target.getAttribute('id')!
+									)
 								}
-							}
-
-							if (
-								event.key === Keys.Home ||
-								event.key === Keys.End
-							) {
-								const isLabel =
-									lastFocusedItemRef.current!.includes(
-										'span'
-									);
-
-								if (
-									(isLabel && event.key === Keys.Home) ||
-									(!isLabel && event.key === Keys.End)
-								) {
-									return;
-								}
-
-								const label =
-									event.currentTarget.querySelector<HTMLElement>(
-										`[id=${lastFocusedItemRef.current?.replace(
-											isLabel ? 'span' : 'close',
-											event.key === Keys.Home
-												? 'span'
-												: 'close'
-										)}]`
-									);
-
-								if (label) {
-									lastFocusedItemRef.current =
-										label.getAttribute('id')!;
-									label.focus();
-								}
-							}
-						}}
-						prepend
-						ref={(ref) => {
-							labelsRef.current = ref;
-						}}
-						role="grid"
-						shrink
-					>
-						{internalItems.map((item, i) => {
-							const id = `${labelId}-label-${
-								item[locator.value]
-							}-span`;
-							const textId = `${labelId}-label-${
-								item[locator.value]
-							}-text`;
-							const closeId = `${labelId}-label-${
-								item[locator.value]
-							}-close`;
-
-							return (
-								<React.Fragment key={id}>
-									<ClayLabel
-										aria-labelledby={textId}
-										id={id}
-										onKeyDown={({key}) => {
-											if (key === Keys.Backspace) {
-												onRemove(
-													item[locator.label],
-													i
-												);
-											}
-										}}
-										role="row"
-										spritemap={spritemap}
-										tabIndex={
-											(lastFocusedItemRef.current ===
-												null &&
-												i === 0) ||
-											lastFocusedItemRef.current === id
-												? 0
-												: -1
-										}
-										withClose={false}
-									>
-										<ClayLabel.ItemExpand
-											id={textId}
-											role="gridcell"
-										>
-											{item[locator.label]}
-										</ClayLabel.ItemExpand>
-
-										<ClayLabel.ItemAfter role="gridcell">
-											<button
-												aria-label={sub(
-													closeButtonAriaLabel,
-													[item[locator.label]]
-												)}
-												className="close"
-												disabled={disabled}
-												id={closeId}
-												onClick={() =>
-													onRemove(
-														item[locator.label],
-														i
+								onKeyDown={(event) => {
+									if (KeysNavigation.includes(event.key)) {
+										// Query labels and buttons to exclude the label that are
+										// focusable the navigation order depends on which orientation
+										// the navigation is happen.
+										// - Left and Right. Query all elements.
+										// - Up and Down. Query for elements of the same type as the
+										//   last focused element.
+										const focusableElements =
+											Array.from<HTMLElement>(
+												event.currentTarget.querySelectorAll(
+													KeysSides.includes(
+														event.key
 													)
-												}
-												ref={(ref) => {
+														? '[role=row], button'
+														: lastFocusedItem?.includes(
+																'span'
+														  )
+														? '[role=row]'
+														: 'button'
+												)
+											);
+
+										const position =
+											focusableElements.indexOf(
+												document.activeElement as HTMLElement
+											);
+
+										const key = KeysSides.includes(
+											event.key
+										)
+											? Keys.Left
+											: Keys.Up;
+
+										const label =
+											focusableElements[
+												event.key === key
+													? position - 1
+													: position + 1
+											];
+
+										if (label) {
+											setLastFocusedItem(
+												label.getAttribute('id')!
+											);
+											label.focus();
+										}
+									}
+
+									if (
+										event.key === Keys.Home ||
+										event.key === Keys.End
+									) {
+										const isLabel =
+											lastFocusedItem!.includes('span');
+
+										if (
+											(isLabel &&
+												event.key === Keys.Home) ||
+											(!isLabel && event.key === Keys.End)
+										) {
+											return;
+										}
+
+										const label =
+											event.currentTarget.querySelector<HTMLElement>(
+												`[id=${lastFocusedItem?.replace(
+													isLabel ? 'span' : 'close',
+													event.key === Keys.Home
+														? 'span'
+														: 'close'
+												)}]`
+											);
+
+										if (label) {
+											setLastFocusedItem(
+												label.getAttribute('id')!
+											);
+											label.focus();
+										}
+									}
+								}}
+								prepend
+								ref={(ref) => {
+									labelsRef.current = ref;
+								}}
+								role="grid"
+								shrink
+							>
+								{internalItems.map((item, i) => {
+									const id = `${labelId}-label-${
+										item[locator.value]
+									}-span`;
+									const textId = `${labelId}-label-${
+										item[locator.value]
+									}-text`;
+									const closeId = `${labelId}-label-${
+										item[locator.value]
+									}-close`;
+
+									return (
+										<React.Fragment key={id}>
+											<ClayLabel
+												aria-labelledby={textId}
+												id={id}
+												onKeyDown={({key}) => {
 													if (
-														i ===
-														internalItems.length - 1
+														key === Keys.Backspace
 													) {
-														lastItemRef.current =
-															ref;
+														onRemove(
+															item[locator.label],
+															i
+														);
 													}
 												}}
+												role="row"
+												spritemap={spritemap}
 												tabIndex={
-													lastFocusedItemRef.current ===
-													closeId
+													(lastFocusedItem === null &&
+														i === 0) ||
+													lastFocusedItem === id
 														? 0
 														: -1
 												}
-												type="button"
+												withClose={false}
 											>
-												<Icon
-													spritemap={spritemap}
-													symbol="times-small"
+												<ClayLabel.ItemExpand
+													id={textId}
+													role="gridcell"
+												>
+													{item[locator.label]}
+												</ClayLabel.ItemExpand>
+
+												<ClayLabel.ItemAfter role="gridcell">
+													<button
+														aria-label={sub(
+															closeButtonAriaLabel,
+															[
+																item[
+																	locator
+																		.label
+																],
+															]
+														)}
+														className="close"
+														disabled={disabled}
+														id={closeId}
+														onClick={() =>
+															onRemove(
+																item[
+																	locator
+																		.label
+																],
+																i
+															)
+														}
+														ref={(ref) => {
+															if (
+																i ===
+																internalItems.length -
+																	1
+															) {
+																lastItemRef.current =
+																	ref;
+															}
+														}}
+														tabIndex={
+															lastFocusedItem ===
+															closeId
+																? 0
+																: -1
+														}
+														type="button"
+													>
+														<Icon
+															spritemap={
+																spritemap
+															}
+															symbol="times-small"
+														/>
+													</button>
+												</ClayLabel.ItemAfter>
+											</ClayLabel>
+
+											{inputName && (
+												<input
+													name={inputName}
+													type="hidden"
+													value={item[locator.value]}
 												/>
-											</button>
-										</ClayLabel.ItemAfter>
-									</ClayLabel>
+											)}
+										</React.Fragment>
+									);
+								})}
+							</ClayInput.GroupItem>
 
-									{inputName && (
-										<input
-											name={inputName}
-											type="hidden"
-											value={item[locator.value]}
-										/>
-									)}
-								</React.Fragment>
-							);
-						})}
-					</ClayInput.GroupItem>
-
-					<ClayInput.GroupItem prepend>
-						<input
-							{...otherProps}
-							className="form-control-inset"
-							disabled={disabled}
-							onBlur={(event) => {
-								onBlur(event);
-								setIsFocused(false);
-							}}
-							onChange={(event) =>
-								setValue(event.target.value.replace(',', ''))
-							}
-							onFocus={(event) => {
-								onFocus(event);
-								setIsFocused(true);
-							}}
-							onKeyDown={handleKeyDown}
-							onPaste={handlePaste}
-							placeholder={
-								internalItems.length ? undefined : placeholder
-							}
-							ref={inputElementRef}
-							type="text"
-							value={internalValue}
-						/>
+							<ClayInput.GroupItem prepend>
+								<input
+									{...otherProps}
+									className="form-control-inset"
+									disabled={disabled}
+									onBlur={(event) => {
+										onBlur(event);
+										setIsFocused(false);
+									}}
+									onChange={(event) =>
+										setValue(
+											event.target.value.replace(',', '')
+										)
+									}
+									onFocus={(event) => {
+										onFocus(event);
+										setIsFocused(true);
+									}}
+									onKeyDown={handleKeyDown}
+									onPaste={handlePaste}
+									placeholder={
+										internalItems.length
+											? undefined
+											: placeholder
+									}
+									ref={inputElementRef}
+									type="text"
+									value={internalValue}
+								/>
+							</ClayInput.GroupItem>
+						</ClayInput.Group>
 					</ClayInput.GroupItem>
 
 					{isLoading && (

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -104,6 +104,12 @@ export interface IProps
 	disabledClearAll?: boolean;
 
 	/**
+	 * Defines the description of hotkeys for the component, use this
+	 * to handle internationalization.
+	 */
+	hotkeysDescription?: string;
+
+	/**
 	 * Value used for each selected item's hidden input name attribute
 	 */
 	inputName?: string;
@@ -214,6 +220,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 			defaultValue = '',
 			disabled,
 			disabledClearAll,
+			hotkeysDescription = 'Use the arrow keys to navigate the labels and pressing backspace will delete.',
 			inputName,
 			inputValue,
 			isLoading = false,
@@ -396,6 +403,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 		);
 
 		const labelId = useId();
+		const ariaDescriptionId = useId();
 
 		return (
 			<FocusScope arrowKeysUpDown={false}>
@@ -410,6 +418,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 					ref={containerRef}
 				>
 					<ClayInput.GroupItem
+						aria-describedby={ariaDescriptionId}
 						aria-labelledby={otherProps['aria-labelledby']}
 						onFocus={(event) => {
 							lastFocusedItemRef.current =
@@ -620,19 +629,6 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 						/>
 					</ClayInput.GroupItem>
 
-					<div className="sr-only">
-						<span aria-live="polite" aria-relevant="text">
-							{lastChangesRef.current
-								? sub(
-										liveRegion[
-											lastChangesRef.current.action
-										],
-										[lastChangesRef.current.label]
-								  )
-								: null}
-						</span>
-					</div>
-
 					{isLoading && (
 						<ClayInput.GroupItem shrink>
 							<ClayLoadingIndicator small />
@@ -667,6 +663,20 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 								/>
 							</ClayInput.GroupItem>
 						)}
+
+					<div className="sr-only">
+						<span id={ariaDescriptionId}>{hotkeysDescription}</span>
+						<span aria-live="polite" aria-relevant="text">
+							{lastChangesRef.current
+								? sub(
+										liveRegion[
+											lastChangesRef.current.action
+										],
+										[lastChangesRef.current.label]
+								  )
+								: null}
+						</span>
+					</div>
 
 					{sourceItems.length > 0 && (
 						<ClayAutocomplete.DropDown

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -19,7 +19,7 @@ import {
 } from '@clayui/shared';
 import classNames from 'classnames';
 import fuzzy from 'fuzzy';
-import React, {useEffect} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 const DELIMITER_KEYS = ['Enter', ','];
 
@@ -221,11 +221,14 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 		}: IProps,
 		ref
 	) => {
-		const containerRef = React.useRef<HTMLDivElement>(null);
-		const inputRef = React.useRef<HTMLInputElement | null>(null);
-		const lastItemRef = React.useRef<HTMLSpanElement | null>(null);
-		const [active, setActive] = React.useState(false);
-		const [isFocused, setIsFocused] = React.useState(false);
+		const containerRef = useRef<HTMLDivElement>(null);
+		const inputRef = useRef<HTMLInputElement | null>(null);
+		const lastItemRef = useRef<HTMLSpanElement | null>(null);
+
+		const lastFocusedItemRef = useRef<HTMLElement | null>(null);
+
+		const [active, setActive] = useState(false);
+		const [isFocused, setIsFocused] = useState(false);
 
 		const [internalItems, setItems] = useInternalState({
 			defaultName: 'defaultItems',
@@ -328,7 +331,14 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 					)}
 					ref={containerRef}
 				>
-					<ClayInput.GroupItem>
+					<ClayInput.GroupItem
+						onFocus={(event) => {
+							if (event.target !== inputElementRef.current) {
+								lastFocusedItemRef.current = event.target;
+							}
+						}}
+						role="grid"
+					>
 						{internalItems.map((item, i) => {
 							const removeItem = () =>
 								setItems([
@@ -359,6 +369,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 													lastItemRef.current = ref;
 												}
 											},
+											tabIndex: -1,
 										}}
 										onKeyDown={({key}) => {
 											if (key !== Keys.Backspace) {
@@ -369,7 +380,14 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 											}
 											removeItem();
 										}}
+										role="row"
 										spritemap={spritemap}
+										tabIndex={
+											lastFocusedItemRef.current ===
+												null && i === 0
+												? 0
+												: -1
+										}
 									>
 										{item[locator.label]}
 									</ClayLabel>

--- a/packages/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/packages/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -55,6 +55,7 @@ const ClayMultiSelectWithAutocomplete = (props: any) => {
 
 	return (
 		<ClayMultiSelect
+			aria-labelledby="multi-select-label"
 			inputName="myInput"
 			items={items}
 			onChange={setValue}
@@ -76,16 +77,19 @@ export const Default = (args: any) => {
 
 	return (
 		<>
-			<label htmlFor="multiSelect">Multi Select</label>
+			<label htmlFor="multiSelect" id="multi-select-label">
+				Multi Select
+			</label>
 
 			<ClayMultiSelect
+				aria-labelledby="multi-select-label"
 				disabled={args.disabled}
 				disabledClearAll={args.disabledClearAll}
 				id="multiSelect"
 				inputName="myInput"
 				isValid={args.isValid}
 				items={items}
-				onItemsChange={setItems}
+				onItemsChange={(items) => setItems(items)}
 				size={args.size}
 			/>
 		</>
@@ -111,9 +115,12 @@ export const ComparingItems = () => {
 
 	return (
 		<>
-			<label htmlFor="multiSelect">Multi Select</label>
+			<label htmlFor="multiSelect" id="multi-select-label">
+				Multi Select
+			</label>
 
 			<ClayMultiSelect
+				aria-labelledby="multi-select-label"
 				id="multiSelect"
 				inputName="myInput"
 				items={items}
@@ -150,9 +157,12 @@ export const SourceItems = () => {
 
 	return (
 		<>
-			<label htmlFor="multiSelect">Multi Select</label>
+			<label htmlFor="multiSelect" id="multi-select-label">
+				Multi Select
+			</label>
 
 			<ClayMultiSelect
+				aria-labelledby="multi-select-label"
 				inputName="myInput"
 				items={items}
 				onChange={setValue}
@@ -207,7 +217,9 @@ export const CustomMenu = () => {
 
 	return (
 		<>
-			<label htmlFor="multiSelect">Multi Select</label>
+			<label htmlFor="multiSelect" id="multi-select-label">
+				Multi Select
+			</label>
 
 			<ClayMultiSelectWithAutocomplete
 				id="multiSelect"
@@ -288,7 +300,9 @@ export const Group = (args: any) => {
 	return (
 		<div className="sheet">
 			<ClayForm.Group className={!args.isValid ? 'has-error' : ''}>
-				<label htmlFor="multiSelect">Composed MultiSelect</label>
+				<label htmlFor="multiSelect" id="multi-select-label">
+					Composed MultiSelect
+				</label>
 
 				<ClayInput.Group>
 					<ClayInput.GroupItem>


### PR DESCRIPTION
Fixes #5194

This PR is just a draft of the accessibility improvements for the MultiSelect component and I will just add the w3c grid layout recommendations here, the combobox pattern will be done by issue #5203 which depends on the revision in Autocomplete.

There are still some things missing here to be ready, also a discussion is about the input if it should be part of the `grid` of pills, this in the w3c implementation, it is outside the grid but our markup needs it to be inside the grid to not visually breaking maybe i need help from @pat270 here to try to solve this. I'm also not sure if this can work very well together the combobox pattern and pills, in Lexicon the navigation behaviors allow them to be very integrated with each other, for example pressing backspace when it's empty input twice it deletes the pill, when deleting the pill the focus moves to the input, these behaviors are quite different according to the w3c use case of https://www.w3.org/WAI/ARIA/apg/example-index/grid/LayoutGrids.html#ex2_label.

I was taking a look at the Gmail use case which is very similar to ours when you type the emails in the box to whom you want to send, they use the default combobox and the input and the pills are a `listbox` with multi selection, where the pill is a selected `option`, it seems that this semantically and also behaviorally might work better with the interactions between the input and the pills. cc @ethib137 @marcoscv-work 

If we continue with the behaviors of w3c, here is what still needs to be done to move forward with this PR:

- [x] Add the tab to the pill that had the last focus
- [x] Navigate between pills using arrow keys
- [x] Add keyboard shortcuts for navigation between pills