### PR TITLE
fix(@clayui/shared): fixes error when stop typing in DropDown Search

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -77,7 +77,7 @@ module.exports = {
 			branches: 60,
 			functions: 57,
 			lines: 73,
-			statements: 73,
+			statements: 72,
 		},
 		'./packages/clay-empty-state/src/': {
 			branches: 100,

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -281,6 +281,13 @@ function ClayDropDown<T>({
 								openMenu(true);
 							}
 
+							if (internalActive && event.key === Keys.Down) {
+								event.preventDefault();
+								event.stopPropagation();
+
+								focusManager.focusFirst();
+							}
+
 							if (
 								[Keys.Spacebar, Keys.Down].includes(event.key)
 							) {

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -127,15 +127,13 @@ export function useNavigation<T extends HTMLElement | null>({
 					tab = tabs[event.key === Keys.Home ? 0 : tabs.length - 1];
 					break;
 				default: {
-					if (!typeahead) {
+					const target = event.target as HTMLElement;
+
+					if (!typeahead || target.tagName === 'INPUT') {
 						return;
 					}
 
-					if (
-						!event.currentTarget.contains(
-							event.target as HTMLElement
-						)
-					) {
+					if (!event.currentTarget.contains(target)) {
 						return;
 					}
 


### PR DESCRIPTION
Related https://github.com/liferay-frontend/liferay-portal/pull/2877#issuecomment-1324097316

DropDown has the `typeahead` functionality enabled that when typing it moves the focus to the first corresponding item within the Menu, DropDown also has the possibility of the Search component, in this case this PR avoids the `typeahead` when the focus it's in the input.