### PR TITLE
feat(@clayui/core): add new property to add `className` to Picker menu

### DIFF
--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -105,9 +105,15 @@ export type Props<T> = {
 	 * The currently selected key (controlled).
 	 */
 	selectedKey?: React.Key;
+
+	/**
+	 * Sets the className for the React.Portal Menu element.
+	 */
+	UNSAFE_menuClassName?: string;
 } & Omit<ICollectionProps<T, unknown>, 'virtualize'>;
 
 export function Picker<T>({
+	UNSAFE_menuClassName,
 	active: externalActive,
 	as: As = 'button',
 	children,
@@ -347,6 +353,7 @@ export function Picker<T>({
 					isCloseOnInteractOutside
 					isKeyboardDismiss
 					isOpen
+					menuClassName={UNSAFE_menuClassName}
 					menuRef={menuRef}
 					onClose={(action) => {
 						if (

--- a/packages/clay-shared/src/Overlay.tsx
+++ b/packages/clay-shared/src/Overlay.tsx
@@ -18,6 +18,7 @@ type Props = {
 	isKeyboardDismiss?: boolean;
 	isModal?: boolean;
 	isOpen: boolean;
+	menuClassName?: string;
 	menuRef: React.RefObject<HTMLElement>;
 	onClose: (action: 'escape' | 'blur') => void;
 	portalRef?: React.RefObject<HTMLElement>;
@@ -36,6 +37,7 @@ export function Overlay({
 	isKeyboardDismiss = false,
 	isModal = false,
 	isOpen = false,
+	menuClassName,
 	menuRef,
 	onClose,
 	portalRef,
@@ -128,7 +130,7 @@ export function Overlay({
 	}, [isModal, isOpen]);
 
 	return (
-		<ClayPortal subPortalRef={portalRef}>
+		<ClayPortal className={menuClassName} subPortalRef={portalRef}>
 			{isModal && (
 				<span
 					aria-hidden="true"


### PR DESCRIPTION
Closes #5271

Ideally we want to avoid these properties in favor of setting the `theme` via the `<ClayProvider />` but at this point there seems to be some conflicting bundler dependencies on the DXP which is loading different versions of the package in core and in the shared package.