### PR TITLE
feat: add prop to remove `aria-current` from `VerticalNav` and `NavigationBar` component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -152,7 +152,7 @@ module.exports = {
 			statements: 98,
 		},
 		'./packages/clay-nav/src/': {
-			branches: 90,
+			branches: 88,
 			functions: 80,
 			lines: 93,
 			statements: 93,

--- a/packages/clay-nav/src/Vertical.tsx
+++ b/packages/clay-nav/src/Vertical.tsx
@@ -49,6 +49,12 @@ interface IItemWithItems extends IItem {
 
 export interface IProps {
 	/**
+	 * Flag to define if the item represents the current page. Disable this
+	 * attribute only if there are multiple navigations on the page.
+	 */
+	'aria-current'?: 'page' | null;
+
+	/**
 	 * Flag to indicate the navigation behavior in the menu.
 	 *
 	 * - manual - it will just move the focus and menu activation is done just
@@ -94,7 +100,9 @@ export interface IProps {
 	spritemap?: string;
 }
 
-export interface INavItemProps extends IItemWithItems {
+export interface INavItemProps extends Omit<IItemWithItems, 'aria-current'> {
+	'aria-current'?: 'page' | null;
+
 	/**
 	 * Integer to keep track of what nested level the item is.
 	 */
@@ -130,6 +138,7 @@ function findSelectedNested(
 
 function Item({
 	active,
+	'aria-current': ariaCurrent = 'page',
 	href,
 	initialExpanded = false,
 	items,
@@ -157,7 +166,7 @@ function Item({
 		<Nav.Item role="none" {...otherProps}>
 			<Nav.Link
 				active={active}
-				aria-current={active ? 'page' : undefined}
+				aria-current={active ? ariaCurrent ?? undefined : undefined}
 				aria-expanded={items ? expanded : undefined}
 				aria-haspopup={items ? true : undefined}
 				collapsed={!expanded}
@@ -233,7 +242,13 @@ function Item({
 				>
 					<div ref={menusRef}>
 						<Nav role="menu" stacked>
-							{renderItems(items, spritemap, level++, itemRef)}
+							{renderItems(
+								items,
+								ariaCurrent,
+								spritemap,
+								level++,
+								itemRef
+							)}
 						</Nav>
 					</div>
 				</CSSTransition>
@@ -244,6 +259,7 @@ function Item({
 
 function renderItems(
 	items: Array<IItem>,
+	ariaCurrent: 'page' | null,
 	spritemap?: string,
 	level = 0,
 	parentItemRef?: React.RefObject<HTMLButtonElement | HTMLAnchorElement>
@@ -254,6 +270,7 @@ function renderItems(
 		return (
 			<Item
 				{...item}
+				aria-current={ariaCurrent}
 				key={key}
 				level={level}
 				parentItemRef={parentItemRef}
@@ -268,6 +285,7 @@ function ClayVerticalNav(props: IProps): JSX.Element & {
 };
 
 function ClayVerticalNav({
+	'aria-current': ariaCurrent = 'page',
 	activation = 'manual',
 	activeLabel,
 	decorated,
@@ -322,7 +340,7 @@ function ClayVerticalNav({
 				ref={containerRef}
 			>
 				<Nav aria-orientation="vertical" nested role="menubar">
-					{renderItems(items, spritemap)}
+					{renderItems(items, ariaCurrent, spritemap)}
 				</Nav>
 			</div>
 		</nav>

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -4,20 +4,15 @@
  */
 
 import classNames from 'classnames';
-import React from 'react';
+import React, {useContext} from 'react';
 
-export interface IItemProps
-	extends Omit<React.HTMLAttributes<HTMLLIElement>, 'aria-current'> {
+import {NavigationBarContext} from './context';
+
+export interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
 	/**
 	 * Determines the active state of an dropdown list item.
 	 */
 	active?: boolean;
-
-	/**
-	 * Flag to define if the item represents the current page. Disable this
-	 * attribute only if there are multiple navigations on the page.
-	 */
-	'aria-current'?: 'page' | null;
 
 	/**
 	 * Children elements received from ClayNavigationBar.Item component.
@@ -27,11 +22,12 @@ export interface IItemProps
 
 const ClayNavigationBarIcon = ({
 	active = false,
-	'aria-current': ariaCurrent = 'page',
 	children,
 	className,
 	...otherProps
 }: IItemProps) => {
+	const {ariaCurrent} = useContext(NavigationBarContext);
+
 	return (
 		<li {...otherProps} className={classNames('nav-item', className)}>
 			{React.Children.map(

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -6,11 +6,18 @@
 import classNames from 'classnames';
 import React from 'react';
 
-export interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
+export interface IItemProps
+	extends Omit<React.HTMLAttributes<HTMLLIElement>, 'aria-current'> {
 	/**
 	 * Determines the active state of an dropdown list item.
 	 */
 	active?: boolean;
+
+	/**
+	 * Flag to define if the item represents the current page. Disable this
+	 * attribute only if there are multiple navigations on the page.
+	 */
+	'aria-current'?: 'page' | null;
 
 	/**
 	 * Children elements received from ClayNavigationBar.Item component.
@@ -20,6 +27,7 @@ export interface IItemProps extends React.HTMLAttributes<HTMLLIElement> {
 
 const ClayNavigationBarIcon = ({
 	active = false,
+	'aria-current': ariaCurrent = 'page',
 	children,
 	className,
 	...otherProps
@@ -37,7 +45,9 @@ const ClayNavigationBarIcon = ({
 					) {
 						return React.cloneElement(child, {
 							...child.props,
-							'aria-current': active ? 'page' : undefined,
+							'aria-current': active
+								? ariaCurrent ?? undefined
+								: undefined,
 							children: (
 								<span className="navbar-text-truncate">
 									{child.props.children}

--- a/packages/clay-navigation-bar/src/context.ts
+++ b/packages/clay-navigation-bar/src/context.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {createContext} from 'react';
+
+type ValueContext = {
+	ariaCurrent: 'page' | null;
+};
+
+export const NavigationBarContext = createContext<ValueContext>({
+	ariaCurrent: 'page',
+});

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -13,8 +13,16 @@ import {CSSTransition} from 'react-transition-group';
 import warning from 'warning';
 
 import Item from './Item';
+import {NavigationBarContext} from './context';
 
-export interface IProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IProps
+	extends Omit<React.HTMLAttributes<HTMLDivElement>, 'aria-current'> {
+	/**
+	 * Flag to define if the item represents the current page. Disable this
+	 * attribute only if there are multiple navigations on the page.
+	 */
+	'aria-current'?: 'page' | null;
+
 	/**
 	 * Children elements received from ClayNavigationBar component.
 	 */
@@ -43,6 +51,7 @@ function ClayNavigationBar(props: IProps): JSX.Element & {
 };
 
 function ClayNavigationBar({
+	'aria-current': ariaCurrent = 'page',
 	children,
 	className,
 	inverted = false,
@@ -78,56 +87,60 @@ function ClayNavigationBar({
 				}
 			)}
 		>
-			<ClayLayout.ContainerFluid>
-				<ClayButton
-					aria-expanded={expanded}
-					className={classNames(
-						'navbar-toggler',
-						'navbar-toggler-link',
-						{
-							collapsed: !expanded,
+			<NavigationBarContext.Provider value={{ariaCurrent}}>
+				<ClayLayout.ContainerFluid>
+					<ClayButton
+						aria-expanded={expanded}
+						className={classNames(
+							'navbar-toggler',
+							'navbar-toggler-link',
+							{
+								collapsed: !expanded,
+							}
+						)}
+						data-testid="navbarToggler"
+						displayType="unstyled"
+						onClick={() => setExpanded(!expanded)}
+					>
+						<span className="navbar-text-truncate">
+							{triggerLabel}
+						</span>
+
+						<ClayIcon spritemap={spritemap} symbol="caret-bottom" />
+					</ClayButton>
+
+					<CSSTransition
+						className={classNames('navbar-collapse', {
+							collapse: !expanded,
+						})}
+						classNames={{
+							enter: 'collapsing',
+							enterActive: `show`,
+							enterDone: 'show',
+							exit: `show`,
+							exitActive: 'collapsing',
+						}}
+						in={expanded}
+						onEnter={(element: HTMLElement) =>
+							element.setAttribute('style', `height: 0px`)
 						}
-					)}
-					data-testid="navbarToggler"
-					displayType="unstyled"
-					onClick={() => setExpanded(!expanded)}
-				>
-					<span className="navbar-text-truncate">{triggerLabel}</span>
-
-					<ClayIcon spritemap={spritemap} symbol="caret-bottom" />
-				</ClayButton>
-
-				<CSSTransition
-					className={classNames('navbar-collapse', {
-						collapse: !expanded,
-					})}
-					classNames={{
-						enter: 'collapsing',
-						enterActive: `show`,
-						enterDone: 'show',
-						exit: `show`,
-						exitActive: 'collapsing',
-					}}
-					in={expanded}
-					onEnter={(element: HTMLElement) =>
-						element.setAttribute('style', `height: 0px`)
-					}
-					onEntering={(element: HTMLElement) =>
-						setElementFullHeight(element)
-					}
-					onExit={(element) => setElementFullHeight(element)}
-					onExiting={(element) =>
-						element.setAttribute('style', `height: 0px`)
-					}
-					timeout={250}
-				>
-					<div>
-						<ClayLayout.ContainerFluid>
-							<ul className="navbar-nav">{children}</ul>
-						</ClayLayout.ContainerFluid>
-					</div>
-				</CSSTransition>
-			</ClayLayout.ContainerFluid>
+						onEntering={(element: HTMLElement) =>
+							setElementFullHeight(element)
+						}
+						onExit={(element) => setElementFullHeight(element)}
+						onExiting={(element) =>
+							element.setAttribute('style', `height: 0px`)
+						}
+						timeout={250}
+					>
+						<div>
+							<ClayLayout.ContainerFluid>
+								<ul className="navbar-nav">{children}</ul>
+							</ClayLayout.ContainerFluid>
+						</div>
+					</CSSTransition>
+				</ClayLayout.ContainerFluid>
+			</NavigationBarContext.Provider>
 		</nav>
 	);
 }


### PR DESCRIPTION
Fixes #5307

This PR adds to the API the possibility of disabling `aria-current` from the `VerticalNav` and `NavigationBar` components when setting `aria-current` to `null`.

```jsx
<ClayNavigationBar>
  <ClayNavigationBar.Item active aria-current={null}>
    <ClayLink href="#">Item 1</ClayLink>
  </ClayNavigationBar.Item>
</ClayNavigationBar>

<ClayVerticalNav
  aria-current={null}
/>
```

I'm not sure if this is the behavior we want when disabling `aria-current={null}` we add `aria-selected` instead, but since they are links I'm not sure if this would be the right behavior. @marcoscv-work could you confirm?