### PR TITLE
feat(@clayui/shared): add component to handle Overlay for Clay components

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -188,10 +188,10 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-shared/src/': {
-			branches: 31,
-			functions: 22,
-			lines: 46,
-			statements: 48,
+			branches: 25,
+			functions: 17,
+			lines: 40,
+			statements: 43,
 		},
 		'./packages/clay-slider/src/': {
 			branches: 92,

--- a/packages/clay-autocomplete/package.json
+++ b/packages/clay-autocomplete/package.json
@@ -31,7 +31,7 @@
 		"@clayui/form": "^3.81.0",
 		"@clayui/loading-indicator": "^3.60.0",
 		"@clayui/shared": "^3.81.0",
-		"aria-hidden": "^1.1.3",
+		"aria-hidden": "^1.2.2",
 		"fuzzy": "^0.1.3"
 	},
 	"peerDependencies": {

--- a/packages/clay-date-picker/package.json
+++ b/packages/clay-date-picker/package.json
@@ -28,7 +28,7 @@
 		"@clayui/icon": "^3.56.0",
 		"@clayui/shared": "^3.81.0",
 		"@clayui/time-picker": "^3.81.0",
-		"aria-hidden": "^1.1.3",
+		"aria-hidden": "^1.2.2",
 		"classnames": "^2.2.6",
 		"date-fns": "^2.14.0"
 	},

--- a/packages/clay-drop-down/package.json
+++ b/packages/clay-drop-down/package.json
@@ -32,7 +32,7 @@
 		"@clayui/icon": "^3.56.0",
 		"@clayui/link": "^3.56.0",
 		"@clayui/shared": "^3.81.0",
-		"aria-hidden": "^1.1.3",
+		"aria-hidden": "^1.2.2",
 		"classnames": "^2.2.6",
 		"react-transition-group": "^4.4.1",
 		"warning": "^4.0.3"

--- a/packages/clay-modal/package.json
+++ b/packages/clay-modal/package.json
@@ -29,7 +29,7 @@
 		"@clayui/button": "^3.81.0",
 		"@clayui/icon": "^3.56.0",
 		"@clayui/shared": "^3.81.0",
-		"aria-hidden": "^1.1.3",
+		"aria-hidden": "^1.2.2",
 		"classnames": "^2.2.6",
 		"warning": "^4.0.3"
 	},

--- a/packages/clay-shared/package.json
+++ b/packages/clay-shared/package.json
@@ -29,6 +29,7 @@
 		"@clayui/button": "^3.81.0",
 		"@clayui/link": "^3.56.0",
 		"@clayui/provider": "^3.77.0",
+		"aria-hidden": "^1.2.2",
 		"classnames": "^2.2.6",
 		"dom-align": "^1.12.2",
 		"warning": "^4.0.3"

--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {hideOthers, suppressOthers} from 'aria-hidden';
+import React, {useCallback, useEffect, useRef} from 'react';
+
+import {Keys} from './Keys';
+import {ClayPortal} from './Portal';
+import {useInteractOutside} from './useInteractOutside';
+
+import type {Undo} from 'aria-hidden';
+
+type Props = {
+	children: React.ReactElement;
+	isCloseOnInteractOutside?: boolean;
+	isKeyboardDismiss?: boolean;
+	isModal?: boolean;
+	isOpen: boolean;
+	menuRef: React.RefObject<HTMLElement>;
+	onClose: () => void;
+	portalRef?: React.RefObject<HTMLElement>;
+	triggerRef: React.RefObject<HTMLElement>;
+};
+
+/**
+ * Inert is a new native feature to better handle DOM arias that are not
+ * assertive to a SR or that should ignore any user interaction.
+ * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+ */
+const hasInertSupport =
+	typeof window !== 'undefined' &&
+	// @ts-ignore
+	typeof document.createElement('div').inert === 'boolean';
+
+/**
+ * Overlay component is used for components like dialog and modal.
+ * For example, Autocomplete, DatePicker, ColorPicker, DropDown are components
+ * that can use and have the same consistent behavior.
+ */
+export function Overlay({
+	children,
+	isCloseOnInteractOutside = false,
+	isKeyboardDismiss = false,
+	isModal = false,
+	isOpen = false,
+	menuRef,
+	onClose,
+	portalRef,
+	triggerRef,
+}: Props) {
+	const unsuppressCallbackRef = useRef<Undo | null>(null);
+
+	useEvent(
+		'focus',
+		useCallback(
+			(event: FocusEvent) => {
+				if (
+					portalRef &&
+					!portalRef.current?.contains(event.target as Node) &&
+					triggerRef.current &&
+					!triggerRef.current.contains(event.target as Node)
+				) {
+					onClose();
+				}
+			},
+			[onClose]
+		),
+		isOpen,
+		true,
+		[isOpen, onClose]
+	);
+
+	useEvent(
+		'keydown',
+		useCallback(
+			(event: KeyboardEvent) => {
+				if (event.key === Keys.Esc) {
+					event.stopImmediatePropagation();
+					event.preventDefault();
+
+					if (triggerRef.current) {
+						// When inert is used to suppress user interaction with the rest of
+						// the document, to retrieve the focus in the trigger we need to
+						// first undo and then move the focus.
+						if (unsuppressCallbackRef.current) {
+							unsuppressCallbackRef.current();
+							unsuppressCallbackRef.current = null;
+						}
+
+						triggerRef.current.focus();
+					}
+
+					onClose();
+				}
+			},
+			[onClose]
+		),
+		isOpen && isKeyboardDismiss,
+		true,
+		[isOpen, onClose]
+	);
+
+	useInteractOutside({
+		isDisabled: isOpen ? !isCloseOnInteractOutside : true,
+		onInteract: (event) => {
+			event.stopPropagation();
+			event.preventDefault();
+			onClose();
+		},
+		ref: portalRef ?? menuRef,
+		triggerRef,
+	});
+
+	useEffect(() => {
+		if (menuRef.current && isOpen) {
+			if (isModal && hasInertSupport) {
+				unsuppressCallbackRef.current = suppressOthers(menuRef.current);
+
+				return () => {
+					if (unsuppressCallbackRef.current) {
+						unsuppressCallbackRef.current();
+					}
+					unsuppressCallbackRef.current = null;
+				};
+			} else {
+				return hideOthers(menuRef.current);
+			}
+		}
+	}, [isModal, isOpen]);
+
+	return (
+		<ClayPortal subPortalRef={portalRef}>
+			{isModal && (
+				<span
+					aria-hidden="true"
+					data-focus-scope-start="true"
+					tabIndex={0}
+				/>
+			)}
+			{children}
+			{isModal && (
+				<span
+					aria-hidden="true"
+					data-focus-scope-end="true"
+					tabIndex={0}
+				/>
+			)}
+		</ClayPortal>
+	);
+}
+
+function useEvent<T extends keyof DocumentEventMap>(
+	name: T,
+	onEvent: (event: DocumentEventMap[T]) => void,
+	conditional: boolean,
+	capture: boolean,
+	deps: Array<any> = []
+) {
+	useEffect(() => {
+		// This check should go away when the Overlay is shown using conditional
+		// instead of class CSS.
+		if (conditional) {
+			document.addEventListener(name, onEvent, capture);
+
+			return () => {
+				document.removeEventListener(name, onEvent, capture);
+			};
+		}
+	}, deps);
+}

--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -21,6 +21,7 @@ type Props = {
 	menuRef: React.RefObject<HTMLElement>;
 	onClose: () => void;
 	portalRef?: React.RefObject<HTMLElement>;
+	suppress?: Array<React.RefObject<HTMLElement>>;
 	triggerRef: React.RefObject<HTMLElement>;
 };
 
@@ -48,6 +49,7 @@ export function Overlay({
 	menuRef,
 	onClose,
 	portalRef,
+	suppress,
 	triggerRef,
 }: Props) {
 	const unsuppressCallbackRef = useRef<Undo | null>(null);
@@ -115,8 +117,12 @@ export function Overlay({
 
 	useEffect(() => {
 		if (menuRef.current && isOpen) {
+			const elements = suppress
+				? suppress.map((ref) => ref.current!)
+				: menuRef.current;
+
 			if (isModal && hasInertSupport) {
-				unsuppressCallbackRef.current = suppressOthers(menuRef.current);
+				unsuppressCallbackRef.current = suppressOthers(elements);
 
 				return () => {
 					if (unsuppressCallbackRef.current) {
@@ -125,7 +131,7 @@ export function Overlay({
 					unsuppressCallbackRef.current = null;
 				};
 			} else {
-				return hideOthers(menuRef.current);
+				return hideOthers(elements);
 			}
 		}
 	}, [isModal, isOpen]);

--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -106,9 +106,7 @@ export function Overlay({
 
 	useInteractOutside({
 		isDisabled: isOpen ? !isCloseOnInteractOutside : true,
-		onInteract: (event) => {
-			event.stopPropagation();
-			event.preventDefault();
+		onInteract: () => {
 			onClose();
 		},
 		ref: portalRef ?? menuRef,

--- a/packages/clay-shared/src/Portal.tsx
+++ b/packages/clay-shared/src/Portal.tsx
@@ -40,7 +40,7 @@ export interface IBaseProps {
 }
 
 interface IProps extends IBaseProps {
-	children: React.ReactElement | Array<React.ReactElement>;
+	children: React.ReactNode;
 
 	/**
 	 * Ref of element to render portal into.

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -13,6 +13,7 @@ export {Keys} from './Keys';
 export {LinkOrButton} from './LinkOrButton';
 export {MouseSafeArea} from './MouseSafeArea';
 export {observeRect} from './observeRect';
+export {Overlay} from './Overlay';
 export {setElementFullHeight} from './setElementFullHeight';
 export {sub} from './sub';
 export {useDebounce} from './useDebounce';

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -23,5 +23,7 @@ export {useInteractionFocus} from './useInteractionFocus';
 export {useInternalState} from './useInternalState';
 export {useMousePosition} from './useMousePosition';
 export {useNavigation} from './useNavigation';
+export {useOverlayPosition} from './useOverlayPositon';
+export type {AlignPoints} from './useOverlayPositon';
 export type {IBaseProps as IPortalBaseProps} from './Portal';
 export type {InternalDispatch} from './useInternalState';

--- a/packages/clay-shared/src/useFocusManagement.ts
+++ b/packages/clay-shared/src/useFocusManagement.ts
@@ -221,8 +221,36 @@ export function useFocusManagement(scope: React.RefObject<null | HTMLElement>) {
 		const nextFocusInDoc = docFocusElements[docPosition + 1];
 		const prevFocusInDoc = docFocusElements[docPosition - 1];
 
-		const nextFocusInFiber = fiberFocusElements[reactFiberPosition + 1];
-		const prevFocusInFiber = fiberFocusElements[reactFiberPosition - 1];
+		let nextFocusInFiber = fiberFocusElements[reactFiberPosition + 1];
+		let prevFocusInFiber = fiberFocusElements[reactFiberPosition - 1];
+
+		// Checks if the focus has reached the end of the scope and should
+		// go back to the beginning.
+		if (
+			nextFocusInFiber &&
+			nextFocusInFiber.getAttribute('data-focus-scope-end') === 'true'
+		) {
+			const focusGuardIndex = docFocusElements.findIndex(
+				(element) =>
+					element.getAttribute('data-focus-scope-start') === 'true'
+			);
+
+			nextFocusInFiber = docFocusElements[focusGuardIndex + 1];
+		}
+
+		// Checks if the focus has arrived at the beginning of the scope and is
+		// returning moves the focus to the end of the scope.
+		if (
+			prevFocusInFiber &&
+			prevFocusInFiber.getAttribute('data-focus-scope-start') === 'true'
+		) {
+			const focusGuardIndex = docFocusElements.findIndex(
+				(element) =>
+					element.getAttribute('data-focus-scope-end') === 'true'
+			);
+
+			prevFocusInFiber = docFocusElements[focusGuardIndex - 1];
+		}
 
 		// Only moves to the next element if it is in scope.
 		if (

--- a/packages/clay-shared/src/useInteractOutside.tsx
+++ b/packages/clay-shared/src/useInteractOutside.tsx
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React, {useEffect, useRef} from 'react';
+
+type Props = {
+	isDisabled?: boolean;
+	onInteract?: (event: Event) => void;
+	ref: React.RefObject<HTMLElement>;
+	triggerRef: React.RefObject<HTMLElement>;
+};
+
+/**
+ * Code ported with some minor modifications
+ * https://github.com/adobe/react-spectrum/blob/810579b671791f1593108f62cdc1893de3a220e3/packages/%40react-aria/interactions/src/useInteractOutside.ts
+ */
+export function useInteractOutside({
+	isDisabled = false,
+	onInteract,
+	ref,
+	triggerRef,
+}: Props) {
+	const stateRef = useRef({
+		ignoreEmulatedMouseEvents: false,
+		isPointerDown: false,
+		onInteract,
+	});
+
+	const state = stateRef.current;
+
+	state.onInteract = onInteract;
+
+	useEffect(() => {
+		if (isDisabled) {
+			return;
+		}
+
+		const onPointerDown = (event: Event) => {
+			if (isValidEvent(event, ref, triggerRef) && state.onInteract) {
+				event.stopPropagation();
+				event.preventDefault();
+
+				state.isPointerDown = true;
+			}
+		};
+
+		// Use pointer events if available. Otherwise, fall back to mouse and touch events.
+		if (typeof PointerEvent !== 'undefined') {
+			const onPointerUp = (event: Event) => {
+				if (
+					state.isPointerDown &&
+					state.onInteract &&
+					isValidEvent(event, ref, triggerRef)
+				) {
+					state.isPointerDown = false;
+					state.onInteract(event);
+				}
+			};
+
+			document.addEventListener('pointerdown', onPointerDown, true);
+			document.addEventListener('pointerup', onPointerUp, true);
+
+			return () => {
+				document.removeEventListener(
+					'pointerdown',
+					onPointerDown,
+					true
+				);
+				document.removeEventListener('pointerup', onPointerUp, true);
+			};
+		} else {
+			const onMouseUp = (event: Event) => {
+				if (state.ignoreEmulatedMouseEvents) {
+					state.ignoreEmulatedMouseEvents = false;
+				} else if (
+					state.isPointerDown &&
+					state.onInteract &&
+					isValidEvent(event, ref, triggerRef)
+				) {
+					state.isPointerDown = false;
+					state.onInteract(event);
+				}
+			};
+
+			const onTouchEnd = (event: Event) => {
+				state.ignoreEmulatedMouseEvents = true;
+
+				if (
+					state.onInteract &&
+					state.isPointerDown &&
+					isValidEvent(event, ref, triggerRef)
+				) {
+					state.isPointerDown = false;
+					state.onInteract(event);
+				}
+			};
+
+			document.addEventListener('mousedown', onPointerDown, true);
+			document.addEventListener('mouseup', onMouseUp, true);
+			document.addEventListener('touchstart', onPointerDown, true);
+			document.addEventListener('touchend', onTouchEnd, true);
+
+			return () => {
+				document.removeEventListener('mousedown', onPointerDown, true);
+				document.removeEventListener('mouseup', onMouseUp, true);
+				document.removeEventListener('touchstart', onPointerDown, true);
+				document.removeEventListener('touchend', onTouchEnd, true);
+			};
+		}
+	}, [ref, state, isDisabled]);
+}
+
+function isValidEvent(
+	event: Event,
+	ref: React.RefObject<HTMLElement>,
+	trigger: React.RefObject<HTMLElement>
+) {
+	// @ts-ignore
+	if (event.button > 0) {
+		return false;
+	}
+
+	// if the event target is no longer in the document
+	if (event.target) {
+		// @ts-ignore
+		const ownerDocument = event.target.ownerDocument;
+
+		if (
+			!ownerDocument ||
+			!ownerDocument.documentElement.contains(event.target)
+		) {
+			return false;
+		}
+	}
+
+	// We disregard the trigger click because we already have an event that
+	// toggles the state of the overlay on the trigger.
+	if (
+		trigger.current &&
+		trigger.current.contains(event.target as HTMLElement)
+	) {
+		return false;
+	}
+
+	return ref.current && !ref.current.contains(event.target as HTMLElement);
+}

--- a/packages/clay-shared/src/useInteractOutside.tsx
+++ b/packages/clay-shared/src/useInteractOutside.tsx
@@ -39,9 +39,6 @@ export function useInteractOutside({
 
 		const onPointerDown = (event: Event) => {
 			if (isValidEvent(event, ref, triggerRef) && state.onInteract) {
-				event.stopPropagation();
-				event.preventDefault();
-
 				state.isPointerDown = true;
 			}
 		};

--- a/packages/clay-shared/src/useOverlayPositon.ts
+++ b/packages/clay-shared/src/useOverlayPositon.ts
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React, {useEffect, useLayoutEffect} from 'react';
+
+import {doAlign} from './doAlign';
+import {observeRect} from './observeRect';
+
+type Props = {
+	isOpen: boolean;
+	ref: React.RefObject<HTMLElement>;
+	alignmentByViewport?: boolean;
+	alignmentPosition?: number | AlignPoints;
+	autoBestAlign?: boolean;
+	getOffset?: (points: AlignPoints) => [number, number];
+	triggerRef: React.RefObject<HTMLElement>;
+};
+
+const ALIGN_INVERSE = {
+	0: 'TopCenter',
+	1: 'TopRight',
+	2: 'RightCenter',
+	3: 'BottomRight',
+	4: 'BottomCenter',
+	5: 'BottomLeft',
+	6: 'LeftCenter',
+	7: 'TopLeft',
+	8: 'RightTop',
+	9: 'RightBottom',
+	10: 'LeftTop',
+	11: 'LeftBottom',
+} as const;
+
+const ALIGN_MAP = {
+	BottomCenter: ['tc', 'bc'],
+	BottomLeft: ['tl', 'bl'],
+	BottomRight: ['tr', 'br'],
+	LeftBottom: ['br', 'bl'],
+	LeftCenter: ['cr', 'cl'],
+	LeftTop: ['tr', 'tl'],
+	RightBottom: ['bl', 'br'],
+	RightCenter: ['cl', 'cr'],
+	RightTop: ['tl', 'tr'],
+	TopCenter: ['bc', 'tc'],
+	TopLeft: ['bl', 'tl'],
+	TopRight: ['br', 'tr'],
+} as const;
+
+export type AlignPoints = typeof ALIGN_MAP[keyof typeof ALIGN_MAP];
+
+/**
+ * For backwards compatability, we are creating a util here so that `metal-position`
+ * number values are used in the same manner and result in the same alignment direction.
+ */
+const getAlignPoints = (val: keyof typeof ALIGN_INVERSE) =>
+	ALIGN_MAP[ALIGN_INVERSE[val]];
+
+const BOTTOM_OFFSET = [0, 4] as const;
+const LEFT_OFFSET = [-4, 0] as const;
+const RIGHT_OFFSET = [4, 0] as const;
+const TOP_OFFSET = [0, -4] as const;
+
+const OFFSET_MAP = {
+	bctc: TOP_OFFSET,
+	blbr: RIGHT_OFFSET,
+	bltl: TOP_OFFSET,
+	brbl: LEFT_OFFSET,
+	brtr: TOP_OFFSET,
+	clcr: RIGHT_OFFSET,
+	crcl: LEFT_OFFSET,
+	tcbc: BOTTOM_OFFSET,
+	tlbl: BOTTOM_OFFSET,
+	tltr: RIGHT_OFFSET,
+	trbr: BOTTOM_OFFSET,
+	trtl: LEFT_OFFSET,
+};
+
+const useIsomorphicLayoutEffect =
+	typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+const defaultOffset = (points: AlignPoints) =>
+	OFFSET_MAP[points.join('') as keyof typeof OFFSET_MAP] as [number, number];
+
+export function useOverlayPosition(
+	{
+		alignmentByViewport,
+		alignmentPosition = 5,
+		autoBestAlign = true,
+		getOffset = defaultOffset,
+		isOpen,
+		ref,
+		triggerRef,
+	}: Props,
+	deps: Array<any> = [isOpen]
+) {
+	useIsomorphicLayoutEffect(() => {
+		function alignElement() {
+			if (triggerRef.current) {
+				let points = alignmentPosition;
+
+				if (typeof points === 'number') {
+					points = getAlignPoints(
+						points as keyof typeof ALIGN_INVERSE
+					);
+				}
+
+				if (ref.current) {
+					doAlign({
+						offset: getOffset(points),
+						overflow: {
+							adjustX: autoBestAlign,
+							adjustY: autoBestAlign,
+							alwaysByViewport: alignmentByViewport,
+						},
+						points,
+						sourceElement: ref.current,
+						targetElement: triggerRef.current,
+					});
+				}
+			}
+		}
+
+		if (isOpen && ref.current) {
+			alignElement();
+
+			return observeRect(ref.current, alignElement);
+		}
+	}, deps);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5920,12 +5920,12 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-hidden@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.3.tgz#bb48de18dc84787a3c6eee113709c473c64ec254"
-  integrity sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==
+aria-hidden@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.2.tgz#8c4f7cc88d73ca42114106fdf6f47e68d31475b8"
+  integrity sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==
   dependencies:
-    tslib "^1.0.0"
+    tslib "^2.0.0"
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -23865,7 +23865,7 @@ tsconfig-paths@^3.11.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.0.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
This PR is a fork of #5208 where it was originally implemented, I'm sending it separately from this PR so we can have this merged into the master and we can work on other issues that depend on it as well while the PR is under review.

In summary, this PR is implementing a new foundation component to handle accessibility and keyboard focus and navigation interactions for components that need Overlay, for example: DatePicker, DropDown, Autocomplete, Modal, ColorPicker and other components.

Currently we have a duplication of implementation spread across these components, for example Modal has its own focus trap system, click outside the modal and suppression of elements outside the modal, this is implemented in other places too, which increases the duplication and possible inconsistent behavior and likely bugs over time.

Adding this component helps resolve these maintenance issues and inconsistency, also this PR implements better features for focus trap and click away from content which are more responsive.

- Improves the suppression system for elements outside the content. Uses the [native implementation of `inert`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert) when available which causes the browser to ignore input events for the element, including focus events and events from assistive technology. When not available we use the old method of using `aria-hidden`.
  - https://developer.chrome.com/articles/inert/
- Adding a new system to handle clicks outside of content that is adaptive and hardware agnostic, using [`pointer` events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events) to handle mouse, touch, and stylus/pen clicks. When the `pointer` is not available it uses the `mouse` and `touch` events.
- A focus trap system integrated with FocusScope, which ensures that the focus is trapped within the content. Good for Modal and DatePicker.
- Closing the Overlay by pressing the Escape key returns focus to the trigger. This makes this behavior consistent for all components that use Overlay.
- When the element has no focus trap, exiting the overlay using focus closes automatically. This was not consistent with some components that had focus inside the overlay but didn't need the focus trap.

