### PR TITLE
feat(@clayui/multi-select): moves the visual focus from the `gridcell` to the label

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -141,9 +141,9 @@ module.exports = {
 		},
 		'./packages/clay-multi-select/src/': {
 			branches: 62,
-			functions: 80,
-			lines: 78,
-			statements: 78,
+			functions: 77,
+			lines: 77,
+			statements: 77,
 		},
 		'./packages/clay-multi-step-nav/src/': {
 			branches: 94,

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -656,6 +656,7 @@
 				}
 			}
 
+			&.focus,
 			&:focus {
 				@include clay-css($focus);
 

--- a/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-multi-select/src/__tests__/__snapshots__/index.tsx.snap
@@ -64,12 +64,14 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-10"
                 class="label-item label-item-expand"
                 id="clay-id-9-label-1-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="0"
               >
                 foo
@@ -99,12 +101,14 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-10"
                 class="label-item label-item-expand"
                 id="clay-id-9-label-2-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="-1"
               >
                 bar
@@ -134,12 +138,14 @@ exports[`ClayMultiSelect renders a custom menu 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-10"
                 class="label-item label-item-expand"
                 id="clay-id-9-label-3-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="-1"
               >
                 baz
@@ -265,12 +271,14 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-8"
                 class="label-item label-item-expand"
                 id="clay-id-7-label-1-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="0"
               >
                 foo
@@ -301,12 +309,14 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-8"
                 class="label-item label-item-expand"
                 id="clay-id-7-label-2-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="-1"
               >
                 bar
@@ -337,12 +347,14 @@ exports[`ClayMultiSelect renders as disabled 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-8"
                 class="label-item label-item-expand"
                 id="clay-id-7-label-3-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="-1"
               >
                 baz
@@ -420,12 +432,14 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-6"
                 class="label-item label-item-expand"
                 id="clay-id-5-label-1-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="0"
               >
                 foo
@@ -455,12 +469,14 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-6"
                 class="label-item label-item-expand"
                 id="clay-id-5-label-2-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="-1"
               >
                 bar
@@ -490,12 +506,14 @@ exports[`ClayMultiSelect renders as not valid 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-6"
                 class="label-item label-item-expand"
                 id="clay-id-5-label-3-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="-1"
               >
                 baz
@@ -590,12 +608,14 @@ exports[`ClayMultiSelect renders with items 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-4"
                 class="label-item label-item-expand"
                 id="clay-id-3-label-1-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="0"
               >
                 foo
@@ -625,12 +645,14 @@ exports[`ClayMultiSelect renders with items 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-4"
                 class="label-item label-item-expand"
                 id="clay-id-3-label-2-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="-1"
               >
                 bar
@@ -660,12 +682,14 @@ exports[`ClayMultiSelect renders with items 1`] = `
             <span
               class="label label-secondary"
               role="row"
+              tabindex="-1"
             >
               <span
                 aria-describedby="clay-id-4"
                 class="label-item label-item-expand"
                 id="clay-id-3-label-3-span"
                 role="gridcell"
+                style="outline: none;"
                 tabindex="-1"
               >
                 baz

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -403,6 +403,10 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 			[internalItems]
 		);
 
+		const [isLabelFocused, setIsLabelFocused] = useState<string | null>(
+			null
+		);
+
 		const labelId = useId();
 		const ariaDescriptionId = useId();
 
@@ -528,6 +532,11 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 									return (
 										<React.Fragment key={id}>
 											<ClayLabel
+												className={
+													isLabelFocused === id
+														? 'focus'
+														: undefined
+												}
 												onKeyDown={({key}) => {
 													if (
 														key === Keys.Backspace
@@ -540,6 +549,7 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 												}}
 												role="row"
 												spritemap={spritemap}
+												tabIndex={-1}
 												withClose={false}
 											>
 												<ClayLabel.ItemExpand
@@ -547,7 +557,14 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 														ariaDescriptionId
 													}
 													id={id}
+													onBlur={() =>
+														setIsLabelFocused(null)
+													}
+													onFocus={() =>
+														setIsLabelFocused(id)
+													}
 													role="gridcell"
+													style={{outline: 'none'}}
 													tabIndex={
 														(lastFocusedItem ===
 															null &&


### PR DESCRIPTION
From https://github.com/liferay/clay/pull/5204#issuecomment-1358397921

I made a different strategy to keep the visual focus on the label and still keep the accessibility focus on the `gridcell`, we are controlling the CSS class of `focus` manually to do that.

![Screen Shot 2022-12-19 at 6 51 26 PM](https://user-images.githubusercontent.com/13750819/208556157-ba3d49ad-c6dc-4bf4-9691-facee27d13c6.png)

@pat270 let me know if the CSS part could cause any problems.
