### PR TITLE
chore(@clayui/core): improves accessibility of Picker custom options example

### DIFF
--- a/packages/clay-core/src/picker/Option.tsx
+++ b/packages/clay-core/src/picker/Option.tsx
@@ -12,6 +12,36 @@ import {usePickerState} from './context';
 
 type Props = {
 	/**
+	 * The global aria-describedby attribute identifies the element (or elements)
+	 * that describes the element on which the attribute is set.
+	 */
+	'aria-describedby'?: string;
+
+	/**
+	 * The `aria-label` attribute defines a string value that labels an interactive
+	 * element.
+	 */
+	'aria-label'?: string;
+
+	/**
+	 * The `aria-labelledby` attribute identifies the element (or elements) that
+	 * labels the element it is applied to.
+	 */
+	'aria-labelledby'?: string;
+
+	/**
+	 * Sets the number or position in the current set of listitems
+	 * or treeitems when not all items are present in the DOM.
+	 */
+	'aria-posinset'?: number;
+
+	/**
+	 * Sets the number of items in the current set of listitems
+	 * or treeitems when not all items in the set are present in the DOM.
+	 */
+	'aria-setsize'?: number;
+
+	/**
 	 * The contents of the component.
 	 */
 	children?: React.ReactNode;
@@ -34,7 +64,17 @@ type Props = {
 	textValue?: string;
 };
 
-export function Option({children, disabled, keyValue, textValue}: Props) {
+export function Option({
+	'aria-describedby': ariaDescribedby,
+	'aria-label': ariaLabel,
+	'aria-labelledby': ariaLabelledby,
+	'aria-posinset': ariaPosInset,
+	'aria-setsize': ariaSetSize,
+	children,
+	disabled,
+	keyValue,
+	textValue,
+}: Props) {
 	const {
 		activeDescendant,
 		isMobile,
@@ -57,7 +97,11 @@ export function Option({children, disabled, keyValue, textValue}: Props) {
 
 	if (isMobile) {
 		return (
-			<option disabled={disabled} value={keyValue}>
+			<option
+				aria-describedby={ariaDescribedby}
+				disabled={disabled}
+				value={keyValue}
+			>
 				{typeof children === 'string' ? children : textValue}
 			</option>
 		);
@@ -67,7 +111,12 @@ export function Option({children, disabled, keyValue, textValue}: Props) {
 		<li role="presentation">
 			<button
 				{...hoverProps}
+				aria-describedby={ariaDescribedby}
+				aria-label={ariaLabel}
+				aria-labelledby={ariaLabelledby}
+				aria-posinset={ariaPosInset}
 				aria-selected={selectedKey === keyValue}
+				aria-setsize={ariaSetSize}
 				className={classNames('dropdown-item', {
 					active: selectedKey === keyValue,
 					focus: activeDescendant === String(keyValue) && isFocus,

--- a/packages/clay-core/src/typography/Text.tsx
+++ b/packages/clay-core/src/typography/Text.tsx
@@ -28,6 +28,12 @@ export type ColorType =
 
 type Props = {
 	/**
+	 * State indicates whether the component will be exposed to an
+	 * accessibility API.
+	 */
+	'aria-hidden'?: boolean;
+
+	/**
 	 * Determine the way in which a text is displayed.
 	 */
 	as?: 'p' | 'span';
@@ -41,6 +47,12 @@ type Props = {
 	 * Determine the color text.
 	 */
 	color?: ColorType;
+
+	/**
+	 * The id global attribute defines an identifier (ID) which must be unique
+	 * in the whole document.
+	 */
+	id?: string;
 
 	/**
 	 * Set the text in italic style.
@@ -69,9 +81,11 @@ type Props = {
 };
 
 export const Text = ({
+	'aria-hidden': ariaHidden,
 	as = 'span',
 	children,
 	color,
+	id,
 	italic,
 	monospace,
 	size = 4,
@@ -82,6 +96,7 @@ export const Text = ({
 
 	return (
 		<TextTag
+			aria-hidden={ariaHidden}
 			className={classNames([`text-${size}`], {
 				[`text-${color}`]: color,
 				['font-italic']: italic,
@@ -89,6 +104,7 @@ export const Text = ({
 				['text-truncate']: truncate,
 				[`font-weight-${weight}`]: weight,
 			})}
+			id={id}
 		>
 			{children}
 		</TextTag>

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -135,18 +135,38 @@ export const CustomOptions = () => {
 					items={['Liam', 'Noah', 'Oliver']}
 				>
 					{(item) => (
-						<Option key={item} textValue={item}>
+						<Option
+							aria-describedby={`${item}-description ${item}-status`}
+							aria-labelledby={`${item}-title`}
+							key={item}
+							textValue={item}
+						>
 							<Layout.ContentRow>
 								<Layout.ContentCol expand>
-									<Text size={3} weight="semi-bold">
+									<Text
+										id={`${item}-title`}
+										size={3}
+										weight="semi-bold"
+									>
 										{item}
 									</Text>
-									<Text color="secondary" size={2}>
+									<Text
+										aria-hidden
+										color="secondary"
+										id={`${item}-description`}
+										size={2}
+									>
 										Description
 									</Text>
 								</Layout.ContentCol>
 								<Layout.ContentCol>
-									<Label displayType="success">Active</Label>
+									<Label
+										aria-hidden
+										displayType="success"
+										id={`${item}-status`}
+									>
+										Active
+									</Label>
 								</Layout.ContentCol>
 							</Layout.ContentRow>
 						</Option>


### PR DESCRIPTION
From https://github.com/liferay/clay/pull/5248#issuecomment-1357329149

I'm using `aria-labelledby` instead of `aria-label` I think it's better here to link the elements with the option and also adding `aria-describedby` to link the description and label texts. I've done some tests with VoiceOver and it seems that even then it continues to read the other texts together as if it were a single word, so I added `aria-hidden` to the description and label to make it work properly.