### PR TITLE
docs: adds in examples accessibility for error validation

### DIFF
--- a/packages/clay-form/docs/markup-text-input.md
+++ b/packages/clay-form/docs/markup-text-input.md
@@ -300,9 +300,9 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 				<use href="/images/icons/icons.svg#asterisk" />
 			</svg>
 		</label>
-		<input class="form-control" id="inputError1" type="text"/>
+		<input aria-describedby="input-error-1-error-message" aria-invalid="true" class="form-control" id="inputError1" type="text"/>
 		<div class="form-feedback-group">
-			<div class="form-feedback-item">This is a form-feedback-item.</div>
+			<div class="form-feedback-item" id="input-error-1-error-message">This is a form-feedback-item.</div>
 			<div class="form-feedback-item">
 				<span class="form-feedback-indicator">
 					<svg class="lexicon-icon lexicon-icon-exclamation-full" focusable="false" role="presentation">
@@ -315,6 +315,46 @@ Set heights using classes like `.form-control-lg` and `.form-control-sm`.
 		</div>
 	</div>
 </div>
+
+```html
+<div class="form-group has-error">
+	<label for="inputError1">
+		has-error
+		<svg
+			class="lexicon-icon lexicon-icon-asterisk reference-mark"
+			focusable="false"
+			role="presentation"
+		>
+			<use href="/images/icons/icons.svg#asterisk" />
+		</svg>
+	</label>
+	<input
+		aria-describedby="input-error-1-error-message"
+		aria-invalid="true"
+		class="form-control"
+		id="inputError1"
+		type="text"
+	/>
+	<div class="form-feedback-group">
+		<div class="form-feedback-item" id="input-error-1-error-message">
+			This is a form-feedback-item.
+		</div>
+		<div class="form-feedback-item">
+			<span class="form-feedback-indicator">
+				<svg
+					class="lexicon-icon lexicon-icon-exclamation-full"
+					focusable="false"
+					role="presentation"
+				>
+					<use href="/images/icons/icons.svg#exclamation-full" />
+				</svg>
+			</span>
+			This is a form-feedback-indicator.
+		</div>
+		<div class="form-text">This is form-text.</div>
+	</div>
+</div>
+```
 
 ## HTML 5 Validations(#css-html-5-validations)
 

--- a/packages/clay-form/stories/Input.stories.tsx
+++ b/packages/clay-form/stories/Input.stories.tsx
@@ -46,13 +46,15 @@ export const InputFeedback = () => (
 			<ClayForm.Group className="has-error">
 				<label htmlFor="Feedback Input">Name</label>
 				<ClayInput
+					aria-describedby="input-group-error"
+					aria-invalid="true"
 					id="Feedback Input"
 					placeholder="Enter some text..."
 					type="text"
 				/>
 
 				<ClayForm.FeedbackGroup>
-					<ClayForm.FeedbackItem>
+					<ClayForm.FeedbackItem id="input-group-error">
 						<ClayForm.FeedbackIndicator symbol="exclamation-full" />
 						This is a description of the error!
 					</ClayForm.FeedbackItem>

--- a/packages/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/packages/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -293,6 +293,10 @@ export const Group = (args: any) => {
 				<ClayInput.Group>
 					<ClayInput.GroupItem>
 						<ClayMultiSelectWithAutocomplete
+							aria-describedby={
+								!args.isValid ? 'multiselect-error' : undefined
+							}
+							aria-invalid={!args.isValid}
 							id="multiSelect"
 							isValid={args.isValid}
 							items={[
@@ -313,7 +317,7 @@ export const Group = (args: any) => {
 
 						{!args.isValid && (
 							<ClayForm.FeedbackGroup>
-								<ClayForm.FeedbackItem>
+								<ClayForm.FeedbackItem id="multiselect-error">
 									<ClayForm.FeedbackIndicator symbol="info-circle" />
 									You made an error
 								</ClayForm.FeedbackItem>


### PR DESCRIPTION
Fixes #5247

This PR just updates the documentation and examples, ideally we want to provide this OOTB but we still don't have validation control and we need to work on issue #4741 first to find out the possibilities for handling form related components, for now we will leave the documentation and the examples following accessibility recommendations.