### PR TITLE
chore(@clayui/shared): uses named export instead of `*`

### DIFF
--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -26,7 +26,7 @@ export {useNavigation, isTypeahead, getFocusableList} from './useNavigation';
 export {useOverlayPosition} from './useOverlayPositon';
 export {useHover} from './useHover';
 export {useIsMobileDevice} from './useIsMobileDevice';
-export * from './platform';
+export {isMac, isIPhone, isIPad, isIOS, isAppleDevice} from './platform';
 export type {AlignPoints} from './useOverlayPositon';
 export type {IBaseProps as IPortalBaseProps} from './Portal';
 export type {InternalDispatch} from './useInternalState';


### PR DESCRIPTION
It looks like this broke the DXP build, an attempt to avoid DXP bugs.