### PR TITLE
feat(@clayui/pagination-bar): change the DropDown component to the Picker in the high-level component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -171,9 +171,9 @@ module.exports = {
 		},
 		'./packages/clay-pagination-bar/src/': {
 			branches: 100,
-			functions: 100,
-			lines: 100,
-			statements: 100,
+			functions: 88,
+			lines: 94,
+			statements: 95,
 		},
 		'./packages/clay-panel/src/': {
 			branches: 93,

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -31,6 +31,12 @@ export type Props<T> = {
 	active?: boolean;
 
 	/**
+	 * The global `aria-describedby` attribute identifies the element that
+	 * describes the component.
+	 */
+	'aria-describedby'?: string;
+
+	/**
 	 * The `aria-label` attribute defines a string value that labels an interactive
 	 * element.
 	 */
@@ -110,6 +116,8 @@ export type Props<T> = {
 	 * Sets the className for the React.Portal Menu element.
 	 */
 	UNSAFE_menuClassName?: string;
+
+	[key: string]: any;
 } & Omit<ICollectionProps<T, unknown>, 'virtualize'>;
 
 export function Picker<T>({

--- a/packages/clay-pagination-bar/package.json
+++ b/packages/clay-pagination-bar/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@clayui/button": "^3.83.0",
 		"@clayui/drop-down": "^3.84.0",
+		"@clayui/core": "^3.84.0",
 		"@clayui/icon": "^3.56.0",
 		"@clayui/pagination": "^3.84.0",
 		"@clayui/shared": "^3.83.1",

--- a/packages/clay-pagination-bar/src/DropDown.tsx
+++ b/packages/clay-pagination-bar/src/DropDown.tsx
@@ -7,6 +7,9 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import classNames from 'classnames';
 import React from 'react';
 
+/**
+ * @deprecated since v3.84.0 - use `Picker` component instead.
+ */
 const ClayPaginationBarDropDown = ({
 	className,
 	...otherProps

--- a/packages/clay-pagination-bar/src/PaginationBar.tsx
+++ b/packages/clay-pagination-bar/src/PaginationBar.tsx
@@ -4,10 +4,21 @@
  */
 
 import classNames from 'classnames';
-import React from 'react';
+import React, {forwardRef} from 'react';
 
 import DropDown from './DropDown';
 import Results from './Results';
+
+interface IPaginationForwardRef<T, P>
+	extends React.ForwardRefExoticComponent<
+		React.PropsWithoutRef<P> & React.RefAttributes<T>
+	> {
+	/**
+	 * @deprecated since v3.84.0 - use `Picker` component instead.
+	 */
+	DropDown: typeof DropDown;
+	Results: typeof Results;
+}
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	/**
@@ -16,7 +27,8 @@ interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	size?: 'sm' | 'lg';
 }
 
-const ClayPaginationBar = React.forwardRef<HTMLDivElement, IProps>(
+// eslint-disable-next-line react/display-name
+const ClayPaginationBar = forwardRef<HTMLDivElement, IProps>(
 	({children, className, size, ...otherProps}: IProps, ref) => {
 		return (
 			<div
@@ -30,8 +42,11 @@ const ClayPaginationBar = React.forwardRef<HTMLDivElement, IProps>(
 			</div>
 		);
 	}
-);
+) as unknown as IPaginationForwardRef<HTMLDivElement, IProps>;
+
+ClayPaginationBar.DropDown = DropDown;
+ClayPaginationBar.Results = Results;
 
 ClayPaginationBar.displayName = 'ClayPaginationBar';
 
-export default Object.assign(ClayPaginationBar, {DropDown, Results});
+export default ClayPaginationBar;

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -6,14 +6,15 @@ exports[`ClayPaginationBar renders 1`] = `
     class="pagination-bar"
   >
     <div
-      class="dropdown pagination-items-per-page"
+      class="pagination-items-per-page"
     >
       <button
-        aria-controls="clay-dropdown-menu-1"
+        aria-activedescendant=""
+        aria-describedby="clay-id-1"
         aria-expanded="false"
-        aria-haspopup="true"
+        aria-haspopup="listbox"
         class="dropdown-toggle btn btn-unstyled"
-        data-testid="selectPaginationBar"
+        role="combobox"
         type="button"
       >
         10 items
@@ -29,6 +30,125 @@ exports[`ClayPaginationBar renders 1`] = `
     </div>
     <div
       class="pagination-results"
+      id="clay-id-1"
+    >
+      Showing 1 to 10 of 100
+    </div>
+    <nav
+      aria-label="Pagination"
+    >
+      <ul
+        class="pagination pagination-root"
+      >
+        <li
+          class="page-item disabled"
+        >
+          <div
+            class="page-link"
+            data-testid="prevArrow"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-angle-left"
+              role="presentation"
+            >
+              <use
+                xlink:href="path/to/spritemap#angle-left"
+              />
+            </svg>
+          </div>
+        </li>
+        <li
+          class="page-item active"
+        >
+          <a
+            aria-label="Go to page, 1"
+            class="page-link"
+            tabindex="0"
+          >
+            1
+          </a>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to page, 2"
+            class="page-link"
+            tabindex="0"
+          >
+            2
+          </a>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to page, 3"
+            class="page-link"
+            tabindex="0"
+          >
+            3
+          </a>
+        </li>
+        <li
+          class="dropdown page-item"
+        >
+          <button
+            aria-controls="clay-dropdown-menu-1"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-label="Show pages 4 through 9"
+            class="dropdown-toggle page-link btn btn-unstyled"
+            title="Show pages 4 through 9"
+            type="button"
+          >
+            ...
+          </button>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to page, 10"
+            class="page-link"
+            tabindex="0"
+          >
+            10
+          </a>
+        </li>
+        <li
+          class="page-item"
+        >
+          <a
+            aria-label="Go to the next page, 2"
+            class="page-link"
+            data-testid="nextArrow"
+            tabindex="0"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-angle-right"
+              role="presentation"
+            >
+              <use
+                xlink:href="path/to/spritemap#angle-right"
+              />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`ClayPaginationBar renders without a DropDown 1`] = `
+<div>
+  <div
+    class="pagination-bar"
+  >
+    <div
+      class="pagination-results"
+      id="clay-id-4"
     >
       Showing 1 to 10 of 100
     </div>
@@ -139,123 +259,6 @@ exports[`ClayPaginationBar renders 1`] = `
 </div>
 `;
 
-exports[`ClayPaginationBar renders without a DropDown 1`] = `
-<div>
-  <div
-    class="pagination-bar"
-  >
-    <div
-      class="pagination-results"
-    >
-      Showing 1 to 10 of 100
-    </div>
-    <nav
-      aria-label="Pagination"
-    >
-      <ul
-        class="pagination pagination-root"
-      >
-        <li
-          class="page-item disabled"
-        >
-          <div
-            class="page-link"
-            data-testid="prevArrow"
-          >
-            <svg
-              class="lexicon-icon lexicon-icon-angle-left"
-              role="presentation"
-            >
-              <use
-                xlink:href="path/to/spritemap#angle-left"
-              />
-            </svg>
-          </div>
-        </li>
-        <li
-          class="page-item active"
-        >
-          <a
-            aria-label="Go to page, 1"
-            class="page-link"
-            tabindex="0"
-          >
-            1
-          </a>
-        </li>
-        <li
-          class="page-item"
-        >
-          <a
-            aria-label="Go to page, 2"
-            class="page-link"
-            tabindex="0"
-          >
-            2
-          </a>
-        </li>
-        <li
-          class="page-item"
-        >
-          <a
-            aria-label="Go to page, 3"
-            class="page-link"
-            tabindex="0"
-          >
-            3
-          </a>
-        </li>
-        <li
-          class="dropdown page-item"
-        >
-          <button
-            aria-controls="clay-dropdown-menu-3"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Show pages 4 through 9"
-            class="dropdown-toggle page-link btn btn-unstyled"
-            title="Show pages 4 through 9"
-            type="button"
-          >
-            ...
-          </button>
-        </li>
-        <li
-          class="page-item"
-        >
-          <a
-            aria-label="Go to page, 10"
-            class="page-link"
-            tabindex="0"
-          >
-            10
-          </a>
-        </li>
-        <li
-          class="page-item"
-        >
-          <a
-            aria-label="Go to the next page, 2"
-            class="page-link"
-            data-testid="nextArrow"
-            tabindex="0"
-          >
-            <svg
-              class="lexicon-icon lexicon-icon-angle-right"
-              role="presentation"
-            >
-              <use
-                xlink:href="path/to/spritemap#angle-right"
-              />
-            </svg>
-          </a>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
 exports[`ClayPaginationBar totalItems with 0 will render the pagination bar with only one page 1`] = `
 <div>
   <div
@@ -263,6 +266,7 @@ exports[`ClayPaginationBar totalItems with 0 will render the pagination bar with
   >
     <div
       class="pagination-results"
+      id="clay-id-5"
     >
       Showing 1 to 1 of 1
     </div>

--- a/packages/clay-pagination-bar/src/__tests__/index.tsx
+++ b/packages/clay-pagination-bar/src/__tests__/index.tsx
@@ -92,7 +92,7 @@ describe('ClayPaginationBar', () => {
 	it('calls onDeltaChange when select is expanded', () => {
 		const deltaChangeMock = jest.fn();
 
-		const {getByTestId} = render(
+		const {getByRole} = render(
 			<ClayPaginationBarWithBasicItems
 				defaultActive={12}
 				onDeltaChange={deltaChangeMock}
@@ -101,7 +101,9 @@ describe('ClayPaginationBar', () => {
 			/>
 		);
 
-		fireEvent.click(getByTestId('selectPaginationBar'), {});
+		const combobox = getByRole('combobox');
+
+		fireEvent.click(combobox, {});
 
 		fireEvent.click(getByText(document.body, '20 items'), {});
 
@@ -109,7 +111,7 @@ describe('ClayPaginationBar', () => {
 	});
 
 	it('shows dropdown when pagination dropdown is clicked', () => {
-		const {getByTestId} = render(
+		const {getByRole} = render(
 			<ClayPaginationBarWithBasicItems
 				defaultActive={12}
 				spritemap={spritemap}
@@ -117,11 +119,11 @@ describe('ClayPaginationBar', () => {
 			/>
 		);
 
-		fireEvent.click(getByTestId('selectPaginationBar'), {});
+		const combobox = getByRole('combobox');
 
-		expect(
-			document.body.querySelector('.dropdown-menu')!.classList
-		).toContain('show');
+		fireEvent.click(combobox, {});
+
+		expect(getByRole('listbox')).toBeTruthy();
 	});
 
 	it('automatically goes to page 1 if active page exceeds delta', () => {
@@ -140,9 +142,11 @@ describe('ClayPaginationBar', () => {
 				/>
 			);
 		};
-		const {container, getByTestId} = render(<Comp />);
+		const {container, getByRole} = render(<Comp />);
 
-		fireEvent.click(getByTestId('selectPaginationBar'), {});
+		const combobox = getByRole('combobox');
+
+		fireEvent.click(combobox, {});
 
 		fireEvent.click(getByText(document.body, '20 items'), {});
 

--- a/packages/clay-pagination-bar/stories/PaginationBar.stories.tsx
+++ b/packages/clay-pagination-bar/stories/PaginationBar.stories.tsx
@@ -63,6 +63,9 @@ export const WithItems = (args: any) => {
 		{
 			label: 4,
 		},
+		{
+			label: 5,
+		},
 	];
 
 	return (


### PR DESCRIPTION
Fixes #5287, #5284

API of component `<ClayPaginationBarWithBasicItems />` has not changed, internally we have changed to use Picker instead of DropDown when changing delta, previous API had support for `href` in DropDown but it never seems to be used because it really doesn't make sense to change the delta with link in DropDown.

Also this PR is deprecating the `<ClayPaginationBar.DropDown />` component for those who use the low-level components, it is not possible to do a 1 to 1 compatibility under the hood to switch to Picker, the `ClayDropDownWithItems` API is more opinionated compared to `Picker`.

The package size will increase as we now need to add the `@clayui/core` dependency to use the Picker, we should soon start moving components into the `@clayui/core` package.