### PR TITLE
fix(@clayui/navigation-bar): Removes classes btn-unstyled and link-unstyled from nav-link

### DIFF
--- a/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
@@ -31,6 +31,7 @@ $cadmin-navigation-bar-base: map-deep-merge(
 		navbar-nav: (
 			nav-link: (
 				border-radius: 0,
+				border-width: 0,
 				outline: 0,
 				font-size: inherit,
 				focus: (

--- a/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_navigation-bar.scss
@@ -32,6 +32,7 @@ $cadmin-navigation-bar-base: map-deep-merge(
 			nav-link: (
 				border-radius: 0,
 				outline: 0,
+				font-size: inherit,
 				focus: (
 					box-shadow: $cadmin-component-focus-box-shadow,
 				),

--- a/packages/clay-css/src/scss/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/variables/_navigation-bar.scss
@@ -22,6 +22,11 @@ $navigation-bar-base: map-deep-merge(
 	(
 		border-color: transparent,
 		border-style: solid,
+		navbar-nav: (
+			nav-link: (
+				font-size: inherit,
+			),
+		),
 		media-breakpoint-down: (),
 		media-breakpoint-up: (),
 	),

--- a/packages/clay-css/src/scss/variables/_navigation-bar.scss
+++ b/packages/clay-css/src/scss/variables/_navigation-bar.scss
@@ -24,6 +24,7 @@ $navigation-bar-base: map-deep-merge(
 		border-style: solid,
 		navbar-nav: (
 			nav-link: (
+				border-width: 0,
 				font-size: inherit,
 			),
 		),

--- a/packages/clay-navigation-bar/src/Item.tsx
+++ b/packages/clay-navigation-bar/src/Item.tsx
@@ -51,7 +51,7 @@ const ClayNavigationBarIcon = ({
 								}
 							),
 							// @ts-ignore
-							displayType: 'unstyled',
+							displayType: null,
 							key: index,
 						});
 					}

--- a/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -16,7 +16,7 @@ exports[`ClayNavigationBar collapses the previously expanded dropdown when trigg
       >
         <a
           aria-current="page"
-          class="nav-link active link-unstyled"
+          class="nav-link active"
           href="#1"
         >
           <span
@@ -30,7 +30,7 @@ exports[`ClayNavigationBar collapses the previously expanded dropdown when trigg
         class="nav-item"
       >
         <button
-          class="nav-link btn btn-unstyled"
+          class="nav-link btn"
           type="button"
         >
           <span
@@ -87,7 +87,7 @@ exports[`ClayNavigationBar renders 1`] = `
             >
               <a
                 aria-current="page"
-                class="nav-link active link-unstyled"
+                class="nav-link active"
                 href="#1"
               >
                 <span
@@ -101,7 +101,7 @@ exports[`ClayNavigationBar renders 1`] = `
               class="nav-item"
             >
               <button
-                class="nav-link btn btn-unstyled"
+                class="nav-link btn"
                 type="button"
               >
                 <span
@@ -115,7 +115,7 @@ exports[`ClayNavigationBar renders 1`] = `
               class="nav-item"
             >
               <a
-                class="nav-link link-unstyled"
+                class="nav-link"
                 href="#3"
               >
                 <span
@@ -204,7 +204,7 @@ exports[`ClayNavigationBar renders a dropdown when clicking the trigger element 
       >
         <a
           aria-current="page"
-          class="nav-link active link-unstyled"
+          class="nav-link active"
           href="#1"
         >
           <span
@@ -218,7 +218,7 @@ exports[`ClayNavigationBar renders a dropdown when clicking the trigger element 
         class="nav-item"
       >
         <button
-          class="nav-link btn btn-unstyled"
+          class="nav-link btn"
           type="button"
         >
           <span
@@ -274,7 +274,7 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
               class="nav-item"
             >
               <a
-                class="nav-link link-unstyled"
+                class="nav-link"
                 href="#1"
               >
                 <span
@@ -289,7 +289,7 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
             >
               <button
                 aria-current="page"
-                class="nav-link active btn btn-unstyled"
+                class="nav-link active btn"
                 type="button"
               >
                 <span
@@ -303,7 +303,7 @@ exports[`ClayNavigationBar renders when passing more than one active item 1`] = 
               class="nav-item"
             >
               <a
-                class="nav-link link-unstyled"
+                class="nav-link"
                 href="#3"
               >
                 <span
@@ -363,7 +363,7 @@ exports[`ClayNavigationBar renders with a single item 1`] = `
             >
               <a
                 aria-current="page"
-                class="nav-link active link-unstyled"
+                class="nav-link active"
                 href="#1"
               >
                 <span
@@ -423,7 +423,7 @@ exports[`ClayNavigationBar throws a warning when passing more than one active pr
             >
               <a
                 aria-current="page"
-                class="nav-link active link-unstyled"
+                class="nav-link active"
                 href="#1"
               >
                 <span
@@ -438,7 +438,7 @@ exports[`ClayNavigationBar throws a warning when passing more than one active pr
             >
               <button
                 aria-current="page"
-                class="nav-link active btn btn-unstyled"
+                class="nav-link active btn"
                 type="button"
               >
                 <span


### PR DESCRIPTION
fixes #5314

@matuzalemsteles I think this should be relatively safe. I checked Portal and seems like the `btn-unstyled` and `link-unstyled` for Navigation Bar aren't used.