### PR TITLE
fix(@clayui/css): Normalize Sass map keys to be closer to the selector name

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_clay-color.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_clay-color.scss
@@ -6,10 +6,18 @@ $clay-color-dropdown-menu-close: map-deep-merge(
 		color: $gray-600,
 		font-size: 1rem,
 		opacity: 1,
-		hover-bg: rgba($gray-900, 0.03),
-		focus-bg: rgba($gray-900, 0.03),
-		active-bg: rgba($gray-900, 0.06),
-		disabled-bg: transparent,
+		hover: (
+			background-color: rgba($gray-900, 0.03),
+		),
+		focus: (
+			background-color: rgba($gray-900, 0.03),
+		),
+		active: (
+			background-color: rgba($gray-900, 0.06),
+		),
+		disabled: (
+			background-color: transparent,
+		),
 	),
 	$clay-color-dropdown-menu-close
 );
@@ -19,10 +27,14 @@ $clay-color-dropdown-menu-close: map-deep-merge(
 $clay-color-dropdown-menu-component-action: () !default;
 $clay-color-dropdown-menu-component-action: map-deep-merge(
 	(
-		hover-bg: null,
-		hover-color: null,
-		focus-box-shadow: null,
-		focus-color: null,
+		hover: (
+			background-color: null,
+			color: null,
+		),
+		focus: (
+			box-shadow: null,
+			color: null,
+		),
 	),
 	$clay-color-dropdown-menu-component-action
 );
@@ -32,7 +44,9 @@ $clay-color-dropdown-menu-component-action: map-deep-merge(
 $clay-color-pointer: () !default;
 $clay-color-pointer: map-deep-merge(
 	(
-		focus-box-shadow: 0 0 0 0.125rem $primary-l1,
+		focus: (
+			box-shadow: 0 0 0 0.125rem $primary-l1,
+		),
 	),
 	$clay-color-pointer
 );

--- a/packages/clay-css/src/scss/atlas/variables/_date-picker.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_date-picker.scss
@@ -13,12 +13,20 @@ $date-picker-dropdown-menu: map-deep-merge(
 $date-picker-nav-btn: () !default;
 $date-picker-nav-btn: map-deep-merge(
 	(
-		hover-color: $gray-900,
-		focus-bg: $gray-200,
-		focus-color: $gray-900,
-		active-bg: $gray-200,
-		disabled-color: $gray-500,
-		disabled-opacity: null,
+		hover: (
+			color: $gray-900,
+		),
+		focus: (
+			background-color: $gray-200,
+			color: $gray-900,
+		),
+		active: (
+			background-color: $gray-200,
+		),
+		disabled: (
+			color: $gray-500,
+			opacity: null,
+		),
 	),
 	$date-picker-nav-btn
 );
@@ -61,11 +69,17 @@ $date-picker-nav-select: map-deep-merge(
 $date-picker-date: () !default;
 $date-picker-date: map-deep-merge(
 	(
-		hover-color: $gray-900,
-		focus-bg: $gray-200,
-		focus-color: $gray-900,
-		disabled-color: $gray-500,
-		disabled-opacity: null,
+		hover: (
+			color: $gray-900,
+		),
+		focus: (
+			background-color: $gray-200,
+			color: $gray-900,
+		),
+		disabled: (
+			color: $gray-500,
+			opacity: null,
+		),
 	),
 	$date-picker-date
 );
@@ -75,7 +89,9 @@ $date-picker-previous-month-date: map-deep-merge(
 	(
 		color: $gray-500,
 		opacity: null,
-		focus-opacity: null,
+		focus: (
+			opacity: null,
+		),
 		active: (
 			background-color: $primary-l2,
 		),
@@ -88,7 +104,9 @@ $date-picker-next-month-date: map-deep-merge(
 	(
 		color: $gray-500,
 		opacity: null,
-		focus-opacity: null,
+		focus: (
+			opacity: null,
+		),
 		active: (
 			background-color: $primary-l2,
 		),

--- a/packages/clay-css/src/scss/atlas/variables/_modals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_modals.scss
@@ -33,14 +33,22 @@ $modal-title-font-weight: $font-weight-bold !default;
 $modal-success: () !default;
 $modal-success: map-deep-merge(
 	(
-		header-bg: $success-l2,
-		header-border-color: $success-l1,
-		header-color: $success,
-		header-close: (
+		modal-header: (
+			background-color: $success-l2,
+			border-color: $success-l1,
 			color: $success,
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: $success,
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$modal-success
@@ -51,14 +59,22 @@ $modal-success: map-deep-merge(
 $modal-info: () !default;
 $modal-info: map-deep-merge(
 	(
-		header-bg: $info-l2,
-		header-border-color: $info-l1,
-		header-color: $info,
-		header-close: (
+		modal-header: (
+			background-color: $info-l2,
+			border-color: $info-l1,
 			color: $info,
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: $info,
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$modal-info
@@ -69,14 +85,22 @@ $modal-info: map-deep-merge(
 $modal-warning: () !default;
 $modal-warning: map-deep-merge(
 	(
-		header-bg: $warning-l2,
-		header-border-color: $warning-l1,
-		header-color: $warning,
-		header-close: (
+		modal-header: (
+			background-color: $warning-l2,
+			border-color: $warning-l1,
 			color: $warning,
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: $warning,
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$modal-warning
@@ -87,14 +111,22 @@ $modal-warning: map-deep-merge(
 $modal-danger: () !default;
 $modal-danger: map-deep-merge(
 	(
-		header-bg: $danger-l2,
-		header-border-color: $danger-l1,
-		header-color: $danger,
-		header-close: (
+		modal-header: (
+			background-color: $danger-l2,
+			border-color: $danger-l1,
 			color: $danger,
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: $danger,
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$modal-danger

--- a/packages/clay-css/src/scss/atlas/variables/_panels.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_panels.scss
@@ -46,7 +46,7 @@ $panel-title-small-margin-left: 0.375rem !default; // 6px
 $panel-group-sm: () !default;
 $panel-group-sm: map-deep-merge(
 	(
-		title: (
+		panel-title: (
 			font-size: 0.75rem,
 		),
 	),
@@ -60,11 +60,11 @@ $panel-secondary: map-deep-merge(
 	(
 		border-color: $gray-300,
 		color: $gray-600,
-		header: (
+		panel-header: (
 			background-color: null,
 			border-color: $gray-300,
 		),
-		footer: (
+		panel-footer: (
 			background-color: null,
 			border-color: $gray-300,
 		),

--- a/packages/clay-css/src/scss/atlas/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_tbar.scss
@@ -12,7 +12,9 @@ $component-tbar: map-deep-merge(
 $subnav-tbar-primary-component-link: () !default;
 $subnav-tbar-primary-component-link: map-deep-merge(
 	(
-		disabled-opacity: 0.65,
+		disabled: (
+			opacity: 0.65,
+		),
 	),
 	$subnav-tbar-primary-component-link
 );
@@ -20,7 +22,9 @@ $subnav-tbar-primary-component-link: map-deep-merge(
 $subnav-tbar-primary-component-label-close: () !default;
 $subnav-tbar-primary-component-label-close: map-deep-merge(
 	(
-		disabled-opacity: 0.65,
+		disabled: (
+			opacity: 0.65,
+		),
 	),
 	$subnav-tbar-primary-component-label-close
 );
@@ -48,7 +52,7 @@ $subnav-tbar-primary-disabled: map-deep-merge(
 $subnav-tbar-light: () !default;
 $subnav-tbar-light: map-deep-merge(
 	(
-		bg-color: $light-l2,
+		background-color: $light-l2,
 		color: $gray-600,
 	),
 	$subnav-tbar-light

--- a/packages/clay-css/src/scss/atlas/variables/_time.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_time.scss
@@ -2,7 +2,9 @@ $clay-time-btn: () !default;
 $clay-time-btn: map-deep-merge(
 	(
 		color: $secondary,
-		focus-box-shadow: 0 0 0 1px #80acff,
+		focus: (
+			box-shadow: 0 0 0 1px #80acff,
+		),
 	),
 	$clay-time-btn
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -374,9 +374,15 @@ $cadmin-card-interactive-after-highlight: map-deep-merge(
 		position: absolute,
 		right: math-sign($cadmin-card-border-width),
 		transition: height 0.15s ease-out,
-		hover-height: 4px,
-		focus-height: 4px,
-		active-height: 4px,
+		hover: (
+			height: 4px,
+		),
+		focus: (
+			height: 4px,
+		),
+		active: (
+			height: 4px,
+		),
 	),
 	$cadmin-card-interactive-after-highlight
 );
@@ -395,10 +401,17 @@ $cadmin-card-interactive: map-deep-merge(
 		cursor: $cadmin-link-cursor,
 		outline: 0,
 		transition: $cadmin-component-transition,
-		hover-bg: #f7f8f9,
-		hover-text-decoration: none,
-		focus-box-shadow: 0 0 0 2px #FFF#{','} 0 0 0 4px #719aff,
-		active-bg: #f1f2f5,
+		hover: (
+			background-color: #f7f8f9,
+			text-decoration: none,
+		),
+		focus: (
+			box-shadow: #{0 0 0 2px #fff,
+			0 0 0 4px #719aff},
+		),
+		active: (
+			background-color: #f1f2f5,
+		),
 		after-highlight: $cadmin-card-interactive-after-highlight,
 		card-body: $cadmin-card-interactive-card-body,
 	),
@@ -410,9 +423,15 @@ $cadmin-card-interactive: map-deep-merge(
 $cadmin-card-interactive-primary-after-highlight: () !default;
 $cadmin-card-interactive-primary-after-highlight: map-deep-merge(
 	(
-		hover-bg: $cadmin-component-active-bg,
-		focus-bg: $cadmin-component-active-bg,
-		active-bg: $cadmin-component-active-bg,
+		hover: (
+			background-color: $cadmin-component-active-bg,
+		),
+		focus: (
+			background-color: $cadmin-component-active-bg,
+		),
+		active: (
+			background-color: $cadmin-component-active-bg,
+		),
 	),
 	$cadmin-card-interactive-primary-after-highlight
 );
@@ -420,8 +439,12 @@ $cadmin-card-interactive-primary-after-highlight: map-deep-merge(
 $cadmin-card-interactive-primary: () !default;
 $cadmin-card-interactive-primary: map-deep-merge(
 	(
-		focus-bg: $cadmin-gray-100,
-		active-bg: $cadmin-gray-200,
+		focus: (
+			background-color: $cadmin-gray-100,
+		),
+		active: (
+			background-color: $cadmin-gray-200,
+		),
 		after-highlight: $cadmin-card-interactive-primary-after-highlight,
 	),
 	$cadmin-card-interactive-primary
@@ -433,13 +456,19 @@ $cadmin-card-interactive-secondary: () !default;
 $cadmin-card-interactive-secondary: map-deep-merge(
 	(
 		color: $cadmin-gray-900,
-		hover-color: $cadmin-gray-900,
-		hover-bg: $cadmin-white,
-		hover-border-color: transparent,
-		hover-box-shadow: 0 0 0 2px #719aff,
-		focus-border-color: transparent,
-		focus-box-shadow: 0 0 0 2px #719aff,
-		active-bg: $cadmin-white,
+		hover: (
+			background-color: $cadmin-white,
+			border-color: transparent,
+			box-shadow: 0 0 0 2px #719aff,
+			color: $cadmin-gray-900,
+		),
+		focus: (
+			border-color: transparent,
+			box-shadow: 0 0 0 2px #719aff,
+		),
+		active: (
+			background-color: $cadmin-white,
+		),
 	),
 	$cadmin-card-interactive-secondary
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_clay-color.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_clay-color.scss
@@ -94,10 +94,18 @@ $cadmin-clay-color-dropdown-menu-close: map-deep-merge(
 		color: $cadmin-gray-600,
 		font-size: 16px,
 		opacity: 1,
-		hover-bg: rgba($cadmin-gray-900, 0.03),
-		focus-bg: rgba($cadmin-gray-900, 0.03),
-		active-bg: rgba($cadmin-gray-900, 0.06),
-		disabled-bg: transparent,
+		hover: (
+			background-color: rgba($cadmin-gray-900, 0.03),
+		),
+		focus: (
+			background-color: rgba($cadmin-gray-900, 0.03),
+		),
+		active: (
+			background-color: rgba($cadmin-gray-900, 0.06),
+		),
+		disabled: (
+			background-color: transparent,
+		),
 	),
 	$cadmin-clay-color-dropdown-menu-close
 );
@@ -164,7 +172,7 @@ $cadmin-clay-color-btn-bordered: map-deep-merge(
 $cadmin-clay-color-pointer: () !default;
 $cadmin-clay-color-pointer: map-deep-merge(
 	(
-		bg: transparent,
+		background-color: transparent,
 		border-radius: 100px,
 		border-color: $cadmin-white,
 		border-style: solid,
@@ -177,8 +185,10 @@ $cadmin-clay-color-pointer: map-deep-merge(
 		position: absolute,
 		transition: box-shadow 0.15s ease-in-out,
 		width: 14px,
-		focus-box-shadow: 0 0 0 2px $cadmin-primary-l1,
-		focus-outline: 0,
+		focus: (
+			box-shadow: 0 0 0 2px $cadmin-primary-l1,
+			outline: 0,
+		),
 	),
 	$cadmin-clay-color-pointer
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_date-picker.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_date-picker.scss
@@ -31,15 +31,23 @@ $cadmin-date-picker-nav-btn: map-deep-merge(
 	(
 		color: $cadmin-gray-600,
 		transition: $cadmin-component-transition,
-		hover-bg: $cadmin-gray-200,
-		hover-color: $cadmin-gray-900,
-		focus-bg: $cadmin-gray-200,
-		focus-box-shadow: $cadmin-component-focus-box-shadow,
-		focus-color: $cadmin-gray-900,
-		active-bg: $cadmin-gray-200,
-		disabled-bg: transparent,
-		disabled-box-shadow: none,
-		disabled-color: $cadmin-gray-500,
+		hover: (
+			background-color: $cadmin-gray-200,
+			color: $cadmin-gray-900,
+		),
+		focus: (
+			background-color: $cadmin-gray-200,
+			box-shadow: $cadmin-component-focus-box-shadow,
+			color: $cadmin-gray-900,
+		),
+		active: (
+			background-color: $cadmin-gray-200,
+		),
+		disabled: (
+			background-color: transparent,
+			box-shadow: none,
+			color: $cadmin-gray-500,
+		),
 	),
 	$cadmin-date-picker-nav-btn
 );
@@ -199,7 +207,8 @@ $cadmin-date-picker-calendar-item: () !default;
 $cadmin-date-picker-calendar-item: map-deep-merge(
 	(
 		align-items: center,
-		bg: transparent,
+		background-color:
+			setter(map-get($cadmin-date-picker-calendar-item, bg) transparent),
 		border-width: 0,
 		disabled-cursor: $cadmin-disabled-cursor,
 		display: inline-flex,
@@ -230,17 +239,25 @@ $cadmin-date-picker-date: map-deep-merge(
 		color: $cadmin-gray-600,
 		cursor: $cadmin-link-cursor,
 		position: relative,
-		hover-bg: $cadmin-gray-200,
-		hover-color: $cadmin-gray-900,
-		focus-bg: $cadmin-gray-200,
-		focus-box-shadow: $cadmin-component-focus-box-shadow,
-		focus-color: $cadmin-gray-900,
-		focus-outline: 0,
-		active-bg: $cadmin-component-active-bg,
-		active-color: $cadmin-component-active-color,
-		disabled-bg: transparent,
-		disabled-box-shadow: none,
-		disabled-color: $cadmin-gray-500,
+		hover: (
+			background-color: $cadmin-gray-200,
+			color: $cadmin-gray-900,
+		),
+		focus: (
+			background-color: $cadmin-gray-200,
+			box-shadow: $cadmin-component-focus-box-shadow,
+			color: $cadmin-gray-900,
+			outline: 0,
+		),
+		active: (
+			background-color: $cadmin-component-active-bg,
+			color: $cadmin-component-active-color,
+		),
+		disabled: (
+			background-color: transparent,
+			box-shadow: none,
+			color: $cadmin-gray-500,
+		),
 	),
 	$cadmin-date-picker-date
 );
@@ -266,7 +283,10 @@ $cadmin-date-picker-next-month-date: map-deep-merge(
 $cadmin-date-picker-input-group-text: () !default;
 $cadmin-date-picker-input-group-text: map-deep-merge(
 	(
-		bg: transparent,
+		background-color:
+			setter(
+				map-get($cadmin-date-picker-input-group-text, bg) transparent
+			),
 		border-color: transparent,
 		min-width: 32px,
 		padding-left: 4px,

--- a/packages/clay-css/src/scss/cadmin/variables/_modals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_modals.scss
@@ -262,14 +262,22 @@ $cadmin-modal-height-full-modal-content-sm-up: map-merge(
 $cadmin-modal-success: () !default;
 $cadmin-modal-success: map-deep-merge(
 	(
-		header-bg: $cadmin-success-l2,
-		header-border-color: $cadmin-success-l1,
-		header-color: $cadmin-success,
-		header-close: (
+		modal-header: (
+			background-color: $cadmin-success-l2,
+			border-color: $cadmin-success-l1,
 			color: $cadmin-success,
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: $cadmin-success,
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$cadmin-modal-success
@@ -280,14 +288,22 @@ $cadmin-modal-success: map-deep-merge(
 $cadmin-modal-info: () !default;
 $cadmin-modal-info: map-deep-merge(
 	(
-		header-bg: $cadmin-info-l2,
-		header-border-color: $cadmin-info-l1,
-		header-color: $cadmin-info,
-		header-close: (
+		modal-header: (
+			background-color: $cadmin-info-l2,
+			border-color: $cadmin-info-l1,
 			color: $cadmin-info,
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: $cadmin-info,
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$cadmin-modal-info
@@ -298,14 +314,22 @@ $cadmin-modal-info: map-deep-merge(
 $cadmin-modal-warning: () !default;
 $cadmin-modal-warning: map-deep-merge(
 	(
-		header-bg: $cadmin-warning-l2,
-		header-border-color: $cadmin-warning-l1,
-		header-color: $cadmin-warning,
-		header-close: (
+		modal-header: (
+			background-color: $cadmin-warning-l2,
+			border-color: $cadmin-warning-l1,
 			color: $cadmin-warning,
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: $cadmin-warning,
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$cadmin-modal-warning
@@ -316,14 +340,22 @@ $cadmin-modal-warning: map-deep-merge(
 $cadmin-modal-danger: () !default;
 $cadmin-modal-danger: map-deep-merge(
 	(
-		header-bg: $cadmin-danger-l2,
-		header-border-color: $cadmin-danger-l1,
-		header-color: $cadmin-danger,
-		header-close: (
+		modal-header: (
+			background-color: $cadmin-danger-l2,
+			border-color: $cadmin-danger-l1,
 			color: $cadmin-danger,
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: $cadmin-danger,
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$cadmin-modal-danger

--- a/packages/clay-css/src/scss/cadmin/variables/_sheets.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_sheets.scss
@@ -125,11 +125,15 @@ $cadmin-sheet-subtitle-link: map-deep-merge(
 		color: $cadmin-sheet-subtitle-link-color,
 		text-decoration: $cadmin-sheet-subtitle-link-text-decoration,
 		transition: box-shadow 0.15s ease-in-out,
-		hover-color: $cadmin-sheet-subtitle-link-hover-color,
-		hover-text-decoration: $cadmin-sheet-subtitle-link-hover-text-decoration,
-		focus-box-shadow: #{0 0 0 4px $cadmin-white,
-		0 0 0 6px $cadmin-primary-l1},
-		focus-outline: 0,
+		hover: (
+			color: $cadmin-sheet-subtitle-link-hover-color,
+			text-decoration: $cadmin-sheet-subtitle-link-hover-text-decoration,
+		),
+		focus: (
+			box-shadow: #{0 0 0 4px $cadmin-white,
+			0 0 0 6px $cadmin-primary-l1},
+			outline: 0,
+		),
 	),
 	$cadmin-sheet-subtitle-link
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_tbar.scss
@@ -10,39 +10,43 @@ $cadmin-tbar-stacked: map-deep-merge(
 		height: 100%,
 		padding-bottom: 8px,
 		padding-top: 8px,
-		nav: (
+		tbar-nav: (
 			flex-direction: column,
 			min-width: 0,
 		),
-		item: (
+		tbar-item: (
 			align-items: center,
 			justify-content: flex-start,
 			padding-left: 0,
 			padding-right: 0,
 		),
-		item-expand: (
+		tbar-item-expand: (
 			flex-shrink: 0,
 			min-width: 0,
 		),
-		divider-before: (
-			background-color: $cadmin-body-color,
-			content: '',
-			display: block,
-			height: 1px,
-			margin-bottom: 4px,
-			margin-top: 4px,
-			width: 40px,
+		tbar-divider-before: (
+			before: (
+				background-color: $cadmin-body-color,
+				content: '',
+				display: block,
+				height: 1px,
+				margin-bottom: 4px,
+				margin-top: 4px,
+				width: 40px,
+			),
 		),
-		divider-after: (
-			background-color: $cadmin-body-color,
-			content: '',
-			display: block,
-			height: 1px,
-			margin-bottom: 4px,
-			margin-top: 4px,
-			width: 40px,
+		tbar-divider-after: (
+			after: (
+				background-color: $cadmin-body-color,
+				content: '',
+				display: block,
+				height: 1px,
+				margin-bottom: 4px,
+				margin-top: 4px,
+				width: 40px,
+			),
 		),
-		btn-monospaced: (
+		tbar-btn-monospaced: (
 			border-color: transparent,
 			border-radius: 0,
 			border-width: 0,
@@ -58,12 +62,14 @@ $cadmin-tbar-stacked: map-deep-merge(
 			position: relative,
 			width: 40px,
 			focus: (
-				box-shadow: inset 0 0 0 2px $cadmin-primary-l1#{','} inset 0 0 0
-					4px $cadmin-white,
+				box-shadow: #{inset 0 0 0 2px $cadmin-primary-l1,
+				inset 0 0 0 4px $cadmin-white},
 			),
-			active-focus: (
-				box-shadow: inset 0 0 0 2px $cadmin-primary-l1#{','} inset 0 0 0
-					4px $cadmin-white,
+			active: (
+				focus: (
+					box-shadow: #{inset 0 0 0 2px $cadmin-primary-l1,
+					inset 0 0 0 4px $cadmin-white},
+				),
 			),
 		),
 	),
@@ -76,7 +82,9 @@ $cadmin-tbar-inline-xs-down: () !default;
 $cadmin-tbar-inline-xs-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($cadmin-grid-breakpoints), 1),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$cadmin-tbar-inline-xs-down
 );
@@ -85,7 +93,9 @@ $cadmin-tbar-inline-sm-down: () !default;
 $cadmin-tbar-inline-sm-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($cadmin-grid-breakpoints), 2),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$cadmin-tbar-inline-sm-down
 );
@@ -94,7 +104,9 @@ $cadmin-tbar-inline-md-down: () !default;
 $cadmin-tbar-inline-md-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($cadmin-grid-breakpoints), 3),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$cadmin-tbar-inline-md-down
 );
@@ -103,7 +115,9 @@ $cadmin-tbar-inline-lg-down: () !default;
 $cadmin-tbar-inline-lg-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($cadmin-grid-breakpoints), 4),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$cadmin-tbar-inline-lg-down
 );
@@ -112,7 +126,9 @@ $cadmin-tbar-inline-xl-down: () !default;
 $cadmin-tbar-inline-xl-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($cadmin-grid-breakpoints), 5),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$cadmin-tbar-inline-xl-down
 );
@@ -140,13 +156,17 @@ $cadmin-tbar-light: map-deep-merge(
 		box-shadow: inset 1px 0 0 0 $cadmin-gray-200#{','} inset -1px 0 0 0
 			$cadmin-gray-200,
 		color: $cadmin-secondary,
-		divider-before: (
-			background-color: $cadmin-gray-200,
+		tbar-divider-before: (
+			before: (
+				background-color: $cadmin-gray-200,
+			),
 		),
-		divider-after: (
-			background-color: $cadmin-gray-200,
+		tbar-divider-after: (
+			after: (
+				background-color: $cadmin-gray-200,
+			),
 		),
-		btn-monospaced: (
+		tbar-btn-monospaced: (
 			hover: (
 				color: $cadmin-dark,
 			),
@@ -172,13 +192,17 @@ $cadmin-tbar-dark-d1: map-deep-merge(
 		box-shadow: inset 1px 0 0 0 rgba($cadmin-white, 0.06) #{','} inset -1px
 			0 0 0 rgba($cadmin-white, 0.06),
 		color: $cadmin-gray-500,
-		divider-before: (
-			background-color: rgba($cadmin-white, 0.06),
+		tbar-divider-before: (
+			before: (
+				background-color: rgba($cadmin-white, 0.06),
+			),
 		),
-		divider-after: (
-			background-color: rgba($cadmin-white, 0.06),
+		tbar-divider-after: (
+			after: (
+				background-color: rgba($cadmin-white, 0.06),
+			),
 		),
-		btn-monospaced: (
+		tbar-btn-monospaced: (
 			hover: (
 				color: $cadmin-white,
 			),
@@ -192,15 +216,17 @@ $cadmin-tbar-dark-d1: map-deep-merge(
 				background-color: rgba($cadmin-white, 0.06),
 				color: $cadmin-white,
 			),
-			active-class-after: (
-				background-color: $cadmin-primary-l1,
-				bottom: 0,
-				content: '',
-				display: block,
-				left: 0,
-				position: absolute,
-				top: 0,
-				width: 4px,
+			active-class: (
+				after: (
+					background-color: $cadmin-primary-l1,
+					bottom: 0,
+					content: '',
+					display: block,
+					left: 0,
+					position: absolute,
+					top: 0,
+					width: 4px,
+				),
 			),
 		),
 	),
@@ -215,13 +241,17 @@ $cadmin-tbar-dark-l2: map-deep-merge(
 			0 0 0 rgba($cadmin-white, 0.06),
 		border-color: rgba($cadmin-white, 0.06),
 		color: $cadmin-gray-500,
-		divider-before: (
-			background-color: rgba($cadmin-white, 0.06),
+		tbar-divider-before: (
+			before: (
+				background-color: rgba($cadmin-white, 0.06),
+			),
 		),
-		divider-after: (
-			background-color: rgba($cadmin-white, 0.06),
+		tbar-divider-after: (
+			after: (
+				background-color: rgba($cadmin-white, 0.06),
+			),
 		),
-		btn-monospaced: (
+		tbar-btn-monospaced: (
 			hover: (
 				color: $cadmin-white,
 			),
@@ -260,8 +290,10 @@ $cadmin-subnav-tbar-component-link: () !default;
 $cadmin-subnav-tbar-component-link: map-deep-merge(
 	(
 		color: $cadmin-link-color,
-		hover-color: $cadmin-link-hover-color,
 		font-weight: $cadmin-font-weight-semi-bold,
+		hover: (
+			color: $cadmin-link-hover-color,
+		),
 	),
 	$cadmin-subnav-tbar-component-link
 );
@@ -282,26 +314,49 @@ $cadmin-subnav-tbar: () !default;
 $cadmin-subnav-tbar: map-deep-merge(
 	(
 		font-size: 14px,
-		section-text-align: left,
-		strong-font-weight: $cadmin-font-weight-semi-bold,
-		item-padding-x: 8px,
-		btn-height: 24px,
-		btn-line-height: 1,
-		btn-margin-y: 2px,
-		btn-padding-y: 0,
-		btn-monospaced-margin-y: 2px,
-		btn-monospaced-padding: 4px,
+		tbar-section: (
+			text-align: left,
+		),
+		strong: (
+			font-weight: $cadmin-font-weight-semi-bold,
+		),
+		tbar-item-padding: (
+			padding-left: 8px,
+			padding-right: 8px,
+		),
+		tbar-btn: (
+			height: 24px,
+			line-height: 1,
+			margin-bottom: 2px,
+			margin-top: 2px,
+			padding-bottom: 0,
+			padding-top: 0,
+		),
+		tbar-btn-monospaced: (
+			margin-bottom: 2px,
+			margin-top: 2px,
+			padding: 4px,
+		),
 		component-link: $cadmin-subnav-tbar-component-link,
 		component-title: $cadmin-subnav-tbar-component-title,
 		component-text: $cadmin-subnav-tbar-component-text,
 		component-label: (
 			font-weight: $cadmin-font-weight-normal,
 		),
-		link-margin-y: 2px,
-		link-padding-x: 4px,
-		link-padding-y: 1.5px,
-		link-monospaced-margin-y: 2px,
-		link-monospaced-size: 24px,
+		tbar-link: (
+			margin-bottom: 2px,
+			margin-top: 2px,
+			padding-bottom: 1.5px,
+			padding-left: 4px,
+			padding-right: 4px,
+			padding-top: 1.5px,
+		),
+		tbar-link-monospaced: (
+			height: 24px,
+			margin-bottom: 2px,
+			margin-top: 2px,
+			width: 24px,
+		),
 	),
 	$cadmin-subnav-tbar
 );
@@ -311,7 +366,11 @@ $cadmin-subnav-tbar: map-deep-merge(
 $cadmin-subnav-tbar-light: () !default;
 $cadmin-subnav-tbar-light: map-deep-merge(
 	(
-		bg-color: $cadmin-light-l2,
+		background-color:
+			setter(
+				map-get($cadmin-subnav-tbar-light, bg-color),
+				$cadmin-light-l2
+			),
 		color: $cadmin-gray-600,
 		padding-y: 2px,
 	),
@@ -324,11 +383,15 @@ $cadmin-subnav-tbar-primary-component-link: () !default;
 $cadmin-subnav-tbar-primary-component-link: map-deep-merge(
 	(
 		color: $cadmin-gray-900,
-		hover-color: $cadmin-gray-900,
-		disabled-color: $cadmin-gray-600,
-		disabled-cursor: $cadmin-disabled-cursor,
-		disabled-opacity: 0.65,
-		disabled-text-decoration: none,
+		hover: (
+			color: $cadmin-gray-900,
+		),
+		disabled: (
+			color: $cadmin-gray-600,
+			cursor: $cadmin-disabled-cursor,
+			opacity: 0.65,
+			text-decoration: none,
+		),
 	),
 	$cadmin-subnav-tbar-primary-component-link
 );
@@ -336,9 +399,13 @@ $cadmin-subnav-tbar-primary-component-link: map-deep-merge(
 $cadmin-subnav-tbar-primary-component-label-close: () !default;
 $cadmin-subnav-tbar-primary-component-label-close: map-deep-merge(
 	(
-		focus-color: inherit,
-		disabled-color: $cadmin-gray-600,
-		disabled-opacity: 0.65,
+		focus: (
+			color: inherit,
+		),
+		disabled: (
+			color: $cadmin-gray-600,
+			opacity: 0.65,
+		),
 	),
 	$cadmin-subnav-tbar-primary-component-label-close
 );
@@ -356,8 +423,10 @@ $cadmin-subnav-tbar-primary-tbar-label-size: map-deep-merge(
 	(
 		font-size: 12px,
 		margin-right: 0,
-		padding-x: 10px,
-		padding-y: 5px,
+		padding-bottom: 5px,
+		padding-left: 10px,
+		padding-right: 10px,
+		padding-top: 5px,
 		text-transform: none,
 	),
 	$cadmin-subnav-tbar-primary-tbar-label-size
@@ -366,18 +435,31 @@ $cadmin-subnav-tbar-primary-tbar-label-size: map-deep-merge(
 $cadmin-subnav-tbar-primary: () !default;
 $cadmin-subnav-tbar-primary: map-deep-merge(
 	(
-		bg-color: $cadmin-primary-l2,
-		padding-x: 4px,
-		padding-y: 10px,
-		item-justify-content: flex-start,
-		item-padding-x: 4px,
-		link-monospaced-border-radius: 0,
-		link-monospaced-border-width: 0,
-		link-monospaced-margin-y: -10px,
-		link-monospaced-size: 48px,
+		background-color:
+			setter(
+				map-get($cadmin-subnav-tbar-primary, bg-color),
+				$cadmin-primary-l2
+			),
+		padding-bottom: 10px,
+		padding-left: 4px,
+		padding-right: 4px,
+		padding-top: 10px,
+		tbar-item: (
+			justify-content: flex-start,
+			padding-left: 4px,
+			padding-right: 4px,
+		),
+		tbar-link-monospaced: (
+			border-radius: 0,
+			border-width: 0,
+			height: 48px,
+			margin-bottom: -10px,
+			margin-top: -10px,
+			width: 48px,
+		),
 		component-link: $cadmin-subnav-tbar-primary-component-link,
 		component-label: $cadmin-subnav-tbar-primary-component-label,
-		tbar-label-size: $cadmin-subnav-tbar-primary-tbar-label-size,
+		tbar-label: $cadmin-subnav-tbar-primary-tbar-label-size,
 	),
 	$cadmin-subnav-tbar-primary
 );
@@ -395,7 +477,11 @@ $cadmin-subnav-tbar-primary-disabled-component-label: map-deep-merge(
 $cadmin-subnav-tbar-primary-disabled: () !default;
 $cadmin-subnav-tbar-primary-disabled: map-deep-merge(
 	(
-		bg-color: clay-lighten(clay-desaturate($cadmin-primary, 27.03), 37.06),
+		background-color:
+			setter(
+				map-get($cadmin-subnav-tbar-primary-disabled, bg-color),
+				clay-lighten(clay-desaturate($cadmin-primary, 27.03), 37.06)
+			),
 		color: #8e94aa,
 		component-label: $cadmin-subnav-tbar-primary-disabled-component-label,
 	),

--- a/packages/clay-css/src/scss/cadmin/variables/_time.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_time.scss
@@ -12,7 +12,9 @@ $cadmin-clay-time-btn: map-deep-merge(
 		padding-right: 0,
 		padding-top: 0,
 		width: 24px,
-		focus-box-shadow: 0 0 0 1px #80acff,
+		focus: (
+			box-shadow: 0 0 0 1px #80acff,
+		),
 	),
 	$cadmin-clay-time-btn
 );
@@ -37,7 +39,9 @@ $cadmin-clay-time-form-control-inset: map-deep-merge(
 		text-align: center,
 		width: 20px,
 		selection-bg: transparent,
-		focus-bg: #b3d8fd,
+		focus: (
+			background-color: #b3d8fd,
+		),
 	),
 	$cadmin-clay-time-form-control-inset
 );

--- a/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
@@ -87,13 +87,13 @@ $cadmin-close: map-deep-merge(
 			cursor: $cadmin-disabled-cursor,
 			opacity: $cadmin-component-disabled-opacity,
 			outline: 0,
+			active: (
+				pointer-events: none,
+			),
 		),
-		disabled-active: (
-			pointer-events: none,
+		lexicon-icon: (
+			margin-top: 0,
 		),
-		btn-focus-box-shadow: $cadmin-component-focus-box-shadow,
-		btn-focus-outline: 0,
-		lexicon-icon-margin-top: 0,
 	),
 	$cadmin-close
 );

--- a/packages/clay-css/src/scss/components/_progress-bars.scss
+++ b/packages/clay-css/src/scss/components/_progress-bars.scss
@@ -124,11 +124,38 @@
 @each $color, $value in $progress-palette {
 	.progress-#{$color} {
 		.progress-bar {
-			background-color: map-get($value, bar-bg);
+			$progress-bar: setter(map-get($value, progress-bar), ());
+			$progress-bar: map-merge(
+				$progress-bar,
+				(
+					background-color:
+						setter(
+							map-get($progress-bar, background-color),
+							map-get($value, bar-bg)
+						),
+				)
+			);
+
+			@include clay-css($progress-bar);
 		}
 
 		.progress-group-feedback {
-			color: map-get($value, group-feedback-color);
+			$progress-group-feedback: setter(
+				map-get($value, progress-group-feedback),
+				()
+			);
+			$progress-group-feedback: map-merge(
+				$progress-group-feedback,
+				(
+					color:
+						setter(
+							map-get($progress-group-feedback, color),
+							map-get($value, group-feedback-color)
+						),
+				)
+			);
+
+			@include clay-css($progress-group-feedback);
 		}
 	}
 }

--- a/packages/clay-css/src/scss/mixins/_input-groups.scss
+++ b/packages/clay-css/src/scss/mixins/_input-groups.scss
@@ -27,7 +27,7 @@
 	$breakpoint: setter(map-get($map, breakpoint), md);
 	$breakpoint-down: clay-breakpoint-prev($breakpoint);
 
-	$item: setter(map-get($map, item), ());
+	$item: setter(map-get($map, input-group-item), map-get($map, item), ());
 	$item: map-merge(
 		$item,
 		(
@@ -55,7 +55,11 @@
 		)
 	);
 
-	$item-shrink: setter(map-get($map, item-shrink), ());
+	$item-shrink: setter(
+		map-get($map, input-group-item-shrink),
+		map-get($map, item-shrink),
+		()
+	);
 	$item-shrink: map-merge(
 		$item-shrink,
 		(

--- a/packages/clay-css/src/scss/mixins/_modals.scss
+++ b/packages/clay-css/src/scss/mixins/_modals.scss
@@ -24,7 +24,7 @@
 	@if (type-of($map) == 'map') {
 		$enabled: setter(map-get($map, enabled), true);
 
-		$header: setter(map-get($map, header), ());
+		$header: setter(map-get($map, modal-header), map-get($map, header), ());
 		$header: map-merge(
 			$header,
 			(
@@ -46,7 +46,11 @@
 			)
 		);
 
-		$header-close: setter(map-get($map, header-close), ());
+		$header-close: setter(
+			map-deep-get($map, header, close),
+			map-get($map, header-close),
+			()
+		);
 		$header-close: map-merge(
 			$header-close,
 			(
@@ -75,7 +79,7 @@
 			)
 		);
 
-		$body: setter(map-get($map, body), ());
+		$body: setter(map-get($map, modal-body), map-get($map, body), ());
 		$body: map-merge(
 			$body,
 			(
@@ -88,7 +92,7 @@
 			)
 		);
 
-		$footer: setter(map-get($map, footer), ());
+		$footer: setter(map-get($map, modal-footer), map-get($map, footer), ());
 		$footer: map-merge(
 			$footer,
 			(

--- a/packages/clay-css/src/scss/mixins/_panels.scss
+++ b/packages/clay-css/src/scss/mixins/_panels.scss
@@ -67,7 +67,7 @@
 			)
 		);
 
-		$header: setter(map-get($map, header), ());
+		$header: setter(map-get($map, panel-header), map-get($map, header), ());
 		$header: map-merge(
 			$header,
 			(
@@ -184,7 +184,7 @@
 		$header-link: setter(map-get($header, link), ());
 		$header-link: map-deep-merge($header-link, $old-header-link);
 
-		$title: setter(map-get($map, title), ());
+		$title: setter(map-get($map, panel-title), map-get($map, title), ());
 		$title: map-merge(
 			$title,
 			(
@@ -238,7 +238,7 @@
 			)
 		);
 
-		$body: setter(map-get($map, body), ());
+		$body: setter(map-get($map, panel-body), map-get($map, body), ());
 		$body: map-merge(
 			$body,
 			(
@@ -285,7 +285,7 @@
 			)
 		);
 
-		$footer: setter(map-get($map, footer), ());
+		$footer: setter(map-get($map, panel-footer), map-get($map, footer), ());
 		$footer: map-merge(
 			$footer,
 			(

--- a/packages/clay-css/src/scss/mixins/_tbar.scss
+++ b/packages/clay-css/src/scss/mixins/_tbar.scss
@@ -122,7 +122,8 @@
 			)
 		);
 
-		$item: setter(map-get($map, item), ());
+		$item: setter(map-get($map, tbar-item), ());
+		$item: map-merge($item, setter(map-get($map, item), ()));
 		$item: map-merge(
 			$item,
 			(
@@ -154,8 +155,9 @@
 			)
 		);
 
-		$btn: setter(map-get($map, btn), ());
-		$btn: map-merge(
+		$btn: setter(map-get($map, tbar-btn), ());
+		$btn: map-deep-merge($btn, setter(map-get($map, btn), ()));
+		$btn: map-deep-merge(
 			$btn,
 			(
 				height:
@@ -218,7 +220,11 @@
 			)
 		);
 
-		$btn-c-inner: setter(map-get($map, btn-c-inner), ());
+		$btn-c-inner: setter(map-get($btn, c-inner), ());
+		$btn-c-inner: map-merge(
+			$btn-c-inner,
+			setter(map-get($map, btn-c-inner), ())
+		);
 		$btn-c-inner: map-merge(
 			(
 				enabled: $enable-c-inner,
@@ -230,8 +236,12 @@
 			$btn-c-inner
 		);
 
-		$btn-monospaced: setter(map-get($map, btn-monospaced), ());
-		$btn-monospaced: map-merge(
+		$btn-monospaced: setter(map-get($map, tbar-btn-monospaced), ());
+		$btn-monospaced: map-deep-merge(
+			$btn-monospaced,
+			setter(map-get($map, btn-monospaced), ())
+		);
+		$btn-monospaced: map-deep-merge(
 			$btn-monospaced,
 			(
 				border-radius:
@@ -289,9 +299,10 @@
 			)
 		);
 
-		$btn-monospaced-c-inner: setter(
-			map-get($map, btn-monospaced-c-inner),
-			()
+		$btn-monospaced-c-inner: setter(map-get($btn-monospaced, c-inner), ());
+		$btn-monospaced-c-inner: map-merge(
+			$btn-monospaced-c-inner,
+			setter(map-get($map, btn-monospaced-c-inner), ())
 		);
 		$btn-monospaced-c-inner: map-merge(
 			(
@@ -301,8 +312,9 @@
 			$btn-monospaced-c-inner
 		);
 
-		$link: setter(map-get($map, link), ());
-		$link: map-merge(
+		$link: setter(map-get($map, tbar-link), ());
+		$link: map-deep-merge($link, setter(map-get($map, link), ()));
+		$link: map-deep-merge(
 			$link,
 			(
 				margin-bottom:
@@ -348,7 +360,11 @@
 			)
 		);
 
-		$link-c-inner: setter(map-get($map, link-c-inner), ());
+		$link-c-inner: setter(map-get($link, c-inner), ());
+		$link-c-inner: map-merge(
+			$link-c-inner,
+			setter(map-get($map, link-c-inner), ())
+		);
 		$link-c-inner: map-merge(
 			(
 				enabled: $enable-c-inner,
@@ -360,8 +376,12 @@
 			$link-c-inner
 		);
 
-		$link-monospaced: setter(map-get($map, link-monospaced), ());
-		$link-monospaced: map-merge(
+		$link-monospaced: setter(map-get($map, tbar-link-monospaced), ());
+		$link-monospaced: map-deep-merge(
+			$link-monospaced,
+			setter(map-get($map, link-monospaced), ())
+		);
+		$link-monospaced: map-deep-merge(
 			(
 				border-radius:
 					setter(
@@ -418,8 +438,12 @@
 		);
 
 		$link-monospaced-c-inner: setter(
-			map-get($map, link-monospaced-c-inner),
+			map-get($link-monospaced, c-inner),
 			()
+		);
+		$link-monospaced-c-inner: map-merge(
+			$link-monospaced-c-inner,
+			setter(map-get($map, link-monospaced-c-inner), ())
 		);
 		$link-monospaced-c-inner: map-merge(
 			(
@@ -429,7 +453,8 @@
 			$link-monospaced-c-inner
 		);
 
-		$section: setter(map-get($map, section), ());
+		$section: setter(map-get($map, tbar-section), ());
+		$section: map-merge($section, setter(map-get($map, section), ()));
 		$section: map-merge(
 			$section,
 			(
@@ -456,23 +481,66 @@
 		}
 
 		.tbar-nav {
-			@include clay-css(map-get($map, nav));
+			$tbar-nav: setter(map-get($map, tbar-nav), ());
+			$tbar-nav: map-merge($tbar-nav, setter(map-get($map, nav), ()));
+
+			@include clay-css($tbar-nav);
 		}
 
 		.tbar-item {
 			@include clay-css($item);
 		}
 
-		.tbar-divider-before::before {
-			@include clay-css(map-get($map, divider-before));
+		.tbar-divider-before {
+			$tbar-divider-before: setter(
+				map-get($map, tbar-divider-before),
+				()
+			);
+
+			@include clay-css($tbar-divider-before);
+
+			&::before {
+				$before: setter(map-get($tbar-divider-before, before), ());
+				$before: map-merge(
+					$before,
+					setter(map-get($map, divider-before), ())
+				);
+
+				@include clay-css($before);
+			}
+
+			&::after {
+				@include clay-css(map-get($tbar-divider-before, after));
+			}
 		}
 
 		.tbar-divider-after::after {
-			@include clay-css(map-get($map, divider-after));
+			$tbar-divider-after: setter(map-get($map, tbar-divider-after), ());
+
+			@include clay-css($tbar-divider-after);
+
+			&::before {
+				@include clay-css(map-get($tbar-divider-after, before));
+			}
+
+			&::after {
+				$after: setter(map-get($tbar-divider-after, after), ());
+				$after: map-merge(
+					$after,
+					setter(map-get($map, divider-after), ())
+				);
+
+				@include clay-css($after);
+			}
 		}
 
 		.tbar-item-expand {
-			@include clay-css(map-get($map, item-expand));
+			$tbar-item-expand: setter(map-get($map, tbar-item-expand), ());
+			$tbar-item-expand: map-merge(
+				$tbar-item-expand,
+				setter(map-get($map, item-expand), ())
+			);
+			@include clay-css($tbar-item-expand);
 		}
 
 		.tbar-btn {
@@ -540,7 +608,13 @@
 		}
 
 		.tbar-label {
-			@include clay-label-size(map-get($map, tbar-label-size));
+			$tbar-label: setter(map-get($map, tbar-label), ());
+			$tbar-label: map-merge(
+				$tbar-label,
+				setter(map-get($map, tbar-label-size), ())
+			);
+
+			@include clay-label-size($tbar-label);
 		}
 	}
 }
@@ -558,8 +632,24 @@
 @mixin clay-tbar-inline-down($map) {
 	@if (type-of($map) == 'map') {
 		$breakpoint-down: map-get($map, breakpoint-down);
-		$item-padding-left: map-get($map, item-padding-left);
-		$item-padding-right: map-get($map, item-padding-right);
+
+		$tbar-item: setter(map-get($map, tbar-item), ());
+		$tbar-item: map-merge(
+			$tbar-item,
+			(
+				display: setter(map-get($tbar-item, display), inline),
+				padding-left:
+					setter(
+						map-get($tbar-item, padding-left),
+						map-get($map, item-padding-left)
+					),
+				padding-right:
+					setter(
+						map-get($tbar-item, padding-right),
+						map-get($map, item-padding-right)
+					),
+			)
+		);
 
 		@if ($breakpoint-down) {
 			@include media-breakpoint-down($breakpoint-down) {
@@ -577,9 +667,7 @@
 				}
 
 				.tbar-item {
-					display: inline;
-					padding-left: $item-padding-left;
-					padding-right: $item-padding-right;
+					@include clay-css($tbar-item);
 				}
 			}
 		}

--- a/packages/clay-css/src/scss/variables/_clay-color.scss
+++ b/packages/clay-css/src/scss/variables/_clay-color.scss
@@ -109,10 +109,14 @@ $clay-color-dropdown-menu-close: () !default;
 $clay-color-dropdown-menu-component-action: () !default;
 $clay-color-dropdown-menu-component-action: map-deep-merge(
 	(
-		hover-bg: transparent,
-		hover-color: $black,
-		focus-box-shadow: $component-focus-box-shadow,
-		focus-color: $black,
+		hover: (
+			background-color: transparent,
+			color: $black,
+		),
+		focus: (
+			box-shadow: $component-focus-box-shadow,
+			color: $black,
+		),
 	),
 	$clay-color-dropdown-menu-component-action
 );
@@ -175,7 +179,7 @@ $clay-color-btn-bordered: map-deep-merge(
 $clay-color-pointer: () !default;
 $clay-color-pointer: map-deep-merge(
 	(
-		bg: transparent,
+		background-color: setter(map-get($clay-color-pointer, bg), transparent),
 		border-radius: 100px,
 		border-color: $white,
 		border-style: solid,
@@ -188,8 +192,10 @@ $clay-color-pointer: map-deep-merge(
 		position: absolute,
 		transition: box-shadow 0.15s ease-in-out,
 		width: 0.875rem,
-		focus-box-shadow: $component-focus-box-shadow,
-		focus-outline: 0,
+		focus: (
+			box-shadow: $component-focus-box-shadow,
+			outline: 0,
+		),
 	),
 	$clay-color-pointer
 );

--- a/packages/clay-css/src/scss/variables/_date-picker.scss
+++ b/packages/clay-css/src/scss/variables/_date-picker.scss
@@ -31,12 +31,18 @@ $date-picker-nav-btn: map-deep-merge(
 	(
 		color: $gray-600,
 		transition: $component-transition,
-		hover-bg: $gray-200,
-		focus-box-shadow: $component-focus-box-shadow,
-		disabled-bg: transparent,
-		disabled-box-shadow: none,
-		disabled-color: $gray-600,
-		disabled-opacity: $component-disabled-opacity,
+		hover: (
+			background-color: $gray-200,
+		),
+		focus: (
+			box-shadow: $input-btn-focus-box-shadow,
+		),
+		disabled: (
+			background-color: transparent,
+			box-shadow: none,
+			color: $gray-600,
+			opacity: $component-disabled-opacity,
+		),
 	),
 	$date-picker-nav-btn
 );
@@ -169,7 +175,8 @@ $date-picker-calendar-item: () !default;
 $date-picker-calendar-item: map-deep-merge(
 	(
 		align-items: center,
-		bg: transparent,
+		background-color:
+			setter(map-get($date-picker-calendar-item, bg) transparent),
 		border-width: 0px,
 		disabled-cursor: $disabled-cursor,
 		display: inline-flex,
@@ -200,14 +207,22 @@ $date-picker-date: map-deep-merge(
 		color: $gray-600,
 		cursor: $link-cursor,
 		position: relative,
-		hover-bg: $gray-200,
-		focus-box-shadow: $component-focus-box-shadow,
-		focus-outline: 0,
-		active-bg: $component-active-bg,
-		active-color: $component-active-color,
-		disabled-bg: transparent,
-		disabled-box-shadow: none,
-		disabled-opacity: $component-disabled-opacity,
+		hover: (
+			background-color: $gray-200,
+		),
+		focus: (
+			box-shadow: $input-btn-focus-box-shadow,
+			outline: 0,
+		),
+		active: (
+			background-color: $component-active-bg,
+			color: $component-active-color,
+		),
+		disabled: (
+			background-color: transparent,
+			box-shadow: none,
+			opacity: $component-disabled-opacity,
+		),
 	),
 	$date-picker-date
 );
@@ -216,7 +231,9 @@ $date-picker-previous-month-date: () !default;
 $date-picker-previous-month-date: map-deep-merge(
 	(
 		opacity: 0.65,
-		focus-opacity: 1,
+		focus: (
+			opacity: 1,
+		),
 		active: (
 			background-color: $primary-l1,
 			color: $primary-l3,
@@ -229,7 +246,9 @@ $date-picker-next-month-date: () !default;
 $date-picker-next-month-date: map-deep-merge(
 	(
 		opacity: 0.65,
-		focus-opacity: 1,
+		focus: (
+			opacity: 1,
+		),
 		active: (
 			background-color: $primary-l1,
 			color: $primary-l3,
@@ -243,7 +262,8 @@ $date-picker-next-month-date: map-deep-merge(
 $date-picker-input-group-text: () !default;
 $date-picker-input-group-text: map-deep-merge(
 	(
-		bg: transparent,
+		background-color:
+			setter(map-get($date-picker-input-group-text, bg) transparent),
 		border-color: transparent,
 		min-width: 2rem,
 		padding-left: 0.25rem,

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -2069,9 +2069,13 @@ $input-group-stacked-sm-down: () !default;
 $input-group-stacked-sm-down: map-deep-merge(
 	(
 		breakpoint: sm,
-		item-margin-bottom: 0.5rem,
-		item-margin-left: 0,
-		shrink-margin-right: 0.5rem,
+		input-group-item: (
+			margin-bottom: 0.5rem,
+			margin-left: 0,
+		),
+		input-group-item-shrink: (
+			margin-right: 0.5rem,
+		),
 	),
 	$input-group-stacked-sm-down
 );

--- a/packages/clay-css/src/scss/variables/_modals.scss
+++ b/packages/clay-css/src/scss/variables/_modals.scss
@@ -262,14 +262,22 @@ $modal-height-full-modal-content-sm-up: map-merge(
 $modal-success: () !default;
 $modal-success: map-deep-merge(
 	(
-		header-bg: theme-color-level(success, -10),
-		header-border-color: theme-color-level(success, -9),
-		header-color: theme-color-level(success, 6),
-		header-close: (
+		modal-header: (
+			background-color: theme-color-level(success, -10),
+			border-color: theme-color-level(success, -9),
 			color: theme-color-level(success, 6),
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: theme-color-level(success, 6),
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$modal-success
@@ -280,14 +288,22 @@ $modal-success: map-deep-merge(
 $modal-info: () !default;
 $modal-info: map-deep-merge(
 	(
-		header-bg: theme-color-level(info, -10),
-		header-border-color: theme-color-level(info, -9),
-		header-color: theme-color-level(info, 6),
-		header-close: (
+		modal-header: (
+			background-color: theme-color-level(info, -10),
+			border-color: theme-color-level(info, -9),
 			color: theme-color-level(info, 6),
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: theme-color-level(info, 6),
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$modal-info
@@ -298,14 +314,22 @@ $modal-info: map-deep-merge(
 $modal-warning: () !default;
 $modal-warning: map-deep-merge(
 	(
-		header-bg: theme-color-level(warning, -10),
-		header-border-color: theme-color-level(warning, -9),
-		header-color: theme-color-level(warning, 6),
-		header-close: (
+		modal-header: (
+			background-color: theme-color-level(warning, -10),
+			border-color: theme-color-level(warning, -9),
 			color: theme-color-level(warning, 6),
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: theme-color-level(warning, 6),
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$modal-warning
@@ -316,14 +340,22 @@ $modal-warning: map-deep-merge(
 $modal-danger: () !default;
 $modal-danger: map-deep-merge(
 	(
-		header-bg: theme-color-level(danger, -10),
-		header-border-color: theme-color-level(danger, -9),
-		header-color: theme-color-level(danger, 6),
-		header-close: (
+		modal-header: (
+			background-color: theme-color-level(danger, -10),
+			border-color: theme-color-level(danger, -9),
 			color: theme-color-level(danger, 6),
-			hover-color: inherit,
-			focus-color: inherit,
-			disabled-color: inherit,
+			close: (
+				color: theme-color-level(danger, 6),
+				hover: (
+					color: inherit,
+				),
+				focus: (
+					color: inherit,
+				),
+				disabled: (
+					color: inherit,
+				),
+			),
 		),
 	),
 	$modal-danger

--- a/packages/clay-css/src/scss/variables/_panels.scss
+++ b/packages/clay-css/src/scss/variables/_panels.scss
@@ -114,11 +114,11 @@ $panel-group-sm: () !default;
 $panel-group-sm: map-deep-merge(
 	(
 		font-size: 0.875rem,
-		header: (
+		panel-header: (
 			padding-bottom: 0.5rem,
 			padding-top: 0.5rem,
 		),
-		title: (
+		panel-title: (
 			font-size: 0.875rem,
 		),
 		collapse-icon: (
@@ -150,7 +150,7 @@ $panel-group-flush-panel-unstyled: () !default;
 $panel-group-flush-panel-unstyled: map-deep-merge(
 	(
 		margin-bottom: 1.5rem,
-		body: (
+		panel-body: (
 			margin-bottom: 0,
 		),
 	),
@@ -165,12 +165,12 @@ $panel-secondary: () !default;
 $panel-secondary: map-deep-merge(
 	(
 		border-color: rgba($black, 0.125),
-		header: (
+		panel-header: (
 			background-color: $gray-100,
 			border-color: rgba($black, 0.125),
 			link: $panel-secondary-header-link,
 		),
-		footer: (
+		panel-footer: (
 			background-color: $gray-100,
 			border-color: rgba($black, 0.125),
 		),
@@ -189,7 +189,7 @@ $panel-unstyled: map-deep-merge(
 		border-radius: 0px,
 		border-width: 0px,
 		margin-bottom: 1.5rem,
-		header: (
+		panel-header: (
 			border-color: $gray-500,
 			border-radius: 0px,
 			border-style: solid,
@@ -203,10 +203,10 @@ $panel-unstyled: map-deep-merge(
 		collapse-icon: (
 			right: 0,
 		),
-		body: (
+		panel-body: (
 			padding: 1rem 0 0.1px 0,
 		),
-		footer: (
+		panel-footer: (
 			padding: 1rem 0 0.1px 0,
 		),
 	),

--- a/packages/clay-css/src/scss/variables/_progress-bars.scss
+++ b/packages/clay-css/src/scss/variables/_progress-bars.scss
@@ -66,20 +66,36 @@ $progress-palette: () !default;
 $progress-palette: map-deep-merge(
 	(
 		success: (
-			bar-bg: $progress-bar-success-bg,
-			group-feedback-color: $progress-group-feedback-success-color,
+			progress-bar: (
+				background-color: $progress-bar-success-bg,
+			),
+			progress-group-feedback: (
+				color: $progress-group-feedback-success-color,
+			),
 		),
 		info: (
-			bar-bg: $progress-bar-info-bg,
-			group-feedback-color: $progress-group-feedback-info-color,
+			progress-bar: (
+				background-color: $progress-bar-info-bg,
+			),
+			progress-group-feedback: (
+				color: $progress-group-feedback-info-color,
+			),
 		),
 		warning: (
-			bar-bg: $progress-bar-warning-bg,
-			group-feedback-color: $progress-group-feedback-warning-color,
+			progress-bar: (
+				background-color: $progress-bar-warning-bg,
+			),
+			progress-group-feedback: (
+				color: $progress-group-feedback-warning-color,
+			),
 		),
 		danger: (
-			bar-bg: $progress-bar-danger-bg,
-			group-feedback-color: $progress-group-feedback-danger-color,
+			progress-bar: (
+				background-color: $progress-bar-danger-bg,
+			),
+			progress-group-feedback: (
+				color: $progress-group-feedback-danger-color,
+			),
 		),
 	),
 	$progress-palette

--- a/packages/clay-css/src/scss/variables/_tbar.scss
+++ b/packages/clay-css/src/scss/variables/_tbar.scss
@@ -10,39 +10,43 @@ $tbar-stacked: map-deep-merge(
 		height: 100%,
 		padding-bottom: 0.5rem,
 		padding-top: 0.5rem,
-		nav: (
+		tbar-nav: (
 			flex-direction: column,
 			min-width: 0,
 		),
-		item: (
+		tbar-item: (
 			align-items: center,
 			justify-content: flex-start,
 			padding-left: 0,
 			padding-right: 0,
 		),
-		item-expand: (
+		tbar-item-expand: (
 			flex-shrink: 0,
 			min-width: 0,
 		),
-		divider-before: (
-			background-color: $body-color,
-			content: '',
-			display: block,
-			height: 1px,
-			margin-bottom: 0.25rem,
-			margin-top: 0.25rem,
-			width: 2.5rem,
+		tbar-divider-before: (
+			before: (
+				background-color: $body-color,
+				content: '',
+				display: block,
+				height: 1px,
+				margin-bottom: 0.25rem,
+				margin-top: 0.25rem,
+				width: 2.5rem,
+			),
 		),
-		divider-after: (
-			background-color: $body-color,
-			content: '',
-			display: block,
-			height: 1px,
-			margin-bottom: 0.25rem,
-			margin-top: 0.25rem,
-			width: 2.5rem,
+		tbar-divider-after: (
+			after: (
+				background-color: $body-color,
+				content: '',
+				display: block,
+				height: 1px,
+				margin-bottom: 0.25rem,
+				margin-top: 0.25rem,
+				width: 2.5rem,
+			),
 		),
-		btn-monospaced: (
+		tbar-btn-monospaced: (
 			border-color: transparent,
 			border-radius: 0px,
 			border-width: 0px,
@@ -76,7 +80,9 @@ $tbar-inline-xs-down: () !default;
 $tbar-inline-xs-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($grid-breakpoints), 1),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$tbar-inline-xs-down
 );
@@ -85,7 +91,9 @@ $tbar-inline-sm-down: () !default;
 $tbar-inline-sm-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($grid-breakpoints), 2),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$tbar-inline-sm-down
 );
@@ -94,7 +102,9 @@ $tbar-inline-md-down: () !default;
 $tbar-inline-md-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($grid-breakpoints), 3),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$tbar-inline-md-down
 );
@@ -103,7 +113,9 @@ $tbar-inline-lg-down: () !default;
 $tbar-inline-lg-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($grid-breakpoints), 4),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$tbar-inline-lg-down
 );
@@ -112,7 +124,9 @@ $tbar-inline-xl-down: () !default;
 $tbar-inline-xl-down: map-deep-merge(
 	(
 		breakpoint-down: nth(map-keys($grid-breakpoints), 5),
-		item-padding-left: 0,
+		tbar-item: (
+			padding-left: 0,
+		),
 	),
 	$tbar-inline-xl-down
 );
@@ -139,13 +153,17 @@ $tbar-light: map-deep-merge(
 		box-shadow: #{inset 1px 0 0 0 $gray-200,
 		inset -1px 0 0 0 $gray-200},
 		color: $secondary,
-		divider-before: (
-			background-color: $gray-200,
+		tbar-divider-before: (
+			before: (
+				background-color: $gray-200,
+			),
 		),
-		divider-after: (
-			background-color: $gray-200,
+		tbar-divider-after: (
+			after: (
+				background-color: $gray-200,
+			),
 		),
-		btn-monospaced: (
+		tbar-btn-monospaced: (
 			hover: (
 				color: $dark,
 			),
@@ -171,13 +189,17 @@ $tbar-dark-d1: map-deep-merge(
 		box-shadow: #{inset 1px 0 0 0 rgba($white, 0.06),
 		inset -1px 0 0 0 rgba($white, 0.06)},
 		color: $gray-500,
-		divider-before: (
-			background-color: rgba($white, 0.06),
+		tbar-divider-before: (
+			before: (
+				background-color: rgba($white, 0.06),
+			),
 		),
-		divider-after: (
-			background-color: rgba($white, 0.06),
+		tbar-divider-after: (
+			after: (
+				background-color: rgba($white, 0.06),
+			),
 		),
-		btn-monospaced: (
+		tbar-btn-monospaced: (
 			hover: (
 				color: $white,
 			),
@@ -191,15 +213,17 @@ $tbar-dark-d1: map-deep-merge(
 				background-color: rgba($white, 0.06),
 				color: $white,
 			),
-			active-class-after: (
-				background-color: $primary-l1,
-				bottom: 0,
-				content: '',
-				display: block,
-				left: 0,
-				position: absolute,
-				top: 0,
-				width: 0.25rem,
+			active-class: (
+				after: (
+					background-color: $primary-l1,
+					bottom: 0,
+					content: '',
+					display: block,
+					left: 0,
+					position: absolute,
+					top: 0,
+					width: 0.25rem,
+				),
 			),
 		),
 	),
@@ -214,13 +238,17 @@ $tbar-dark-l2: map-deep-merge(
 		inset -1px 0 0 0 rgba($white, 0.06)},
 		border-color: rgba($white, 0.06),
 		color: $gray-500,
-		divider-before: (
-			background-color: rgba($white, 0.06),
+		tbar-divider-before: (
+			before: (
+				background-color: rgba($white, 0.06),
+			),
 		),
-		divider-after: (
-			background-color: rgba($white, 0.06),
+		tbar-divider-after: (
+			after: (
+				background-color: rgba($white, 0.06),
+			),
 		),
-		btn-monospaced: (
+		tbar-btn-monospaced: (
 			hover: (
 				color: $white,
 			),
@@ -259,8 +287,13 @@ $subnav-tbar-component-link: () !default;
 $subnav-tbar-component-link: map-deep-merge(
 	(
 		color: $link-color,
-		hover-color: $link-hover-color,
 		font-weight: $font-weight-semi-bold,
+		hover: (
+			color: $link-hover-color,
+		),
+		disabled: (
+			box-shadow: none,
+		),
 	),
 	$subnav-tbar-component-link
 );
@@ -281,26 +314,49 @@ $subnav-tbar: () !default;
 $subnav-tbar: map-deep-merge(
 	(
 		font-size: 0.875rem,
-		section-text-align: left,
-		strong-font-weight: $font-weight-semi-bold,
-		item-padding-x: 0.5rem,
-		btn-height: 1.5rem,
-		btn-line-height: 1,
-		btn-margin-y: 0.125rem,
-		btn-padding-y: 0,
-		btn-monospaced-margin-y: 0.125rem,
-		btn-monospaced-padding: 0.25rem,
+		tbar-section: (
+			text-align: left,
+		),
+		strong: (
+			font-weight: $font-weight-semi-bold,
+		),
+		tbar-item: (
+			padding-left: 0.5rem,
+			padding-right: 0.5rem,
+		),
+		tbar-btn: (
+			height: 1.5rem,
+			line-height: 1,
+			margin-bottom: 0.125rem,
+			margin-top: 0.125rem,
+			padding-left: 0,
+			padding-right: 0,
+		),
+		tbar-btn-monospaced: (
+			margin-bottom: 0.125rem,
+			margin-top: 0.125rem,
+			padding: 0.25rem,
+		),
 		component-link: $subnav-tbar-component-link,
 		component-title: $subnav-tbar-component-title,
 		component-text: $subnav-tbar-component-text,
 		component-label: (
 			font-weight: $font-weight-normal,
 		),
-		link-margin-y: 0.125rem,
-		link-padding-x: 0.25rem,
-		link-padding-y: 0.09375rem,
-		link-monospaced-margin-y: 0.125rem,
-		link-monospaced-size: 1.5rem,
+		tbar-link: (
+			margin-bottom: 0.125rem,
+			margin-top: 0.125rem,
+			padding-bottom: 0.09375rem,
+			padding-left: 0.25rem,
+			padding-right: 0.25rem,
+			padding-top: 0.09375rem,
+		),
+		tbar-link-monospaced: (
+			height: 1.5rem,
+			margin-bottom: 0.125rem,
+			margin-top: 0.125rem,
+			width: 1.5rem,
+		),
 	),
 	$subnav-tbar
 );
@@ -310,14 +366,15 @@ $subnav-tbar: map-deep-merge(
 $subnav-tbar-light: () !default;
 $subnav-tbar-light: map-deep-merge(
 	(
-		bg-color: $light,
+		background-color: setter(map-get($subnav-tbar-light, bg-color), $light),
 		color:
 			if(
 				variable-exists(navbar-light-color),
 				$navbar-light-color,
 				rgba($black, 0.5)
 			),
-		padding-y: 0.125rem,
+		padding-bottom: 0.125rem,
+		padding-top: 0.125rem,
 	),
 	$subnav-tbar-light
 );
@@ -328,11 +385,15 @@ $subnav-tbar-primary-component-link: () !default;
 $subnav-tbar-primary-component-link: map-deep-merge(
 	(
 		color: $gray-900,
-		hover-color: $gray-900,
-		disabled-color: $gray-600,
-		disabled-cursor: $disabled-cursor,
-		disabled-opacity: $component-disabled-opacity,
-		disabled-text-decoration: none,
+		hover: (
+			color: $gray-900,
+		),
+		disabled: (
+			color: $gray-600,
+			cursor: $disabled-cursor,
+			opacity: $component-disabled-opacity,
+			text-decoration: none,
+		),
 	),
 	$subnav-tbar-primary-component-link
 );
@@ -340,9 +401,13 @@ $subnav-tbar-primary-component-link: map-deep-merge(
 $subnav-tbar-primary-component-label-close: () !default;
 $subnav-tbar-primary-component-label-close: map-deep-merge(
 	(
-		focus-color: inherit,
-		disabled-color: $gray-600,
-		disabled-opacity: $component-disabled-opacity,
+		focus: (
+			color: inherit,
+		),
+		disabled: (
+			color: $gray-600,
+			opacity: $component-disabled-opacity,
+		),
 	),
 	$subnav-tbar-primary-component-label-close
 );
@@ -360,8 +425,10 @@ $subnav-tbar-primary-tbar-label-size: map-deep-merge(
 	(
 		font-size: 0.75rem,
 		margin-right: 0,
-		padding-x: 0.625rem,
-		padding-y: 0.3125rem,
+		padding-bottom: 0.3125rem,
+		padding-left: 0.625rem,
+		padding-right: 0.625rem,
+		padding-top: 0.3125rem,
 		text-transform: none,
 	),
 	$subnav-tbar-primary-tbar-label-size
@@ -370,18 +437,28 @@ $subnav-tbar-primary-tbar-label-size: map-deep-merge(
 $subnav-tbar-primary: () !default;
 $subnav-tbar-primary: map-deep-merge(
 	(
-		bg-color: $primary-l2,
-		padding-x: 0.25rem,
-		padding-y: 0.625rem,
-		item-justify-content: flex-start,
-		item-padding-x: 0.25rem,
-		link-monospaced-border-radius: 0px,
-		link-monospaced-border-width: 0px,
-		link-monospaced-margin-y: -0.625rem,
-		link-monospaced-size: 3rem,
+		background-color:
+			setter(map-get($subnav-tbar-primary, bg-color), $primary-l2),
+		padding-bottom: 0.625rem,
+		padding-left: 0.25rem,
+		padding-right: 0.25rem,
+		padding-top: 0.625rem,
+		tbar-item: (
+			justify-content: flex-start,
+			padding-left: 0.25rem,
+			padding-right: 0.25rem,
+		),
+		tbar-link-monospaced: (
+			border-radius: 0px,
+			border-width: 0px,
+			height: 3rem,
+			margin-bottom: -0.625rem,
+			margin-top: -0.625rem,
+			width: 3rem,
+		),
 		component-link: $subnav-tbar-primary-component-link,
 		component-label: $subnav-tbar-primary-component-label,
-		tbar-label-size: $subnav-tbar-primary-tbar-label-size,
+		tbar-label: $subnav-tbar-primary-tbar-label-size,
 	),
 	$subnav-tbar-primary
 );
@@ -399,7 +476,11 @@ $subnav-tbar-primary-disabled-component-label: map-deep-merge(
 $subnav-tbar-primary-disabled: () !default;
 $subnav-tbar-primary-disabled: map-deep-merge(
 	(
-		bg-color: clay-lighten(clay-desaturate($primary, 27.03), 37.06),
+		background-color:
+			setter(
+				map-get($subnav-tbar-primary-disabled, bg-color),
+				clay-lighten(clay-desaturate($primary, 27.03), 37.06)
+			),
 		color: #6c757d,
 		component-label: $subnav-tbar-primary-disabled-component-label,
 	),


### PR DESCRIPTION
fixes #5217

Everything should be backward compatible.