### PR TITLE
fix(@clayui/core): fix Vertical Bar component error change behavior from controlled to uncontrolled

### DIFF
--- a/packages/clay-core/src/vertical-bar/Item.tsx
+++ b/packages/clay-core/src/vertical-bar/Item.tsx
@@ -77,14 +77,12 @@ export const Item = React.forwardRef<HTMLLIElement, Props>(function Item(
 						return;
 					}
 
-					onActivePanel(
-						keyValue === activePanel ? undefined : keyValue!
-					);
+					onActivePanel(keyValue === activePanel ? null : keyValue!);
 				},
 				role: 'tab',
 				tabIndex:
-					(activePanel !== undefined && activePanel !== keyValue) ||
-					(activePanel === undefined && index !== 0)
+					(activePanel !== null && activePanel !== keyValue) ||
+					(activePanel === null && index !== 0)
 						? -1
 						: null,
 			})}

--- a/packages/clay-core/src/vertical-bar/Panel.tsx
+++ b/packages/clay-core/src/vertical-bar/Panel.tsx
@@ -46,7 +46,7 @@ export function Panel({children, keyValue, tabIndex}: Props) {
 
 	const isFirst = useIsFirstRender();
 
-	const previousActivePanelRef = useRef<React.Key | undefined>(undefined);
+	const previousActivePanelRef = useRef<React.Key | null>(null);
 
 	useEffect(() => {
 		previousActivePanelRef.current = activePanel;
@@ -71,10 +71,10 @@ export function Panel({children, keyValue, tabIndex}: Props) {
 			role="tabpanel"
 			tabIndex={tabIndex}
 			timeout={
-				(activePanel !== undefined &&
-					previousActivePanelRef.current === undefined) ||
-				(activePanel === undefined &&
-					previousActivePanelRef.current !== undefined)
+				(activePanel !== null &&
+					previousActivePanelRef.current === null) ||
+				(activePanel === null &&
+					previousActivePanelRef.current !== null)
 					? {enter: 300, exit: 200}
 					: 0
 			}

--- a/packages/clay-core/src/vertical-bar/VerticalBar.tsx
+++ b/packages/clay-core/src/vertical-bar/VerticalBar.tsx
@@ -47,17 +47,17 @@ type Props = {
 	/**
 	 * Sets the current active panel (controlled).
 	 */
-	active?: React.Key | undefined;
+	active?: React.Key | null;
 
 	/**
 	 * Sets the default active panel (uncontrolled).
 	 */
-	defaultActive?: React.Key | undefined;
+	defaultActive?: React.Key | null;
 
 	/**
 	 * Callback is called when the active state changes (controlled).
 	 */
-	onActiveChange?: InternalDispatch<React.Key | undefined>;
+	onActiveChange?: InternalDispatch<React.Key | null>;
 };
 
 export function VerticalBar(props: Props): JSX.Element & {
@@ -73,13 +73,11 @@ export function VerticalBar({
 	active,
 	children,
 	className,
-	defaultActive,
+	defaultActive = null,
 	onActiveChange,
 	position = 'right',
 }: Props) {
-	const [activePanel, setActivePanel] = useInternalState<
-		React.Key | undefined
-	>({
+	const [activePanel, setActivePanel] = useInternalState<React.Key | null>({
 		defaultName: 'defaultItems',
 		defaultValue: defaultActive,
 		handleName: 'onActiveChange',

--- a/packages/clay-core/src/vertical-bar/context.ts
+++ b/packages/clay-core/src/vertical-bar/context.ts
@@ -10,9 +10,9 @@ import type {Key} from 'react';
 
 type Context = {
 	activation?: 'manual' | 'automatic';
-	activePanel: Key | undefined;
+	activePanel: Key | null;
 	id: string;
-	onActivePanel: InternalDispatch<React.Key | undefined>;
+	onActivePanel: InternalDispatch<React.Key | null>;
 };
 
 export const VerticalBarContext = createContext<Context>({} as Context);

--- a/packages/clay-core/stories/VerticalBar.stories.tsx
+++ b/packages/clay-core/stories/VerticalBar.stories.tsx
@@ -5,7 +5,7 @@
 
 import Button from '@clayui/button';
 import Icon from '@clayui/icon';
-import React from 'react';
+import React, {useState} from 'react';
 
 import {VerticalBar} from '../src/vertical-bar';
 
@@ -145,8 +145,13 @@ export const DynamicContent = (args: any) => {
 		},
 	];
 
+	const [active, setActive] = useState('Tag');
+
 	return (
-		<VerticalBar defaultActive="Tag">
+		<VerticalBar
+			active={active}
+			onActiveChange={(active) => setActive(active)}
+		>
 			<VerticalBar.Content
 				displayType={args.contentDisplayType}
 				items={items}

--- a/packages/clay-core/stories/VerticalBar.stories.tsx
+++ b/packages/clay-core/stories/VerticalBar.stories.tsx
@@ -34,19 +34,20 @@ export const Default = (args: any) => {
 			<VerticalBar activation={args.activation} position="left">
 				<VerticalBar.Bar displayType={args.barDisplayType}>
 					<VerticalBar.Item>
-						<Button displayType={null}>
+						<Button aria-label="Tag tab" displayType={null}>
 							<Icon symbol="tag" />
 						</Button>
 					</VerticalBar.Item>
 
 					<VerticalBar.Item divider>
-						<Button displayType={null}>
+						<Button aria-label="Message tab" displayType={null}>
 							<Icon symbol="message" />
 						</Button>
 					</VerticalBar.Item>
 
 					<VerticalBar.Item>
 						<Button
+							aria-label="Effects tab"
 							displayType={null}
 							onClick={(event) => {
 								event.preventDefault();
@@ -91,19 +92,20 @@ export const Default = (args: any) => {
 
 				<VerticalBar.Bar displayType={args.barDisplayType}>
 					<VerticalBar.Item>
-						<Button displayType={null}>
+						<Button aria-label="Tag tab" displayType={null}>
 							<Icon symbol="tag" />
 						</Button>
 					</VerticalBar.Item>
 
 					<VerticalBar.Item divider>
-						<Button displayType={null}>
+						<Button aria-label="Message tab" displayType={null}>
 							<Icon symbol="message" />
 						</Button>
 					</VerticalBar.Item>
 
 					<VerticalBar.Item>
 						<Button
+							aria-label="Effects tab"
 							displayType={null}
 							onClick={(event) => {
 								event.preventDefault();
@@ -165,7 +167,10 @@ export const DynamicContent = (args: any) => {
 			>
 				{(item) => (
 					<VerticalBar.Item divider={item.divider} key={item.title}>
-						<Button displayType={null}>
+						<Button
+							aria-label={`${item.title} tab`}
+							displayType={null}
+						>
 							<Icon symbol={item.icon} />
 						</Button>
 					</VerticalBar.Item>

--- a/packages/clay-shared/src/useInternalState.ts
+++ b/packages/clay-shared/src/useInternalState.ts
@@ -28,7 +28,9 @@ export function useInternalState<Value>({
 	onChange,
 	value,
 }: Props<Value>) {
-	const [internalValue, setInternalValue] = useState(defaultValue ?? value);
+	const [internalValue, setInternalValue] = useState(
+		defaultValue === undefined ? value : defaultValue
+	);
 
 	warning(
 		!(typeof value === 'undefined' && typeof onChange !== 'undefined'),


### PR DESCRIPTION
Fixes #5292

The issue with the animation not working correctly was that when the component was configured to be controlled, the state changed from controlled to uncontrolled which broke the implementation internally.

This PR fixes this so that this can be `React.Key` or `null` instead of `undefined` which is the type that `useInternalState` uses to determine controlled or uncontrolled behavior.