### PR TITLE
feat(@clayui/pagination): PaginationWithBasicItems should have aria-labels by default

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -158,7 +158,7 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-pagination/src/': {
-			branches: 89,
+			branches: 86,
 			functions: 100,
 			lines: 100,
 			statements: 100,

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -32,103 +32,105 @@ exports[`ClayPaginationBar renders 1`] = `
     >
       Showing 1 to 10 of 100
     </div>
-    <ul
-      class="pagination pagination-root"
+    <nav
+      aria-label="Pagination"
     >
-      <li
-        class="page-item disabled"
+      <ul
+        class="pagination pagination-root"
       >
-        <button
-          aria-label="Previous"
-          class="page-link"
-          data-testid="prevArrow"
-          disabled=""
-          type="button"
+        <li
+          class="page-item disabled"
         >
-          <svg
-            class="lexicon-icon lexicon-icon-angle-left"
-            role="presentation"
+          <a
+            aria-label="Go to the previous page, 0"
+            class="page-link"
+            data-testid="prevArrow"
           >
-            <use
-              xlink:href="path/to/spritemap#angle-left"
-            />
-          </svg>
-        </button>
-      </li>
-      <li
-        class="page-item active"
-      >
-        <button
-          class="page-link"
-          disabled=""
-          type="button"
+            <svg
+              class="lexicon-icon lexicon-icon-angle-left"
+              role="presentation"
+            >
+              <use
+                xlink:href="path/to/spritemap#angle-left"
+              />
+            </svg>
+          </a>
+        </li>
+        <li
+          class="page-item active"
         >
-          1
-        </button>
-      </li>
-      <li
-        class="page-item"
-      >
-        <button
-          class="page-link"
-          type="button"
-        >
-          2
-        </button>
-      </li>
-      <li
-        class="page-item"
-      >
-        <button
-          class="page-link"
-          type="button"
-        >
-          3
-        </button>
-      </li>
-      <li
-        class="dropdown page-item"
-      >
-        <button
-          aria-controls="clay-dropdown-menu-2"
-          aria-expanded="false"
-          aria-haspopup="true"
-          class="dropdown-toggle page-link btn btn-unstyled"
-          type="button"
-        >
-          ...
-        </button>
-      </li>
-      <li
-        class="page-item"
-      >
-        <button
-          class="page-link"
-          type="button"
-        >
-          10
-        </button>
-      </li>
-      <li
-        class="page-item"
-      >
-        <button
-          aria-label="Next"
-          class="page-link"
-          data-testid="nextArrow"
-          type="button"
-        >
-          <svg
-            class="lexicon-icon lexicon-icon-angle-right"
-            role="presentation"
+          <a
+            aria-label="Go to page, 1"
+            class="page-link"
           >
-            <use
-              xlink:href="path/to/spritemap#angle-right"
-            />
-          </svg>
-        </button>
-      </li>
-    </ul>
+            1
+          </a>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to page, 2"
+            class="page-link"
+          >
+            2
+          </a>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to page, 3"
+            class="page-link"
+          >
+            3
+          </a>
+        </li>
+        <li
+          class="dropdown page-item"
+        >
+          <button
+            aria-controls="clay-dropdown-menu-2"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Show pages 4 through 9"
+            class="dropdown-toggle page-link btn btn-unstyled"
+            title="Show pages 4 through 9"
+            type="button"
+          >
+            ...
+          </button>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to page, 10"
+            class="page-link"
+          >
+            10
+          </a>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to the next page, 2"
+            class="page-link"
+            data-testid="nextArrow"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-angle-right"
+              role="presentation"
+            >
+              <use
+                xlink:href="path/to/spritemap#angle-right"
+              />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
   </div>
 </div>
 `;
@@ -143,103 +145,105 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
     >
       Showing 1 to 10 of 100
     </div>
-    <ul
-      class="pagination pagination-root"
+    <nav
+      aria-label="Pagination"
     >
-      <li
-        class="page-item disabled"
+      <ul
+        class="pagination pagination-root"
       >
-        <button
-          aria-label="Previous"
-          class="page-link"
-          data-testid="prevArrow"
-          disabled=""
-          type="button"
+        <li
+          class="page-item disabled"
         >
-          <svg
-            class="lexicon-icon lexicon-icon-angle-left"
-            role="presentation"
+          <a
+            aria-label="Go to the previous page, 0"
+            class="page-link"
+            data-testid="prevArrow"
           >
-            <use
-              xlink:href="path/to/spritemap#angle-left"
-            />
-          </svg>
-        </button>
-      </li>
-      <li
-        class="page-item active"
-      >
-        <button
-          class="page-link"
-          disabled=""
-          type="button"
+            <svg
+              class="lexicon-icon lexicon-icon-angle-left"
+              role="presentation"
+            >
+              <use
+                xlink:href="path/to/spritemap#angle-left"
+              />
+            </svg>
+          </a>
+        </li>
+        <li
+          class="page-item active"
         >
-          1
-        </button>
-      </li>
-      <li
-        class="page-item"
-      >
-        <button
-          class="page-link"
-          type="button"
-        >
-          2
-        </button>
-      </li>
-      <li
-        class="page-item"
-      >
-        <button
-          class="page-link"
-          type="button"
-        >
-          3
-        </button>
-      </li>
-      <li
-        class="dropdown page-item"
-      >
-        <button
-          aria-controls="clay-dropdown-menu-3"
-          aria-expanded="false"
-          aria-haspopup="true"
-          class="dropdown-toggle page-link btn btn-unstyled"
-          type="button"
-        >
-          ...
-        </button>
-      </li>
-      <li
-        class="page-item"
-      >
-        <button
-          class="page-link"
-          type="button"
-        >
-          10
-        </button>
-      </li>
-      <li
-        class="page-item"
-      >
-        <button
-          aria-label="Next"
-          class="page-link"
-          data-testid="nextArrow"
-          type="button"
-        >
-          <svg
-            class="lexicon-icon lexicon-icon-angle-right"
-            role="presentation"
+          <a
+            aria-label="Go to page, 1"
+            class="page-link"
           >
-            <use
-              xlink:href="path/to/spritemap#angle-right"
-            />
-          </svg>
-        </button>
-      </li>
-    </ul>
+            1
+          </a>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to page, 2"
+            class="page-link"
+          >
+            2
+          </a>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to page, 3"
+            class="page-link"
+          >
+            3
+          </a>
+        </li>
+        <li
+          class="dropdown page-item"
+        >
+          <button
+            aria-controls="clay-dropdown-menu-3"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Show pages 4 through 9"
+            class="dropdown-toggle page-link btn btn-unstyled"
+            title="Show pages 4 through 9"
+            type="button"
+          >
+            ...
+          </button>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to page, 10"
+            class="page-link"
+          >
+            10
+          </a>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to the next page, 2"
+            class="page-link"
+            data-testid="nextArrow"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-angle-right"
+              role="presentation"
+            >
+              <use
+                xlink:href="path/to/spritemap#angle-right"
+              />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
   </div>
 </div>
 `;

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -39,17 +39,17 @@ const ClayPaginationEllipsis = ({
 				onClick: () => onPageChange && onPageChange(page),
 		  }));
 
-	const ariaLabel = otherProps['aria-label']
+	const ariaLabel = otherProps['aria-label'] && !disabled
 		? sub(otherProps['aria-label'], [
-				pages[0]?.label.toString(),
-				pages[pages.length - 1]?.label.toString(),
+				pages[0]?.label as string,
+				pages[pages.length - 1]?.label as string,
 		  ])
 		: undefined;
 
-	const title = otherProps['title']
+	const title = otherProps['title'] && !disabled
 		? sub(otherProps['title'], [
-				pages[0]?.label.toString(),
-				pages[pages.length - 1]?.label.toString(),
+				pages[0]?.label as string,
+				pages[pages.length - 1]?.label as string,
 		  ])
 		: undefined;
 

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -39,19 +39,21 @@ const ClayPaginationEllipsis = ({
 				onClick: () => onPageChange && onPageChange(page),
 		  }));
 
-	const ariaLabel = otherProps['aria-label'] && !disabled
-		? sub(otherProps['aria-label'], [
-				pages[0]?.label as string,
-				pages[pages.length - 1]?.label as string,
-		  ])
-		: undefined;
+	const ariaLabel =
+		otherProps['aria-label'] && !disabled
+			? sub(otherProps['aria-label'], [
+					pages[0]?.label as string,
+					pages[pages.length - 1]?.label as string,
+			  ])
+			: undefined;
 
-	const title = otherProps['title'] && !disabled
-		? sub(otherProps['title'], [
-				pages[0]?.label as string,
-				pages[pages.length - 1]?.label as string,
-		  ])
-		: undefined;
+	const title =
+		otherProps['title'] && !disabled
+			? sub(otherProps['title'], [
+					pages[0]?.label as string,
+					pages[pages.length - 1]?.label as string,
+			  ])
+			: undefined;
 
 	return (
 		<ClayDropDownWithItems

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -5,6 +5,7 @@
 
 import ClayButton from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
+import {sub} from '@clayui/shared';
 import React from 'react';
 
 export interface IPaginationEllipsisProps {
@@ -38,17 +39,19 @@ const ClayPaginationEllipsis = ({
 				onClick: () => onPageChange && onPageChange(page),
 		  }));
 
-	const replacePlaceholders = (str: string | undefined) => {
-		if (str) {
-			str = str.replace(/%START%|%END%/g, (s: string | undefined) => {
-				return s === '%START%'
-					? pages[0]?.label.toString()
-					: pages[pages.length - 1]?.label.toString();
-			});
-		}
+	const ariaLabel = otherProps['aria-label']
+		? sub(otherProps['aria-label'], [
+				pages[0]?.label.toString(),
+				pages[pages.length - 1]?.label.toString(),
+		  ])
+		: undefined;
 
-		return str;
-	};
+	const title = otherProps['title']
+		? sub(otherProps['title'], [
+				pages[0]?.label.toString(),
+				pages[pages.length - 1]?.label.toString(),
+		  ])
+		: undefined;
 
 	return (
 		<ClayDropDownWithItems
@@ -59,11 +62,11 @@ const ClayPaginationEllipsis = ({
 			trigger={
 				<ClayButton
 					{...otherProps}
-					aria-label={replacePlaceholders(otherProps['aria-label'])}
+					aria-label={ariaLabel}
 					className="page-link"
 					disabled={disabled}
 					displayType="unstyled"
-					title={replacePlaceholders(otherProps?.title)}
+					title={title}
 				>
 					...
 				</ClayButton>

--- a/packages/clay-pagination/src/Ellipsis.tsx
+++ b/packages/clay-pagination/src/Ellipsis.tsx
@@ -38,6 +38,18 @@ const ClayPaginationEllipsis = ({
 				onClick: () => onPageChange && onPageChange(page),
 		  }));
 
+	const replacePlaceholders = (str: string | undefined) => {
+		if (str) {
+			str = str.replace(/%START%|%END%/g, (s: string | undefined) => {
+				return s === '%START%'
+					? pages[0]?.label.toString()
+					: pages[pages.length - 1]?.label.toString();
+			});
+		}
+
+		return str;
+	};
+
 	return (
 		<ClayDropDownWithItems
 			alignmentPosition={alignmentPosition}
@@ -47,9 +59,11 @@ const ClayPaginationEllipsis = ({
 			trigger={
 				<ClayButton
 					{...otherProps}
+					aria-label={replacePlaceholders(otherProps['aria-label'])}
 					className="page-link"
 					disabled={disabled}
 					displayType="unstyled"
+					title={replacePlaceholders(otherProps?.title)}
 				>
 					...
 				</ClayButton>

--- a/packages/clay-pagination/src/Item.tsx
+++ b/packages/clay-pagination/src/Item.tsx
@@ -21,20 +21,16 @@ const ClayPaginationItem = ({
 	href,
 	...otherProps
 }: IPaginationItemProps) => {
-	const ElementTag = href ? ClayLink : 'button';
-
 	return (
 		<li className={classNames('page-item', {active, disabled})}>
-			<ElementTag
-				type={href ? undefined : 'button'}
+			<ClayLink
 				{...otherProps}
 				aria-current={active && href ? 'page' : undefined}
 				className="page-link"
-				disabled={href ? undefined : disabled || active}
 				href={disabled || active ? undefined : href}
 			>
 				{children}
-			</ElementTag>
+			</ClayLink>
 		</li>
 	);
 };

--- a/packages/clay-pagination/src/Item.tsx
+++ b/packages/clay-pagination/src/Item.tsx
@@ -28,6 +28,15 @@ const ClayPaginationItem = ({
 				aria-current={active && href ? 'page' : undefined}
 				className="page-link"
 				href={disabled || active ? undefined : href}
+				onClick={(event) => {
+					if (!href) {
+						event.preventDefault();
+					}
+
+					if (otherProps.onClick) {
+						otherProps.onClick(event);
+					}
+				}}
 			>
 				{children}
 			</ClayLink>

--- a/packages/clay-pagination/src/Pagination.tsx
+++ b/packages/clay-pagination/src/Pagination.tsx
@@ -11,30 +11,15 @@ import Item from './Item';
 
 interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	/**
-	 * Use this property for defining `otherProps` that will be passed to the `nav` element.
-	 */
-	navProps?: {
-		'aria-label'?: string;
-		role?: string;
-	};
-
-	/**
 	 * The size of pagination element.
 	 */
 	size?: 'lg' | 'sm';
 }
 
 const ClayPagination = React.forwardRef<HTMLUListElement, IProps>(
-	(
-		{children, className, navProps = {}, size, ...otherProps}: IProps,
-		ref
-	) => {
+	({children, className, size, ...otherProps}: IProps, ref) => {
 		return (
-			<nav
-				aria-label={navProps['aria-label'] || 'Pagination'}
-				role={navProps?.role || 'navigation'}
-				{...navProps}
-			>
+			<nav aria-label={otherProps['aria-label'] || 'Pagination'}>
 				<ul
 					{...otherProps}
 					className={classNames(

--- a/packages/clay-pagination/src/Pagination.tsx
+++ b/packages/clay-pagination/src/Pagination.tsx
@@ -11,23 +11,44 @@ import Item from './Item';
 
 interface IProps extends React.HTMLAttributes<HTMLUListElement> {
 	/**
+	 * Use this property for defining `otherProps` that will be passed to the `nav` element.
+	 */
+	navProps?: {
+		'aria-label'?: string;
+		role?: string;
+	};
+
+	/**
 	 * The size of pagination element.
 	 */
 	size?: 'lg' | 'sm';
 }
 
 const ClayPagination = React.forwardRef<HTMLUListElement, IProps>(
-	({children, className, size, ...otherProps}: IProps, ref) => {
+	(
+		{children, className, navProps = {}, size, ...otherProps}: IProps,
+		ref
+	) => {
 		return (
-			<ul
-				{...otherProps}
-				className={classNames('pagination pagination-root', className, {
-					[`pagination-${size}`]: size,
-				})}
-				ref={ref}
+			<nav
+				aria-label={navProps['aria-label'] || 'Pagination'}
+				role={navProps?.role || 'navigation'}
+				{...navProps}
 			>
-				{children}
-			</ul>
+				<ul
+					{...otherProps}
+					className={classNames(
+						'pagination pagination-root',
+						className,
+						{
+							[`pagination-${size}`]: size,
+						}
+					)}
+					ref={ref}
+				>
+					{children}
+				</ul>
+			</nav>
 		);
 	}
 );

--- a/packages/clay-pagination/src/PaginationWithBasicItems.tsx
+++ b/packages/clay-pagination/src/PaginationWithBasicItems.tsx
@@ -7,6 +7,7 @@ import ClayIcon from '@clayui/icon';
 import {
 	InternalDispatch,
 	getEllipsisItems,
+	sub,
 	useInternalState,
 } from '@clayui/shared';
 import React from 'react';
@@ -16,18 +17,6 @@ import Pagination from './Pagination';
 import type {IPaginationEllipsisProps} from './Ellipsis';
 
 const ELLIPSIS_BUFFER = 2;
-
-const replacePlaceholders = (
-	str: string,
-	page: number | JSX.Element | Object | undefined
-) => {
-	if (str) {
-		return str.replace(
-			/%PREVIOUS%|%NEXT%|%PAGE%/g,
-			page ? page.toString() : ''
-		);
-	}
-};
 
 interface IProps extends React.ComponentProps<typeof Pagination> {
 	/**
@@ -118,17 +107,17 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 			activePage,
 			alignmentPosition,
 			ariaLabels = {
-				link: 'Go to page, %PAGE%',
-				next: 'Go to the next page, %NEXT%',
-				previous: 'Go to the previous page, %PREVIOUS%',
+				link: 'Go to page, {0}',
+				next: 'Go to the next page, {0}',
+				previous: 'Go to the previous page, {0}',
 			},
 			defaultActive,
 			disabledPages = [],
 			disableEllipsis = false,
 			ellipsisBuffer = ELLIPSIS_BUFFER,
 			ellipsisProps = {
-				'aria-label': 'Show pages %START% through %END%',
-				title: 'Show pages %START% through %END%',
+				'aria-label': 'Show pages {0} through {1}',
+				title: 'Show pages {0} through {1}',
 			},
 			hrefConstructor,
 			onActiveChange,
@@ -161,10 +150,7 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 		return (
 			<Pagination {...otherProps} ref={ref}>
 				<Pagination.Item
-					aria-label={replacePlaceholders(
-						ariaLabels.previous,
-						previousPage
-					)}
+					aria-label={sub(ariaLabels.previous, [previousPage])}
 					data-testid="prevArrow"
 					disabled={internalActive === 1}
 					href={previousHref}
@@ -191,35 +177,28 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 							internalActive - 1
 					  )
 					: pages
-				).map(
-					(page: number | JSX.Element | Object, index: number) =>
-						React.isValidElement(page) ? (
-							React.cloneElement(page, {key: `ellipsis${index}`})
-						) : (
-							<Pagination.Item
-								active={page === internalActive}
-								aria-label={replacePlaceholders(
-									ariaLabels.link,
-									page
-								)}
-								disabled={disabledPages.includes(
-									page as number
-								)}
-								href={
-									hrefConstructor &&
-									hrefConstructor(page as number)
-								}
-								key={page as number}
-								onClick={() => setActive(page as number)}
-							>
-								{page}
-							</Pagination.Item>
-						),
-					replacePlaceholders
+				).map((page: number | JSX.Element | Object, index: number) =>
+					React.isValidElement(page) ? (
+						React.cloneElement(page, {key: `ellipsis${index}`})
+					) : (
+						<Pagination.Item
+							active={page === internalActive}
+							aria-label={sub(ariaLabels.link, [page as number])}
+							disabled={disabledPages.includes(page as number)}
+							href={
+								hrefConstructor &&
+								hrefConstructor(page as number)
+							}
+							key={page as number}
+							onClick={() => setActive(page as number)}
+						>
+							{page}
+						</Pagination.Item>
+					)
 				)}
 
 				<Pagination.Item
-					aria-label={replacePlaceholders(ariaLabels.next, nextPage)}
+					aria-label={sub(ariaLabels.next, [nextPage])}
 					data-testid="nextArrow"
 					disabled={internalActive === totalPages}
 					href={nextHref}

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -2,204 +2,208 @@
 
 exports[`ClayPagination renders 1`] = `
 <div>
-  <ul
-    class="pagination pagination-root pagination-lg"
+  <nav
+    aria-label="Pagination"
   >
-    <li
-      class="page-item"
+    <ul
+      class="pagination pagination-root pagination-lg"
     >
-      <button
-        aria-label="Previous"
-        class="page-link"
-        data-testid="prevArrow"
-        type="button"
+      <li
+        class="page-item"
       >
-        <svg
-          class="lexicon-icon lexicon-icon-angle-left"
-          role="presentation"
+        <a
+          aria-label="Go to the previous page, 11"
+          class="page-link"
+          data-testid="prevArrow"
         >
-          <use
-            xlink:href="path/to/spritemap#angle-left"
-          />
-        </svg>
-      </button>
-    </li>
-    <li
-      class="page-item"
-    >
-      <button
-        class="page-link"
-        type="button"
+          <svg
+            class="lexicon-icon lexicon-icon-angle-left"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#angle-left"
+            />
+          </svg>
+        </a>
+      </li>
+      <li
+        class="page-item"
       >
-        1
-      </button>
-    </li>
-    <li
-      class="dropdown page-item"
-    >
-      <button
-        aria-controls="clay-dropdown-menu-1"
-        aria-expanded="false"
-        aria-haspopup="true"
-        class="dropdown-toggle page-link btn btn-unstyled"
-        type="button"
-      >
-        ...
-      </button>
-    </li>
-    <li
-      class="page-item"
-    >
-      <button
-        class="page-link"
-        type="button"
-      >
-        10
-      </button>
-    </li>
-    <li
-      class="page-item"
-    >
-      <button
-        class="page-link"
-        type="button"
-      >
-        11
-      </button>
-    </li>
-    <li
-      class="page-item active"
-    >
-      <button
-        class="page-link"
-        disabled=""
-        type="button"
-      >
-        12
-      </button>
-    </li>
-    <li
-      class="page-item"
-    >
-      <button
-        class="page-link"
-        type="button"
-      >
-        13
-      </button>
-    </li>
-    <li
-      class="page-item"
-    >
-      <button
-        class="page-link"
-        type="button"
-      >
-        14
-      </button>
-    </li>
-    <li
-      class="dropdown page-item"
-    >
-      <button
-        aria-controls="clay-dropdown-menu-2"
-        aria-expanded="false"
-        aria-haspopup="true"
-        class="dropdown-toggle page-link btn btn-unstyled"
-        type="button"
-      >
-        ...
-      </button>
-    </li>
-    <li
-      class="page-item"
-    >
-      <button
-        class="page-link"
-        type="button"
-      >
-        25
-      </button>
-    </li>
-    <li
-      class="page-item"
-    >
-      <button
-        aria-label="Next"
-        class="page-link"
-        data-testid="nextArrow"
-        type="button"
-      >
-        <svg
-          class="lexicon-icon lexicon-icon-angle-right"
-          role="presentation"
+        <a
+          aria-label="Go to page, 1"
+          class="page-link"
         >
-          <use
-            xlink:href="path/to/spritemap#angle-right"
-          />
-        </svg>
-      </button>
-    </li>
-  </ul>
+          1
+        </a>
+      </li>
+      <li
+        class="dropdown page-item"
+      >
+        <button
+          aria-controls="clay-dropdown-menu-1"
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Show pages 2 through 9"
+          class="dropdown-toggle page-link btn btn-unstyled"
+          title="Show pages 2 through 9"
+          type="button"
+        >
+          ...
+        </button>
+      </li>
+      <li
+        class="page-item"
+      >
+        <a
+          aria-label="Go to page, 10"
+          class="page-link"
+        >
+          10
+        </a>
+      </li>
+      <li
+        class="page-item"
+      >
+        <a
+          aria-label="Go to page, 11"
+          class="page-link"
+        >
+          11
+        </a>
+      </li>
+      <li
+        class="page-item active"
+      >
+        <a
+          aria-label="Go to page, 12"
+          class="page-link"
+        >
+          12
+        </a>
+      </li>
+      <li
+        class="page-item"
+      >
+        <a
+          aria-label="Go to page, 13"
+          class="page-link"
+        >
+          13
+        </a>
+      </li>
+      <li
+        class="page-item"
+      >
+        <a
+          aria-label="Go to page, 14"
+          class="page-link"
+        >
+          14
+        </a>
+      </li>
+      <li
+        class="dropdown page-item"
+      >
+        <button
+          aria-controls="clay-dropdown-menu-2"
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Show pages 15 through 24"
+          class="dropdown-toggle page-link btn btn-unstyled"
+          title="Show pages 15 through 24"
+          type="button"
+        >
+          ...
+        </button>
+      </li>
+      <li
+        class="page-item"
+      >
+        <a
+          aria-label="Go to page, 25"
+          class="page-link"
+        >
+          25
+        </a>
+      </li>
+      <li
+        class="page-item"
+      >
+        <a
+          aria-label="Go to the next page, 13"
+          class="page-link"
+          data-testid="nextArrow"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-angle-right"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#angle-right"
+            />
+          </svg>
+        </a>
+      </li>
+    </ul>
+  </nav>
 </div>
 `;
 
 exports[`ClayPagination renders with only one page 1`] = `
 <div>
-  <ul
-    class="pagination pagination-root"
+  <nav
+    aria-label="Pagination"
   >
-    <li
-      class="page-item disabled"
+    <ul
+      class="pagination pagination-root"
     >
-      <button
-        aria-label="Previous"
-        class="page-link"
-        data-testid="prevArrow"
-        disabled=""
-        type="button"
+      <li
+        class="page-item disabled"
       >
-        <svg
-          class="lexicon-icon lexicon-icon-angle-left"
-          role="presentation"
+        <a
+          aria-label="Go to the previous page, 0"
+          class="page-link"
+          data-testid="prevArrow"
         >
-          <use
-            xlink:href="path/to/spritemap#angle-left"
-          />
-        </svg>
-      </button>
-    </li>
-    <li
-      class="page-item active"
-    >
-      <button
-        class="page-link"
-        disabled=""
-        type="button"
+          <svg
+            class="lexicon-icon lexicon-icon-angle-left"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#angle-left"
+            />
+          </svg>
+        </a>
+      </li>
+      <li
+        class="page-item active"
       >
-        1
-      </button>
-    </li>
-    <li
-      class="page-item disabled"
-    >
-      <button
-        aria-label="Next"
-        class="page-link"
-        data-testid="nextArrow"
-        disabled=""
-        type="button"
-      >
-        <svg
-          class="lexicon-icon lexicon-icon-angle-right"
-          role="presentation"
+        <a
+          aria-label="Go to page, 1"
+          class="page-link"
         >
-          <use
-            xlink:href="path/to/spritemap#angle-right"
-          />
-        </svg>
-      </button>
-    </li>
-  </ul>
+          1
+        </a>
+      </li>
+      <li
+        class="page-item disabled"
+      >
+        <a
+          aria-label="Go to the next page, 2"
+          class="page-link"
+          data-testid="nextArrow"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-angle-right"
+            role="presentation"
+          >
+            <use
+              xlink:href="path/to/spritemap#angle-right"
+            />
+          </svg>
+        </a>
+      </li>
+    </ul>
+  </nav>
 </div>
 `;

--- a/packages/clay-pagination/stories/Pagination.stories.tsx
+++ b/packages/clay-pagination/stories/Pagination.stories.tsx
@@ -16,7 +16,9 @@ export const Default = () => (
 	<ClayPagination>
 		<ClayPagination.Item>1</ClayPagination.Item>
 		<ClayPagination.Ellipsis aria-label="More" title="More" />
-		<ClayPagination.Item>End</ClayPagination.Item>
+		<ClayPagination.Item aria-label="Go to the end">
+			End
+		</ClayPagination.Item>
 	</ClayPagination>
 );
 
@@ -24,8 +26,11 @@ export const WithLinks = (args: any) => (
 	<ClayPaginationWithBasicItems
 		activePage={args.activePage}
 		ellipsisBuffer={args.ellipsisBuffer}
-		ellipsisProps={{'aria-label': 'More', title: 'More'}}
-		hrefConstructor={(page) => `/#${page}`}
+		ellipsisProps={{
+			'aria-label': 'More {0} through {1}',
+			title: 'More {0} through {1}',
+		}}
+		hrefConstructor={(page) => `#${page}`}
 		totalPages={args.totalPages}
 	/>
 );
@@ -36,16 +41,15 @@ WithLinks.args = {
 	totalPages: 25,
 };
 
-export const WithButtons = (args: any) => (
+export const NoHref = (args: any) => (
 	<ClayPaginationWithBasicItems
 		defaultActive={8}
 		ellipsisBuffer={args.ellipsisBuffer}
-		ellipsisProps={{'aria-label': 'More', title: 'More'}}
 		totalPages={args.totalPages}
 	/>
 );
 
-WithButtons.args = {
+NoHref.args = {
 	ellipsisBuffer: 2,
 	totalPages: 25,
 };
@@ -55,23 +59,32 @@ export const Sizes = () => (
 		<ClayPaginationWithBasicItems
 			defaultActive={number('Active Page', 8)}
 			ellipsisBuffer={number('Ellipsis Buffer', 2)}
-			ellipsisProps={{'aria-label': 'More', title: 'More'}}
-			hrefConstructor={(page) => `/#${page}`}
+			ellipsisProps={{
+				'aria-label': 'More {0} through {1}',
+				title: 'More {0} through {1}',
+			}}
+			hrefConstructor={(page) => `#${page}`}
 			size="sm"
 			totalPages={25}
 		/>
 		<ClayPaginationWithBasicItems
 			defaultActive={number('Active Page', 8)}
 			ellipsisBuffer={number('Ellipsis Buffer', 2)}
-			ellipsisProps={{'aria-label': 'More', title: 'More'}}
-			hrefConstructor={(page) => `/#${page}`}
+			ellipsisProps={{
+				'aria-label': 'More {0} through {1}',
+				title: 'More {0} through {1}',
+			}}
+			hrefConstructor={(page) => `#${page}`}
 			totalPages={25}
 		/>
 		<ClayPaginationWithBasicItems
 			defaultActive={number('Active Page', 8)}
 			ellipsisBuffer={number('Ellipsis Buffer', 2)}
-			ellipsisProps={{'aria-label': 'More', title: 'More'}}
-			hrefConstructor={(page) => `/#${page}`}
+			ellipsisProps={{
+				'aria-label': 'More {0} through {1}',
+				title: 'More {0} through {1}',
+			}}
+			hrefConstructor={(page) => `#${page}`}
 			size="lg"
 			totalPages={25}
 		/>
@@ -83,7 +96,10 @@ export const DisabledPages = () => (
 		defaultActive={8}
 		disabledPages={[4, 5]}
 		ellipsisBuffer={2}
-		ellipsisProps={{'aria-label': 'More', title: 'More'}}
+		ellipsisProps={{
+			'aria-label': 'Show page links {0} to {1}',
+			title: 'Show page links {0} to {1}',
+		}}
 		totalPages={5}
 	/>
 );


### PR DESCRIPTION
fixes #5233

- This wraps the pagination in `<nav aria-label="Pagination" role="navigation">`. You can change the nav attributes with `navProps`.
- Adds a default `aria-label` for previous, items, and next buttons
- Adds a default `aria-label` and `title` "Show pages %START% through %END%"
- Only output a `ClayLink` no buttons for items. The ellipsis menu still contains buttons.

I think [Warning about dropdown/level-2](https://github.com/liferay/clay/issues/5233#issue-1475584259) should be done in another pr.

I still need to write documentation on this. I need feedback before I start.
