### PR TITLE
fix(@clayui/css): Mixins clay-select-variant `$option` should be scop…

### DIFF
--- a/packages/clay-css/src/scss/mixins/_forms.scss
+++ b/packages/clay-css/src/scss/mixins/_forms.scss
@@ -866,8 +866,6 @@
 			)
 		);
 
-		$option: setter(map-get($map, option), ());
-
 		@if ($enabled) {
 			@include clay-css($base);
 
@@ -963,6 +961,8 @@
 			}
 
 			option {
+				$option: setter(map-get($map, option), ());
+
 				@include clay-css($option);
 
 				&:checked {

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -1293,6 +1293,7 @@ $input-select-size: map-deep-merge(
 	(
 		background-image: none,
 		height: auto,
+		margin-left: 0,
 		padding-left: 0.5rem,
 		padding-right: 0.5rem,
 		scrollbar-width: thin,


### PR DESCRIPTION
…ed to the selector

fixes #5261

![fixed](https://user-images.githubusercontent.com/788266/208743197-38c87527-f7bd-46d4-82d9-d20947e3b9c2.jpg)
