### PR TITLE
feat(@clayui/core): adds new selection API to configure more options

### DIFF
--- a/packages/clay-core/src/tree-view/context.ts
+++ b/packages/clay-core/src/tree-view/context.ts
@@ -54,11 +54,13 @@ export function useTreeViewContext(): ITreeViewContext<unknown> {
 	return useContext(TreeViewContext);
 }
 
+type SelectionToggleOptions = {
+	selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null;
+	parentSelection?: boolean;
+};
+
 export type Selection = {
-	toggle: (
-		key: Key,
-		selectionMode?: 'single' | 'multiple' | 'multiple-recursive' | null
-	) => void;
+	toggle: (key: Key, options?: SelectionToggleOptions) => void;
 	has: (key: Key) => boolean;
 };
 

--- a/packages/clay-core/src/tree-view/useMultipleSelection.tsx
+++ b/packages/clay-core/src/tree-view/useMultipleSelection.tsx
@@ -36,11 +36,16 @@ export interface IMultipleSelection {
 
 type SelectionMode = 'single' | 'multiple' | 'multiple-recursive' | null;
 
+type SelectionToggleOptions = {
+	selectionMode?: SelectionMode;
+	parentSelection?: boolean;
+};
+
 export interface IMultipleSelectionState {
 	isIndeterminate: (key: Key) => boolean;
 	replaceIndeterminateKeys: (keys: Array<Key>) => void;
 	selectedKeys: Set<Key>;
-	toggleSelection: (key: Key, mode?: SelectionMode) => void;
+	toggleSelection: (key: Key, options?: SelectionToggleOptions) => void;
 }
 
 export interface IMultipleSelectionProps<T>
@@ -325,7 +330,9 @@ export function useMultipleSelection<T>(
 	);
 
 	const toggleSelection = useCallback(
-		(key: Key, mode?: SelectionMode) => {
+		(key: Key, options?: SelectionToggleOptions) => {
+			const {parentSelection = true, selectionMode: mode} = options ?? {};
+
 			switch (mode ?? selectionMode) {
 				case 'multiple': {
 					const selecteds = new Set(selectedKeys);
@@ -363,7 +370,9 @@ export function useMultipleSelection<T>(
 						selecteds.has(key)
 					);
 
-					toggleParentSelection(false, keyMap, selecteds);
+					if (parentSelection) {
+						toggleParentSelection(false, keyMap, selecteds);
+					}
 
 					setSelectionKeys(selecteds);
 					break;


### PR DESCRIPTION
Closes #5336

We recently added a new API to set the TreeView selection mode when calling the `selection` method in the render props to allow new interaction possibilities and now also providing more options to disable certain selection behaviors.