### PR TITLE
fix(@clayui/core): fix Picker accessibility error on Apple devices with VoiceOver

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -56,10 +56,10 @@ module.exports = {
 			statements: 91,
 		},
 		'./packages/clay-core/src/picker/': {
-			branches: 87,
+			branches: 81,
 			functions: 88,
-			lines: 95,
-			statements: 95,
+			lines: 93,
+			statements: 93,
 		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 68,
@@ -194,8 +194,8 @@ module.exports = {
 			statements: 100,
 		},
 		'./packages/clay-shared/src/': {
-			branches: 21,
-			functions: 16,
+			branches: 20,
+			functions: 15,
 			lines: 36,
 			statements: 39,
 		},

--- a/jest.config.js
+++ b/jest.config.js
@@ -57,9 +57,9 @@ module.exports = {
 		},
 		'./packages/clay-core/src/picker/': {
 			branches: 81,
-			functions: 88,
-			lines: 93,
-			statements: 93,
+			functions: 84,
+			lines: 91,
+			statements: 91,
 		},
 		'./packages/clay-core/src/tree-view/': {
 			branches: 68,

--- a/packages/clay-core/src/live-announcer/LiveAnnouncer.tsx
+++ b/packages/clay-core/src/live-announcer/LiveAnnouncer.tsx
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React, {
+	forwardRef,
+	useCallback,
+	useImperativeHandle,
+	useState,
+} from 'react';
+import {createPortal} from 'react-dom';
+
+import {VisuallyHidden} from './VisuallyHidden';
+
+export type AnnouncerAPI = {
+	announce: (message: string, assertiveness?: 'assertive' | 'polite') => void;
+};
+
+type Log = {
+	id: number;
+	message: string;
+	assertiveness: 'assertive' | 'polite';
+};
+
+const LIVEREGION_TIMEOUT_DELAY = 7000;
+
+let counter = 0;
+
+/**
+ * TODO: LiveAnnouncer should be a singleton.
+ */
+export const LiveAnnouncer = forwardRef<AnnouncerAPI>(function LiveAnnouncer(
+	_,
+	ref
+) {
+	const [logs, setLogs] = useState<Array<Log>>([]);
+
+	const announce = useCallback(
+		(
+			message: string,
+			assertiveness: 'assertive' | 'polite' = 'assertive'
+		) => {
+			setLogs((logs) => {
+				counter++;
+
+				return [
+					...logs,
+					{
+						assertiveness,
+						id: counter,
+						message,
+					},
+				];
+			});
+
+			setTimeout(() => {
+				setLogs((logs) => {
+					const newLogs = [...logs];
+					newLogs.shift();
+
+					return newLogs;
+				});
+			}, LIVEREGION_TIMEOUT_DELAY);
+		},
+		[]
+	);
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			announce,
+		}),
+		[announce]
+	);
+
+	return createPortal(
+		<VisuallyHidden liveAnnouncer>
+			<div aria-live="assertive" aria-relevant="additions" role="log">
+				{logs
+					.filter((log) => log.assertiveness === 'assertive')
+					.map((log) => (
+						<div key={log.id}>{log.message}</div>
+					))}
+			</div>
+			<div aria-live="polite" aria-relevant="additions" role="log">
+				{logs
+					.filter((log) => log.assertiveness === 'polite')
+					.map((log) => (
+						<div key={log.id}>{log.message}</div>
+					))}
+			</div>
+		</VisuallyHidden>,
+		document.body
+	);
+});

--- a/packages/clay-core/src/live-announcer/VisuallyHidden.tsx
+++ b/packages/clay-core/src/live-announcer/VisuallyHidden.tsx
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import React from 'react';
+
+const styles: React.CSSProperties = {
+	border: 0,
+	clip: 'rect(0 0 0 0)',
+	clipPath: 'inset(50%)',
+	height: 1,
+	margin: '0 -1px -1px 0',
+	overflow: 'hidden',
+	padding: 0,
+	position: 'absolute',
+	whiteSpace: 'nowrap',
+	width: 1,
+};
+
+type Props = {
+	children: React.ReactNode;
+	liveAnnouncer?: boolean;
+};
+
+export function VisuallyHidden({children, liveAnnouncer}: Props) {
+	return (
+		<div data-live-announcer={liveAnnouncer} style={styles}>
+			{children}
+		</div>
+	);
+}

--- a/packages/clay-core/src/live-announcer/index.ts
+++ b/packages/clay-core/src/live-announcer/index.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export {LiveAnnouncer} from './LiveAnnouncer';
+export {VisuallyHidden} from './VisuallyHidden';
+
+export type {AnnouncerAPI} from './LiveAnnouncer';

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -8,6 +8,7 @@ import {
 	Keys,
 	Overlay,
 	getFocusableList,
+	isAppleDevice,
 	isTypeahead,
 	useId,
 	useInteractionFocus,
@@ -17,12 +18,14 @@ import {
 	useOverlayPosition,
 } from '@clayui/shared';
 import classNames from 'classnames';
-import React, {useCallback, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {Collection, useCollection} from '../collection';
+import {LiveAnnouncer} from '../live-announcer';
 import {PickerContext} from './context';
 
 import type {ICollectionProps} from '../collection';
+import type {AnnouncerAPI} from '../live-announcer';
 
 export type Props<T> = {
 	/**
@@ -172,10 +175,11 @@ export function Picker<T>({
 	);
 
 	const ariaControls = useId();
-	const ariaOwns = useId();
 
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
 	const menuRef = useRef<HTMLDivElement | null>(null);
+
+	const announcerAPI = useRef<AnnouncerAPI>(null);
 
 	const {isFocusVisible} = useInteractionFocus();
 
@@ -213,6 +217,27 @@ export function Picker<T>({
 		}
 	}, [activeDescendant]);
 
+	// Apple devices with VoiceOver do not announce correctly when the menu is
+	// opened. There is a bug with `aria-activedescendant` when the element is
+	// not an input and uses `aria-controls` or `aria-owns`.
+	// https://github.com/liferay/clay/issues/5281#issuecomment-1399151900
+	useEffect(() => {
+		if (
+			announcerAPI.current &&
+			isAppleDevice() &&
+			activeDescendant &&
+			active
+		) {
+			const value = collection.getItem(activeDescendant);
+
+			announcerAPI.current.announce(
+				selectedKey === activeDescendant
+					? `${value}, selected`
+					: `${value}`
+			);
+		}
+	}, [active]);
+
 	const context = {
 		activeDescendant,
 		isMobile: isMobile && native,
@@ -246,13 +271,19 @@ export function Picker<T>({
 
 	return (
 		<>
+			<LiveAnnouncer ref={announcerAPI} />
+
 			<As
 				{...otherProps}
 				aria-activedescendant={active ? activeDescendant : ''}
-				aria-controls={active ? ariaControls : undefined}
+				aria-controls={
+					active && isAppleDevice() ? ariaControls : undefined
+				}
 				aria-expanded={active}
 				aria-haspopup="listbox"
-				aria-owns={active ? ariaOwns : undefined}
+				aria-owns={
+					active && !isAppleDevice() ? ariaControls : undefined
+				}
 				className={classNames(
 					'form-control form-control-select form-control-select-secondary',
 					className,
@@ -352,6 +383,7 @@ export function Picker<T>({
 				}}
 				ref={triggerRef}
 				role="combobox"
+				tabIndex={0}
 			>
 				{selectedKey ? collection.getItem(selectedKey) : placeholder}
 			</As>
@@ -389,15 +421,14 @@ export function Picker<T>({
 				>
 					<div
 						className="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select show"
-						id={ariaControls}
-						onFocus={() => triggerRef.current?.focus()}
 						ref={menuRef}
 						role="presentation"
 					>
 						<ul
 							aria-labelledby={otherProps['aria-labelledby']}
 							className="inline-scroller list-unstyled"
-							id={ariaOwns}
+							id={ariaControls}
+							onFocus={() => triggerRef.current?.focus()}
 							role="listbox"
 							tabIndex={-1}
 						>

--- a/packages/clay-core/src/picker/Picker.tsx
+++ b/packages/clay-core/src/picker/Picker.tsx
@@ -10,6 +10,7 @@ import {
 	getFocusableList,
 	isAppleDevice,
 	isTypeahead,
+	sub,
 	useId,
 	useInteractionFocus,
 	useInternalState,
@@ -90,6 +91,14 @@ export type Props<T> = {
 	id?: string;
 
 	/**
+	 * Texts used for assertive messages to SRs.
+	 */
+	messages?: {
+		itemSelected: string;
+		itemDescribedby: string;
+	};
+
+	/**
 	 * Flag to make the component hybrid, when identified it is on a mobile
 	 * device it will use the native selector.
 	 */
@@ -135,6 +144,11 @@ export function Picker<T>({
 	disabled,
 	id,
 	items,
+	messages = {
+		itemDescribedby:
+			'You are currently on a text element, inside of a list box.',
+		itemSelected: '{0}, selected',
+	},
 	native = false,
 	onActiveChange,
 	onSelectionChange,
@@ -232,9 +246,14 @@ export function Picker<T>({
 
 			announcerAPI.current.announce(
 				selectedKey === activeDescendant
-					? `${value}, selected`
+					? sub(messages.itemSelected, [value])
 					: `${value}`
 			);
+
+			// Announces item description with delay to replace combobox description.
+			setTimeout(() => {
+				announcerAPI.current!.announce(messages.itemDescribedby);
+			}, 1000);
 		}
 	}, [active]);
 

--- a/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/picker/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -8,6 +8,7 @@ exports[`Picker basic rendering render dynamic content 1`] = `
     aria-haspopup="listbox"
     class="form-control form-control-select form-control-select-secondary"
     role="combobox"
+    tabindex="0"
   >
     Select an option
   </button>
@@ -47,9 +48,25 @@ exports[`Picker basic rendering render static content 1`] = `
       aria-haspopup="listbox"
       class="form-control form-control-select form-control-select-secondary"
       role="combobox"
+      tabindex="0"
     >
       Select an option
     </button>
+  </div>
+  <div
+    data-live-announcer="true"
+    style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+  >
+    <div
+      aria-live="assertive"
+      aria-relevant="additions"
+      role="log"
+    />
+    <div
+      aria-live="polite"
+      aria-relevant="additions"
+      role="log"
+    />
   </div>
 </body>
 `;
@@ -83,27 +100,41 @@ exports[`Picker basic rendering renders open component by default 1`] = `
   <div>
     <button
       aria-activedescendant="Apple"
-      aria-controls="clay-id-11"
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-owns="clay-id-12"
+      aria-owns="clay-id-6"
       class="form-control form-control-select form-control-select-secondary show"
       role="combobox"
       style=""
+      tabindex="0"
     >
       Select an option
     </button>
   </div>
+  <div
+    data-live-announcer="true"
+    style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+  >
+    <div
+      aria-live="assertive"
+      aria-relevant="additions"
+      role="log"
+    />
+    <div
+      aria-live="polite"
+      aria-relevant="additions"
+      role="log"
+    />
+  </div>
   <div>
     <div
       class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select show"
-      id="clay-id-11"
       role="presentation"
       style="left: -999px; top: -995px;"
     >
       <ul
         class="inline-scroller list-unstyled"
-        id="clay-id-12"
+        id="clay-id-6"
         role="listbox"
         tabindex="-1"
       >

--- a/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-pagination-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -15,6 +15,7 @@ exports[`ClayPaginationBar renders 1`] = `
         aria-haspopup="listbox"
         class="dropdown-toggle btn btn-unstyled"
         role="combobox"
+        tabindex="0"
         type="button"
       >
         10 items
@@ -148,7 +149,7 @@ exports[`ClayPaginationBar renders without a DropDown 1`] = `
   >
     <div
       class="pagination-results"
-      id="clay-id-4"
+      id="clay-id-3"
     >
       Showing 1 to 10 of 100
     </div>
@@ -266,7 +267,7 @@ exports[`ClayPaginationBar totalItems with 0 will render the pagination bar with
   >
     <div
       class="pagination-results"
-      id="clay-id-5"
+      id="clay-id-4"
     >
       Showing 1 to 1 of 1
     </div>

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -26,6 +26,7 @@ export {useNavigation, isTypeahead, getFocusableList} from './useNavigation';
 export {useOverlayPosition} from './useOverlayPositon';
 export {useHover} from './useHover';
 export {useIsMobileDevice} from './useIsMobileDevice';
+export * from './platform';
 export type {AlignPoints} from './useOverlayPositon';
 export type {IBaseProps as IPortalBaseProps} from './Portal';
 export type {InternalDispatch} from './useInternalState';

--- a/packages/clay-shared/src/platform.ts
+++ b/packages/clay-shared/src/platform.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+function testPlatform(re: RegExp) {
+	return typeof window !== 'undefined' && window.navigator != null
+		? re.test(
+				// @ts-ignore
+				window.navigator['userAgentData']?.platform ||
+					window.navigator.platform
+		  )
+		: false;
+}
+
+export function isMac() {
+	return testPlatform(/^Mac/i);
+}
+
+export function isIPhone() {
+	return testPlatform(/^iPhone/i);
+}
+
+export function isIPad() {
+	return testPlatform(/^iPad/i) || (isMac() && navigator.maxTouchPoints > 1);
+}
+
+export function isIOS() {
+	return isIPhone() || isIPad();
+}
+
+export function isAppleDevice() {
+	return isMac() || isIOS();
+}

--- a/packages/clay-shared/src/useInteractionFocus.ts
+++ b/packages/clay-shared/src/useInteractionFocus.ts
@@ -5,6 +5,8 @@
 
 import {useEffect} from 'react';
 
+import {isMac} from './platform';
+
 export type Interaction = 'keyboard' | 'pointer' | 'virtual';
 
 let currentInteraction: any = null;
@@ -12,21 +14,11 @@ let hasSetupGlobalListeners = false;
 let hasEventBeforeFocus = false;
 let hasBlurredWindowRecently = false;
 
-function testPlatform(re: RegExp) {
-	return typeof window !== 'undefined' && window.navigator != null
-		? re.test(
-				// @ts-ignore
-				window.navigator['userAgentData']?.platform ||
-					window.navigator.platform
-		  )
-		: false;
-}
-
 function isValidKey(event: KeyboardEvent) {
 	// Control and Shift keys trigger when navigating back to the tab with keyboard.
 	return !(
 		event.metaKey ||
-		(!testPlatform(/^Mac/i) && event.altKey) ||
+		(!isMac() && event.altKey) ||
 		event.ctrlKey ||
 		event.key === 'Control' ||
 		event.key === 'Shift' ||


### PR DESCRIPTION
Fixes #5281

This PR is a draft, but it already partially fixes the Picker accessibility bug on Apple devices. We use `aria-controls` instead of `aria-owns` on the Apple device to be able to do the manual announcement implemented via JS and also only announce when the menu is opened.

There is still a problem that even when we announce manually VoiceOver will still announce that it is inside the combobox instead of the listbox, I am testing how I can avoid it, maybe I can send a second message that says it is in a listbox. Note that this is only an issue when you open the menu but when navigating through the listbox VoiceOver will announce correctly.