### PR TITLE
feat(@clayui/multi-select): allows to prevent default behavior of `onPaste` and `onKeyDown`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -142,8 +142,8 @@ module.exports = {
 		'./packages/clay-multi-select/src/': {
 			branches: 62,
 			functions: 77,
-			lines: 77,
-			statements: 77,
+			lines: 76,
+			statements: 75,
 		},
 		'./packages/clay-multi-step-nav/src/': {
 			branches: 94,

--- a/packages/clay-multi-select/src/index.tsx
+++ b/packages/clay-multi-select/src/index.tsx
@@ -322,6 +322,10 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 		) => {
 			onKeyDown(event);
 
+			if (event.defaultPrevented) {
+				return;
+			}
+
 			const {key} = event;
 
 			if (key === Keys.Backspace && !internalValue) {
@@ -350,6 +354,10 @@ const ClayMultiSelect = React.forwardRef<HTMLDivElement, IProps>(
 
 		const handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
 			onPaste(event);
+
+			if (event.defaultPrevented) {
+				return;
+			}
 
 			const pastedText = event.clipboardData.getData('Text');
 


### PR DESCRIPTION
Fixes #5303

It allows the developer to prevent default behavior of MultiSelect in `onPaste` and `onKeyDown`, the same way we did in newer components like TreeView just calling `event.preventDefault()` will ignore the default behavior.

```jsx
<ClayMultiSelect
  onPaste={(event) => event.preventDefault()}
  inputName="myInput"
/>
```