### PR TITLE
fix(@clayui/core): VerticalBar should animate the panel open / close in a controlled component

### DIFF
--- a/packages/clay-core/src/vertical-bar/Panel.tsx
+++ b/packages/clay-core/src/vertical-bar/Panel.tsx
@@ -62,22 +62,17 @@ export function Panel({children, keyValue, tabIndex}: Props) {
 			})}
 			classNames={{
 				enter: 'c-slideout-transition c-slideout-transition-in',
-				enterActive: 'c-slideout-show',
+				enterActive:
+					'c-slideout-show c-slideout-transition c-slideout-transition-in',
 				enterDone: 'c-slideout-show',
 				exit: 'c-slideout-transition c-slideout-transition-out',
 			}}
 			id={`${id}-tabpanel-${keyValue}`}
 			in={activePanel === keyValue}
+			exit={!activePanel}
 			role="tabpanel"
 			tabIndex={tabIndex}
-			timeout={
-				(activePanel !== undefined &&
-					previousActivePanelRef.current === undefined) ||
-				(activePanel === undefined &&
-					previousActivePanelRef.current !== undefined)
-					? {enter: 300, exit: 200}
-					: 0
-			}
+			timeout={{enter: 300, exit: 200}}
 			unmountOnExit
 		>
 			<div>{children}</div>

--- a/packages/clay-core/stories/VerticalBar.stories.tsx
+++ b/packages/clay-core/stories/VerticalBar.stories.tsx
@@ -5,7 +5,7 @@
 
 import Button from '@clayui/button';
 import Icon from '@clayui/icon';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {VerticalBar} from '../src/vertical-bar';
 
@@ -143,8 +143,15 @@ export const DynamicContent = (args: any) => {
 		},
 	];
 
+	const [activeItem, setActiveItem] = useState(null);
+
 	return (
-		<VerticalBar defaultActive="Tag">
+		<VerticalBar
+			active={activeItem}
+			onActiveChange={() => {
+				console.log('onActiveChange');
+			}}
+		>
 			<VerticalBar.Content
 				displayType={args.contentDisplayType}
 				items={items}
@@ -165,7 +172,16 @@ export const DynamicContent = (args: any) => {
 			>
 				{(item) => (
 					<VerticalBar.Item divider={item.divider} key={item.title}>
-						<Button displayType={null}>
+						<Button
+							displayType={null}
+							onClick={() => {
+								if (activeItem !== item.title) {
+									setActiveItem(item.title);
+								} else {
+									setActiveItem(null);
+								}
+							}}
+						>
 							<Icon symbol={item.icon} />
 						</Button>
 					</VerticalBar.Item>


### PR DESCRIPTION
#5292

@matuzalemsteles here is the draft pr I mentioned in #5298. I couldn't animate open and close when switching tabs because CSSTransition runs both animations simultaneously. I don't know if there's a way to execute the close animation before running open. I couldn't find anything on it.

I tried [SwitchTransition](http://reactcommunity.org/react-transition-group/switch-transition) but it wasn't what I was expecting.