### PR TITLE
docs: Adds `aria-label` and `title` to documentation examples

### DIFF
--- a/packages/clay-breadcrumb/docs/index.js
+++ b/packages/clay-breadcrumb/docs/index.js
@@ -14,6 +14,7 @@ const BreadcrumbCode = `const Component = () => {
 	return (
 		<ClayBreadcrumb
 			ellipsisBuffer={1}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			items={[
 				{
 					active: true,

--- a/packages/clay-breadcrumb/docs/markup-breadcrumb.md
+++ b/packages/clay-breadcrumb/docs/markup-breadcrumb.md
@@ -98,7 +98,7 @@ Use `<span class="breadcrumb-text-truncate"></span>` inside breadcrumb links to 
 <div class="sheet-example">
     <ol class="breadcrumb">
         <li class="breadcrumb-item dropdown">
-            <a aria-expanded="false" aria-haspopup="true" class="breadcrumb-link dropdown-toggle" data-toggle="dropdown" href="" id="breadcrumb2Dropdown1" role="button">
+            <a aria-expanded="false" aria-label="More" aria-haspopup="true" class="breadcrumb-link dropdown-toggle" data-toggle="dropdown" href="" id="breadcrumb2Dropdown1" role="button">
                 <svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
                     <use href="/images/icons/icons.svg#ellipsis-h"></use>
                 </svg>
@@ -132,6 +132,7 @@ Use `<span class="breadcrumb-text-truncate"></span>` inside breadcrumb links to 
 <ol class="breadcrumb">
 	<li class="breadcrumb-item dropdown">
 		<a
+			aria-label="More"
 			aria-expanded="false"
 			aria-haspopup="true"
 			class="breadcrumb-link dropdown-toggle"
@@ -216,7 +217,7 @@ Use `<span class="breadcrumb-text-truncate"></span>` inside breadcrumb links to 
             </ul>
         </li>
         <li class="breadcrumb-item dropdown">
-            <button aria-expanded="false" aria-haspopup="true" class="breadcrumb-link btn btn-unstyled dropdown-toggle" data-toggle="dropdown" id="breadcrumb2Dropdown2" type="button">
+            <button aria-expanded="false" aria-label="More" aria-haspopup="true" class="breadcrumb-link btn btn-unstyled dropdown-toggle" data-toggle="dropdown" id="breadcrumb2Dropdown2" type="button">
                 <svg class="lexicon-icon lexicon-icon-ellipsis-h" focusable="false" role="presentation">
                     <use href="/images/icons/icons.svg#ellipsis-h"></use>
                 </svg>
@@ -309,6 +310,7 @@ Use `<span class="breadcrumb-text-truncate"></span>` inside breadcrumb links to 
 	</li>
 	<li class="breadcrumb-item dropdown">
 		<button
+			aria-label="More"
 			aria-expanded="false"
 			aria-haspopup="true"
 			class="breadcrumb-link btn btn-unstyled dropdown-toggle"

--- a/packages/clay-breadcrumb/src/Ellipsis.tsx
+++ b/packages/clay-breadcrumb/src/Ellipsis.tsx
@@ -22,21 +22,24 @@ interface IEllipsisProps extends React.HTMLAttributes<HTMLLIElement> {
 	spritemap?: string;
 }
 
-const Ellipsis = ({items, spritemap, ...otherProps}: IEllipsisProps) => (
+const Ellipsis = ({items, spritemap, title, ...otherProps}: IEllipsisProps) => (
 	<ClayDropDown
 		className="breadcrumb-item"
 		containerElement="li"
 		trigger={
 			<ClayButton
+				aria-label={otherProps['aria-label']}
 				className="breadcrumb-link"
 				data-testid="breadcrumbDropdownTrigger"
 				displayType="unstyled"
+				title={title}
 			>
 				<ClayIcon spritemap={spritemap} symbol="ellipsis-h" />
 				<ClayIcon spritemap={spritemap} symbol="caret-bottom" />
 			</ClayButton>
 		}
 		{...otherProps}
+		aria-label={undefined}
 	>
 		<ClayDropDown.ItemList>
 			{items.map(({href, label, onClick}, i) => (

--- a/packages/clay-breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/clay-breadcrumb/stories/Breadcrumb.stories.tsx
@@ -15,6 +15,7 @@ export default {
 export const Default = (args: any) => (
 	<ClayBreadcrumb
 		ellipsisBuffer={args.ellipsisBuffer}
+		ellipsisProps={{'aria-label': 'More', title: 'More'}}
 		items={[
 			{
 				active: true,
@@ -75,6 +76,7 @@ export const Buttons = (args: any) => {
 	return (
 		<ClayBreadcrumb
 			ellipsisBuffer={args.ellipsisBuffer}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			items={[
 				{
 					active: true,
@@ -161,5 +163,11 @@ export const ActiveState = () => {
 		},
 	];
 
-	return <ClayBreadcrumb ellipsisBuffer={1} items={items} />;
+	return (
+		<ClayBreadcrumb
+			ellipsisBuffer={1}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
+			items={items}
+		/>
+	);
 };

--- a/packages/clay-button/docs/index.js
+++ b/packages/clay-button/docs/index.js
@@ -107,7 +107,7 @@ import ClayIcon from '@clayui/icon;`;
 const ButtonIconCode = `const Component = () => {
 	return (
 		<>
-			<ClayButtonWithIcon spritemap={spritemap} symbol="times" />
+			<ClayButtonWithIcon aria-label="Close" spritemap={spritemap} symbol="times" title="Close" />
 
 			<br />
 			<br />

--- a/packages/clay-button/docs/markup-button.md
+++ b/packages/clay-button/docs/markup-button.md
@@ -185,36 +185,36 @@ Try adding the modifier class `.btn-monospaced`.
 
 <div class="sheet-example">
 	<div class="mb-2">
-		<button class="btn btn-monospaced btn-primary btn-xs" type="button">
+		<button aria-label="Blogs" title="Blogs" class="btn btn-monospaced btn-primary btn-xs" type="button">
 			<svg class="lexicon-icon lexicon-icon-blogs" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#blogs"></use>
 			</svg>
 		</button>
-		<button class="btn btn-monospaced btn-secondary btn-xs" type="button">
+		<button aria-label="Blogs" title="Blogs" class="btn btn-monospaced btn-secondary btn-xs" type="button">
 			<svg class="lexicon-icon lexicon-icon-blogs" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#blogs"></use>
 			</svg>
 		</button>
 	</div>
 	<div class="mb-2">
-		<button class="btn btn-monospaced btn-primary btn-sm" type="button">
+		<button aria-label="Blogs" title="Blogs" class="btn btn-monospaced btn-primary btn-sm" type="button">
 			<svg class="lexicon-icon lexicon-icon-blogs" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#blogs"></use>
 			</svg>
 		</button>
-		<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+		<button aria-label="Blogs" title="Blogs" class="btn btn-monospaced btn-secondary btn-sm" type="button">
 			<svg class="lexicon-icon lexicon-icon-blogs" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#blogs"></use>
 			</svg>
 		</button>
 	</div>
 	<div>
-		<button class="btn btn-monospaced btn-primary" type="button">
+		<button aria-label="Blogs" title="Blogs" class="btn btn-monospaced btn-primary" type="button">
 			<svg class="lexicon-icon lexicon-icon-blogs" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#blogs"></use>
 			</svg>
 		</button>
-		<button class="btn btn-monospaced btn-secondary" type="button">
+		<button aria-label="Blogs" title="Blogs" class="btn btn-monospaced btn-secondary" type="button">
 			<svg class="lexicon-icon lexicon-icon-blogs" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#blogs"></use>
 			</svg>
@@ -223,7 +223,12 @@ Try adding the modifier class `.btn-monospaced`.
 </div>
 
 ```html
-<button class="btn btn-monospaced btn-primary btn-xs" type="button">
+<button
+	aria-label="Blogs"
+	title="Blogs"
+	class="btn btn-monospaced btn-primary btn-xs"
+	type="button"
+>
 	<svg
 		class="lexicon-icon lexicon-icon-blogs"
 		focusable="false"
@@ -233,7 +238,12 @@ Try adding the modifier class `.btn-monospaced`.
 	</svg>
 </button>
 
-<button class="btn btn-monospaced btn-secondary btn-xs" type="button">
+<button
+	aria-label="Blogs"
+	title="Blogs"
+	class="btn btn-monospaced btn-secondary btn-xs"
+	type="button"
+>
 	<svg
 		class="lexicon-icon lexicon-icon-blogs"
 		focusable="false"
@@ -243,7 +253,12 @@ Try adding the modifier class `.btn-monospaced`.
 	</svg>
 </button>
 
-<button class="btn btn-monospaced btn-primary btn-sm" type="button">
+<button
+	aria-label="Blogs"
+	title="Blogs"
+	class="btn btn-monospaced btn-primary btn-sm"
+	type="button"
+>
 	<svg
 		class="lexicon-icon lexicon-icon-blogs"
 		focusable="false"
@@ -253,7 +268,12 @@ Try adding the modifier class `.btn-monospaced`.
 	</svg>
 </button>
 
-<button class="btn btn-monospaced btn-secondary btn-sm" type="button">
+<button
+	aria-label="Blogs"
+	title="Blogs"
+	class="btn btn-monospaced btn-secondary btn-sm"
+	type="button"
+>
 	<svg
 		class="lexicon-icon lexicon-icon-blogs"
 		focusable="false"
@@ -263,7 +283,12 @@ Try adding the modifier class `.btn-monospaced`.
 	</svg>
 </button>
 
-<button class="btn btn-monospaced btn-primary" type="button">
+<button
+	aria-label="Blogs"
+	title="Blogs"
+	class="btn btn-monospaced btn-primary"
+	type="button"
+>
 	<svg
 		class="lexicon-icon lexicon-icon-blogs"
 		focusable="false"
@@ -273,7 +298,12 @@ Try adding the modifier class `.btn-monospaced`.
 	</svg>
 </button>
 
-<button class="btn btn-monospaced btn-secondary" type="button">
+<button
+	aria-label="Blogs"
+	title="Blogs"
+	class="btn btn-monospaced btn-secondary"
+	type="button"
+>
 	<svg
 		class="lexicon-icon lexicon-icon-blogs"
 		focusable="false"

--- a/packages/clay-card/docs/markup-card.md
+++ b/packages/clay-card/docs/markup-card.md
@@ -1090,7 +1090,7 @@ Just add `image-card` class on the same element that `card` class have being add
 						</div>
 						<div class="autofit-col">
 							<div class="dropdown dropdown-action">
-								<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+								<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
                                     <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                                         <use href="/images/icons/icons.svg#ellipsis-v"></use>
                                     </svg>
@@ -1336,7 +1336,7 @@ To make the whole card clickable just wrap the checkbox and card in:
                             </div>
                             <div class="autofit-col">
                                 <div class="dropdown dropdown-action">
-                                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+                                    <a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
                                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#ellipsis-v"></use>
                                         </svg>
@@ -1354,7 +1354,7 @@ To make the whole card clickable just wrap the checkbox and card in:
         </div>
         <div class="col-md-8">
             <div class="card-type-directory form-check form-check-card form-check-middle-left">
-                <label class="form-check-label">
+                <label class="form-check-labe#l">
                     <input class="form-check-input" type="checkbox">
                     <div class="card card-horizontal">
                         <div class="card-body">
@@ -1379,7 +1379,7 @@ To make the whole card clickable just wrap the checkbox and card in:
                                 </div>
                                 <div class="autofit-col">
                                     <div class="dropdown dropdown-action">
-                                        <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+                                        <a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
                                             <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                                                 <use href="/images/icons/icons.svg#ellipsis-v"></use>
                                             </svg>
@@ -2756,7 +2756,7 @@ A predefined `card-page` column used in Liferay Portal's card view layouts, gene
 							</div>
 							<div class="autofit-col">
 								<div class="dropdown dropdown-action">
-									<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+									<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
 										<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 											<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
 										</svg>
@@ -2812,7 +2812,7 @@ A predefined `card-page` column used in Liferay Portal's card view layouts, gene
 							</div>
 							<div class="autofit-col">
 								<div class="dropdown dropdown-action">
-									<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+									<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
 										<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 											<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
 										</svg>
@@ -2868,7 +2868,7 @@ A predefined `card-page` column used in Liferay Portal's card view layouts, gene
 							</div>
 							<div class="autofit-col">
 								<div class="dropdown dropdown-action">
-									<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+									<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
 										<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 											<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
 										</svg>
@@ -2924,7 +2924,7 @@ A predefined `card-page` column used in Liferay Portal's card view layouts, gene
 							</div>
 							<div class="autofit-col">
 								<div class="dropdown dropdown-action">
-									<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+									<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
 										<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 											<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
 										</svg>
@@ -2991,7 +2991,7 @@ A predefined `card-page` column used in Liferay Portal's card view layouts, gene
 									</div>
 									<div class="autofit-col">
 										<div class="dropdown dropdown-action">
-											<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+											<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
 												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
 												</svg>
@@ -3042,7 +3042,7 @@ A predefined `card-page` column used in Liferay Portal's card view layouts, gene
 									</div>
 									<div class="autofit-col">
 										<div class="dropdown dropdown-action">
-											<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+											<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
 												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
 												</svg>
@@ -3093,7 +3093,7 @@ A predefined `card-page` column used in Liferay Portal's card view layouts, gene
 									</div>
 									<div class="autofit-col">
 										<div class="dropdown dropdown-action">
-											<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+											<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
 												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
 												</svg>
@@ -3144,7 +3144,7 @@ A predefined `card-page` column used in Liferay Portal's card view layouts, gene
 									</div>
 									<div class="autofit-col">
 										<div class="dropdown dropdown-action">
-											<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
+											<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" role="button">
 												<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 													<use xlink:href="/images/icons/icons.svg#ellipsis-v" />
 												</svg>

--- a/packages/clay-drop-down/docs/markup-dropdown.md
+++ b/packages/clay-drop-down/docs/markup-dropdown.md
@@ -1693,7 +1693,7 @@ A monospaced `dropdown-toggle` for a dropdown containing several actions, add `d
 
 <div class="sheet-example">
 	<div class="dropdown dropdown-action">
-		<a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+		<a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
 			<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#ellipsis-v"></use>
 			</svg>
@@ -1743,7 +1743,7 @@ A monospaced `dropdown-toggle` for a dropdown containing several actions, add `d
 
 <div class="sheet-example">
 	<div class="dropdown dropdown-action">
-		<button aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" id="dropdownBtnAction1" type="button">
+		<button aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" id="dropdownBtnAction1" type="button">
 			<svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#ellipsis-v"></use>
 			</svg>

--- a/packages/clay-label/docs/index.js
+++ b/packages/clay-label/docs/index.js
@@ -16,6 +16,8 @@ const LabelCode = `const Component = () => {
 		<ClayLabel
 			closeButtonProps={
 				{
+					'aria-label': 'Close',
+					title: 'Close',
 					onClick: () => setVisible(val => !val)
 				}
 			}
@@ -40,11 +42,11 @@ const labelClosingActionsImportsCode = `import ClayLabel from '@clayui/label';`;
 
 const LabelClosingActionsCode = `const Component = () => (
 	<ClayLabel
-		closeButtonProps={
-			{
-				id: 'closeId'
-			}
-		}
+		closeButtonProps={{
+			'aria-label': 'Close',
+			title: 'Close',
+			id: 'closeId'
+		}}
 		displayType="success"
 		spritemap={spritemap}
 	>

--- a/packages/clay-link/docs/markup-link.md
+++ b/packages/clay-link/docs/markup-link.md
@@ -205,28 +205,28 @@ Use these patterns for actions in components.
 ## Monospaced(#css-monospaced)
 
 <div class="sheet-example">
-	<a class="link-monospaced link-outline link-outline-primary" href="#1">
+	<a aria-label="Add cell" title="Add cell" class="link-monospaced link-outline link-outline-primary" href="#1">
 		<span class="inline-item">
 			<svg class="lexicon-icon lexicon-icon-add-cell" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#add-cell" />
 			</svg>
 		</span>
 	</a>
-	<a class="link-monospaced link-outline link-outline-borderless link-outline-primary" href="#1">
+	<a aria-label="Add cell" title="Add cell" class="link-monospaced link-outline link-outline-borderless link-outline-primary" href="#1">
 		<span class="inline-item">
 			<svg class="lexicon-icon lexicon-icon-add-cell" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#add-cell" />
 			</svg>
 		</span>
 	</a>
-	<a class="link-monospaced link-outline link-outline-secondary" href="#1">
+	<a aria-label="Image" title="Image" class="link-monospaced link-outline link-outline-secondary" href="#1">
 		<span class="inline-item">
 			<svg class="lexicon-icon lexicon-icon-picture" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#picture" />
 			</svg>
 		</span>
 	</a>
-	<a class="link-monospaced link-outline link-outline-borderless link-outline-secondary" href="#1">
+	<a aria-label="Image" title="Image" class="link-monospaced link-outline link-outline-borderless link-outline-secondary" href="#1">
 		<span class="inline-item">
 			<svg class="lexicon-icon lexicon-icon-picture" focusable="false" role="presentation">
 				<use href="/images/icons/icons.svg#picture" />
@@ -236,7 +236,12 @@ Use these patterns for actions in components.
 </div>
 
 ```html
-<a class="link-monospaced link-outline link-outline-primary" href="#1">
+<a
+	aria-label="Add cell"
+	title="Add cell"
+	class="link-monospaced link-outline link-outline-primary"
+	href="#1"
+>
 	<span class="inline-item">
 		<svg
 			class="lexicon-icon lexicon-icon-add-cell"
@@ -249,6 +254,8 @@ Use these patterns for actions in components.
 </a>
 
 <a
+	aria-label="Add cell"
+	title="Add cell"
 	class="link-monospaced link-outline link-outline-borderless link-outline-primary"
 	href="#1"
 >
@@ -263,7 +270,12 @@ Use these patterns for actions in components.
 	</span>
 </a>
 
-<a class="link-monospaced link-outline link-outline-secondary" href="#1">
+<a
+	aria-label="Image"
+	title="Image"
+	class="link-monospaced link-outline link-outline-secondary"
+	href="#1"
+>
 	<span class="inline-item">
 		<svg
 			class="lexicon-icon lexicon-icon-picture"
@@ -276,6 +288,8 @@ Use these patterns for actions in components.
 </a>
 
 <a
+	aria-label="Image"
+	title="Image"
 	class="link-monospaced link-outline link-outline-borderless link-outline-secondary"
 	href="#1"
 >

--- a/packages/clay-list/docs/index.js
+++ b/packages/clay-list/docs/index.js
@@ -37,12 +37,16 @@ const ListCode = `const Component = () => {
 				<ClayList.ItemField>
 					<ClayList.QuickActionMenu>
 						<ClayList.QuickActionMenu.Item
+							aria-label="Delete"
+							title="Delete"
 							onClick={() => alert('Clicked the trash!')}
 							spritemap={spritemap}
 							symbol="trash"
 						/>
 
 						<ClayList.QuickActionMenu.Item
+							aria-label="Settings"
+							title="Settings"
 							onClick={() => alert('Clicked the cog!')}
 							spritemap={spritemap}
 							symbol="cog"
@@ -89,11 +93,15 @@ const ListQuickActionsMenuCode = `const Component = () => {
 				<ClayList.ItemField>
 					<ClayList.QuickActionMenu>
 						<ClayList.QuickActionMenu.Item
+							aria-label="Delete"
+							title="Delete"
 							onClick={() => alert('Clicked the trash!')}
 							spritemap={spritemap}
 							symbol="trash"
 						/>
 						<ClayList.QuickActionMenu.Item
+							aria-label="Settings"
+							title="Settings"
 							onClick={() => alert('Clicked the cog!')}
 							spritemap={spritemap}
 							symbol="cog"

--- a/packages/clay-list/docs/markup-list.md
+++ b/packages/clay-list/docs/markup-list.md
@@ -79,24 +79,24 @@ Add the class `show-dropdown-action-on-active` to display `dropdown-menu`s when 
             </div>
             <div class="autofit-col">
                 <div class="quick-action-menu">
-                    <a class="component-action quick-action-item" href="#1" role="button">
+                    <a aria-label="Delete" title="Delete" class="component-action quick-action-item" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#trash" />
                         </svg>
                     </a>
-                    <a class="component-action quick-action-item" href="#1" role="button">
+                    <a aria-label="Download" title="Download" class="component-action quick-action-item" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#download" />
                         </svg>
                     </a>
-                    <a class="component-action quick-action-item" href="#1" role="button">
+                    <a aria-label="Info" title="Info" class="component-action quick-action-item" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-info-circle-open" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#info-circle-open" />
                         </svg>
                     </a>
                 </div>
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v" />
                         </svg>
@@ -143,24 +143,24 @@ Add the class `show-dropdown-action-on-active` to display `dropdown-menu`s when 
             </div>
             <div class="autofit-col">
                 <div class="quick-action-menu">
-                    <a class="component-action quick-action-item" href="#1" role="button">
+                    <a aria-label="Delete" title="Delete" class="component-action quick-action-item" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#trash" />
                         </svg>
                     </a>
-                    <a class="component-action quick-action-item" href="#1" role="button">
+                    <a aria-label="Download" title="Download" class="component-action quick-action-item" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#download" />
                         </svg>
                     </a>
-                    <a class="component-action quick-action-item" href="#1" role="button">
+                    <a aria-label="Info" title="Info" class="component-action quick-action-item" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-info-circle-open" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#info-circle-open" />
                         </svg>
                     </a>
                 </div>
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v" />
                         </svg>
@@ -212,6 +212,8 @@ Add the class `show-dropdown-action-on-active` to display `dropdown-menu`s when 
 		<div class="autofit-col">
 			<div class="quick-action-menu">
 				<a
+					aria-label="Delete"
+					title="Delete"
 					class="component-action quick-action-item"
 					href="#1"
 					role="button"
@@ -219,6 +221,8 @@ Add the class `show-dropdown-action-on-active` to display `dropdown-menu`s when 
 					...
 				</a>
 				<a
+					aria-label="Download"
+					title="Download"
 					class="component-action quick-action-item"
 					href="#1"
 					role="button"
@@ -226,6 +230,8 @@ Add the class `show-dropdown-action-on-active` to display `dropdown-menu`s when 
 					...
 				</a>
 				<a
+					aria-label="Info"
+					title="Info"
 					class="component-action quick-action-item"
 					href="#1"
 					role="button"
@@ -268,6 +274,8 @@ Add the class `show-dropdown-action-on-active` to display `dropdown-menu`s when 
 		<div class="autofit-col">
 			<div class="quick-action-menu">
 				<a
+					aria-label="Delete"
+					title="Delete"
 					class="component-action quick-action-item"
 					href="#1"
 					role="button"
@@ -275,6 +283,8 @@ Add the class `show-dropdown-action-on-active` to display `dropdown-menu`s when 
 					...
 				</a>
 				<a
+					aria-label="Download"
+					title="Download"
 					class="component-action quick-action-item"
 					href="#1"
 					role="button"
@@ -282,6 +292,8 @@ Add the class `show-dropdown-action-on-active` to display `dropdown-menu`s when 
 					...
 				</a>
 				<a
+					aria-label="Info"
+					title="Info"
 					class="component-action quick-action-item"
 					href="#1"
 					role="button"
@@ -357,7 +369,7 @@ Use `.list-group-bordered` on `.list-group` to style `.list-group-item-flex` lik
             </div>
             <div class="autofit-col">
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v" />
                         </svg>
@@ -403,7 +415,7 @@ Use `.list-group-bordered` on `.list-group` to style `.list-group-item-flex` lik
             </div>
             <div class="autofit-col">
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v" />
                         </svg>
@@ -560,7 +572,7 @@ Use `.list-group-bordered` on `.list-group` to style `.list-group-item-flex` lik
             </div>
             <div class="autofit-col">
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v" />
                         </svg>
@@ -638,7 +650,7 @@ Use `.list-group-bordered` on `.list-group` to style `.list-group-item-flex` lik
             </div>
             <div class="autofit-col">
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v" />
                         </svg>
@@ -679,7 +691,7 @@ Use `.list-group-bordered` on `.list-group` to style `.list-group-item-flex` lik
             </div>
             <div class="autofit-col">
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v" />
                         </svg>
@@ -797,7 +809,7 @@ Use the `.list-group-header` and `.list-group-header-title` class.
             </div>
             <div class="autofit-col">
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v" />
                         </svg>
@@ -997,24 +1009,24 @@ Use the `.list-group-header` and `.list-group-header-title` class.
             </div>
             <div class="autofit-col">
                 <div class="quick-action-menu">
-                    <a class="component-action quick-action-item" href="#1" role="button">
+                    <a aria-label="Delete" title="Delete" class="component-action quick-action-item" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
                             <use xlink:href="/images/icons/icons.svg#trash"></use>
                         </svg>
                     </a>
-                    <a class="component-action quick-action-item" href="#1" role="button">
+                    <a aria-label="Download" title="Download" class="component-action quick-action-item" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
                             <use xlink:href="/images/icons/icons.svg#download"></use>
                         </svg>
                     </a>
-                    <a class="component-action quick-action-item" href="#1" role="button">
+                    <a aria-label="Expand" title="Expand" class="component-action quick-action-item" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
                             <use xlink:href="/images/icons/icons.svg#expand"></use>
                         </svg>
                     </a>
                 </div>
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use xlink:href="/images/icons/icons.svg#ellipsis-v"></use>
                         </svg>
@@ -1056,6 +1068,8 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 		<div class="autofit-col">
 			<div class="quick-action-menu">
 				<a
+					aria-label="Delete"
+					title="Delete"
 					class="component-action quick-action-item"
 					href="#1"
 					role="button"
@@ -1063,6 +1077,8 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 					...
 				</a>
 				<a
+					aria-label="Download"
+					title="Download"
 					class="component-action quick-action-item"
 					href="#1"
 					role="button"
@@ -1070,6 +1086,8 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 					...
 				</a>
 				<a
+					aria-label="Expand"
+					title="Expand"
 					class="component-action quick-action-item"
 					href="#1"
 					role="button"
@@ -1079,6 +1097,8 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 			</div>
 			<div class="dropdown dropdown-action">
 				<a
+					aria-label="More Actions"
+					title="More Actions"
 					aria-expanded="false"
 					aria-haspopup="true"
 					class="component-action dropdown-toggle"
@@ -1153,24 +1173,24 @@ Use the `.list-group-header` and `.list-group-header-title` class.
             </div>
             <div class="autofit-col">
                 <div class="quick-action-menu">
-                    <button class="component-action quick-action-item" type="button">
+                    <button aria-label="Delete" title="Delete" class="component-action quick-action-item" type="button">
                         <svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
                             <use xlink:href="/images/icons/icons.svg#trash"></use>
                         </svg>
                     </button>
-                    <button class="component-action quick-action-item" type="button">
+                    <button aria-label="Download" title="Download" class="component-action quick-action-item" type="button">
                         <svg class="lexicon-icon lexicon-icon-download" focusable="false" role="presentation">
                             <use xlink:href="/images/icons/icons.svg#download"></use>
                         </svg>
                     </button>
-                    <button class="component-action quick-action-item" type="button">
+                    <button aria-label="Expand" title="Expand" class="component-action quick-action-item" type="button">
                         <svg class="lexicon-icon lexicon-icon-expand" focusable="false" role="presentation">
                             <use xlink:href="/images/icons/icons.svg#expand"></use>
                         </svg>
                     </button>
                 </div>
                 <div class="dropdown dropdown-action">
-                    <button aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" id="dropdownAction1" type="button">
+                    <button aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" id="dropdownAction1" type="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use xlink:href="/images/icons/icons.svg#ellipsis-v"></use>
                         </svg>
@@ -1227,18 +1247,24 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 		<div class="autofit-col">
 			<div class="quick-action-menu">
 				<button
+					aria-label="Delete"
+					title="Delete"
 					class="component-action quick-action-item"
 					type="button"
 				>
 					...
 				</button>
 				<button
+					aria-label="Download"
+					title="Download"
 					class="component-action quick-action-item"
 					type="button"
 				>
 					...
 				</button>
 				<button
+					aria-label="Expand"
+					title="Expand"
 					class="component-action quick-action-item"
 					type="button"
 				>
@@ -1247,6 +1273,8 @@ Use the `.list-group-header` and `.list-group-header-title` class.
 			</div>
 			<div class="dropdown dropdown-action">
 				<button
+					aria-label="More Actions"
+					title="More Actions"
 					aria-expanded="false"
 					aria-haspopup="true"
 					class="component-action dropdown-toggle"
@@ -1314,7 +1342,7 @@ Use the `.active` class on the same element that you putted `.list-group-item`.
             </div>
             <div class="autofit-col">
                 <div class="dropdown dropdown-action">
-                    <a aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
+                    <a aria-label="More Actions" title="More Actions" aria-expanded="false" aria-haspopup="true" class="component-action dropdown-toggle" data-toggle="dropdown" href="#1" id="dropdownAction1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v" />
                         </svg>

--- a/packages/clay-list/stories/List.stories.tsx
+++ b/packages/clay-list/stories/List.stories.tsx
@@ -116,13 +116,17 @@ export const Simple = () => (
 			<ClayList.ItemField>
 				<ClayList.QuickActionMenu>
 					<ClayList.QuickActionMenu.Item
+						aria-label="Delete"
 						onClick={() => alert('Clicked the trash!')}
 						symbol="trash"
+						title="Delete"
 					/>
 
 					<ClayList.QuickActionMenu.Item
+						aria-label="Settings"
 						onClick={() => alert('Clicked the cog!')}
 						symbol="cog"
+						title="Settings"
 					/>
 				</ClayList.QuickActionMenu>
 			</ClayList.ItemField>
@@ -168,13 +172,17 @@ export const Complex = (args: any) => (
 				<ClayList.ItemField>
 					<ClayList.QuickActionMenu>
 						<ClayList.QuickActionMenu.Item
+							aria-label="Delete"
 							onClick={() => alert('Clicked the trash!')}
 							symbol="trash"
+							title="Delete"
 						/>
 
 						<ClayList.QuickActionMenu.Item
+							aria-label="Settings"
 							onClick={() => alert('Clicked the cog!')}
 							symbol="cog"
+							title="Settings"
 						/>
 					</ClayList.QuickActionMenu>
 				</ClayList.ItemField>

--- a/packages/clay-management-toolbar/docs/index.js
+++ b/packages/clay-management-toolbar/docs/index.js
@@ -34,6 +34,7 @@ const MinimalManagementToolbarCode = `const Component = () => {
 							/>
 							<ClayInput.GroupInsetItem after tag="span">
 							<ClayButtonWithIcon
+								aria-label="Close search"
 								className="navbar-breakpoint-d-none"
 								displayType="unstyled"
 								onClick={() => setSearchMobile(false)}
@@ -41,6 +42,7 @@ const MinimalManagementToolbarCode = `const Component = () => {
 								symbol="times"
 							/>
 							<ClayButtonWithIcon
+								aria-label="Search"
 								displayType="unstyled"
 								spritemap={spritemap}
 								symbol="search"
@@ -53,6 +55,7 @@ const MinimalManagementToolbarCode = `const Component = () => {
 				
 				<ClayManagementToolbar.Item>
 					<ClayButton
+						aria-label="Info"
 						className="nav-link nav-link-monospaced"
 						displayType="unstyled"
 						onClick={() => {}}
@@ -63,6 +66,7 @@ const MinimalManagementToolbarCode = `const Component = () => {
 
 				<ClayManagementToolbar.Item>
 					<ClayButtonWithIcon
+						aria-label="Add"
 						className="nav-btn nav-btn-monospaced"
 						spritemap={spritemap}
 						symbol="plus"
@@ -229,6 +233,7 @@ const ManagementToolbarCode = `const Component = () => {
 
 					<ClayManagementToolbar.Item>
 						<ClayButton
+							aria-label="Order"
 							className="nav-link nav-link-monospaced"
 							displayType="unstyled"
 							onClick={() => {}}
@@ -252,6 +257,7 @@ const ManagementToolbarCode = `const Component = () => {
 							/>
 							<ClayInput.GroupInsetItem after tag="span">
 								<ClayButtonWithIcon
+									aria-label="Close search"
 									className="navbar-breakpoint-d-none"
 									displayType="unstyled"
 									onClick={() => setSearchMobile(false)}
@@ -259,6 +265,7 @@ const ManagementToolbarCode = `const Component = () => {
 									symbol="times"
 								/>
 								<ClayButtonWithIcon
+									aria-label="Search"
 									displayType="unstyled"
 									spritemap={spritemap}
 									symbol="search"
@@ -272,6 +279,7 @@ const ManagementToolbarCode = `const Component = () => {
 				<ClayManagementToolbar.ItemList>
 					<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
 						<ClayButton
+							aria-label="Search"
 							className="nav-link nav-link-monospaced"
 							displayType="unstyled"
 							onClick={() => setSearchMobile(true)}
@@ -285,6 +293,7 @@ const ManagementToolbarCode = `const Component = () => {
 
 					<ClayManagementToolbar.Item>
 						<ClayButton
+							aria-label="Info"
 							className="nav-link nav-link-monospaced"
 							displayType="unstyled"
 							onClick={() => {}}
@@ -302,6 +311,7 @@ const ManagementToolbarCode = `const Component = () => {
 							spritemap={spritemap}
 							trigger={
 								<ClayButton
+									aria-label="Display view"
 									className="nav-link-monospaced nav-link"
 									displayType="unstyled"
 								>
@@ -320,6 +330,7 @@ const ManagementToolbarCode = `const Component = () => {
 
 					<ClayManagementToolbar.Item>
 						<ClayButtonWithIcon
+							aria-label="Add"
 							className="nav-btn nav-btn-monospaced"
 							spritemap={spritemap}
 							symbol="plus"

--- a/packages/clay-management-toolbar/docs/markup-management-toolbar.md
+++ b/packages/clay-management-toolbar/docs/markup-management-toolbar.md
@@ -55,7 +55,7 @@ mainTabURL: 'docs/components/management-toolbar.html'
                             <use href="/images/icons/icons.svg#caret-bottom"></use>
                         </svg>
                     </a>
-                    <a aria-expanded="false" aria-haspopup="true"
+                    <a aria-label="Order" aria-expanded="false" aria-haspopup="true"
                         class="nav-link nav-link-monospaced dropdown-toggle navbar-breakpoint-d-none" data-toggle="dropdown"
                         href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-filter" focusable="false" role="presentation">
@@ -69,7 +69,7 @@ mainTabURL: 'docs/components/management-toolbar.html'
                     </ul>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Order" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-order-list-up" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#order-list-up"></use>
                         </svg>
@@ -84,12 +84,12 @@ mainTabURL: 'docs/components/management-toolbar.html'
                                 <input class="form-control input-group-inset input-group-inset-after"
                                     placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
+                                    <button aria-label="Search" class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
+                                    <button aria-label="Close search" class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -102,14 +102,14 @@ mainTabURL: 'docs/components/management-toolbar.html'
             </div>
             <ul class="navbar-nav">
                 <li class="nav-item navbar-breakpoint-d-none">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Search" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#search"></use>
                         </svg>
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced" href="#uniqueSidenavCollapseId2" id="uniqueSidenavToggler2"
+                    <a aria-label="Open" class="nav-link nav-link-monospaced" href="#uniqueSidenavCollapseId2" id="uniqueSidenavToggler2"
                         role="button">
                         <svg class="lexicon-icon lexicon-icon-circle-open" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#circle-open"></use>
@@ -117,7 +117,7 @@ mainTabURL: 'docs/components/management-toolbar.html'
                     </a>
                 </li>
                 <li class="dropdown nav-item">
-                    <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced"
+                    <a aria-label="Display view" aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced"
                         data-toggle="dropdown" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-list" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#list"></use>
@@ -157,14 +157,14 @@ mainTabURL: 'docs/components/management-toolbar.html'
                     </ul>
                 </li>
                 <li class="nav-item">
-                    <a class="btn btn-primary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none" href="#1">
+                    <a aria-label="Add" class="btn btn-primary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none" href="#1">
                         <svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#plus"></use>
                         </svg>
                     </a>
                 </li>
                 <li class="dropdown nav-item">
-                    <a aria-expanded="false" aria-haspopup="true"
+                    <a aria-label="More Actions" aria-expanded="false" aria-haspopup="true"
                         class="btn btn-primary dropdown-toggle nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none"
                         data-toggle="dropdown" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
@@ -218,21 +218,21 @@ mainTabURL: 'docs/components/management-toolbar.html'
             </ul>
             <ul class="navbar-nav">
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Delete" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-trash" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#trash"></use>
                         </svg>
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Paste" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-paste" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#paste"></use>
                         </svg>
                     </a>
                 </li>
                 <li class="dropdown nav-item">
-                    <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced"
+                    <a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced"
                         data-toggle="dropdown" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#ellipsis-v"></use>
@@ -272,7 +272,7 @@ mainTabURL: 'docs/components/management-toolbar.html'
                     </ul>
                 </li>
                 <li class="nav-item nav-divider">
-                    <a class="nav-link nav-link-monospaced" href="#1">
+                    <a aria-label="Info" class="nav-link nav-link-monospaced" href="#1">
                         <svg class="lexicon-icon lexicon-icon-info-circle-open" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#info-circle-open"></use>
                         </svg>
@@ -306,7 +306,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </div>
                 </li>
                 <li class="dropdown nav-item">
-                    <a aria-expanded="false" aria-haspopup="true"
+                    <a aria-label="Order" aria-expanded="false" aria-haspopup="true"
                         class="dropdown-toggle nav-link nav-link-monospaced navbar-breakpoint-d-none" data-toggle="dropdown"
                         href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-filter" focusable="false" role="presentation">
@@ -331,7 +331,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </ul>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Order" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-order-list-up" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#order-list-up"></use>
                         </svg>
@@ -346,12 +346,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                                 <input class="form-control input-group-inset input-group-inset-after"
                                     placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
+                                    <button aria-label="Search" class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
+                                    <button aria-label="Close search" class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -364,20 +364,20 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
             </div>
             <ul class="navbar-nav">
                 <li class="nav-item navbar-breakpoint-d-none">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Search" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#search"></use>
                         </svg>
                     </a>
                 </li>
-                <li class="nav-item navbar-breakpoint-down-d-none">
+                <li aria-label="View" class="nav-item navbar-breakpoint-down-d-none">
                     <a class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-view" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#view"></use>
                         </svg>
                     </a>
                 </li>
-                <li class="nav-item navbar-breakpoint-down-d-none">
+                <li aria-label="Table" class="nav-item navbar-breakpoint-down-d-none">
                     <a class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-table" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#table"></use>
@@ -412,7 +412,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </ul>
                     <ul class="navbar-nav">
                         <li class="dropdown nav-item">
-                            <a aria-expanded="false" aria-haspopup="true"
+                            <a aria-label="More Actions" aria-expanded="false" aria-haspopup="true"
                                 class="dropdown-toggle nav-link nav-link-monospaced" data-toggle="dropdown" href="#1"
                                 role="button">
                                 <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
@@ -451,6 +451,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 			</li>
 			<li class="dropdown nav-item">
 				<a
+					aria-label="Filter"
 					aria-expanded="false"
 					aria-haspopup="true"
 					class="dropdown-toggle nav-link nav-link-monospaced navbar-breakpoint-d-none"
@@ -506,7 +507,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 				</ul>
 			</li>
 			<li class="nav-item">
-				<a class="nav-link nav-link-monospaced" href="#1" role="button">
+				<a
+					aria-label="Order"
+					class="nav-link nav-link-monospaced"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-order-list-up"
 						focusable="false"
@@ -533,6 +539,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 								class="input-group-inset-item input-group-inset-item-after"
 							>
 								<button
+									aria-label="search"
 									class="btn btn-monospaced btn-unstyled"
 									type="submit"
 								>
@@ -547,6 +554,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 									</svg>
 								</button>
 								<button
+									aria-label="Close search"
 									class="btn btn-monospaced btn-unstyled d-none"
 									type="button"
 								>
@@ -568,7 +576,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 		</div>
 		<ul class="navbar-nav">
 			<li class="nav-item navbar-breakpoint-d-none">
-				<a class="nav-link nav-link-monospaced" href="#1" role="button">
+				<a
+					aria-label="Search"
+					class="nav-link nav-link-monospaced"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-search"
 						focusable="false"
@@ -579,7 +592,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 				</a>
 			</li>
 			<li class="nav-item navbar-breakpoint-down-d-none">
-				<a class="nav-link nav-link-monospaced" href="#1" role="button">
+				<a
+					aria-label="View"
+					class="nav-link nav-link-monospaced"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-view"
 						focusable="false"
@@ -590,7 +608,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 				</a>
 			</li>
 			<li class="nav-item navbar-breakpoint-down-d-none">
-				<a class="nav-link nav-link-monospaced" href="#1" role="button">
+				<a
+					aria-label="Table"
+					class="nav-link nav-link-monospaced"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-table"
 						focusable="false"
@@ -635,6 +658,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 				<ul class="navbar-nav">
 					<li class="dropdown nav-item">
 						<a
+							aria-label="More Actions"
 							aria-expanded="false"
 							aria-haspopup="true"
 							class="dropdown-toggle nav-link nav-link-monospaced"
@@ -706,7 +730,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </div>
                 </li>
                 <li class="dropdown nav-item">
-                    <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced navbar-breakpoint-d-none" data-toggle="dropdown" href="#1" role="button">
+                    <a aria-label="Filter" aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced navbar-breakpoint-d-none" data-toggle="dropdown" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-filter" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#filter"></use>
                         </svg>
@@ -728,7 +752,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </ul>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Order" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-order-list-up" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#order-list-up"></use>
                         </svg>
@@ -742,12 +766,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                             <div class="input-group-item">
                                 <input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
+                                    <button aria-label="Search" class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
+                                    <button aria-label="Close search" class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -760,21 +784,21 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
             </div>
             <ul class="navbar-nav">
                 <li class="nav-item navbar-breakpoint-d-none">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Search" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#search"></use>
                         </svg>
                     </a>
                 </li>
                 <li class="nav-item navbar-breakpoint-down-d-none">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="View" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-view" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#view"></use>
                         </svg>
                     </a>
                 </li>
                 <li class="nav-item navbar-breakpoint-down-d-none">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Table" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-table" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#table"></use>
                         </svg>
@@ -808,7 +832,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </ul>
                     <ul class="navbar-nav">
                         <li class="dropdown nav-item">
-                            <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced" data-toggle="dropdown" href="#1" role="button">
+                            <a aria-label="More Actions" aria-expanded="false" aria-haspopup="true" class="dropdown-toggle nav-link nav-link-monospaced" data-toggle="dropdown" href="#1" role="button">
                                 <svg class="lexicon-icon lexicon-icon-ellipsis-v" focusable="false" role="presentation">
                                     <use href="/images/icons/icons.svg#ellipsis-v"></use>
                                 </svg>
@@ -845,6 +869,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 			</li>
 			<li class="dropdown nav-item">
 				<a
+					aria-label="Filter"
 					aria-expanded="false"
 					aria-haspopup="true"
 					class="dropdown-toggle nav-link nav-link-monospaced navbar-breakpoint-d-none"
@@ -900,7 +925,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 				</ul>
 			</li>
 			<li class="nav-item">
-				<a class="nav-link nav-link-monospaced" href="#1" role="button">
+				<a
+					aria-label="Order"
+					class="nav-link nav-link-monospaced"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-order-list-up"
 						focusable="false"
@@ -927,6 +957,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 								class="input-group-inset-item input-group-inset-item-after"
 							>
 								<button
+									aria-label="Search"
 									class="btn btn-monospaced btn-unstyled"
 									type="submit"
 								>
@@ -941,6 +972,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 									</svg>
 								</button>
 								<button
+									aria-label="Close search"
 									class="btn btn-monospaced btn-unstyled d-none"
 									type="button"
 								>
@@ -962,7 +994,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 		</div>
 		<ul class="navbar-nav">
 			<li class="nav-item navbar-breakpoint-d-none">
-				<a class="nav-link nav-link-monospaced" href="#1" role="button">
+				<a
+					aria-label="Search"
+					class="nav-link nav-link-monospaced"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-search"
 						focusable="false"
@@ -973,7 +1010,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 				</a>
 			</li>
 			<li class="nav-item navbar-breakpoint-down-d-none">
-				<a class="nav-link nav-link-monospaced" href="#1" role="button">
+				<a
+					aria-label="View"
+					class="nav-link nav-link-monospaced"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-view"
 						focusable="false"
@@ -983,7 +1025,10 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 					</svg>
 				</a>
 			</li>
-			<li class="nav-item navbar-breakpoint-down-d-none">
+			<li
+				aria-label="Table"
+				class="nav-item navbar-breakpoint-down-d-none"
+			>
 				<a class="nav-link nav-link-monospaced" href="#1" role="button">
 					<svg
 						class="lexicon-icon lexicon-icon-table"
@@ -1029,6 +1074,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 				<ul class="navbar-nav">
 					<li class="dropdown nav-item">
 						<a
+							aria-label="More Actions"
 							aria-expanded="false"
 							aria-haspopup="true"
 							class="dropdown-toggle nav-link nav-link-monospaced"
@@ -1093,12 +1139,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                             <input class="form-control input-group-inset input-group-inset-after"
                                 placeholder="Search for..." type="text">
                             <span class="input-group-inset-item input-group-inset-item-after">
-                                <button class="btn btn-monospaced btn-unstyled" type="submit">
+                                <button aria-label="Search" class="btn btn-monospaced btn-unstyled" type="submit">
                                     <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                         <use href="/images/icons/icons.svg#search"></use>
                                     </svg>
                                 </button>
-                                <button class="btn btn-monospaced btn-unstyled d-none" type="button">
+                                <button aria-label="Close search" class="btn btn-monospaced btn-unstyled d-none" type="button">
                                     <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                         <use href="/images/icons/icons.svg#times"></use>
                                     </svg>
@@ -1128,6 +1174,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 							class="input-group-inset-item input-group-inset-item-after"
 						>
 							<button
+								aria-label="Search"
 								class="btn btn-monospaced btn-unstyled"
 								type="submit"
 							>
@@ -1142,6 +1189,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 								</svg>
 							</button>
 							<button
+								aria-label="Close search"
 								class="btn btn-monospaced btn-unstyled d-none"
 								type="button"
 							>
@@ -1177,12 +1225,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                                 <input class="form-control input-group-inset input-group-inset-after"
                                     placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
+                                    <button aria-label="Search" class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
+                                    <button aria-label="Close search" class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -1195,7 +1243,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
             </div>
             <ul class="navbar-nav navbar-nav-last">
                 <li class="nav-item navbar-breakpoint-d-none">
-                    <a class="nav-link nav-link-monospaced" href="#1" role="button">
+                    <a aria-label="Search" class="nav-link nav-link-monospaced" href="#1" role="button">
                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#search"></use>
                         </svg>
@@ -1225,6 +1273,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 								class="input-group-inset-item input-group-inset-item-after"
 							>
 								<button
+									aria-label="Search"
 									class="btn btn-monospaced btn-unstyled"
 									type="submit"
 								>
@@ -1239,6 +1288,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 									</svg>
 								</button>
 								<button
+									aria-label="Close search"
 									class="btn btn-monospaced btn-unstyled d-none"
 									type="button"
 								>
@@ -1260,7 +1310,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 		</div>
 		<ul class="navbar-nav navbar-nav-last">
 			<li class="nav-item navbar-breakpoint-d-none">
-				<a class="nav-link nav-link-monospaced" href="#1" role="button">
+				<a
+					aria-label="Search"
+					class="nav-link nav-link-monospaced"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-search"
 						focusable="false"
@@ -1545,7 +1600,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                             <use href="/images/icons/icons.svg#caret-bottom"></use>
                         </svg>
                     </button>
-                    <button aria-expanded="false" aria-haspopup="true"
+                    <button aria-label="Filter" aria-expanded="false" aria-haspopup="true"
                         class="btn btn-unstyled dropdown-toggle nav-btn nav-btn-monospaced navbar-breakpoint-d-none"
                         data-toggle="dropdown" type="button">
                         <svg class="lexicon-icon lexicon-icon-filter" focusable="false" role="presentation">
@@ -1554,7 +1609,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </button>
                 </li>
                 <li class="nav-item">
-                    <button class="btn btn-unstyled nav-btn nav-btn-monospaced" type="button">
+                    <button aria-label="Order" class="btn btn-unstyled nav-btn nav-btn-monospaced" type="button">
                     <svg class="lexicon-icon lexicon-icon-order-list-up" focusable="false" role="presentation">
                         <use href="/images/icons/icons.svg#order-list-up"></use>
                     </svg>
@@ -1569,12 +1624,12 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                                 <input class="form-control input-group-inset input-group-inset-after"
                                     placeholder="Search for..." type="text">
                                 <span class="input-group-inset-item input-group-inset-item-after">
-                                    <button class="btn btn-monospaced btn-unstyled" type="submit">
+                                    <button aria-label="Search" class="btn btn-monospaced btn-unstyled" type="submit">
                                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#search"></use>
                                         </svg>
                                     </button>
-                                    <button class="btn btn-monospaced btn-unstyled d-none" type="button">
+                                    <button aria-label="Close search" class="btn btn-monospaced btn-unstyled d-none" type="button">
                                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                                             <use href="/images/icons/icons.svg#times"></use>
                                         </svg>
@@ -1587,14 +1642,14 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
             </div>
             <ul class="navbar-nav">
                 <li class="nav-item navbar-breakpoint-d-none">
-                    <button class="btn btn-unstyled nav-btn nav-btn-monospaced" type="button">
+                    <button aria-label="Search" class="btn btn-unstyled nav-btn nav-btn-monospaced" type="button">
                         <svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#search"></use>
                         </svg>
                     </button>
                 </li>
                 <li class="dropdown nav-item">
-                    <button aria-expanded="false" aria-haspopup="true"
+                    <button aria-label="List" aria-expanded="false" aria-haspopup="true"
                         class="btn btn-unstyled dropdown-toggle nav-btn nav-btn-monospaced" data-toggle="dropdown"
                         type="button">
                         <svg class="lexicon-icon lexicon-icon-list" focusable="false" role="presentation">
@@ -1603,7 +1658,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </button>
                 </li>
                 <li class="nav-item">
-                    <button class="btn btn-secondary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none"
+                    <button aria-label="Add" class="btn btn-secondary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none"
                         type="button">
                         <svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#plus"></use>
@@ -1611,7 +1666,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                     </button>
                 </li>
                 <li class="nav-item">
-                    <button class="btn btn-primary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none" type="button">
+                    <button aria-label="Add" class="btn btn-primary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none" type="button">
                         <svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#plus"></use>
                         </svg>
@@ -1652,6 +1707,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 					</svg>
 				</button>
 				<button
+					aria-label="Filter"
 					aria-expanded="false"
 					aria-haspopup="true"
 					class="btn btn-unstyled dropdown-toggle nav-btn nav-btn-monospaced navbar-breakpoint-d-none"
@@ -1669,6 +1725,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 			</li>
 			<li class="nav-item">
 				<button
+					aria-label="Order"
 					class="btn btn-unstyled nav-btn nav-btn-monospaced"
 					type="button"
 				>
@@ -1698,6 +1755,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 								class="input-group-inset-item input-group-inset-item-after"
 							>
 								<button
+									aria-label="Search"
 									class="btn btn-monospaced btn-unstyled"
 									type="submit"
 								>
@@ -1712,6 +1770,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 									</svg>
 								</button>
 								<button
+									aria-label="Close search"
 									class="btn btn-monospaced btn-unstyled d-none"
 									type="button"
 								>
@@ -1734,6 +1793,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 		<ul class="navbar-nav">
 			<li class="nav-item navbar-breakpoint-d-none">
 				<button
+					aria-label="Search"
 					class="btn btn-unstyled nav-btn nav-btn-monospaced"
 					type="button"
 				>
@@ -1748,6 +1808,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 			</li>
 			<li class="dropdown nav-item">
 				<button
+					aria-label="List"
 					aria-expanded="false"
 					aria-haspopup="true"
 					class="btn btn-unstyled dropdown-toggle nav-btn nav-btn-monospaced"
@@ -1765,6 +1826,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 			</li>
 			<li class="nav-item">
 				<button
+					aria-label="Add"
 					class="btn btn-secondary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none"
 					type="button"
 				>
@@ -1779,6 +1841,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 			</li>
 			<li class="nav-item">
 				<button
+					aria-label="Add"
 					class="btn btn-primary nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none"
 					type="button"
 				>

--- a/packages/clay-modal/docs/markup-modal.md
+++ b/packages/clay-modal/docs/markup-modal.md
@@ -55,7 +55,7 @@ mainTabURL: 'docs/components/modal.html'
             <div class="modal-content">
                 <div class="modal-header">
                     <div class="modal-title" id="claySmallModalLabel">Modal Title</div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" role="button" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" role="button" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -106,7 +106,8 @@ mainTabURL: 'docs/components/modal.html'
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					role="button"
@@ -160,7 +161,7 @@ mainTabURL: 'docs/components/modal.html'
             <div class="modal-content">
                 <div class="modal-header">
                     <div class="modal-title" id="clayDefaultModalLabel">Modal Title</div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" role="button" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" role="button" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -202,7 +203,8 @@ mainTabURL: 'docs/components/modal.html'
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					role="button"
@@ -256,7 +258,7 @@ The large modal is an 800px wide window on displays greater than 992px. It is a 
             <div class="modal-content">
                 <div class="modal-header">
                     <div class="modal-title" id="clayLargeModalLabel">Modal Title</div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" role="button" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" role="button" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -298,7 +300,8 @@ The large modal is an 800px wide window on displays greater than 992px. It is a 
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					role="button"
@@ -354,7 +357,7 @@ The full screen modal stretches to fit the browser window, with 45px spacing on 
             <div class="modal-content">
                 <div class="modal-header">
                     <div class="modal-title" id="clayLargeModalLabel">Add Picture to Documents and Media Library in Liferay Seven</div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -416,7 +419,8 @@ The full screen modal stretches to fit the browser window, with 45px spacing on 
 					Add Picture to Documents and Media Library in Liferay Seven
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -508,7 +512,7 @@ Add `modal-full-screen-sm-down` to any `modal-dialog` to stretch to fit the brow
             <div class="modal-content">
                 <div class="modal-header">
                     <div class="modal-title" id="clayModalFullScreenSmDownLabel">Modal Title</div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -561,7 +565,8 @@ Add `modal-full-screen-sm-down` to any `modal-dialog` to stretch to fit the brow
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -642,7 +647,7 @@ Add the class `modal-height-sm` to the `modal` or `modal-dialog` element to fix 
 						</div>
 					</div>
 				</div>
-				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
+				<button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="/images/icons/icons.svg#times" />
 					</svg>
@@ -700,6 +705,7 @@ Add the class `modal-height-sm` to the `modal` or `modal-dialog` element to fix 
 				</div>
 				<button
 					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -758,7 +764,7 @@ Add the class `modal-height-md` to the `modal` or `modal-dialog` element to fix 
 						</div>
 					</div>
 				</div>
-				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
+				<button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="/images/icons/icons.svg#times" />
 					</svg>
@@ -816,6 +822,7 @@ Add the class `modal-height-md` to the `modal` or `modal-dialog` element to fix 
 				</div>
 				<button
 					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -874,7 +881,7 @@ Add the class `modal-height-lg` to the `modal` or `modal-dialog` element to fix 
 						</div>
 					</div>
 				</div>
-				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
+				<button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="/images/icons/icons.svg#times" />
 					</svg>
@@ -932,6 +939,7 @@ Add the class `modal-height-lg` to the `modal` or `modal-dialog` element to fix 
 				</div>
 				<button
 					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -990,7 +998,7 @@ Add the class `modal-height-xl` to the `modal` or `modal-dialog` element to fix 
 						</div>
 					</div>
 				</div>
-				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
+				<button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="/images/icons/icons.svg#times" />
 					</svg>
@@ -1048,6 +1056,7 @@ Add the class `modal-height-xl` to the `modal` or `modal-dialog` element to fix 
 				</div>
 				<button
 					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -1106,7 +1115,7 @@ Add the class `modal-height-full` to the `modal` or `modal-dialog` element to ex
 						</div>
 					</div>
 				</div>
-				<button aria-label="Close" class="close" data-dismiss="modal" type="button">
+				<button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
 					<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 						<use xlink:href="/images/icons/icons.svg#times" />
 					</svg>
@@ -1164,6 +1173,7 @@ Add the class `modal-height-full` to the `modal` or `modal-dialog` element to ex
 				</div>
 				<button
 					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -1220,7 +1230,7 @@ A classic modal window is composed of three main parts: header, body, and footer
             <div class="modal-content">
                 <div class="modal-header">
                     <div class="modal-title" id="clayDefaultModalLabel">Modal Title</div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" role="button" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" role="button" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -1262,7 +1272,8 @@ A classic modal window is composed of three main parts: header, body, and footer
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					role="button"
@@ -1324,7 +1335,7 @@ Insert a Navigation or Input Group between the Header and Body
 							</div>
 						</div>
 					</div>
-					<button aria-label="Close" class="close" data-dismiss="modal" type="button">
+					<button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
 						<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 							<use xlink:href="/images/icons/icons.svg#times" />
 						</svg>
@@ -1338,12 +1349,12 @@ Insert a Navigation or Input Group between the Header and Body
 									<div class="input-group-item">
 										<input class="form-control input-group-inset input-group-inset-after" placeholder="Search for..." type="text">
 										<span class="input-group-inset-item input-group-inset-item-after">
-											<button class="btn btn-monospaced btn-unstyled" type="submit">
+											<button aria-label="Search" class="btn btn-monospaced btn-unstyled" type="submit">
 												<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
 													<use xlink:href="/images/icons/icons.svg#search" />
 												</svg>
 											</button>
-											<button class="btn btn-monospaced btn-unstyled d-none" type="button">
+											<button aria-label="Close search" class="btn btn-monospaced btn-unstyled d-none" type="button">
 												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 													<use xlink:href="/images/icons/icons.svg#times" />
 												</svg>
@@ -1355,7 +1366,7 @@ Insert a Navigation or Input Group between the Header and Body
 						</div>
 						<ul class="navbar-nav">
 							<li class="dropdown nav-item">
-								<button aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle nav-btn nav-btn-monospaced" data-toggle="dropdown" type="button">
+								<button aria-label="Add" aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle nav-btn nav-btn-monospaced" data-toggle="dropdown" type="button">
 									<svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation">
 										<use xlink:href="/images/icons/icons.svg#plus" />
 									</svg>
@@ -1451,6 +1462,7 @@ Insert a Navigation or Input Group between the Header and Body
 				</div>
 				<button
 					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -1481,6 +1493,7 @@ Insert a Navigation or Input Group between the Header and Body
 										class="input-group-inset-item input-group-inset-item-after"
 									>
 										<button
+											aria-label="Search"
 											class="btn btn-monospaced btn-unstyled"
 											type="submit"
 										>
@@ -1495,6 +1508,7 @@ Insert a Navigation or Input Group between the Header and Body
 											</svg>
 										</button>
 										<button
+											aria-label="Close search"
 											class="btn btn-monospaced btn-unstyled d-none"
 											type="button"
 										>
@@ -1516,6 +1530,7 @@ Insert a Navigation or Input Group between the Header and Body
 					<ul class="navbar-nav">
 						<li class="dropdown nav-item">
 							<button
+								aria-label="Add"
 								aria-expanded="false"
 								aria-haspopup="true"
 								class="btn btn-primary dropdown-toggle nav-btn nav-btn-monospaced"
@@ -1639,7 +1654,7 @@ Insert a Navigation or Input Group between the Header and Body
 							</div>
 						</div>
 					</div>
-					<button aria-label="Close" class="close" data-dismiss="modal" type="button">
+					<button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
 						<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 							<use xlink:href="/images/icons/icons.svg#times" />
 						</svg>
@@ -1649,12 +1664,12 @@ Insert a Navigation or Input Group between the Header and Body
 					<div class="input-group-item">
 						<input aria-label="Search for" class="form-control input-group-inset input-group-inset-after" placeholder="Search..." type="text">
 						<div class="input-group-inset-item input-group-inset-item-after">
-							<button class="btn btn-unstyled d-md-none" type="button">
+							<button aria-label="Close search" class="btn btn-unstyled d-md-none" type="button">
 								<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 									<use xlink:href="/images/icons/icons.svg#times" />
 								</svg>
 							</button>
-							<button class="btn btn-unstyled d-none d-md-inline-block" type="button">
+							<button aria-label="Search" class="btn btn-unstyled d-none d-md-inline-block" type="button">
 								<svg class="lexicon-icon lexicon-icon-search" focusable="false" role="presentation">
 									<use xlink:href="/images/icons/icons.svg#search" />
 								</svg>
@@ -1662,7 +1677,7 @@ Insert a Navigation or Input Group between the Header and Body
 						</div>
 					</div>
 					<div class="input-group-item input-group-item-shrink">
-						<button aria-expanded="false" aria-haspopup="true" class="btn btn-primary btn-monospaced btn-sm dropdown-toggle" data-toggle="dropdown" type="button">
+						<button aria-label="Add" aria-expanded="false" aria-haspopup="true" class="btn btn-primary btn-monospaced btn-sm dropdown-toggle" data-toggle="dropdown" type="button">
 							<svg class="lexicon-icon lexicon-icon-plus" focusable="false" role="presentation"><use xlink:href="/images/icons/icons.svg#plus" /></svg>
 						</button>
 						<ul class="dropdown-menu dropdown-menu-right">
@@ -1729,6 +1744,7 @@ Insert a Navigation or Input Group between the Header and Body
 				</div>
 				<button
 					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -1754,6 +1770,7 @@ Insert a Navigation or Input Group between the Header and Body
 						class="input-group-inset-item input-group-inset-item-after"
 					>
 						<button
+							aria-label="Close search"
 							class="btn btn-unstyled d-md-none"
 							type="button"
 						>
@@ -1768,6 +1785,7 @@ Insert a Navigation or Input Group between the Header and Body
 							</svg>
 						</button>
 						<button
+							aria-label="Search"
 							class="btn btn-unstyled d-none d-md-inline-block"
 							type="button"
 						>
@@ -1785,6 +1803,7 @@ Insert a Navigation or Input Group between the Header and Body
 				</div>
 				<div class="input-group-item input-group-item-shrink">
 					<button
+						aria-label="Add"
 						aria-expanded="false"
 						aria-haspopup="true"
 						class="btn btn-primary btn-monospaced btn-sm dropdown-toggle"
@@ -1861,7 +1880,7 @@ When you don't need a footer bar to place your icons, you can just have a header
             <div class="modal-content">
                 <div class="modal-header">
                     <div class="modal-title" id="clayHeaderBodyModalLabel">Modal Title</div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" role="button" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" role="button" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -1898,7 +1917,8 @@ When you don't need a footer bar to place your icons, you can just have a header
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					role="button"
@@ -2000,7 +2020,7 @@ Utilize the Bootstrap grid system within a modal by nesting `.container-fluid` w
             <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="gridModalLabel">Grids in modals</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close" title="Close"><span aria-hidden="true">×</span></button>
             </div>
             <div class="modal-body">
                 <div class="container-fluid bd-example-row">
@@ -2066,6 +2086,7 @@ Utilize the Bootstrap grid system within a modal by nesting `.container-fluid` w
 					class="close"
 					data-dismiss="modal"
 					aria-label="Close"
+					title="Close"
 				>
 					<span aria-hidden="true">×</span>
 				</button>
@@ -2146,7 +2167,7 @@ In mobile safari (iOS 8.3), any content inside an iframe that triggers a browser
             <div class="modal-content">
                 <div class="modal-header">
                     <div class="modal-title" id="clayFullScreenModalIframeLabel">Add Picture to Documents and Media Library in Liferay Seven</div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -2195,7 +2216,8 @@ In mobile safari (iOS 8.3), any content inside an iframe that triggers a browser
 						Seven
 					</div>
 					<button
-						aria-labelledby="Close"
+						aria-label="Close"
+						title="Close"
 						class="close"
 						data-dismiss="modal"
 						type="button"
@@ -2260,7 +2282,7 @@ Add one of the following helper classes to the `modal-dialog` element to style i
                         </span>
                         Modal Title
                     </div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -2316,7 +2338,8 @@ Add one of the following helper classes to the `modal-dialog` element to style i
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -2379,7 +2402,7 @@ Add one of the following helper classes to the `modal-dialog` element to style i
                         </span>
                         Modal Title
                     </div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -2432,7 +2455,8 @@ Add one of the following helper classes to the `modal-dialog` element to style i
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -2490,7 +2514,7 @@ Add one of the following helper classes to the `modal-dialog` element to style i
                         </span>
                         Modal Title
                     </div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -2543,7 +2567,8 @@ Add one of the following helper classes to the `modal-dialog` element to style i
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -2601,7 +2626,7 @@ Add one of the following helper classes to the `modal-dialog` element to style i
                         </span>
                         Modal Title
                     </div>
-                    <button aria-labelledby="Close" class="close" data-dismiss="modal" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -2660,7 +2685,8 @@ Add one of the following helper classes to the `modal-dialog` element to style i
 					Modal Title
 				</div>
 				<button
-					aria-labelledby="Close"
+					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"
@@ -2725,7 +2751,7 @@ Add `.modal-dialog-centered` to `.modal-dialog` to vertically center the modal.
             <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="exampleModalCenterTitle">Modal title</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close" title="Close">
                 <span aria-hidden="true">×</span>
                 </button>
             </div>
@@ -2770,6 +2796,7 @@ Add `.modal-dialog-centered` to `.modal-dialog` to vertically center the modal.
 					class="close"
 					data-dismiss="modal"
 					aria-label="Close"
+					title="Close"
 				>
 					<span aria-hidden="true">×</span>
 				</button>
@@ -2813,7 +2840,7 @@ For modals that simply appear rather than fade in to view, remove the `.fade` cl
             <div class="modal-content">
                 <div class="modal-header">
                     <div class="modal-title" id="claySmallModalInlineScrollerLabel">Modal Title</div>
-                    <button aria-label="Close" class="close" data-dismiss="modal" type="button">
+                    <button aria-label="Close" title="Close" class="close" data-dismiss="modal" type="button">
                         <svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
                             <use href="/images/icons/icons.svg#times"></use>
                         </svg>
@@ -2879,6 +2906,7 @@ For modals that simply appear rather than fade in to view, remove the `.fade` cl
 				</div>
 				<button
 					aria-label="Close"
+					title="Close"
 					class="close"
 					data-dismiss="modal"
 					type="button"

--- a/packages/clay-pagination-bar/docs/index.js
+++ b/packages/clay-pagination-bar/docs/index.js
@@ -45,6 +45,7 @@ const PaginationBarCode = `const Component = () => {
 
 			<ClayPaginationWithBasicItems
 				defaultActive={1}
+				ellipsisProps={{'aria-label': 'More', title: 'More'}}
 				spritemap={spritemap}
 				totalPages={10}
 			/>
@@ -94,6 +95,7 @@ const PaginationBarWithBasicItemsCode = `const Component = () => {
 			activeDelta={delta}
 			deltas={deltas}
 			ellipsisBuffer={3}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			onDeltaChange={setDelta}
 			spritemap={spritemap}
 			totalItems={21}
@@ -126,6 +128,7 @@ const PaginationBarWithBasicItemsWithoutDropDownCode = `const Component = () => 
 			activeDelta={delta}
 			defaultActive={1}
 			ellipsisBuffer={3}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			onDeltaChange={setDelta}
 			showDeltasDropDown={false}
 			spritemap={spritemap}

--- a/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
+++ b/packages/clay-pagination-bar/src/PaginationBarWithBasicItems.tsx
@@ -92,6 +92,11 @@ interface IProps extends React.ComponentProps<typeof PaginationBar> {
 	ellipsisBuffer?: number;
 
 	/**
+	 * Properties to pass to the ellipsis trigger.
+	 */
+	ellipsisProps?: Object;
+
+	/**
 	 * Function used to create the href provided for each page link.
 	 */
 	hrefConstructor?: (page?: number) => string;
@@ -159,6 +164,7 @@ export const ClayPaginationBarWithBasicItems = ({
 	disabledPages,
 	disableEllipsis = false,
 	ellipsisBuffer,
+	ellipsisProps,
 	hrefConstructor,
 	labels = DEFAULT_LABELS,
 	onActiveChange,
@@ -249,6 +255,7 @@ export const ClayPaginationBarWithBasicItems = ({
 				disableEllipsis={disableEllipsis}
 				disabledPages={disabledPages}
 				ellipsisBuffer={ellipsisBuffer}
+				ellipsisProps={ellipsisProps}
 				hrefConstructor={hrefConstructor}
 				onActiveChange={setActive}
 				spritemap={spritemap}

--- a/packages/clay-pagination-bar/stories/PaginationBar.stories.tsx
+++ b/packages/clay-pagination-bar/stories/PaginationBar.stories.tsx
@@ -38,6 +38,7 @@ export const Default = () => (
 
 		<ClayPaginationWithBasicItems
 			activePage={1}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			onPageChange={() => {}}
 			totalPages={10}
 		/>
@@ -69,6 +70,7 @@ export const WithItems = (args: any) => {
 			activeDelta={delta}
 			deltas={deltas}
 			ellipsisBuffer={args.ellipsisBuffer}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			onDeltaChange={setDelta}
 			totalItems={args.totalItems}
 		/>
@@ -88,6 +90,7 @@ export const WithoutDropdown = () => {
 			activeDelta={delta}
 			defaultActive={3}
 			ellipsisBuffer={3}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			onDeltaChange={setDelta}
 			showDeltasDropDown={false}
 			totalItems={21}

--- a/packages/clay-pagination/docs/index.js
+++ b/packages/clay-pagination/docs/index.js
@@ -14,7 +14,7 @@ const PaginationCode = `const Component = () => {
 	return (
 		<ClayPagination>
 			<ClayPagination.Item>{1}</ClayPagination.Item>
-			<ClayPagination.Ellipsis items={[2,3,4,5]} />
+			<ClayPagination.Ellipsis aria-label="More" title="More" items={[2,3,4,5]} />
 			<ClayPagination.Item>{'End'}</ClayPagination.Item>
 		</ClayPagination>
 	);
@@ -38,6 +38,7 @@ const PaginationWithBasicItemsCode = `const Component = () => {
 		<ClayPaginationWithBasicItems
 			active={active}
 			ellipsisBuffer={2}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			onActiveChange={setActive}
 			spritemap={spritemap}
 			totalPages={25}

--- a/packages/clay-pagination/docs/markup-pagination.md
+++ b/packages/clay-pagination/docs/markup-pagination.md
@@ -49,7 +49,7 @@ Use `pagination-bar`'s preset styles to give your users more control over the co
             <li class="active page-item"><a class="page-link" href="#1" tabindex="-1">1</a></li>
             <li class="page-item"><a class="page-link" href="#1">2</a></li>
             <li class="dropdown page-item">
-                <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">...</a>
+                <a aria-label="More" title="More" aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">...</a>
                 <ul class="dropdown-menu dropdown-menu-top-center">
                     <li>
                         <ul class="inline-scroller">
@@ -125,6 +125,8 @@ Use `pagination-bar`'s preset styles to give your users more control over the co
 		<li class="page-item"><a class="page-link" href="#1">2</a></li>
 		<li class="dropdown page-item">
 			<a
+				aria-label="More"
+				title="More"
 				aria-expanded="false"
 				aria-haspopup="true"
 				class="dropdown-toggle page-link"
@@ -200,7 +202,7 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
             <li class="active page-item"><a class="page-link" href="#1" tabindex="-1">1</a></li>
             <li class="page-item"><a class="page-link" href="#1">2</a></li>
             <li class="dropdown page-item">
-                <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">...</a>
+                <a aria-label="More" title="More" aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">...</a>
                 <ul class="dropdown-menu dropdown-menu-top-center">
                     <li>
                         <ul class="inline-scroller">
@@ -276,6 +278,8 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
 		<li class="page-item"><a class="page-link" href="#1">2</a></li>
 		<li class="dropdown page-item">
 			<a
+				aria-label="More"
+				title="More"
 				aria-expanded="false"
 				aria-haspopup="true"
 				class="dropdown-toggle page-link"
@@ -347,7 +351,7 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
             <li class="active page-item"><a class="page-link" href="#1" tabindex="-1">1</a></li>
             <li class="page-item"><a class="page-link" href="#1">2</a></li>
             <li class="dropdown page-item">
-                <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">...</a>
+                <a aria-label="More" title="More" aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">...</a>
                 <ul class="dropdown-menu dropdown-menu-top-center">
                     <li>
                         <ul class="inline-scroller">
@@ -423,6 +427,8 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
 		<li class="page-item"><a class="page-link" href="#1">2</a></li>
 		<li class="dropdown page-item">
 			<a
+				aria-label="More"
+				title="More"
 				aria-expanded="false"
 				aria-haspopup="true"
 				class="dropdown-toggle page-link"
@@ -494,7 +500,7 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
             <li class="active page-item"><a class="page-link" href="#1" tabindex="-1">1</a></li>
             <li class="page-item"><a class="page-link" href="#1">2</a></li>
             <li class="dropdown page-item">
-                <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">...</a>
+                <a aria-label="More" title="More" aria-expanded="false" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="dropdown" href="#1" role="button">...</a>
                 <ul class="dropdown-menu dropdown-menu-top-center">
                     <li>
                         <ul class="inline-scroller">
@@ -570,6 +576,8 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
 		<li class="page-item"><a class="page-link" href="#1">2</a></li>
 		<li class="dropdown page-item">
 			<a
+				aria-label="More"
+				title="More"
 				aria-expanded="false"
 				aria-haspopup="true"
 				class="dropdown-toggle page-link"
@@ -645,7 +653,7 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
                 <button class="btn btn-unstyled page-link" type="button">2</button>
             </li>
             <li class="dropdown page-item">
-                <button aria-expanded="false" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle page-link" data-toggle="dropdown" type="button">...</button>
+                <button aria-label="More" title="More" aria-expanded="false" aria-haspopup="true" class="btn btn-unstyled dropdown-toggle page-link" data-toggle="dropdown" type="button">...</button>
                 <ul class="dropdown-menu dropdown-menu-top-center">
                     <li>
                         <ul class="inline-scroller">
@@ -734,6 +742,8 @@ More sizing options, add `pagination-sm` or `pagination-lg` to any pagination co
 		</li>
 		<li class="dropdown page-item">
 			<button
+				aria-label="More"
+				title="More"
 				aria-expanded="false"
 				aria-haspopup="true"
 				class="btn btn-unstyled dropdown-toggle page-link"

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -8,6 +8,7 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import React from 'react';
 
 export interface IPaginationEllipsisProps {
+	'aria-label'?: string;
 	alignmentPosition?: React.ComponentProps<
 		typeof ClayDropDownWithItems
 	>['alignmentPosition'];
@@ -16,6 +17,7 @@ export interface IPaginationEllipsisProps {
 	hrefConstructor?: (page?: number) => string;
 	items?: Array<number>;
 	onPageChange?: (page?: number) => void;
+	title?: string;
 }
 
 const ClayPaginationEllipsis = ({
@@ -25,6 +27,7 @@ const ClayPaginationEllipsis = ({
 	hrefConstructor,
 	items = [],
 	onPageChange,
+	...otherProps
 }: IPaginationEllipsisProps) => {
 	const pages = disabled
 		? []
@@ -43,6 +46,7 @@ const ClayPaginationEllipsis = ({
 			items={pages}
 			trigger={
 				<ClayButton
+					{...otherProps}
 					className="page-link"
 					disabled={disabled}
 					displayType="unstyled"

--- a/packages/clay-pagination/src/PaginationWithBasicItems.tsx
+++ b/packages/clay-pagination/src/PaginationWithBasicItems.tsx
@@ -50,6 +50,11 @@ interface IProps extends React.ComponentProps<typeof Pagination> {
 	ellipsisBuffer?: number;
 
 	/**
+	 * Properties to pass to the ellipsis trigger.
+	 */
+	ellipsisProps?: Object;
+
+	/**
 	 * Sets the default active page (uncontrolled).
 	 */
 	defaultActive?: number;
@@ -107,6 +112,7 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 			disabledPages = [],
 			disableEllipsis = false,
 			ellipsisBuffer = ELLIPSIS_BUFFER,
+			ellipsisProps = {},
 			hrefConstructor,
 			onActiveChange,
 			onPageChange,
@@ -152,6 +158,7 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 							{
 								EllipsisComponent: Pagination.Ellipsis,
 								ellipsisProps: {
+									...ellipsisProps,
 									alignmentPosition,
 									disabled: disableEllipsis,
 									disabledPages,

--- a/packages/clay-pagination/stories/Pagination.stories.tsx
+++ b/packages/clay-pagination/stories/Pagination.stories.tsx
@@ -15,7 +15,7 @@ export default {
 export const Default = () => (
 	<ClayPagination>
 		<ClayPagination.Item>1</ClayPagination.Item>
-		<ClayPagination.Ellipsis />
+		<ClayPagination.Ellipsis aria-label="More" title="More" />
 		<ClayPagination.Item>End</ClayPagination.Item>
 	</ClayPagination>
 );
@@ -24,6 +24,7 @@ export const WithLinks = (args: any) => (
 	<ClayPaginationWithBasicItems
 		activePage={args.activePage}
 		ellipsisBuffer={args.ellipsisBuffer}
+		ellipsisProps={{'aria-label': 'More', title: 'More'}}
 		hrefConstructor={(page) => `/#${page}`}
 		totalPages={args.totalPages}
 	/>
@@ -39,6 +40,7 @@ export const WithButtons = (args: any) => (
 	<ClayPaginationWithBasicItems
 		defaultActive={8}
 		ellipsisBuffer={args.ellipsisBuffer}
+		ellipsisProps={{'aria-label': 'More', title: 'More'}}
 		totalPages={args.totalPages}
 	/>
 );
@@ -53,6 +55,7 @@ export const Sizes = () => (
 		<ClayPaginationWithBasicItems
 			defaultActive={number('Active Page', 8)}
 			ellipsisBuffer={number('Ellipsis Buffer', 2)}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			hrefConstructor={(page) => `/#${page}`}
 			size="sm"
 			totalPages={25}
@@ -60,12 +63,14 @@ export const Sizes = () => (
 		<ClayPaginationWithBasicItems
 			defaultActive={number('Active Page', 8)}
 			ellipsisBuffer={number('Ellipsis Buffer', 2)}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			hrefConstructor={(page) => `/#${page}`}
 			totalPages={25}
 		/>
 		<ClayPaginationWithBasicItems
 			defaultActive={number('Active Page', 8)}
 			ellipsisBuffer={number('Ellipsis Buffer', 2)}
+			ellipsisProps={{'aria-label': 'More', title: 'More'}}
 			hrefConstructor={(page) => `/#${page}`}
 			size="lg"
 			totalPages={25}
@@ -78,6 +83,7 @@ export const DisabledPages = () => (
 		defaultActive={8}
 		disabledPages={[4, 5]}
 		ellipsisBuffer={2}
+		ellipsisProps={{'aria-label': 'More', title: 'More'}}
 		totalPages={5}
 	/>
 );

--- a/packages/clay-toolbar/docs/index.js
+++ b/packages/clay-toolbar/docs/index.js
@@ -19,10 +19,12 @@ const ToolbarCode = `const Component = () => {
 			<ClayToolbar.Nav>
 				<ClayToolbar.Item>
 					<ClayToolbar.Action
+						aria-label="Previous"
 						disabled
 						href="#"
 						spritemap={spritemap}
 						symbol="angle-left"
+						title="Previous"
 					/>
 				</ClayToolbar.Item>
 
@@ -46,6 +48,8 @@ const ToolbarCode = `const Component = () => {
 
 				<ClayToolbar.Item>
 					<ClayToolbar.Action
+						aria-label="Next"
+						title="Next"
 						disabled
 						href="#"
 						spritemap={spritemap}
@@ -55,6 +59,8 @@ const ToolbarCode = `const Component = () => {
 
 				<ClayToolbar.Item>
 					<ClayToolbar.Action
+						aria-label="Close"
+						title="Close"
 						disabled
 						href="#"
 						spritemap={spritemap}
@@ -105,6 +111,8 @@ const ComplexToolbarCode = `const Component = () => {
 					<ClayToolbar.Section>
 						<ClayButton.Group>
 							<ClayButtonWithIcon
+								aria-label="Previous"
+								title="Previous"
 								displayType="secondary"
 								onClick={() => {}}
 								small
@@ -113,6 +121,8 @@ const ComplexToolbarCode = `const Component = () => {
 							/>
 
 							<ClayButtonWithIcon
+								aria-label="Next"
+								title="Next"
 								displayType="secondary"
 								onClick={() => {}}
 								small
@@ -146,6 +156,8 @@ const ComplexToolbarCode = `const Component = () => {
 						spritemap={spritemap}
 						trigger={
 							<ClayButtonWithIcon
+								aria-label="More Actions"
+								title="More Actions"
 								displayType="unstyled"
 								small
 								spritemap={spritemap}

--- a/packages/clay-toolbar/docs/markup-toolbar.md
+++ b/packages/clay-toolbar/docs/markup-toolbar.md
@@ -22,7 +22,7 @@ mainTabURL: 'docs/components/toolbar.html'
 		<div class="container-fluid container-fluid-max-xl">
 			<ul class="tbar-nav">
 				<li class="tbar-item">
-					<a class="component-action disabled" href="#1" role="button" tabindex="-1">
+					<a aria-label="Previous" title="Previous" class="component-action disabled" href="#1" role="button" tabindex="-1">
 						<svg class="lexicon-icon lexicon-icon-angle-left" focusable="false" role="presentation">
 							<use xlink:href="/images/icons/icons.svg#angle-left" />
 						</svg>
@@ -36,14 +36,14 @@ mainTabURL: 'docs/components/toolbar.html'
 					</div>
 				</li>
 				<li class="tbar-item">
-					<a class="component-action" href="#1" role="button">
+					<a aria-label="Next" title="Next" class="component-action" href="#1" role="button">
 						<svg class="lexicon-icon lexicon-icon-angle-right" focusable="false" role="presentation">
 							<use xlink:href="/images/icons/icons.svg#angle-right" />
 						</svg>
 					</a>
 				</li>
 				<li class="tbar-item">
-					<a class="component-action" href="#1" role="button">
+					<a aria-label="Close" title="Close" class="component-action" href="#1" role="button">
 						<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
 							<use xlink:href="/images/icons/icons.svg#times" />
 						</svg>
@@ -60,6 +60,8 @@ mainTabURL: 'docs/components/toolbar.html'
 		<ul class="tbar-nav">
 			<li class="tbar-item">
 				<a
+					aria-label="Previous"
+					title="Previous"
 					class="component-action disabled"
 					href="#1"
 					role="button"
@@ -85,7 +87,13 @@ mainTabURL: 'docs/components/toolbar.html'
 				</div>
 			</li>
 			<li class="tbar-item">
-				<a class="component-action" href="#1" role="button">
+				<a
+					aria-label="Next"
+					title="Next"
+					class="component-action"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-angle-right"
 						focusable="false"
@@ -96,7 +104,13 @@ mainTabURL: 'docs/components/toolbar.html'
 				</a>
 			</li>
 			<li class="tbar-item">
-				<a class="component-action" href="#1" role="button">
+				<a
+					aria-label="Close"
+					title="Close"
+					class="component-action"
+					href="#1"
+					role="button"
+				>
 					<svg
 						class="lexicon-icon lexicon-icon-times"
 						focusable="false"

--- a/packages/clay-toolbar/stories/Toolbar.stories.tsx
+++ b/packages/clay-toolbar/stories/Toolbar.stories.tsx
@@ -19,7 +19,13 @@ export const Default = () => (
 	<ClayToolbar>
 		<ClayToolbar.Nav>
 			<ClayToolbar.Item>
-				<ClayToolbar.Action disabled href="#" symbol="angle-left" />
+				<ClayToolbar.Action
+					aria-label="Previous"
+					disabled
+					href="#"
+					symbol="angle-left"
+					title="Previous"
+				/>
 			</ClayToolbar.Item>
 
 			<ClayToolbar.Item expand>
@@ -38,11 +44,23 @@ export const Default = () => (
 			</ClayToolbar.Item>
 
 			<ClayToolbar.Item>
-				<ClayToolbar.Action disabled href="#" symbol="angle-right" />
+				<ClayToolbar.Action
+					aria-label="Next"
+					disabled
+					href="#"
+					symbol="angle-right"
+					title="Next"
+				/>
 			</ClayToolbar.Item>
 
 			<ClayToolbar.Item>
-				<ClayToolbar.Action disabled href="#" symbol="times" />
+				<ClayToolbar.Action
+					aria-label="Close"
+					disabled
+					href="#"
+					symbol="times"
+					title="Close"
+				/>
 			</ClayToolbar.Item>
 		</ClayToolbar.Nav>
 	</ClayToolbar>
@@ -53,7 +71,13 @@ export const ComponentToolbar = () => (
 		<ClayLayout.ContainerFluid>
 			<ClayToolbar.Nav>
 				<ClayToolbar.Item>
-					<ClayToolbar.Action disabled href="#" symbol="angle-left" />
+					<ClayToolbar.Action
+						aria-label="Previous"
+						disabled
+						href="#"
+						symbol="angle-left"
+						title="Previous"
+					/>
 				</ClayToolbar.Item>
 
 				<ClayToolbar.Item expand>
@@ -63,14 +87,22 @@ export const ComponentToolbar = () => (
 
 				<ClayToolbar.Item>
 					<ClayToolbar.Action
+						aria-label="Next"
 						disabled
 						href="#"
 						symbol="angle-right"
+						title="Next"
 					/>
 				</ClayToolbar.Item>
 
 				<ClayToolbar.Item>
-					<ClayToolbar.Action disabled href="#" symbol="times" />
+					<ClayToolbar.Action
+						aria-label="Close"
+						disabled
+						href="#"
+						symbol="times"
+						title="Close"
+					/>
 				</ClayToolbar.Item>
 			</ClayToolbar.Nav>
 		</ClayLayout.ContainerFluid>
@@ -198,14 +230,18 @@ export const UpperToolbar = () => (
 				<ClayToolbar.Item>
 					<ClayButton.Group>
 						<ClayButtonWithIcon
+							aria-label="Previous"
 							displayType="secondary"
 							small
 							symbol="angle-left"
+							title="Previous"
 						/>
 						<ClayButtonWithIcon
+							aria-label="Next"
 							displayType="secondary"
 							small
 							symbol="angle-right"
+							title="Next"
 						/>
 					</ClayButton.Group>
 				</ClayToolbar.Item>
@@ -227,9 +263,11 @@ export const UpperToolbar = () => (
 
 				<ClayToolbar.Item>
 					<ClayButtonWithIcon
+						aria-label="More Actions"
 						displayType="unstyled"
 						small
 						symbol="ellipsis-v"
+						title="Previous"
 					/>
 				</ClayToolbar.Item>
 			</ClayToolbar.Nav>


### PR DESCRIPTION
Fixes #5237

This PR is further updating all the examples to add `aria-label` and `title` to elements that only have icons. I also ended up adding a new property to the Breadcrumb, Pagination and PaginationBar component to be able to configure `aria-label` and `title` for the ellipsis trigger.