### PR TITLE
fix(@clayui/css): Mixins clay-tbar-variant fix typo in `.tbar-divider…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_tbar.scss
+++ b/packages/clay-css/src/scss/mixins/_tbar.scss
@@ -514,7 +514,7 @@
 			}
 		}
 
-		.tbar-divider-after::after {
+		.tbar-divider-after {
 			$tbar-divider-after: setter(map-get($map, tbar-divider-after), ());
 
 			@include clay-css($tbar-divider-after);


### PR DESCRIPTION
…-after` selector

#5217