### PR TITLE
feat(@clayui/core): Adds new Picker/Custom Select component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -190,7 +190,7 @@ module.exports = {
 		'./packages/clay-shared/src/': {
 			branches: 21,
 			functions: 16,
-			lines: 37,
+			lines: 36,
 			statements: 39,
 		},
 		'./packages/clay-slider/src/': {

--- a/jest.config.js
+++ b/jest.config.js
@@ -55,6 +55,12 @@ module.exports = {
 			lines: 91,
 			statements: 91,
 		},
+		'./packages/clay-core/src/picker/': {
+			branches: 87,
+			functions: 93,
+			lines: 95,
+			statements: 95,
+		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 68,
 			functions: 73,

--- a/jest.config.js
+++ b/jest.config.js
@@ -57,7 +57,7 @@ module.exports = {
 		},
 		'./packages/clay-core/src/picker/': {
 			branches: 87,
-			functions: 93,
+			functions: 88,
 			lines: 95,
 			statements: 95,
 		},

--- a/jest.config.js
+++ b/jest.config.js
@@ -188,10 +188,10 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-shared/src/': {
-			branches: 25,
-			functions: 17,
-			lines: 40,
-			statements: 43,
+			branches: 21,
+			functions: 16,
+			lines: 37,
+			statements: 39,
 		},
 		'./packages/clay-slider/src/': {
 			branches: 92,

--- a/packages/clay-core/docs/api-picker.mdx
+++ b/packages/clay-core/docs/api-picker.mdx
@@ -1,0 +1,13 @@
+---
+title: 'Picker'
+description: 'A select is very similar to a dropdown visually but it let users select options from the panel and then represent the selection in the button.'
+mainTabURL: 'docs/components/picker.html'
+---
+
+## Picker
+
+<div>[APITable "clay-core/src/picker/Picker.tsx"]</div>
+
+## Option
+
+<div>[APITable "clay-core/src/picker/Option.tsx"]</div>

--- a/packages/clay-core/docs/picker.js
+++ b/packages/clay-core/docs/picker.js
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Editor from '$clayui.com/src/components/Editor';
+import {Option, Picker} from '@clayui/core';
+import Form from '@clayui/form';
+import React from 'react';
+
+const exampleImports = `import {Option, Picker} from '@clayui/core';
+import Form from '@clayui/form';
+import React from 'react';`;
+
+const exampleCode = `const SelectAnFruit = () => {
+  return (
+    <div style={{width: '150px'}}>
+			<Form.Group>
+        <label htmlFor="picker" id="picker-label">
+					Choose a fruit
+				</label>
+				<Picker
+          aria-labelledby="picker-label"
+          id="picker"
+					items={[
+						'Apple',
+						'Banana',
+						'Mangos',
+						'Blueberry',
+						'Boysenberry',
+						'Cherry',
+						'Cranberry',
+						'Eggplant',
+						'Fig',
+						'Grape',
+						'Guava',
+						'Huckleberry',
+					]}
+          placeholder="Select a fruit"
+				>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			</Form.Group>
+		</div>
+  );
+};
+
+render(<SelectAnFruit />)`;
+
+const PickerExample = () => {
+	const scope = {Form, Option, Picker};
+
+	return <Editor code={exampleCode} imports={exampleImports} scope={scope} />;
+};
+
+export {PickerExample};

--- a/packages/clay-core/docs/picker.mdx
+++ b/packages/clay-core/docs/picker.mdx
@@ -1,0 +1,153 @@
+---
+title: 'Picker'
+description: 'A select is very similar to a dropdown visually but it let users select options from the panel and then represent the selection in the button.'
+packageNpm: '@clayui/core'
+packageStatus: 'Beta'
+storybookPath: 'design-system-components-picker'
+---
+
+import {PickerExample} from '$packages/clay-core/docs/picker';
+
+<div class="nav-toc-absolute">
+<div class="nav-toc">
+
+-   [Example](#example)
+-   [Introduction](#introduction)
+-   [Content](#content)
+    -   [Static](#static)
+    -   [Dynamic](#dynamic)
+-   [Controlled and Uncontrolled component](#controlled-and-uncontrolled-component)
+-   [Hybrid component](#hybrid-component)
+
+</div>
+</div>
+
+## Example
+
+<PickerExample />
+
+## Introduction
+
+The Picker component is visually similar to a DropDown component but developed specifically for the user to select options from the menu but following the [w3c accessibility](https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html) recommendations.
+
+Like the TreeView, VerticalBar and other components this is a middle-level component rather than a low-level or high-level component. Unlike a DropDown, the Picker has simplified APIs and OOTB features to follow accessibility patterns for a combobox-only but following the same APIs pattern and allowing flexibility to customize the content of the options and the trigger.
+
+## Content
+
+Content rendered in the `<Picker />` Menu can be done in two different ways, static and dynamic content just like in DropDown, the choice depends on the use case.
+
+### Static
+
+Static content is when the `<Picker />` options do not change during the lifecycle of the application or are hardcoded options.
+
+```jsx
+<Form.Group>
+	<label htmlFor="picker" id="picker-label">
+		Choose a fruit
+	</label>
+	<Picker aria-labelledby="picker-label" id="picker">
+		<Option key="apple">Apple</Option>
+		<Option disabled key="banana">
+			Banana
+		</Option>
+		<Option key="mangos">Mangos</Option>
+		<Option key="blueberry">Blueberry</Option>
+	</Picker>
+</Form.Group>
+```
+
+### Dynamic
+
+Unlike static content, dynamic content is when the options can change during the lifecycle of the application or when the data comes from a service. Dynamic content rendering is data agnostic, this allows you to configure how to render the component options regardless of the chosen data structure.
+
+```jsx
+<Form.Group>
+	<label htmlFor="picker" id="picker-label">
+		Choose a fruit
+	</label>
+	<Picker
+		aria-labelledby="picker-label"
+		id="picker"
+		items={['Apple', 'Banana', 'Mangos']}
+	>
+		{(item) => <Option key={item}>{item}</Option>}
+	</Picker>
+</Form.Group>
+```
+
+## Controlled and Uncontrolled component
+
+As with any component in Clay, controlled and uncontrolled components are the ability to manage state in the parent or let Clay control the state of the component. You can [read more about this in our blog](/blog/2022/05/02/api-consistency-improvements-for-controlled-and-uncontrolled-components.html).
+
+For the `<Picker />` component you can control the `selectedKey` and `active` states by adding a state to your component, this is only advisable when you need this information otherwise don't use it.
+
+If you just need to set the initial state of the `selectedKey`, use the `defaultSelectedKey` property which is appropriate for that use case.
+
+<div class="clay-site-alert alert alert-info">
+	<strong class="lead">Info</strong>
+	The <code class="language-text">selectedKey</code> property is represented by
+	the <code class="language-text">key</code> property configured in the <code class="language-text">
+		Option
+	</code> component, so the component can identify which value is selected and
+	which should be shown in the trigger. <br />
+	<br />
+	When the content rendering is dynamic and the data has <code class="language-text">
+		id
+	</code> property defined, the component uses <code class="language-text">
+		id
+	</code> instead of <code class="language-text">key</code>.
+</div>
+
+```jsx
+function Example() {
+	// Controlled
+	const [active, setActive] = useState(false);
+
+	// Controlled
+	const [selectedKey, setSelectedKey] = useState('');
+
+	return (
+		<Form.Group>
+			<label htmlFor="picker" id="picker-label">
+				Choose a fruit
+			</label>
+			<Picker
+				active={active}
+				aria-labelledby="picker-label"
+				id="picker"
+				onActiveChange={setActive}
+				onSelectionChange={setSelectedKey}
+				selectedKey={selectedKey}
+			>
+				<Option key="apple">Apple</Option>
+				<Option key="banana">Banana</Option>
+				<Option key="mangos">Mangos</Option>
+			</Picker>
+		</Form.Group>
+	);
+}
+```
+
+## Hybrid component
+
+Native select for mobile devices offers a better experience compared to Picker in some cases. The Picker offers the possibility to render using the native selector of the browser of the device when it is detected that it is on a mobile device, by default this property is disabled but it can be enabled by setting the `native` property to `true`.
+
+<div class="clay-site-alert alert alert-warning">
+	<strong class="lead">Warning</strong>
+	If the content of the Option component is not simple text, for it to work correctly
+	set the property <code class="language-text">textValue</code> to ensure that
+	the component knows what the option label is.
+</div>
+
+```jsx
+<Form.Group>
+	<label htmlFor="picker" id="picker-label">
+		Choose a fruit
+	</label>
+	<Picker aria-labelledby="picker-label" id="picker" native>
+		<Option key="apple">Apple</Option>
+		<Option key="banana">Banana</Option>
+		<Option key="mangos">Mangos</Option>
+	</Picker>
+</Form.Group>
+```

--- a/packages/clay-core/src/collection/Collection.tsx
+++ b/packages/clay-core/src/collection/Collection.tsx
@@ -4,30 +4,20 @@
  */
 
 import {useVirtualizer} from '@tanstack/react-virtual';
-import React, {useCallback, useEffect, useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 
-export type ChildrenFunction<T, P> = P extends Array<unknown>
-	? (item: T, ...args: P) => React.ReactElement
-	: (item: T) => React.ReactElement;
+import {useCollection} from './useCollection';
+import {excludeProps, getKey} from './utils';
 
-export interface ICollectionProps<T, P> {
-	/**
-	 * Children content to render a dynamic or static content.
-	 */
-	children: React.ReactNode | ChildrenFunction<T, P>;
+import type {
+	ChildElement,
+	ChildrenFunction,
+	CollectionState,
+	ICollectionProps,
+	Props,
+} from './types';
 
-	/**
-	 * Property to render content with dynamic data.
-	 */
-	items?: Array<T>;
-
-	/**
-	 * Flag to indicate whether the list should be virtualized.
-	 */
-	virtualize?: boolean;
-}
-
-interface IProps<P, K>
+interface IProps
 	extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
 	/**
 	 * Component to render.
@@ -35,15 +25,14 @@ interface IProps<P, K>
 	as?: 'div' | React.ComponentType | React.ForwardRefExoticComponent<any>;
 
 	/**
+	 * Suspense collection that was initialized before the component rendered.
+	 */
+	collection?: CollectionState;
+
+	/**
 	 * Flag to estimate the default height of a list item in pixels.
 	 */
 	estimateSize?: number;
-
-	/**
-	 * Properties that should be omitted from item data when passed to
-	 * children function.
-	 */
-	exclude?: Set<K>;
 
 	/**
 	 * Flag to enable infinite scroll.
@@ -56,16 +45,6 @@ interface IProps<P, K>
 	isLoading?: boolean;
 
 	/**
-	 * Test method for filtering elements in children (static only).
-	 */
-	filter?: (value: string) => boolean;
-
-	/**
-	 * Defines the name of the property key that is used in the filter (static only).
-	 */
-	filterKey?: string;
-
-	/**
 	 * Add the reference of the parent element that will be used to define the
 	 * scroll and get the height of the element for virtualization of the
 	 * collection.
@@ -73,79 +52,17 @@ interface IProps<P, K>
 	parentRef: React.RefObject<HTMLElement>;
 
 	/**
-	 * Flag to pass the key value to the element.
-	 */
-	passthroughKey?: boolean;
-
-	/**
 	 * Callback called when the last element of the list is rendered in
 	 * virtualization and infiniteScroll is enabled.
 	 */
 	onBottom?: () => void;
-
-	/**
-	 * Set for the parent's key to create the unique key of the list items, if
-	 * the collection is rendered nested.
-	 */
-	parentKey?: React.Key;
-
-	/**
-	 * Defines the public APIs that are passed in the children function when
-	 * it is a dynamic collection.
-	 */
-	publicApi?: P;
-
-	/**
-	 * Defines a component that will be used as a wrapper for items in the
-	 * collection if defined.
-	 */
-	itemContainer?: (props: any) => JSX.Element | null;
 }
 
-type ChildElement = React.ReactElement<any> & {
-	ref?: (node: HTMLElement | null) => void;
-};
-
-/**
- * Helper function to create a unique key for list or tree when defined by
- * developer data or obtained by component in React.
- */
-export function getKey(
-	index: number,
-	key?: React.Key | null,
-	parentKey?: React.Key
-) {
-	if (
-		key != null &&
-		(!String(key).startsWith('.') || String(key).startsWith('.$'))
-	) {
-		return key;
-	}
-
-	return parentKey ? `${parentKey}.${index}` : `$.${index}`;
-}
-
-/**
- * Helper function for omitting properties of an object, similar to
- * TypeScript's Omit<T, K>.
- */
-export function excludeProps<T extends Record<string, any>, K extends keyof T>(
-	props: T,
-	items: Set<K>
-) {
-	return (Object.keys(props) as Array<K>).reduce<T>((previous, key) => {
-		if (!items.has(key)) {
-			previous[key] = props[key];
-		}
-
-		return previous;
-	}, {} as T);
-}
-
-type VirtualProps<T, P, K> = Omit<IProps<P, K>, 'filter'> & {
-	children: ChildrenFunction<T, P>;
-	items: Array<T>;
-};
+type VirtualProps<T, P, K> = Omit<IProps, 'filter' | 'collection'> &
+	Props<P, K> & {
+		children: ChildrenFunction<T, P>;
+		items: Array<T>;
+	};
 
 function VirtualDynamicCollection<T extends Record<any, any>, P, K>({
 	as: Container = 'div',
@@ -266,6 +183,36 @@ function VirtualDynamicCollection<T extends Record<any, any>, P, K>({
 	);
 }
 
+function DynamicCollection<
+	T extends Record<any, any>,
+	P = unknown,
+	K = unknown
+>({
+	children,
+	exclude,
+	filter,
+	filterKey,
+	itemContainer,
+	items,
+	parentKey,
+	passthroughKey,
+	publicApi,
+}: ICollectionProps<T, P> & Props<P, K>) {
+	const state = useCollection({
+		children,
+		exclude,
+		filter,
+		filterKey,
+		itemContainer,
+		items,
+		parentKey,
+		passthroughKey,
+		publicApi,
+	});
+
+	return <>{state.collection}</>;
+}
+
 export function Collection<
 	T extends Record<any, any>,
 	P = unknown,
@@ -273,13 +220,14 @@ export function Collection<
 >({
 	as,
 	children,
+	collection,
 	estimateSize,
 	exclude,
 	filter,
 	filterKey,
 	infiniteScroll,
 	isLoading,
-	itemContainer: ItemContainer,
+	itemContainer,
 	items,
 	onBottom,
 	parentKey,
@@ -288,33 +236,7 @@ export function Collection<
 	publicApi,
 	virtualize = false,
 	...otherProps
-}: ICollectionProps<T, P> & Partial<IProps<P, K>>) {
-	const performFilter = useCallback(
-		(
-			child:
-				| React.ReactPortal
-				| React.ReactElement<
-						unknown,
-						string | React.JSXElementConstructor<any>
-				  >
-		) => {
-			if (!filter) {
-				return false;
-			}
-
-			if (typeof child.props.children === 'string') {
-				return !filter(child.props.children);
-			}
-
-			if (filterKey && child.props[filterKey]) {
-				return !filter(child.props[filterKey]);
-			}
-
-			return false;
-		},
-		[filter]
-	);
-
+}: Partial<ICollectionProps<T, P>> & Props<P, K> & Partial<IProps>) {
 	if (virtualize && children instanceof Function && items && parentRef) {
 		return (
 			<VirtualDynamicCollection
@@ -323,7 +245,7 @@ export function Collection<
 				estimateSize={estimateSize}
 				infiniteScroll={infiniteScroll}
 				isLoading={isLoading}
-				itemContainer={ItemContainer}
+				itemContainer={itemContainer}
 				items={items}
 				onBottom={onBottom}
 				parentKey={parentKey}
@@ -338,78 +260,26 @@ export function Collection<
 
 	const Container = as ?? React.Fragment;
 
-	return (
-		<Container {...otherProps}>
-			{children instanceof Function && items
-				? items.map((item, index) => {
-						const publicItem = exclude
-							? excludeProps(item, exclude)
-							: item;
-						const child: ChildElement = Array.isArray(publicApi)
-							? children(publicItem, ...publicApi)
-							: children(publicItem);
+	let content;
 
-						const key = getKey(
-							index,
-							item.id ?? child.key,
-							parentKey
-						);
+	if (collection) {
+		content = <>{collection.collection}</>;
+	} else {
+		content = (
+			<DynamicCollection
+				exclude={exclude}
+				filter={filter}
+				filterKey={filterKey}
+				itemContainer={itemContainer}
+				items={items}
+				parentKey={parentKey}
+				passthroughKey={passthroughKey}
+				publicApi={publicApi}
+			>
+				{children}
+			</DynamicCollection>
+		);
+	}
 
-						if (performFilter(child)) {
-							return;
-						}
-
-						if (ItemContainer) {
-							return (
-								<ItemContainer
-									index={index}
-									item={item}
-									key={key}
-									keyValue={key}
-								>
-									{child}
-								</ItemContainer>
-							);
-						}
-
-						return React.cloneElement(child, {
-							key,
-							...(passthroughKey ? {index, keyValue: key} : {}),
-						});
-				  })
-				: React.Children.map(children, (child, index) => {
-						if (!React.isValidElement(child)) {
-							return null;
-						}
-
-						if (performFilter(child)) {
-							return;
-						}
-
-						const key = getKey(index, child.key, parentKey);
-
-						if (ItemContainer) {
-							return (
-								<ItemContainer
-									index={index}
-									key={key}
-									keyValue={key}
-								>
-									{child}
-								</ItemContainer>
-							);
-						}
-
-						return React.cloneElement(
-							child as React.ReactElement<{keyValue?: React.Key}>,
-							{
-								key,
-								...(passthroughKey
-									? {index, keyValue: key}
-									: {}),
-							}
-						);
-				  })}
-		</Container>
-	);
+	return <Container {...otherProps}>{content}</Container>;
 }

--- a/packages/clay-core/src/collection/Collection.tsx
+++ b/packages/clay-core/src/collection/Collection.tsx
@@ -131,7 +131,7 @@ function VirtualDynamicCollection<T extends Record<any, any>, P, K>({
 
 				const publicItem = exclude ? excludeProps(item, exclude) : item;
 
-				const child: ChildElement = Array.isArray(publicApi)
+				const child = Array.isArray(publicApi)
 					? children(publicItem, ...publicApi)
 					: children(publicItem);
 
@@ -145,8 +145,10 @@ function VirtualDynamicCollection<T extends Record<any, any>, P, K>({
 					ref: (node: HTMLElement) => {
 						virtual.measureElement(node);
 
-						if (typeof child.ref === 'function') {
-							child.ref(node);
+						const ref = (child as ChildElement).ref;
+
+						if (typeof ref === 'function') {
+							ref(node);
 						}
 					},
 					style: {

--- a/packages/clay-core/src/collection/index.ts
+++ b/packages/clay-core/src/collection/index.ts
@@ -3,10 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-export {
-	Collection,
-	ChildrenFunction,
-	excludeProps,
-	ICollectionProps,
-	getKey,
-} from './Collection';
+export {getKey, excludeProps} from './utils';
+export {Collection} from './Collection';
+export {useCollection} from './useCollection';
+export type {ChildrenFunction, ICollectionProps} from './types';

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export type ChildElement = React.ReactElement<any> & {
+	ref?: (node: HTMLElement | null) => void;
+};
+
+export type ChildrenFunction<T, P> = P extends Array<unknown>
+	? (item: T, ...args: P) => React.ReactElement
+	: (item: T) => React.ReactElement;
+
+export interface ICollectionProps<T, P> {
+	/**
+	 * Children content to render a dynamic or static content.
+	 */
+	children: React.ReactNode | ChildrenFunction<T, P>;
+
+	/**
+	 * Property to render content with dynamic data.
+	 */
+	items?: Array<T>;
+
+	/**
+	 * Flag to indicate whether the list should be virtualized.
+	 */
+	virtualize?: boolean;
+}
+
+export type CollectionState = {
+	collection: Array<JSX.Element | null | undefined>;
+	getItem: (key: React.Key) => any;
+};
+
+export type Props<P, K> = {
+	/**
+	 * Properties that should be omitted from item data when passed to
+	 * children function.
+	 */
+	exclude?: Set<K>;
+
+	/**
+	 * Test method for filtering elements in children (static only).
+	 */
+	filter?: (value: string) => boolean;
+
+	/**
+	 * Defines the name of the property key that is used in the filter (static only).
+	 */
+	filterKey?: string;
+
+	/**
+	 * Flag to pass the key value to the element.
+	 */
+	passthroughKey?: boolean;
+
+	/**
+	 * Set for the parent's key to create the unique key of the list items, if
+	 * the collection is rendered nested.
+	 */
+	parentKey?: React.Key;
+
+	/**
+	 * Defines the public APIs that are passed in the children function when
+	 * it is a dynamic collection.
+	 */
+	publicApi?: P;
+
+	/**
+	 * Defines a component that will be used as a wrapper for items in the
+	 * collection if defined.
+	 */
+	itemContainer?: (props: any) => JSX.Element | null;
+
+	suppressTextValueWarning?: boolean;
+};

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -29,8 +29,9 @@ export interface ICollectionProps<T, P> {
 }
 
 export type CollectionState = {
-	collection: Array<JSX.Element | null | undefined>;
-	getItem: (key: React.Key) => any;
+	collection: JSX.Element;
+	getFirstItem: () => {key: string; value: string};
+	getItem: (key: React.Key) => string;
 };
 
 export type Props<P, K> = {

--- a/packages/clay-core/src/collection/types.ts
+++ b/packages/clay-core/src/collection/types.ts
@@ -3,7 +3,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-export type ChildElement = React.ReactElement<any> & {
+type ChildType = {
+	displayName?: string;
+	passthroughKey?: boolean;
+};
+
+interface IReactTypeElement extends Omit<React.ReactElement<any>, 'type'> {
+	type: ChildType;
+}
+
+export type ChildElement = IReactTypeElement & {
 	ref?: (node: HTMLElement | null) => void;
 };
 

--- a/packages/clay-core/src/collection/useCollection.tsx
+++ b/packages/clay-core/src/collection/useCollection.tsx
@@ -1,0 +1,176 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React, {useCallback, useMemo, useRef} from 'react';
+
+import {excludeProps, getKey} from './utils';
+
+import type {ChildElement, ICollectionProps, Props} from './types';
+
+export type CollectionState = {
+	collection: Array<JSX.Element | null | undefined>;
+	getFirstItem: () => {key: string; value: string};
+	getItem: (key: React.Key) => string;
+};
+
+export function useCollection<
+	T extends Record<any, any>,
+	P = unknown,
+	K = unknown
+>({
+	children,
+	exclude,
+	filter,
+	filterKey,
+	itemContainer: ItemContainer,
+	items,
+	parentKey,
+	passthroughKey = true,
+	publicApi,
+	suppressTextValueWarning = true,
+}: ICollectionProps<T, P> & Props<P, K>): CollectionState {
+	const layoutRef = useRef<Map<React.Key, any>>(new Map());
+
+	const performFilter = useCallback(
+		(
+			child:
+				| React.ReactPortal
+				| React.ReactElement<
+						unknown,
+						string | React.JSXElementConstructor<any>
+				  >
+		) => {
+			if (!filter) {
+				return false;
+			}
+
+			if (typeof child.props.children === 'string') {
+				return !filter(child.props.children);
+			}
+
+			if (filterKey && child.props[filterKey]) {
+				return !filter(child.props[filterKey]);
+			}
+
+			return false;
+		},
+		[filter]
+	);
+
+	const getItem = useCallback((key: React.Key) => {
+		return layoutRef.current.get(key);
+	}, []);
+
+	const getFirstItem = useCallback(() => {
+		const key = layoutRef.current.keys().next().value;
+
+		return {
+			key,
+			value: layoutRef.current.get(key),
+		};
+	}, []);
+
+	const collection = useMemo(() => {
+		if (children instanceof Function && items) {
+			return items.map((item, index) => {
+				const publicItem = exclude ? excludeProps(item, exclude) : item;
+				const child: ChildElement = Array.isArray(publicApi)
+					? children(publicItem, ...publicApi)
+					: children(publicItem);
+
+				const key = getKey(index, item.id ?? child.key, parentKey);
+
+				layoutRef.current.set(
+					key,
+					getTextValue(key, child, suppressTextValueWarning)
+				);
+
+				if (performFilter(child)) {
+					return;
+				}
+
+				if (ItemContainer) {
+					return (
+						<ItemContainer
+							index={index}
+							item={item}
+							key={key}
+							keyValue={key}
+						>
+							{child}
+						</ItemContainer>
+					);
+				}
+
+				return React.cloneElement(child, {
+					key,
+					...(passthroughKey ? {index, keyValue: key} : {}),
+				});
+			});
+		}
+
+		return React.Children.map(children, (child, index) => {
+			if (!React.isValidElement(child)) {
+				return null;
+			}
+
+			const key = getKey(index, child.key, parentKey);
+
+			layoutRef.current.set(
+				key,
+				getTextValue(key, child, suppressTextValueWarning)
+			);
+
+			if (performFilter(child)) {
+				return;
+			}
+
+			if (ItemContainer) {
+				return (
+					<ItemContainer index={index} key={key} keyValue={key}>
+						{child}
+					</ItemContainer>
+				);
+			}
+
+			return React.cloneElement(
+				child as React.ReactElement<{keyValue?: React.Key}>,
+				{
+					key,
+					...(passthroughKey ? {index, keyValue: key} : {}),
+				}
+			);
+		});
+	}, [children, performFilter, items, publicApi]);
+
+	return {collection, getFirstItem, getItem};
+}
+
+function getTextValue(
+	key: React.Key,
+	child:
+		| React.ReactPortal
+		| React.ReactElement<
+				unknown,
+				string | React.JSXElementConstructor<any>
+		  >,
+	suppressTextValueWarning: boolean
+) {
+	if (typeof child.props.children === 'string') {
+		return child.props.children;
+	}
+
+	if (child.props.textValue) {
+		return child.props.textValue;
+	}
+
+	if (!suppressTextValueWarning) {
+		console.warn(
+			`Clay: <Item key="${key}" /> with non-plain text content is not compatible with the type being selected. Please add a \`textValue\` prop.`
+		);
+	}
+
+	return '';
+}

--- a/packages/clay-core/src/collection/utils.ts
+++ b/packages/clay-core/src/collection/utils.ts
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Helper function to create a unique key for list or tree when defined by
+ * developer data or obtained by component in React.
+ */
+export function getKey(
+	index: number,
+	key?: React.Key | null,
+	parentKey?: React.Key
+) {
+	if (
+		key != null &&
+		(!String(key).startsWith('.') || String(key).startsWith('.$'))
+	) {
+		return key;
+	}
+
+	return parentKey ? `${parentKey}.${index}` : `$.${index}`;
+}
+
+/**
+ * Helper function for omitting properties of an object, similar to
+ * TypeScript's Omit<T, K>.
+ */
+export function excludeProps<T extends Record<string, any>, K extends keyof T>(
+	props: T,
+	items: Set<K>
+) {
+	return (Object.keys(props) as Array<K>).reduce<T>((previous, key) => {
+		if (!items.has(key)) {
+			previous[key] = props[key];
+		}
+
+		return previous;
+	}, {} as T);
+}

--- a/packages/clay-core/src/index.ts
+++ b/packages/clay-core/src/index.ts
@@ -19,6 +19,7 @@ export {Heading, Text} from './typography';
 export {OverlayMask} from './overlay-mask';
 export {TreeView} from './tree-view';
 export {VerticalBar} from './vertical-bar';
+export {Picker, Option} from './picker';
 
 // Internal dependencies not public but exposed to other Clay packages.
 export * as __NOT_PUBLIC_COLLECTION from './collection';

--- a/packages/clay-core/src/picker/Option.tsx
+++ b/packages/clay-core/src/picker/Option.tsx
@@ -90,3 +90,5 @@ export function Option({children, disabled, keyValue, textValue}: Props) {
 		</li>
 	);
 }
+
+Option.displayName = 'Item';

--- a/packages/clay-core/src/picker/Option.tsx
+++ b/packages/clay-core/src/picker/Option.tsx
@@ -6,7 +6,7 @@
 import Icon from '@clayui/icon';
 import {useHover, useInteractionFocus} from '@clayui/shared';
 import classNames from 'classnames';
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback} from 'react';
 
 import {usePickerState} from './context';
 
@@ -25,12 +25,6 @@ type Props = {
 	 * Internal property.
 	 * @ignore
 	 */
-	index?: React.Key;
-
-	/**
-	 * Internal property.
-	 * @ignore
-	 */
 	keyValue?: React.Key;
 
 	/**
@@ -40,36 +34,15 @@ type Props = {
 	textValue?: string;
 };
 
-export function Option({
-	children,
-	disabled,
-	index,
-	keyValue,
-	textValue,
-}: Props) {
+export function Option({children, disabled, keyValue}: Props) {
 	const {
 		activeDescendant,
 		onActiveDescendant,
-		onItemRendered,
 		onSelectionChange,
 		selectedKey,
 	} = usePickerState();
 
 	const {isFocusVisible} = useInteractionFocus();
-
-	if (typeof children !== 'string' && !textValue) {
-		console.warn(
-			'Clay: <Option /> with non-plain text content is not compatible with the type being selected. Please add a `textValue` prop.'
-		);
-	}
-
-	// Sets the initial activeDescendant value when the first one is rendered if
-	// it is empty.
-	useEffect(() => {
-		if (index === 0 && !activeDescendant) {
-			onActiveDescendant(String(keyValue));
-		}
-	}, []);
 
 	const hoverProps = useHover({
 		disabled,
@@ -93,12 +66,7 @@ export function Option({
 				})}
 				disabled={disabled}
 				id={String(keyValue)}
-				onClick={() => {
-					onSelectionChange(keyValue!);
-					onItemRendered(
-						typeof children === 'string' ? children : textValue!
-					);
-				}}
+				onClick={() => onSelectionChange(keyValue!)}
 				role="option"
 				tabIndex={-1}
 			>

--- a/packages/clay-core/src/picker/Option.tsx
+++ b/packages/clay-core/src/picker/Option.tsx
@@ -34,9 +34,10 @@ type Props = {
 	textValue?: string;
 };
 
-export function Option({children, disabled, keyValue}: Props) {
+export function Option({children, disabled, keyValue, textValue}: Props) {
 	const {
 		activeDescendant,
+		isMobile,
 		onActiveDescendant,
 		onSelectionChange,
 		selectedKey,
@@ -53,6 +54,14 @@ export function Option({children, disabled, keyValue}: Props) {
 	});
 
 	const isFocus = isFocusVisible();
+
+	if (isMobile) {
+		return (
+			<option disabled={disabled} value={keyValue}>
+				{typeof children === 'string' ? children : textValue}
+			</option>
+		);
+	}
 
 	return (
 		<li role="presentation">

--- a/packages/clay-core/src/picker/Option.tsx
+++ b/packages/clay-core/src/picker/Option.tsx
@@ -4,7 +4,7 @@
  */
 
 import Icon from '@clayui/icon';
-import {useHover} from '@clayui/shared';
+import {useHover, useInteractionFocus} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useCallback, useEffect} from 'react';
 
@@ -55,6 +55,8 @@ export function Option({
 		selectedKey,
 	} = usePickerState();
 
+	const {isFocusVisible} = useInteractionFocus();
+
 	if (typeof children !== 'string' && !textValue) {
 		console.warn(
 			'Clay: <Option /> with non-plain text content is not compatible with the type being selected. Please add a `textValue` prop.'
@@ -77,15 +79,17 @@ export function Option({
 		),
 	});
 
+	const isFocus = isFocusVisible();
+
 	return (
 		<li role="presentation">
 			<button
 				{...hoverProps}
 				aria-selected={selectedKey === keyValue}
 				className={classNames('dropdown-item', {
-					active:
-						selectedKey === keyValue ||
-						activeDescendant === String(keyValue),
+					active: selectedKey === keyValue,
+					focus: activeDescendant === String(keyValue) && isFocus,
+					hover: activeDescendant === String(keyValue) && !isFocus,
 				})}
 				disabled={disabled}
 				id={String(keyValue)}

--- a/packages/clay-core/src/picker/Option.tsx
+++ b/packages/clay-core/src/picker/Option.tsx
@@ -91,4 +91,5 @@ export function Option({children, disabled, keyValue, textValue}: Props) {
 	);
 }
 
+Option.passthroughKey = true;
 Option.displayName = 'Item';

--- a/packages/clay-core/src/picker/Option.tsx
+++ b/packages/clay-core/src/picker/Option.tsx
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Icon from '@clayui/icon';
+import {useHover} from '@clayui/shared';
+import classNames from 'classnames';
+import React, {useCallback, useEffect} from 'react';
+
+import {usePickerState} from './context';
+
+type Props = {
+	/**
+	 * The contents of the component.
+	 */
+	children?: React.ReactNode;
+
+	/**
+	 * Flag that indicates if option is disabled.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Internal property.
+	 * @ignore
+	 */
+	index?: React.Key;
+
+	/**
+	 * Internal property.
+	 * @ignore
+	 */
+	keyValue?: React.Key;
+
+	/**
+	 * Sets a text value if the component's content is not plain text. This value
+	 * is used in the combobox element to show the selected option.
+	 */
+	textValue?: string;
+};
+
+export function Option({
+	children,
+	disabled,
+	index,
+	keyValue,
+	textValue,
+}: Props) {
+	const {
+		activeDescendant,
+		onActiveDescendant,
+		onItemRendered,
+		onSelectionChange,
+		selectedKey,
+	} = usePickerState();
+
+	if (typeof children !== 'string' && !textValue) {
+		console.warn(
+			'Clay: <Option /> with non-plain text content is not compatible with the type being selected. Please add a `textValue` prop.'
+		);
+	}
+
+	// Sets the initial activeDescendant value when the first one is rendered if
+	// it is empty.
+	useEffect(() => {
+		if (index === 0 && !activeDescendant) {
+			onActiveDescendant(String(keyValue));
+		}
+	}, []);
+
+	const hoverProps = useHover({
+		disabled,
+		onHover: useCallback(
+			() => onActiveDescendant(String(keyValue)),
+			[keyValue]
+		),
+	});
+
+	return (
+		<li role="presentation">
+			<button
+				{...hoverProps}
+				aria-selected={selectedKey === keyValue}
+				className={classNames('dropdown-item', {
+					active:
+						selectedKey === keyValue ||
+						activeDescendant === String(keyValue),
+				})}
+				disabled={disabled}
+				id={String(keyValue)}
+				onClick={() => {
+					onSelectionChange(keyValue!);
+					onItemRendered(
+						typeof children === 'string' ? children : textValue!
+					);
+				}}
+				role="option"
+				tabIndex={-1}
+			>
+				{selectedKey === keyValue && (
+					<span className="dropdown-item-indicator-start">
+						<Icon symbol="check" />
+					</span>
+				)}
+
+				{children}
+			</button>
+		</li>
+	);
+}

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -44,7 +44,10 @@ export type Props<T> = {
 	/**
 	 * Custom trigger component.
 	 */
-	as?: 'button' | React.ComponentType | React.ForwardRefExoticComponent<any>;
+	as?:
+		| 'button'
+		| React.ForwardRefExoticComponent<any>
+		| ((props: React.HTMLAttributes<HTMLElement>) => JSX.Element);
 
 	/**
 	 *  Property to set the default value of `active` (uncontrolled).
@@ -96,7 +99,7 @@ export function Picker<T>({
 	active: externalActive,
 	as: As = 'button',
 	children,
-	defaultActive,
+	defaultActive = false,
 	defaultSelectedKey,
 	direction = 'bottom',
 	disabled,
@@ -323,9 +326,7 @@ export function Picker<T>({
 					triggerRef={triggerRef}
 				>
 					<div
-						className={classNames(
-							'dropdown-menu dropdown-menu-select dropdown-menu-indicator-start show'
-						)}
+						className="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select show"
 						id={ariaControls}
 						onFocus={() => triggerRef.current?.focus()}
 						ref={menuRef}

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -322,6 +322,7 @@ export function Picker<T>({
 
 						setActive(false);
 					}}
+					portalRef={menuRef}
 					suppress={[triggerRef, menuRef]}
 					triggerRef={triggerRef}
 				>

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -176,10 +176,10 @@ export function Picker<T>({
 			<As
 				{...otherProps}
 				aria-activedescendant={active ? activeDescendant : ''}
-				aria-controls={ariaControls}
+				aria-controls={active ? ariaControls : undefined}
 				aria-expanded={active}
 				aria-haspopup="listbox"
-				aria-owns={ariaOwns}
+				aria-owns={active ? ariaOwns : undefined}
 				className={classNames(
 					'form-control form-control-select form-control-select-secondary',
 					{
@@ -316,6 +316,7 @@ export function Picker<T>({
 							'dropdown-menu dropdown-menu-select dropdown-menu-indicator-start show'
 						)}
 						id={ariaControls}
+						onFocus={() => triggerRef.current?.focus()}
 						ref={menuRef}
 						role="presentation"
 					>

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -1,0 +1,295 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {
+	InternalDispatch,
+	Keys,
+	Overlay,
+	useId,
+	useInternalState,
+	useNavigation,
+	useOverlayPosition,
+} from '@clayui/shared';
+import classNames from 'classnames';
+import React, {useCallback, useRef, useState} from 'react';
+
+import {Collection} from '../collection';
+import {PickerContext} from './context';
+
+import type {ICollectionProps} from '../collection';
+
+export type Props<T> = {
+	/**
+	 * Flag to indicate if the DropDown menu is active or not (controlled).
+	 */
+	active?: boolean;
+
+	/**
+	 * The `aria-labelledby` attribute identifies the element (or elements) that
+	 * labels the element it is applied to.
+	 */
+	'aria-labelledby'?: string;
+
+	/**
+	 * Custom trigger component.
+	 */
+	as?: 'button' | React.ComponentType | React.ForwardRefExoticComponent<any>;
+
+	/**
+	 *  Property to set the default value of `active` (uncontrolled).
+	 */
+	defaultActive?: boolean;
+
+	/**
+	 * The initial selected key (uncontrolled).
+	 */
+	defaultSelectedKey?: React.Key;
+
+	/**
+	 * Direction the menu will render relative to the Picker.
+	 */
+	direction?: 'bottom' | 'top';
+
+	/**
+	 * Flag to indicate that the component is disabled.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * The id of the component.
+	 */
+	id?: string;
+
+	/**
+	 * Callback for when the active state changes (controlled).
+	 */
+	onActiveChange?: InternalDispatch<boolean>;
+
+	/**
+	 * Callback calling when an option is selected.
+	 */
+	onSelectionChange?: InternalDispatch<React.Key>;
+
+	/**
+	 * Text that appears when you don't have an item selected.
+	 */
+	placeholder?: string;
+
+	/**
+	 * The currently selected key (controlled).
+	 */
+	selectedKey?: React.Key;
+} & Omit<ICollectionProps<T, unknown>, 'virtualize'>;
+
+export function Picker<T>({
+	active: externalActive,
+	as: As = 'button',
+	children,
+	defaultActive,
+	defaultSelectedKey,
+	direction = 'bottom',
+	disabled,
+	id,
+	items,
+	onActiveChange,
+	onSelectionChange,
+	placeholder = 'Select an option',
+	selectedKey: externalSelectedKey,
+	...otherProps
+}: Props<T>) {
+	const [active, setActive] = useInternalState({
+		defaultName: 'defaultActive',
+		defaultValue: defaultActive,
+		handleName: 'onActiveChange',
+		name: 'active',
+		onChange: onActiveChange,
+		value: externalActive,
+	});
+
+	const [selectedKey, setSelectedKey] = useInternalState({
+		defaultName: 'defaultSelectedKey',
+		defaultValue: defaultSelectedKey,
+		handleName: 'onSelectionChange',
+		name: 'selectedKey',
+		onChange: onSelectionChange,
+		value: externalSelectedKey,
+	});
+
+	const [itemRendered, setItemRendered] = useState('');
+	const [activeDescendant, setActiveDescendant] = useState('');
+
+	const ariaControls = useId();
+	const ariaOwns = useId();
+
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
+	const menuRef = useRef<HTMLDivElement | null>(null);
+
+	useOverlayPosition(
+		{
+			alignmentByViewport: true,
+			alignmentPosition: direction === 'bottom' ? 5 : 7,
+			autoBestAlign: true,
+			isOpen: active,
+			ref: menuRef,
+			triggerRef,
+		},
+		[active, children]
+	);
+
+	const navigationProps = useNavigation({
+		activation: 'manual',
+		active: activeDescendant,
+		containeRef: menuRef,
+		onNavigate: (tab) => setActiveDescendant(tab.getAttribute('id')!),
+		orientation: 'vertical',
+		typeahead: true,
+		visible: active,
+	});
+
+	const onPress = useCallback(() => {
+		if (menuRef.current && activeDescendant) {
+			const item = menuRef.current.querySelector<HTMLButtonElement>(
+				`#${activeDescendant}`
+			);
+
+			if (item) {
+				item.click();
+			}
+		}
+	}, [activeDescendant]);
+
+	return (
+		<>
+			<As
+				{...otherProps}
+				aria-activedescendant={active ? activeDescendant : ''}
+				aria-controls={ariaControls}
+				aria-expanded={active}
+				aria-haspopup="listbox"
+				aria-owns={ariaOwns}
+				className={classNames(
+					'form-control form-control-select form-control-select-secondary',
+					{
+						show: active,
+					}
+				)}
+				disabled={disabled}
+				id={id}
+				onClick={() => setActive(!active)}
+				onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>) => {
+					switch (event.key) {
+						case Keys.Enter:
+						case Keys.Spacebar: {
+							event.preventDefault();
+							setActive(true);
+
+							if (active && activeDescendant) {
+								onPress();
+							}
+							break;
+						}
+						case Keys.Tab:
+							onPress();
+							break;
+						case Keys.Home:
+						case Keys.End: {
+							if (!active) {
+								setActive(true);
+							}
+							navigationProps.onKeyDown(event);
+							break;
+						}
+						case Keys.Up:
+						case Keys.Down: {
+							if (
+								active &&
+								event.altKey &&
+								event.key === Keys.Up
+							) {
+								event.stopPropagation();
+								onPress();
+								setActive(false);
+
+								return;
+							}
+
+							if (!active) {
+								return setActive(true);
+							}
+
+							navigationProps.onKeyDown(event);
+							break;
+						}
+						default:
+							navigationProps.onKeyDown(event);
+							break;
+					}
+				}}
+				ref={triggerRef}
+				role="combobox"
+			>
+				{selectedKey ? itemRendered : placeholder}
+			</As>
+
+			{active && (
+				<Overlay
+					isCloseOnInteractOutside
+					isKeyboardDismiss
+					isOpen
+					menuRef={menuRef}
+					onClose={() => {
+						const key =
+							String(selectedKey) === 'undefined'
+								? ''
+								: String(selectedKey);
+						if (key !== activeDescendant) {
+							setActiveDescendant(key);
+						}
+
+						setActive(false);
+					}}
+					suppress={[triggerRef, menuRef]}
+					triggerRef={triggerRef}
+				>
+					<div
+						className={classNames(
+							'dropdown-menu dropdown-menu-select dropdown-menu-indicator-start show'
+						)}
+						id={ariaControls}
+						ref={menuRef}
+						role="presentation"
+					>
+						<ul
+							aria-labelledby={otherProps['aria-labelledby']}
+							className="inline-scroller list-unstyled"
+							id={ariaOwns}
+							role="listbox"
+							tabIndex={-1}
+						>
+							<PickerContext.Provider
+								value={{
+									activeDescendant,
+									onActiveDescendant: setActiveDescendant,
+									onItemRendered: setItemRendered,
+									onSelectionChange: (key: React.Key) => {
+										triggerRef.current!.focus();
+										setActiveDescendant(String(key));
+										setSelectedKey(key);
+										setActive(false);
+									},
+									selectedKey,
+								}}
+							>
+								<Collection<T> items={items}>
+									{children}
+								</Collection>
+							</PickerContext.Provider>
+						</ul>
+					</div>
+				</Overlay>
+			)}
+		</>
+	);
+}

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -7,6 +7,7 @@ import {
 	InternalDispatch,
 	Keys,
 	Overlay,
+	isTypeahead,
 	useId,
 	useInternalState,
 	useNavigation,
@@ -25,6 +26,12 @@ export type Props<T> = {
 	 * Flag to indicate if the DropDown menu is active or not (controlled).
 	 */
 	active?: boolean;
+
+	/**
+	 * The `aria-label` attribute defines a string value that labels an interactive
+	 * element.
+	 */
+	'aria-label'?: string;
 
 	/**
 	 * The `aria-labelledby` attribute identifies the element (or elements) that
@@ -222,9 +229,14 @@ export function Picker<T>({
 							navigationProps.onKeyDown(event);
 							break;
 						}
-						default:
+						default: {
+							if (isTypeahead(event)) {
+								setActive(true);
+							}
+
 							navigationProps.onKeyDown(event);
 							break;
+						}
 					}
 				}}
 				ref={triggerRef}

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -7,6 +7,7 @@ import {
 	InternalDispatch,
 	Keys,
 	Overlay,
+	getFocusableList,
 	isTypeahead,
 	useId,
 	useInteractionFocus,
@@ -148,7 +149,7 @@ export function Picker<T>({
 		[active, children]
 	);
 
-	const navigationProps = useNavigation({
+	const {accessibilityFocus, navigationProps} = useNavigation({
 		activation: 'manual',
 		active: activeDescendant,
 		containeRef: menuRef,
@@ -230,6 +231,39 @@ export function Picker<T>({
 							}
 
 							navigationProps.onKeyDown(event);
+							break;
+						}
+						case 'PageUp':
+						case 'PageDown': {
+							if (!active) {
+								return;
+							}
+
+							event.preventDefault();
+
+							const list = getFocusableList(menuRef);
+
+							const position = list.findIndex(
+								(element) =>
+									element.getAttribute('id') ===
+									activeDescendant
+							);
+
+							if (position === -1) {
+								break;
+							}
+
+							const option =
+								list[
+									event.key === 'PageUp'
+										? position - 10
+										: position + 10
+								] ??
+								list[
+									event.key === 'PageUp' ? 0 : list.length - 1
+								];
+
+							accessibilityFocus(option);
 							break;
 						}
 						default: {

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -9,6 +9,7 @@ import {
 	Overlay,
 	isTypeahead,
 	useId,
+	useInteractionFocus,
 	useInternalState,
 	useNavigation,
 	useOverlayPosition,
@@ -133,6 +134,8 @@ export function Picker<T>({
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
 	const menuRef = useRef<HTMLDivElement | null>(null);
 
+	const {isFocusVisible} = useInteractionFocus();
+
 	useOverlayPosition(
 		{
 			alignmentByViewport: true,
@@ -251,13 +254,22 @@ export function Picker<T>({
 					isKeyboardDismiss
 					isOpen
 					menuRef={menuRef}
-					onClose={() => {
-						const key =
-							String(selectedKey) === 'undefined'
-								? ''
-								: String(selectedKey);
-						if (key !== activeDescendant) {
-							setActiveDescendant(key);
+					onClose={(action) => {
+						if (
+							isFocusVisible() &&
+							activeDescendant &&
+							action === 'blur'
+						) {
+							onPress();
+						} else {
+							const key =
+								String(selectedKey) === 'undefined'
+									? ''
+									: String(selectedKey);
+
+							if (key !== activeDescendant) {
+								setActiveDescendant(key);
+							}
 						}
 
 						setActive(false);

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -182,7 +182,7 @@ export function Picker<T>({
 	const {accessibilityFocus, navigationProps} = useNavigation({
 		activation: 'manual',
 		active: activeDescendant,
-		containeRef: menuRef,
+		containerRef: menuRef,
 		onNavigate: (tab) => setActiveDescendant(tab.getAttribute('id')!),
 		orientation: 'vertical',
 		typeahead: true,

--- a/packages/clay-core/src/picker/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/picker/__tests__/BasicRendering.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import Icon from '@clayui/icon';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 
@@ -73,5 +74,96 @@ describe('Picker basic rendering', () => {
 
 		expect(apple.getAttribute('aria-selected')).toBe('true');
 		expect(apple.textContent).toBe('Apple');
+	});
+
+	it('renders the component as disabled', () => {
+		const {getByRole} = render(
+			<Picker
+				defaultSelectedKey="Banana"
+				disabled
+				items={['Apple', 'Banana', 'Blueberry']}
+			>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const selectedValue = getByRole('combobox');
+
+		expect(selectedValue.getAttribute('disabled')).toBe('');
+		expect(selectedValue.textContent).toBe('Banana');
+	});
+
+	it('renders component with custom placeholder', () => {
+		const {getByRole} = render(
+			<Picker
+				items={['Apple', 'Banana', 'Blueberry']}
+				placeholder="Select a fruit"
+			>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const selectedValue = getByRole('combobox');
+
+		expect(selectedValue.textContent).toBe('Select a fruit');
+	});
+
+	it('render component with label id', () => {
+		const {getByRole} = render(
+			<>
+				<label htmlFor="picker" id="picker-label">
+					Choose a fruit
+				</label>
+				<Picker
+					aria-labelledby="picker-label"
+					id="picker"
+					items={['Apple', 'Banana', 'Blueberry']}
+					placeholder="Select a fruit"
+				>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			</>
+		);
+
+		const selectedValue = getByRole('combobox') as HTMLButtonElement;
+		const label = selectedValue.labels[0];
+
+		expect(selectedValue.getAttribute('id')).toBe('picker');
+		expect(selectedValue.getAttribute('aria-labelledby')).toBe(
+			'picker-label'
+		);
+		expect(label.getAttribute('id')).toBe('picker-label');
+		expect(label.getAttribute('for')).toBe('picker');
+	});
+
+	it('render component with custom trigger', () => {
+		const Trigger = React.forwardRef<
+			HTMLDivElement,
+			React.HTMLAttributes<HTMLDivElement>
+		>(({children, ...otherProps}, ref) => (
+			<div ref={ref} {...otherProps} tabIndex={0}>
+				<Icon className="mr-2" symbol="user" />
+				{children}
+			</div>
+		));
+
+		Trigger.displayName = 'Trigger';
+
+		const {getByRole} = render(
+			<Picker as={Trigger} items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const svg = getByRole('presentation');
+		const selectedValue = getByRole('combobox');
+
+		expect(selectedValue.textContent).toBe('Select an option');
+		expect(svg.tagName).toBe('svg');
+		expect(selectedValue.getAttribute('aria-activedescendant')).toBe('');
+		expect(selectedValue.getAttribute('aria-haspopup')).toBe('listbox');
+		expect(selectedValue.getAttribute('role')).toBe('combobox');
+		expect(selectedValue.getAttribute('aria-expanded')).toBe('false');
+		expect(selectedValue.getAttribute('tabindex')).toBe('0');
 	});
 });

--- a/packages/clay-core/src/picker/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/picker/__tests__/BasicRendering.tsx
@@ -34,6 +34,48 @@ describe('Picker basic rendering', () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it('render dynamic content using native selector', () => {
+		window.innerWidth = 600;
+
+		const {container} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']} native>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('render static content using native selector', () => {
+		window.innerWidth = 600;
+
+		const {container} = render(
+			<Picker native>
+				<Option key="apple">Apple</Option>
+				<Option key="banana">Banana</Option>
+				<Option key="blueberry">Blueberry</Option>
+			</Picker>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders component with selected by default using native selector', () => {
+		window.innerWidth = 600;
+
+		const {getByRole} = render(
+			<Picker defaultSelectedKey="apple" native>
+				<Option key="apple">Apple</Option>
+				<Option key="banana">Banana</Option>
+				<Option key="blueberry">Blueberry</Option>
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox') as HTMLSelectElement;
+
+		expect(combobox.value).toBe('apple');
+	});
+
 	it('renders open component by default', () => {
 		render(
 			<Picker defaultActive items={['Apple', 'Banana', 'Blueberry']}>

--- a/packages/clay-core/src/picker/__tests__/BasicRendering.tsx
+++ b/packages/clay-core/src/picker/__tests__/BasicRendering.tsx
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import React from 'react';
+
+import {Option, Picker} from '../../';
+
+describe('Picker basic rendering', () => {
+	afterEach(cleanup);
+
+	it('render static content', () => {
+		render(
+			<Picker>
+				<Option key="apple">Apple</Option>
+				<Option key="banana">Banana</Option>
+				<Option key="blueberry">Blueberry</Option>
+			</Picker>
+		);
+
+		expect(document.body).toMatchSnapshot();
+	});
+
+	it('render dynamic content', () => {
+		const {container} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders open component by default', () => {
+		render(
+			<Picker defaultActive items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		expect(document.body).toMatchSnapshot();
+	});
+
+	it('renders component with selected by default', () => {
+		const {getByRole} = render(
+			<Picker
+				defaultSelectedKey="Apple"
+				items={['Apple', 'Banana', 'Blueberry']}
+			>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const selectedValue = getByRole('combobox');
+
+		expect(selectedValue.innerHTML).toBe('Apple');
+	});
+
+	it('renders component with selected by default and open', () => {
+		const {getAllByRole} = render(
+			<Picker
+				defaultActive
+				defaultSelectedKey="Apple"
+				items={['Apple', 'Banana', 'Blueberry']}
+			>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const [apple] = getAllByRole('option');
+
+		expect(apple.getAttribute('aria-selected')).toBe('true');
+		expect(apple.textContent).toBe('Apple');
+	});
+});

--- a/packages/clay-core/src/picker/__tests__/IncrementalInteractions.tsx
+++ b/packages/clay-core/src/picker/__tests__/IncrementalInteractions.tsx
@@ -1,0 +1,489 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import {Option, Picker} from '../../';
+
+describe('Picker incremental interactions', () => {
+	afterEach(cleanup);
+
+	it('click trigger expand menu', () => {
+		const {getByRole, queryByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('false');
+		expect(queryByRole('listbox')).toBeFalsy();
+
+		userEvent.click(combobox);
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('true');
+		expect(getByRole('listbox')).toBeTruthy();
+	});
+
+	it.concurrent.each([
+		['down arrow', '[ArrowDown]'],
+		['up arrow', '[ArrowUp]'],
+		['enter', '[Enter]'],
+		['spacebar', '[Space]'],
+		['home', '[Home]'],
+		['alt + down arrow', '{Alt>}{ArrowDown/}'],
+	])('pressing the (%s) key expands the menu', (_, key) => {
+		const {getByRole, queryByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('false');
+		expect(queryByRole('listbox')).toBeFalsy();
+
+		userEvent.tab();
+		userEvent.keyboard(key);
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('true');
+		expect(getByRole('listbox')).toBeTruthy();
+		expect(combobox.getAttribute('aria-activedescendant')).toBe('Apple');
+	});
+
+	it('pressing the end key expands the menu and accessibility focus on the last option', () => {
+		const {getByRole, queryByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('false');
+		expect(queryByRole('listbox')).toBeFalsy();
+
+		userEvent.tab();
+		userEvent.keyboard('[End]');
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('true');
+		expect(getByRole('listbox')).toBeTruthy();
+		expect(combobox.getAttribute('aria-activedescendant')).toBe(
+			'Blueberry'
+		);
+	});
+
+	it('pressing typing keys expands the menu and accessibility focus with the first option that matches', () => {
+		const {getByRole, queryByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('false');
+		expect(queryByRole('listbox')).toBeFalsy();
+
+		userEvent.tab();
+		userEvent.keyboard('{b}');
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('true');
+		expect(getByRole('listbox')).toBeTruthy();
+		expect(combobox.getAttribute('aria-activedescendant')).toBe('Banana');
+	});
+
+	it('typing the same character successively expands the menu and accessibility focus cycles through the corresponding options', () => {
+		const {getByRole, queryByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('false');
+		expect(queryByRole('listbox')).toBeFalsy();
+
+		userEvent.tab();
+		userEvent.keyboard('{b}');
+
+		expect(combobox.getAttribute('aria-expanded')).toBe('true');
+		expect(getByRole('listbox')).toBeTruthy();
+		expect(combobox.getAttribute('aria-activedescendant')).toBe('Banana');
+
+		userEvent.keyboard('{b}');
+
+		expect(combobox.getAttribute('aria-activedescendant')).toBe(
+			'Blueberry'
+		);
+	});
+
+	it('when expanding the menu the focus should persist on the trigger', () => {
+		const {getByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		userEvent.click(combobox);
+
+		expect(document.activeElement).toEqual(combobox);
+	});
+
+	it('when closing the menu the focus should persist on the trigger', () => {
+		const {getByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		userEvent.click(combobox);
+
+		expect(document.activeElement).toEqual(combobox);
+
+		userEvent.keyboard('[Escape]');
+
+		expect(document.activeElement === combobox).toBe(true);
+		expect(combobox.getAttribute('aria-expanded')).toBe('false');
+	});
+
+	it('when expanding the menu the accessibility focus should be on the first option', () => {
+		const {getByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		userEvent.click(combobox);
+
+		expect(combobox.getAttribute('aria-activedescendant')).toBe('Apple');
+	});
+
+	it('close the expanded menu without selecting and expand again the first option must have accessibility focus', () => {
+		const {getByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		userEvent.click(combobox);
+		userEvent.keyboard('[ArrowDown]');
+
+		expect(document.activeElement === combobox).toBe(true);
+		expect(combobox.getAttribute('aria-activedescendant')).toBe('Banana');
+	});
+
+	describe('expanded menu', () => {
+		it.concurrent.each([
+			['enter', '[Enter]'],
+			['spacebar', '[Space]'],
+			['alt + up arrow', '{Alt>}{ArrowUp/}'],
+		])('pressing (%s) selects option with visual focus', (_, key) => {
+			const {getByRole} = render(
+				<Picker items={['Apple', 'Banana', 'Blueberry']}>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			);
+
+			const combobox = getByRole('combobox');
+
+			userEvent.click(combobox);
+			userEvent.keyboard(key);
+
+			expect(combobox.getAttribute('aria-expanded')).toBe('false');
+			expect(combobox.getAttribute('aria-activedescendant')).toBe('');
+			expect(combobox.textContent).toBe('Apple');
+		});
+
+		it('pressing the down arrow key navigates down and update the visual focus', () => {
+			const {getByRole} = render(
+				<Picker items={['Apple', 'Banana', 'Blueberry']}>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			);
+
+			const combobox = getByRole('combobox');
+
+			userEvent.click(combobox);
+			userEvent.keyboard('[ArrowDown]');
+
+			expect(combobox.getAttribute('aria-expanded')).toBe('true');
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Banana'
+			);
+			expect(combobox.textContent).not.toBe('Banana');
+
+			userEvent.keyboard('[ArrowDown]');
+
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Blueberry'
+			);
+			expect(combobox.textContent).not.toBe('Blueberry');
+
+			// Maintains visual focus on the last option when there are no more
+			// options.
+			userEvent.keyboard('[ArrowDown]');
+
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Blueberry'
+			);
+			expect(combobox.textContent).not.toBe('Blueberry');
+		});
+
+		it('pressing the up arrow key navigates up and update the visual focus', () => {
+			const {getByRole} = render(
+				<Picker items={['Apple', 'Banana', 'Blueberry']}>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			);
+
+			const combobox = getByRole('combobox');
+
+			userEvent.click(combobox);
+			userEvent.keyboard('[ArrowDown]');
+			userEvent.keyboard('[ArrowDown]');
+
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Blueberry'
+			);
+			expect(combobox.textContent).not.toBe('Blueberry');
+
+			userEvent.keyboard('[ArrowUp]');
+
+			expect(combobox.getAttribute('aria-expanded')).toBe('true');
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Banana'
+			);
+			expect(combobox.textContent).not.toBe('Banana');
+
+			userEvent.keyboard('[ArrowUp]');
+
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Apple'
+			);
+			expect(combobox.textContent).not.toBe('Apple');
+
+			// Maintains visual focus on the first option when there are no more
+			// options.
+			userEvent.keyboard('[ArrowUp]');
+
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Apple'
+			);
+			expect(combobox.textContent).not.toBe('Apple');
+		});
+
+		it('pressing the tab key selects the option with visual focus and moves the focus to the next element on the screen', () => {
+			const {getByRole} = render(
+				<Picker items={['Apple', 'Banana', 'Blueberry']}>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			);
+
+			const combobox = getByRole('combobox');
+
+			userEvent.click(combobox);
+			userEvent.keyboard('[ArrowDown]');
+
+			expect(combobox.getAttribute('aria-expanded')).toBe('true');
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Banana'
+			);
+			expect(combobox.textContent).not.toBe('Banana');
+
+			userEvent.tab();
+
+			expect(combobox.getAttribute('aria-expanded')).toBe('false');
+			expect(combobox.getAttribute('aria-activedescendant')).toBe('');
+			expect(combobox.textContent).toBe('Banana');
+		});
+
+		it('pressing the page up key jumps visual focus up 10 options', () => {
+			const {getByRole} = render(
+				<Picker
+					items={[
+						'Apple',
+						'Banana',
+						'Mangos',
+						'Blueberry',
+						'Boysenberry',
+						'Cherry',
+						'Cranberry',
+						'Eggplant',
+						'Fig',
+						'Grape',
+						'Guava',
+						'Huckleberry',
+					]}
+				>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			);
+
+			const combobox = getByRole('combobox');
+
+			userEvent.click(combobox);
+			userEvent.keyboard('[PageDown]');
+			userEvent.keyboard('[PageDown]');
+			userEvent.keyboard('[PageUp]');
+
+			expect(combobox.getAttribute('aria-expanded')).toBe('true');
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Banana'
+			);
+			expect(combobox.textContent).not.toBe('Banana');
+
+			userEvent.keyboard('[PageUp]');
+
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Apple'
+			);
+			expect(combobox.textContent).not.toBe('Apple');
+		});
+
+		it('pressing the page down key jumps visual focus down 10 options', () => {
+			const {getByRole} = render(
+				<Picker
+					items={[
+						'Apple',
+						'Banana',
+						'Mangos',
+						'Blueberry',
+						'Boysenberry',
+						'Cherry',
+						'Cranberry',
+						'Eggplant',
+						'Fig',
+						'Grape',
+						'Guava',
+						'Huckleberry',
+					]}
+				>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			);
+
+			const combobox = getByRole('combobox');
+
+			userEvent.click(combobox);
+			userEvent.keyboard('[PageDown]');
+
+			expect(combobox.getAttribute('aria-expanded')).toBe('true');
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Guava'
+			);
+			expect(combobox.textContent).not.toBe('Guava');
+
+			userEvent.keyboard('[PageDown]');
+
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Huckleberry'
+			);
+			expect(combobox.textContent).not.toBe('Huckleberry');
+		});
+
+		it('moving the mouse over the option updates the visual focus', () => {
+			const {getAllByRole, getByRole} = render(
+				<Picker items={['Apple', 'Banana', 'Blueberry']}>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			);
+
+			const combobox = getByRole('combobox');
+
+			userEvent.click(combobox);
+
+			expect(combobox.getAttribute('aria-expanded')).toBe('true');
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Apple'
+			);
+
+			const [, , blueberry] = getAllByRole('option');
+
+			userEvent.hover(blueberry);
+
+			expect(combobox.getAttribute('aria-activedescendant')).toBe(
+				'Blueberry'
+			);
+			expect(blueberry.classList).toContain('hover');
+		});
+
+		it.concurrent.each([
+			['up arrow', '[ArrowUp]'],
+			['down arrow', '[ArrowDown]'],
+		])(
+			'pressing (%s) moves to next option from last mouse over over some option',
+			(_, key) => {
+				const {getAllByRole, getByRole} = render(
+					<Picker items={['Apple', 'Banana', 'Blueberry']}>
+						{(item) => <Option key={item}>{item}</Option>}
+					</Picker>
+				);
+
+				const combobox = getByRole('combobox');
+
+				userEvent.click(combobox);
+
+				expect(combobox.getAttribute('aria-expanded')).toBe('true');
+				expect(combobox.getAttribute('aria-activedescendant')).toBe(
+					'Apple'
+				);
+
+				const [apple, banana, blueberry] = getAllByRole('option');
+
+				userEvent.hover(banana);
+
+				expect(combobox.getAttribute('aria-activedescendant')).toBe(
+					'Banana'
+				);
+
+				userEvent.keyboard(key);
+
+				if (key === '[ArrowUp]') {
+					expect(combobox.getAttribute('aria-activedescendant')).toBe(
+						'Apple'
+					);
+					expect(apple.classList).toContain('focus');
+				} else {
+					expect(combobox.getAttribute('aria-activedescendant')).toBe(
+						'Blueberry'
+					);
+					expect(blueberry.classList).toContain('focus');
+				}
+			}
+		);
+	});
+
+	it('when navigating through the menu and closing and reopening the visual focus persists in the first option', () => {
+		const {getByRole} = render(
+			<Picker items={['Apple', 'Banana', 'Blueberry']}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		userEvent.click(combobox);
+		userEvent.keyboard('[ArrowDown]');
+		userEvent.keyboard('[Escape]');
+
+		userEvent.click(combobox);
+
+		expect(combobox.getAttribute('aria-activedescendant')).toBe('Apple');
+	});
+});

--- a/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -4,6 +4,7 @@ exports[`Picker basic rendering render dynamic content 1`] = `
 <div>
   <button
     aria-activedescendant=""
+    aria-expanded="false"
     aria-haspopup="listbox"
     class="form-control form-control-select form-control-select-secondary"
     role="combobox"
@@ -18,6 +19,7 @@ exports[`Picker basic rendering render static content 1`] = `
   <div>
     <button
       aria-activedescendant=""
+      aria-expanded="false"
       aria-haspopup="listbox"
       class="form-control form-control-select form-control-select-secondary"
       role="combobox"

--- a/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Picker basic rendering render dynamic content 1`] = `
+<div>
+  <button
+    aria-activedescendant=""
+    aria-haspopup="listbox"
+    class="form-control form-control-select form-control-select-secondary"
+    role="combobox"
+  >
+    Select an option
+  </button>
+</div>
+`;
+
+exports[`Picker basic rendering render static content 1`] = `
+<body>
+  <div>
+    <button
+      aria-activedescendant=""
+      aria-haspopup="listbox"
+      class="form-control form-control-select form-control-select-secondary"
+      role="combobox"
+    >
+      Select an option
+    </button>
+  </div>
+</body>
+`;
+
+exports[`Picker basic rendering renders open component by default 1`] = `
+<body>
+  <div>
+    <button
+      aria-activedescendant="Apple"
+      aria-controls="clay-id-5"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-owns="clay-id-6"
+      class="form-control form-control-select form-control-select-secondary show"
+      role="combobox"
+      style=""
+    >
+      Select an option
+    </button>
+  </div>
+  <div>
+    <div
+      class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select show"
+      id="clay-id-5"
+      role="presentation"
+      style="left: -999px; top: -995px;"
+    >
+      <ul
+        class="inline-scroller list-unstyled"
+        id="clay-id-6"
+        role="listbox"
+        tabindex="-1"
+      >
+        <li
+          role="presentation"
+        >
+          <button
+            aria-selected="false"
+            class="dropdown-item focus"
+            id="Apple"
+            role="option"
+            tabindex="-1"
+          >
+            Apple
+          </button>
+        </li>
+        <li
+          role="presentation"
+        >
+          <button
+            aria-selected="false"
+            class="dropdown-item"
+            id="Banana"
+            role="option"
+            tabindex="-1"
+          >
+            Banana
+          </button>
+        </li>
+        <li
+          role="presentation"
+        >
+          <button
+            aria-selected="false"
+            class="dropdown-item"
+            id="Blueberry"
+            role="option"
+            tabindex="-1"
+          >
+            Blueberry
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -14,6 +14,30 @@ exports[`Picker basic rendering render dynamic content 1`] = `
 </div>
 `;
 
+exports[`Picker basic rendering render dynamic content using native selector 1`] = `
+<div>
+  <select
+    class="form-control form-control-select form-control-select-secondary"
+  >
+    <option
+      value="Apple"
+    >
+      Apple
+    </option>
+    <option
+      value="Banana"
+    >
+      Banana
+    </option>
+    <option
+      value="Blueberry"
+    >
+      Blueberry
+    </option>
+  </select>
+</div>
+`;
+
 exports[`Picker basic rendering render static content 1`] = `
 <body>
   <div>
@@ -30,15 +54,39 @@ exports[`Picker basic rendering render static content 1`] = `
 </body>
 `;
 
+exports[`Picker basic rendering render static content using native selector 1`] = `
+<div>
+  <select
+    class="form-control form-control-select form-control-select-secondary"
+  >
+    <option
+      value="apple"
+    >
+      Apple
+    </option>
+    <option
+      value="banana"
+    >
+      Banana
+    </option>
+    <option
+      value="blueberry"
+    >
+      Blueberry
+    </option>
+  </select>
+</div>
+`;
+
 exports[`Picker basic rendering renders open component by default 1`] = `
 <body>
   <div>
     <button
       aria-activedescendant="Apple"
-      aria-controls="clay-id-5"
+      aria-controls="clay-id-11"
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-owns="clay-id-6"
+      aria-owns="clay-id-12"
       class="form-control form-control-select form-control-select-secondary show"
       role="combobox"
       style=""
@@ -49,13 +97,13 @@ exports[`Picker basic rendering renders open component by default 1`] = `
   <div>
     <div
       class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select show"
-      id="clay-id-5"
+      id="clay-id-11"
       role="presentation"
       style="left: -999px; top: -995px;"
     >
       <ul
         class="inline-scroller list-unstyled"
-        id="clay-id-6"
+        id="clay-id-12"
         role="listbox"
         tabindex="-1"
       >

--- a/packages/clay-core/src/picker/context.ts
+++ b/packages/clay-core/src/picker/context.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {createContext, useContext} from 'react';
+
+import type {InternalDispatch} from '@clayui/shared';
+
+type PickerContextProps = {
+	onSelectionChange: InternalDispatch<React.Key>;
+	selectedKey: React.Key;
+	onItemRendered: (value: string) => void;
+	activeDescendant: string;
+	onActiveDescendant: (value: string) => void;
+};
+
+export const PickerContext = createContext({} as PickerContextProps);
+
+export function usePickerState() {
+	return useContext(PickerContext);
+}

--- a/packages/clay-core/src/picker/context.ts
+++ b/packages/clay-core/src/picker/context.ts
@@ -10,7 +10,6 @@ import type {InternalDispatch} from '@clayui/shared';
 type PickerContextProps = {
 	onSelectionChange: InternalDispatch<React.Key>;
 	selectedKey: React.Key;
-	onItemRendered: (value: string) => void;
 	activeDescendant: string;
 	onActiveDescendant: (value: string) => void;
 };

--- a/packages/clay-core/src/picker/context.ts
+++ b/packages/clay-core/src/picker/context.ts
@@ -8,10 +8,11 @@ import {createContext, useContext} from 'react';
 import type {InternalDispatch} from '@clayui/shared';
 
 type PickerContextProps = {
+	activeDescendant: string;
+	isMobile: boolean;
+	onActiveDescendant: (value: string) => void;
 	onSelectionChange: InternalDispatch<React.Key>;
 	selectedKey: React.Key;
-	activeDescendant: string;
-	onActiveDescendant: (value: string) => void;
 };
 
 export const PickerContext = createContext({} as PickerContextProps);

--- a/packages/clay-core/src/picker/index.ts
+++ b/packages/clay-core/src/picker/index.ts
@@ -1,0 +1,7 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export {Picker} from './Picker';
+export {Option} from './Option';

--- a/packages/clay-core/src/vertical-bar/Bar.tsx
+++ b/packages/clay-core/src/vertical-bar/Bar.tsx
@@ -40,7 +40,7 @@ export function Bar<T>({
 
 	const {navigationProps} = useNavigation({
 		activation,
-		containeRef: parentRef,
+		containerRef: parentRef,
 		orientation: 'vertical',
 	});
 

--- a/packages/clay-core/src/vertical-bar/Bar.tsx
+++ b/packages/clay-core/src/vertical-bar/Bar.tsx
@@ -38,7 +38,7 @@ export function Bar<T>({
 
 	const {activation} = useContext(VerticalBarContext);
 
-	const {onKeyDown} = useNavigation({
+	const {navigationProps} = useNavigation({
 		activation,
 		containeRef: parentRef,
 		orientation: 'vertical',
@@ -46,11 +46,11 @@ export function Bar<T>({
 
 	return (
 		<nav
+			{...navigationProps}
 			className={classNames('tbar tbar-stacked c-slideout-show', {
 				'tbar-dark-l2': displayType === 'dark',
 				'tbar-light': displayType === 'light',
 			})}
-			onKeyDown={onKeyDown}
 			ref={parentRef}
 		>
 			<Collection<T>

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -5,10 +5,13 @@
 
 import Form from '@clayui/form';
 import Icon from '@clayui/icon';
+import Label from '@clayui/label';
+import Layout from '@clayui/layout';
 import {useId} from '@clayui/shared';
 import React from 'react';
 
 import {Option, Picker} from '../src/picker';
+import {Text} from '../src/typography';
 
 export default {
 	component: Picker,
@@ -105,6 +108,40 @@ export const CustomTrigger = () => {
 				</label>
 				<Picker as={Trigger} items={['Liam', 'Noah', 'Oliver']}>
 					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			</Form.Group>
+		</div>
+	);
+};
+
+export const CustomOptions = () => {
+	const pickerId = useId();
+	const labelId = useId();
+
+	return (
+		<div style={{width: '180px'}}>
+			<Form.Group>
+				<label htmlFor={pickerId} id={labelId}>
+					Choose a user
+				</label>
+				<Picker items={['Liam', 'Noah', 'Oliver']}>
+					{(item) => (
+						<Option key={item} textValue={item}>
+							<Layout.ContentRow>
+								<Layout.ContentCol expand>
+									<Text size={3} weight="semi-bold">
+										{item}
+									</Text>
+									<Text color="secondary" size={2}>
+										Description
+									</Text>
+								</Layout.ContentCol>
+								<Layout.ContentCol>
+									<Label displayType="success">Active</Label>
+								</Layout.ContentCol>
+							</Layout.ContentRow>
+						</Option>
+					)}
 				</Picker>
 			</Form.Group>
 		</div>

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import Form from '@clayui/form';
+import {useId} from '@clayui/shared';
+import React from 'react';
+
+import {Option, Picker} from '../src/picker';
+
+export default {
+	component: Picker,
+	title: 'Design System/Components/Picker',
+};
+
+export const Default = () => {
+	const pickerId = useId();
+	const labelId = useId();
+
+	return (
+		<div style={{width: '150px'}}>
+			<Form.Group>
+				<label htmlFor={pickerId} id={labelId}>
+					Choose a fruit
+				</label>
+				<Picker aria-labelledby={labelId} id={pickerId}>
+					<Option key="apple">Apple</Option>
+					<Option disabled key="banana">
+						Banana
+					</Option>
+					<Option key="mangos">Mangos</Option>
+					<Option key="blueberry">Blueberry</Option>
+					<Option key="boysenberry">Boysenberry</Option>
+					<Option key="cherry">Cherry</Option>
+					<Option key="cranberry">Cranberry</Option>
+					<Option key="eggplant">Eggplant</Option>
+					<Option key="fig">Fig</Option>
+					<Option key="grape">Grape</Option>
+					<Option key="guava">Guava</Option>
+					<Option key="huckleberry">Huckleberry</Option>
+				</Picker>
+			</Form.Group>
+		</div>
+	);
+};
+
+export const Dynamic = () => {
+	const pickerId = useId();
+	const labelId = useId();
+
+	return (
+		<div style={{width: '150px'}}>
+			<Form.Group>
+				<label htmlFor={pickerId} id={labelId}>
+					Choose a fruit
+				</label>
+				<Picker
+					aria-labelledby={labelId}
+					id={pickerId}
+					items={[
+						'Apple',
+						'Banana',
+						'Mangos',
+						'Blueberry',
+						'Boysenberry',
+						'Cherry',
+						'Cranberry',
+						'Eggplant',
+						'Fig',
+						'Grape',
+						'Guava',
+						'Huckleberry',
+					]}
+				>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			</Form.Group>
+		</div>
+	);
+};

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -4,6 +4,7 @@
  */
 
 import Form from '@clayui/form';
+import Icon from '@clayui/icon';
 import {useId} from '@clayui/shared';
 import React from 'react';
 
@@ -73,6 +74,36 @@ export const Dynamic = () => {
 						'Huckleberry',
 					]}
 				>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			</Form.Group>
+		</div>
+	);
+};
+
+const Trigger = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
+>(({children, ...otherProps}, ref) => (
+	<div ref={ref} {...otherProps} tabIndex={0}>
+		<Icon className="mr-2" symbol="user" />
+		{children}
+	</div>
+));
+
+Trigger.displayName = 'Trigger';
+
+export const CustomTrigger = () => {
+	const pickerId = useId();
+	const labelId = useId();
+
+	return (
+		<div style={{width: '180px'}}>
+			<Form.Group>
+				<label htmlFor={pickerId} id={labelId}>
+					Choose a user
+				</label>
+				<Picker as={Trigger} items={['Liam', 'Noah', 'Oliver']}>
 					{(item) => <Option key={item}>{item}</Option>}
 				</Picker>
 			</Form.Group>

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -106,7 +106,12 @@ export const CustomTrigger = () => {
 				<label htmlFor={pickerId} id={labelId}>
 					Choose a user
 				</label>
-				<Picker as={Trigger} items={['Liam', 'Noah', 'Oliver']}>
+				<Picker
+					aria-labelledby={labelId}
+					as={Trigger}
+					id={pickerId}
+					items={['Liam', 'Noah', 'Oliver']}
+				>
 					{(item) => <Option key={item}>{item}</Option>}
 				</Picker>
 			</Form.Group>
@@ -124,7 +129,11 @@ export const CustomOptions = () => {
 				<label htmlFor={pickerId} id={labelId}>
 					Choose a user
 				</label>
-				<Picker items={['Liam', 'Noah', 'Oliver']}>
+				<Picker
+					aria-labelledby={labelId}
+					id={pickerId}
+					items={['Liam', 'Noah', 'Oliver']}
+				>
 					{(item) => (
 						<Option key={item} textValue={item}>
 							<Layout.ContentRow>

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -201,7 +201,7 @@ function ClayDropDown<T>({
 		[initialized]
 	);
 
-	const navigationProps = useNavigation({
+	const {navigationProps} = useNavigation({
 		activation: 'manual',
 		containeRef: menuElementRef,
 		loop: true,

--- a/packages/clay-drop-down/src/DropDown.tsx
+++ b/packages/clay-drop-down/src/DropDown.tsx
@@ -203,7 +203,7 @@ function ClayDropDown<T>({
 
 	const {navigationProps} = useNavigation({
 		activation: 'manual',
-		containeRef: menuElementRef,
+		containerRef: menuElementRef,
 		loop: true,
 		orientation: 'vertical',
 		typeahead: true,

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -297,7 +297,7 @@ const Contextual = ({
 		[items]
 	);
 
-	const navigationProps = useNavigation({
+	const {navigationProps} = useNavigation({
 		activation: 'manual',
 		containeRef: menuElementRef,
 		loop: true,

--- a/packages/clay-drop-down/src/DropDownWithItems.tsx
+++ b/packages/clay-drop-down/src/DropDownWithItems.tsx
@@ -299,7 +299,7 @@ const Contextual = ({
 
 	const {navigationProps} = useNavigation({
 		activation: 'manual',
-		containeRef: menuElementRef,
+		containerRef: menuElementRef,
 		loop: true,
 		orientation: 'vertical',
 		typeahead: true,

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -281,7 +281,7 @@ function ClayVerticalNav({
 	const [active, setActive] = useState(false);
 	const containerRef = useRef<HTMLDivElement | null>(null);
 
-	const {onKeyDown} = useNavigation({
+	const {navigationProps} = useNavigation({
 		activation,
 		containeRef: containerRef,
 		orientation: 'vertical',
@@ -315,10 +315,10 @@ function ClayVerticalNav({
 			</CustomTrigger>
 
 			<div
+				{...navigationProps}
 				className={classNames('collapse menubar-collapse', {
 					show: active,
 				})}
-				onKeyDown={onKeyDown}
 				ref={containerRef}
 			>
 				<Nav aria-orientation="vertical" nested role="menubar">

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -283,7 +283,7 @@ function ClayVerticalNav({
 
 	const {navigationProps} = useNavigation({
 		activation,
-		containeRef: containerRef,
+		containerRef,
 		orientation: 'vertical',
 	});
 

--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -19,7 +19,7 @@ type Props = {
 	isModal?: boolean;
 	isOpen: boolean;
 	menuRef: React.RefObject<HTMLElement>;
-	onClose: () => void;
+	onClose: (action: 'escape' | 'blur') => void;
 	portalRef?: React.RefObject<HTMLElement>;
 	suppress?: Array<React.RefObject<HTMLElement>>;
 	triggerRef: React.RefObject<HTMLElement>;
@@ -54,7 +54,7 @@ export function Overlay({
 					triggerRef.current &&
 					!triggerRef.current.contains(event.target as Node)
 				) {
-					onClose();
+					onClose('blur');
 				}
 			},
 			[onClose]
@@ -84,7 +84,7 @@ export function Overlay({
 						triggerRef.current.focus();
 					}
 
-					onClose();
+					onClose('escape');
 				}
 			},
 			[onClose]
@@ -97,7 +97,7 @@ export function Overlay({
 	useInteractOutside({
 		isDisabled: isOpen ? !isCloseOnInteractOutside : true,
 		onInteract: () => {
-			onClose();
+			onClose('blur');
 		},
 		ref: portalRef ?? menuRef,
 		triggerRef,

--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {hideOthers, suppressOthers} from 'aria-hidden';
+import {hideOthers, supportsInert, suppressOthers} from 'aria-hidden';
 import React, {useCallback, useEffect, useRef} from 'react';
 
 import {Keys} from './Keys';
@@ -24,16 +24,6 @@ type Props = {
 	suppress?: Array<React.RefObject<HTMLElement>>;
 	triggerRef: React.RefObject<HTMLElement>;
 };
-
-/**
- * Inert is a new native feature to better handle DOM arias that are not
- * assertive to a SR or that should ignore any user interaction.
- * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
- */
-const hasInertSupport =
-	typeof window !== 'undefined' &&
-	// @ts-ignore
-	typeof document.createElement('div').inert === 'boolean';
 
 /**
  * Overlay component is used for components like dialog and modal.
@@ -119,7 +109,10 @@ export function Overlay({
 				? suppress.map((ref) => ref.current!)
 				: menuRef.current;
 
-			if (isModal && hasInertSupport) {
+			// Inert is a new native feature to better handle DOM arias that are not
+			// assertive to a SR or that should ignore any user interaction.
+			// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+			if (isModal && supportsInert()) {
 				unsuppressCallbackRef.current = suppressOthers(elements);
 
 				return () => {

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -24,6 +24,7 @@ export {useInternalState} from './useInternalState';
 export {useMousePosition} from './useMousePosition';
 export {useNavigation} from './useNavigation';
 export {useOverlayPosition} from './useOverlayPositon';
+export {useHover} from './useHover';
 export type {AlignPoints} from './useOverlayPositon';
 export type {IBaseProps as IPortalBaseProps} from './Portal';
 export type {InternalDispatch} from './useInternalState';

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -22,7 +22,7 @@ export {useId} from './useId';
 export {useInteractionFocus} from './useInteractionFocus';
 export {useInternalState} from './useInternalState';
 export {useMousePosition} from './useMousePosition';
-export {useNavigation} from './useNavigation';
+export {useNavigation, isTypeahead} from './useNavigation';
 export {useOverlayPosition} from './useOverlayPositon';
 export {useHover} from './useHover';
 export type {AlignPoints} from './useOverlayPositon';

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -22,7 +22,7 @@ export {useId} from './useId';
 export {useInteractionFocus} from './useInteractionFocus';
 export {useInternalState} from './useInternalState';
 export {useMousePosition} from './useMousePosition';
-export {useNavigation, isTypeahead} from './useNavigation';
+export {useNavigation, isTypeahead, getFocusableList} from './useNavigation';
 export {useOverlayPosition} from './useOverlayPositon';
 export {useHover} from './useHover';
 export type {AlignPoints} from './useOverlayPositon';

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -25,6 +25,7 @@ export {useMousePosition} from './useMousePosition';
 export {useNavigation, isTypeahead, getFocusableList} from './useNavigation';
 export {useOverlayPosition} from './useOverlayPositon';
 export {useHover} from './useHover';
+export {useIsMobileDevice} from './useIsMobileDevice';
 export type {AlignPoints} from './useOverlayPositon';
 export type {IBaseProps as IPortalBaseProps} from './Portal';
 export type {InternalDispatch} from './useInternalState';

--- a/packages/clay-shared/src/useHover.ts
+++ b/packages/clay-shared/src/useHover.ts
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {useMemo, useRef} from 'react';
+
+type PointerType = 'mouse' | 'pen' | 'touch';
+
+type Event = {
+	type: string;
+	target: HTMLElement;
+	pointerType: PointerType;
+};
+
+type Props = {
+	disabled?: boolean;
+	onHover: (event: Event) => void;
+};
+
+type State = {
+	isEmulatedMouseEvents: boolean;
+	isHovered: boolean;
+	pointerType?: PointerType;
+	target: HTMLElement | null;
+};
+
+// Handles pointer hover interactions for an element.
+// Adapted from https://github.com/adobe/react-spectrum/blob/0182ad0748bcdddf7eb010540c453f9a35a7c753/packages/%40react-aria/interactions/src/useHover.ts
+export function useHover<T extends HTMLElement>({disabled, onHover}: Props) {
+	const state = useRef<State>({
+		isEmulatedMouseEvents: false,
+		isHovered: false,
+		pointerType: undefined,
+		target: null,
+	}).current;
+
+	return useMemo(() => {
+		const props: React.DOMAttributes<T> = {};
+
+		const onStart = (
+			event: React.SyntheticEvent<HTMLElement>,
+			pointerType: PointerType
+		) => {
+			if (
+				disabled ||
+				pointerType === 'touch' ||
+				state.isHovered ||
+				!event.currentTarget.contains(event.target as HTMLElement)
+			) {
+				return;
+			}
+
+			state.isHovered = true;
+			const target = event.currentTarget;
+			state.target = target as HTMLElement;
+
+			onHover({
+				pointerType,
+				target,
+				type: 'hoverstart',
+			});
+		};
+
+		const onEnd = (pointerType: PointerType) => {
+			state.pointerType = undefined;
+			state.target = null;
+
+			if (pointerType === 'touch' || !state.isHovered) {
+				return;
+			}
+
+			state.isHovered = false;
+		};
+
+		if (typeof PointerEvent !== 'undefined') {
+			props.onPointerEnter = (event) => {
+				onStart(event, event.pointerType);
+			};
+
+			props.onPointerLeave = (event) => {
+				if (
+					!disabled &&
+					event.currentTarget.contains(event.target as Element)
+				) {
+					onEnd(event.pointerType);
+				}
+			};
+		} else {
+			props.onTouchStart = () => {
+				state.isEmulatedMouseEvents = true;
+			};
+
+			props.onMouseEnter = (event) => {
+				if (!state.isEmulatedMouseEvents) {
+					onStart(event, 'mouse');
+				}
+
+				state.isEmulatedMouseEvents = false;
+			};
+
+			props.onMouseLeave = (event) => {
+				if (
+					!disabled &&
+					event.currentTarget.contains(event.target as Element)
+				) {
+					onEnd('mouse');
+				}
+			};
+		}
+
+		return props;
+	}, [onHover]);
+}

--- a/packages/clay-shared/src/useIsMobileDevice.ts
+++ b/packages/clay-shared/src/useIsMobileDevice.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export function useIsMobileDevice(): boolean {
+	if (typeof window === 'undefined') {
+		return false;
+	}
+
+	return window.screen.width <= 700;
+}

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -228,7 +228,7 @@ export function useNavigation<T extends HTMLElement | null>({
 
 						tab = orderedList.find(
 							(element) =>
-								element.innerText
+								(element.innerText ?? element.textContent)
 									?.toLowerCase()
 									.indexOf(
 										stringRef.current.toLocaleLowerCase()

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {useCallback, useEffect, useRef} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 
 import {Keys} from './Keys';
 import {FOCUSABLE_ELEMENTS, isFocusable} from './useFocusManagement';
@@ -19,6 +19,12 @@ type Props<T> = {
 	activation?: 'manual' | 'automatic';
 
 	/**
+	 * The id of the currently active item that is highlighted.
+	 * Typically used when navigation is not done via focus.
+	 */
+	active?: string;
+
+	/**
 	 * Reference of the parent element of the focusable elements.
 	 */
 	containeRef: React.MutableRefObject<T>;
@@ -27,6 +33,11 @@ type Props<T> = {
 	 * Flag to indicate if navigation should loop.
 	 */
 	loop?: boolean;
+
+	/**
+	 * Callback is called when the intent is to move to the element.
+	 */
+	onNavigate?: (element: HTMLElement, index: number) => void;
 
 	/**
 	 * Indicates whether the element's orientation is horizontal or vertical.
@@ -50,8 +61,10 @@ const horizontalKeys = [Keys.Left, Keys.Right, Keys.Home, Keys.End];
 
 export function useNavigation<T extends HTMLElement | null>({
 	activation = 'manual',
+	active,
 	containeRef,
 	loop = false,
+	onNavigate,
 	orientation = 'horizontal',
 	typeahead = false,
 	visible = false,
@@ -61,6 +74,12 @@ export function useNavigation<T extends HTMLElement | null>({
 	const prevIndexRef = useRef<number | null>(-1);
 	const matchIndexRef = useRef<number | null>(null);
 
+	// An event can be scheduled when the content is not visible in the DOM, it
+	// will be executed in sequence after the element is visible in the DOM.
+	const pendingEventStack = useRef<Array<React.KeyboardEvent<HTMLElement>>>(
+		[]
+	);
+
 	useEffect(() => {
 		if (visible) {
 			clearTimeout(timeoutIdRef.current);
@@ -69,140 +88,177 @@ export function useNavigation<T extends HTMLElement | null>({
 		}
 	}, [visible]);
 
-	const onKeyDown = useCallback((event: React.KeyboardEvent<HTMLElement>) => {
-		if (!containeRef.current) {
-			return;
-		}
+	const onKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLElement>) => {
+			if (!containeRef.current) {
+				event.persist();
+				pendingEventStack.current.push(event);
 
-		const keys = orientation === 'vertical' ? verticalKeys : horizontalKeys;
-		const alternativeKeys =
-			orientation === 'vertical' ? horizontalKeys : verticalKeys;
+				return;
+			}
 
-		if (
-			keys.includes(event.key) ||
-			(typeahead && !alternativeKeys.includes(event.key))
-		) {
-			const tabs = Array.from<HTMLElement>(
-				containeRef.current.querySelectorAll(
-					FOCUSABLE_ELEMENTS.join(',')
-				)
-			).filter((element) =>
-				isFocusable({
-					contentEditable: element.contentEditable,
-					disabled: element.getAttribute('disabled') !== null,
-					offsetParent: element.offsetParent,
-					tabIndex: 0,
-					tagName: element.tagName,
-				})
-			);
+			const keys =
+				orientation === 'vertical' ? verticalKeys : horizontalKeys;
+			const alternativeKeys =
+				orientation === 'vertical' ? horizontalKeys : verticalKeys;
 
-			let tab: HTMLElement | undefined;
+			if (
+				keys.includes(event.key) ||
+				(typeahead && !alternativeKeys.includes(event.key))
+			) {
+				const tabs = Array.from<HTMLElement>(
+					containeRef.current.querySelectorAll(
+						FOCUSABLE_ELEMENTS.join(',')
+					)
+				).filter((element) =>
+					isFocusable({
+						contentEditable: element.contentEditable,
+						disabled: element.getAttribute('disabled') !== null,
+						offsetParent: element.offsetParent,
+						tabIndex: 0,
+						tagName: element.tagName,
+					})
+				);
 
-			switch (event.key) {
-				case Keys.Left:
-				case Keys.Right:
-				case Keys.Down:
-				case Keys.Up: {
-					const activeElement = document.activeElement as HTMLElement;
+				let tab: HTMLElement | undefined;
 
-					const position = tabs.indexOf(activeElement);
+				switch (event.key) {
+					case Keys.Left:
+					case Keys.Right:
+					case Keys.Down:
+					case Keys.Up: {
+						const activeElement =
+							document.activeElement as HTMLElement;
 
-					if (position === -1) {
+						let position = tabs.indexOf(activeElement);
+
+						if (typeof active === 'string') {
+							position = tabs.findIndex(
+								(element) =>
+									element.getAttribute('id') === active
+							);
+						}
+
+						if (position === -1) {
+							break;
+						}
+
+						const key =
+							orientation === 'vertical' ? Keys.Up : Keys.Left;
+
+						tab =
+							tabs[
+								event.key === key ? position - 1 : position + 1
+							];
+
+						if (loop && !tab) {
+							tab = tabs[event.key === key ? tabs.length - 1 : 0];
+						}
+
 						break;
 					}
+					case Keys.Home:
+					case Keys.End:
+						tab =
+							tabs[event.key === Keys.Home ? 0 : tabs.length - 1];
+						break;
+					default: {
+						const target = event.target as HTMLElement;
 
-					const key =
-						orientation === 'vertical' ? Keys.Up : Keys.Left;
-
-					tab = tabs[event.key === key ? position - 1 : position + 1];
-
-					if (loop && !tab) {
-						tab = tabs[event.key === key ? tabs.length - 1 : 0];
-					}
-
-					break;
-				}
-				case Keys.Home:
-				case Keys.End:
-					tab = tabs[event.key === Keys.Home ? 0 : tabs.length - 1];
-					break;
-				default: {
-					const target = event.target as HTMLElement;
-
-					if (!typeahead || target.tagName === 'INPUT') {
-						return;
-					}
-
-					if (!event.currentTarget.contains(target)) {
-						return;
-					}
-
-					if (
-						stringRef.current.length > 0 &&
-						stringRef.current[0] !== Keys.Spacebar
-					) {
-						if (event.key === Keys.Spacebar) {
-							event.preventDefault();
-							event.stopPropagation();
+						if (!typeahead || target.tagName === 'INPUT') {
+							return;
 						}
+
+						if (!event.currentTarget.contains(target)) {
+							return;
+						}
+
+						if (
+							stringRef.current.length > 0 &&
+							stringRef.current[0] !== Keys.Spacebar
+						) {
+							if (event.key === Keys.Spacebar) {
+								event.preventDefault();
+								event.stopPropagation();
+							}
+						}
+
+						if (
+							event.key.length !== 1 ||
+							event.ctrlKey ||
+							event.metaKey ||
+							event.altKey
+						) {
+							return;
+						}
+
+						if (stringRef.current === event.key) {
+							stringRef.current = '';
+							prevIndexRef.current = matchIndexRef.current;
+						}
+
+						stringRef.current += event.key;
+
+						clearTimeout(timeoutIdRef.current);
+
+						timeoutIdRef.current = setTimeout(() => {
+							stringRef.current = '';
+							prevIndexRef.current = matchIndexRef.current;
+						}, 1000);
+
+						const prevIndex = prevIndexRef.current;
+
+						const orderedList = [
+							...tabs.slice((prevIndex ?? 0) + 1),
+							...tabs.slice(0, (prevIndex ?? 0) + 1),
+						];
+
+						tab = orderedList.find(
+							(element) =>
+								element.innerText
+									?.toLowerCase()
+									.indexOf(
+										stringRef.current.toLocaleLowerCase()
+									) === 0
+						);
+
+						if (tab) {
+							matchIndexRef.current = tabs.indexOf(tab);
+						}
+						break;
+					}
+				}
+
+				if (tab) {
+					event.preventDefault();
+					if (onNavigate) {
+						onNavigate(tab, tabs.indexOf(tab));
+					} else {
+						tab.focus();
 					}
 
-					if (
-						event.key.length !== 1 ||
-						event.ctrlKey ||
-						event.metaKey ||
-						event.altKey
-					) {
-						return;
+					if (activation === 'automatic') {
+						tab.click();
 					}
-
-					if (stringRef.current === event.key) {
-						stringRef.current = '';
-						prevIndexRef.current = matchIndexRef.current;
-					}
-
-					stringRef.current += event.key;
-
-					clearTimeout(timeoutIdRef.current);
-
-					timeoutIdRef.current = setTimeout(() => {
-						stringRef.current = '';
-						prevIndexRef.current = matchIndexRef.current;
-					}, 1000);
-
-					const prevIndex = prevIndexRef.current;
-
-					const orderedList = [
-						...tabs.slice((prevIndex ?? 0) + 1),
-						...tabs.slice(0, (prevIndex ?? 0) + 1),
-					];
-
-					tab = orderedList.find(
-						(element) =>
-							element.innerText
-								?.toLowerCase()
-								.indexOf(
-									stringRef.current.toLocaleLowerCase()
-								) === 0
-					);
-
-					if (tab) {
-						matchIndexRef.current = tabs.indexOf(tab);
-					}
-					break;
 				}
 			}
+		},
+		[active]
+	);
 
-			if (tab) {
-				event.preventDefault();
-				tab.focus();
+	useEffect(() => {
+		if (visible && pendingEventStack.current.length !== 0) {
+			for (
+				let index = 0;
+				index < pendingEventStack.current.length;
+				index++
+			) {
+				const event = pendingEventStack.current.shift();
 
-				if (activation === 'automatic') {
-					tab.click();
-				}
+				onKeyDown(event!);
 			}
 		}
-	}, []);
+	}, [visible]);
 
 	return {onKeyDown};
 }

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -81,7 +81,7 @@ export function useNavigation<T extends HTMLElement | null>({
 	);
 
 	useEffect(() => {
-		if (visible) {
+		if (!visible) {
 			clearTimeout(timeoutIdRef.current);
 			matchIndexRef.current = null;
 			stringRef.current = '';
@@ -169,7 +169,10 @@ export function useNavigation<T extends HTMLElement | null>({
 							return;
 						}
 
-						if (!event.currentTarget.contains(target)) {
+						if (
+							event.currentTarget &&
+							!event.currentTarget.contains(target)
+						) {
 							return;
 						}
 
@@ -191,6 +194,8 @@ export function useNavigation<T extends HTMLElement | null>({
 						) {
 							return;
 						}
+
+						event.stopPropagation();
 
 						if (stringRef.current === event.key) {
 							stringRef.current = '';
@@ -288,6 +293,15 @@ export function useNavigation<T extends HTMLElement | null>({
 	}, [visible]);
 
 	return {onKeyDown};
+}
+
+export function isTypeahead(event: React.KeyboardEvent<HTMLElement>) {
+	return (
+		event.key.length === 1 &&
+		!event.ctrlKey &&
+		!event.metaKey &&
+		!event.altKey
+	);
 }
 
 function isElementInView(element: HTMLElement) {

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -27,7 +27,7 @@ type Props<T> = {
 	/**
 	 * Reference of the parent element of the focusable elements.
 	 */
-	containeRef: React.MutableRefObject<T>;
+	containerRef: React.MutableRefObject<T>;
 
 	/**
 	 * Flag to indicate if navigation should loop.
@@ -62,7 +62,7 @@ const horizontalKeys = [Keys.Left, Keys.Right, Keys.Home, Keys.End];
 export function useNavigation<T extends HTMLElement | null>({
 	activation = 'manual',
 	active,
-	containeRef,
+	containerRef,
 	loop = false,
 	onNavigate,
 	orientation = 'horizontal',
@@ -92,7 +92,8 @@ export function useNavigation<T extends HTMLElement | null>({
 		(tab: HTMLElement, tabs?: Array<HTMLElement>) => {
 			onNavigate!(tab, tabs ? tabs.indexOf(tab) : null);
 
-			const child = containeRef.current!.firstElementChild as HTMLElement;
+			const child = containerRef.current!
+				.firstElementChild as HTMLElement;
 
 			if (isScrollable(child)) {
 				maintainScrollVisibility(tab, child);
@@ -110,7 +111,7 @@ export function useNavigation<T extends HTMLElement | null>({
 
 	const onKeyDown = useCallback(
 		(event: React.KeyboardEvent<HTMLElement>) => {
-			if (!containeRef.current) {
+			if (!containerRef.current) {
 				event.persist();
 				pendingEventStack.current.push(event);
 
@@ -126,7 +127,7 @@ export function useNavigation<T extends HTMLElement | null>({
 				keys.includes(event.key) ||
 				(typeahead && !alternativeKeys.includes(event.key))
 			) {
-				const tabs = getFocusableList(containeRef);
+				const tabs = getFocusableList(containerRef);
 
 				let tab: HTMLElement | undefined;
 
@@ -261,10 +262,10 @@ export function useNavigation<T extends HTMLElement | null>({
 
 	useEffect(() => {
 		// Moves the scroll to the element with visual "focus" if it exists.
-		if (visible && containeRef.current && active && onNavigate) {
-			const child = containeRef.current.firstElementChild as HTMLElement;
+		if (visible && containerRef.current && active && onNavigate) {
+			const child = containerRef.current.firstElementChild as HTMLElement;
 			const activeElement =
-				containeRef.current.querySelector<HTMLElement>(`#${active}`);
+				containerRef.current.querySelector<HTMLElement>(`#${active}`);
 
 			if (activeElement && isScrollable(child)) {
 				maintainScrollVisibility(activeElement, child);

--- a/packages/clay-tabs/src/List.tsx
+++ b/packages/clay-tabs/src/List.tsx
@@ -68,7 +68,7 @@ export function List({
 }: IProps) {
 	const tabsRef = useRef<HTMLUListElement>(null);
 
-	const {onKeyDown} = useNavigation({
+	const {navigationProps} = useNavigation({
 		activation,
 		containeRef: tabsRef,
 		orientation: 'horizontal',
@@ -77,6 +77,7 @@ export function List({
 	return (
 		<ul
 			{...otherProps}
+			{...navigationProps}
 			className={classNames(
 				'nav',
 				{'nav-justified': justified},
@@ -92,7 +93,6 @@ export function List({
 
 				className
 			)}
-			onKeyDown={onKeyDown}
 			ref={tabsRef}
 			role="tablist"
 		>

--- a/packages/clay-tabs/src/List.tsx
+++ b/packages/clay-tabs/src/List.tsx
@@ -70,7 +70,7 @@ export function List({
 
 	const {navigationProps} = useNavigation({
 		activation,
-		containeRef: tabsRef,
+		containerRef: tabsRef,
 		orientation: 'horizontal',
 	});
 


### PR DESCRIPTION
Closes #5226

I'm submitting it as a separate PR from #5246, so I can add more info on the component's implementation in React.js and also to better separate the discussions. There are some CSS issues that still need to be fixed, I added some comments about that in PR #5246.

Firstly I went ahead with the `<Picker />` name here for combobox-only selection, I can't find another alternative here, names with Custom Select synthetically are bad to read and sound like customization/alternative, in which case I I think we don't want to just leave this as an alternative but be the main component to replace the native Select component.

Well, this component is following the w3c recommendations https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html. It also implements Clay patterns like Collection and Controlled and Uncontrolled components, which makes the component simple to use. This component doesn't have all Collection features implemented, for example virtualization and load more, we still need to improve keyboard navigation in a virtualized list, this is being done in #5205, so I haven't enabled virtualization here, and we do not have the load more/data paginated implemented for a non-virtualized list, I will create an issue to be able to work on that soon.

## Design Principles

As this component only tends to support behaviors of a select with OOTB accessibility and other resources delivered by the Clay foundation, the composition is very close and common to a DropDown, VerticalBar plus some more simplified APIs that do not exist in a DropDown for example.

```jsx
<Form.Group>
    <label htmlFor={pickerId} id={labelId}>
        Choose a fruit
    </label>
    <Picker aria-labelledby={labelId} id={pickerId}>
        <Option key="apple">Apple</Option>
        <Option disabled key="banana">Banana</Option>
        <Option key="mangos">Mangos</Option>
    </Picker>
</Form.Group>
```

The component's design is very close to a native Select, this allows us to implement this component as a hybrid that allows switching between a native selector or the custom implementation.

Data-agnostic composition also allows you to add composition as a custom content of the options, where possible, and still provide support for the native selector with the support of some attributes, for example:

```jsx
<Form.Group>
    <label htmlFor={pickerId} id={labelId}>
        Choose a fruit
    </label>
    <Picker aria-labelledby={labelId} id={pickerId}>
        <Option key="apple" textValue="Apple">
            <Text>Apple</Text>
            <Text size={3} color="secondary">Edible fruit produced by an apple tree.</Text>
        </Option>
        <Option key="banana" textValue="Banana">
            <Text>Banana</Text>
            <Text size={3} color="secondary">Elongated, edible fruit – botanically a berry.</Text>
        </Option>
        <Option key="mangos" textValue="Mangos">
            <Text>Mangos</Text>
            <Text size={3} color="secondary">Edible stone fruit produced by the tropical tree Mangifera indica.</Text>
        </Option>
    </Picker>
</Form.Group>
```

This allows switching to a native picker easily just by setting the attribute on the `<Picker />` component, this part is yet to be implemented.

Unlike a component like DropDown, customizing the trigger is not possible, because that can easily break the accessibility part, but we can improve this over time as it becomes clearer what alternatives people want.

### ToDo

- [x] Add component documentation
- [x] Add tests
- [x] Add native selector support

#### Accessibility

- [x] Printable Characters - add support for typeahead when the Menu is closed, this already works when the Menu is open.
- [x] Navigation with the PageUp & PageDown keys
- [x] Click outside Menu select option with activeDescendant