### PR TITLE
feat(@clayui/css): Links adds c-link to be used with utility classes

### DIFF
--- a/packages/clay-css/src/scss/atlas/variables/_links.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_links.scss
@@ -17,6 +17,10 @@ $link-primary: map-deep-merge(
 	(
 		border-radius: 1px,
 		transition: box-shadow 0.15s ease-in-out,
+		hover: (
+			background-color: $primary-l3,
+			color: clay-darken($primary, 15%),
+		),
 		focus: (
 			color: clay-darken($primary, 15%),
 			box-shadow: $component-focus-box-shadow,
@@ -32,6 +36,7 @@ $link-secondary: map-deep-merge(
 		border-radius: 1px,
 		transition: box-shadow 0.15s ease-in-out,
 		hover: (
+			background-color: $gray-200,
 			color: $gray-900,
 		),
 		focus: (

--- a/packages/clay-css/src/scss/cadmin/components/_links.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_links.scss
@@ -1,3 +1,7 @@
+.c-link {
+	@include clay-link($cadmin-c-link);
+}
+
 .component-link {
 	@include clay-link($cadmin-component-link);
 }

--- a/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/cadmin/components/_utilities-functional-important.scss
@@ -806,8 +806,18 @@
 	text-shadow: none;
 }
 
-.text-decoration-none {
-	text-decoration: none !important;
+@each $key, $value in $cadmin-text-decorations {
+	$selector: if(
+		starts-with($key, '.') or
+			starts-with($key, '#') or
+			starts-with($key, '%'),
+		$key,
+		str-insert($key, '.', 1)
+	);
+
+	#{$selector} {
+		@include clay-link($value);
+	}
 }
 
 .text-break {

--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -693,9 +693,20 @@ $cadmin-link: map-deep-merge(
 		color: $cadmin-link-color,
 		cursor: $cadmin-link-cursor,
 		text-decoration: $cadmin-link-decoration,
+		text-underline-offset: 0.23em,
 		hover: (
 			color: $cadmin-link-hover-color,
 			text-decoration: $cadmin-link-hover-decoration,
+		),
+		inline-item-before: (
+			margin-right: 4px,
+		),
+		inline-item-middle: (
+			margin-left: 4px,
+			margin-right: 4px,
+		),
+		inline-item-after: (
+			margin-left: 4px,
 		),
 	),
 	$cadmin-link

--- a/packages/clay-css/src/scss/cadmin/variables/_links.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_links.scss
@@ -1,4 +1,36 @@
-$cadmin-single-link-font-weight: $cadmin-font-weight-semi-bold !default;
+$cadmin-c-link: () !default;
+$cadmin-c-link: map-deep-merge(
+	(
+		text-decoration: none,
+		transition: clay-enable-transitions(box-shadow 0.15s ease-in-out),
+		hover: (
+			text-decoration: none,
+		),
+		focus: (
+			border-radius: 1px,
+			box-shadow: $cadmin-component-focus-box-shadow,
+			outline: 0,
+		),
+		c-link-variants: (
+			text-secondary: (
+				color: $cadmin-gray-900 !important,
+				hover: (
+					color: $cadmin-black !important,
+				),
+				focus: (
+					color: $cadmin-black !important,
+				),
+			),
+			text-tertiary: (
+				color: $cadmin-gray-900 !important,
+				hover: (
+					color: $cadmin-black !important,
+				),
+			),
+		),
+	),
+	$cadmin-c-link
+);
 
 $cadmin-component-link: () !default;
 $cadmin-component-link: map-deep-merge(
@@ -53,6 +85,8 @@ $cadmin-link-secondary: map-deep-merge(
 	),
 	$cadmin-link-secondary
 );
+
+$cadmin-single-link-font-weight: $cadmin-font-weight-semi-bold !default;
 
 // Link Outline
 

--- a/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_utilities.scss
@@ -528,3 +528,16 @@ $cadmin-text-theme-colors: map-deep-merge(
 	),
 	$cadmin-text-theme-colors
 );
+
+$cadmin-text-decorations: () !default;
+$cadmin-text-decorations: map-deep-merge(
+	(
+		text-decoration-none: (
+			text-decoration: none !important,
+		),
+		text-decoration-underline: (
+			text-decoration: underline !important,
+		),
+	),
+	$cadmin-text-decorations
+);

--- a/packages/clay-css/src/scss/components/_links.scss
+++ b/packages/clay-css/src/scss/components/_links.scss
@@ -1,3 +1,7 @@
+.c-link {
+	@include clay-link($c-link);
+}
+
 .component-link {
 	@include clay-link($component-link);
 }

--- a/packages/clay-css/src/scss/components/_utilities-functional-important.scss
+++ b/packages/clay-css/src/scss/components/_utilities-functional-important.scss
@@ -782,8 +782,18 @@
 	text-shadow: none;
 }
 
-.text-decoration-none {
-	text-decoration: none !important;
+@each $key, $value in $text-decorations {
+	$selector: if(
+		starts-with($key, '.') or
+			starts-with($key, '#') or
+			starts-with($key, '%'),
+		$key,
+		str-insert($key, '.', 1)
+	);
+
+	#{$selector} {
+		@include clay-link($value);
+	}
 }
 
 .text-break {

--- a/packages/clay-css/src/scss/mixins/_links.scss
+++ b/packages/clay-css/src/scss/mixins/_links.scss
@@ -628,7 +628,8 @@
 				}
 			}
 
-			&:hover {
+			&:hover,
+			&.hover {
 				@include clay-css($hover);
 
 				&::before {
@@ -845,6 +846,22 @@
 
 			.lexicon-icon {
 				@include clay-css($lexicon-icon);
+			}
+
+			$c-link-variants: map-get($map, c-link-variants);
+
+			@if ($c-link-variants) {
+				@each $key, $value in $c-link-variants {
+					$selector: if(
+						starts-with($key, '.') or starts-with($key, '#'),
+						$key,
+						str-insert($key, '.', 1)
+					);
+
+					&#{$selector} {
+						@include clay-link($value);
+					}
+				}
 			}
 		}
 	}

--- a/packages/clay-css/src/scss/variables/_globals.scss
+++ b/packages/clay-css/src/scss/variables/_globals.scss
@@ -579,9 +579,20 @@ $link: map-deep-merge(
 	(
 		color: $link-color,
 		text-decoration: $link-decoration,
+		text-underline-offset: 0.23em,
 		hover: (
 			color: $link-hover-color,
 			text-decoration: $link-hover-decoration,
+		),
+		inline-item-before: (
+			margin-right: 0.25rem,
+		),
+		inline-item-middle: (
+			margin-left: 0.25rem,
+			margin-right: 0.25rem,
+		),
+		inline-item-after: (
+			margin-left: 0.25rem,
 		),
 	),
 	$link

--- a/packages/clay-css/src/scss/variables/_links.scss
+++ b/packages/clay-css/src/scss/variables/_links.scss
@@ -2,7 +2,40 @@
 /// @group Links
 ////
 
-$single-link-font-weight: $font-weight-semi-bold !default;
+$c-link: () !default;
+$c-link: map-deep-merge(
+	(
+		text-decoration: none,
+		transition: clay-enable-transitions(box-shadow 0.15s ease-in-out),
+		hover: (
+			text-decoration: none,
+		),
+		focus: (
+			border-radius: 1px,
+			box-shadow: $component-focus-box-shadow,
+			outline: 0,
+		),
+		c-link-variants: (
+			text-secondary: (
+				color: $gray-900 !important,
+				hover: (
+					color: $black !important,
+				),
+				focus: (
+					color: $black !important,
+				),
+			),
+			text-tertiary: (
+				color: $gray-900 !important,
+				hover: (
+					color: $black !important,
+					text-decoration: underline,
+				),
+			),
+		),
+	),
+	$c-link
+);
 
 $component-link: () !default;
 $component-link: map-deep-merge(
@@ -36,6 +69,8 @@ $link-secondary: map-deep-merge(
 	),
 	$link-secondary
 );
+
+$single-link-font-weight: $font-weight-semi-bold !default;
 
 // Link Outline
 

--- a/packages/clay-css/src/scss/variables/_utilities.scss
+++ b/packages/clay-css/src/scss/variables/_utilities.scss
@@ -512,3 +512,16 @@ $text-theme-colors: map-deep-merge(
 	),
 	$text-theme-colors
 );
+
+$text-decorations: () !default;
+$text-decorations: map-deep-merge(
+	(
+		text-decoration-none: (
+			text-decoration: none !important,
+		),
+		text-decoration-underline: (
+			text-decoration: underline !important,
+		),
+	),
+	$text-decorations
+);

--- a/packages/clay-link/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-link/src/__tests__/__snapshots__/index.tsx.snap
@@ -34,7 +34,7 @@ exports[`ClayLink renders with a children content 1`] = `
 
 exports[`ClayLink renders with a display type 1`] = `
 <a
-  className="link-secondary"
+  className="c-link link-secondary text-decoration-underline"
 />
 `;
 
@@ -56,7 +56,7 @@ exports[`ClayLink renders with monospaced 1`] = `
 
 exports[`ClayLink uses custom link component via context 1`] = `
 <a
-  className="link-secondary"
+  className="c-link link-secondary text-decoration-underline"
   href="#1"
 >
   <strong>

--- a/packages/clay-link/src/index.tsx
+++ b/packages/clay-link/src/index.tsx
@@ -8,6 +8,34 @@ import React from 'react';
 
 import ClayLinkContext from './Context';
 
+const LINK_PRESETS = {
+	danger: {
+		base: 'c-link text-danger',
+		decoration: 'underline',
+	},
+	primary: {
+		base: 'c-link link-primary',
+		decoration: 'underline',
+	},
+	secondary: {
+		base: 'c-link link-secondary',
+		decoration: 'underline',
+	},
+	tertiary: {
+		base: 'c-link text-tertiary',
+		decoration: null,
+	},
+	unstyled: {
+		base: 'link-unstyled',
+		decoration: null,
+	},
+} as const;
+
+const FONT_WEIGHTS = {
+	normal: 'font-weight-normal',
+	'semi-bold': 'font-weight-semi-bold',
+};
+
 interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	/**
 	 * Renders the button as a block element.
@@ -31,24 +59,39 @@ interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 		  };
 
 	/**
-	 * Determines how the link is displayed.
+	 * Indicates if the text should be underlined
 	 */
-	displayType?: 'primary' | 'secondary' | 'unstyled';
+	decoration?: 'none' | 'underline' | null;
 
 	/**
-	 * Flag to indicate if link should be monospaced.
+	 * Determines how the link is displayed.
+	 */
+	displayType?: 'danger' | 'primary' | 'secondary' | 'tertiary' | 'unstyled';
+
+	/**
+	 * Sets the text size based on a number scale.
+	 */
+	fontSize?: Number;
+
+	/**
+	 * Flag to indicate if the link should be monospaced.
 	 */
 	monospaced?: boolean;
 
 	/**
-	 * Flag to indicate if link need have an outline.
+	 * Flag to indicate if the link should use the outlined style.
 	 */
 	outline?: boolean;
 
 	/**
-	 * Indicates button should be a small variant.
+	 * Indicates whether the button should use the small variant.
 	 */
 	small?: boolean;
+
+	/**
+	 * Determines the font-weight of the link.
+	 */
+	weight?: 'normal' | 'semi-bold';
 }
 
 const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
@@ -59,12 +102,15 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 			button,
 			children,
 			className,
+			decoration,
 			displayType,
+			fontSize,
 			monospaced,
 			outline,
 			rel,
 			small,
 			target,
+			weight,
 			...otherProps
 		}: IProps,
 		ref
@@ -85,14 +131,28 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 				[`btn-${displayType}`]: displayType && !outline && !borderless,
 				[`btn-outline-${displayType}`]:
 					displayType && (outline || borderless),
+				[weight ? FONT_WEIGHTS[weight] : '']: weight,
+				[`text-${fontSize}`]: fontSize,
+				[`text-decoration-${decoration}`]: decoration,
 			};
 		} else {
+			if (displayType && LINK_PRESETS[displayType]) {
+				if (decoration !== null && !outline) {
+					decoration =
+						decoration || LINK_PRESETS[displayType]?.decoration;
+				}
+			}
+
 			classes = {
 				'link-monospaced': monospaced,
 				'link-outline': outline,
 				'link-outline-borderless': borderless,
-				[`link-${displayType}`]: displayType && !outline,
+				[displayType ? LINK_PRESETS[displayType]?.base : '']:
+					displayType && !outline,
 				[`link-outline-${displayType}`]: displayType && outline,
+				[weight ? FONT_WEIGHTS[weight] : '']: weight,
+				[`text-${fontSize}`]: fontSize,
+				[`text-decoration-${decoration}`]: decoration,
 			};
 		}
 

--- a/packages/clay-link/src/index.tsx
+++ b/packages/clay-link/src/index.tsx
@@ -131,26 +131,23 @@ const ClayLink = React.forwardRef<HTMLAnchorElement, IProps>(
 				[`btn-${displayType}`]: displayType && !outline && !borderless,
 				[`btn-outline-${displayType}`]:
 					displayType && (outline || borderless),
-				[weight ? FONT_WEIGHTS[weight] : '']: weight,
+				[FONT_WEIGHTS[weight!]]: weight,
 				[`text-${fontSize}`]: fontSize,
 				[`text-decoration-${decoration}`]: decoration,
 			};
 		} else {
-			if (displayType && LINK_PRESETS[displayType]) {
-				if (decoration !== null && !outline) {
-					decoration =
-						decoration || LINK_PRESETS[displayType]?.decoration;
-				}
-			}
+			decoration =
+				decoration === null || outline
+					? undefined
+					: decoration || LINK_PRESETS[displayType!]?.decoration;
 
 			classes = {
 				'link-monospaced': monospaced,
 				'link-outline': outline,
 				'link-outline-borderless': borderless,
-				[displayType ? LINK_PRESETS[displayType]?.base : '']:
-					displayType && !outline,
+				[LINK_PRESETS[displayType!]?.base]: displayType && !outline,
 				[`link-outline-${displayType}`]: displayType && outline,
-				[weight ? FONT_WEIGHTS[weight] : '']: weight,
+				[FONT_WEIGHTS[weight!]]: weight,
 				[`text-${fontSize}`]: fontSize,
 				[`text-decoration-${decoration}`]: decoration,
 			};

--- a/packages/clay-link/stories/Link.stories.tsx
+++ b/packages/clay-link/stories/Link.stories.tsx
@@ -15,26 +15,55 @@ export default {
 
 export const Default = () => (
 	<div>
-		<ClayLink href="#link-styles">Default</ClayLink>
-
-		<ClayLink displayType="secondary" href="#link-styles">
-			Secondary
-		</ClayLink>
-
+		<h1>Regular</h1>
+		<ClayLink href="#link-styles">Default</ClayLink>{' '}
 		<ClayLink aria-label="My Link" href="#link-styles">
 			With Aria Label
-		</ClayLink>
-
+		</ClayLink>{' '}
+		<ClayLink displayType="primary" href="#link-styles">
+			Primary
+		</ClayLink>{' '}
+		<ClayLink displayType="secondary" href="#link-styles">
+			Secondary
+		</ClayLink>{' '}
+		<ClayLink displayType="danger" href="#link-styles">
+			Danger
+		</ClayLink>{' '}
+		<ClayLink displayType="tertiary" href="#link-styles">
+			Tertiary
+		</ClayLink>{' '}
+		<ClayLink displayType="unstyled" href="#link-styles">
+			Unstyled
+		</ClayLink>{' '}
 		<div id="link-styles" />
+		<h1>Semi Bold</h1>
+		<ClayLink href="#link-styles" weight="semi-bold">
+			Default
+		</ClayLink>{' '}
+		<ClayLink displayType="primary" href="#link-styles" weight="semi-bold">
+			Primary
+		</ClayLink>{' '}
+		<ClayLink
+			displayType="secondary"
+			href="#link-styles"
+			weight="semi-bold"
+		>
+			Secondary
+		</ClayLink>{' '}
+		<ClayLink displayType="danger" href="#link-styles" weight="semi-bold">
+			Danger
+		</ClayLink>{' '}
+		<ClayLink displayType="tertiary" href="#link-styles" weight="semi-bold">
+			Tertiary
+		</ClayLink>{' '}
 	</div>
 );
 
 export const Borderless = () => (
 	<>
-		<ClayLink borderless href="#1">
+		<ClayLink borderless href="#1" outline>
 			Borderless
-		</ClayLink>
-
+		</ClayLink>{' '}
 		<div id="1" />
 	</>
 );
@@ -43,17 +72,16 @@ export const Outline = () => (
 	<>
 		<ClayLink displayType="primary" href="#1" outline>
 			Outline Primary
-		</ClayLink>
+		</ClayLink>{' '}
 		<ClayLink displayType="secondary" href="#1" outline>
 			Outline Secondary
-		</ClayLink>
+		</ClayLink>{' '}
 		<ClayLink borderless displayType="primary" href="#1" outline>
 			Outline Borderless Primary
-		</ClayLink>
+		</ClayLink>{' '}
 		<ClayLink borderless displayType="secondary" href="#1" outline>
 			Outline Borderless Secondary
-		</ClayLink>
-
+		</ClayLink>{' '}
 		<div id="1" />
 	</>
 );
@@ -62,14 +90,13 @@ export const DisplayedAsButton = () => (
 	<>
 		<ClayLink button displayType="primary" href="#1">
 			Primary
-		</ClayLink>
+		</ClayLink>{' '}
 		<ClayLink button displayType="secondary" href="#1">
 			Secondary
-		</ClayLink>
+		</ClayLink>{' '}
 		<ClayLink borderless button displayType="secondary" href="#1" outline>
 			Borderless Secondary
-		</ClayLink>
-
+		</ClayLink>{' '}
 		<div id="1" />
 	</>
 );
@@ -84,7 +111,7 @@ export const Monospaced = () => (
 			outline
 		>
 			<ClayIcon symbol="add-cell" />
-		</ClayLink>
+		</ClayLink>{' '}
 		<ClayLink
 			aria-label="Monospaced link with icon borderless"
 			borderless
@@ -94,7 +121,7 @@ export const Monospaced = () => (
 			outline
 		>
 			<ClayIcon symbol="add-cell" />
-		</ClayLink>
+		</ClayLink>{' '}
 		<ClayLink
 			aria-label="Monospaced link with icon secondary"
 			displayType="secondary"
@@ -103,7 +130,7 @@ export const Monospaced = () => (
 			outline
 		>
 			<ClayIcon symbol="picture" />
-		</ClayLink>
+		</ClayLink>{' '}
 		<ClayLink
 			aria-label="Monospaced link with icon secondary borderless"
 			borderless
@@ -113,8 +140,7 @@ export const Monospaced = () => (
 			outline
 		>
 			<ClayIcon symbol="picture" />
-		</ClayLink>
-
+		</ClayLink>{' '}
 		<div id="1" />
 	</>
 );


### PR DESCRIPTION
fixes #5283 

Update: I made most of the changes in this update. I changed `underline` to `decoration` because the underline isn't always set by ClayLink. We can have underlined text coming from CSS and the utility `text-decoration-none` will undo that and vice versa. The attribute `decoration` also has a `null` option to undo the presets in `primary` for example. We can use `decoration={null}` to prevent the primary link from outputting the underline utility.

This one might be a little confusing. I decided to adopt the utility classes since there were so many variants, but didn't want to break the api by changing the `link-primary` and `link-secondary` classes to use text utilities. I also added the base `c-link` class that should be used in every link.

|Regular Links|Classes|
|---|---|
|primary|c-link link-primary text-underline text-4|
|secondary|c-link link-secondary text-underline text-4|
|danger|c-link text-danger text-underline text-4|
|tertiary|c-link text-tertiary text-4|

|Semi Bold Links|Classes|
|---|---|
|primary|c-link link-primary font-weight-semi-bold text-underline text-4|
|secondary|c-link link-secondary font-weight-semi-bold text-underline text-4|
|tertiary|c-link text-tertiary font-weight-semi-bold text-underline text-4|
|danger|c-link text-danger font-weight-semi-bold text-underline text-4|

|With Icon|Classes|
|---|---|
|primary|c-link link-primary font-weight-semi-bold text-4|
|secondary|c-link link-secondary font-weight-semi-bold text-4|
|tertiary|c-link text-tertiary font-weight-semi-bold text-4|
|danger|c-link text-danger font-weight-semi-bold text-4|

These property settings are kind of hard to remember, we should probably bundle it in an easy to remember way. 