### PR TITLE
fix(@clayui/date-picker): Date Range should be selectable with a sing…

### DIFF
--- a/packages/clay-date-picker/src/index.tsx
+++ b/packages/clay-date-picker/src/index.tsx
@@ -438,7 +438,7 @@ const ClayDatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			let daysSelectedToString;
 
 			if (range) {
-				if (startDate !== endDate) {
+				if (startDate.toString() !== endDate.toString()) {
 					newDaysSelected = [date, date];
 				} else if (date < startDate) {
 					newDaysSelected = [date, endDate];


### PR DESCRIPTION
…le click

fixes #5318

I'm not sure why comparing the Date objects? didn't compare correctly even when they printed the same Date. Converting the dates to string seem to fix the problem.

I also found another bug that's easier to replicate with this pr. I'll file a separate issue for that.