### PR TITLE
fix(@clayui/core): improves interactions of moving item in TreeView

### DIFF
--- a/packages/clay-core/src/tree-view/__tests__/useTree.ts
+++ b/packages/clay-core/src/tree-view/__tests__/useTree.ts
@@ -185,7 +185,7 @@ describe('useTree', () => {
 
 		const immutableTree = createImmutableTree(tree, 'children');
 
-		immutableTree.produce({from: [0], op: 'move', path: [1]});
+		immutableTree.produce({from: [0], op: 'move', path: [2]});
 
 		const result = immutableTree.applyPatches();
 

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -226,7 +226,8 @@ export function ItemContextProvider({children, value}: Props) {
 				currentPosition = TARGET_POSITION.TOP;
 			} else if (
 				clientOffsetY >
-				dropItemRect.bottom - dropItemRect.height * DISTANCE
+					dropItemRect.bottom - dropItemRect.height * DISTANCE &&
+				!expandedKeys.has(item.key)
 			) {
 				currentPosition = TARGET_POSITION.BOTTOM;
 			}

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -207,22 +207,6 @@ export function ItemContextProvider({children, value}: Props) {
 
 			const child = item[nestedKey!];
 
-			if (
-				typeof hoverTimeoutIdRef.current !== 'number' &&
-				!expandedKeys.has(item.key) &&
-				child &&
-				Array.isArray(child) &&
-				child.length > 0
-			) {
-				hoverTimeoutIdRef.current = setTimeout(() => {
-					hoverTimeoutIdRef.current = null;
-
-					if (monitor.isOver({shallow: true})) {
-						open(item.key);
-					}
-				}, 500) as unknown as number;
-			}
-
 			const dropItemRect = (
 				childRef.current! as HTMLElement
 			).getBoundingClientRect();
@@ -241,6 +225,23 @@ export function ItemContextProvider({children, value}: Props) {
 				!expandedKeys.has(item.key)
 			) {
 				currentPosition = TARGET_POSITION.BOTTOM;
+			}
+
+			if (
+				currentPosition === TARGET_POSITION.MIDDLE &&
+				typeof hoverTimeoutIdRef.current !== 'number' &&
+				!expandedKeys.has(item.key) &&
+				child &&
+				Array.isArray(child) &&
+				child.length > 0
+			) {
+				hoverTimeoutIdRef.current = setTimeout(() => {
+					hoverTimeoutIdRef.current = null;
+
+					if (monitor.isOver({shallow: true})) {
+						open(item.key);
+					}
+				}, 500) as unknown as number;
 			}
 
 			if (onItemHover) {

--- a/packages/clay-core/src/tree-view/useItem.tsx
+++ b/packages/clay-core/src/tree-view/useItem.tsx
@@ -51,19 +51,20 @@ function isMovingIntoItself(from: Array<number>, path: Array<number>) {
 	);
 }
 
-function getNewItemPath(item: Value, overPosition: Position) {
-	let indexes = [...item.indexes];
-	const lastIndex = indexes.pop();
+function getNewItemPath(path: Array<number>, overPosition: Position) {
+	let indexes = [...path];
+
+	const lastPathIndex = indexes.pop() as number;
 
 	switch (overPosition) {
 		case TARGET_POSITION.BOTTOM:
-			indexes = [...indexes, lastIndex! + 1];
+			indexes = [...indexes, lastPathIndex + 1];
 			break;
 		case TARGET_POSITION.MIDDLE:
-			indexes = [...indexes, lastIndex!, 0];
+			indexes = [...indexes, lastPathIndex, 0];
 			break;
 		case TARGET_POSITION.TOP:
-			indexes = [...indexes, lastIndex!];
+			indexes = [...indexes, lastPathIndex];
 			break;
 		default:
 			break;
@@ -174,7 +175,7 @@ export function ItemContextProvider({children, value}: Props) {
 				return;
 			}
 
-			const indexes = getNewItemPath(item, overPosition!);
+			const indexes = getNewItemPath(item.indexes, overPosition!);
 
 			if (onItemMove) {
 				const tree = createImmutableTree(items as any, nestedKey!);
@@ -204,9 +205,14 @@ export function ItemContextProvider({children, value}: Props) {
 				return;
 			}
 
+			const child = item[nestedKey!];
+
 			if (
 				typeof hoverTimeoutIdRef.current !== 'number' &&
-				!expandedKeys.has(item.key)
+				!expandedKeys.has(item.key) &&
+				child &&
+				Array.isArray(child) &&
+				child.length > 0
 			) {
 				hoverTimeoutIdRef.current = setTimeout(() => {
 					hoverTimeoutIdRef.current = null;
@@ -239,7 +245,7 @@ export function ItemContextProvider({children, value}: Props) {
 
 			if (onItemHover) {
 				const tree = createImmutableTree(items as any, nestedKey!);
-				const indexes = getNewItemPath(item, currentPosition);
+				const indexes = getNewItemPath(item.indexes, currentPosition);
 
 				onItemHover(
 					removeItemInternalProps(

--- a/packages/clay-core/src/tree-view/useLayout.ts
+++ b/packages/clay-core/src/tree-view/useLayout.ts
@@ -25,6 +25,7 @@ export type Layout = {
 		parentKey?: Key
 	) => () => void;
 	layoutKeys: React.MutableRefObject<Map<Key, LayoutInfo>>;
+	patchItem: (key: Key, loc: Array<number>) => void;
 };
 
 export function useLayout(): Layout {
@@ -111,5 +112,19 @@ export function useLayout(): Layout {
 		[layoutKeys]
 	);
 
-	return {createPartialLayoutItem, layoutKeys};
+	const patchItem = useCallback(
+		(key: Key, loc: Array<number>) => {
+			const keyMap = layoutKeys.current.get(key);
+
+			if (keyMap) {
+				layoutKeys.current.set(key, {
+					...keyMap,
+					loc,
+				});
+			}
+		},
+		[layoutKeys]
+	);
+
+	return {createPartialLayoutItem, layoutKeys, patchItem};
 }


### PR DESCRIPTION
Fixes #5213

I ended up discovering more problems with the mechanism of moving items inside the TreeView behaving wrongly and moving to wrong positions, so I fixed that as well. I also improved the part of expanding the item when the drag hovers over the item, it was always expanded regardless of whether the user's intention was to move above or below the item, I added it only to expand when the intention to move is inside the item, this greatly improves the user experience.