### PR TITLE
fix(@clayui/autocomplete): fix error when filtering autocomplete with regex special character

### DIFF
--- a/packages/clay-autocomplete/src/Autocomplete.tsx
+++ b/packages/clay-autocomplete/src/Autocomplete.tsx
@@ -118,6 +118,8 @@ export interface IProps<T>
 	loadingState?: number;
 }
 
+const ESCAPE_REGEXP = /[.*+?^${}()|[\]\\]/g;
+
 export function Autocomplete<T extends Record<string, any>>({
 	active: externalActive,
 	alignmentByViewport,
@@ -212,7 +214,10 @@ export function Autocomplete<T extends Record<string, any>>({
 	}, [value]);
 
 	const filterFn = useCallback(
-		(itemValue: string) => itemValue.match(new RegExp(value, 'i')) !== null,
+		(itemValue: string) =>
+			itemValue.match(
+				new RegExp(value.replace(ESCAPE_REGEXP, '\\$&'), 'i')
+			) !== null,
 		[value]
 	);
 


### PR DESCRIPTION
Fixes #5349

We escape value with special characters from regex when filtering the list of items, we don't remove the input value because it causes a bad user experience when typing.