### PR TITLE
fix(@clayui/pagination): remove link from Prev and Next when disabled

### DIFF
--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -41,8 +41,7 @@ exports[`ClayPaginationBar renders 1`] = `
         <li
           class="page-item disabled"
         >
-          <a
-            aria-label="Go to the previous page, 0"
+          <div
             class="page-link"
             data-testid="prevArrow"
           >
@@ -54,7 +53,7 @@ exports[`ClayPaginationBar renders 1`] = `
                 xlink:href="path/to/spritemap#angle-left"
               />
             </svg>
-          </a>
+          </div>
         </li>
         <li
           class="page-item active"
@@ -159,8 +158,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
         <li
           class="page-item disabled"
         >
-          <a
-            aria-label="Go to the previous page, 0"
+          <div
             class="page-link"
             data-testid="prevArrow"
           >
@@ -172,7 +170,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
                 xlink:href="path/to/spritemap#angle-left"
               />
             </svg>
-          </a>
+          </div>
         </li>
         <li
           class="page-item active"

--- a/packages/clay-pagination/src/Item.tsx
+++ b/packages/clay-pagination/src/Item.tsx
@@ -8,13 +8,15 @@ import classNames from 'classnames';
 import React from 'react';
 
 export interface IPaginationItemProps
-	extends React.HTMLAttributes<HTMLAnchorElement | HTMLButtonElement> {
+	extends React.HTMLAttributes<HTMLAnchorElement | HTMLDivElement> {
+	as?: 'div' | typeof ClayLink;
 	active?: boolean;
 	disabled?: boolean;
 	href?: string;
 }
 
 const ClayPaginationItem = ({
+	as: As = ClayLink,
 	active = false,
 	children,
 	disabled = false,
@@ -23,24 +25,30 @@ const ClayPaginationItem = ({
 }: IPaginationItemProps) => {
 	return (
 		<li className={classNames('page-item', {active, disabled})}>
-			<ClayLink
-				{...otherProps}
-				aria-current={active && href ? 'page' : undefined}
-				className="page-link"
-				href={disabled || active ? undefined : href}
-				onClick={(event) => {
-					if (!href) {
-						event.preventDefault();
-					}
+			{As === 'div' ? (
+				<As {...otherProps} className="page-link">
+					{children}
+				</As>
+			) : (
+				<As
+					{...otherProps}
+					aria-current={active && href ? 'page' : undefined}
+					className="page-link"
+					href={disabled || active ? undefined : href}
+					onClick={(event) => {
+						if (!href) {
+							event.preventDefault();
+						}
 
-					if (otherProps.onClick) {
-						otherProps.onClick(event);
-					}
-				}}
-				tabIndex={active || (!href && !disabled) ? 0 : undefined}
-			>
-				{children}
-			</ClayLink>
+						if (otherProps.onClick) {
+							otherProps.onClick(event as any);
+						}
+					}}
+					tabIndex={active || (!href && !disabled) ? 0 : undefined}
+				>
+					{children}
+				</As>
+			)}
 		</li>
 	);
 };

--- a/packages/clay-pagination/src/PaginationWithBasicItems.tsx
+++ b/packages/clay-pagination/src/PaginationWithBasicItems.tsx
@@ -150,7 +150,12 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 		return (
 			<Pagination {...otherProps} ref={ref}>
 				<Pagination.Item
-					aria-label={sub(ariaLabels.previous, [previousPage])}
+					aria-label={
+						internalActive !== 1
+							? sub(ariaLabels.previous, [previousPage])
+							: undefined
+					}
+					as={internalActive === 1 ? 'div' : undefined}
 					data-testid="prevArrow"
 					disabled={internalActive === 1}
 					href={previousHref}
@@ -198,7 +203,12 @@ const ClayPaginationWithBasicItems = React.forwardRef<HTMLUListElement, IProps>(
 				)}
 
 				<Pagination.Item
-					aria-label={sub(ariaLabels.next, [nextPage])}
+					aria-label={
+						internalActive !== totalPages
+							? sub(ariaLabels.next, [nextPage])
+							: undefined
+					}
+					as={internalActive === totalPages ? 'div' : undefined}
 					data-testid="nextArrow"
 					disabled={internalActive === totalPages}
 					href={nextHref}

--- a/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination/src/__tests__/__snapshots__/index.tsx.snap
@@ -169,8 +169,7 @@ exports[`ClayPagination renders with only one page 1`] = `
       <li
         class="page-item disabled"
       >
-        <a
-          aria-label="Go to the previous page, 0"
+        <div
           class="page-link"
           data-testid="prevArrow"
         >
@@ -182,7 +181,7 @@ exports[`ClayPagination renders with only one page 1`] = `
               xlink:href="path/to/spritemap#angle-left"
             />
           </svg>
-        </a>
+        </div>
       </li>
       <li
         class="page-item active"
@@ -198,8 +197,7 @@ exports[`ClayPagination renders with only one page 1`] = `
       <li
         class="page-item disabled"
       >
-        <a
-          aria-label="Go to the next page, 2"
+        <div
           class="page-link"
           data-testid="nextArrow"
         >
@@ -211,7 +209,7 @@ exports[`ClayPagination renders with only one page 1`] = `
               xlink:href="path/to/spritemap#angle-right"
             />
           </svg>
-        </a>
+        </div>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
Fixes #5297

The case of the issue that `span` has a `tabIndex` could be a DXP specific implementation that is using the low-level APIs instead of the `PaginationWithBasicItems` component, I will check this when I update the Clay dependencies in the DXP .

This PR removes the link of `Prev` and `Next` when they are disabled, I'm also removing the `aria-label` as the element will not have focus and would also generate more confusion and noise.