### PR TITLE
fix(@clayui/modal): fix Modal accessibility bugs

### DIFF
--- a/packages/clay-modal/docs/index.js
+++ b/packages/clay-modal/docs/index.js
@@ -25,29 +25,24 @@ const modalCode = `const Component = () => {
 					spritemap={spritemap}
 					status="info"
 				>
-					<ClayModal.Header>{'Title'}</ClayModal.Header>
+					<ClayModal.Header>Documents</ClayModal.Header>
 					<ClayModal.Body>
-						<h1>{'Hello world!'}</h1>
+						<p>Do you want to save your documents?</p>
 					</ClayModal.Body>
 					<ClayModal.Footer
-						first={
-							<ClayButton.Group spaced>
-								<ClayButton displayType="secondary">
-									{'Secondary'}
-								</ClayButton>
-								<ClayButton displayType="secondary">
-									{'Secondary'}
-								</ClayButton>
-							</ClayButton.Group>
-						}
 						last={
-							<ClayButton onClick={() => onOpenChange(false)}>{'Primary'}</ClayButton>
+							<ClayButton.Group spaced>
+								<ClayButton displayType="secondary" onClick={() => onOpenChange(false)}>
+									Cancel
+								</ClayButton>
+								<ClayButton onClick={() => onOpenChange(false)}>Save changes</ClayButton>
+							</ClayButton.Group>
 						}
 					/>
 				</ClayModal>
 			)}
 			<ClayButton onClick={() => onOpenChange(true)}>
-				{'Open modal'}
+				Open modal
 			</ClayButton>
 		</>
 	);

--- a/packages/clay-modal/src/Header.tsx
+++ b/packages/clay-modal/src/Header.tsx
@@ -64,13 +64,13 @@ export const Title = ({
 	const {ariaLabelledby} = React.useContext(Context);
 
 	return (
-		<div
+		<h1
 			className={classNames('modal-title', className)}
 			{...otherProps}
 			id={ariaLabelledby}
 		>
 			{children}
-		</div>
+		</h1>
 	);
 };
 

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -87,6 +87,7 @@ const ClayModal = ({
 	containerProps = {},
 	disableAutoClose = false,
 	observer,
+	role = 'dialog',
 	size,
 	spritemap,
 	status,
@@ -161,7 +162,7 @@ const ClayModal = ({
 						'modal-dialog-centered': center,
 					})}
 					ref={modalBodyElementRef}
-					role="dialog"
+					role={role}
 					tabIndex={-1}
 				>
 					<div className="modal-content">

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -104,7 +104,10 @@ const ClayModal = ({
 		() => !disableAutoClose && observer.dispatch(ObserverType.Close)
 	);
 
-	useEffect(() => observer.dispatch(ObserverType.Open), []);
+	useEffect(() => {
+		observer.dispatch(ObserverType.RestoreFocus, document.activeElement);
+		observer.dispatch(ObserverType.Open);
+	}, []);
 
 	useEffect(() => {
 		if (modalBodyElementRef.current) {

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -97,6 +97,9 @@ const ClayModal = ({
 	const modalElementRef = useRef<HTMLDivElement | null>(null);
 	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
 
+	const [show, content] =
+		observer && observer.mutation ? observer.mutation : [false, false];
+
 	warning(observer !== undefined, warningMessage);
 
 	useUserInteractions(
@@ -111,19 +114,16 @@ const ClayModal = ({
 	}, []);
 
 	useEffect(() => {
-		if (modalBodyElementRef.current) {
+		if (modalBodyElementRef.current && show && content) {
 			modalBodyElementRef.current.focus();
 		}
-	}, [modalBodyElementRef]);
+	}, [show, content]);
 
 	const ariaLabelledby = useMemo(() => {
 		counter++;
 
 		return `clay-modal-label-${counter}`;
 	}, []);
-
-	const [show, content] =
-		observer && observer.mutation ? observer.mutation : [false, false];
 
 	useEffect(() => {
 		if (modalElementRef.current && show) {

--- a/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -42,12 +42,12 @@ exports[`ModalProvider -> IncrementalInteractions renders a modal when dispatchi
           <div
             class="modal-header"
           >
-            <div
+            <h1
               class="modal-title"
               id="clay-modal-label-9"
             >
               Title
-            </div>
+            </h1>
             <button
               aria-label="close"
               class="close btn btn-unstyled"

--- a/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-modal/src/__tests__/__snapshots__/index.tsx.snap
@@ -26,12 +26,12 @@ exports[`ClayModal renders 1`] = `
           <div
             class="modal-header"
           >
-            <div
+            <h1
               class="modal-title"
               id="clay-modal-label-1"
             >
               Foo
-            </div>
+            </h1>
             <button
               aria-label="close"
               class="close btn btn-unstyled"
@@ -120,12 +120,12 @@ exports[`ClayModal renders Header w/ low-level API 1`] = `
                 <div
                   class="modal-title-section"
                 >
-                  <div
+                  <h1
                     class="modal-title"
                     id="clay-modal-label-3"
                   >
                     Modal Title
-                  </div>
+                  </h1>
                 </div>
               </div>
               <div
@@ -290,12 +290,12 @@ exports[`ClayModal renders with Header 1`] = `
           <div
             class="modal-header"
           >
-            <div
+            <h1
               class="modal-title"
               id="clay-modal-label-2"
             >
               Foo
-            </div>
+            </h1>
             <button
               aria-label="close"
               class="close btn btn-unstyled"

--- a/packages/clay-modal/src/types.ts
+++ b/packages/clay-modal/src/types.ts
@@ -10,9 +10,10 @@ export type Size = 'full-screen' | 'lg' | 'sm';
 export enum ObserverType {
 	Close = 0,
 	Open = 1,
+	RestoreFocus = 2,
 }
 
 export type Observer = {
-	dispatch: (type: ObserverType) => void;
+	dispatch: (type: ObserverType, payload?: any) => void;
 	mutation: [boolean, boolean];
 };

--- a/packages/clay-modal/src/useModal.tsx
+++ b/packages/clay-modal/src/useModal.tsx
@@ -60,6 +60,8 @@ export const useModal = ({
 	const [visible, setVisible] = useState<[boolean, boolean]>([false, false]);
 	const timerIdRef = useRef<NodeJS.Timeout | null>(null);
 
+	const restoreTriggerRef = useRef<HTMLElement | null>(null);
+
 	/**
 	 * Control the close of the modal to create the component's "unmount"
 	 * animation and call the onClose prop with delay.
@@ -73,6 +75,11 @@ export const useModal = ({
 				onClose();
 			}
 
+			if (restoreTriggerRef.current) {
+				restoreTriggerRef.current.focus();
+				restoreTriggerRef.current = null;
+			}
+
 			setOpen(false);
 			setVisible([false, false]);
 		});
@@ -84,13 +91,19 @@ export const useModal = ({
 		timerIdRef.current = delay(() => setVisible([true, true]));
 	};
 
-	const handleObserverDispatch = (type: ObserverType) => {
+	const handleObserverDispatch = (
+		type: ObserverType,
+		payload: HTMLElement
+	) => {
 		switch (type) {
 			case ObserverType.Close:
 				handleCloseModal();
 				break;
 			case ObserverType.Open:
 				handleOpenModal();
+				break;
+			case ObserverType.RestoreFocus:
+				restoreTriggerRef.current = payload;
 				break;
 			default:
 				break;

--- a/packages/clay-modal/stories/Modal.stories.tsx
+++ b/packages/clay-modal/stories/Modal.stories.tsx
@@ -47,8 +47,7 @@ export const Default = (args: any) => {
 						scrollable={args.scrollable}
 						url={args.url}
 					>
-						<h1>Hello world!</h1>
-						<div>
+						<p>
 							Lorem ipsum dolor sit amet, consectetur adipiscing
 							elit. Curabitur dignissim eu ante eget lobortis.
 							Praesent a mattis diam, nec auctor nisi. Nam porta
@@ -64,23 +63,21 @@ export const Default = (args: any) => {
 							posuere enim porttitor, mollis justo eget, molestie
 							mauris. Duis lobortis purus quis risus sodales
 							dictum ut eu velit.
-						</div>
+						</p>
 					</ClayModal.Body>
 					<ClayModal.Footer
-						first={
+						last={
 							<ClayButton.Group spaced>
-								<ClayButton displayType="secondary">
-									Secondary
+								<ClayButton
+									displayType="secondary"
+									onClick={() => onOpenChange(false)}
+								>
+									Cancel
 								</ClayButton>
-								<ClayButton displayType="secondary">
-									Secondary
+								<ClayButton onClick={() => onOpenChange(false)}>
+									Save changes
 								</ClayButton>
 							</ClayButton.Group>
-						}
-						last={
-							<ClayButton onClick={() => onOpenChange(false)}>
-								Primary
-							</ClayButton>
 						}
 					/>
 				</ClayModal>
@@ -96,12 +93,12 @@ export const Default = (args: any) => {
 };
 
 Default.args = {
-	autoClose: true,
+	autoClose: false,
 	center: false,
 	scrollable: false,
 	size: 'lg',
 	status: undefined,
-	title: 'Title',
+	title: 'Modal Title',
 	url: '',
 };
 
@@ -298,7 +295,7 @@ const MyApp = () => {
 			onClick={() =>
 				dispatch({
 					payload: {
-						body: <h1>Hello world!</h1>,
+						body: <h2>Hello world!</h2>,
 						footer: [
 							<></>,
 							<></>,
@@ -327,7 +324,7 @@ const MyAppWithoutFooterAndHeader = () => {
 			onClick={() =>
 				dispatch({
 					payload: {
-						body: <h1>Hello world!</h1>,
+						body: <h2>Hello world!</h2>,
 						size: 'lg',
 					},
 					type: 1,


### PR DESCRIPTION
Fixes #5295

This PR fixes some Modal accessibility errors, the problem was that the focus happened before the content rendered for some reason that made it not correctly announce the dialog, probably because it didn't find the id of `aria-labelledby`.

Also some small features and fixes:

- Allows you to modify the `role` of the modal
- Restores trigger focus when closing the modal
- Change title tag to h1