### PR TITLE
feat(@clayui/css): Adds variants to be used in Custom Select

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_forms.scss
@@ -75,6 +75,10 @@ $input: map-deep-merge(
 	$input
 );
 
+// Form Control Variants
+
+$input-palette: () !default;
+
 $input-height-border: calc(
 	#{$input-border-bottom-width} + #{$input-border-top-width}
 ) !default;
@@ -396,6 +400,36 @@ $input-select-icon-disabled: clay-icon(
 	caret-double-l,
 	$input-select-icon-disabled-color
 ) !default;
+
+// Form Control Select Variants
+
+$form-control-select-palette: () !default;
+$form-control-select-palette: map-deep-merge(
+	(
+		form-control-select-secondary: (
+			background-color: $white,
+			color: $gray-600,
+			hover: (
+				color: $gray-600,
+			),
+			focus: (
+				background-image: clay-icon(caret-double-l, $gray-900),
+				color: $gray-900,
+			),
+			disabled: (
+				background-color: $white,
+				color: $gray-600,
+				opacity: $component-disabled-opacity,
+			),
+			show: (
+				background-color: $gray-200,
+				background-image: clay-icon(caret-double-l, $gray-900),
+				color: $gray-900,
+			),
+		),
+	),
+	$form-control-select-palette
+);
 
 // select.form-control[size]
 

--- a/packages/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_forms.scss
@@ -180,6 +180,18 @@ fieldset[disabled] .form-control {
 	}
 }
 
+@each $key, $value in $cadmin-input-palette {
+	$selector: if(
+		starts-with($key, '.') or starts-with($key, '#'),
+		$key,
+		str-insert($key, '.', 1)
+	);
+
+	#{$selector} {
+		@include clay-form-control-variant($value);
+	}
+}
+
 .form-control-hidden {
 	left: 0;
 	opacity: 0;
@@ -307,6 +319,20 @@ select.form-control[size] {
 
 select.form-control[multiple] {
 	@include clay-select-variant($cadmin-input-select-multiple);
+}
+
+// Form Control Select Variants
+
+@each $key, $value in $cadmin-form-control-select-palette {
+	$selector: if(
+		starts-with($key, '.') or starts-with($key, '#'),
+		$key,
+		str-insert($key, '.', 1)
+	);
+
+	#{$selector} {
+		@include clay-select-variant($value);
+	}
 }
 
 // Textarea

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -1209,6 +1209,7 @@ $cadmin-form-control-select: map-deep-merge(
 				appearance: null,
 				cursor: null,
 				overflow: hidden,
+				text-align: left,
 				text-overflow: ellipsis,
 				white-space: nowrap,
 				hover: (

--- a/packages/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -112,6 +112,10 @@ $cadmin-input: map-deep-merge(
 	$cadmin-input
 );
 
+// Form Control Variants
+
+$cadmin-input-palette: () !default;
+
 // Form Control Plaintext
 
 $cadmin-input-plaintext-color: $cadmin-body-color !default;
@@ -1215,6 +1219,36 @@ $cadmin-form-control-select: map-deep-merge(
 		)
 	),
 	$cadmin-form-control-select
+);
+
+// Form Control Select Variants
+
+$cadmin-form-control-select-palette: () !default;
+$cadmin-form-control-select-palette: map-deep-merge(
+	(
+		form-control-select-secondary: (
+			background-color: $cadmin-white,
+			color: $cadmin-gray-600,
+			hover: (
+				color: $cadmin-gray-600,
+			),
+			focus: (
+				background-image: clay-icon(caret-double-l, $cadmin-gray-900),
+				color: $cadmin-gray-900,
+			),
+			disabled: (
+				background-color: $cadmin-white,
+				color: $cadmin-gray-600,
+				opacity: $cadmin-component-disabled-opacity,
+			),
+			show: (
+				background-color: $cadmin-gray-200,
+				background-image: clay-icon(caret-double-l, $cadmin-gray-900),
+				color: $cadmin-gray-900,
+			),
+		),
+	),
+	$cadmin-form-control-select-palette
 );
 
 $cadmin-form-control-select-sm: () !default;

--- a/packages/clay-css/src/scss/components/_dropdowns.scss
+++ b/packages/clay-css/src/scss/components/_dropdowns.scss
@@ -121,6 +121,20 @@
 	}
 }
 
+// Dropdown Menu Variants
+
+@each $key, $value in $dropdown-menu-palette {
+	$selector: if(
+		starts-with($key, '.') or starts-with($key, '#'),
+		$key,
+		str-insert($key, '.', 1)
+	);
+
+	#{$selector} {
+		@include clay-dropdown-menu-variant($value);
+	}
+}
+
 // Dropdown Menu Alignment
 
 @each $breakpoint in map-keys($grid-breakpoints) {

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -157,6 +157,18 @@ fieldset[disabled] .form-control {
 	}
 }
 
+@each $key, $value in $input-palette {
+	$selector: if(
+		starts-with($key, '.') or starts-with($key, '#'),
+		$key,
+		str-insert($key, '.', 1)
+	);
+
+	#{$selector} {
+		@include clay-form-control-variant($value);
+	}
+}
+
 .form-control-hidden {
 	left: 0;
 	opacity: 0;
@@ -278,6 +290,20 @@ select.form-control[size] {
 
 select.form-control[multiple] {
 	@include clay-select-variant($input-select-multiple);
+}
+
+// Form Control Select Variants
+
+@each $key, $value in $form-control-select-palette {
+	$selector: if(
+		starts-with($key, '.') or starts-with($key, '#'),
+		$key,
+		str-insert($key, '.', 1)
+	);
+
+	#{$selector} {
+		@include clay-select-variant($value);
+	}
 }
 
 // Textarea

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -549,7 +549,8 @@
 		@if ($enabled) {
 			@include clay-css($base);
 
-			&:hover {
+			&:hover,
+			&.hover {
 				@include clay-css($hover);
 
 				&::before {
@@ -565,7 +566,8 @@
 				}
 			}
 
-			&:focus {
+			&:focus,
+			&.focus {
 				@include clay-css($focus);
 
 				&::before {

--- a/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
+++ b/packages/clay-css/src/scss/mixins/_dropdown-menu.scss
@@ -99,10 +99,34 @@
 				@include clay-css(map-get($map, show));
 			}
 
+			.dropdown-header {
+				@include clay-css(map-get($map, dropdown-header));
+			}
+
+			.dropdown-subheader {
+				@include clay-css(map-get($map, dropdown-subheader));
+			}
+
+			.dropdown-section {
+				@include clay-css(map-get($map, dropdown-section));
+			}
+
+			.dropdown-caption {
+				@include clay-css(map-get($map, dropdown-caption));
+			}
+
 			.dropdown-item {
 				@include clay-dropdown-item-variant(
 					map-deep-get($map, dropdown-item)
 				);
+			}
+
+			.dropdown-divider {
+				@include clay-css(map-get($map, dropdown-divider));
+			}
+
+			.dropdown-footer {
+				@include clay-css(map-get($map, dropdown-footer));
 			}
 
 			.alert {
@@ -111,6 +135,54 @@
 
 			.alert-fluid {
 				@include clay-alert-variant(map-get($map, alert-fluid));
+			}
+
+			&.dropdown-menu-indicator-start {
+				$dropdown-menu-indicator-start: setter(
+					map-get($map, dropdown-menu-indicator-start),
+					()
+				);
+
+				@include clay-css($dropdown-menu-indicator-start);
+
+				.dropdown-item {
+					@include clay-dropdown-item-variant(
+						map-get($dropdown-menu-indicator-start, dropdown-item)
+					);
+				}
+
+				.dropdown-item-indicator-start {
+					@include clay-link(
+						map-get(
+							$dropdown-menu-indicator-start,
+							dropdown-item-indicator-start
+						)
+					);
+				}
+			}
+
+			&.dropdown-menu-indicator-end {
+				$dropdown-menu-indicator-end: setter(
+					map-get($map, dropdown-menu-indicator-end),
+					()
+				);
+
+				@include clay-css($dropdown-menu-indicator-end);
+
+				.dropdown-item {
+					@include clay-dropdown-item-variant(
+						map-get($dropdown-menu-indicator-end, dropdown-item)
+					);
+				}
+
+				.dropdown-item-indicator-end {
+					@include clay-link(
+						map-get(
+							$dropdown-menu-indicator-end,
+							dropdown-item-indicator-end
+						)
+					);
+				}
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -543,7 +543,8 @@
 				@include clay-css(map-deep-get($map, input-group-inset-item));
 			}
 
-			&:hover {
+			&:hover,
+			&.hover {
 				@include clay-css($hover);
 
 				&::placeholder {
@@ -870,7 +871,8 @@
 		@if ($enabled) {
 			@include clay-css($base);
 
-			&:hover {
+			&:hover,
+			&.hover {
 				@include clay-css($hover);
 
 				> option {
@@ -972,7 +974,8 @@
 				@-moz-document url-prefix() {
 					@include clay-css(map-get($map, firefox-only));
 
-					&:hover {
+					&:hover,
+					&.hover {
 						@include clay-css(
 							map-deep-get($map, firefox-only, hover)
 						);

--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -572,6 +572,14 @@
 				}
 			}
 
+			&:active {
+				@include clay-css(map-get($map, active));
+			}
+
+			&.active {
+				@include clay-css(map-get($map, active-class));
+			}
+
 			// @deprecated after v2.18.0 [readonly] can have hover focus styles, declare a separate selector and use `clay-form-control-variant` mixin (e.g., `.form-control[readonly] { @include clay-form-control-variant($the-readonly-map); }`).
 
 			&[readonly] {
@@ -887,6 +895,54 @@
 						@include clay-css(
 							map-deep-get($focus, option, checked)
 						);
+					}
+				}
+			}
+
+			&:active {
+				$active: setter(map-get($map, active), ());
+
+				@include clay-css($active);
+
+				> option {
+					$option: setter(map-get($active, option), ());
+
+					@include clay-css($option);
+
+					&:checked {
+						@include clay-css(map-get($option, checked));
+					}
+				}
+			}
+
+			&.active {
+				$active-class: setter(map-get($map, active-class), ());
+
+				@include clay-css($active-class);
+
+				> option {
+					$option: setter(map-get($active-class, option), ());
+
+					@include clay-css($option);
+
+					&:checked {
+						@include clay-css(map-get($option, checked));
+					}
+				}
+			}
+
+			&.show {
+				$show: setter(map-get($map, show), ());
+
+				@include clay-css($show);
+
+				> option {
+					$option: setter(map-get($show, option), ());
+
+					@include clay-css($option);
+
+					&:checked {
+						@include clay-css(map-get($option, checked));
 					}
 				}
 			}

--- a/packages/clay-css/src/scss/variables/_dropdowns.scss
+++ b/packages/clay-css/src/scss/variables/_dropdowns.scss
@@ -936,3 +936,55 @@ $dropdown-menu: map-deep-merge(
 	),
 	$dropdown-menu
 );
+
+// Dropdown Menu Variants
+
+$dropdown-menu-palette: () !default;
+$dropdown-menu-palette: map-deep-merge(
+	(
+		'.dropdown-menu-select.dropdown-menu': (
+			dropdown-header: (
+				padding-bottom: 0.375rem,
+				padding-left: 1.75rem,
+				padding-right: 1.75rem,
+				padding-top: 0.3125rem,
+			),
+			dropdown-subheader: (
+				padding-bottom: 0.4375rem,
+				padding-left: 1.75rem,
+				padding-right: 1.75rem,
+				padding-top: 0.4375rem,
+			),
+			dropdown-section: (
+				padding-left: 1.75rem,
+				padding-right: 1.75rem,
+			),
+			dropdown-item: (
+				padding-bottom: 0.375rem,
+				padding-left: 1.75rem,
+				padding-right: 1.75rem,
+				padding-top: 0.3125rem,
+				'&.autofit-row': (
+					padding-left: 1.5rem,
+					padding-right: 1.5rem,
+				),
+			),
+			dropdown-divider: (
+				margin: 0.3125rem 0,
+			),
+			dropdown-menu-indicator-start: (
+				dropdown-item-indicator-start: (
+					left: 0.5rem,
+					top: 0.5rem,
+				),
+			),
+			dropdown-menu-indicator-end: (
+				dropdown-item-indicator-end: (
+					right: 0.5rem,
+					top: 0.5rem,
+				),
+			),
+		),
+	),
+	$dropdown-menu-palette
+);

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -110,6 +110,10 @@ $input: map-deep-merge(
 	$input
 );
 
+// Form Control Variants
+
+$input-palette: () !default;
+
 // Form Control Plaintext
 
 $input-plaintext-color: $body-color !default;
@@ -1259,6 +1263,12 @@ $form-control-select: map-deep-merge(
 	),
 	$form-control-select
 );
+
+// Form Control Select Variants
+
+$form-control-select-palette: () !default;
+
+// Form Control Select Sizes
 
 $form-control-select-sm: () !default;
 $form-control-select-sm: map-deep-merge(

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -1252,6 +1252,7 @@ $form-control-select: map-deep-merge(
 				appearance: null,
 				cursor: null,
 				overflow: hidden,
+				text-align: left,
 				text-overflow: ellipsis,
 				white-space: nowrap,
 				hover: (


### PR DESCRIPTION
#5226

@matuzalemsteles I added the variants `form-control-select-secondary` and `dropdown-menu-select`. The custom select element markup looks like:

```html
<div class="form-group">
	<label for="formControlSelectSecondary1">A Button Styled Like a Select Element</label>
	<button class="form-control form-control-select form-control-select-secondary" id="formControlSelectSecondary1" type="button">Custom Select</button>
</div>
```

For the dropdown menu, we just need to add the class `dropdown-menu-select`. It should work with all the `dropdown-menu` modifier classes. I'm going to mark this as draft since the specs don't seem to be done. 