### PR TITLE
feat(@clayui/core): adds initial implementation of drag and drop via keyboard in treeview

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -62,10 +62,10 @@ module.exports = {
 			statements: 91,
 		},
 		'./packages/clay-core/src/tree-view/': {
-			branches: 68,
-			functions: 73,
-			lines: 76,
-			statements: 75,
+			branches: 59,
+			functions: 70,
+			lines: 71,
+			statements: 71,
 		},
 		'./packages/clay-data-provider/src/': {
 			branches: 69,

--- a/packages/clay-core/package.json
+++ b/packages/clay-core/package.json
@@ -34,6 +34,7 @@
 		"@clayui/provider": "^3.77.0",
 		"@clayui/shared": "^3.87.0",
 		"@tanstack/react-virtual": "3.0.0-beta.18",
+		"aria-hidden": "^1.2.2",
 		"classnames": "^2.2.6",
 		"fuzzy": "^0.1.3",
 		"react-dnd": "^11.1.1",

--- a/packages/clay-core/src/live-announcer/VisuallyHidden.tsx
+++ b/packages/clay-core/src/live-announcer/VisuallyHidden.tsx
@@ -19,14 +19,21 @@ const styles: React.CSSProperties = {
 };
 
 type Props = {
-	children: React.ReactNode;
+	children?: React.ReactNode;
 	liveAnnouncer?: boolean;
-};
+} & React.HTMLAttributes<HTMLDivElement>;
 
-export function VisuallyHidden({children, liveAnnouncer}: Props) {
-	return (
-		<div data-live-announcer={liveAnnouncer} style={styles}>
-			{children}
-		</div>
-	);
-}
+export const VisuallyHidden = React.forwardRef<HTMLDivElement, Props>(
+	function VisuallyHidden({children, liveAnnouncer, ...props}, ref) {
+		return (
+			<div
+				{...props}
+				data-live-announcer={liveAnnouncer}
+				ref={ref}
+				style={styles}
+			>
+				{children}
+			</div>
+		);
+	}
+);

--- a/packages/clay-core/src/tree-view/Collection.tsx
+++ b/packages/clay-core/src/tree-view/Collection.tsx
@@ -57,12 +57,14 @@ export function Collection<T extends Record<string, any>>({
 	as,
 	children,
 	items,
+	...otherProps
 }: Props & ICollectionProps<T>) {
 	const api = useAPI();
 	const {key: parentKey} = useItem();
 
 	return (
 		<CollectionBase
+			{...otherProps}
 			as={as}
 			exclude={exclude}
 			itemContainer={ItemContainer}

--- a/packages/clay-core/src/tree-view/DragAndDrop.tsx
+++ b/packages/clay-core/src/tree-view/DragAndDrop.tsx
@@ -183,13 +183,14 @@ export const DragAndDropProvider = ({children, rootRef}: Props) => {
 
 	useEffect(() => {
 		if (rootRef.current && state.mode === 'keyboard') {
-			return suppressOthers(
-				Array.from(
-					rootRef.current.querySelectorAll(
-						'[aria-roledescription="drop indicator"], [data-draggable="true"]'
-					)
-				)
-			);
+			return suppressOthers([
+				...rootRef.current.querySelectorAll(
+					'[aria-roledescription="drop indicator"], [data-draggable="true"], [class="component-text"]'
+				),
+				document.body.querySelector<Element>(
+					'[data-live-announcer="true"]'
+				)!,
+			]);
 		}
 	}, [state.mode]);
 

--- a/packages/clay-core/src/tree-view/DragAndDrop.tsx
+++ b/packages/clay-core/src/tree-view/DragAndDrop.tsx
@@ -1,0 +1,315 @@
+/**
+ * SPDX-FileCopyrightText: © 2022 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {Keys, useId} from '@clayui/shared';
+import React, {
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from 'react';
+import {createPortal} from 'react-dom';
+
+import {LiveAnnouncer} from '../live-announcer';
+import {useTreeViewContext} from './context';
+
+import type {AnnouncerAPI} from '../live-announcer';
+
+type ContextProps = {
+	mode: 'keyboard' | 'mouse' | null;
+	position: 'bottom' | 'middle' | 'top' | null;
+	currentDrag: React.Key | null;
+	dragDescribedBy: string;
+	dragDropDescribedBy: string;
+	dragCancelDescribedBy: string;
+	currentTarget: React.Key | null;
+	lastDrop: React.Key | null;
+	onDragStart: (target: React.Key) => void;
+	onDrop: () => void;
+};
+
+type State = Pick<
+	ContextProps,
+	'mode' | 'currentTarget' | 'currentDrag' | 'position' | 'lastDrop'
+>;
+
+const DnDContext = React.createContext<ContextProps>({} as ContextProps);
+
+type Props = {
+	rootRef: React.RefObject<HTMLUListElement>;
+	children: React.ReactNode;
+};
+
+function getFocusableTree(rootRef: React.RefObject<HTMLUListElement>) {
+	if (!rootRef.current) {
+		return [];
+	}
+
+	return [...rootRef.current.querySelectorAll('[role="treeitem"]')].filter(
+		(element) =>
+			!(
+				element.getAttribute('disabled') ||
+				element.closest('.treeview-item-dragging')
+			)
+	);
+}
+
+function getNextTarget(
+	rootRef: React.RefObject<HTMLUListElement>,
+	dragKey: React.Key
+) {
+	const focusableTree = getFocusableTree(rootRef);
+
+	let dragPosition = 0;
+
+	const items = focusableTree.filter((element, index) => {
+		const [type, key] = element.getAttribute('data-id')!.split(',');
+		const reactKey = type === 'number' ? Number(key) : key;
+
+		if (reactKey === dragKey) {
+			dragPosition = index;
+		}
+
+		return !(
+			reactKey === dragKey ||
+			element.closest(
+				`[data-id="${
+					typeof dragKey === 'number'
+						? `number,${dragKey}`
+						: `string,${dragKey}`
+				}"]`
+			)
+		);
+	});
+
+	const target =
+		items[dragPosition === items.length ? dragPosition - 1 : dragPosition];
+
+	const [type, key] = target.getAttribute('data-id')!.split(',');
+
+	return type === 'number' ? Number(key) : key;
+}
+
+export const DragAndDropProvider = ({children, rootRef}: Props) => {
+	const {dragAndDrop, layout, reorder} = useTreeViewContext();
+
+	const announcerRef = useRef<AnnouncerAPI>(null);
+
+	const [state, setState] = useState<State>({
+		currentDrag: null,
+		currentTarget: null,
+		lastDrop: null,
+		mode: null,
+		position: null,
+	});
+
+	const onDragStart = useCallback((dragKey: React.Key) => {
+		announcerRef.current?.announce(
+			'Started dragging. Press Tab to navigate to a drop target, then press Enter to drop, or press Escape to cancel.'
+		);
+
+		const nextTargetKey = getNextTarget(rootRef, dragKey);
+
+		setState((state) => ({
+			...state,
+			currentDrag: dragKey,
+			currentTarget: nextTargetKey,
+			mode: 'keyboard',
+			position: 'bottom',
+		}));
+	}, []);
+
+	const onDrop = useCallback(() => {
+		const {currentDrag, currentTarget, position} = state;
+		const dropItem = layout.layoutKeys.current.get(currentTarget!);
+		const dragItem = layout.layoutKeys.current.get(currentDrag!);
+
+		reorder(dragItem!.loc, getNewItemPath(dropItem!.loc, position!));
+		setState((state) => ({
+			...state,
+			currentDrag: null,
+			currentTarget: null,
+			lastDrop: currentTarget,
+			mode: null,
+			position: null,
+		}));
+		announcerRef.current?.announce('Drop complete.');
+	}, [state]);
+
+	const dragDescribedBy = useId();
+	const dragDropDescribedBy = useId();
+	const dragCancelDescribedBy = useId();
+
+	useEffect(() => {
+		if (state.mode === 'keyboard') {
+			const onKeyDown = (event: KeyboardEvent) => {
+				switch (event.key) {
+					case Keys.Esc:
+						announcerRef.current?.announce('Drop cancelled.');
+						setState((state) => ({
+							...state,
+							currentDrag: null,
+							currentTarget: null,
+							mode: null,
+							position: null,
+						}));
+						break;
+					case Keys.Enter: {
+						onDrop();
+						break;
+					}
+					case Keys.Up:
+					case Keys.Down: {
+						event.preventDefault();
+						event.stopPropagation();
+
+						const items = getFocusableTree(rootRef);
+						const position = items.findIndex((element) =>
+							element.getAttribute('data-dnd-dropping')
+						);
+
+						const item =
+							items[
+								event.key === Keys.Up
+									? position - 1
+									: position + 1
+							];
+
+						if (
+							(event.key === Keys.Down &&
+								state.position === 'top') ||
+							(event.key === Keys.Up &&
+								state.position === 'bottom')
+						) {
+							setState((state) => ({
+								...state,
+								position: 'middle',
+							}));
+						} else {
+							if (!item) {
+								setState((state) => ({
+									...state,
+									position: position === 0 ? 'top' : 'bottom',
+								}));
+
+								return;
+							}
+
+							const [type, key] = item
+								.getAttribute('data-id')!
+								.split(',');
+
+							setState((state) => ({
+								...state,
+								currentTarget:
+									type === 'number' ? Number(key) : key,
+								position:
+									event.key === Keys.Up ? 'bottom' : 'top',
+							}));
+						}
+						break;
+					}
+					default:
+						break;
+				}
+			};
+
+			document.addEventListener('keydown', onKeyDown, true);
+
+			return () => {
+				document.removeEventListener('keydown', onKeyDown, true);
+			};
+		}
+	}, [state]);
+
+	return (
+		<DnDContext.Provider
+			value={{
+				...state,
+				dragCancelDescribedBy,
+				dragDescribedBy,
+				dragDropDescribedBy,
+				onDragStart,
+				onDrop,
+			}}
+		>
+			{dragAndDrop && <LiveAnnouncer ref={announcerRef} />}
+
+			{children}
+
+			{dragAndDrop && (
+				<>
+					{createPortal(
+						<div id={dragDescribedBy} style={{display: 'none'}}>
+							Press Enter to start dragging.
+						</div>,
+						document.body
+					)}
+
+					{state.mode === 'keyboard' && (
+						<>
+							{createPortal(
+								<div
+									id={dragDropDescribedBy}
+									style={{display: 'none'}}
+								>
+									Press Enter to drop. Press Escape to cancel
+									drag.
+								</div>,
+								document.body
+							)}
+							{createPortal(
+								<div
+									id={dragCancelDescribedBy}
+									style={{display: 'none'}}
+								>
+									Dragging. Press Enter to cancel drag.
+								</div>,
+								document.body
+							)}
+						</>
+					)}
+				</>
+			)}
+		</DnDContext.Provider>
+	);
+};
+
+export const TARGET_POSITION = {
+	BOTTOM: 'bottom',
+	MIDDLE: 'middle',
+	TOP: 'top',
+} as const;
+
+type ValueOf<T> = T[keyof T];
+
+export type Position = ValueOf<typeof TARGET_POSITION>;
+
+export function getNewItemPath(path: Array<number>, overPosition: Position) {
+	let indexes = [...path];
+
+	const lastPathIndex = indexes.pop() as number;
+
+	switch (overPosition) {
+		case TARGET_POSITION.BOTTOM:
+			indexes = [...indexes, lastPathIndex + 1];
+			break;
+		case TARGET_POSITION.MIDDLE:
+			indexes = [...indexes, lastPathIndex, 0];
+			break;
+		case TARGET_POSITION.TOP:
+			indexes = [...indexes, lastPathIndex];
+			break;
+		default:
+			break;
+	}
+
+	return indexes;
+}
+
+export const useDnD = () => {
+	return useContext(DnDContext);
+};

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -10,7 +10,7 @@ import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {ChildrenFunction, Collection, ICollectionProps} from './Collection';
-import {DragAndDropProvider} from './DragAndDrop';
+import {DragAndDropMessages, DragAndDropProvider} from './DragAndDrop';
 import DragLayer from './DragLayer';
 import {TreeViewGroup} from './TreeViewGroup';
 import {TreeViewItem, TreeViewItemStack} from './TreeViewItem';
@@ -66,6 +66,12 @@ interface ITreeViewProps<T>
 	 * in drag preview.
 	 */
 	itemNameKey?: string;
+
+	/**
+	 * Messages that the TreeView uses to announce to the screen reader. Use
+	 * this to handle internationalization.
+	 */
+	messages?: DragAndDropMessages;
 
 	/**
 	 * The callback is called whenever there is an item dragging over
@@ -134,6 +140,7 @@ export function TreeView<T>({
 	indeterminate = true,
 	itemNameKey = 'name',
 	items,
+	messages,
 	nestedKey = 'children',
 	onExpandedChange,
 	onItemHover,
@@ -213,7 +220,10 @@ export function TreeView<T>({
 					context={dragAndDropContext}
 				>
 					<TreeViewContext.Provider value={context}>
-						<DragAndDropProvider rootRef={rootRef}>
+						<DragAndDropProvider
+							messages={messages}
+							rootRef={rootRef}
+						>
 							<Collection<T> items={state.items}>
 								{children}
 							</Collection>

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -206,6 +206,7 @@ export function TreeView<T>({
 				)}
 				ref={rootRef}
 				role="tree"
+				tabIndex={-1}
 			>
 				<DndProvider
 					backend={HTML5Backend}

--- a/packages/clay-core/src/tree-view/TreeView.tsx
+++ b/packages/clay-core/src/tree-view/TreeView.tsx
@@ -10,6 +10,7 @@ import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import {ChildrenFunction, Collection, ICollectionProps} from './Collection';
+import {DragAndDropProvider} from './DragAndDrop';
 import DragLayer from './DragLayer';
 import {TreeViewGroup} from './TreeViewGroup';
 import {TreeViewItem, TreeViewItemStack} from './TreeViewItem';
@@ -148,7 +149,7 @@ export function TreeView<T>({
 	showExpanderOnHover = true,
 	...otherProps
 }: ITreeViewProps<T>) {
-	const rootRef = React.useRef(null);
+	const rootRef = useRef<HTMLUListElement>(null);
 
 	const state = useTree<T>({
 		defaultExpandedKeys,
@@ -211,10 +212,12 @@ export function TreeView<T>({
 					context={dragAndDropContext}
 				>
 					<TreeViewContext.Provider value={context}>
-						<Collection<T> items={state.items}>
-							{children}
-						</Collection>
-						<DragLayer itemNameKey={itemNameKey} />
+						<DragAndDropProvider rootRef={rootRef}>
+							<Collection<T> items={state.items}>
+								{children}
+							</Collection>
+							<DragLayer itemNameKey={itemNameKey} />
+						</DragAndDropProvider>
 					</TreeViewContext.Provider>
 				</DndProvider>
 			</ul>

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -16,9 +16,12 @@ interface ITreeViewGroupProps<T>
 	extends ICollectionProps<T>,
 		Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {}
 
-function List({children}: React.HTMLAttributes<HTMLUListElement>) {
+function List({
+	children,
+	...otherProps
+}: React.HTMLAttributes<HTMLUListElement>) {
 	return (
-		<ul className="treeview-group" role="group">
+		<ul {...otherProps} className="treeview-group" role="group">
 			{children}
 		</ul>
 	);
@@ -40,7 +43,6 @@ export function TreeViewGroup<T extends Record<any, any>>({
 
 	return (
 		<CSSTransition
-			{...otherProps}
 			className={classNames('collapse', className, {
 				show: expandedKeys.has(item.key),
 			})}
@@ -73,7 +75,7 @@ export function TreeViewGroup<T extends Record<any, any>>({
 			unmountOnExit
 		>
 			<div>
-				<Collection<T> as={List} items={items}>
+				<Collection<T> as={List} items={items} {...otherProps}>
 					{children}
 				</Collection>
 			</div>

--- a/packages/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -51,6 +51,11 @@ export function TreeViewGroup<T extends Record<any, any>>({
 				exit: 'show',
 				exitActive: 'collapsing',
 			}}
+			data-id={
+				typeof item.key === 'number'
+					? `number,${item.key}`
+					: `string,${item.key}`
+			}
 			id={item.key}
 			in={expandedKeys.has(item.key)}
 			onEnter={(element: HTMLElement) =>

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -160,6 +160,7 @@ export const TreeViewItem = React.forwardRef<
 	}, [item, group, load.loadMore]);
 
 	const labelId = useId();
+	const ariaOwns = useId();
 
 	if (!group && nestedKey && item[nestedKey] && childrenRoot.current) {
 		return React.cloneElement(
@@ -216,6 +217,8 @@ export const TreeViewItem = React.forwardRef<
 					aria-expanded={
 						group ? expandedKeys.has(item.key) : undefined
 					}
+					aria-labelledby={labelId}
+					aria-owns={ariaOwns}
 					className={classNames(
 						'treeview-link',
 						itemStackProps.className,
@@ -485,12 +488,13 @@ export const TreeViewItem = React.forwardRef<
 						{typeof left === 'string' && !right ? (
 							<Layout.ContentRow>
 								<Layout.ContentCol expand>
-									<div
+									<span
 										className="component-text"
 										id={labelId}
+										tabIndex={-1}
 									>
 										{left}
-									</div>
+									</span>
 								</Layout.ContentCol>
 
 								{actions && <Actions>{actions}</Actions>}
@@ -523,7 +527,11 @@ export const TreeViewItem = React.forwardRef<
 					target={{dropPosition: 'bottom', key: item.key}}
 				/>
 
-				{group}
+				{group &&
+					React.cloneElement(group as React.ReactElement, {
+						'aria-labelledby': labelId,
+						id: ariaOwns,
+					})}
 
 				{left && group && Boolean(otherElements.length) && (
 					<div
@@ -649,7 +657,6 @@ export function TreeViewItemStack({
 		toggle,
 	} = useTreeViewContext();
 
-	const dragElement = useRef<HTMLButtonElement>(null);
 	const item = useItem();
 
 	const {
@@ -662,6 +669,7 @@ export function TreeViewItemStack({
 	} = useDnD();
 
 	const isFocusVisible = useFocusVisible();
+	const dragButtonId = useId();
 
 	const childrenCount = React.Children.count(children);
 
@@ -719,10 +727,11 @@ export function TreeViewItemStack({
 								: dragDescribedBy
 						}
 						aria-label="Drag"
+						aria-labelledby={`${dragButtonId} ${labelId}`}
 						data-draggable={currentDrag === item.key}
-						disabled={disabled}
 						displayType={null}
 						draggable
+						id={dragButtonId}
 						monospaced
 						onClick={(event) => {
 							event.stopPropagation();
@@ -741,10 +750,9 @@ export function TreeViewItemStack({
 								event.stopPropagation();
 							}
 						}}
-						ref={dragElement}
 						tabIndex={currentDrag === item.key || !mode ? 0 : -1}
 					>
-						<Icon symbol="drag" />
+						<Icon aria-hidden symbol="drag" />
 					</Button>
 				</Layout.ContentCol>
 			)}
@@ -763,9 +771,13 @@ export function TreeViewItemStack({
 					child?.type.displayName === 'Text'
 				) {
 					content = (
-						<div className="component-text" id={labelId}>
+						<span
+							className="component-text"
+							id={labelId}
+							tabIndex={-1}
+						>
 							{child}
-						</div>
+						</span>
 					);
 
 					// @ts-ignore

--- a/packages/clay-core/src/tree-view/TreeViewItem.tsx
+++ b/packages/clay-core/src/tree-view/TreeViewItem.tsx
@@ -663,6 +663,7 @@ export function TreeViewItemStack({
 		currentDrag,
 		dragCancelDescribedBy,
 		dragDescribedBy,
+		messages,
 		mode,
 		onCancel,
 		onDragStart,
@@ -726,7 +727,7 @@ export function TreeViewItemStack({
 								? dragCancelDescribedBy
 								: dragDescribedBy
 						}
-						aria-label="Drag"
+						aria-label={messages.dragItem}
 						aria-labelledby={`${dragButtonId} ${labelId}`}
 						data-draggable={currentDrag === item.key}
 						displayType={null}
@@ -951,7 +952,8 @@ type ItemIndicatorProps = {
 };
 
 function ItemIndicator({labelId, target}: ItemIndicatorProps) {
-	const {currentTarget, dragDropDescribedBy, mode, position} = useDnD();
+	const {currentTarget, dragDropDescribedBy, messages, mode, position} =
+		useDnD();
 	const indicatorRef = useRef<HTMLDivElement>(null);
 
 	const id = useId();
@@ -975,12 +977,12 @@ function ItemIndicator({labelId, target}: ItemIndicatorProps) {
 			aria-describedby={dragDropDescribedBy}
 			aria-hidden={mode !== 'keyboard' ? true : undefined}
 			aria-label={classNames({
-				'Drop on': target.dropPosition === 'middle',
-				'Insert on bottom of the': target.dropPosition === 'bottom',
-				'Insert on top of the': target.dropPosition === 'top',
+				[messages.dropOn]: target.dropPosition === 'middle',
+				[messages.insertAfter]: target.dropPosition === 'bottom',
+				[messages.insertBefore]: target.dropPosition === 'top',
 			})}
 			aria-labelledby={`${id} ${labelId}`}
-			aria-roledescription="drop indicator"
+			aria-roledescription={messages.dropIndicator}
 			id={id}
 			ref={indicatorRef}
 			role="button"

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -13,6 +13,7 @@ exports[`TreeView basic rendering render dynamic content 1`] = `
       <div
         aria-expanded="false"
         class="treeview-link"
+        data-id="string,Root"
         role="treeitem"
         style="padding-left: 0px;"
         tabindex="0"
@@ -88,6 +89,7 @@ exports[`TreeView basic rendering render nested dynamic content 1`] = `
       <div
         aria-expanded="false"
         class="treeview-link"
+        data-id="string,Foo"
         role="treeitem"
         style="padding-left: 0px;"
         tabindex="0"
@@ -163,6 +165,7 @@ exports[`TreeView basic rendering render static content 1`] = `
       <div
         aria-expanded="false"
         class="treeview-link"
+        data-id="string,$.0"
         role="treeitem"
         style="padding-left: 0px;"
         tabindex="0"
@@ -237,6 +240,7 @@ exports[`TreeView basic rendering render with actions 1`] = `
     >
       <div
         class="treeview-link"
+        data-id="string,$.0"
         role="treeitem"
         style="padding-left: 24px;"
         tabindex="0"
@@ -330,6 +334,7 @@ exports[`TreeView basic rendering render with checkbox 1`] = `
       <div
         aria-expanded="false"
         class="treeview-link"
+        data-id="string,$.0"
         role="treeitem"
         style="padding-left: 0px;"
         tabindex="0"
@@ -422,6 +427,7 @@ exports[`TreeView basic rendering render with item active 1`] = `
       <div
         aria-expanded="false"
         class="treeview-link active"
+        data-id="string,$.0"
         role="treeitem"
         style="padding-left: 0px;"
         tabindex="0"
@@ -514,6 +520,7 @@ exports[`TreeView basic rendering render with text 1`] = `
       <div
         aria-expanded="false"
         class="treeview-link"
+        data-id="string,$.0"
         role="treeitem"
         style="padding-left: 0px;"
         tabindex="0"

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -13,6 +13,8 @@ exports[`TreeView basic rendering render dynamic content 1`] = `
     >
       <div
         aria-expanded="false"
+        aria-labelledby="clay-id-13"
+        aria-owns="clay-id-14"
         class="treeview-link"
         data-id="string,Root"
         role="treeitem"
@@ -63,12 +65,13 @@ exports[`TreeView basic rendering render dynamic content 1`] = `
             <div
               class="autofit-col autofit-col-expand"
             >
-              <div
+              <span
                 class="component-text"
-                id="clay-id-11"
+                id="clay-id-13"
+                tabindex="-1"
               >
                 Root
-              </div>
+              </span>
             </div>
           </div>
         </span>
@@ -91,6 +94,8 @@ exports[`TreeView basic rendering render nested dynamic content 1`] = `
     >
       <div
         aria-expanded="false"
+        aria-labelledby="clay-id-22"
+        aria-owns="clay-id-23"
         class="treeview-link"
         data-id="string,Foo"
         role="treeitem"
@@ -141,12 +146,13 @@ exports[`TreeView basic rendering render nested dynamic content 1`] = `
             <div
               class="autofit-col autofit-col-expand"
             >
-              <div
+              <span
                 class="component-text"
-                id="clay-id-18"
+                id="clay-id-22"
+                tabindex="-1"
               >
                 Foo
-              </div>
+              </span>
             </div>
           </div>
         </span>
@@ -169,6 +175,8 @@ exports[`TreeView basic rendering render static content 1`] = `
     >
       <div
         aria-expanded="false"
+        aria-labelledby="clay-id-4"
+        aria-owns="clay-id-5"
         class="treeview-link"
         data-id="string,$.0"
         role="treeitem"
@@ -219,12 +227,13 @@ exports[`TreeView basic rendering render static content 1`] = `
             <div
               class="autofit-col autofit-col-expand"
             >
-              <div
+              <span
                 class="component-text"
                 id="clay-id-4"
+                tabindex="-1"
               >
                 Root
-              </div>
+              </span>
             </div>
           </div>
         </span>
@@ -246,6 +255,8 @@ exports[`TreeView basic rendering render with actions 1`] = `
       role="none"
     >
       <div
+        aria-labelledby="clay-id-58"
+        aria-owns="clay-id-59"
         class="treeview-link"
         data-id="string,$.0"
         role="treeitem"
@@ -263,12 +274,13 @@ exports[`TreeView basic rendering render with actions 1`] = `
             <div
               class="autofit-col autofit-col-expand"
             >
-              <div
+              <span
                 class="component-text"
-                id="clay-id-46"
+                id="clay-id-58"
+                tabindex="-1"
               >
                 Root
-              </div>
+              </span>
             </div>
             <div
               class="autofit-col"
@@ -342,6 +354,8 @@ exports[`TreeView basic rendering render with checkbox 1`] = `
     >
       <div
         aria-expanded="false"
+        aria-labelledby="clay-id-84"
+        aria-owns="clay-id-85"
         class="treeview-link"
         data-id="string,$.0"
         role="treeitem"
@@ -409,12 +423,13 @@ exports[`TreeView basic rendering render with checkbox 1`] = `
             <div
               class="autofit-col autofit-col-expand"
             >
-              <div
+              <span
                 class="component-text"
-                id="clay-id-67"
+                id="clay-id-84"
+                tabindex="-1"
               >
                 Root
-              </div>
+              </span>
             </div>
           </div>
         </span>
@@ -437,6 +452,8 @@ exports[`TreeView basic rendering render with item active 1`] = `
     >
       <div
         aria-expanded="false"
+        aria-labelledby="clay-id-140"
+        aria-owns="clay-id-141"
         class="treeview-link active"
         data-id="string,$.0"
         role="treeitem"
@@ -504,12 +521,13 @@ exports[`TreeView basic rendering render with item active 1`] = `
             <div
               class="autofit-col autofit-col-expand"
             >
-              <div
+              <span
                 class="component-text"
-                id="clay-id-110"
+                id="clay-id-140"
+                tabindex="-1"
               >
                 Root
-              </div>
+              </span>
             </div>
           </div>
         </span>
@@ -532,6 +550,8 @@ exports[`TreeView basic rendering render with text 1`] = `
     >
       <div
         aria-expanded="false"
+        aria-labelledby="clay-id-93"
+        aria-owns="clay-id-94"
         class="treeview-link"
         data-id="string,$.0"
         role="treeitem"
@@ -599,16 +619,17 @@ exports[`TreeView basic rendering render with text 1`] = `
             <div
               class="autofit-col autofit-col-expand"
             >
-              <div
+              <span
                 class="component-text"
-                id="clay-id-74"
+                id="clay-id-93"
+                tabindex="-1"
               >
                 <span
                   class="text-3 text-truncate"
                 >
                   Root
                 </span>
-              </div>
+              </span>
             </div>
           </div>
         </span>

--- a/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-core/src/tree-view/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -5,6 +5,7 @@ exports[`TreeView basic rendering render dynamic content 1`] = `
   <ul
     class="treeview show-quick-actions-on-hover treeview-light show-component-expander-on-hover"
     role="tree"
+    tabindex="-1"
   >
     <li
       class="treeview-item"
@@ -64,6 +65,7 @@ exports[`TreeView basic rendering render dynamic content 1`] = `
             >
               <div
                 class="component-text"
+                id="clay-id-11"
               >
                 Root
               </div>
@@ -81,6 +83,7 @@ exports[`TreeView basic rendering render nested dynamic content 1`] = `
   <ul
     class="treeview show-quick-actions-on-hover treeview-light show-component-expander-on-hover"
     role="tree"
+    tabindex="-1"
   >
     <li
       class="treeview-item"
@@ -140,6 +143,7 @@ exports[`TreeView basic rendering render nested dynamic content 1`] = `
             >
               <div
                 class="component-text"
+                id="clay-id-18"
               >
                 Foo
               </div>
@@ -157,6 +161,7 @@ exports[`TreeView basic rendering render static content 1`] = `
   <ul
     class="treeview show-quick-actions-on-hover treeview-light show-component-expander-on-hover"
     role="tree"
+    tabindex="-1"
   >
     <li
       class="treeview-item"
@@ -216,6 +221,7 @@ exports[`TreeView basic rendering render static content 1`] = `
             >
               <div
                 class="component-text"
+                id="clay-id-4"
               >
                 Root
               </div>
@@ -233,6 +239,7 @@ exports[`TreeView basic rendering render with actions 1`] = `
   <ul
     class="treeview show-quick-actions-on-hover treeview-light show-component-expander-on-hover"
     role="tree"
+    tabindex="-1"
   >
     <li
       class="treeview-item"
@@ -258,6 +265,7 @@ exports[`TreeView basic rendering render with actions 1`] = `
             >
               <div
                 class="component-text"
+                id="clay-id-46"
               >
                 Root
               </div>
@@ -326,6 +334,7 @@ exports[`TreeView basic rendering render with checkbox 1`] = `
   <ul
     class="treeview show-quick-actions-on-hover treeview-light show-component-expander-on-hover"
     role="tree"
+    tabindex="-1"
   >
     <li
       class="treeview-item"
@@ -402,6 +411,7 @@ exports[`TreeView basic rendering render with checkbox 1`] = `
             >
               <div
                 class="component-text"
+                id="clay-id-67"
               >
                 Root
               </div>
@@ -419,6 +429,7 @@ exports[`TreeView basic rendering render with item active 1`] = `
   <ul
     class="treeview show-quick-actions-on-hover treeview-light show-component-expander-on-hover"
     role="tree"
+    tabindex="-1"
   >
     <li
       class="treeview-item"
@@ -495,6 +506,7 @@ exports[`TreeView basic rendering render with item active 1`] = `
             >
               <div
                 class="component-text"
+                id="clay-id-110"
               >
                 Root
               </div>
@@ -512,6 +524,7 @@ exports[`TreeView basic rendering render with text 1`] = `
   <ul
     class="treeview show-quick-actions-on-hover treeview-light show-component-expander-on-hover"
     role="tree"
+    tabindex="-1"
   >
     <li
       class="treeview-item"
@@ -588,6 +601,7 @@ exports[`TreeView basic rendering render with text 1`] = `
             >
               <div
                 class="component-text"
+                id="clay-id-74"
               >
                 <span
                   class="text-3 text-truncate"

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -578,7 +578,7 @@ export const PageElements = () => {
 	];
 
 	const [expandedKeys, setExpandedKeys] = useState<Set<React.Key>>(
-		new Set(['1', '2', '3', '4', '5'])
+		new Set([1, 2, 3, 4, 5])
 	);
 
 	return (

--- a/packages/clay-core/stories/TreeView.stories.tsx
+++ b/packages/clay-core/stories/TreeView.stories.tsx
@@ -583,6 +583,7 @@ export const PageElements = () => {
 
 	return (
 		<TreeView
+			aria-label="Treeview page elements example"
 			defaultItems={items}
 			expandedKeys={expandedKeys}
 			expanderIcons={{

--- a/packages/clay-shared/src/index.tsx
+++ b/packages/clay-shared/src/index.tsx
@@ -19,7 +19,7 @@ export {sub} from './sub';
 export {useDebounce} from './useDebounce';
 export {useFocusManagement, FOCUSABLE_ELEMENTS} from './useFocusManagement';
 export {useId} from './useId';
-export {useInteractionFocus} from './useInteractionFocus';
+export {useInteractionFocus, useFocusVisible} from './useInteractionFocus';
 export {useInternalState} from './useInternalState';
 export {useMousePosition} from './useMousePosition';
 export {useNavigation, isTypeahead, getFocusableList} from './useNavigation';


### PR DESCRIPTION
Fixes #5146

This commit still needs some implementation refinements, we need to change the way we handle the element indicator to improve indicator announcer to SRs.

I also still need to move the announcer messages to be configured for internationalization.

### ToDo

- [x] Refactor the drop indicator implementation
- [x] Add new API to configure announcement messages