### PR TITLE
feat(@clayui/tabs): adds the pattern of uncontrolled to the `active` property of Tabs.Item in the new composition

### DIFF
--- a/packages/clay-tabs/src/Item.tsx
+++ b/packages/clay-tabs/src/Item.tsx
@@ -11,6 +11,10 @@ export interface IProps
 	extends Omit<React.HTMLAttributes<HTMLLIElement>, 'onClick'> {
 	/**
 	 * Flag to indicate if the component is active or not.
+	 *
+	 * OBS: The `active` API in the new pattern has uncontrolled behavior,
+	 * working just like `defaultActive` as in the prop declared in the
+	 * root component.
 	 */
 	active?: boolean;
 

--- a/packages/clay-tabs/src/__tests__/index.tsx
+++ b/packages/clay-tabs/src/__tests__/index.tsx
@@ -192,4 +192,25 @@ describe('ClayTabs', () => {
 		expect(getAllByRole('tab').length).toBe(3);
 		expect(getAllByRole('tabpanel').length).toBe(3);
 	});
+
+	it('renders the tab item active when `active` is set on uncontrolled state', () => {
+		const {getByRole} = render(
+			<ClayTabs>
+				<ClayTabs.List>
+					<ClayTabs.Item>Tab 1</ClayTabs.Item>
+					<ClayTabs.Item active>Tab 2</ClayTabs.Item>
+					<ClayTabs.Item>Tab 3</ClayTabs.Item>
+				</ClayTabs.List>
+				<ClayTabs.Panels>
+					<ClayTabs.TabPanel>Tab Content 1</ClayTabs.TabPanel>
+					<ClayTabs.TabPanel>Tab Content 2</ClayTabs.TabPanel>
+					<ClayTabs.TabPanel>Tab Content 3</ClayTabs.TabPanel>
+				</ClayTabs.Panels>
+			</ClayTabs>
+		);
+
+		const activeTab = getByRole('tab', {selected: true});
+
+		expect(activeTab.innerHTML).toBe('Tab 2');
+	});
 });

--- a/packages/clay-tabs/src/index.tsx
+++ b/packages/clay-tabs/src/index.tsx
@@ -82,7 +82,7 @@ function ClayTabs({
 	onActiveChange,
 	...otherProps
 }: IProps) {
-	const [active, setActive] = useInternalState({
+	const [active, setActive, isUncontrolled] = useInternalState({
 		defaultName: 'defaultActive',
 		defaultValue: defaultActive,
 		handleName: 'onActiveChange',
@@ -106,6 +106,7 @@ function ClayTabs({
 					justified,
 					modern,
 					onActiveChange: setActive,
+					shouldUseActive: isUncontrolled,
 					tabsId,
 				})}
 


### PR DESCRIPTION
Fixes #5344