### PR TITLE
docs(@clayui/management-toolbar): update checkbox accessibility in documentations

### DIFF
--- a/packages/clay-management-toolbar/docs/index.js
+++ b/packages/clay-management-toolbar/docs/index.js
@@ -191,6 +191,7 @@ const ManagementToolbarCode = `const Component = () => {
 	];
 
 	const [searchMobile, setSearchMobile] = useState(false);
+	const [checked, setChecked] = useState(false);
 
 	const viewTypeActive = viewTypes.find(type => type.active);
 
@@ -199,7 +200,13 @@ const ManagementToolbarCode = `const Component = () => {
 			<ClayManagementToolbar>
 				<ClayManagementToolbar.ItemList>
 					<ClayManagementToolbar.Item>
-						<ClayCheckbox checked={false} onChange={() => {}} />
+						<ClayCheckbox
+							aria-label={checked ? 'Unselect all' : 'Select all'}
+							checked={checked}
+							onChange={(event) =>
+								setChecked(event.target.checked)
+							}
+						/>
 					</ClayManagementToolbar.Item>
 
 					<ClayDropDownWithItems

--- a/packages/clay-management-toolbar/docs/markup-management-toolbar.md
+++ b/packages/clay-management-toolbar/docs/markup-management-toolbar.md
@@ -41,7 +41,7 @@ mainTabURL: 'docs/components/management-toolbar.html'
                 <li class="nav-item">
                     <div class="custom-control custom-checkbox">
                         <label>
-                            <input class="custom-control-input" type="checkbox">
+                            <input class="custom-control-input" aria-label="Select all" type="checkbox">
                             <span class="custom-control-label"></span>
                         </label>
                     </div>
@@ -197,13 +197,13 @@ mainTabURL: 'docs/components/management-toolbar.html'
                 <li class="nav-item">
                     <div class="custom-control custom-checkbox">
                         <label>
-                            <input class="custom-control-input" type="checkbox">
+                            <input aria-label="Select all" aria-describedby="checkbox-description-1" class="custom-control-input" type="checkbox">
                             <span class="custom-control-label"></span>
                         </label>
                     </div>
                 </li>
                 <li class="nav-item nav-item-shrink">
-                    <span class="navbar-text">
+                    <span class="navbar-text" id="checkbox-description-1">
                         3 of 7
                         <span class="navbar-breakpoint-down-d-none">items selected</span>
                     </span>
@@ -300,7 +300,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                 <li class="nav-item">
                     <div class="custom-control custom-checkbox">
                         <label>
-                            <input class="custom-control-input" type="checkbox">
+                            <input aria-label="Select all" class="custom-control-input" type="checkbox">
                             <span class="custom-control-label"></span>
                         </label>
                     </div>
@@ -1586,7 +1586,7 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
                 <li class="nav-item">
                     <div class="custom-control custom-checkbox">
                         <label>
-                            <input class="custom-control-input" type="checkbox">
+                            <input aria-label="Select all" class="custom-control-input" type="checkbox">
                             <span class="custom-control-label"></span>
                         </label>
                     </div>
@@ -1684,7 +1684,11 @@ Use `navbar-overlay navbar-overlay-up` on any direct descendant of navbar to cre
 			<li class="nav-item">
 				<div class="custom-control custom-checkbox">
 					<label>
-						<input class="custom-control-input" type="checkbox" />
+						<input
+							aria-label="Select all"
+							class="custom-control-input"
+							type="checkbox"
+						/>
 						<span class="custom-control-label"></span>
 					</label>
 				</div>

--- a/packages/clay-management-toolbar/stories/ManagementToolbar.stories.tsx
+++ b/packages/clay-management-toolbar/stories/ManagementToolbar.stories.tsx
@@ -43,6 +43,7 @@ const viewTypes = [
 
 export const Default = () => {
 	const [searchMobile, setSearchMobile] = useState<boolean>(false);
+	const [checked, setChecked] = useState<boolean>(false);
 	const viewTypeActive = viewTypes.find((type) => type.active);
 
 	return (
@@ -50,7 +51,13 @@ export const Default = () => {
 			<ClayManagementToolbar aria-label="Management toolbar">
 				<ClayManagementToolbar.ItemList>
 					<ClayManagementToolbar.Item>
-						<ClayCheckbox checked={false} onChange={() => {}} />
+						<ClayCheckbox
+							aria-label={checked ? 'Unselect all' : 'Select all'}
+							checked={checked}
+							onChange={(event) =>
+								setChecked(event.target.checked)
+							}
+						/>
 					</ClayManagementToolbar.Item>
 
 					<ClayManagementToolbar.Item>

--- a/packages/demos/stories/ListPage.tsx
+++ b/packages/demos/stories/ListPage.tsx
@@ -10,7 +10,7 @@ import ClayIcon from '@clayui/icon';
 import {ClayListWithItems} from '@clayui/list';
 import ClayManagementToolbar from '@clayui/management-toolbar';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
-import {sub} from '@clayui/shared';
+import {sub, useId} from '@clayui/shared';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import React, {useState} from 'react';
 
@@ -89,6 +89,8 @@ export default function ListPage() {
 
 	const isActive = !!numOfSelected;
 
+	const checkboxDescribedby = useId();
+
 	return (
 		<ClayTooltipProvider>
 			<div>
@@ -96,6 +98,12 @@ export default function ListPage() {
 					<ClayManagementToolbar.ItemList expand={isActive}>
 						<ClayManagementToolbar.Item>
 							<ClayCheckbox
+								aria-describedby={checkboxDescribedby}
+								aria-label={
+									numOfSelected === totalItems
+										? 'Unselect all'
+										: 'Select all'
+								}
 								checked={allSelected}
 								data-tooltip-align="top"
 								onChange={() => {
@@ -116,7 +124,10 @@ export default function ListPage() {
 						{isActive && (
 							<>
 								<ClayManagementToolbar.Item>
-									<span className="navbar-text">
+									<span
+										className="navbar-text"
+										id={checkboxDescribedby}
+									>
 										{numOfSelected === totalItems ? (
 											'All Selected'
 										) : (
@@ -180,6 +191,11 @@ export default function ListPage() {
 
 								<ClayManagementToolbar.Item>
 									<ClayButton
+										aria-label={
+											sortAsc
+												? 'Order list up'
+												: 'Order list down'
+										}
 										className="nav-link nav-link-monospaced"
 										displayType="unstyled"
 										onClick={() => setSortAsc(!sortAsc)}
@@ -219,6 +235,7 @@ export default function ListPage() {
 											tag="span"
 										>
 											<ClayButtonWithIcon
+												aria-label="Close"
 												className="navbar-breakpoint-d-none"
 												displayType="unstyled"
 												onClick={() =>
@@ -227,6 +244,7 @@ export default function ListPage() {
 												symbol="times"
 											/>
 											<ClayButtonWithIcon
+												aria-label="Search for..."
 												displayType="unstyled"
 												symbol="search"
 												type="submit"
@@ -239,6 +257,7 @@ export default function ListPage() {
 							<ClayManagementToolbar.ItemList>
 								<ClayManagementToolbar.Item className="navbar-breakpoint-d-none">
 									<ClayButton
+										aria-label="Search"
 										className="nav-link nav-link-monospaced"
 										displayType="unstyled"
 										onClick={() => setSearchMobile(true)}
@@ -249,6 +268,7 @@ export default function ListPage() {
 
 								<ClayManagementToolbar.Item>
 									<ClayButton
+										aria-label="Info"
 										className="nav-link nav-link-monospaced"
 										displayType="unstyled"
 										onClick={() => {}}
@@ -262,6 +282,7 @@ export default function ListPage() {
 										items={viewTypes}
 										trigger={
 											<ClayButton
+												aria-label="Display view"
 												className="nav-link nav-link-monospaced"
 												displayType="unstyled"
 											>
@@ -273,6 +294,7 @@ export default function ListPage() {
 
 								<ClayManagementToolbar.Item>
 									<ClayButtonWithIcon
+										aria-label="Add New Item"
 										className="nav-btn nav-btn-monospaced"
 										data-tooltip-align="bottom"
 										symbol="plus"


### PR DESCRIPTION
Fixes #5330

Updates the documentation examples with the accessibility improvement for the checkbox, this component doesn't handle this because being a low-level component and purely composition, so it doesn't have the visibility to provide this OOTB.

The React.js implementation of this component is also deprecated and moved to the DXP, so we also need to update this in the DXP to be usable, we're just showing you how to use the Management Toolbar and best practices, in this case checkbox accessibility.