### PR TITLE
fix(@clayui/pagination): Adds tabindex to links with no href

### DIFF
--- a/packages/clay-css/src/scss/variables/_pagination.scss
+++ b/packages/clay-css/src/scss/variables/_pagination.scss
@@ -57,7 +57,7 @@ $pagination-link-border-radius: 0px !default;
 
 /// @deprecated as of v2 use the Sass map `$pagination-link` instead
 
-$pagination-link-cursor: null !default;
+$pagination-link-cursor: pointer !default;
 
 /// @deprecated as of v2 use the Sass map `$pagination-link` instead
 

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -62,6 +62,7 @@ exports[`ClayPaginationBar renders 1`] = `
           <a
             aria-label="Go to page, 1"
             class="page-link"
+            tabindex="0"
           >
             1
           </a>
@@ -72,6 +73,7 @@ exports[`ClayPaginationBar renders 1`] = `
           <a
             aria-label="Go to page, 2"
             class="page-link"
+            tabindex="0"
           >
             2
           </a>
@@ -82,6 +84,7 @@ exports[`ClayPaginationBar renders 1`] = `
           <a
             aria-label="Go to page, 3"
             class="page-link"
+            tabindex="0"
           >
             3
           </a>
@@ -107,6 +110,7 @@ exports[`ClayPaginationBar renders 1`] = `
           <a
             aria-label="Go to page, 10"
             class="page-link"
+            tabindex="0"
           >
             10
           </a>
@@ -118,6 +122,7 @@ exports[`ClayPaginationBar renders 1`] = `
             aria-label="Go to the next page, 2"
             class="page-link"
             data-testid="nextArrow"
+            tabindex="0"
           >
             <svg
               class="lexicon-icon lexicon-icon-angle-right"
@@ -175,6 +180,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
           <a
             aria-label="Go to page, 1"
             class="page-link"
+            tabindex="0"
           >
             1
           </a>
@@ -185,6 +191,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
           <a
             aria-label="Go to page, 2"
             class="page-link"
+            tabindex="0"
           >
             2
           </a>
@@ -195,6 +202,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
           <a
             aria-label="Go to page, 3"
             class="page-link"
+            tabindex="0"
           >
             3
           </a>
@@ -220,6 +228,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
           <a
             aria-label="Go to page, 10"
             class="page-link"
+            tabindex="0"
           >
             10
           </a>
@@ -231,6 +240,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
             aria-label="Go to the next page, 2"
             class="page-link"
             data-testid="nextArrow"
+            tabindex="0"
           >
             <svg
               class="lexicon-icon lexicon-icon-angle-right"

--- a/packages/clay-pagination/src/Item.tsx
+++ b/packages/clay-pagination/src/Item.tsx
@@ -37,6 +37,7 @@ const ClayPaginationItem = ({
 						otherProps.onClick(event);
 					}
 				}}
+				tabIndex={active || (!href && !disabled) ? 0 : undefined}
 			>
 				{children}
 			</ClayLink>

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -15,6 +15,7 @@ exports[`ClayPagination renders 1`] = `
           aria-label="Go to the previous page, 11"
           class="page-link"
           data-testid="prevArrow"
+          tabindex="0"
         >
           <svg
             class="lexicon-icon lexicon-icon-angle-left"
@@ -32,6 +33,7 @@ exports[`ClayPagination renders 1`] = `
         <a
           aria-label="Go to page, 1"
           class="page-link"
+          tabindex="0"
         >
           1
         </a>
@@ -57,6 +59,7 @@ exports[`ClayPagination renders 1`] = `
         <a
           aria-label="Go to page, 10"
           class="page-link"
+          tabindex="0"
         >
           10
         </a>
@@ -67,6 +70,7 @@ exports[`ClayPagination renders 1`] = `
         <a
           aria-label="Go to page, 11"
           class="page-link"
+          tabindex="0"
         >
           11
         </a>
@@ -77,6 +81,7 @@ exports[`ClayPagination renders 1`] = `
         <a
           aria-label="Go to page, 12"
           class="page-link"
+          tabindex="0"
         >
           12
         </a>
@@ -87,6 +92,7 @@ exports[`ClayPagination renders 1`] = `
         <a
           aria-label="Go to page, 13"
           class="page-link"
+          tabindex="0"
         >
           13
         </a>
@@ -97,6 +103,7 @@ exports[`ClayPagination renders 1`] = `
         <a
           aria-label="Go to page, 14"
           class="page-link"
+          tabindex="0"
         >
           14
         </a>
@@ -122,6 +129,7 @@ exports[`ClayPagination renders 1`] = `
         <a
           aria-label="Go to page, 25"
           class="page-link"
+          tabindex="0"
         >
           25
         </a>
@@ -133,6 +141,7 @@ exports[`ClayPagination renders 1`] = `
           aria-label="Go to the next page, 13"
           class="page-link"
           data-testid="nextArrow"
+          tabindex="0"
         >
           <svg
             class="lexicon-icon lexicon-icon-angle-right"
@@ -181,6 +190,7 @@ exports[`ClayPagination renders with only one page 1`] = `
         <a
           aria-label="Go to page, 1"
           class="page-link"
+          tabindex="0"
         >
           1
         </a>


### PR DESCRIPTION
fixes #5286

@marcoscv-work I added `tabindex="0"` to links that are active or don't have a `href` attribute. It should receive focus when tabbing now. Disabled links don't receive focus when tabbing. I think this is a better way than making `href` mandatory. We don't need to make up a placeholder url that may or may not make sense.

