### PR TITLE
fix(@clayui/button): improves the error message for button accessibility and the ButtonWithIcon component type

### DIFF
--- a/packages/clay-button/src/Button.tsx
+++ b/packages/clay-button/src/Button.tsx
@@ -20,7 +20,7 @@ export type DisplayType =
 	| 'info'
 	| 'unstyled';
 
-interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 	/**
 	 * Flag to indicate if button is used within an alert component.
 	 */
@@ -94,9 +94,10 @@ const ClayButton = React.forwardRef<HTMLButtonElement, IProps>(
 				childArray.length === 1 &&
 				// @ts-ignore
 				childArray[0].type?.displayName === 'ClayIcon' &&
-				typeof otherProps['aria-label'] !== 'string'
+				typeof otherProps['aria-label'] !== 'string' &&
+				typeof otherProps['aria-labelledby'] !== 'string'
 			),
-			'Button Accessibility: Component has only the Icon declared. Define an `aria-label` or `title` attribute (consult your design team) that labels the interactive button that screen readers can read.'
+			'Button Accessibility: Component has only the Icon declared. Define an `aria-label` or `aria-labelledby` attribute that labels the interactive button that screen readers can read. The `title` attribute is optional but consult your design team.'
 		);
 
 		return (

--- a/packages/clay-button/src/ButtonWithIcon.tsx
+++ b/packages/clay-button/src/ButtonWithIcon.tsx
@@ -8,12 +8,25 @@ import React from 'react';
 
 import ClayButton from './Button';
 
-interface IProps extends React.ComponentProps<typeof ClayButton> {
-	/**
-	 * Define a value that labels the button.
-	 */
-	'aria-label': string;
+import type {IProps} from './Button';
 
+type ButtonAria =
+	| {
+			/**
+			 * Define a value that labels the button.
+			 */
+			'aria-label': string;
+			'aria-labelledby'?: never;
+	  }
+	| {
+			/**
+			 * Define a value that labels the button.
+			 */
+			'aria-label'?: never;
+			'aria-labelledby': string;
+	  };
+
+interface ICommonProps extends Omit<IProps, 'aria-label' | 'aria-labelledby'> {
 	/**
 	 * Path to the location of the spritemap resource.
 	 */
@@ -25,8 +38,10 @@ interface IProps extends React.ComponentProps<typeof ClayButton> {
 	symbol: string;
 }
 
-const ClayButtonWithIcon = React.forwardRef<HTMLButtonElement, IProps>(
-	({monospaced = true, spritemap, symbol, ...otherProps}: IProps, ref) => (
+export type Props = ICommonProps & ButtonAria;
+
+const ClayButtonWithIcon = React.forwardRef<HTMLButtonElement, Props>(
+	({monospaced = true, spritemap, symbol, ...otherProps}: Props, ref) => (
 		<ClayButton {...otherProps} monospaced={monospaced} ref={ref}>
 			<ClayIcon spritemap={spritemap} symbol={symbol} />
 		</ClayButton>

--- a/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,128 +1,152 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ClayButton renders 1`] = `
-<button
-  className="btn btn-primary"
-  type="button"
-/>
-`;
-
-exports[`ClayButton renders ButtonWithIcon 1`] = `
-<button
-  aria-label="Delete"
-  className="btn btn-monospaced btn-primary"
-  type="button"
->
-  <svg
-    className="lexicon-icon lexicon-icon-trash"
-    role="presentation"
-  >
-    <use
-      xlinkHref="/some/path#trash"
-    />
-  </svg>
-</button>
-`;
-
-exports[`ClayButton renders ButtonWithIcon without monospaced 1`] = `
-<button
-  aria-label="Delete"
-  className="btn btn-primary"
-  type="button"
->
-  <svg
-    className="lexicon-icon lexicon-icon-trash"
-    role="presentation"
-  >
-    <use
-      xlinkHref="/some/path#trash"
-    />
-  </svg>
-</button>
-`;
-
-exports[`ClayButton renders a ButtonGroup with spaced 1`] = `
-<div
-  className="btn-group"
-  role="group"
->
-  <div
-    className="btn-group-item"
-  >
-    <button
-      className="btn btn-primary"
-      type="button"
-    />
-  </div>
-  <div
-    className="btn-group-item"
-  >
-    <button
-      className="btn btn-primary"
-      type="button"
-    />
-  </div>
-</div>
-`;
-
-exports[`ClayButton renders block 1`] = `
-<button
-  className="btn btn-block btn-primary"
-  type="button"
-/>
-`;
-
-exports[`ClayButton renders borderless 1`] = `
-<button
-  className="btn btn-outline-borderless btn-outline-primary"
-  type="button"
-/>
-`;
-
-exports[`ClayButton renders disabled 1`] = `
-<button
-  className="btn btn-primary"
-  disabled={true}
-  type="button"
-/>
-`;
-
-exports[`ClayButton renders monospaced 1`] = `
-<button
-  className="btn btn-monospaced btn-primary"
-  type="button"
-/>
-`;
-
-exports[`ClayButton renders outline 1`] = `
-<button
-  className="btn btn-outline-primary"
-  type="button"
-/>
-`;
-
-exports[`ClayButton renders small 1`] = `
-<button
-  className="btn btn-sm btn-primary"
-  type="button"
-/>
-`;
-
-exports[`ClayButton renders with a ButtonGroup 1`] = `
-<div
-  className="btn-group"
-  role="group"
->
+<div>
   <button
-    className="btn btn-primary"
+    class="btn btn-primary"
     type="button"
   />
 </div>
 `;
 
+exports[`ClayButton renders ButtonWithIcon 1`] = `
+<div>
+  <button
+    aria-label="Delete"
+    class="btn btn-monospaced btn-primary"
+    type="button"
+  >
+    <svg
+      class="lexicon-icon lexicon-icon-trash"
+      role="presentation"
+    >
+      <use
+        xlink:href="/some/path#trash"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`ClayButton renders ButtonWithIcon without monospaced 1`] = `
+<div>
+  <button
+    aria-label="Delete"
+    class="btn btn-primary"
+    type="button"
+  >
+    <svg
+      class="lexicon-icon lexicon-icon-trash"
+      role="presentation"
+    >
+      <use
+        xlink:href="/some/path#trash"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`ClayButton renders a ButtonGroup with spaced 1`] = `
+<div>
+  <div
+    class="btn-group"
+    role="group"
+  >
+    <div
+      class="btn-group-item"
+    >
+      <button
+        class="btn btn-primary"
+        type="button"
+      />
+    </div>
+    <div
+      class="btn-group-item"
+    >
+      <button
+        class="btn btn-primary"
+        type="button"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClayButton renders block 1`] = `
+<div>
+  <button
+    class="btn btn-block btn-primary"
+    type="button"
+  />
+</div>
+`;
+
+exports[`ClayButton renders borderless 1`] = `
+<div>
+  <button
+    class="btn btn-outline-borderless btn-outline-primary"
+    type="button"
+  />
+</div>
+`;
+
+exports[`ClayButton renders disabled 1`] = `
+<div>
+  <button
+    class="btn btn-primary"
+    disabled=""
+    type="button"
+  />
+</div>
+`;
+
+exports[`ClayButton renders monospaced 1`] = `
+<div>
+  <button
+    class="btn btn-monospaced btn-primary"
+    type="button"
+  />
+</div>
+`;
+
+exports[`ClayButton renders outline 1`] = `
+<div>
+  <button
+    class="btn btn-outline-primary"
+    type="button"
+  />
+</div>
+`;
+
+exports[`ClayButton renders small 1`] = `
+<div>
+  <button
+    class="btn btn-sm btn-primary"
+    type="button"
+  />
+</div>
+`;
+
+exports[`ClayButton renders with a ButtonGroup 1`] = `
+<div>
+  <div
+    class="btn-group"
+    role="group"
+  >
+    <button
+      class="btn btn-primary"
+      type="button"
+    />
+  </div>
+</div>
+`;
+
 exports[`ClayButton renders with a different display type 1`] = `
-<button
-  className="btn btn-link"
-  type="button"
-/>
+<div>
+  <button
+    class="btn btn-link"
+    type="button"
+  />
+</div>
 `;

--- a/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-button/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,15 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClayButton renders 1`] = `
+exports[`Button renders 1`] = `
 <div>
   <button
     class="btn btn-primary"
     type="button"
-  />
+  >
+    Button
+  </button>
 </div>
 `;
 
-exports[`ClayButton renders ButtonWithIcon 1`] = `
+exports[`Button renders ClayButtonWithIcon 1`] = `
 <div>
   <button
     aria-label="Delete"
@@ -28,7 +30,7 @@ exports[`ClayButton renders ButtonWithIcon 1`] = `
 </div>
 `;
 
-exports[`ClayButton renders ButtonWithIcon without monospaced 1`] = `
+exports[`Button renders ClayButtonWithIcon without monospaced 1`] = `
 <div>
   <button
     aria-label="Delete"
@@ -47,7 +49,7 @@ exports[`ClayButton renders ButtonWithIcon without monospaced 1`] = `
 </div>
 `;
 
-exports[`ClayButton renders a ButtonGroup with spaced 1`] = `
+exports[`Button renders a ButtonGroup with spaced 1`] = `
 <div>
   <div
     class="btn-group"
@@ -59,7 +61,9 @@ exports[`ClayButton renders a ButtonGroup with spaced 1`] = `
       <button
         class="btn btn-primary"
         type="button"
-      />
+      >
+        Button
+      </button>
     </div>
     <div
       class="btn-group-item"
@@ -67,68 +71,82 @@ exports[`ClayButton renders a ButtonGroup with spaced 1`] = `
       <button
         class="btn btn-primary"
         type="button"
-      />
+      >
+        Button
+      </button>
     </div>
   </div>
 </div>
 `;
 
-exports[`ClayButton renders block 1`] = `
+exports[`Button renders block 1`] = `
 <div>
   <button
     class="btn btn-block btn-primary"
     type="button"
-  />
+  >
+    Button
+  </button>
 </div>
 `;
 
-exports[`ClayButton renders borderless 1`] = `
+exports[`Button renders borderless 1`] = `
 <div>
   <button
     class="btn btn-outline-borderless btn-outline-primary"
     type="button"
-  />
+  >
+    Button
+  </button>
 </div>
 `;
 
-exports[`ClayButton renders disabled 1`] = `
+exports[`Button renders disabled 1`] = `
 <div>
   <button
     class="btn btn-primary"
     disabled=""
     type="button"
-  />
+  >
+    Button
+  </button>
 </div>
 `;
 
-exports[`ClayButton renders monospaced 1`] = `
+exports[`Button renders monospaced 1`] = `
 <div>
   <button
     class="btn btn-monospaced btn-primary"
     type="button"
-  />
+  >
+    Button
+  </button>
 </div>
 `;
 
-exports[`ClayButton renders outline 1`] = `
+exports[`Button renders outline 1`] = `
 <div>
   <button
     class="btn btn-outline-primary"
     type="button"
-  />
+  >
+    Button
+  </button>
 </div>
 `;
 
-exports[`ClayButton renders small 1`] = `
+exports[`Button renders small 1`] = `
 <div>
   <button
     class="btn btn-sm btn-primary"
     type="button"
-  />
+  >
+    Button
+  </button>
 </div>
 `;
 
-exports[`ClayButton renders with a ButtonGroup 1`] = `
+exports[`Button renders with a ButtonGroup 1`] = `
 <div>
   <div
     class="btn-group"
@@ -137,16 +155,20 @@ exports[`ClayButton renders with a ButtonGroup 1`] = `
     <button
       class="btn btn-primary"
       type="button"
-    />
+    >
+      Button
+    </button>
   </div>
 </div>
 `;
 
-exports[`ClayButton renders with a different display type 1`] = `
+exports[`Button renders with a different display type 1`] = `
 <div>
   <button
     class="btn btn-link"
     type="button"
-  />
+  >
+    Button
+  </button>
 </div>
 `;

--- a/packages/clay-button/src/__tests__/index.tsx
+++ b/packages/clay-button/src/__tests__/index.tsx
@@ -129,3 +129,52 @@ describe('Button', () => {
 		expect(container).toMatchSnapshot();
 	});
 });
+
+describe('Button accessibility error', () => {
+	afterEach(cleanup);
+
+	it('<Button /> with <Icon /> without an ARIA property throws an exception', () => {
+		const originalError = console.error;
+		console.error = jest.fn();
+
+		render(
+			<Button displayType="primary" outline>
+				<Icon spritemap="icons.svg" symbol="plus" />
+			</Button>
+		);
+
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining(
+				'Button Accessibility: Component has only the Icon declared.'
+			)
+		);
+
+		console.error = originalError;
+	});
+
+	it.concurrent.each(['aria-label', 'aria-labelledby'])(
+		'<Button /> with <Icon /> with `%s` property does not throw an exception',
+		(property) => {
+			const originalError = console.error;
+			console.error = jest.fn();
+
+			const props = {
+				[property]: 'some text',
+			};
+
+			render(
+				<Button {...props} displayType="primary" outline>
+					<Icon spritemap="icons.svg" symbol="plus" />
+				</Button>
+			);
+
+			expect(console.error).not.toBeCalledWith(
+				expect.stringContaining(
+					'Button Accessibility: Component has only the Icon declared.'
+				)
+			);
+
+			console.error = originalError;
+		}
+	);
+});

--- a/packages/clay-button/src/__tests__/index.tsx
+++ b/packages/clay-button/src/__tests__/index.tsx
@@ -3,28 +3,31 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import ClayButton, {ClayButtonWithIcon} from '..';
+import Button, {ClayButtonWithIcon} from '..';
+import Icon from '@clayui/icon';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 
-describe('ClayButton', () => {
+describe('Button', () => {
 	afterEach(cleanup);
 
 	it('renders', () => {
-		const {container} = render(<ClayButton />);
+		const {container} = render(<Button>Button</Button>);
 
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with a different display type', () => {
-		const {container} = render(<ClayButton displayType="link" />);
+		const {container} = render(<Button displayType="link">Button</Button>);
 
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders disabled', () => {
 		const {container} = render(
-			<ClayButton disabled displayType="primary" />
+			<Button disabled displayType="primary">
+				Button
+			</Button>
 		);
 
 		expect(container).toMatchSnapshot();
@@ -32,21 +35,29 @@ describe('ClayButton', () => {
 
 	it('renders borderless', () => {
 		const {container} = render(
-			<ClayButton borderless displayType="primary" />
+			<Button borderless displayType="primary">
+				Button
+			</Button>
 		);
 
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders block', () => {
-		const {container} = render(<ClayButton block displayType="primary" />);
+		const {container} = render(
+			<Button block displayType="primary">
+				Button
+			</Button>
+		);
 
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders outline', () => {
 		const {container} = render(
-			<ClayButton displayType="primary" outline />
+			<Button displayType="primary" outline>
+				Button
+			</Button>
 		);
 
 		expect(container).toMatchSnapshot();
@@ -54,23 +65,29 @@ describe('ClayButton', () => {
 
 	it('renders monospaced', () => {
 		const {container} = render(
-			<ClayButton displayType="primary" monospaced />
+			<Button displayType="primary" monospaced>
+				Button
+			</Button>
 		);
 
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders small', () => {
-		const {container} = render(<ClayButton displayType="primary" small />);
+		const {container} = render(
+			<Button displayType="primary" small>
+				Button
+			</Button>
+		);
 
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with a ButtonGroup', () => {
 		const {container} = render(
-			<ClayButton.Group>
-				<ClayButton />
-			</ClayButton.Group>
+			<Button.Group>
+				<Button>Button</Button>
+			</Button.Group>
 		);
 
 		expect(container).toMatchSnapshot();
@@ -78,16 +95,16 @@ describe('ClayButton', () => {
 
 	it('renders a ButtonGroup with spaced', () => {
 		const {container} = render(
-			<ClayButton.Group spaced>
-				<ClayButton />
-				<ClayButton />
-			</ClayButton.Group>
+			<Button.Group spaced>
+				<Button>Button</Button>
+				<Button>Button</Button>
+			</Button.Group>
 		);
 
 		expect(container).toMatchSnapshot();
 	});
 
-	it('renders ButtonWithIcon', () => {
+	it('renders ClayButtonWithIcon', () => {
 		const {container} = render(
 			<ClayButtonWithIcon
 				aria-label="Delete"
@@ -99,7 +116,7 @@ describe('ClayButton', () => {
 		expect(container).toMatchSnapshot();
 	});
 
-	it('renders ButtonWithIcon without monospaced', () => {
+	it('renders ClayButtonWithIcon without monospaced', () => {
 		const {container} = render(
 			<ClayButtonWithIcon
 				aria-label="Delete"

--- a/packages/clay-button/src/__tests__/index.tsx
+++ b/packages/clay-button/src/__tests__/index.tsx
@@ -4,95 +4,91 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '..';
+import {cleanup, render} from '@testing-library/react';
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
 
 describe('ClayButton', () => {
-	it('renders', () => {
-		const testRenderer = TestRenderer.create(<ClayButton />);
+	afterEach(cleanup);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+	it('renders', () => {
+		const {container} = render(<ClayButton />);
+
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with a different display type', () => {
-		const testRenderer = TestRenderer.create(
-			<ClayButton displayType="link" />
-		);
+		const {container} = render(<ClayButton displayType="link" />);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders disabled', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayButton disabled displayType="primary" />
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders borderless', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayButton borderless displayType="primary" />
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders block', () => {
-		const testRenderer = TestRenderer.create(
-			<ClayButton block displayType="primary" />
-		);
+		const {container} = render(<ClayButton block displayType="primary" />);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders outline', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayButton displayType="primary" outline />
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders monospaced', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayButton displayType="primary" monospaced />
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders small', () => {
-		const testRenderer = TestRenderer.create(
-			<ClayButton displayType="primary" small />
-		);
+		const {container} = render(<ClayButton displayType="primary" small />);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders with a ButtonGroup', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayButton.Group>
 				<ClayButton />
 			</ClayButton.Group>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a ButtonGroup with spaced', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayButton.Group spaced>
 				<ClayButton />
 				<ClayButton />
 			</ClayButton.Group>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders ButtonWithIcon', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayButtonWithIcon
 				aria-label="Delete"
 				spritemap="/some/path"
@@ -100,11 +96,11 @@ describe('ClayButton', () => {
 			/>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders ButtonWithIcon without monospaced', () => {
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayButtonWithIcon
 				aria-label="Delete"
 				monospaced={false}
@@ -113,6 +109,6 @@ describe('ClayButton', () => {
 			/>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 });

--- a/packages/clay-button/src/index.tsx
+++ b/packages/clay-button/src/index.tsx
@@ -6,5 +6,6 @@
 import Button from './Button';
 import ClayButtonWithIcon from './ButtonWithIcon';
 
+export type {Props as ButtonWithIconProps} from './ButtonWithIcon';
 export {ClayButtonWithIcon};
 export default Button;

--- a/packages/clay-card/src/CardWithHorizontal.tsx
+++ b/packages/clay-card/src/CardWithHorizontal.tsx
@@ -14,6 +14,8 @@ import React from 'react';
 import ClayCard from './Card';
 import {ClayCardHorizontal} from './CardHorizontal';
 
+import type {ButtonWithIconProps} from '@clayui/button';
+
 export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	actions?: React.ComponentProps<typeof ClayDropDownWithItems>['items'];
 
@@ -30,7 +32,10 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * Props to add to the dropdown trigger element
 	 */
-	dropDownTriggerProps?: React.HTMLAttributes<HTMLButtonElement>;
+	dropDownTriggerProps?: Omit<
+		ButtonWithIconProps,
+		'symbol' | 'spritemap' | 'displayType' | 'className'
+	>;
 
 	/**
 	 * Path or URL to item
@@ -67,7 +72,9 @@ export const ClayCardWithHorizontal = ({
 	actions,
 	checkboxProps = {},
 	disabled,
-	dropDownTriggerProps = {},
+	dropDownTriggerProps = {
+		'aria-label': 'More actions',
+	},
 	href,
 	onSelectChange,
 	selected = false,
@@ -102,8 +109,7 @@ export const ClayCardWithHorizontal = ({
 							spritemap={spritemap}
 							trigger={
 								<ClayButtonWithIcon
-									aria-label="More actions"
-									{...dropDownTriggerProps}
+									{...(dropDownTriggerProps as ButtonWithIconProps)}
 									className="component-action"
 									disabled={disabled}
 									displayType="unstyled"

--- a/packages/clay-card/src/CardWithInfo.tsx
+++ b/packages/clay-card/src/CardWithInfo.tsx
@@ -15,6 +15,8 @@ import React from 'react';
 
 import ClayCard from './Card';
 
+import type {ButtonWithIconProps} from '@clayui/button';
+
 export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * List of actions in the dropdown menu
@@ -44,7 +46,10 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * Props to add to the dropdown trigger element
 	 */
-	dropDownTriggerProps?: React.HTMLAttributes<HTMLButtonElement>;
+	dropDownTriggerProps?: Omit<
+		ButtonWithIconProps,
+		'symbol' | 'spritemap' | 'displayType' | 'className'
+	>;
 
 	/**
 	 * Flag to indicate if `aspect-ratio-item-flush` class should be
@@ -116,7 +121,9 @@ export const ClayCardWithInfo = ({
 	description,
 	disabled,
 	displayType,
-	dropDownTriggerProps = {},
+	dropDownTriggerProps = {
+		'aria-label': 'More actions',
+	},
 	flushHorizontal,
 	flushVertical,
 	href,
@@ -251,8 +258,7 @@ export const ClayCardWithInfo = ({
 								spritemap={spritemap}
 								trigger={
 									<ClayButtonWithIcon
-										aria-label="More actions"
-										{...dropDownTriggerProps}
+										{...(dropDownTriggerProps as ButtonWithIconProps)}
 										className="component-action"
 										disabled={disabled}
 										displayType="unstyled"

--- a/packages/clay-card/src/CardWithUser.tsx
+++ b/packages/clay-card/src/CardWithUser.tsx
@@ -13,6 +13,8 @@ import React from 'react';
 
 import ClayCard from './Card';
 
+import type {ButtonWithIconProps} from '@clayui/button';
+
 export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * List of actions in the dropdown menu
@@ -37,7 +39,10 @@ export interface IProps extends React.BaseHTMLAttributes<HTMLDivElement> {
 	/**
 	 * Props to add to the dropdown trigger element
 	 */
-	dropDownTriggerProps?: React.HTMLAttributes<HTMLButtonElement>;
+	dropDownTriggerProps?: Omit<
+		ButtonWithIconProps,
+		'symbol' | 'spritemap' | 'displayType' | 'className'
+	>;
 
 	/**
 	 * Path or URL to user
@@ -90,7 +95,9 @@ export const ClayCardWithUser = ({
 	checkboxProps = {},
 	description,
 	disabled,
-	dropDownTriggerProps = {},
+	dropDownTriggerProps = {
+		'aria-label': 'More actions',
+	},
 	href,
 	name,
 	onSelectChange,
@@ -166,8 +173,7 @@ export const ClayCardWithUser = ({
 								spritemap={spritemap}
 								trigger={
 									<ClayButtonWithIcon
-										aria-label="More actions"
-										{...dropDownTriggerProps}
+										{...(dropDownTriggerProps as ButtonWithIconProps)}
 										className="component-action"
 										disabled={disabled}
 										displayType="unstyled"


### PR DESCRIPTION
Fixes #5249

This improves the message for the button accessibility error which only ignored the message when `aria-label` was set but did not consider `aria-labelledby`. The message is that you have to define either one and the `title` attribute is optional.

It also improves the type of the `<ButtonWithIcon />` component that makes the type conditional, that is, if you don't declare any of the two properties the build will fail but if you declare any of the two the error will disappear.