### PR TITLE
fix(@clayui/core): computes nested collections to mount the layout

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -33,6 +33,11 @@ const config = {
 		storyStoreV7: true,
 		postcss: false,
 	},
+	webpackFinal: (config) => {
+		config.resolve.mainFields = ['ts:main', ...config.resolve.mainFields];
+
+		return config;
+	},
 };
 
 module.exports = config;

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -191,9 +191,7 @@ export function Picker<T>({
 
 	const onPress = useCallback(() => {
 		if (menuRef.current && activeDescendant) {
-			const item = menuRef.current.querySelector<HTMLButtonElement>(
-				`#${activeDescendant}`
-			);
+			const item = document.getElementById(activeDescendant);
 
 			if (item) {
 				item.click();

--- a/packages/clay-core/stories/Picker.stories.tsx
+++ b/packages/clay-core/stories/Picker.stories.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import DropDown from '@clayui/drop-down';
 import Form from '@clayui/form';
 import Icon from '@clayui/icon';
 import Label from '@clayui/label';
@@ -170,6 +171,54 @@ export const CustomOptions = () => {
 								</Layout.ContentCol>
 							</Layout.ContentRow>
 						</Option>
+					)}
+				</Picker>
+			</Form.Group>
+		</div>
+	);
+};
+
+export const CustomGroup = () => {
+	const pickerId = useId();
+	const labelId = useId();
+
+	return (
+		<div style={{width: '180px'}}>
+			<Form.Group>
+				<label htmlFor={pickerId} id={labelId}>
+					Select an option
+				</label>
+				<Picker
+					aria-labelledby={labelId}
+					id={pickerId}
+					items={[
+						{
+							items: [
+								{label: 'Apple', value: '1'},
+								{label: 'Banana', value: '2'},
+								{label: 'Mangos', value: '3'},
+							],
+							label: 'Fruit',
+						},
+						{
+							items: [
+								{label: 'Onions', value: '4'},
+								{label: 'abc', value: '5'},
+								{label: 'def', value: '6'},
+							],
+							label: 'Vegetable',
+						},
+					]}
+				>
+					{(group) => (
+						<DropDown.Group
+							header={group.label}
+							items={group.items}
+						>
+							{(item) => (
+								<Option key={item.value}>{item.label}</Option>
+							)}
+						</DropDown.Group>
 					)}
 				</Picker>
 			</Form.Group>

--- a/packages/clay-drop-down/src/Group.tsx
+++ b/packages/clay-drop-down/src/Group.tsx
@@ -79,4 +79,6 @@ function ClayDropDownGroup<T>({
 	);
 }
 
+ClayDropDownGroup.displayName = 'Group';
+
 export default ClayDropDownGroup;

--- a/packages/clay-shared/src/useNavigation.tsx
+++ b/packages/clay-shared/src/useNavigation.tsx
@@ -264,8 +264,7 @@ export function useNavigation<T extends HTMLElement | null>({
 		// Moves the scroll to the element with visual "focus" if it exists.
 		if (visible && containerRef.current && active && onNavigate) {
 			const child = containerRef.current.firstElementChild as HTMLElement;
-			const activeElement =
-				containerRef.current.querySelector<HTMLElement>(`#${active}`);
+			const activeElement = document.getElementById(active);
 
 			if (activeElement && isScrollable(child)) {
 				maintainScrollVisibility(activeElement, child);


### PR DESCRIPTION
Fixes #5260

Now this works better with nested collection, it assembles nested collections even if the Menu is not rendered, there are still some improvements we can do to optimize, for example cache the nested collection result and reuse when React renders the component, for now this just builds the structure of the layout. I'll work on that later.

Also fix the error of the `key` being defined with numbers, let's find for the item by the global `id`, so the `key` must be unique in the entire document so we also respect the rule for the `id` attribute.