### PR TITLE
fix(@clayui/css): fix build error when `$secondary` variable is a CSS variable

### DIFF
--- a/packages/clay-css/src/scss/_license-text.scss
+++ b/packages/clay-css/src/scss/_license-text.scss
@@ -1,5 +1,5 @@
 /**
- * Clay 3.78.0
+ * Clay 3.87.0
  *
  * SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
  * SPDX-FileCopyrightText: © 2020 Contributors to the project Clay <https://github.com/liferay/clay/graphs/contributors>

--- a/packages/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/packages/clay-css/src/scss/atlas/variables/_globals.scss
@@ -110,7 +110,10 @@ $primary-l3: clay-lighten($primary, 44.9) !default;
 $secondary: #6b6c7e !default;
 $secondary-d1: clay-darken(clay-saturate($secondary, 4.82), 20) !default;
 $secondary-d2: clay-darken(clay-saturate($secondary, 5.36), 23.92) !default;
-$secondary-l0: clay-lighten(saturate(adjust-hue($secondary, 3), 0.03), 11.18);
+$secondary-l0: clay-lighten(
+	saturate(clay-adjust-hue($secondary, 3), 0.03),
+	11.18
+);
 $secondary-l1: clay-lighten(
 	clay-saturate(clay-adjust-hue($secondary, -3), 5.39),
 	23.92

--- a/packages/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/packages/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -134,7 +134,7 @@ $cadmin-secondary-d2: clay-darken(
 	23.92
 ) !default;
 $cadmin-secondary-l0: clay-lighten(
-	saturate(adjust-hue($cadmin-secondary, 3), 0.03),
+	saturate(clay-adjust-hue($cadmin-secondary, 3), 0.03),
 	11.18
 );
 $cadmin-secondary-l1: clay-lighten(


### PR DESCRIPTION
Follow up #5364

The DXP build with the dialect theme is failing since the `$secondary` variable could be a CSS variable.